### PR TITLE
Fix some example data applications being in the future

### DIFF
--- a/TWLight/applications/management/commands/applications_example_data.py
+++ b/TWLight/applications/management/commands/applications_example_data.py
@@ -73,9 +73,14 @@ class Command(BaseCommand):
             # For closed applications, assign date_closed and date_open
             if app.status in Application.FINAL_STATUS_LIST:
                 if not imported:
+                    potential_end_date = app.date_created + relativedelta(years=1)
+                    if potential_end_date > datetime.datetime.now():
+                        end_date = "now"
+                    else:
+                        end_date = potential_end_date
                     app.date_closed = fake.date_time_between(
                         start_date = app.date_created,
-                        end_date = app.date_created + relativedelta(years=1),
+                        end_date = end_date,
                         tzinfo=None)
                     app.days_open = (app.date_closed - app.date_created).days
 


### PR DESCRIPTION
For application date closed we were naively adding one year to the application date, forgetting that that could land it in the future.

If the application was made more recently than a year ago, set today as the upper limit instead.