### PR TITLE
Don't show negative numbers for accounts available (T211022)

### DIFF
--- a/TWLight/resources/templates/resources/partner_detail.html
+++ b/TWLight/resources/templates/resources/partner_detail.html
@@ -535,29 +535,33 @@
     </h3>
     <ul>
       {% for stream_name, total_accounts in total_accounts_available_stream.items %}
-        <li>{{ stream_name }}: {% if total_accounts < 0 %}
-                                  0
-                                  {% if user|coordinators_only %}
-                                    {% comment %} Translators: This help text is visible to coordinators and superusers when a negative accounts available number is displayed. {% endcomment %}
-                                    <span title="{% trans "Actual negative number visible to coordinators and superusers only" %}">({{ total_accounts }})</span>
-                                  {% endif %}
-                               {% else %}
-                                  {{ total_accounts }}
-                               {% endif %}</li>
+        <li>
+          {{ stream_name }}:
+          {% if total_accounts < 0 %}
+              0
+            {% if user|coordinators_only %}
+              {% comment %} Translators: This help text is visible to coordinators and superusers when a negative accounts available number is displayed. {% endcomment %}
+              <span title="{% trans "Actual negative number visible to coordinators and superusers only" %}">({{ total_accounts }})</span>
+            {% endif %}
+          {% else %}
+            {{ total_accounts }}
+          {% endif %}
+        </li>
       {% endfor %}
     </ul>
   {% elif object.accounts_available %}
     <h3>
       {% comment %} Translators: This is the label which shows the number of accounts available for the particular partner. (e.g. https://wikipedialibrary.wmflabs.org/partners/8/). {% endcomment %}
-      {% trans "Accounts available:" %} {% if total_accounts_available_partner < 0 %}
-                            0
-                              {% if user|coordinators_only %}
-                                {% comment %} Translators: This help text is visible to coordinators and superusers when a negative accounts available number is displayed. {% endcomment %}
-                                <span title="{% trans "Actual negative number visible to coordinators and superusers only" %}">({{ total_accounts_available_partner }})</span>
-                              {% endif %}
-                           {% else %}
-                              {{ total_accounts_available_partner }}
-                           {% endif %}
+      {% trans "Accounts available:" %}
+      {% if total_accounts_available_partner < 0 %}
+        0
+        {% if user|coordinators_only %}
+          {% comment %} Translators: This help text is visible to coordinators and superusers when a negative accounts available number is displayed. {% endcomment %}
+          <span title="{% trans "Actual negative number visible to coordinators and superusers only" %}">({{ total_accounts_available_partner }})</span>
+        {% endif %}
+      {% else %}
+          {{ total_accounts_available_partner }}
+      {% endif %}
     </h3>
   {% endif %}
   

--- a/TWLight/resources/templates/resources/partner_detail.html
+++ b/TWLight/resources/templates/resources/partner_detail.html
@@ -535,15 +535,29 @@
     </h3>
     <ul>
       {% for stream_name, total_accounts in total_accounts_available_stream.items %}
-        <li>{{ stream_name }}: {{ total_accounts }}</li>
+        <li>{{ stream_name }}: {% if total_accounts < 0 %}
+                                  0
+                                  {% if user|coordinators_only %}
+                                    {% comment %} Translators: This help text is visible to coordinators and superusers when a negative accounts available number is displayed. {% endcomment %}
+                                    <span title="{% trans "Actual negative number visible to coordinators and superusers only" %}">({{ total_accounts }})</span>
+                                  {% endif %}
+                               {% else %}
+                                  {{ total_accounts }}
+                               {% endif %}</li>
       {% endfor %}
     </ul>
   {% elif object.accounts_available %}
     <h3>
-      {% comment %} Translators: This is the label and the number which shows the number of accounts available for the particular partner. (e.g. https://wikipedialibrary.wmflabs.org/partners/8/). Don't translate {{ accounts_available }}. {% endcomment %}
-      {% blocktrans trimmed %}
-        Accounts available: {{ total_accounts_available_partner }}
-      {% endblocktrans %}
+      {% comment %} Translators: This is the label which shows the number of accounts available for the particular partner. (e.g. https://wikipedialibrary.wmflabs.org/partners/8/). Don't translate {{ accounts_available }}. {% endcomment %}
+      {% trans "Accounts available:" %} {% if total_accounts_available_partner < 0 %}
+                            0
+                              {% if user|coordinators_only %}
+                                {% comment %} Translators: This help text is visible to coordinators and superusers when a negative accounts available number is displayed. {% endcomment %}
+                                <span title="{% trans "Actual negative number visible to coordinators and superusers only" %}">({{ total_accounts_available_partner }})</span>
+                              {% endif %}
+                           {% else %}
+                              {{ total_accounts_available_partner }}
+                           {% endif %}
     </h3>
   {% endif %}
   

--- a/TWLight/resources/templates/resources/partner_detail.html
+++ b/TWLight/resources/templates/resources/partner_detail.html
@@ -548,7 +548,7 @@
     </ul>
   {% elif object.accounts_available %}
     <h3>
-      {% comment %} Translators: This is the label which shows the number of accounts available for the particular partner. (e.g. https://wikipedialibrary.wmflabs.org/partners/8/). Don't translate {{ accounts_available }}. {% endcomment %}
+      {% comment %} Translators: This is the label which shows the number of accounts available for the particular partner. (e.g. https://wikipedialibrary.wmflabs.org/partners/8/). {% endcomment %}
       {% trans "Accounts available:" %} {% if total_accounts_available_partner < 0 %}
                             0
                               {% if user|coordinators_only %}


### PR DESCRIPTION
Negative numbers are now visible to only coordinators and superusers.