### PR TITLE
Fix 'Send data to partners' page having variables as field labels instead of human-readable labels (T191886)

### DIFF
--- a/TWLight/applications/helpers.py
+++ b/TWLight/applications/helpers.py
@@ -101,6 +101,23 @@ FIELD_LABELS = {
     AGREEMENT_WITH_TERMS_OF_USE: _("You must agree with the partner's terms of use"),
 }
 
+SEND_DATA_FIELD_LABELS = {
+    # Translators: When sending application data to partners, this is the text labelling a user's real name
+    REAL_NAME: _('Real name'),
+    # Translators: When sending application data to partners, this is the text labelling a user's country of residence
+    COUNTRY_OF_RESIDENCE: _('Country of residence'),
+    # Translators: When sending application data to partners, this is the text labelling a user's occupation
+    OCCUPATION: _('Occupation'),
+    # Translators: When sending application data to partners, this is the text labelling a user's affiliation
+    AFFILIATION: _('Affiliation'),
+    # Translators: When sending application data to partners, this is the text labelling the stream/collection a user requested
+    SPECIFIC_STREAM: _('Stream requested'),
+    # Translators: When sending application data to partners, this is the text labelling the specific title (e.g. a particular book) a user requested
+    SPECIFIC_TITLE: _('Title requested'),
+    # Translators: When sending application data to partners, this is the text labelling whether a user agreed with the partner's Terms of Use
+    AGREEMENT_WITH_TERMS_OF_USE: _('Agreed with terms of use'),
+}
+
 
 def get_output_for_application(app):
     """
@@ -112,15 +129,17 @@ def get_output_for_application(app):
     """
     output = {}
     # Translators: This labels a user's email address on a form for account coordinators
-    output[_('Email')] = app.editor.user.email
+    output[_('Email')] = {'label': 'Email', 'data': app.editor.user.email}
 
     for field in PARTNER_FORM_OPTIONAL_FIELDS:
         if getattr(app.partner, field): # Will be True if required by Partner.
-            output[field] = getattr(app, field)
+            field_label = SEND_DATA_FIELD_LABELS[field]
+            output[field] = {'label': field_label, 'data': getattr(app, field)}
 
     for field in USER_FORM_FIELDS:
         if getattr(app.partner, field): # Will be True if required by Partner.
-            output[field] = getattr(app.editor, field)
+            field_label = SEND_DATA_FIELD_LABELS[field]
+            output[field] = {'label': field_label, 'data': getattr(app.editor, field)}
 
     return output
 

--- a/TWLight/applications/templates/applications/send_partner.html
+++ b/TWLight/applications/templates/applications/send_partner.html
@@ -108,8 +108,8 @@
                 <label for="app_{{ app.pk }}">
                   <h4 class="media-heading">{{ app }}</h4>
                   <ul class="list-unstyled pull-left">
-                    {% for key, value in output.items %}
-                      <li><strong>{{ key }}</strong> &mdash; {{ value }}</li>
+                    {% for key, send_data in output.items %}
+                      <li><strong>{{ send_data.label }}</strong> &mdash; {{ send_data.data }}</li>
                     {% endfor %}
                   </ul>                
                 </label>

--- a/TWLight/applications/tests.py
+++ b/TWLight/applications/tests.py
@@ -225,14 +225,14 @@ class SynchronizeFieldsTest(TestCase):
         app.refresh_from_db()
 
         output = get_output_for_application(app)
-        self.assertEqual(output[REAL_NAME], 'Alice')
-        self.assertEqual(output[COUNTRY_OF_RESIDENCE], 'Holy Roman Empire')
-        self.assertEqual(output[OCCUPATION], 'Dog surfing instructor')
-        self.assertEqual(output[AFFILIATION], 'The Long Now Foundation')
-        self.assertEqual(output[SPECIFIC_STREAM], stream)
-        self.assertEqual(output[SPECIFIC_TITLE], 'Alice in Wonderland')
-        self.assertEqual(output['Email'], 'alice@example.com')
-        self.assertEqual(output[AGREEMENT_WITH_TERMS_OF_USE], True)
+        self.assertEqual(output[REAL_NAME]['data'], 'Alice')
+        self.assertEqual(output[COUNTRY_OF_RESIDENCE]['data'], 'Holy Roman Empire')
+        self.assertEqual(output[OCCUPATION]['data'], 'Dog surfing instructor')
+        self.assertEqual(output[AFFILIATION]['data'], 'The Long Now Foundation')
+        self.assertEqual(output[SPECIFIC_STREAM]['data'], stream)
+        self.assertEqual(output[SPECIFIC_TITLE]['data'], 'Alice in Wonderland')
+        self.assertEqual(output['Email']['data'], 'alice@example.com')
+        self.assertEqual(output[AGREEMENT_WITH_TERMS_OF_USE]['data'], True)
 
         # Make sure that in enumerating the keys we didn't miss any (e.g. if
         # the codebase changes).
@@ -266,7 +266,7 @@ class SynchronizeFieldsTest(TestCase):
         app.refresh_from_db()
 
         output = get_output_for_application(app)
-        self.assertEqual(output['Email'], 'alice@example.com')
+        self.assertEqual(output['Email']['data'], 'alice@example.com')
 
         # Make sure that in enumerating the keys we didn't miss any (e.g. if
         # the codebase changes).
@@ -305,11 +305,11 @@ class SynchronizeFieldsTest(TestCase):
         app.refresh_from_db()
 
         output = get_output_for_application(app)
-        self.assertEqual(output[REAL_NAME], 'Alice')
-        self.assertEqual(output[COUNTRY_OF_RESIDENCE], 'Holy Roman Empire')
-        self.assertEqual(output[OCCUPATION], 'Dog surfing instructor')
-        self.assertEqual(output[AFFILIATION], 'The Long Now Foundation')
-        self.assertEqual(output['Email'], 'alice@example.com')
+        self.assertEqual(output[REAL_NAME]['data'], 'Alice')
+        self.assertEqual(output[COUNTRY_OF_RESIDENCE]['data'], 'Holy Roman Empire')
+        self.assertEqual(output[OCCUPATION]['data'], 'Dog surfing instructor')
+        self.assertEqual(output[AFFILIATION]['data'], 'The Long Now Foundation')
+        self.assertEqual(output['Email']['data'], 'alice@example.com')
 
         # Make sure that in enumerating the keys we didn't miss any (e.g. if
         # the codebase changes).


### PR DESCRIPTION
Tests ran OK.

Not sure if this was the best way to do this - we seem to be building this form manually so this feels hacky, but it works.