### PR TITLE
Added specific error message in the case that a coordinator doesn't select any applications to batch edit (T174680)

### DIFF
--- a/TWLight/applications/tests.py
+++ b/TWLight/applications/tests.py
@@ -2193,10 +2193,6 @@ class BatchEditTest(TestCase):
         response = self.client.post(self.url, data={}, follow=True)
         self.assertEqual(response.status_code, 400)
 
-        # Missing the 'applications' parameter: bad.
-        response = self.client.post(self.url, data={'batch_status': 1}, follow=True)
-        self.assertEqual(response.status_code, 400)
-
         # Missing the 'batch_status' parameter: bad.
         response = self.client.post(self.url, data={'applications': 1}, follow=True)
         self.assertEqual(response.status_code, 400)

--- a/TWLight/applications/views.py
+++ b/TWLight/applications/views.py
@@ -694,7 +694,6 @@ class BatchEditView(CoordinatorsOnly, ToURequired, View):
 
     def post(self, request, *args, **kwargs):
         try:
-            assert 'applications' in request.POST
             assert 'batch_status' in request.POST
 
             status = request.POST['batch_status']
@@ -707,6 +706,14 @@ class BatchEditView(CoordinatorsOnly, ToURequired, View):
             # ValueError will be raised if the status cannot be cast to int.
             logger.exception('Did not find valid data for batch editing')
             return HttpResponseBadRequest()
+
+        try:
+            assert 'applications' in request.POST
+        except AssertionError:
+            messages.add_message(self.request, messages.INFO,
+                #Translators: When a coordinator is batch editing (https://wikipedialibrary.wmflabs.org/applications/list/), they receive this message if they click Set Status without selecting any applications.
+                _('Please select at least one application.'))
+            return HttpResponseRedirect(reverse('applications:list'))
 
         # IMPORTANT! It would be tempting to just do QuerySet.update() here,
         # but that does NOT send the pre_save signal, which is doing some


### PR DESCRIPTION
No errors raised, except for the part I removed. Not sure if removing was the right option but it seemed sensible to me given that no error is raised when no applications are selected now; users just reload the page and receive an info message.