### PR TITLE
account_email should be an EmailField

### DIFF
--- a/TWLight/applications/helpers.py
+++ b/TWLight/applications/helpers.py
@@ -78,7 +78,7 @@ FIELD_TYPES = {
     SPECIFIC_TITLE: forms.CharField(max_length=128),
     COMMENTS: forms.CharField(widget=forms.Textarea, required=False),
     AGREEMENT_WITH_TERMS_OF_USE: forms.BooleanField(),
-    ACCOUNT_EMAIL: forms.CharField(max_length=64),
+    ACCOUNT_EMAIL: forms.EmailField(),
     HIDDEN: forms.BooleanField(required=False)
 }
 

--- a/TWLight/applications/models.py
+++ b/TWLight/applications/models.py
@@ -97,7 +97,7 @@ class Application(models.Model):
                             blank=True, null=True)
     comments = models.TextField(blank=True)
     agreement_with_terms_of_use = models.BooleanField(default=False)
-    account_email = models.CharField(max_length=64, blank=True, null=True)
+    account_email = models.EmailField(blank=True, null=True)
 
     # Was this application imported via CLI?
     imported = models.NullBooleanField(default=False)


### PR DESCRIPTION
Nikki noticed an issue with many users skimming over the instructions to pre-register and simply entering "None" for `account_email`. Hopefully enforcing email formatting through `EmailField` form validation will improve this - it probably shouldn't have been a `CharField` to begin with.