### PR TITLE
Fix comment notification emails not including partner name (T190048)

### DIFF
--- a/TWLight/emails/tasks.py
+++ b/TWLight/emails/tasks.py
@@ -136,7 +136,8 @@ def send_comment_notification_emails(sender, **kwargs):
                 {'user': app.editor.wp_username,
                  'lang': app.editor.user.userprofile.lang,
                  'app': app,
-                 'app_url': app_url})
+                 'app_url': app_url,
+                 'partner': app.partner})
             logger.info('Email queued for {app.editor.user.email} about '
                 'app #{app.pk}'.format(app=app))
 
@@ -164,7 +165,8 @@ def send_comment_notification_emails(sender, **kwargs):
                 {'user': user.editor.wp_username,
                  'lang': user.userprofile.lang,
                  'app': app,
-                 'app_url': app_url})
+                 'app_url': app_url,
+                 'partner': app.partner})
             logger.info('Email queued for {app.editor.user.email} about app '
                 '#{app.pk}'.format(app=app))
 


### PR DESCRIPTION
The template never received the 'partner' variable, leaving a double space instead of the partner name. Luckily the emails still kinda made sense, but this was intended to be here.

Verified that comment emails being sent now include the partner name where they didn't before and ran tests with no issues.