### PR TITLE
Agreement with Terms of Use is a required field

### DIFF
--- a/TWLight/applications/helpers.py
+++ b/TWLight/applications/helpers.py
@@ -75,7 +75,7 @@ FIELD_TYPES = {
     SPECIFIC_STREAM: forms.ModelChoiceField(queryset=Stream.objects.all()),
     SPECIFIC_TITLE: forms.CharField(max_length=128),
     COMMENTS: forms.CharField(widget=forms.Textarea, required=False),
-    AGREEMENT_WITH_TERMS_OF_USE: forms.BooleanField(required=False),
+    AGREEMENT_WITH_TERMS_OF_USE: forms.BooleanField(),
 }
 
 FIELD_LABELS = {


### PR DESCRIPTION
Came across this while looking at something else - despite the text making it clear that agreement with ToU is required, you could submit an application without checking the box because the field had `required=False`.

Ran tests with no issues and tested applying to partners with and without ToU agreement required, with and without checking the box, and everything functioned as intended.