### PR TITLE
(re-)Added optional account lengths and user renewal notices

### DIFF
--- a/TWLight/applications/models.py
+++ b/TWLight/applications/models.py
@@ -362,5 +362,10 @@ def post_revision_commit(sender, instance, **kwargs):
         if instance.partner.authorization_method == Partner.PROXY:
             one_year_from_now = datetime.date.today() + timedelta(years=1)
             authorization.date_expires = one_year_from_now
+        # Alternatively, if this partner has a specified account_length,
+        # we'll use that to set the expiry.
+        elif instance.partner.account_length:
+            # account_length should be a timedelta
+            authorization.date_expires = datetime.date.today() + instance.partner.account_length
 
         authorization.save()

--- a/TWLight/emails/templates/emails/user_renewal_notice-body-html.html
+++ b/TWLight/emails/templates/emails/user_renewal_notice-body-html.html
@@ -1,0 +1,13 @@
+{% load i18n %}
+<html>
+<body>
+{% comment %} Translators: This email is sent to users when they have an account that is soon to expire. Don't translate Jinja variables in curly braces like {{ partner_name }} or {{ partner_link }}; don't translate html tags either. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).{% endcomment %}
+{% blocktrans trimmed %}
+  <p>Dear {{ user }},</p>
+	<p>According to our records, your access to {{ partner_name }} will soon expire and you may lose access.
+   If you want to continue making use of your free account, you can request renewal of your account by clicking the Renew button at {{ partner_link }}.</p>
+	<p>Best,</p>
+	<p>The Wikipedia Library</p>
+{% endblocktrans %}
+</body>
+</html>

--- a/TWLight/emails/templates/emails/user_renewal_notice-body-html.html
+++ b/TWLight/emails/templates/emails/user_renewal_notice-body-html.html
@@ -8,6 +8,7 @@
    If you want to continue making use of your free account, you can request renewal of your account by clicking the Renew button at {{ partner_link }}.</p>
 	<p>Best,</p>
 	<p>The Wikipedia Library</p>
+  <p>You can disable these emails in your user page preferences: https://wikipedialibrary.wmflabs.org/users/</p>
 {% endblocktrans %}
 </body>
 </html>

--- a/TWLight/emails/templates/emails/user_renewal_notice-body-text.html
+++ b/TWLight/emails/templates/emails/user_renewal_notice-body-text.html
@@ -9,4 +9,6 @@ If you want to continue making use of your free account, you can request renewal
 Best,
 
 The Wikipedia Library
+
+You can disable these emails in your user page preferences: https://wikipedialibrary.wmflabs.org/users/
 {% endblocktrans %}

--- a/TWLight/emails/templates/emails/user_renewal_notice-body-text.html
+++ b/TWLight/emails/templates/emails/user_renewal_notice-body-text.html
@@ -1,0 +1,12 @@
+{% load i18n %}
+{% comment %} Translators: This email is sent to users when they have an account that is soon to expire. Don't translate Jinja variables in curly braces like {{ partner_name }} or {{ partner_link }}; don't translate html tags either. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).{% endcomment %}
+{% blocktrans trimmed %}
+Dear {{ user }},
+
+According to our records, your access to {{ partner_name }} will soon expire and you may lose access.
+If you want to continue making use of your free account, you can request renewal of your account by clicking the Renew button at {{ partner_link }}.
+
+Best,
+
+The Wikipedia Library
+{% endblocktrans %}

--- a/TWLight/emails/templates/emails/user_renewal_notice-subject.html
+++ b/TWLight/emails/templates/emails/user_renewal_notice-subject.html
@@ -1,0 +1,4 @@
+{% load i18n %}
+
+{% comment %} Translators: This is the subject of an email sent to users when they have an account that is soon to expire. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).{% endcomment %}
+{% trans 'Your Wikipedia Library access may soon expire' %}

--- a/TWLight/emails/tests.py
+++ b/TWLight/emails/tests.py
@@ -496,14 +496,3 @@ class UserRenewalNoticeTest(TestCase):
         # got 1 of each email.
         self.assertEqual(set([mail.outbox[0].to[0],mail.outbox[1].to[0]]),
             set(['editor@example.com', 'editor2@example.com']))
-
-    def test_user_renewal_notice_emails_disabled(self):
-        """
-        If the user has disabled these emails in their user preferences
-        we shouldn't be sending anything to them.
-        """
-        self.user.userprofile.send_renewal_notices = False
-        self.user.userprofile.save()
-        call_command('user_renewal_notice')
-
-        self.assertEqual(len(mail.outbox), 0)

--- a/TWLight/emails/tests.py
+++ b/TWLight/emails/tests.py
@@ -426,6 +426,18 @@ class UserRenewalNoticeTest(TestCase):
         self.assertEqual(len(mail.outbox), 1)
         self.assertEqual(mail.outbox[0].to, [self.user.email])
 
+    def test_user_renewal_notice_disabled(self):
+        """
+        Users have the option to disable renewal notices. If users have
+        disabled emails, we shouldn't send them one.
+        """
+        self.user.userprofile.send_renewal_notices = False
+        self.user.userprofile.save()
+
+        call_command('user_renewal_notice')
+
+        self.assertEqual(len(mail.outbox), 0)
+
     def test_user_renewal_notice_doesnt_duplicate(self):
         """
         If we run the command a second time, the same user shouldn't receive
@@ -484,3 +496,14 @@ class UserRenewalNoticeTest(TestCase):
         # got 1 of each email.
         self.assertEqual(set([mail.outbox[0].to[0],mail.outbox[1].to[0]]),
             set(['editor@example.com', 'editor2@example.com']))
+
+    def test_user_renewal_notice_emails_disabled(self):
+        """
+        If the user has disabled these emails in their user preferences
+        we shouldn't be sending anything to them.
+        """
+        self.user.userprofile.send_renewal_notices = False
+        self.user.userprofile.save()
+        call_command('user_renewal_notice')
+
+        self.assertEqual(len(mail.outbox), 0)

--- a/TWLight/graphs/tests.py
+++ b/TWLight/graphs/tests.py
@@ -234,7 +234,6 @@ class GraphsTestCase(TestCase):
         """
         Test that the CSVUserCountByPartner csv download works
         """
-        print("a")
         request = self.factory.get(reverse('csv:user_count_by_partner',
             kwargs={'pk': self.partner.pk}))
         request.user = self.user
@@ -251,7 +250,6 @@ class GraphsTestCase(TestCase):
         """
         Test that the CSVAppDistribution csv download works
         """
-        print("b")
         for app_status in [Application.PENDING, Application.APPROVED, Application.QUESTION]:
             app = ApplicationFactory(partner=self.partner)
             app.status = app_status

--- a/TWLight/resources/models.py
+++ b/TWLight/resources/models.py
@@ -264,6 +264,14 @@ class Partner(models.Model):
             "content.")
         )
 
+    account_length = models.DurationField(
+        blank=True, null=True,
+        # Translators: In the administrator interface, this text is help text for a field where staff can specify the standard duration of a manually granted account for this partner.
+        help_text=_("The standard length of an access grant from this Partner. "
+            "Entered as <days hours:minutes:seconds>."
+            )
+        )
+
     tags = TaggableManager(through=TaggedTextField, blank=True)
 
     # This field has to stick around until all servers are using the new tags.

--- a/TWLight/tests.py
+++ b/TWLight/tests.py
@@ -441,3 +441,10 @@ class ExampleApplicationsDataTest(TestCase):
         call_command('user_example_data', '200')
         call_command('resources_example_data', '50')
         call_command('applications_example_data', '300')
+
+class UserRenewalNoticeTest(TestCase):
+    """
+    Test the user renewal notice management command
+    """
+    def test_command_output(self):
+        call_command('user_renewal_notice')

--- a/TWLight/users/forms.py
+++ b/TWLight/users/forms.py
@@ -71,6 +71,15 @@ class SetLanguageForm(forms.Form):
 
 
 
+class UserEmailForm(forms.Form):
+    send_renewal_notices = forms.BooleanField(required=False)
+
+    def __init__(self, user, *args, **kwargs):
+        super(UserEmailForm, self).__init__(*args, **kwargs)
+        self.fields['send_renewal_notices'].initial = user.userprofile.send_renewal_notices
+
+
+
 class RestrictDataForm(forms.Form):
     restricted = forms.BooleanField(required= False)
 

--- a/TWLight/users/management/commands/user_renewal_notice.py
+++ b/TWLight/users/management/commands/user_renewal_notice.py
@@ -10,12 +10,15 @@ class Command(BaseCommand):
 
     def handle(self, *args, **options):
         # Get all authorization objects with an expiry date in the next
-        # two weeks, for which we haven't yet sent a reminder email.
+        # two weeks, for which we haven't yet sent a reminder email, and
+        # exclude users who disabled these emails.
         expiring_authorizations = Authorization.objects.filter(
             date_expires__lt=datetime.today()+timedelta(weeks=4),
             date_expires__gte=datetime.today(),
             reminder_email_sent=False
-            )
+            ).exclude(
+                authorized_user__userprofile__send_renewal_notices=False
+                )
 
         for authorization_object in expiring_authorizations:
             Notice.user_renewal_notice.send(

--- a/TWLight/users/management/commands/user_renewal_notice.py
+++ b/TWLight/users/management/commands/user_renewal_notice.py
@@ -1,0 +1,32 @@
+from datetime import datetime, timedelta
+
+from django.core.management.base import BaseCommand, CommandError
+
+from TWLight.users.signals import Notice
+from TWLight.users.models import Authorization
+
+class Command(BaseCommand):
+    help = "Sends advance notice to users with expiring authorizations, prompting them to apply for renewal."
+
+    def handle(self, *args, **options):
+        # Get all authorization objects with an expiry date in the next
+        # two weeks, for which we haven't yet sent a reminder email.
+        expiring_authorizations = Authorization.objects.filter(
+            date_expires__lt=datetime.today()+timedelta(weeks=4),
+            date_expires__gte=datetime.today(),
+            reminder_email_sent=False
+            )
+
+        for authorization_object in expiring_authorizations:
+            Notice.user_renewal_notice.send(
+                       sender=self.__class__,
+                       user_wp_username=authorization_object.authorized_user.editor.wp_username,
+                       user_email=authorization_object.authorized_user.email,
+                       user_lang=authorization_object.authorized_user.userprofile.lang,
+                       partner_name=authorization_object.partner.company_name,
+                       partner_link=authorization_object.partner.get_absolute_url()
+                   )
+
+            # Record that we sent the email so that we only send one.
+            authorization_object.reminder_email_sent = True
+            authorization_object.save()

--- a/TWLight/users/models.py
+++ b/TWLight/users/models.py
@@ -73,6 +73,9 @@ class UserProfile(models.Model):
         choices=settings.LANGUAGES,
         # Translators: Users' detected or selected language.
         help_text=_("Language"))
+    send_renewal_notices = models.BooleanField(default=True,
+        # Translators: Description of the option users have to enable or disable reminder emails for renewals
+        help_text=_("Does this user want renewal reminder notices?"))
 
 
 # Create user profiles automatically when users are created.

--- a/TWLight/users/models.py
+++ b/TWLight/users/models.py
@@ -419,6 +419,10 @@ class Authorization(models.Model):
         # Translators: In the administrator interface, this text is help text for a field where staff can specify the partner for which the editor is authoried.
         help_text=_('The stream for which the editor is authorized.'))
 
+    reminder_email_sent = models.BooleanField(default=False,
+        # Translators: In the administrator interface, this text is help text for a field which tracks whether a reminder has been sent about this authorization yet.
+        help_text=_("Have we sent a reminder email about this authorization?"))
+
     # Try to return a useful object name, if fields were set appropriately.
     def __unicode__(self):
         if self.stream:

--- a/TWLight/users/signals.py
+++ b/TWLight/users/signals.py
@@ -1,0 +1,4 @@
+import django.dispatch
+
+class Notice(object):
+    user_renewal_notice = django.dispatch.Signal(providing_args=['user_wp_username', 'user_email', 'user_lang', 'partner_name', 'partner_link'])

--- a/TWLight/users/templates/users/preferences.html
+++ b/TWLight/users/templates/users/preferences.html
@@ -14,6 +14,17 @@
 
   <hr />
 
+  <div class="row clearfix">
+    <div class="col-xs-12 col-sm-3">
+      <strong>{% trans "Emails" %}</strong>
+    </div>
+    <div class="col-xs-12 col-sm-9">
+      {% include 'users/user_email_preferences.html' %}    
+    </div>
+  </div>
+  
+  <hr />
+
   {% if user.has_usable_password %}
     <div class="row clearfix">
       <div class="col-xs-12 col-sm-3">

--- a/TWLight/users/templates/users/user_email_preferences.html
+++ b/TWLight/users/templates/users/user_email_preferences.html
@@ -1,0 +1,16 @@
+{% load i18n %}
+
+<div class="row clearfix">
+  <form method="post" class="form-inline">
+    {% csrf_token %}
+    {% for field in email_form %}
+      <div id="div_{{ field.auto_id }}" class="form-group">
+        {{ field.label }}: {{ field }}
+      </div>
+    {% endfor %}
+    <div style="padding-top: 10px">
+      {% comment %} Translators: This is a button which updates user preference settings {% endcomment %}
+      <input type="submit" name="update_email_settings" value="{% trans "Update" %}" class="btn btn-default"/>
+    </div>
+  </form>
+</div>

--- a/TWLight/users/tests.py
+++ b/TWLight/users/tests.py
@@ -380,6 +380,74 @@ class ViewsTestCase(TestCase):
         self.assertEqual(response.get('Content-Disposition'),
             'attachment; filename=user_data.json')
 
+    def test_user_email_form(self):
+        """
+        Users have a form available on their user pages which enables them to
+        control which emails they receive. Verify that they can post this form
+        without error.
+        """
+        # Need a password so we can login
+        self.user_editor2.set_password('editor')
+        self.user_editor2.save()
+
+        self.client = Client()
+        session = self.client.session
+        self.client.login(username=self.username2, password='editor')
+
+        response = self.client.post(self.url2,
+            {'update_email_settings': ['Update']})
+
+        # Should be successfully redirected back to the user page.
+        self.assertEqual(response.status_code, 302)
+
+    def test_user_email_disable_renewal_update(self):
+        """
+        Verify that users can disable renewal notices in the email form.
+        """
+        # Need a password so we can login
+        self.user_editor2.set_password('editor')
+        self.user_editor2.save()
+
+        self.client = Client()
+        session = self.client.session
+        self.client.login(username=self.username2, password='editor')
+
+        response = self.client.post(self.url2,
+            {'update_email_settings': ['Update']})
+
+        # Should be successfully redirected back to the user page.
+        self.assertEqual(response.status_code, 302)
+
+        self.user_editor2.userprofile.refresh_from_db()
+
+        # We didn't send send_renewal_notices in POST to simulate an
+        # unchecked box.
+        self.assertEqual(self.user_editor2.userprofile.send_renewal_notices, False)
+
+    def test_user_email_enable_renewal_update(self):
+        """
+        Verify that users can enable renewal notices in the email form.
+        """
+        # Need a password so we can login
+        self.user_editor2.set_password('editor')
+        self.user_editor2.userprofile.send_renewal_notices = False
+        self.user_editor2.save()
+
+        self.client = Client()
+        session = self.client.session
+        self.client.login(username=self.username2, password='editor')
+
+        response = self.client.post(self.url2,
+            {'update_email_settings': ['Update'],
+             'send_renewal_notices': ['on']})
+
+        # Should be successfully redirected back to the user page.
+        self.assertEqual(response.status_code, 302)
+
+        self.user_editor2.userprofile.refresh_from_db()
+
+        self.assertEqual(self.user_editor2.userprofile.send_renewal_notices, True)
+
 
 
 class UserProfileModelTestCase(TestCase):

--- a/bin/virtualenv_user_renewal_notice.sh
+++ b/bin/virtualenv_user_renewal_notice.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+#
+# Sends notices to users with authorizations that are soon to expire.
+
+# Environment variables may not be loaded under all conditions.
+if [ -z "${TWLIGHT_HOME}" ]
+then
+    source /etc/environment
+fi
+
+# Load virtual environment
+if source ${TWLIGHT_HOME}/bin/virtualenv_activate.sh
+then
+    echo "Sending user emails"
+    python manage.py user_renewal_notice || exit
+else
+    exit 1
+fi


### PR DESCRIPTION
In https://github.com/WikipediaLibrary/TWLight/pull/48 we removed account-length functionality - it was presented in a way that was ultimately confusing to users, and we didn't have other necessary pieces (i.e. authorization objects) to properly leverage it.

This pull requests re-adds account lengths as an optional per-resource field, and uses them to set expiry dates on authorization objects when applications are marked sent. Additionally, this PR includes a management command and related script which can be fired on a regular basis to send email notices to users with expiring authorizations to encourage them to file for renewal. While at the moment this will only be useful for the handful of partners where we know for sure that access only last one year, it also forms the basis of this functionality for proxy. Users can disable these emails via a preference on their user page.