### PR TITLE
Use pandoc.convert_text rather than pandoc.convert to prevent server errors (T196253)

### DIFF
--- a/TWLight/applications/templatetags/twlight_wikicode2html.py
+++ b/TWLight/applications/templatetags/twlight_wikicode2html.py
@@ -7,5 +7,5 @@ register = template.Library()
 @register.filter
 def twlight_wikicode2html(value):
   """Passes string through pandoc and returns html"""
-  output = pypandoc.convert(value, 'html', format='mediawiki')
+  output = pypandoc.convert_text(value, 'html', format='mediawiki')
   return output

--- a/TWLight/resources/templatetags/twlight_wikicode2html.py
+++ b/TWLight/resources/templatetags/twlight_wikicode2html.py
@@ -7,5 +7,5 @@ register = template.Library()
 @register.filter
 def twlight_wikicode2html(value):
   """Passes string through pandoc and returns html"""
-  output = pypandoc.convert(value, 'html', format='mediawiki')
+  output = pypandoc.convert_text(value, 'html', format='mediawiki')
   return output


### PR DESCRIPTION
Per https://github.com/bebraw/pypandoc/issues/136 we should use `pandoc.convert_text()` to avoid errors when text starts with a URL. `pandoc.convert` guesses that this is a URL and then fails to parse it.