### PR TITLE
Began tidying dashboard and hid link from non-staff

### DIFF
--- a/TWLight/graphs/helpers.py
+++ b/TWLight/graphs/helpers.py
@@ -93,7 +93,7 @@ def get_application_status_data(queryset, data_format=JSON):
     """
     status_data = []
 
-    for status in Application.STATUS_CHOICES:
+    for status in Application.STATUS_CHOICES[0:3]:
         status_count = queryset.filter(status=status[0]).count()
         # We have to force unicode here because we used ugettext_lazy, not
         # ugettext, to internationalize the status labels in

--- a/TWLight/graphs/urls.py
+++ b/TWLight/graphs/urls.py
@@ -4,11 +4,6 @@ from django.contrib.auth.decorators import login_required
 from . import views
 
 csv_urlpatterns = [
-    url(r'^num_partners/$',
-        views.CSVNumPartners.as_view(),
-        name='num_partners'
-    ),
-
     url(r'^app_time_histogram/$',
         views.CSVAppTimeHistogram.as_view(),
         name='app_time_histogram'

--- a/TWLight/graphs/views.py
+++ b/TWLight/graphs/views.py
@@ -128,7 +128,8 @@ class DashboardView(TemplateView):
         # Application status pie chart -----------------------------------------
 
         context['app_distribution_data'] = get_application_status_data(
-                Application.objects.all()
+                Application.objects.exclude(
+                    status__in=(Application.SENT, Application.NOT_APPROVED))
             )
 
         return context

--- a/TWLight/graphs/views.py
+++ b/TWLight/graphs/views.py
@@ -83,13 +83,6 @@ class DashboardView(TemplateView):
         context['total_editors'] = Editor.objects.count()
         context['total_partners'] = Partner.objects.count()
 
-        # Partnership data
-        # ----------------------------------------------------------------------
-
-        context['partner_time_data'] = get_data_count_by_month(
-                Partner.objects.all()
-            )
-
         # Application data
         # ----------------------------------------------------------------------
 
@@ -165,32 +158,6 @@ class _CSVDownloadView(View):
     def _write_data(self, response):
         raise NotImplementedError
 
-
-
-class CSVNumPartners(_CSVDownloadView):
-    def _write_data(self, response):
-        if 'pk' in self.kwargs:
-            pk = self.kwargs['pk']
-
-            try:
-                queryset = Partner.objects.get(pk=pk)
-            except Partner.DoesNotExist:
-                logger.exception('Tried to access data for partner #{pk}, who '
-                                 'does not exist'.format(pk=pk))
-                raise
-
-        else:
-            queryset =Partner.objects.all()
-
-        data = get_data_count_by_month(queryset, data_format=PYTHON)
-        writer = csv.writer(response)
-        # Translators: This is the heading of a data file, for a column containing date data.
-        writer.writerow([_('Date'), 
-                         # Translators: This is the heading of a data file. 'Number of partners' refers to the total number of publishers/databases open to applications on the website.
-                         _('Number of partners')])
-
-        for row in data:
-            writer.writerow(row)
 
 
 class CSVAppTimeHistogram(_CSVDownloadView):

--- a/TWLight/templates/base.html
+++ b/TWLight/templates/base.html
@@ -115,16 +115,16 @@
 					{% trans "Latest activity" %}
 				</a>
 			</li>
-		
+
+		{% if user.is_authenticated %}
+			{% if user.is_staff %}
 			<li role="presentation" class="mobile-menu">
 				<a href="{% url 'dashboard' %}">
           {% comment %} Translators: Shown in the top bar of almost every page, linking to the statitics for applications. {% endcomment %}
 					{% trans "Metrics" %}
 				</a>
 			</li>
-			
-		{% if user.is_authenticated %}			
-			{% if user.is_staff %}
+
 				<li role="presentation" class="mobile-menu">
 					<a href="{% url 'admin:index' %}">
 			  {% comment %} Translators: Shown in the top bar of almost every page when the current user is staff, linking to the administrator interface. {% endcomment %}

--- a/TWLight/templates/dashboard.html
+++ b/TWLight/templates/dashboard.html
@@ -139,24 +139,6 @@
 
   {% endif %}
 
-  <!-- begin partner metrics -->
-  <div class="row">
-    <div class="col-lg-12">
-      {% comment %} Translators: On the dashboard page (https://wikipedialibrary.wmflabs.org/dashboard/), this text is the title of the section showing the number of available partners over time.{% endcomment %}
-      <h2 class="page-header">{% trans "Partners" %}</h2>
-    </div>
-  </div>
-
-  <div class="row">
-    <div class="col-lg-12">
-      {% comment %} Translators: On the dashboard page (https://wikipedialibrary.wmflabs.org/dashboard/), this text is the title of the graph showing the number of available partners over time.{% endcomment %}
-      <h3>{% trans "Number of partners over time" %} <a href="{% url 'csv:num_partners' %}" class="pull-right btn btn-default">{% trans "download as csv" %}</a></h3>
-      <div id="partner-time-graph" style="width:600px;height:300px"></div>
-    </div>
-  </div>
-  <!-- end partner metrics -->
-
-
   <!-- begin application metrics -->
   <div class="row">
     <div class="col-lg-12">
@@ -213,20 +195,6 @@
 
   <script type="text/javascript">
     $(function() {
-      // Partners over time
-      var partner_time_graph = $("#partner-time-graph");
-      var partner_time_data = {{ partner_time_data }};
-      var partner_time_plot = $.plot(partner_time_graph, [partner_time_data], {
-        xaxis: {
-          mode: "time",
-        },
-        yaxis: {
-          min: 0,
-          minTickSize: 1,
-          tickDecimals: 0,
-        },
-        colors: ['#5cb85c'],
-      });
 
       // Application time-to-decision (histogram)
       var app_time_histogram_graph = $("#app-time-histogram-graph");

--- a/TWLight/templates/dashboard.html
+++ b/TWLight/templates/dashboard.html
@@ -45,8 +45,6 @@
         <a href="#users-section">
           <div class="panel-footer">
             {% comment %} Translators: On the dashboard page (https://wikipedialibrary.wmflabs.org/dashboard/), this labels a button which moves the page down to metrics about users. {% endcomment %}
-            <span class="pull-left">{% trans 'Jump to user metrics' %}</span>
-            <span class="pull-right"><i class="fa fa-arrow-circle-right"></i></span>
             <div class="clearfix"></div>
           </div>
         </a>

--- a/TWLight/templates/dashboard.html
+++ b/TWLight/templates/dashboard.html
@@ -169,9 +169,9 @@
       {% comment %} Translators: On the dashboard page (https://wikipedialibrary.wmflabs.org/dashboard/), this text is the title of the graph showing the current distribution of applications.{% endcomment %}
       <h3>{% trans "Current application status distribution" %} <a href="{% url 'csv:app_distribution' %}" class="pull-right btn btn-default">{% trans "download as csv" %}</a></h3>
       <p>
-        {% comment %} Translators: On the dashboard page (https://wikipedialibrary.wmflabs.org/dashboard/), this text is located above the graph showing the current distribution of applications.{% endcomment %}
+        {% comment %} Translators: On the dashboard page (https://wikipedialibrary.wmflabs.org/dashboard/), this text is located above the graph showing the current distribution of open applications.{% endcomment %}
         {% blocktrans trimmed %}
-          This graph includes all applications opened ever on this site.
+          This graph shows all open applicattion (i.e. not those sent or denied).
         {% endblocktrans %}
       </p>
       <div id="app-distribution-graph" style="width:600px;height:300px"></div>

--- a/TWLight/templates/dashboard.html
+++ b/TWLight/templates/dashboard.html
@@ -14,7 +14,7 @@
             <div class="col-xs-9 text-right">
               <div class="huge">{{ total_partners }}</div>
               {% comment %} Translators: On the dashboard page (https://wikipedialibrary.wmflabs.org/dashboard/), this labels a box showing the total number of available partners. {% endcomment %}
-              <div>{% trans 'Total partners (all time)' %}</div>
+              <div>{% trans 'Total partners' %}</div>
             </div>
           </div>
         </div>
@@ -38,7 +38,7 @@
             <div class="col-xs-9 text-right">
               <div class="huge">{{ total_editors }}</div>
               {% comment %} Translators: On the dashboard page (https://wikipedialibrary.wmflabs.org/dashboard/), this labels a box showing the total number of editors (users) who registered. {% endcomment %}
-              <div>{% trans 'Number of editors (all time)' %}</div>
+              <div>{% trans 'Number of editors' %}</div>
             </div>
           </div>
         </div>
@@ -59,7 +59,7 @@
             </div>
             <div class="col-xs-9 text-right">
               <div class="huge">{{ total_apps }}</div>
-              <div>{% trans 'Total applications (all time)' %}</div>
+              <div>{% trans 'Total applications' %}</div>
             </div>
           </div>
         </div>

--- a/TWLight/templates/dashboard.html
+++ b/TWLight/templates/dashboard.html
@@ -167,13 +167,7 @@
       </p>
       <div id="app-medians-graph" style="width:600px;height:300px"></div>
       {% comment %} Translators: On the dashboard page (https://wikipedialibrary.wmflabs.org/dashboard/), this text is the title of the graph showing the current distribution of applications.{% endcomment %}
-      <h3>{% trans "Current application status distribution" %} <a href="{% url 'csv:app_distribution' %}" class="pull-right btn btn-default">{% trans "download as csv" %}</a></h3>
-      <p>
-        {% comment %} Translators: On the dashboard page (https://wikipedialibrary.wmflabs.org/dashboard/), this text is located above the graph showing the current distribution of open applications.{% endcomment %}
-        {% blocktrans trimmed %}
-          This graph shows all open applicattion (i.e. not those sent or denied).
-        {% endblocktrans %}
-      </p>
+      <h3>{% trans "Open application status distribution" %} <a href="{% url 'csv:app_distribution' %}" class="pull-right btn btn-default">{% trans "download as csv" %}</a></h3>
       <div id="app-distribution-graph" style="width:600px;height:300px"></div>
 
     </div>


### PR DESCRIPTION
Some initial tidying of the dashboard page, removing a dead link, taking out the partners over time graph, limiting the applications graph to those that aren't closed, and some text removal.

Also hid the Metrics button from non-staff. They can still access the page directly if, for some reason, necessary.

Tests ran ok.