### PR TITLE
Fix potential bug with counting unique approved or sent

### DIFF
--- a/TWLight/resources/views.py
+++ b/TWLight/resources/views.py
@@ -74,7 +74,7 @@ class PartnersDetailView(DetailView):
 
         context['unique_users_approved_or_sent'] = User.objects.filter(
             editor__applications__partner=partner,
-            editor__applications__status=(Application.APPROVED, Application.SENT)).distinct().count()
+            editor__applications__status__in=(Application.APPROVED, Application.SENT)).distinct().count()
 
         application_end_states = [Application.APPROVED, Application.NOT_APPROVED, Application.SENT]
         partner_app_time = Application.objects.filter(

--- a/TWLight/resources/views.py
+++ b/TWLight/resources/views.py
@@ -72,7 +72,9 @@ class PartnersDetailView(DetailView):
             editor__applications__partner=partner,
             editor__applications__status=Application.SENT).distinct().count()
 
-        context['unique_users_approved_or_sent'] = context['unique_users_approved'] + context['unique_users_sent']
+        context['unique_users_approved_or_sent'] = User.objects.filter(
+            editor__applications__partner=partner,
+            editor__applications__status=(Application.APPROVED, Application.SENT)).distinct().count()
 
         application_end_states = [Application.APPROVED, Application.NOT_APPROVED, Application.SENT]
         partner_app_time = Application.objects.filter(


### PR DESCRIPTION
If the same user had both an Approved and Sent application (for different streams), they'd be counted twice until the Approved app was marked Sent.