### PR TITLE
Added some alt text to images without any

### DIFF
--- a/TWLight/templates/base.html
+++ b/TWLight/templates/base.html
@@ -44,7 +44,7 @@
       <div class="navbar-left">
 			<!-- logo -->
 			<a href="{% url 'homepage' %}">
-				<img src="{% static 'img/Wikipedia_Library_owl.svg' %}" class="img-responsive logo">
+				<img src="{% static 'img/Wikipedia_Library_owl.svg' %}" class="img-responsive logo" alt="Library Card Platform home">
 			</a>
 			
 			<!-- site name -->

--- a/TWLight/templates/home.html
+++ b/TWLight/templates/home.html
@@ -30,7 +30,7 @@
   <div class="row">
 	<div class="col-md-6">
                 {% comment %} Translators: On the main page of the website (https://wikipedialibrary.wmflabs.org/), the 'Benefits' section describes why editors would want to use the project. This is the header for that section.{% endcomment %}
-		<h2><img src="/static/img/benefits.PNG" class="icons">{% trans "Benefits" %}</h2>
+		<h2><img src="/static/img/benefits.PNG" class="icons" alt="">{% trans "Benefits" %}</h2>
 		
 		<div class="border">
                 {% comment %} Translators: On the main page of the website (https://wikipedialibrary.wmflabs.org/), the 'Benefits' section describes why editors would want to use the project. This is the content of that section.{% endcomment %}
@@ -51,7 +51,7 @@
 	
 	<div class="col-md-6">
                 {% comment %} Translators: On the main page of the website (https://wikipedialibrary.wmflabs.org/), the 'partners' section contains a list of links to featured partner resources. This is the header for that section.{% endcomment %}
-		<h2><img src="/static/img/favorite.png" class="icons">{% trans "Partners" %}</h2>
+		<h2><img src="/static/img/favorite.png" class="icons" alt="">{% trans "Partners" %}</h2>
 			<div class="border">
                                 {% comment %} Translators: On the main page of the website (https://wikipedialibrary.wmflabs.org/), the 'partners' section contains a list of links to featured partner resources. This is the introductory text to that list.{% endcomment %}
 				<p>{% trans "Below are a few of our featured partners:" %}</p>


### PR DESCRIPTION
Benefits and Partners images are decorative but for accessibility reasons should be given empty alt attributes.