### PR TITLE
Fixed median days bug for partners with imported applications (T177200)

### DIFF
--- a/TWLight/resources/views.py
+++ b/TWLight/resources/views.py
@@ -75,7 +75,7 @@ class PartnersDetailView(DetailView):
         context['unique_users_approved_or_sent'] = context['unique_users_approved'] + context['unique_users_sent']
 
         partner_app_time = Application.objects.filter(
-            partner=partner).values_list('days_open', flat=True)
+            partner=partner).exclude(days_open=None).values_list('days_open', flat=True)
 
         context['median_days'] = get_median(list(partner_app_time))
 


### PR DESCRIPTION
Imported applications have days_open = None which was breaking the median days statistic on partner pages. Excluding None values from the queryset fixes this.

Tests ran with no issues.