### PR TITLE
Fix partner pages excluding sent/not approved apps from pie chart (T192346)

### DIFF
--- a/TWLight/graphs/helpers.py
+++ b/TWLight/graphs/helpers.py
@@ -85,7 +85,7 @@ def get_data_count_by_month(queryset, data_format=JSON):
 
 
 # Application stats ------------------------------------------------------------
-def get_application_status_data(queryset, data_format=JSON):
+def get_application_status_data(queryset, statuses=Application.STATUS_CHOICES, data_format=JSON):
     """
     Returns data about the status of Applications in a queryset. By default,
     returns json in a format suitable for display as a flot.js pie chart; can
@@ -93,7 +93,7 @@ def get_application_status_data(queryset, data_format=JSON):
     """
     status_data = []
 
-    for status in Application.STATUS_CHOICES[0:3]:
+    for status in statuses:
         status_count = queryset.filter(status=status[0]).count()
         # We have to force unicode here because we used ugettext_lazy, not
         # ugettext, to internationalize the status labels in

--- a/TWLight/graphs/views.py
+++ b/TWLight/graphs/views.py
@@ -129,7 +129,8 @@ class DashboardView(TemplateView):
 
         context['app_distribution_data'] = get_application_status_data(
                 Application.objects.exclude(
-                    status__in=(Application.SENT, Application.NOT_APPROVED))
+                    status__in=(Application.NOT_APPROVED, Application.SENT)),
+                    statuses=Application.STATUS_CHOICES[0:3]
             )
 
         return context


### PR DESCRIPTION
This pie chart still isn't very useful for partners with lots of applications, where we get the same issue as for the dashboard page, but for now this is an improvement over partners with zero open apps showing a blank space.