### PR TITLE
Median days stat improvements

### DIFF
--- a/TWLight/resources/templates/resources/partner_detail.html
+++ b/TWLight/resources/templates/resources/partner_detail.html
@@ -359,7 +359,13 @@
               <i class="fa fa-clock-o fa-5x"></i>
             </div>
             <div class="col-xs-9 text-right">
-              <div class="huge">{{ median_days }}</div>
+              <div class="huge">
+                {% if median_days %}
+                    {{ median_days }}
+                {% else %}
+                    -
+                {% endif %}
+              </div>
               {% comment %} Translators: This is the label for a number which shows the median (not mean) number of days between users applying and a coordinator making a decision on their application. (e.g. https://wikipedialibrary.wmflabs.org/partners/8/). {% endcomment %}
               <div>{% trans 'Median days from application to decision' %}</div>
             </div>

--- a/TWLight/resources/views.py
+++ b/TWLight/resources/views.py
@@ -81,7 +81,7 @@ class PartnersDetailView(DetailView):
         if len(partner_app_time) > 0:
             context['median_days'] = get_median(list(partner_app_time))
         else:
-            context['median_days'] = "-"
+            context['median_days'] = None
 
         context['app_distribution_data'] = get_application_status_data(
                 Application.objects.filter(partner=partner)

--- a/TWLight/resources/views.py
+++ b/TWLight/resources/views.py
@@ -74,10 +74,14 @@ class PartnersDetailView(DetailView):
 
         context['unique_users_approved_or_sent'] = context['unique_users_approved'] + context['unique_users_sent']
 
+        application_end_states = [Application.APPROVED, Application.NOT_APPROVED, Application.SENT]
         partner_app_time = Application.objects.filter(
-            partner=partner).values_list('days_open', flat=True)
+            partner=partner, status__in=application_end_states).exclude(imported=True).values_list('days_open', flat=True)
 
-        context['median_days'] = get_median(list(partner_app_time))
+        if len(partner_app_time) > 0:
+            context['median_days'] = get_median(list(partner_app_time))
+        else:
+            context['median_days'] = "-"
 
         context['app_distribution_data'] = get_application_status_data(
                 Application.objects.filter(partner=partner)


### PR DESCRIPTION
Fixed median days showing 0 for imported applications (T177200). Also fixed it including apps that weren't yet closed, and now displays a dash if the partner has no closed, not imported, applications.