### PR TITLE
Allow designated coordinators to view a table of approved/sent users for their partner (T170795)

### DIFF
--- a/TWLight/resources/templates/resources/partner_detail.html
+++ b/TWLight/resources/templates/resources/partner_detail.html
@@ -153,6 +153,10 @@
           {% endblocktrans %}
         {% endif %}
       </div>
+      {% if object.coordinator == user or user.is_staff %}
+        {% comment %} Translators: This text labels a button coordinators can click to view a list of users who have applied for access for a particular partner {% endcomment %}
+        <a href="{% url 'partners:users' pk=object.pk %}" class="btn btn-primary btn-lg hidden-xs btn-block">{% trans "List applications" %}</a>
+      {% endif %}
     {% endif %}
     </div>
     <li class="timeline-inverted">

--- a/TWLight/resources/templates/resources/partner_users.html
+++ b/TWLight/resources/templates/resources/partner_users.html
@@ -1,0 +1,86 @@
+{% extends "base.html" %}
+{% load i18n %}
+
+{% block content %}
+  {% comment %} Translators: This is the heading of a page listing editors who have applications for this partner ({{ object }}). {% endcomment %}
+  <h1>
+  {% blocktrans with partner=object.company_name %}
+  {{ object }} approved users
+  {% endblocktrans %}
+  </h1>
+
+  <div class="alert alert-info">
+    {% comment %} Translators: This message is shown on pages where coordinators can see personal information about applicants. {% endcomment %}
+    {% trans 'Coordinators: This page may contain personal information such as real names and email addresses. Please remember that this information is confidential.' %}
+  </div>
+
+  {% if approved_applications|length > 0 %}
+    {% comment %} Translators: On the page listing approved users for a partner, this is the title of the section listing applications with the 'approved' status {% endcomment %}
+    <h2>{% trans "Approved applications" %}</h2>
+    <table class="table table-sm">
+      <thead>
+        <tr>
+          <th>User</th>
+          <th>Email</th>
+          <th>Application date</th>
+          <th>Application approved</th>
+          <th>Renewal?</th>
+          {% if partner_streams %}
+            <th>Stream</th>
+          {% endif %}
+        </tr>
+      </thead>
+      <tbody>
+      {% for application in approved_applications %}
+        <tr>
+          <td><a href="https://meta.wikimedia.org/wiki/User:{{ application.editor.wp_username }}">
+            {{ application.editor.wp_username }}
+          </a></td>
+          <td>{{ application.editor.user.email }}</td>
+          <td><a href="{% url 'applications:evaluate' pk=application.pk %}">
+            {% if application.imported %}<i>Imported</i>{% else %}{{ application.date_created }}{% endif %}
+          </a></td>
+          <td>{{ application.date_closed }}</td>
+          <td>{% if application.parent %}<i>Renewal</i>{% endif %}</td>
+          {% if application.specific_stream %}<td>{{ application.specific_stream }}</td>{% endif %}
+        </tr>      
+      {% endfor %}
+      </tbody>
+    </table>
+  {% endif %}
+
+  {% if sent_applications|length > 0 %}
+    {% comment %} Translators: On the page listing approved users for a partner, this is the title of the section listing applications with the 'sent' status {% endcomment %}
+    <h2>{% trans "Sent applications" %}</h2>
+    <table class="table table-sm">
+      <thead>
+        <tr>
+          <th>User</th>
+          <th>Email</th>
+          <th>Application date</th>
+          <th>Application approved</th>
+          <th>Renewal?</th>
+          {% if partner_streams %}
+            <th>Stream</th>
+          {% endif %}
+        </tr>
+      </thead>
+      <tbody>
+      {% for application in sent_applications %}
+        <tr>
+          <td><a href="https://meta.wikimedia.org/wiki/User:{{ application.editor.wp_username }}">
+            {{ application.editor.wp_username }}
+          </a></td>
+          <td>{{ application.editor.user.email }}</td>
+          <td><a href="{% url 'applications:evaluate' pk=application.pk %}">
+            {% if application.imported %}<i>Imported</i>{% else %}{{ application.date_created }}{% endif %}
+          </a></td>
+          <td>{{ application.date_closed }}</td>
+          <td>{% if application.parent %}<i>Renewal</i>{% endif %}</td>
+          {% if application.specific_stream %}<td>{{ application.specific_stream }}</td>{% endif %}
+        </tr>      
+      {% endfor %}
+      </tbody>
+    </table>
+  {% endif %}
+{% endblock content %}

--- a/TWLight/resources/templates/resources/partner_users.html
+++ b/TWLight/resources/templates/resources/partner_users.html
@@ -17,70 +17,90 @@
   {% if approved_applications|length > 0 %}
     {% comment %} Translators: On the page listing approved users for a partner, this is the title of the section listing applications with the 'approved' status {% endcomment %}
     <h2>{% trans "Approved applications" %}</h2>
-    <table class="table table-sm">
-      <thead>
-        <tr>
-          <th>User</th>
-          <th>Email</th>
-          <th>Application date</th>
-          <th>Application approved</th>
-          <th>Renewal?</th>
-          {% if partner_streams %}
-            <th>Stream</th>
-          {% endif %}
-        </tr>
-      </thead>
-      <tbody>
-      {% for application in approved_applications %}
-        <tr>
-          <td><a href="https://meta.wikimedia.org/wiki/User:{{ application.editor.wp_username }}">
-            {{ application.editor.wp_username }}
-          </a></td>
-          <td>{{ application.editor.user.email }}</td>
-          <td><a href="{% url 'applications:evaluate' pk=application.pk %}">
-            {% if application.imported %}<i>Imported</i>{% else %}{{ application.date_created }}{% endif %}
-          </a></td>
-          <td>{{ application.date_closed }}</td>
-          <td>{% if application.parent %}<i>Renewal</i>{% endif %}</td>
-          {% if application.specific_stream %}<td>{{ application.specific_stream }}</td>{% endif %}
-        </tr>      
-      {% endfor %}
-      </tbody>
-    </table>
+    <div class="table-responsive">
+      <table class="table table-sm">
+        <thead>
+          <tr>
+            {% comment %} Translators: On the page where coordinators can view data on applications to a partner they coordinate, this is a table column heading for the username. {% endcomment %}
+            <th>{% trans "User" %}</th>
+            {% comment %} Translators: On the page where coordinators can view data on applications to a partner they coordinate, this is a table column heading for a user's email address. {% endcomment %}
+            <th>{% trans "Email" %}</th>
+            {% comment %} Translators: On the page where coordinators can view data on applications to a partner they coordinate, this is a table column heading for date an application was made. {% endcomment %}
+            <th>{% trans "Application date" %}</th>
+            {% comment %} Translators: On the page where coordinators can view data on applications to a partner they coordinate, this is a table column heading for date an application was approved by a coordinator. {% endcomment %}
+            <th>{% trans "Application approved" %}</th>
+            {% comment %} Translators: On the page where coordinators can view data on applications to a partner they coordinate, this is a table column heading denoting whether an application was a renewal. {% endcomment %}
+            <th>{% trans "Renewal?" %}</th>
+            {% if partner_streams %}
+              {% comment %} Translators: On the page where coordinators can view data on applications to a partner they coordinate, this is a table column heading for the stream (collection) the user applied for. {% endcomment %}
+              <th>{% trans "Stream" %}</th>
+            {% endif %}
+          </tr>
+        </thead>
+        <tbody>
+        {% for application in approved_applications %}
+          <tr>
+            <td><a href="https://meta.wikimedia.org/wiki/User:{{ application.editor.wp_username }}">
+              {{ application.editor.wp_username }}
+            </a></td>
+            <td>{{ application.editor.user.email }}</td>
+            <td><a href="{% url 'applications:evaluate' pk=application.pk %}">
+              {% comment %} Translators: Denotes whether an application was imported to the platform, because it was submitted before the library card was launched. {% endcomment %}
+              {% if application.imported %}<i>{% trans "Imported" %}</i>{% else %}{{ application.date_created }}{% endif %}
+            </a></td>
+            <td>{{ application.date_closed }}</td>
+            {% comment %} Translators: Denotes whether an application was a renewal request for a previous application. {% endcomment %}
+            <td>{% if application.parent %}<i>{% trans "Renewal" %}</i>{% endif %}</td>
+            {% if application.specific_stream %}<td>{{ application.specific_stream }}</td>{% endif %}
+          </tr>      
+        {% endfor %}
+        </tbody>
+      </table>
+    </div>
   {% endif %}
 
   {% if sent_applications|length > 0 %}
     {% comment %} Translators: On the page listing approved users for a partner, this is the title of the section listing applications with the 'sent' status {% endcomment %}
     <h2>{% trans "Sent applications" %}</h2>
-    <table class="table table-sm">
-      <thead>
-        <tr>
-          <th>User</th>
-          <th>Email</th>
-          <th>Application date</th>
-          <th>Application approved</th>
-          <th>Renewal?</th>
-          {% if partner_streams %}
-            <th>Stream</th>
-          {% endif %}
-        </tr>
-      </thead>
-      <tbody>
-      {% for application in sent_applications %}
-        <tr>
-          <td><a href="https://meta.wikimedia.org/wiki/User:{{ application.editor.wp_username }}">
-            {{ application.editor.wp_username }}
-          </a></td>
-          <td>{{ application.editor.user.email }}</td>
-          <td><a href="{% url 'applications:evaluate' pk=application.pk %}">
-            {% if application.imported %}<i>Imported</i>{% else %}{{ application.date_created }}{% endif %}
-          </a></td>
-          <td>{{ application.date_closed }}</td>
-          <td>{% if application.parent %}<i>Renewal</i>{% endif %}</td>
-          {% if application.specific_stream %}<td>{{ application.specific_stream }}</td>{% endif %}
-        </tr>      
-      {% endfor %}
-      </tbody>
-    </table>
+    <div class="table-responsive">
+      <table class="table table-sm">
+        <thead>
+          <tr>
+            {% comment %} Translators: On the page where coordinators can view data on applications to a partner they coordinate, this is a table column heading for the username. {% endcomment %}
+            <th>{% trans "User" %}</th>
+            {% comment %} Translators: On the page where coordinators can view data on applications to a partner they coordinate, this is a table column heading for a user's email address. {% endcomment %}
+            <th>{% trans "Email" %}</th>
+            {% comment %} Translators: On the page where coordinators can view data on applications to a partner they coordinate, this is a table column heading for date an application was made. {% endcomment %}
+            <th>{% trans "Application date" %}</th>
+            {% comment %} Translators: On the page where coordinators can view data on applications to a partner they coordinate, this is a table column heading for date an application was approved by a coordinator. {% endcomment %}
+            <th>{% trans "Application approved" %}</th>
+            {% comment %} Translators: On the page where coordinators can view data on applications to a partner they coordinate, this is a table column heading denoting whether an application was a renewal. {% endcomment %}
+            <th>{% trans "Renewal?" %}</th>
+            {% if partner_streams %}
+              {% comment %} Translators: On the page where coordinators can view data on applications to a partner they coordinate, this is a table column heading for the stream (collection) the user applied for. {% endcomment %}
+              <th>{% trans "Stream" %}</th>
+            {% endif %}
+          </tr>
+        </thead>
+        <tbody>
+        {% for application in sent_applications %}
+          <tr>
+            <td><a href="https://meta.wikimedia.org/wiki/User:{{ application.editor.wp_username }}">
+              {{ application.editor.wp_username }}
+            </a></td>
+            <td>{{ application.editor.user.email }}</td>
+            <td><a href="{% url 'applications:evaluate' pk=application.pk %}">
+              {% comment %} Translators: Denotes whether an application was imported to the platform, because it was submitted before the library card was launched. {% endcomment %}
+              {% if application.imported %}<i>{% trans "Imported" %}</i>{% else %}{{ application.date_created }}{% endif %}
+            </a></td>
+            <td>{{ application.date_closed }}</td>
+            {% comment %} Translators: Denotes whether an application was a renewal request for a previous application. {% endcomment %}
+            <td>{% if application.parent %}<i>{% trans "Renewal" %}</i>{% endif %}</td>
+            {% if application.specific_stream %}<td>{{ application.specific_stream }}</td>{% endif %}
+          </tr>      
+        {% endfor %}
+        </tbody>
+      </table>
+    </div>
   {% endif %}
 {% endblock content %}

--- a/TWLight/resources/tests.py
+++ b/TWLight/resources/tests.py
@@ -561,24 +561,20 @@ class PartnerViewTests(TestCase):
         request.user = AnonymousUser()
 
         # Anonymous users can't view the user list
-        print("anonymous")
         with self.assertRaises(PermissionDenied):
             _ = views.PartnerUsers.as_view()(request, pk=self.partner.pk)
 
         request.user = self.editor
         # Non-coordinators can't view the user list
-        print("non-coord")
         with self.assertRaises(PermissionDenied):
             _ = views.PartnerUsers.as_view()(request, pk=self.partner.pk)
 
         request.user = self.coordinator2
-        print("unassigned")
         # Unassigned coordinators can't view the user list
         with self.assertRaises(PermissionDenied):
             _ = views.PartnerUsers.as_view()(request, pk=self.partner.pk)
 
         request.user = self.coordinator
-        print("coord")
         # The assigned coordinator can see the user list!
         response = views.PartnerUsers.as_view()(request, pk=self.partner.pk)
         self.assertEqual(response.status_code, 200)

--- a/TWLight/resources/urls.py
+++ b/TWLight/resources/urls.py
@@ -18,4 +18,8 @@ urlpatterns = [
         views.PartnersToggleWaitlistView.as_view(),
         name='toggle_waitlist'
     ),
+    url(r'^(?P<pk>\d+)/users/$',
+        views.PartnerUsers.as_view(),
+        name='users'
+    ),
 ]

--- a/TWLight/resources/views.py
+++ b/TWLight/resources/views.py
@@ -10,7 +10,7 @@ from TWLight.graphs.helpers import (get_median,
                                     get_application_status_data,
                                     get_data_count_by_month,
                                     get_users_by_partner_by_month)
-from TWLight.view_mixins import CoordinatorsOnly, PartnerCoordinatorOnly
+from TWLight.view_mixins import CoordinatorsOnly, CoordinatorOrSelf
 
 from .models import Partner, Stream
 
@@ -177,7 +177,7 @@ class PartnersToggleWaitlistView(CoordinatorsOnly, View):
 
 
 
-class PartnerUsers(PartnerCoordinatorOnly, DetailView):
+class PartnerUsers(CoordinatorOrSelf, DetailView):
     model = Partner
     template_name_suffix = '_users'
 

--- a/TWLight/users/templatetags/twlight_perms.py
+++ b/TWLight/users/templatetags/twlight_perms.py
@@ -12,6 +12,13 @@ def coordinators_only(user):
             user.is_superuser)
 
 @register.filter
+def partner_coordinator_only(user):
+    """Return True if user is the coordinator for a partner"""
+    coordinators = get_coordinators()
+    return (coordinators in user.groups.all() or
+            user.is_superuser)
+
+@register.filter
 def restricted(user):
     """Return True if user is in the restricted group, else False"""
     restricted = get_restricted()

--- a/TWLight/users/templatetags/twlight_perms.py
+++ b/TWLight/users/templatetags/twlight_perms.py
@@ -12,13 +12,6 @@ def coordinators_only(user):
             user.is_superuser)
 
 @register.filter
-def partner_coordinator_only(user):
-    """Return True if user is the coordinator for a partner"""
-    coordinators = get_coordinators()
-    return (coordinators in user.groups.all() or
-            user.is_superuser)
-
-@register.filter
 def restricted(user):
     """Return True if user is in the restricted group, else False"""
     restricted = get_restricted()

--- a/TWLight/view_mixins.py
+++ b/TWLight/view_mixins.py
@@ -27,7 +27,6 @@ logger = logging.getLogger(__name__)
 
 coordinators = get_coordinators()
 
-
 class CoordinatorOrSelf(object):
     """
     Restricts visibility to:
@@ -75,6 +74,10 @@ class CoordinatorOrSelf(object):
                             obj_coordinator_test = (
                                 obj.partner.coordinator.pk == user.pk
                             )
+                        elif isinstance(obj, Partner):
+                            obj_coordinator_test = (
+                                obj.coordinator.pk == user.pk
+                            )
             except AttributeError:
                 # Keep the default.
                 pass
@@ -115,46 +118,6 @@ class CoordinatorsOnly(object):
             raise PermissionDenied
 
         return super(CoordinatorsOnly, self).dispatch(
-            request, *args, **kwargs)
-
-
-
-class PartnerCoordinatorOnly(object):
-    """
-    Restricts visibility to:
-    * Coordinators for the partner denoted by object; or
-    * Superusers.
-    """
-
-    def test_func_partner_coordinator(self, user):
-        obj_coordinator_test = False # Set default.
-
-        # If the user is a coordinator run more tests
-        if user in coordinators.user_set.all():
-            try:
-                obj = self.get_object()
-                if obj:
-                    # Return true if the object is a partner for whom
-                    # the user is a designated coordinator
-                    if isinstance(obj, Partner):
-                        obj_coordinator_test = (
-                            obj.coordinator.pk == user.pk
-                        )
-            except AttributeError as e:
-                # Keep the default.
-                pass
-
-        return (user.is_superuser or
-                obj_coordinator_test)
-
-
-    def dispatch(self, request, *args, **kwargs):
-        if not self.test_func_partner_coordinator(request.user):
-            messages.add_message(request, messages.WARNING, 'You must be the '
-                    'designated coordinator to do that.')
-            raise PermissionDenied
-
-        return super(PartnerCoordinatorOnly, self).dispatch(
             request, *args, **kwargs)
 
 


### PR DESCRIPTION
I know we'd talked about using a reporting tool, but not sure how far that progressed, so put something simple together!