### PR TITLE
Added some missing translation comments and improved behaviour of partner detail contextual button

### DIFF
--- a/TWLight/resources/templates/resources/partner_detail.html
+++ b/TWLight/resources/templates/resources/partner_detail.html
@@ -27,6 +27,7 @@
     {% url 'applications:apply_single' object.pk as app_url %}
     {% if object.is_waitlisted %}
     <div class="alert alert-warning visible-xs resource-label-warning">
+       {% comment %} Translators: This text labels partners who have no available accounts remaining and therefore have a waitlist for access {% endcomment %}
        <span class="resource-label">{% trans "Waitlisted" %}</span>
        <p>
        {% comment %} Translators: If we have no available accounts for a partner, the coordinator can change the application system to a waiting list. {% endcomment %}
@@ -39,21 +40,28 @@
     </div>
     {% endif %}
     {% if user_sent_apps %}
+      {% if object.renewals_available %}
         {% if user|restricted %}
+          {% comment %} Translators: This text labels a button which users can click to renew a previously approved application. {% endcomment %}
           <button type="button" class="btn btn-primary text-center visible-xs z-index-100 disabled">{% trans "Renew" %}</button><br />
         {% else %}
           <a href="{% url 'applications:renew' latest_sent_app_pk %}" class="btn btn-primary text-center visible-xs z-index-100">{% trans "Renew" %}</a>
         {% endif %}
+      {% endif %}
     {% elif user_open_apps %}
         {% if multiple_open_apps %}
+            {% comment %} Translators: This text labels a button which users can click to view previously submitted applications. {% endcomment %}
             <a href="{% url 'users:home' %}" class="btn btn-primary text-center visible-xs z-index-100">{% trans "View applications" %}</a>
         {% else %}
+            {% comment %} Translators: This text labels a button which users can click to view a previously submitted application. {% endcomment %}
             <a href="{% url 'applications:evaluate' open_app_pk %}" class="btn btn-primary text-center visible-xs z-index-100">{% trans "View application" %}</a>
         {% endif %}
     {% else %}
         {% if user|restricted %}
+          {% comment %} Translators: This text labels a button which users can click to submit an application. {% endcomment %}
           <button type="button" class="btn btn-primary text-center visible-xs z-index-100 disabled btn-block">{% trans "Apply" %}</button><br />
         {% else %}
+          {% comment %} Translators: This text labels a button which users can click to submit an application. {% endcomment %}
           <a href="{{ app_url }}" class="btn btn-primary text-center visible-xs z-index-100">{% trans "Apply" %}</a><br />
         {% endif %}
     {% endif %}
@@ -89,10 +97,12 @@
     </div>
     {% endif %}
     {% if user_sent_apps %}
-      {% if user|restricted %}
-        <button type="button" class="btn btn-primary btn-lg hidden-xs btn-block disabled">{% trans "Renew" %}</button><br />
-      {% else %}
-        <a href="{% url 'applications:renew' latest_sent_app_pk %}" class="btn btn-primary btn-lg hidden-xs btn-block">{% trans "Renew" %}</a>
+      {% if object.renewals_available %}
+        {% if user|restricted %}
+          <button type="button" class="btn btn-primary btn-lg hidden-xs btn-block disabled">{% trans "Renew" %}</button><br />
+        {% else %}
+          <a href="{% url 'applications:renew' latest_sent_app_pk %}" class="btn btn-primary btn-lg hidden-xs btn-block">{% trans "Renew" %}</a>
+        {% endif %}
       {% endif %}
     {% elif user_open_apps %}
     {% if multiple_open_apps %}

--- a/TWLight/resources/views.py
+++ b/TWLight/resources/views.py
@@ -14,6 +14,9 @@ from TWLight.view_mixins import CoordinatorsOnly, CoordinatorOrSelf
 
 from .models import Partner, Stream
 
+import logging
+
+logger = logging.getLogger(__name__)
 
 class PartnersFilterView(FilterView):
     model = Partner
@@ -109,7 +112,7 @@ class PartnersDetailView(DetailView):
                                         editor=self.request.user.editor,
                                         status=Application.SENT,
                                         partner=partner
-                                     ).order_by('date_closed')
+                                     ).order_by('-date_closed')
             open_apps = Application.objects.filter(
                                         editor=self.request.user.editor,
                                         status__in=(Application.PENDING, Application.QUESTION, Application.APPROVED),
@@ -117,16 +120,16 @@ class PartnersDetailView(DetailView):
                                      )
             context['user_sent_apps'] = False
             context['user_open_apps'] = False
-            if sent_apps.count() > 0:
-                context['latest_sent_app_pk'] = sent_apps[0].pk
-                context['user_sent_apps'] = True
-            elif open_apps.count() > 0:
+            if open_apps.count() > 0:
                 context['user_open_apps'] = True
                 if open_apps.count() > 1:
                     context['multiple_open_apps'] = True
                 else:
                     context['multiple_open_apps'] = False
                     context['open_app_pk'] = open_apps[0].pk
+            elif sent_apps.count() > 0:
+                context['latest_sent_app_pk'] = sent_apps[0].pk
+                context['user_sent_apps'] = True
 
         partner_streams = Stream.objects.filter(partner=partner)
         if partner_streams.count() > 0:


### PR DESCRIPTION
This fixes the bug with partner detail picking the wrong account to attempt to renew (it had the order reversed), and the page now prefers to display open applications rather than sent ones.