### PR TITLE
Fix 'not yet reviewed' message on imported applications in application list (T192141)

### DIFF
--- a/TWLight/applications/templates/applications/application_list_include.html
+++ b/TWLight/applications/templates/applications/application_list_include.html
@@ -23,7 +23,10 @@
         <a href="mailto:{{ app.user.email|urlencode|safe }}">{{ app.user.email|safe }}</a>
       <br />
       {% endif %}
-      {% if app.get_version_count > 1 %} {# first version is original submission, not later review #}
+      {% if app.imported %}
+        {% comment %} Translators: On the page listing applications, this shows next to an application which was imported to the website. {% endcomment %}
+        {% trans 'Imported application' %}
+      {% elif app.get_version_count > 1 %} {# first version is original submission, not later review #}
         {% if app.get_latest_reviewer %}
           {% comment %} Translators: On the page listing applications, this shows next to an application which was previously reviewed. Don't translate {{ reviewer }} or {{ review_date }}. {% endcomment %}
           {% blocktrans trimmed with reviewer=app.get_latest_reviewer review_date=app.get_latest_review_date|localize %}


### PR DESCRIPTION
Says 'Imported application' instead.