### PR TITLE
Apply button changes to Renew if user already has a sent application (T174942)

### DIFF
--- a/TWLight/resources/templates/resources/partner_detail.html
+++ b/TWLight/resources/templates/resources/partner_detail.html
@@ -35,7 +35,11 @@
     </div>
   {% else %}
     {% url 'applications:apply_single' object.pk as app_url %}
-    <a href="{{ app_url }}" class="btn btn-primary text-center visible-xs z-index-100">{% trans "Apply" %}</a>
+    {% if user_sent_apps %}
+        <a href="{% url 'applications:renew' latest_app_pk %}" class="btn btn-primary text-center visible-xs z-index-100">{% trans "Renew" %}</a>
+    {% else %}
+        <a href="{{ app_url }}" class="btn btn-primary text-center visible-xs z-index-100">{% trans "Apply" %}</a>
+    {% endif %}
   {% endif %}
   {% if user|coordinators_only %}
     <form class="margin-bottom-2em" action="{% url 'partners:toggle_waitlist' object.pk %}" method="POST">
@@ -64,7 +68,11 @@
         </div>
       {% else %}
         {% url 'applications:apply_single' object.pk as app_url %}
-        <a href="{{ app_url }}" class="btn btn-primary btn-lg hidden-xs btn-block">{% trans "Apply" %}</a><br/>
+        {% if user_sent_apps %}
+            <a href="{% url 'applications:renew' latest_app_pk %}" class="btn btn-primary btn-lg hidden-xs btn-block">{% trans "Renew" %}</a>
+        {% else %}
+            <a href="{{ app_url }}" class="btn btn-primary btn-lg hidden-xs btn-block">{% trans "Apply" %}</a>
+        {% endif %}
       {% endif %}
 
       {% if user|coordinators_only %}

--- a/TWLight/resources/views.py
+++ b/TWLight/resources/views.py
@@ -96,6 +96,14 @@ class PartnersDetailView(DetailView):
 
         context['users_time_data'] = get_users_by_partner_by_month(partner)
 
+        sent_apps = Application.objects.filter(
+                                    editor=self.request.user.editor,
+                                    status=Application.SENT
+                                 ).order_by('date_closed')
+
+        context['latest_app_pk'] = sent_apps[0].pk
+        context['user_sent_apps'] = sent_apps.count()
+
         return context
 
 


### PR DESCRIPTION
This is only part of the task at https://phabricator.wikimedia.org/T174942 (the renewal part).

If the user has an open application I'm not sure what the behaviour should be - changing the Apply button to be deactivated is probably the right thing to do, but there should really be a link to their existing application somewhere.