### PR TITLE
Streamline dependencies and update those used by mwoauth

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -16,7 +16,7 @@ docutils==0.14
 factory_boy>=2.10.0,<3.0
 futures==3.2.0
 mock==2.0.0
-mwoauth==git+https://github.com/WikipediaLibrary/python-mwoauth.git@update-dependencies
+git+https://github.com/WikipediaLibrary/python-mwoauth.git@update-dependencies
 pillow==5.4.1
 pypandoc==1.4
 python-dateutil==2.7.5

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -16,14 +16,10 @@ docutils==0.14
 factory_boy>=2.10.0,<3.0
 futures==3.2.0
 mock==2.0.0
-mwoauth==0.3.2
-oauthlib==2.1.0
+mwoauth==git+https://github.com/WikipediaLibrary/python-mwoauth.git@update-dependencies
 pillow==5.4.1
 pypandoc==1.4
 python-dateutil==2.7.5
-PyJWT==1.7.1
 pytz==2018.9
-requests==2.21.0
-requests-oauthlib==1.0.0
 six==1.12.0
 wheel==0.32.3


### PR DESCRIPTION
During the last round of dependabot PRs, I took a look at our dependency graph and realized that we weren't handling oauth dependencies correctly. This PR fixes that by moving to a mwoauth fork with updated dependencies and pulling them out of TWLight's requirements.txt.