### PR TITLE
Upload partner images, rather than link to them

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# media files uploaded by users
+media/
+
 # bin files now created by puppet module
 collectedstatic/
 staticfiles/
@@ -11,8 +14,12 @@ TWLight/settings/production_vars.py
 TWLight/settings/staging_vars.py
 TWLight/settings/vagrant_vars.py
 
-Let's compile our messages at deploy time
+# compile messages at deploy time
 django.mo
+
+# generate rtl stylesheets at deploy time
+TWLight/static/css/*-rtl.css
+TWLight/static/css/*/*-rtl.css
 
 # Created by https://www.gitignore.io/api/osx,django,python,sublimetext,vim,emacs
 

--- a/TWLight/resources/admin.py
+++ b/TWLight/resources/admin.py
@@ -2,7 +2,7 @@ from django import forms
 from django.contrib import admin
 from TWLight.users.groups import get_coordinators
 
-from .models import Partner, Stream, Contact, Language
+from .models import Partner, PartnerLogo, Stream, Contact, Language
 
 
 class LanguageAdmin(admin.ModelAdmin):
@@ -11,6 +11,9 @@ class LanguageAdmin(admin.ModelAdmin):
 
 admin.site.register(Language, LanguageAdmin)
 
+
+class PartnerLogoInline(admin.TabularInline):
+    model = PartnerLogo
 
 
 class PartnerAdmin(admin.ModelAdmin):
@@ -41,6 +44,7 @@ class PartnerAdmin(admin.ModelAdmin):
 
     search_fields = ('company_name',)
     list_display = ('company_name', 'description', 'id', 'get_languages')
+    inlines = [PartnerLogoInline]
 
 admin.site.register(Partner, PartnerAdmin)
 

--- a/TWLight/resources/migrations/0037_auto_20180222_1614.py
+++ b/TWLight/resources/migrations/0037_auto_20180222_1614.py
@@ -1,0 +1,30 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('resources', '0036_auto_20170716_1235'),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name='PartnerLogo',
+            fields=[
+                ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
+                ('logo', models.ImageField(help_text='Optional image file that can be used to represent this partner.', null=True, upload_to=b'', blank=True)),
+            ],
+        ),
+        migrations.RemoveField(
+            model_name='partner',
+            name='logo_url',
+        ),
+        migrations.AddField(
+            model_name='partnerlogo',
+            name='partner',
+            field=models.OneToOneField(related_name='logos', to='resources.Partner'),
+        ),
+    ]

--- a/TWLight/resources/models.py
+++ b/TWLight/resources/models.py
@@ -167,10 +167,6 @@ class Partner(models.Model):
     send_instructions = models.TextField(blank=True, null=True,
         help_text=_("Optional instructions for sending application data to "
             "this partner."))
-    logo_url = models.URLField(blank=True, null=True,
-        # Translators: In the administrator interface, this text is help text for a field where staff can provide the URL of an image to be used as this partner's logo.
-        help_text=_('Optional URL of an image that can be used to represent '
-                    'this partner.'))
 
     mutually_exclusive = models.NullBooleanField(
         blank=True, null=True,
@@ -271,6 +267,15 @@ class Partner(models.Model):
     @property
     def is_waitlisted(self):
         return self.status == self.WAITLIST
+
+
+
+class PartnerLogo(models.Model):
+    partner = models.OneToOneField('Partner', related_name='logos')
+    logo = models.ImageField(blank=True, null=True,
+        # Translators: In the administrator interface, this text is help text for a field where staff can upload an image to be used as this partner's logo.
+        help_text=_('Optional image file that can be used to represent this '
+        'partner.'))
 
 
 

--- a/TWLight/resources/templates/resources/partner_detail.html
+++ b/TWLight/resources/templates/resources/partner_detail.html
@@ -73,9 +73,8 @@
           <input type="submit" class="btn btn-default btn-block text-center hidden-xs" value="{% if object.is_waitlisted %}{% trans "Remove from waitlist" %}{% else %}{% trans "Set as waitlisted" %}{% endif %}"/>
         </form>
       {% endif %}
-
-      {% if object.logo_url %}
-        <img src="{{ object.logo_url }}" class="img-responsive hidden-xs center-block partner-logo">
+      {% if object.logos.logo.url %}
+        <img src="{{ object.logos.logo.url }}" class="img-responsive hidden-xs center-block partner-logo">
       {% endif %}
 
       <div class="well hidden-xs">

--- a/TWLight/resources/templates/resources/partner_tile.html
+++ b/TWLight/resources/templates/resources/partner_tile.html
@@ -18,9 +18,9 @@
     </a>
   </div>
   <div class="panel-body">
-    {% if partner.logo_url %}
+    {% if partner.logos.logo.url %}
       <a href="{% url 'partners:detail' partner.pk %}">
-        <img src="{{ partner.logo_url }}" class="img-responsive partner-logo">
+        <img src="{{ partner.logos.logo.url }}" class="img-responsive partner-logo">
       </a>
       <hr />
     {% endif %}

--- a/TWLight/settings/base.py
+++ b/TWLight/settings/base.py
@@ -24,7 +24,7 @@ from django.core.urlresolvers import reverse_lazy
 from django.utils.translation import ugettext_lazy as _
 
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-
+MEDIA_ROOT = os.path.join(os.path.dirname(BASE_DIR), 'media')
 
 # ------------------------------------------------------------------------------
 # ------------------------> core django configurations <------------------------

--- a/TWLight/settings/base.py
+++ b/TWLight/settings/base.py
@@ -24,7 +24,6 @@ from django.core.urlresolvers import reverse_lazy
 from django.utils.translation import ugettext_lazy as _
 
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-MEDIA_ROOT = os.path.join(os.path.dirname(BASE_DIR), 'media')
 
 # ------------------------------------------------------------------------------
 # ------------------------> core django configurations <------------------------
@@ -208,6 +207,14 @@ STATIC_ROOT = os.path.join(BASE_DIR, 'collectedstatic')
 STATIC_URL = '/static/'
 STATICFILES_DIRS = [os.path.join(BASE_DIR, 'static')]
 STATICFILES_STORAGE = 'django.contrib.staticfiles.storage.ManifestStaticFilesStorage'
+
+# MEDIA FILE CONFIGURATION
+# ------------------------------------------------------------------------------
+
+# https://docs.djangoproject.com/en/1.8/topics/files/
+
+MEDIA_ROOT = os.path.join(os.path.dirname(BASE_DIR), 'media')
+MEDIA_URL = '/media/'
 
 # LOGGING CONFIGURATION
 # ------------------------------------------------------------------------------

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -15,6 +15,7 @@ futures==3.1.1
 mock==2.0.0
 mwoauth==0.2.8
 oauthlib==0.6.3
+pillow==5.0.0
 pypandoc==1.4
 python-dateutil==2.6.0
 PyJWT==1.0.1


### PR DESCRIPTION
This PR replaces the partner logo_url field with an image upload field.  Before this can be merged into master, twlight_puppet needs to be updated to add the new /media/ location to nginx, and that puppet update needs to be pushed to production. Once this PR gets merged in and applied to production, all partner logos will disappear until Jason goes in and uploads the files.  This is planned for early am CST on 2018-03-07.