### PR TITLE
Added a user application list template instead of using the default one (T174682)

### DIFF
--- a/TWLight/applications/templates/applications/application_list_include.html
+++ b/TWLight/applications/templates/applications/application_list_include.html
@@ -49,16 +49,6 @@
       {% endif %}
       Filter by partner: <a href="?Partner={{ app.partner.pk|urlencode|safe }}">{{ app.partner }}</a>
     </div>
-    {% ifequal app.editor.user.pk user.pk %}
-      <div class="col-xs-8 col-xs-offset-4 col-sm-4 col-sm-offset-0">
-          <strong>{% trans "Has your account expired?" %}</strong> <br />
-          {% if app.is_renewable %}
-            <a class="btn btn-default btn-sm" href="{% url 'applications:renew' app.pk %}">{% trans "Request renewal" %}</a>
-          {% else %}
-            <em>{% trans "Unfortunately renewals are not available right now or you have already requested a renewal." %}</em>
-          {% endif %}
-      </div>      
-    {% endifequal %}
     {% if not forloop.last %}
       <div class="col-sm-10 col-sm-offset-2 col-xs-12">
         <hr />

--- a/TWLight/applications/templates/applications/application_list_user_include.html
+++ b/TWLight/applications/templates/applications/application_list_user_include.html
@@ -1,0 +1,58 @@
+{% load i18n %}
+{% load l10n %}
+
+{% for app in object_list %}
+  <div class="row">
+    <div class="col-xs-4 col-sm-2">
+      <span class="label label{{ app.get_bootstrap_class }} pull-right">
+        {% if app.parent %}
+          Renewal - 
+        {% endif %}
+        {{ app.get_status_display }}
+      </span>
+    </div>    
+    <div class="col-xs-8 col-sm-6">
+      <h4>
+      <a href="{{ app.get_absolute_url }}">
+        {{ app.partner }}
+      </a>
+      </h4>
+      {% if app.get_version_count > 1 %} {# first version is original submission, not later review #}
+        {% if app.get_latest_reviewer %}
+          {% comment %} Translators: On the page listing applications, this shows next to an application which was previously reviewed. Don't translate {{ reviewer }} or {{ review_date }}. {% endcomment %}
+          {% blocktrans trimmed with reviewer=app.get_latest_reviewer review_date=app.get_latest_review_date|localize %}
+            Last reviewed by {{ reviewer }} on {{ review_date }}
+          {% endblocktrans %}
+        {% else %}
+          {% comment %} Translators: On the page listing applications, this shows next to an application which was previously reviewed. Don't translate {{ review_date }}. {% endcomment %}
+          {% blocktrans trimmed with review_date=app.get_latest_review_date|localize %}
+            Last reviewed on {{ review_date }}
+          {% endblocktrans %}
+        {% endif %}
+      {% else %}
+        {% comment %} Translators: On the page listing applications, this shows next to an application which has not yet been reviewed. {% endcomment %}
+        {% trans 'Not yet reviewed.' %}
+      {% endif %}
+      <br />
+    </div>
+    {% ifequal app.editor.user.pk user.pk %}
+      {% if app.status == app.SENT %}
+        <div class="col-xs-8 col-xs-offset-4 col-sm-4 col-sm-offset-0">
+            <strong>{% trans "Has your account expired?" %}</strong> <br />
+            {% if app.is_renewable %}
+              <a class="btn btn-default btn-sm" href="{% url 'applications:renew' app.pk %}">{% trans "Request renewal" %}</a>
+            {% else %}
+              <em>{% trans "Unfortunately renewals are not available right now or you have already requested a renewal." %}</em>
+            {% endif %}
+        </div>
+      {% endif %}
+    {% endifequal %}
+    {% if not forloop.last %}
+      <div class="col-sm-10 col-sm-offset-2 col-xs-12">
+        <hr />
+      </div>
+    {% endif %}
+  </div>
+{% empty %}
+  {% trans 'No applications right now.' %}
+{% endfor %}

--- a/TWLight/users/templates/users/editor_detail.html
+++ b/TWLight/users/templates/users/editor_detail.html
@@ -18,7 +18,7 @@
     </a>
   </p>
 
-  {% include 'applications/application_list_include.html' %}
+  {% include 'applications/application_list_user_include.html' %}
 
   {% comment %} Translators: This is the heading for user information on profile and application pages. {% endcomment %}
   <h2>{% trans 'Editor data' %}</h2>

--- a/TWLight/users/tests.py
+++ b/TWLight/users/tests.py
@@ -233,10 +233,10 @@ class ViewsTestCase(TestCase):
             set([app1, app2, app3, app4]))
         content = response.render().content
 
-        self.assertIn(app1.__str__(), content)
-        self.assertIn(app2.__str__(), content)
-        self.assertIn(app3.__str__(), content)
-        self.assertIn(app4.__str__(), content)
+        self.assertIn(app1.partner.company_name, content)
+        self.assertIn(app2.partner.company_name, content)
+        self.assertIn(app3.partner.company_name, content)
+        self.assertIn(app4.partner.company_name, content)
 
         # We can't use assertTemplateUsed with RequestFactory (only with
         # Client), and testing that the rendered content is equal to an


### PR DESCRIPTION
The template also doesn't display the renewal message if the application isn't Sent; there's no point showing it for applications that either aren't yet sent or are declined.

Tests ran OK, after slight modification since the new template doesn't display "Username - Partner name" anymore.