### PR TITLE
Don't send users to /comments/post/ with a form error if they try to comment without an email set (T206614)

### DIFF
--- a/TWLight/comments/__init__.py
+++ b/TWLight/comments/__init__.py
@@ -1,0 +1,3 @@
+def get_form():
+    from .forms import CommentWithoutEmail
+    return CommentWithoutEmail

--- a/TWLight/comments/forms.py
+++ b/TWLight/comments/forms.py
@@ -1,0 +1,24 @@
+import datetime
+
+from django_comments.forms import CommentForm
+from django.contrib.contenttypes.models import ContentType
+from django.utils.encoding import force_unicode
+from django.conf import settings
+
+
+class CommentWithoutEmail(CommentForm):
+    def get_comment_create_data(self):
+        # Overide the default comment form behaviour, with two left out fields
+        return dict(
+            content_type = ContentType.objects.get_for_model(self.target_object),
+            object_pk    = force_unicode(self.target_object._get_pk_val()),
+            user_name    = self.cleaned_data["name"],
+            comment      = self.cleaned_data["comment"],
+            submit_date  = datetime.datetime.now(),
+            site_id      = settings.SITE_ID,
+            is_public    = True,
+            is_removed   = False,
+        )
+
+CommentWithoutEmail.base_fields.pop('url')
+CommentWithoutEmail.base_fields.pop('email')

--- a/TWLight/settings/base.py
+++ b/TWLight/settings/base.py
@@ -101,6 +101,7 @@ TWLIGHT_APPS = [
     'TWLight.applications',
     'TWLight.emails',
     'TWLight.graphs',
+    'TWLight.comments',
 ]
 
 # dal (autocomplete_light) and modeltranslation must go before django.contrib.admin.
@@ -315,7 +316,7 @@ TWLIGHT_OAUTH_CONSUMER_SECRET = os.environ.get('TWLIGHT_OAUTH_CONSUMER_SECRET', 
 
 # COMMENTS CONFIGURATION
 # ------------------------------------------------------------------------------
-
+COMMENTS_APP = 'TWLight.comments'
 
 # TAGGIT CONFIGURATION
 # ------------------------------------------------------------------------------


### PR DESCRIPTION
Email no longer required to post comments on applications.