### PR TITLE
General pass on translation comments and translation tagging

### DIFF
--- a/TWLight/applications/forms.py
+++ b/TWLight/applications/forms.py
@@ -189,7 +189,7 @@ class BaseApplicationForm(forms.Form):
         self._validate_user_data(user_data)
 
         if user_data:
-            # Translators: This labels a section of a form where we ask users to enter info (like country of residence) when applying for resource access.
+            # Translators: This labels a section of a form where we ask users to enter personal information (such as their country of residence) when making an application.
             user_data_layout = Fieldset(_('About you'))
             for datum in user_data:
                 self.fields[datum] = FIELD_TYPES[datum]
@@ -197,8 +197,9 @@ class BaseApplicationForm(forms.Form):
                 # Show which partner wants which personal data if applying
                 # for more than one.
                 if len(self.field_params) > 1:
-                    self.fields[datum].help_text = "Requested by: {partner_list}".format(
-                        partner_list= ", ".join(user_data[datum]))
+                    # Translators: This text is shown in the application form under each piece of personal information requested. {partner_list} will be a list of 2 or more organisations that require this personal data, and should not be translated.
+                    self.fields[datum].help_text = _("Requested by: {partner_list}".format(
+                        partner_list= ", ".join(user_data[datum])))
                 user_data_layout.append(datum)
 
             self.helper.layout.append(user_data_layout)
@@ -213,7 +214,7 @@ class BaseApplicationForm(forms.Form):
         partner_data = self.field_params[partner]
         partner_object = self._get_partner_object(partner)
         partner_layout = Fieldset(
-            # Translators: This goes into a form legend that acts as the title of a form or fieldset for a partner application. It lets the user know which partner application they are entering data for.
+            # Translators: This is the title of the application form page, where users enter information required for the application. It lets the user know which partner application they are entering data for. {partner}
             _('Your application to {partner}').format(partner=partner_object))
 
         self._validate_partner_data(partner_data)
@@ -249,7 +250,8 @@ class BaseApplicationForm(forms.Form):
                 if datum == ACCOUNT_EMAIL:
                     # If partner requires pre-registration, make sure users
                     # get a link where they can sign up.
-                    help_text = ('You must register at <a href="{url}">{url}</a> '
+                    # Translators: For some applications, users must register at another website before finishing the application form, and must then enter their email address used when registering.
+                    help_text = _('You must register at <a href="{url}">{url}</a> '
                                  'before applying.').format(
                                     url=partner_object.registration_url)
                     self.fields[field_name].help_text = help_text

--- a/TWLight/applications/models.py
+++ b/TWLight/applications/models.py
@@ -38,7 +38,7 @@ class Application(models.Model):
         (QUESTION, _('Under discussion')),
         # Translators: This is the status of an application which has been approved by a reviewer.
         (APPROVED, _('Approved')),
-        # Translators: This is the status of an application which has been denied by a reviewer.
+        # Translators: This is the status of an application which has been declined by a reviewer.
         (NOT_APPROVED, _('Not approved')),
         # Translators: This is the status of an application that has been sent to a partner.
         (SENT, _('Sent to partner')),
@@ -56,7 +56,7 @@ class Application(models.Model):
     # Will be set on save() if status changes from PENDING/QUESTION to
     # APPROVED/NOT APPROVED.
     date_closed = models.DateField(blank=True, null=True,
-        # Translators: Shown in the administrator interface for editing applications directly. Admins should rarely ever have to change this number.
+        # Translators: Shown in the administrator interface for editing applications directly. Site administrators should rarely, if ever, have to change this number.
         help_text=_('Please do not override this field! Its value is set '
                   'automatically.'))
 

--- a/TWLight/applications/templates/applications/application_evaluation.html
+++ b/TWLight/applications/templates/applications/application_evaluation.html
@@ -119,7 +119,7 @@
       {% if object.parent %}
         {% with object.parent.get_absolute_url as parent_url %}
           {% comment %}Translators: This message is shown next to the 'Renewal of existing access grant?' label if the application is a renewal. Don't translate HTML tags or {{ parent_url }}.{% endcomment %}
-          {% blocktrans %}
+          {% blocktrans trimmed %}
             Yes (<a href="{{ parent_url }}">previous application</a>)
           {% endblocktrans %}
         {% endwith %}

--- a/TWLight/resources/models.py
+++ b/TWLight/resources/models.py
@@ -175,7 +175,7 @@ class Partner(models.Model):
     status = models.IntegerField(choices=STATUS_CHOICES,
         default=NOT_AVAILABLE,
         # Translators: In the administrator interface, this text is help text for a field where staff can specify whether this partner should be displayed to users.
-        help_text=_('Should this Partner be displayed to end users? Is it '
+        help_text=_('Should this Partner be displayed to users? Is it '
                     'open for applications right now?'))
 
     renewals_available = models.BooleanField(default=False,
@@ -196,6 +196,7 @@ class Partner(models.Model):
         help_text=_("Optional description of this partner's resources."))
 
     send_instructions = models.TextField(blank=True, null=True,
+        # Translators: In the administrator interface, this text is help text for a field where staff can provide instructions to coordinators on sending user data to partners.
         help_text=_("Optional instructions for sending application data to "
             "this partner."))
 
@@ -263,7 +264,7 @@ class Partner(models.Model):
         help_text=_("Mark as true if this partner requires applicants to agree "
                     "with the partner's terms of use."))
     account_email = models.BooleanField(default=False,
-        # Translators: TODO
+        # Translators: In the administrator interface, this text is help text for a check box where staff can select whether users must first register at the organisation's website before finishing their application.
         help_text=_("Mark as true if this partner requires applicants to have "
                     "already signed up at the partner website."))
 

--- a/TWLight/resources/templates/resources/partner_detail.html
+++ b/TWLight/resources/templates/resources/partner_detail.html
@@ -234,7 +234,7 @@
               {% if object.agreement_with_terms_of_use %}
                 <li>
                   {% comment %} Translators: If a user must agree to a Terms of Use document, they see this message, and must enter the name of the resource. Don't translate {{ publisher }} or {{ url }}. {% endcomment %}
-                  {% blocktrans with publisher=object.company_name url=object.terms_of_use %}
+                  {% blocktrans trimmed with publisher=object.company_name url=object.terms_of_use %}
                     {{ publisher }} requires that you agree with its <a href="{{ url }}">terms
                     of use</a>.
                   {% endblocktrans %}
@@ -244,7 +244,7 @@
               {% if object.real_name %}
                 <li>
                   {% comment %} Translators: If a user must provide their real name to apply to a partner, they see this message, and must enter the name of the resource. Don't translate {{ publisher }}. {% endcomment %}
-                  {% blocktrans with publisher=object.company_name %}
+                  {% blocktrans trimmed with publisher=object.company_name %}
                     {{ publisher }} requires that you provide your real name.
                   {% endblocktrans %}
                 </li>
@@ -253,7 +253,7 @@
               {% if object.country_of_residence %}
                 <li>
                   {% comment %} Translators: If a user must provide the name of the country where they currently live to apply to a partner, they see this message, and must enter the name of the resource. Don't translate {{ publisher }}. {% endcomment %}
-                  {% blocktrans with publisher=object.company_name %}
+                  {% blocktrans trimmed with publisher=object.company_name %}
                     {{ publisher }} requires that you provide your country of residence.
                   {% endblocktrans %}
                 </li>
@@ -262,7 +262,7 @@
               {% if object.occupation %}
                 <li>
                   {% comment %} Translators: If a user must provide their occupation to apply to a partner, they see this message, and must enter the name of the resource. Don't translate {{ publisher }}. {% endcomment %}
-                  {% blocktrans with publisher=object.company_name %}
+                  {% blocktrans trimmed with publisher=object.company_name %}
                     {{ publisher }} requires that you provide your occupation.
                   {% endblocktrans %}
                 </li>
@@ -271,7 +271,7 @@
               {% if object.affiliation %}
                 <li>
                   {% comment %} Translators: If a user must provide their institutional affiliation (e.g. university) to apply to a partner, they see this message, and must enter the name of the resource. Don't translate {{ publisher }}. {% endcomment %}
-                  {% blocktrans with publisher=object.company_name %}
+                  {% blocktrans trimmed with publisher=object.company_name %}
                     {{ publisher }} requires that you provide your institutional affiliation.
                   {% endblocktrans %}
                 </li>
@@ -280,7 +280,7 @@
               {% if object.specific_title %}
                 <li>
                   {% comment %} Translators: If a user must select a specific resource to apply for, they see this message, and must enter the name of the resource. Don't translate {{ publisher }}. {% endcomment %}
-                  {% blocktrans with publisher=object.company_name %}
+                  {% blocktrans trimmed with publisher=object.company_name %}
                     {{ publisher }} requires that you specify a particular title that you want
                     to access.
                   {% endblocktrans %}
@@ -291,14 +291,14 @@
                 <li>
                   {% if object.mutually_exclusive %}
                     {% comment %} Translators: If a user must select a specific collection of resources to apply for, they see this message. Don't translate {{ publisher }}. {% endcomment %}
-                    {% blocktrans with publisher=object.company_name %}
+                    {% blocktrans trimmed with publisher=object.company_name %}
                       {{ publisher }} requires that you specify a specific collection that you
                       want to access. You may only apply for access to one collection at a
                       time.
                     {% endblocktrans %}
                   {% else %}
                     {% comment %} Translators: If a user must select one or more collections of resources to apply for, they see this message. Don't translate {{ publisher }}. {% endcomment %}
-                    {% blocktrans with publisher=object.company_name %}
+                    {% blocktrans trimmed with publisher=object.company_name %}
                       {{ publisher }} requires that you specify one or more specific
                       collections that you want to access.
                     {% endblocktrans %}
@@ -309,7 +309,7 @@
               {% if object.account_email %}
                 <li>
                   {% comment %} Translators: If a user must register on the partner website before applying, they see this message. Don't translate {{ partner }}. {% endcomment %}
-                  {% blocktrans with publisher=object.company_name %}
+                  {% blocktrans trimmed with publisher=object.company_name %}
                     {{ publisher }} requires that you sign up for an account before applying
                     for access.
                   {% endblocktrans %}

--- a/TWLight/resources/templates/resources/partner_users.html
+++ b/TWLight/resources/templates/resources/partner_users.html
@@ -2,10 +2,10 @@
 {% load i18n %}
 
 {% block content %}
-  {% comment %} Translators: This is the heading of a page listing editors who have applications for this partner ({{ object }}). {% endcomment %}
+  {% comment %} Translators: This is the heading of a page listing editors who have applications for this partner. Don't translate {{ partner }}. {% endcomment %}
   <h1>
-  {% blocktrans with partner=object.company_name %}
-  {{ object }} approved users
+  {% blocktrans trimmed with partner=object.company_name %}
+  {{ partner }} approved users
   {% endblocktrans %}
   </h1>
 

--- a/TWLight/resources/translation.py
+++ b/TWLight/resources/translation.py
@@ -19,7 +19,7 @@ class MultilingualTagTO(TranslationOptions):
     # This setting lets name be nullable in the database. This is important
     # because unique=True for name, and an empty CharField is normally not
     # nullable so it is stored as ''; this means two empty CharFields violate
-    # the uniqueness constraint, which means if we try to save more than on
+    # the uniqueness constraint, which means if we try to save more than one
     # tag without full translations we will be sad.
     empty_values = {'name': None}
 

--- a/TWLight/resources/views.py
+++ b/TWLight/resources/views.py
@@ -46,7 +46,7 @@ class PartnersDetailView(DetailView):
             assert self.request.user.is_staff
             # Translators: Staff members can view partner pages which are hidden from other users. This message appears on those specific partner resource pages.
             messages.add_message(self.request, messages.WARNING,
-                _("This Partner is not available. You can see it because you "
+                _("This partner is not available. You can see it because you "
                     "are a staff member, but it is not visible to non-staff "
                     "users."))
 

--- a/TWLight/templates/base.html
+++ b/TWLight/templates/base.html
@@ -72,12 +72,12 @@
           {% url 'users:home' as home_url %}
             {% if user.editor %}
               {% comment %} Translators: Shown on the left in the top bar of almost every page when the current user is logged in. Don't translate {{ home_url }} or {{ username }}. {% endcomment %}
-              {% blocktrans with username=user.editor.wp_username%}
+              {% blocktrans trimmed with username=user.editor.wp_username%}
                 Hi, <a href="{{ home_url }}">{{ username }}</a>!
               {% endblocktrans %}
             {% else %}
               {% comment %} Translators: Shown on the left in the top bar of almost every page when the current user is logged in. Don't translate {{ home_url }} or {{ username }}. {% endcomment %}
-              {% blocktrans with username=user.username %}
+              {% blocktrans trimmed with username=user.username %}
                 Hi, <a href="{{ home_url }}">{{ username }}</a>!
               {% endblocktrans %}            
             {% endif %}

--- a/TWLight/users/templates/users/editor_detail.html
+++ b/TWLight/users/templates/users/editor_detail.html
@@ -32,7 +32,7 @@
 
   <p>
     {% comment %} Translators: This is shown on editor profiles, in their profile page or on applications. {% endcomment %}
-    {% blocktrans %}
+    {% blocktrans trimmed %}
       Information with an * was retrieved from Wikipedia directly.
       Other information was entered directly by users or site admins,
       in their preferred language.
@@ -44,7 +44,7 @@
       <div class="col-xs-12 col-md-10 col-md-offset-1">
         <p class="well">
             {% comment %} Translators: This distinguishes users who have been flagged as account coordinators. Don't translate {{ username }}. {% endcomment %}
-            {% blocktrans with username=editor.wp_username %}
+            {% blocktrans trimmed with username=editor.wp_username %}
               {{ username }} has coordinator privileges on this site.
             {% endblocktrans %}
         </p>

--- a/TWLight/users/templates/users/user_detail.html
+++ b/TWLight/users/templates/users/user_detail.html
@@ -6,7 +6,7 @@
     {% comment %}
       Translators: this should show up for people who log in with a username/password and not OAuth, so we don't know what their Wikipedia identity is.
     {% endcomment %}
-    {% blocktrans with username=user.username %}
+    {% blocktrans trimmed with username=user.username %}
       Hi, {{ username }}! You don't have a Wikipedia editor profile attached
       to your account here, so you are probably a site administrator.
     {% endblocktrans %}

--- a/TWLight/users/views.py
+++ b/TWLight/users/views.py
@@ -255,7 +255,7 @@ class PIIUpdateView(SelfOnly, UpdateView):
         form.helper.add_input(Submit(
             'submit',
             # Translators: This is the button users click to confirm changes to their personal information.
-            _('Update information'),
+            _('Update'),
             css_class='center-block'))
 
         return form
@@ -302,6 +302,7 @@ class EmailChangeView(SelfOnly, FormView):
             assert self.request.user.is_authenticated()
         except AssertionError:
             messages.add_message (request, messages.WARNING,
+                # Translators: If a user tries to do something (such as updating their email) when not logged in, this message is presented.
                 _('You must be logged in to do that.'))
             raise PermissionDenied
 


### PR DESCRIPTION
Per comments at https://phabricator.wikimedia.org/T162479.

- Added missing translation comments for some strings 
- Converted all `blocktrans` to `blocktrans trimmed` where that was causing formatting issues in the .po files
- In a handful of places I reworded strings or translation comments, but this still needs a more detailed pass.