### PR TITLE
Add missing URL tags to email html

### DIFF
--- a/TWLight/emails/templates/emails/comment_notification_coordinator-body-html.html
+++ b/TWLight/emails/templates/emails/comment_notification_coordinator-body-html.html
@@ -4,7 +4,7 @@
 {% comment %} Translators: This email is sent to coordinators when a comment is left on an application they are processing. Don't translate Jinja variables in curly braces like {{ user }} or {{ partner }}. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).{% endcomment %}
 {% blocktrans trimmed  %}
   <p>Dear {{ user }},</p>
-  <p>Thank you for coordinating {{ partner }} resources through The Wikipedia Library. There are one or more comments on an application that require a response from you. Please reply to these at: {{ app_url }}</p>
+  <p>Thank you for coordinating {{ partner }} resources through The Wikipedia Library. There are one or more comments on an application that require a response from you. Please reply to these at: <a href="{{ app_url }}">{{ app_url }}</a></p>
   <p>Best,</p>
   <p>The Wikipedia Library</p>
 {% endblocktrans %}

--- a/TWLight/emails/templates/emails/comment_notification_editors-body-html.html
+++ b/TWLight/emails/templates/emails/comment_notification_editors-body-html.html
@@ -4,7 +4,7 @@
 {% comment %} Translators: This email is sent to users when they receive a comment on their application. Don't translate Jinja variables in curly braces like {{ user }} or {{ partner }}; don't translate html tags either. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).{% endcomment %}
 {% blocktrans trimmed  %}
   <p>Dear {{ user }},</p>
-  <p>Thank you for applying for access to {{ partner }} resources through The Wikipedia Library. There are one or more comments on your application that require a response from you. Please reply to these at {{ app_url }} so we can evaluate your application.</p>
+  <p>Thank you for applying for access to {{ partner }} resources through The Wikipedia Library. There are one or more comments on your application that require a response from you. Please reply to these at <a href="{{ app_url }}">{{ app_url }}</a> so we can evaluate your application.</p>
   <p>Best,</p>
   <p>The Wikipedia Library</p>
 {% endblocktrans %}


### PR DESCRIPTION
A couple of our email HTML files didn't have app_url wrapped in <a> tags so they weren't rendering as links when received.