### PR TITLE
'Approved applications only' graph now shows approved and sent (T169520)

### DIFF
--- a/TWLight/graphs/urls.py
+++ b/TWLight/graphs/urls.py
@@ -46,8 +46,8 @@ csv_urlpatterns = [
 
     url(r'^app_count/approved/(?P<pk>\d+)/$',
         views.CSVAppCountByPartner.as_view(),
-        kwargs={'approved': True},
-        name='approved_app_count_by_partner'
+        kwargs={'approved_or_sent': True},
+        name='approved_or_sent_app_count_by_partner'
     ),
 
     url(r'^user_count/(?P<pk>\d+)/$',

--- a/TWLight/graphs/views.py
+++ b/TWLight/graphs/views.py
@@ -312,8 +312,8 @@ class CSVAppCountByPartner(_CSVDownloadView):
 
         queryset = Application.objects.filter(partner=partner)
 
-        if 'approved' in self.kwargs:
-            queryset = queryset.filter(status=Application.APPROVED)
+        if 'approved_or_sent' in self.kwargs:
+            queryset = queryset.filter(status__in=(Application.APPROVED, Application.SENT))
 
         data = get_data_count_by_month(queryset, data_format=PYTHON)
 

--- a/TWLight/resources/templates/resources/partner_detail.html
+++ b/TWLight/resources/templates/resources/partner_detail.html
@@ -410,10 +410,10 @@
   
   {% comment %} Translators: This is the title of a graph on partner pages (e.g. https://wikipedialibrary.wmflabs.org/partners/8/) for a graph showing the number of approved applications over time. {% endcomment %}
   <h4>{% trans "Approved applications only" %}
-    <a href="{% url 'csv:approved_app_count_by_partner' object.pk %}" class="pull-right btn btn-default">{% trans "download as csv" %}
+    <a href="{% url 'csv:approved_or_sent_app_count_by_partner' object.pk %}" class="pull-right btn btn-default">{% trans "download as csv" %}
   </a></h4>
   
-  <div id="approved-signups-time-graph" style="width:600px;height:300px"></div>
+  <div id="approved-or-sent-signups-time-graph" style="width:600px;height:300px"></div>
   
   {% comment %} Translators: This is the title of a graph on partner pages (e.g. https://wikipedialibrary.wmflabs.org/partners/8/) for a graph showing the number of unique applicants over time. {% endcomment %}
   <h3>{% trans "Unique users over time" %}
@@ -451,9 +451,9 @@
       });
 
       // Approved applications by time
-      var approved_signups_time_graph = $("#approved-signups-time-graph");
-      var approved_signups_time_data = {{ approved_signups_time_data | safe }};
-      var approved_signups_time_plot = $.plot(approved_signups_time_graph, [approved_signups_time_data], {
+      var approved_or_sent_signups_time_graph = $("#approved-or-sent-signups-time-graph");
+      var approved_or_sent_signups_time_data = {{ approved_or_sent_signups_time_data | safe }};
+      var approved_or_sent_signups_time_plot = $.plot(approved_or_sent_signups_time_graph, [approved_or_sent_signups_time_data], {
         xaxis: {
           mode: "time",
           tickSize: [1, 'month'],

--- a/TWLight/resources/views.py
+++ b/TWLight/resources/views.py
@@ -87,10 +87,10 @@ class PartnersDetailView(DetailView):
                 Application.objects.filter(partner=partner)
             )
 
-        context['approved_signups_time_data'] = get_data_count_by_month(
+        context['approved_or_sent_signups_time_data'] = get_data_count_by_month(
                 Application.objects.filter(
                     partner=partner,
-                    status=Application.APPROVED
+                    status__in=(Application.APPROVED, Application.SENT)
                 )
             )
 


### PR DESCRIPTION
Followup from https://github.com/WikipediaLibrary/TWLight/pull/31.

Looks for both approved or sent applications this time. Ran tests with no errors.