### PR TITLE
Send comment notifications to coordinator processing an application

### DIFF
--- a/TWLight/emails/templates/emails/comment_notification_coordinator-body-html.html
+++ b/TWLight/emails/templates/emails/comment_notification_coordinator-body-html.html
@@ -1,0 +1,12 @@
+{% load i18n %}
+<html>
+<body>
+{% comment %} Translators: This email is sent to coordinators when a comment is left on an application they are processing. Don't translate Jinja variables in curly braces like {{ user }} or {{ partner }}. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).{% endcomment %}
+{% blocktrans trimmed  %}
+  <p>Dear {{ user }},</p>
+  <p>Thank you for coordinating {{ partner }} resources through The Wikipedia Library. There are one or more comments on an application that require a response from you. Please reply to these at: {{ app_url }}</p>
+  <p>Best,</p>
+  <p>The Wikipedia Library</p>
+{% endblocktrans %}
+</body>
+</html>

--- a/TWLight/emails/templates/emails/comment_notification_coordinator-body-text.html
+++ b/TWLight/emails/templates/emails/comment_notification_coordinator-body-text.html
@@ -1,0 +1,14 @@
+{% load i18n %}
+{% comment %} Translators: This email is sent to coordinators when a comment is left on an application they are processing. Don't translate Jinja variables in curly braces like {{ user }} or {{ partner }}. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).{% endcomment %}
+{% blocktrans %}
+Dear {{ user }},
+
+Thank you for coordinating {{ partner }} resources through
+The Wikipedia Library. There are one or more comments on an application that
+require a response from you. Please reply to these at:
+{{ app_url }}
+
+Best,
+
+The Wikipedia Library
+{% endblocktrans %}

--- a/TWLight/emails/templates/emails/comment_notification_coordinator-subject.html
+++ b/TWLight/emails/templates/emails/comment_notification_coordinator-subject.html
@@ -1,0 +1,3 @@
+{% load i18n %}
+{% comment %} Translators: This is the subject line of an email sent to coordinators when a comment is left on an application they processed.{% endcomment %}
+{% trans 'New comment on a Wikipedia Library application you processed' %}

--- a/TWLight/emails/tests.py
+++ b/TWLight/emails/tests.py
@@ -175,8 +175,9 @@ class ApplicationCommentTest(TestCase):
 
     def test_comment_email_sending_5(self):
         """
-        A comment made on an application that has had no actions taken on it
-        and no existing comments should not fire an email to anyone.
+        A comment from the applying editor made on an application that
+        has had no actions taken on it and no existing comments should
+        not fire an email to anyone.
         """
         app, request = self._set_up_email_test_objects()
         self.assertEqual(len(mail.outbox), 0)


### PR DESCRIPTION
If a coordinator has made a status change to an application, and a comment is later posted on it, that coordinator should really receive a notification.