### PR TITLE
Added form option for having already signed up (T172095)

### DIFF
--- a/TWLight/applications/forms.py
+++ b/TWLight/applications/forms.py
@@ -33,7 +33,8 @@ from .helpers import (USER_FORM_FIELDS,
                       FIELD_TYPES,
                       FIELD_LABELS,
                       SPECIFIC_STREAM,
-                      AGREEMENT_WITH_TERMS_OF_USE)
+                      AGREEMENT_WITH_TERMS_OF_USE,
+                      ALREADY_SIGNED_UP)
 from .models import Application
 
 
@@ -219,11 +220,15 @@ class BaseApplicationForm(forms.Form):
                 self.fields[field_name] = FIELD_TYPES[datum]
                 self.fields[field_name].label = FIELD_LABELS[datum]
 
-                if datum == AGREEMENT_WITH_TERMS_OF_USE:
+                if datum == AGREEMENT_WITH_TERMS_OF_USE or datum == ALREADY_SIGNED_UP:
                     # Make sure that, if the partner requires agreement with
-                    # terms of use, that link is provided inline.
+                    # terms of use or previous signup, that link is provided inline.
+                    if datum == AGREEMENT_WITH_TERMS_OF_USE:
+                        partner_url = partner_object.terms_of_use
+                    if datum == ALREADY_SIGNED_UP:
+                        partner_url = partner_object.sign_up_link
                     help_text = '<a href="{url}">{url}</a>'.format(
-                        url=partner_object.terms_of_use)
+                        url=partner_url)
                     self.fields[field_name].help_text = help_text
 
                 if datum == SPECIFIC_STREAM:

--- a/TWLight/applications/helpers.py
+++ b/TWLight/applications/helpers.py
@@ -47,6 +47,7 @@ SPECIFIC_STREAM = 'specific_stream'
 SPECIFIC_TITLE = 'specific_title'
 COMMENTS = 'comments'
 AGREEMENT_WITH_TERMS_OF_USE = 'agreement_with_terms_of_use'
+ALREADY_SIGNED_UP = 'already_signed_up'
 
 
 # ~~~~ Basic field names ~~~~ #
@@ -59,7 +60,7 @@ PARTNER_FORM_BASE_FIELDS = [RATIONALE, COMMENTS]
 # These fields are displayed only when a specific partner requires that
 # information.
 PARTNER_FORM_OPTIONAL_FIELDS = [SPECIFIC_STREAM, SPECIFIC_TITLE,
-                                AGREEMENT_WITH_TERMS_OF_USE]
+                                AGREEMENT_WITH_TERMS_OF_USE, ALREADY_SIGNED_UP]
 
 
 # ~~~~ Field information ~~~~ #
@@ -76,6 +77,7 @@ FIELD_TYPES = {
     SPECIFIC_TITLE: forms.CharField(max_length=128),
     COMMENTS: forms.CharField(widget=forms.Textarea, required=False),
     AGREEMENT_WITH_TERMS_OF_USE: forms.BooleanField(required=False),
+    ALREADY_SIGNED_UP: forms.BooleanField()
 }
 
 FIELD_LABELS = {
@@ -99,6 +101,8 @@ FIELD_LABELS = {
     COMMENTS: _('Anything else you want to say'),
     # Translators: When filling out an application, users may be required to check a box to say they agree with the website's Terms of Use document, which is linked
     AGREEMENT_WITH_TERMS_OF_USE: _("You must agree with the partner's terms of use"),
+    # Translators: When filling out an application, users may be required to check a box to confirm that they have signed up for an account already
+    ALREADY_SIGNED_UP: _("You must sign up for an account before making a request"),
 }
 
 

--- a/TWLight/applications/migrations/0018_application_already_signed_up.py
+++ b/TWLight/applications/migrations/0018_application_already_signed_up.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('applications', '0017_auto_20170709_1859'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='application',
+            name='already_signed_up',
+            field=models.BooleanField(default=False),
+        ),
+    ]

--- a/TWLight/applications/models.py
+++ b/TWLight/applications/models.py
@@ -92,6 +92,7 @@ class Application(models.Model):
                             blank=True, null=True)
     comments = models.TextField(blank=True)
     agreement_with_terms_of_use = models.BooleanField(default=False)
+    already_signed_up = models.BooleanField(default=False)
 
     # Was this application imported via CLI?
     imported = models.NullBooleanField(default=False)

--- a/TWLight/applications/tests.py
+++ b/TWLight/applications/tests.py
@@ -28,6 +28,7 @@ from .helpers import (USER_FORM_FIELDS,
                       SPECIFIC_STREAM,
                       SPECIFIC_TITLE,
                       AGREEMENT_WITH_TERMS_OF_USE,
+                      ALREADY_SIGNED_UP,
                       REAL_NAME,
                       COUNTRY_OF_RESIDENCE,
                       OCCUPATION,
@@ -221,6 +222,7 @@ class SynchronizeFieldsTest(TestCase):
         setattr(app, AGREEMENT_WITH_TERMS_OF_USE, True)
         setattr(app, SPECIFIC_STREAM, stream)
         setattr(app, SPECIFIC_TITLE, 'Alice in Wonderland')
+        setattr(app, ALREADY_SIGNED_UP, True)
         app.save()
 
         app.refresh_from_db()
@@ -234,10 +236,11 @@ class SynchronizeFieldsTest(TestCase):
         self.assertEqual(output[SPECIFIC_TITLE], 'Alice in Wonderland')
         self.assertEqual(output['Email'], 'alice@example.com')
         self.assertEqual(output[AGREEMENT_WITH_TERMS_OF_USE], True)
+        self.assertEqual(output[ALREADY_SIGNED_UP], True)
 
         # Make sure that in enumerating the keys we didn't miss any (e.g. if
         # the codebase changes).
-        self.assertEqual(8, len(output.keys()))
+        self.assertEqual(9, len(output.keys()))
 
 
 
@@ -263,6 +266,7 @@ class SynchronizeFieldsTest(TestCase):
             rationale='just because',
             comments='nope')
         app.agreement_with_terms_of_use = False
+        app.already_signed_up = False
         app.save()
 
         app.refresh_from_db()
@@ -303,6 +307,7 @@ class SynchronizeFieldsTest(TestCase):
             rationale='just because',
             comments='nope')
         app.agreement_with_terms_of_use = False
+        app.already_signed_up = False
         app.save()
 
         app.refresh_from_db()
@@ -796,6 +801,8 @@ class SubmitApplicationTest(BaseApplicationViewTest):
             id=p1.id), form.fields)
         self.assertNotIn('partner_{id}_agreement_with_terms_of_use'.format(
             id=p1.id), form.fields)
+        self.assertNotIn('partner_{id}_already_signed_up'.format(
+            id=p1.id), form.fields)
         self.assertIn('partner_{id}_rationale'.format(
             id=p1.id), form.fields)
         self.assertIn('partner_{id}_comments'.format(
@@ -814,7 +821,8 @@ class SubmitApplicationTest(BaseApplicationViewTest):
             specific_stream=False,
             occupation=False,
             affiliation=False,
-            agreement_with_terms_of_use=False
+            agreement_with_terms_of_use=False,
+            already_signed_up=False,
         )
 
         # This has identical conditions to p1; a form encompassing both
@@ -827,7 +835,8 @@ class SubmitApplicationTest(BaseApplicationViewTest):
             specific_stream=False,
             occupation=False,
             affiliation=False,
-            agreement_with_terms_of_use=False
+            agreement_with_terms_of_use=False,
+            already_signed_up=False,
         )
 
         # Test just p1.
@@ -849,6 +858,8 @@ class SubmitApplicationTest(BaseApplicationViewTest):
             id=p1.id), form.fields)
         self.assertNotIn('partner_{id}_agreement_with_terms_of_use'.format(
             id=p1.id), form.fields)
+        self.assertNotIn('partner_{id}_already_signed_up'.format(
+            id=p1.id), form.fields)
         self.assertIn('partner_{id}_rationale'.format(
             id=p1.id), form.fields)
         self.assertIn('partner_{id}_comments'.format(
@@ -860,6 +871,8 @@ class SubmitApplicationTest(BaseApplicationViewTest):
         self.assertNotIn('partner_{id}_specific_title'.format(
             id=p2.id), form.fields)
         self.assertNotIn('partner_{id}_agreement_with_terms_of_use'.format(
+            id=p2.id), form.fields)
+        self.assertNotIn('partner_{id}_already_signed_up'.format(
             id=p2.id), form.fields)
         self.assertIn('partner_{id}_rationale'.format(
             id=p2.id), form.fields)
@@ -882,7 +895,8 @@ class SubmitApplicationTest(BaseApplicationViewTest):
             specific_stream=False,
             occupation=False,
             affiliation=False,
-            agreement_with_terms_of_use=False
+            agreement_with_terms_of_use=False,
+            already_signed_up=False
         )
 
         # This has different conditions than p1; a form encompassing both
@@ -895,7 +909,8 @@ class SubmitApplicationTest(BaseApplicationViewTest):
             specific_stream=False,
             occupation=True,
             affiliation=False,
-            agreement_with_terms_of_use=False
+            agreement_with_terms_of_use=False,
+            already_signed_up=False
         )
 
         view = self._get_isolated_view(views.SubmitApplicationView)
@@ -916,6 +931,8 @@ class SubmitApplicationTest(BaseApplicationViewTest):
             id=p1.id), form.fields)
         self.assertNotIn('partner_{id}_agreement_with_terms_of_use'.format(
             id=p1.id), form.fields)
+        self.assertNotIn('partner_{id}_already_signed_up'.format(
+            id=p1.id), form.fields)
         self.assertIn('partner_{id}_rationale'.format(
             id=p1.id), form.fields)
         self.assertIn('partner_{id}_comments'.format(
@@ -927,6 +944,8 @@ class SubmitApplicationTest(BaseApplicationViewTest):
         self.assertIn('partner_{id}_specific_title'.format(
             id=p2.id), form.fields)
         self.assertNotIn('partner_{id}_agreement_with_terms_of_use'.format(
+            id=p2.id), form.fields)
+        self.assertNotIn('partner_{id}_already_signed_up'.format(
             id=p2.id), form.fields)
         self.assertIn('partner_{id}_rationale'.format(
             id=p2.id), form.fields)
@@ -946,7 +965,8 @@ class SubmitApplicationTest(BaseApplicationViewTest):
             specific_stream=False,
             occupation=True,
             affiliation=True,
-            agreement_with_terms_of_use=False
+            agreement_with_terms_of_use=False,
+            already_signed_up=False
         )
 
         user = UserFactory(username='alice')
@@ -991,7 +1011,8 @@ class SubmitApplicationTest(BaseApplicationViewTest):
             specific_stream=False,
             occupation=False,
             affiliation=False,
-            agreement_with_terms_of_use=False
+            agreement_with_terms_of_use=False,
+            already_signed_up=False
         )
 
         factory = RequestFactory()
@@ -1028,7 +1049,8 @@ class SubmitApplicationTest(BaseApplicationViewTest):
             specific_stream=False,
             occupation=True,
             affiliation=False,
-            agreement_with_terms_of_use=False
+            agreement_with_terms_of_use=False,
+            already_signed_up=False
         )
 
         user = UserFactory()
@@ -1084,7 +1106,8 @@ class SubmitApplicationTest(BaseApplicationViewTest):
             specific_stream=False,
             occupation=False,
             affiliation=False,
-            agreement_with_terms_of_use=False
+            agreement_with_terms_of_use=False,
+            already_signed_up=False
         )
         p2 = PartnerFactory(
             real_name=False,
@@ -1093,7 +1116,8 @@ class SubmitApplicationTest(BaseApplicationViewTest):
             specific_stream=True,
             occupation=False,
             affiliation=False,
-            agreement_with_terms_of_use=False
+            agreement_with_terms_of_use=False,
+            already_signed_up=False
         )
 
         s1 = Stream()
@@ -1137,6 +1161,7 @@ class SubmitApplicationTest(BaseApplicationViewTest):
         self.assertEqual(app1.specific_title, 'Open Access for n00bs')
         self.assertEqual(app1.specific_stream, None)
         self.assertEqual(app1.agreement_with_terms_of_use, False)
+        self.assertEqual(app1.already_signed_up, False)
 
         self.assertEqual(app2.status, Application.PENDING)
         self.assertEqual(app2.rationale, 'Saving the world')
@@ -1144,6 +1169,7 @@ class SubmitApplicationTest(BaseApplicationViewTest):
         self.assertEqual(app2.specific_title, '')
         self.assertEqual(app2.specific_stream, s1)
         self.assertEqual(app2.agreement_with_terms_of_use, False)
+        self.assertEqual(app2.already_signed_up, False)
 
 
     def test_get_partners(self):
@@ -1180,6 +1206,7 @@ class SubmitApplicationTest(BaseApplicationViewTest):
             occupation=False,
             affiliation=False,
             agreement_with_terms_of_use=True,
+            already_signed_up=False
         )
         p2 = PartnerFactory(
             real_name=False,
@@ -1188,7 +1215,8 @@ class SubmitApplicationTest(BaseApplicationViewTest):
             specific_stream=True,
             occupation=False,
             affiliation=False,
-            agreement_with_terms_of_use=False
+            agreement_with_terms_of_use=False,
+            already_signed_up=False
         )
 
         view = self._get_isolated_view(views.SubmitApplicationView)
@@ -1212,6 +1240,7 @@ class SubmitApplicationTest(BaseApplicationViewTest):
             occupation=True,
             affiliation=True,
             agreement_with_terms_of_use=True,
+            already_signed_up=False
         )
         p2 = PartnerFactory(
             real_name=True,
@@ -1220,7 +1249,8 @@ class SubmitApplicationTest(BaseApplicationViewTest):
             specific_stream=True,
             occupation=True,
             affiliation=False,
-            agreement_with_terms_of_use=False
+            agreement_with_terms_of_use=False,
+            already_signed_up=False
         )
 
         view = self._get_isolated_view(views.SubmitApplicationView)

--- a/TWLight/resources/migrations/0037_auto_20180307_1306.py
+++ b/TWLight/resources/migrations/0037_auto_20180307_1306.py
@@ -1,0 +1,24 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('resources', '0036_auto_20170716_1235'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='partner',
+            name='already_signed_up',
+            field=models.BooleanField(default=False, help_text="Mark as true if this partner requires applicants to sign up on the partner's website before applying."),
+        ),
+        migrations.AddField(
+            model_name='partner',
+            name='sign_up_link',
+            field=models.URLField(help_text='Link to signup page. Required if users must register an account before applying for access; optional otherwise.', null=True, blank=True),
+        ),
+    ]

--- a/TWLight/resources/models.py
+++ b/TWLight/resources/models.py
@@ -171,6 +171,10 @@ class Partner(models.Model):
         # Translators: In the administrator interface, this text is help text for a field where staff can provide the URL of an image to be used as this partner's logo.
         help_text=_('Optional URL of an image that can be used to represent '
                     'this partner.'))
+    sign_up_link = models.URLField(blank=True, null=True,
+        # Translators: In the administrator interface, this text is help text for a field where staff can link to a partner's signup page.
+        help_text=_("Link to signup page. Required if users must register "
+            "an account before applying for access; optional otherwise."))
 
     mutually_exclusive = models.NullBooleanField(
         blank=True, null=True,
@@ -231,6 +235,10 @@ class Partner(models.Model):
         # Translators: In the administrator interface, this text is help text for a check box where staff can select whether users must agree to Terms of Use when applying.
         help_text=_("Mark as true if this partner requires applicants to agree "
                     "with the partner's terms of use."))
+    already_signed_up = models.BooleanField(default=False,
+        # Translators: In the administrator interface, this text is help text for a check box where staff can select whether users must sign up before applying.
+        help_text=_("Mark as true if this partner requires applicants to sign "
+                    "up on the partner's website before applying."))
 
 
     def __unicode__(self):
@@ -241,6 +249,9 @@ class Partner(models.Model):
         if self.agreement_with_terms_of_use and not self.terms_of_use:
             raise ValidationError('When agreement with terms of use is '
                 'required, a link to terms of use must be provided.')
+        if self.already_signed_up and not self.sign_up_link:
+            raise ValidationError('When prior signup is required, '
+                'a link to the signup page must be provided.')
         if self.streams.count() > 1:
             if self.mutually_exclusive is None:
                 raise ValidationError('Since this resource has multiple '

--- a/TWLight/resources/templates/resources/partner_detail.html
+++ b/TWLight/resources/templates/resources/partner_detail.html
@@ -167,7 +167,7 @@
         </div>
       </div>      
     </li>
-    {% if object.agreement_with_terms_of_use or object.real_name or object.country_of_residence or object.occupation or object.affiliation or object.specific_title or object.specific_stream %}
+    {% if object.agreement_with_terms_of_use or object.real_name or object.country_of_residence or object.occupation or object.affiliation or object.specific_title or object.specific_stream or object.already_signed_up %}
       <li class="timeline-inverted">
         <div class="timeline-badge"><i class="fa fa-exclamation"></i>
         </div>
@@ -251,6 +251,16 @@
                       collections that you want to access.
                     {% endblocktrans %}
                   {% endif %}
+                </li>
+              {% endif %}
+              
+              {% if object.already_signed_up %}
+                <li>
+                  {% comment %} Translators: If a user must sign up before requesting access, they see this message. Don't translate {{ publisher }} or {{ url }}. {% endcomment %}
+                  {% blocktrans with publisher=object.company_name url=object.sign_up_link %}
+                    {{ publisher }} requires that you <a href="{{ url }}">sign
+                    up</a> before requesting access.
+                  {% endblocktrans %}
                 </li>
               {% endif %}
             </ul>


### PR DESCRIPTION
https://phabricator.wikimedia.org/T172095

Functionality seems to work correctly - tested various combinations of link and requirement both in applying and in the admin interface. Tests ran with no problems, though I did have to update the application tests to include already_signed_up first, which is the part I'm least confident about.