### PR TITLE
Fix graph date ranges bug for certain partners (T171159)

### DIFF
--- a/TWLight/graphs/helpers.py
+++ b/TWLight/graphs/helpers.py
@@ -3,6 +3,7 @@ import json
 import logging
 from numbers import Number
 import time
+import datetime
 
 from django.contrib.auth.models import User
 from django.utils import timezone
@@ -58,7 +59,11 @@ def get_data_count_by_month(queryset, data_format=JSON):
     data_series = []
 
     if queryset:
-        earliest_date = queryset.earliest('date_created').date_created
+        # Some imported applications had no date and were given
+        # creation dates of Jan 1, 1970. This screws up the graphs.
+        earliest_date = queryset.exclude(
+            date_created=datetime.date(1970,1,1)).earliest(
+                'date_created').date_created
 
         current_date = timezone.now().date()
 
@@ -272,7 +277,10 @@ def get_users_by_partner_by_month(partner, data_format=JSON):
     partner_apps = Application.objects.filter(partner=partner)
 
     if partner_apps:
-        earliest_date = partner_apps.earliest('date_created').date_created
+        # Again removing undated (Jan 1 1970) applications
+        earliest_date = partner_apps.exclude(
+            date_created=datetime.date(1970,1,1)).earliest(
+                'date_created').date_created
 
         current_date = timezone.now().date()
 


### PR DESCRIPTION
Imported applications with no date were given dates of Jan 1 1970. These weren't being excluded from graphs so certain partners (e.g. Highbeam, JSTOR) had graphs that extended all the way back to that date. This was only an issue for two types of graphs, so the queryset is only modified for them.

Tests ran with no errors.