### PR TITLE
Distinguish unreviewed apps from imported ones on user page (T193725)

### DIFF
--- a/TWLight/applications/templates/applications/application_list_user_include.html
+++ b/TWLight/applications/templates/applications/application_list_user_include.html
@@ -17,7 +17,10 @@
         {{ app.partner }}
       </a>
       </h4>
-      {% if app.get_version_count > 1 %} {# first version is original submission, not later review #}
+      {% if app.imported %}
+        {% comment %} Translators: On the page listing applications, this shows next to an application which was imported to the website. {% endcomment %}
+        {% trans 'Imported application' %}
+      {% elif app.get_version_count > 1 %} {# first version is original submission, not later review #}
         {% if app.get_latest_reviewer %}
           {% comment %} Translators: On the page listing applications, this shows next to an application which was previously reviewed. Don't translate {{ reviewer }} or {{ review_date }}. {% endcomment %}
           {% blocktrans trimmed with reviewer=app.get_latest_reviewer review_date=app.get_latest_review_date|localize %}


### PR DESCRIPTION
This change was made to the general applications template but I forgot to do it on the new user page applications template too.