### PR TITLE
add translation sync back script for travis.

### DIFF
--- a/.travis/deploy.sh
+++ b/.travis/deploy.sh
@@ -3,11 +3,22 @@
 # Search for missing migrations and count them.
 export TWLIGHT_MISSING_MIGRATIONS=$(git ls-files --others --exclude-standard 'TWLight/*/migrations/*.py' | wc -l)
 
+# Search for new translation files and count them.
+TWLIGHT_TRANSLATION_FILES_ADDED=$(git ls-files --others --exclude-standard 'locale/*/LC_MESSAGES/django.po' | wc -l)
+
+# Search for updated translation files and count them.
+TWLIGHT_TRANSLATION_FILES_UPDATED=$(git diff --name-only -- 'locale/*/LC_MESSAGES/django.po' | wc -l)
+
+# Add new and updated to get change count.
+TWLIGHT_TRANSLATION_FILES_CHANGED=$((TWLIGHT_TRANSLATION_FILES_ADDED+TWLIGHT_TRANSLATION_FILES_UPDATED))
+
+
 # Print Travis environment variables and migration count.
 echo "TRAVIS_PULL_REQUEST: ${TRAVIS_PULL_REQUEST}"
 echo "TRAVIS_TAG: ${TRAVIS_TAG}"
 echo "TRAVIS_BRANCH: ${TRAVIS_BRANCH}"
 echo "TWLIGHT_MISSING_MIGRATIONS: ${TWLIGHT_MISSING_MIGRATIONS}"
+echo "TWLIGHT_TRANSLATION_FILES_CHANGED: ${TWLIGHT_TRANSLATION_FILES_CHANGED}"
 
 # Sync back to master if is build was fired from a push to master and there are missing migrations.
 if [ "${TRAVIS_PULL_REQUEST}" = "false" ] && [ -z "${TRAVIS_TAG}" ] && [ "${TRAVIS_BRANCH}" = "master" ] && [ -n "${gh_bot_username+isset}" ] && [ -n "${gh_bot_token+isset}" ] && [ -n "${TWLIGHT_MISSING_MIGRATIONS+isset}" ] && [ "${TWLIGHT_MISSING_MIGRATIONS}" -gt 0 ]
@@ -15,8 +26,15 @@ then
    TWLIGHT_MISSING_MIGRATIONS=${TWLIGHT_MISSING_MIGRATIONS} .travis/./migrations.sh
 fi
 
-# Deploy to production if is build was fired from a push to master and there are no missing migrations.
-if [ "${TRAVIS_PULL_REQUEST}" = "false" ] && [ -z "${TRAVIS_TAG}" ] && [ "${TRAVIS_BRANCH}" = "master" ] && [ -n "${gh_bot_username+isset}" ] && [ -n "${gh_bot_token+isset}" ] && [ -n "${TWLIGHT_MISSING_MIGRATIONS+isset}" ] && [ "${TWLIGHT_MISSING_MIGRATIONS}" -eq 0 ]
+# Sync back to master if this is build was fired from a push to master and there are changed translations.
+if [ "${TRAVIS_PULL_REQUEST}" = "false" ] && [ -z "${TRAVIS_TAG}" ] && [ "${TRAVIS_BRANCH}" = "master" ] && [ -n "${gh_bot_username+isset}" ] && [ -n "${gh_bot_token+isset}" ] && [ -n "${TWLIGHT_TRANSLATION_FILES_CHANGED+isset}" ] && [ "${TWLIGHT_TRANSLATION_FILES_CHANGED}" -gt 0 ]
 then
-   TWLIGHT_MISSING_MIGRATIONS=${TWLIGHT_MISSING_MIGRATIONS} .travis/./production.sh
+   TWLIGHT_TRANSLATION_FILES_CHANGED=${TWLIGHT_TRANSLATION_FILES_CHANGED} .travis/./translations.sh
+fi
+
+
+# Deploy to production if is build was fired from a push to master and there are no missing migrations or changed translations.
+if [ "${TRAVIS_PULL_REQUEST}" = "false" ] && [ -z "${TRAVIS_TAG}" ] && [ "${TRAVIS_BRANCH}" = "master" ] && [ -n "${gh_bot_username+isset}" ] && [ -n "${gh_bot_token+isset}" ] && [ -n "${TWLIGHT_MISSING_MIGRATIONS+isset}" ] && [ "${TWLIGHT_MISSING_MIGRATIONS}" -eq 0 ] && [ "${TWLIGHT_TRANSLATION_FILES_CHANGED}" -eq 0 ]
+then
+   TWLIGHT_MISSING_MIGRATIONS=${TWLIGHT_MISSING_MIGRATIONS} TWLIGHT_TRANSLATION_FILES_CHANGED=${TWLIGHT_TRANSLATION_FILES_CHANGED} .travis/./production.sh
 fi

--- a/.travis/migrations.sh
+++ b/.travis/migrations.sh
@@ -39,7 +39,7 @@ then
         # https://git-scm.com/docs/merge-strategies#merge-strategies-theirs
         git fetch origin master --quiet
 
-        # We should only be adding missing files, so if their's a conflict, keep the version from the remote.
+        # We should only be adding missing files, so if there is a conflict, keep the version from the remote.
         git merge --strategy recursive -X theirs origin/master --message "Travis build #${TRAVIS_BUILD_NUMBER} merged." --quiet
 
         # Push to remote master branch.

--- a/.travis/production.sh
+++ b/.travis/production.sh
@@ -5,9 +5,10 @@ echo "TRAVIS_PULL_REQUEST: ${TRAVIS_PULL_REQUEST}"
 echo "TRAVIS_TAG: ${TRAVIS_TAG}"
 echo "TRAVIS_BRANCH: ${TRAVIS_BRANCH}"
 echo "TWLIGHT_MISSING_MIGRATIONS: ${TWLIGHT_MISSING_MIGRATIONS}"
+echo "TWLIGHT_TRANSLATION_FILES_CHANGED: ${TWLIGHT_TRANSLATION_FILES_CHANGED}"
 
-# Only act if this is build was fired from a push to master and there are no missing migrations.
-if [ "${TRAVIS_PULL_REQUEST}" = "false" ] && [ -z "${TRAVIS_TAG}" ] && [ "${TRAVIS_BRANCH}" = "master" ] && [ -n "${gh_bot_username+isset}" ] && [ -n "${gh_bot_token+isset}" ] && [ -n "${TWLIGHT_MISSING_MIGRATIONS+isset}" ]  && [ "${TWLIGHT_MISSING_MIGRATIONS}" -eq 0 ]
+# Only act if this is build was fired from a push to master and there are no missing migrations or changed translations.
+if [ "${TRAVIS_PULL_REQUEST}" = "false" ] && [ -z "${TRAVIS_TAG}" ] && [ "${TRAVIS_BRANCH}" = "master" ] && [ -n "${gh_bot_username+isset}" ] && [ -n "${gh_bot_token+isset}" ] && [ -n "${TWLIGHT_MISSING_MIGRATIONS+isset}" ]  && [ "${TWLIGHT_MISSING_MIGRATIONS}" -eq 0 ] && [ "${TWLIGHT_TRANSLATION_FILES_CHANGED}" -eq 0 ]
 then
     # Configure git.
     git_config() {

--- a/.travis/translations.sh
+++ b/.travis/translations.sh
@@ -4,10 +4,10 @@
 echo "TRAVIS_PULL_REQUEST: ${TRAVIS_PULL_REQUEST}"
 echo "TRAVIS_TAG: ${TRAVIS_TAG}"
 echo "TRAVIS_BRANCH: ${TRAVIS_BRANCH}"
-echo "TWLIGHT_CHANGED_TRANSLATIONS: ${TWLIGHT_CHANGED_TRANSLATIONS}"
+echo "TWLIGHT_TRANSLATION_FILES_CHANGED: ${TWLIGHT_TRANSLATION_FILES_CHANGED}"
 
 # Only act if this is build was fired from a push to master and there are changed translations.
-if [ "${TRAVIS_PULL_REQUEST}" = "false" ] && [ -z "${TRAVIS_TAG}" ] && [ "${TRAVIS_BRANCH}" = "master" ] && [ -n "${gh_bot_username+isset}" ] && [ -n "${gh_bot_token+isset}" ] && [ -n "${TWLIGHT_CHANGED_TRANSLATIONS+isset}" ] && [ "${TWLIGHT_CHANGED_TRANSLATIONS}" -gt 0 ]
+if [ "${TRAVIS_PULL_REQUEST}" = "false" ] && [ -z "${TRAVIS_TAG}" ] && [ "${TRAVIS_BRANCH}" = "master" ] && [ -n "${gh_bot_username+isset}" ] && [ -n "${gh_bot_token+isset}" ] && [ -n "${TWLIGHT_TRANSLATION_FILES_CHANGED+isset}" ] && [ "${TWLIGHT_TRANSLATION_FILES_CHANGED}" -gt 0 ]
 then
     # Configure git.
     git_config() {
@@ -21,7 +21,7 @@ then
         # Add our authenticated origin using encrypted travis environment variables.
         git remote add origin https://${gh_bot_username}:${gh_bot_token}@github.com/${TRAVIS_REPO_SLUG}.git > /dev/null 2>&1
     }
-    
+
     # Commit any changes to local master branch.
     git_commit() {
 
@@ -33,7 +33,7 @@ then
         git add 'locale/*/LC_MESSAGES/*.mo'
         git commit --message "Travis build #${TRAVIS_BUILD_NUMBER} translations." || :
     }
-    
+
     # Push to remote master branch.
     git_push() {
         # Fetch and merge before the push.

--- a/.travis/translations.sh
+++ b/.travis/translations.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+
+# Print Travis environment variables and changed translation count.
+echo "TRAVIS_PULL_REQUEST: ${TRAVIS_PULL_REQUEST}"
+echo "TRAVIS_TAG: ${TRAVIS_TAG}"
+echo "TRAVIS_BRANCH: ${TRAVIS_BRANCH}"
+echo "TWLIGHT_CHANGED_TRANSLATIONS: ${TWLIGHT_CHANGED_TRANSLATIONS}"
+
+# Only act if this is build was fired from a push to master and there are changed translations.
+if [ "${TRAVIS_PULL_REQUEST}" = "false" ] && [ -z "${TRAVIS_TAG}" ] && [ "${TRAVIS_BRANCH}" = "master" ] && [ -n "${gh_bot_username+isset}" ] && [ -n "${gh_bot_token+isset}" ] && [ -n "${TWLIGHT_CHANGED_TRANSLATIONS+isset}" ] && [ "${TWLIGHT_CHANGED_TRANSLATIONS}" -gt 0 ]
+then
+    # Configure git.
+    git_config() {
+        # Configure user.
+        git config --global user.email "deploy@travis-ci.org"
+        git config --global user.name "Deployment Bot"
+
+        # Remove the anonymous origin.
+        git remote rm origin
+
+        # Add our authenticated origin using encrypted travis environment variables.
+        git remote add origin https://${gh_bot_username}:${gh_bot_token}@github.com/${TRAVIS_REPO_SLUG}.git > /dev/null 2>&1
+    }
+    
+    # Commit any changes to local master branch.
+    git_commit() {
+
+        # Checkout master branch
+        git checkout master
+
+        # Add and commit.
+        git add 'locale/*/LC_MESSAGES/*.po'
+        git add 'locale/*/LC_MESSAGES/*.mo'
+        git commit --message "Travis build #${TRAVIS_BUILD_NUMBER} translations." || :
+    }
+    
+    # Push to remote master branch.
+    git_push() {
+        # Fetch and merge before the push.
+        # https://git-scm.com/docs/merge-strategies#merge-strategies-ours
+        git fetch origin master --quiet
+
+        # We'll probably be rewriting quite a few files, so if there is a conflict, keep the local version.
+        git merge --strategy recursive -X ours origin/master --message "Travis build #${TRAVIS_BUILD_NUMBER} merged." --quiet
+
+        # Push to remote master branch.
+        git push origin master --quiet
+    }
+
+    git_config
+    git_commit
+    git_push && echo "Translations pushed to master."
+else
+    echo "Doesn't meet conditions for capturing changed translations. Skipping push to master."
+fi


### PR DESCRIPTION
managing translation files in PRs has become a bit of a sticking point since they become stale so quickly and require a full build to regenerate. They also junk up PRs with many huge diffs. I'm going to apply the work I did on syncing back migrations to this problem so that this chore/problem can mostly take care of itself.