### PR TITLE
Fix tests creating unrealistic comments and fix self-comment emails

### DIFF
--- a/TWLight/emails/tasks.py
+++ b/TWLight/emails/tasks.py
@@ -135,7 +135,7 @@ def send_comment_notification_emails(sender, **kwargs):
 
     # If the editor who owns this application was not the comment poster, notify
     # them of the new comment.
-    if current_comment.user_email != app.editor.user.email:
+    if current_comment.user != app.editor.user:
         if app.editor.user.email:
             logger.info('we should notify the editor')
             email = CommentNotificationEmailEditors()

--- a/TWLight/emails/tests.py
+++ b/TWLight/emails/tests.py
@@ -52,7 +52,6 @@ class ApplicationCommentTest(TestCase):
             object_pk=app.pk,
             user=user,
             user_name=user.username,
-            user_email=user.email,
             comment="Content!",
             site=Site.objects.get_current(),
         )


### PR DESCRIPTION
I'm not entirely sure why we were comparing user emails in the first place, rather than the user objects directly. I assume the intention was to avoid sending multiple emails to people who have multiple accounts, but that seems unlikely to come up, and getting multiple emails for multiple accounts should probably seem quite reasonable to anyone in that situation.

I also fixed tests, which were creating comment applications that included the `user_email` field, despite the fact we strip that information in the live site. This was causing tests to pass when they should have revealed a broken system. We might want to reconsider how we created those comment tests.