### PR TITLE
Cleanup access code leftovers & remove stray print statement in tests

### DIFF
--- a/TWLight/applications/templates/applications/application_list_user_include.html
+++ b/TWLight/applications/templates/applications/application_list_user_include.html
@@ -37,10 +37,6 @@
         {% trans 'Not yet reviewed.' %}
       {% endif %}
       <br />
-      {% if app.accesscodes %}
-        {{ app.accesscodes.code }}
-        <br />
-      {% endif %}
     </div>
     {% ifequal app.editor.user.pk user.pk %}
       {% if app.status == app.SENT %}

--- a/TWLight/graphs/tests.py
+++ b/TWLight/graphs/tests.py
@@ -48,7 +48,6 @@ class GraphsTestCase(TestCase):
         reader_list = csv.reader(resp.content.splitlines())
         reader_list.next() # Skip header row
         for row in reader_list:
-            print(row)
             assert row in expected_data
 
         # The total number of lines in our CSV should be one more than the

--- a/TWLight/resources/templates/resources/partner_users.html
+++ b/TWLight/resources/templates/resources/partner_users.html
@@ -35,10 +35,6 @@
               {% comment %} Translators: On the page where coordinators can view data on applications to a partner they coordinate, this is a table column heading for the stream (collection) the user applied for. {% endcomment %}
               <th>{% trans "Stream" %}</th>
             {% endif %}
-            {% if object.authorization_method == object.CODES %}
-              {% comment %} Translators: On the page where coordinators can view data on applications to a partner they coordinate, this is a table column heading for the access code this user was assigned. {% endcomment %}
-              <th>{% trans "Access code" %}</th>
-            {% endif %}
           </tr>
         </thead>
         <tbody>
@@ -59,13 +55,6 @@
               <td>
               {% if application.specific_stream %}
                 {{ application.specific_stream }}
-              {% endif %}
-              </td>
-            {% endif %}
-            {% if object.authorization_method == object.CODES %}
-              <td>
-              {% if application.accesscodes %}
-                {{ application.accesscodes.code }} <a href="{% url 'partners:unassign_code' pk=application.accesscodes.pk%}" title={% trans "Unassign" %} class="glyphicon glyphicon-remove"></a>
               {% endif %}
               </td>
             {% endif %}
@@ -97,10 +86,6 @@
               {% comment %} Translators: On the page where coordinators can view data on applications to a partner they coordinate, this is a table column heading for the stream (collection) the user applied for. {% endcomment %}
               <th>{% trans "Stream" %}</th>
             {% endif %}
-            {% if object.authorization_method == object.CODES %}
-              {% comment %} Translators: On the page where coordinators can view data on applications to a partner they coordinate, this is a table column heading for the access code this user was assigned. {% endcomment %}
-              <th>{% trans "Access code" %}</th>
-            {% endif %}
           </tr>
         </thead>
         <tbody>
@@ -121,14 +106,6 @@
               <td>
               {% if application.specific_stream %}
                 {{ application.specific_stream }}
-              {% endif %}
-              </td>
-            {% endif %}
-            {% if object.authorization_method == object.CODES %}
-              <td>
-              {% if application.accesscodes %}
-                {% comment %} Translators: On the page listing approved users, this is hover text for a button staff can click to unassign (remove) an access code from a user. {% endcomment %}
-                {{ application.accesscodes.code }} <a href="{% url 'partners:unassign_code' pk=application.accesscodes.pk%}" title={% trans "Unassign" %} class="glyphicon glyphicon-remove"></a>
               {% endif %}
               </td>
             {% endif %}


### PR DESCRIPTION
When access codes were tied to applications it was straightforward to display them on user pages and on the per-partner approved users list. Now that they're linked to authorizations that code doesn't work anymore, so this is just a quick PR to remove that stray (and nonfunctional) code.

We'll re-add this functionality later when Authorizations are in a slightly better place and they can be what's primarily displayed, in place of applications.

Also, I accidentally left a print statement in tests yesterday, removed that in this PR too.