### PR TITLE
Update ToU link text and move privacy policy link to terms page (T192747)

### DIFF
--- a/TWLight/templates/base.html
+++ b/TWLight/templates/base.html
@@ -210,14 +210,9 @@
             </a>
           </li>
           <li>
-            <a href="https://wikimediafoundation.org/wiki/Privacy_policy">
-              {% comment %} Translators: This button is at the bottom of every page and links to the Wikimedia Foundation Privacy Policy (https://wikimediafoundation.org/wiki/Privacy_policy). {% endcomment %}
-              {% trans "Privacy policy" %}
-            </a>
-          </li>
-          <li>
             <a href="{% url 'terms' %}">
-              {% trans "Terms of use" %}
+              {% comment %} Translators: This button is at the bottom of every page and can be clicked by users to navigate to the Terms of Use page. {% endcomment %}
+              {% trans "Terms of use and privacy policy" %}
             </a>
           </li>
           <li>

--- a/TWLight/users/templates/users/terms.html
+++ b/TWLight/users/templates/users/terms.html
@@ -18,8 +18,13 @@
 {# Translators: use the date *when you are translating*, in a language-appropriate format. #}
 <em>{% trans "Last updated 8 August 2016" %}</em>
 
+<a href="https://wikimediafoundation.org/wiki/Privacy_policy" style="float:right">
+{% comment %} Translators: This link is on the Terms of Use page and links to the Wikimedia Foundation Privacy Policy (https://wikimediafoundation.org/wiki/Privacy_policy). {% endcomment %}
+{% trans "Wikimedia Foundation privacy policy" %}
+</a>
+
 {% comment %} Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library). {% endcomment %}
-<h2>{% trans "Welcome to the Wikipedia Library Card Terms of Use and Privacy Statement!" %}</h2>
+<h2>{% trans "Wikipedia Library Card Terms of Use and Privacy Statement" %}</h2>
 
 {% comment %}
 You can also view these TOU on [[Meta]], where they may be translated in other languages. <-- awaiting link on meta


### PR DESCRIPTION
I also thought "Welcome to...!" was a bit oddly informal for the ToU page.