### PR TITLE
 Keep Apply button even when waitlisted (T170117)

### DIFF
--- a/TWLight/resources/templates/resources/partner_detail.html
+++ b/TWLight/resources/templates/resources/partner_detail.html
@@ -26,15 +26,16 @@
   <a href="{{ app_url }}" class="btn btn-primary text-center visible-xs z-index-100">{% trans "Apply" %}</a>
   
   {% if object.is_waitlisted %}
-    <div class="alert alert-warning visible-xs">
-      {% url 'applications:apply_single' object.pk as app_url %}
-      {% comment %} Translators: If we have no available accounts for a partner, the coordinator can change the application system to a waiting list. Don't translate {{ app_url }}. {% endcomment %}
-      {% blocktrans trimmed %}
-        <strong>Waitlisted</strong> &mdash; There are no access grants available
-        for this partner at this time. You can still apply for access;
-        applications will be processed when access is available.
-      {% endblocktrans %}      
-    </div>
+    <div class="alert alert-warning visible-xs resource-label-warning">
+       <span class="resource-label">{% trans "Waitlisted" %}</span>
+       <p>
+       {% comment %} Translators: If we have no available accounts for a partner, the coordinator can change the application system to a waiting list. {% endcomment %}
+       {% blocktrans trimmed %}
+       There are no access grants available for this partner
+       at this time. You can still apply for access; applications will
+       be processed when access is available.
+       {% endblocktrans %}
+       </p>
   {% endif %}
   {% if user|coordinators_only %}
     <form class="margin-bottom-2em" action="{% url 'partners:toggle_waitlist' object.pk %}" method="POST">
@@ -56,12 +57,16 @@
       <a href="{{ app_url }}" class="btn btn-primary btn-lg hidden-xs btn-block">{% trans "Apply" %}</a><br/>
       {% if object.is_waitlisted %}
         {% url 'applications:apply_single' object.pk as app_url %}
-        <div class="hidden-xs alert alert-warning">
-          {% blocktrans trimmed %}
-            <strong>Waitlisted</strong> &mdash; There are no access grants available
-            for this partner at this time. You can still apply for access;
-            applications will be processed when access is available.
-          {% endblocktrans %}
+        <div class="hidden-xs alert alert-warning resource-label-warning">
+            <span class="resource-label">{% trans "Waitlisted" %}</span>
+            <p>
+            {% comment %} Translators: If we have no available accounts for a partner, the coordinator can change the application system to a waiting list. {% endcomment %}
+            {% blocktrans trimmed %}
+            There are no access grants available for this partner
+            at this time. You can still apply for access; applications will
+            be processed when access is available.
+            {% endblocktrans %}
+            </p>
         </div>
       {% endif %}
 

--- a/TWLight/resources/templates/resources/partner_detail.html
+++ b/TWLight/resources/templates/resources/partner_detail.html
@@ -22,20 +22,19 @@
 
 {% block content %}
   <h1>{{ object }}</h1>
-
+  {% url 'applications:apply_single' object.pk as app_url %}
+  <a href="{{ app_url }}" class="btn btn-primary text-center visible-xs z-index-100">{% trans "Apply" %}</a>
+  
   {% if object.is_waitlisted %}
     <div class="alert alert-warning visible-xs">
       {% url 'applications:apply_single' object.pk as app_url %}
       {% comment %} Translators: If we have no available accounts for a partner, the coordinator can change the application system to a waiting list. Don't translate {{ app_url }}. {% endcomment %}
       {% blocktrans trimmed %}
         <strong>Waitlisted</strong> &mdash; There are no access grants available
-        for this partner at this time. You can still <a href="{{ app_url }}">apply for access</a>;
+        for this partner at this time. You can still apply for access;
         applications will be processed when access is available.
       {% endblocktrans %}      
     </div>
-  {% else %}
-    {% url 'applications:apply_single' object.pk as app_url %}
-    <a href="{{ app_url }}" class="btn btn-primary text-center visible-xs z-index-100">{% trans "Apply" %}</a>
   {% endif %}
   {% if user|coordinators_only %}
     <form class="margin-bottom-2em" action="{% url 'partners:toggle_waitlist' object.pk %}" method="POST">
@@ -53,6 +52,8 @@
   <ul class="timeline half-timeline margin-bottom-2em">
 
     <div class="col-sm-5 col-md-4 pull-right timeline-right-overlay">
+      {% url 'applications:apply_single' object.pk as app_url %}
+      <a href="{{ app_url }}" class="btn btn-primary btn-lg hidden-xs btn-block">{% trans "Apply" %}</a><br/>
       {% if object.is_waitlisted %}
         {% url 'applications:apply_single' object.pk as app_url %}
         <div class="hidden-xs alert alert-warning">
@@ -62,9 +63,6 @@
             applications will be processed when access is available.
           {% endblocktrans %}
         </div>
-      {% else %}
-        {% url 'applications:apply_single' object.pk as app_url %}
-        <a href="{{ app_url }}" class="btn btn-primary btn-lg hidden-xs btn-block">{% trans "Apply" %}</a><br/>
       {% endif %}
 
       {% if user|coordinators_only %}

--- a/TWLight/resources/templates/resources/partner_detail.html
+++ b/TWLight/resources/templates/resources/partner_detail.html
@@ -59,7 +59,7 @@
         <div class="hidden-xs alert alert-warning">
           {% blocktrans trimmed %}
             <strong>Waitlisted</strong> &mdash; There are no access grants available
-            for this partner at this time. You can still <a href="{{ app_url }}">apply for access</a>;
+            for this partner at this time. You can still apply for access;
             applications will be processed when access is available.
           {% endblocktrans %}
         </div>


### PR DESCRIPTION
Users shouldn't be discouraged from applying when a partner is waitlisted, so while we'll keep the notice about it, the big Apply button should remain.