### PR TITLE
Link to CentralAuth in addition to SUL Info tool (T180145)

### DIFF
--- a/TWLight/users/models.py
+++ b/TWLight/users/models.py
@@ -190,6 +190,14 @@ class Editor(models.Model):
         return url
 
 
+    @cached_property
+    def wp_link_central_auth(self):
+        url = u'{base_url}&target={self.wp_username}'.format(
+            base_url='https://meta.wikimedia.org/w/index.php?title=Special%3ACentralAuth',
+            self=self
+        )
+        return url
+
     @property
     def get_wp_rights_display(self):
         """

--- a/TWLight/users/templates/users/editor_detail_data.html
+++ b/TWLight/users/templates/users/editor_detail_data.html
@@ -21,7 +21,12 @@
       {% if editor.wp_link_sul_info %}
         <br />
         {% comment %} Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this is a button for viewing a Wikipedian's SUL info through an external tool. (e.g. https://tools.wmflabs.org/quentinv57-tools/tools/sulinfo.php?username=Samwalton9%20(WMF)) {% endcomment %}
-        <a href="{{ editor.wp_link_sul_info }}">({% trans "view Wikipedia SUL info" %})</a>
+        <a href="{{ editor.wp_link_sul_info }}">({% trans "SUL info" %})</a>
+      {% endif %}
+      {% if editor.wp_link_central_auth %}
+        <br />
+        {% comment %} Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this is a button for viewing a Wikipedian's account information through https://meta.wikimedia.org/wiki/Special:CentralAuth/) {% endcomment %}
+        <a href="{{ editor.wp_link_central_auth }}">({% trans "CentralAuth" %})</a>
       {% endif %}
     </div>
   </div>

--- a/TWLight/users/tests.py
+++ b/TWLight/users/tests.py
@@ -424,6 +424,10 @@ class EditorModelTestCase(TestCase):
         self.assertEqual(expected_url, self.test_editor.wp_link_sul_info)
 
 
+    def test_wp_link_central_auth(self):
+        expected_url = 'https://meta.wikimedia.org/w/index.php?title=Special%3ACentralAuth&target=editor_model_test'
+        self.assertEqual(expected_url, self.test_editor.wp_link_central_auth)
+
     def test_get_wp_rights_display(self):
         expected_text = ['cat floofing', 'the big red button']
         self.assertEqual(expected_text, self.test_editor.get_wp_rights_display)


### PR DESCRIPTION
Especially important because the SUL Info tool is down right now.