### PR TITLE
Fixed a couple of bugs with coordinators able to approve and send applications they shouldn't be able to

### DIFF
--- a/TWLight/applications/templates/applications/application_evaluation.html
+++ b/TWLight/applications/templates/applications/application_evaluation.html
@@ -15,7 +15,7 @@
     </div>
   {% endif %}
 
-  {% if user|coordinators_only %}
+  {% if partner_coordinator %}
     <div class="alert alert-info">
       {% comment %} Translators: This message is shown on pages where coordinators can see personal information about applicants. {% endcomment %}
       {% trans 'Coordinators: This page may contain personal information such as real names and email addresses. Please remember that this information is confidential.' %}

--- a/TWLight/applications/views.py
+++ b/TWLight/applications/views.py
@@ -763,6 +763,14 @@ class EvaluateApplicationView(NotDeleted, CoordinatorOrSelf, ToURequired, Update
         context = super(EvaluateApplicationView, self).get_context_data(**kwargs)
         context['editor'] = self.object.editor
         context['versions'] = Version.objects.get_for_object(self.object)
+
+        # Check if the person viewing this application is actually this
+        # partner's coordinator, and not *a* coordinator who happens to
+        # have applied, or a superuser.
+        partner_coordinator = self.request.user == self.object.partner.coordinator
+        superuser = self.request.user.is_superuser
+        context['partner_coordinator'] = partner_coordinator or superuser
+
         return context
 
 

--- a/TWLight/applications/views.py
+++ b/TWLight/applications/views.py
@@ -31,6 +31,7 @@ from django.views.generic.list import ListView
 
 from TWLight.view_mixins import (CoordinatorOrSelf,
                                  CoordinatorsOnly,
+                                 PartnerCoordinatorOnly,
                                  EditorsOnly,
                                  ToURequired,
                                  EmailRequired,
@@ -856,7 +857,7 @@ class ListReadyApplicationsView(CoordinatorsOnly, ListView):
                 )
 
 
-class SendReadyApplicationsView(CoordinatorsOnly, DetailView):
+class SendReadyApplicationsView(PartnerCoordinatorOnly, DetailView):
     model = Partner
     template_name = 'applications/send_partner.html'
 


### PR DESCRIPTION
* Coordinators now can't navigate directly to the send_partner URL for partners they don't coordinate
* Coordinators now can't change the status of their application to partners they don't coordinate
* Added a new test for the former.