### PR TITLE
Add matomo tracking support

### DIFF
--- a/.travis/local_vars.py
+++ b/.travis/local_vars.py
@@ -5,8 +5,6 @@ TWLIGHT_OAUTH_CONSUMER_KEY='null'
 TWLIGHT_OAUTH_CONSUMER_SECRET='null'
 ALLOWED_HOSTS = ['localhost']
 REQUEST_BASE_URL = 'http://localhost/'
-MATOMO_HOSTNAME = None
-MATOMO_SITE_ID = None
 # Ugh. Have to set debug to false to get the storage engine to return URLS with hashes.
 # Travis was returning some interesting errors when this was not happening.
 # https://docs.djangoproject.com/en/1.11/ref/contrib/staticfiles/#manifeststaticfilesstorage

--- a/.travis/local_vars.py
+++ b/.travis/local_vars.py
@@ -5,6 +5,8 @@ TWLIGHT_OAUTH_CONSUMER_KEY='null'
 TWLIGHT_OAUTH_CONSUMER_SECRET='null'
 ALLOWED_HOSTS = ['localhost']
 REQUEST_BASE_URL = 'http://localhost/'
+MATOMO_HOSTNAME = None
+MATOMO_SITE_ID = None
 # Ugh. Have to set debug to false to get the storage engine to return URLS with hashes.
 # Travis was returning some interesting errors when this was not happening.
 # https://docs.djangoproject.com/en/1.11/ref/contrib/staticfiles/#manifeststaticfilesstorage

--- a/TWLight/applications/templates/applications/application_list.html
+++ b/TWLight/applications/templates/applications/application_list.html
@@ -5,12 +5,12 @@
 {% load urlencode %}
 
 
-{% block head_javascript %}
+{% block extra_javascript %}
   <script
     src="https://code.jquery.com/jquery-2.2.4.min.js"
     integrity="sha256-BbhdlvQf/xTY9gja0Dq3HiwQF8LaCRTXxZKRutelT44="
     crossorigin="anonymous"></script>
-{% endblock head_javascript %}
+{% endblock extra_javascript %}
 
 {% block content %}
   <div class="row">

--- a/TWLight/common/templates/matomo.html
+++ b/TWLight/common/templates/matomo.html
@@ -1,0 +1,17 @@
+{% if hostname and id %}
+  <!-- Matomo -->
+  <script type="text/javascript">
+    var _paq = _paq || [];
+    /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
+    _paq.push(['trackPageView']);
+    _paq.push(['enableLinkTracking']);
+    (function() {
+      var u="//{{ hostname }}/";
+      _paq.push(['setTrackerUrl', u+'piwik.php']);
+      _paq.push(['setSiteId', '{{ id }}']);
+      var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
+      g.type='text/javascript'; g.async=true; g.defer=true; g.src=u+'piwik.js'; s.parentNode.insertBefore(g,s);
+    })();
+  </script>
+  <!-- End Matomo Code -->
+{% endif %}

--- a/TWLight/common/templates/matomo.html
+++ b/TWLight/common/templates/matomo.html
@@ -13,5 +13,8 @@
       g.type='text/javascript'; g.async=true; g.defer=true; g.src=u+'piwik.js'; s.parentNode.insertBefore(g,s);
     })();
   </script>
+  <noscript>
+    <p><img src="https://{{ hostname }}/piwik.php?idsite={{ id }}&amp;rec=1" style="border:0;" alt="" /></p>
+  </noscript>
   <!-- End Matomo Code -->
 {% endif %}

--- a/TWLight/common/templates/matomo.html
+++ b/TWLight/common/templates/matomo.html
@@ -6,7 +6,7 @@
     _paq.push(['trackPageView']);
     _paq.push(['enableLinkTracking']);
     (function() {
-      var u="//{{ hostname }}/";
+      var u="https://{{ hostname }}/";
       _paq.push(['setTrackerUrl', u+'piwik.php']);
       _paq.push(['setSiteId', '{{ id }}']);
       var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];

--- a/TWLight/common/templatetags/twlight_matomo.py
+++ b/TWLight/common/templatetags/twlight_matomo.py
@@ -1,0 +1,22 @@
+# -*- coding: utf-8 -*-
+"""Matomo template tag."""
+
+from django import template
+from django.conf import settings
+from django.contrib.sites.shortcuts import get_current_site
+
+
+register = template.Library()
+
+
+@register.inclusion_tag('matomo.html')
+def twlight_matomo_tracking():
+    try:
+        hostname = settings.MATOMO_HOSTNAME
+    except AttributeError:
+        hostname = None
+    try:
+        id = settings.MATOMO_SITE_ID
+    except AttributeError:
+        id = None
+    return {'id': id, 'hostname': hostname}

--- a/TWLight/resources/templates/resources/suggest.html
+++ b/TWLight/resources/templates/resources/suggest.html
@@ -4,12 +4,12 @@
 {% load i18n %}
 {% load twlight_perms %}
 
-{% block head_javascript %}
+{% block extra_javascript %}
  <script
    src="https://code.jquery.com/jquery-2.2.4.min.js"
    integrity="sha256-BbhdlvQf/xTY9gja0Dq3HiwQF8LaCRTXxZKRutelT44="
    crossorigin="anonymous"></script>
-{% endblock head_javascript %}
+{% endblock extra_javascript %}
 
 {% block content %}
     <div class="panel panel-default full-width">

--- a/TWLight/settings/base.py
+++ b/TWLight/settings/base.py
@@ -95,6 +95,7 @@ THIRD_PARTY_APPS = [
 ]
 
 TWLIGHT_APPS = [
+    'TWLight.common',
     'TWLight.i18n',
     'TWLight.users',
     'TWLight.resources',

--- a/TWLight/settings/local.py
+++ b/TWLight/settings/local.py
@@ -21,8 +21,6 @@ try:
                                   ALLOWED_HOSTS,
                                   DEBUG,
                                   REQUEST_BASE_URL,
-                                  MATOMO_SITE_ID,
-                                  MATOMO_HOSTNAME,
     )
 except ImportError:
     # If there's no local_vars file on this system (e.g. because it isn't
@@ -35,6 +33,10 @@ except ImportError:
           'local settings.',
           file=sys.stderr)
     raise
+
+# Local environment doesn't need Matomo.
+MATOMO_HOSTNAME = None
+MATOMO_SITE_ID = None
 
 # Let Django know about external URLs in case they differ from internal
 # Needed to be added for /admin

--- a/TWLight/settings/local.py
+++ b/TWLight/settings/local.py
@@ -20,7 +20,10 @@ try:
                                   MYSQL_PASSWORD,
                                   ALLOWED_HOSTS,
                                   DEBUG,
-                                  REQUEST_BASE_URL)
+                                  REQUEST_BASE_URL,
+                                  MATOMO_SITE_ID,
+                                  MATOMO_HOSTNAME,
+)
 except ImportError:
     # If there's no local_vars file on this system (e.g. because it isn't
     # a local system), this import will fail, which can cause things

--- a/TWLight/settings/local.py
+++ b/TWLight/settings/local.py
@@ -23,7 +23,7 @@ try:
                                   REQUEST_BASE_URL,
                                   MATOMO_SITE_ID,
                                   MATOMO_HOSTNAME,
-)
+    )
 except ImportError:
     # If there's no local_vars file on this system (e.g. because it isn't
     # a local system), this import will fail, which can cause things

--- a/TWLight/settings/production.py
+++ b/TWLight/settings/production.py
@@ -19,7 +19,10 @@ try:
                                   TWLIGHT_OAUTH_CONSUMER_SECRET,
                                   MYSQL_PASSWORD,
                                   ALLOWED_HOSTS,
-                                  REQUEST_BASE_URL)
+                                  REQUEST_BASE_URL,
+                                  MATOMO_SITE_ID,
+                                  MATOMO_HOSTNAME,
+    )
 except ImportError:
     # If there's no production_vars file on this system (e.g. because it isn't
     # a production system), this import will fail, which can cause things

--- a/TWLight/settings/production.py
+++ b/TWLight/settings/production.py
@@ -20,8 +20,6 @@ try:
                                   MYSQL_PASSWORD,
                                   ALLOWED_HOSTS,
                                   REQUEST_BASE_URL,
-                                  MATOMO_SITE_ID,
-                                  MATOMO_HOSTNAME,
     )
 except ImportError:
     # If there's no production_vars file on this system (e.g. because it isn't
@@ -34,6 +32,10 @@ except ImportError:
           'production settings.',
           file=sys.stderr)
     raise
+
+# Matomo configuration for Production.
+MATOMO_HOSTNAME = 'wikipedialibrarytracker.wmflabs.org'
+MATOMO_SITE_ID = 2
 
 # Let Django know about external URLs in case they differ from internal
 # Needed to be added for /admin

--- a/TWLight/settings/staging.py
+++ b/TWLight/settings/staging.py
@@ -21,8 +21,6 @@ try:
                                   ALLOWED_HOSTS,
                                   DEBUG,
                                   REQUEST_BASE_URL,
-                                  MATOMO_SITE_ID,
-                                  MATOMO_HOSTNAME,
     )
 except ImportError:
     # If there's no staging_vars file on this system (e.g. because it isn't
@@ -35,6 +33,10 @@ except ImportError:
           'staging settings.',
           file=sys.stderr)
     raise
+
+# Matomo configuration for staging.
+MATOMO_HOSTNAME = 'wikipedialibrarytracker.wmflabs.org'
+MATOMO_SITE_ID = 1
 
 # Let Django know about external URLs in case they differ from internal
 # Needed to be added for /admin

--- a/TWLight/settings/staging.py
+++ b/TWLight/settings/staging.py
@@ -20,7 +20,10 @@ try:
                                   MYSQL_PASSWORD,
                                   ALLOWED_HOSTS,
                                   DEBUG,
-                                  REQUEST_BASE_URL)
+                                  REQUEST_BASE_URL,
+                                  MATOMO_SITE_ID,
+                                  MATOMO_HOSTNAME,
+    )
 except ImportError:
     # If there's no staging_vars file on this system (e.g. because it isn't
     # a staging system), this import will fail, which can cause things

--- a/TWLight/templates/base.html
+++ b/TWLight/templates/base.html
@@ -1,6 +1,7 @@
 {% load i18n %}
 {% load staticfiles %}
 {% load twlight_perms %}
+{% load twlight_matomo %}
 
 <!DOCTYPE html>
 <html lang="en">
@@ -39,9 +40,10 @@
   {% block extra_css %}    
   {% endblock extra_css %}
 
-  {% block head_javascript %}
-    {# We don't use any JS by default; individual pages that need it can add it here. #}
-  {% endblock head_javascript %}
+  {% twlight_matomo_tracking %}
+
+  {% block extra_javascript %}
+  {% endblock extra_javascript %}
 </head>
 {% if LANGUAGE_BIDI %}
   <body dir="rtl">


### PR DESCRIPTION
Should be good to go, but we can't merge it in quite yet. Requires a small update to [twlight_puppet](https://github.com/wikipedialibrary/twlight_puppet) so that we're setting values for matomo in the environment_vars.py files.