### PR TITLE
Added an authorization method for standardised emails

### DIFF
--- a/TWLight/applications/tests.py
+++ b/TWLight/applications/tests.py
@@ -2533,9 +2533,9 @@ class EvaluateApplicationTest(TestCase):
 
         self.assertEqual(self.application.status, Application.QUESTION)
 
-    def test_immediately_sent(self):
+    def test_immediately_sent_collection(self):
         """
-        Given a partner with the Partner.LINK authorization method,
+        Given a collection with the Partner.LINK authorization method,
         an application flagged as APPROVED should update to SENT.
         """
         factory = RequestFactory()
@@ -2566,9 +2566,9 @@ class EvaluateApplicationTest(TestCase):
         self.application.refresh_from_db()
         self.assertEqual(self.application.status, Application.SENT)
 
-    def test_immediately_sent_collection(self):
+    def test_immediately_sent(self):
         """
-        Given a collection with Partner.LINK authorization method,
+        Given a partner with the Partner.LINK authorization method,
         an application flagged as APPROVED should update to SENT.
         """
         factory = RequestFactory()

--- a/TWLight/applications/tests.py
+++ b/TWLight/applications/tests.py
@@ -2540,6 +2540,39 @@ class EvaluateApplicationTest(TestCase):
         """
         factory = RequestFactory()
 
+        self.partner.specific_stream = True
+        self.partner.save()
+        stream = StreamFactory(partner=self.partner)
+        stream.authorization_method = Partner.LINK
+        stream.save()
+
+        self.application.status = Application.PENDING
+        self.application.specific_stream = stream
+        self.application.save()
+
+        # Create an coordinator with a test client session
+        coordinator = EditorCraftRoom(self, Terms=True, Coordinator=True)
+
+        self.partner.coordinator = coordinator.user
+        self.partner.authorization_method = Partner.LINK
+        self.partner.save()
+
+        # Approve the application
+        response = self.client.post(self.url,
+            data={'status': Application.APPROVED},
+            follow=True)
+
+        # Verify status
+        self.application.refresh_from_db()
+        self.assertEqual(self.application.status, Application.SENT)
+
+    def test_immediately_sent_collection(self):
+        """
+        Given a collection with Partner.LINK authorization method,
+        an application flagged as APPROVED should update to SENT.
+        """
+        factory = RequestFactory()
+
         self.application.status = Application.PENDING
         self.application.save()
 
@@ -2558,6 +2591,67 @@ class EvaluateApplicationTest(TestCase):
         # Verify status
         self.application.refresh_from_db()
         self.assertEqual(self.application.status, Application.SENT)
+
+    def test_user_instructions_email(self):
+        """
+        For a partner with the Partner.LINK authorization method,
+        approving an application should send an email containing
+        user_instructions.
+        """
+        factory = RequestFactory()
+
+        # Create an coordinator with a test client session
+        coordinator = EditorCraftRoom(self, Terms=True, Coordinator=True)
+
+        self.partner.authorization_method = Partner.LINK
+        self.partner.user_instructions = "Instructions for account setup."
+        self.partner.coordinator = coordinator.user
+        self.partner.save()
+
+        # Approve the application
+        response = self.client.post(self.url,
+            data={'status': Application.APPROVED},
+            follow=True)
+
+        # We expect that one email should now be sent.
+        self.assertEqual(len(mail.outbox), 1)
+
+        # The email should contain user_instructions
+        self.assertTrue(self.partner.user_instructions in mail.outbox[0].body)
+
+    def test_user_instructions_email(self):
+        """
+        For a collection with the Partner.LINK authorization method,
+        approving an application should send an email containing
+        user_instructions.
+        """
+        factory = RequestFactory()
+
+        # Create an coordinator with a test client session
+        coordinator = EditorCraftRoom(self, Terms=True, Coordinator=True)
+
+        self.partner.specific_stream = True
+        self.partner.coordinator = coordinator.user
+        self.partner.save()
+
+        stream = StreamFactory(partner=self.partner)
+        stream.authorization_method = Partner.LINK
+        stream.user_instructions = "Instructions for account setup."
+        stream.save()
+
+        self.application.specific_stream = stream
+        self.application.save()
+
+        # Approve the application
+        response = self.client.post(self.url,
+            data={'status': Application.APPROVED},
+            follow=True)
+
+        # We expect that one email should now be sent.
+        self.assertEqual(len(mail.outbox), 1)
+
+        # The email should contain user_instructions
+        self.assertTrue(stream.user_instructions in mail.outbox[0].body)
 
 
 class BatchEditTest(TestCase):

--- a/TWLight/applications/tests.py
+++ b/TWLight/applications/tests.py
@@ -2619,7 +2619,7 @@ class EvaluateApplicationTest(TestCase):
         # The email should contain user_instructions
         self.assertTrue(self.partner.user_instructions in mail.outbox[0].body)
 
-    def test_user_instructions_email(self):
+    def test_user_instructions_email_collection(self):
         """
         For a collection with the Partner.LINK authorization method,
         approving an application should send an email containing

--- a/TWLight/applications/tests.py
+++ b/TWLight/applications/tests.py
@@ -2533,6 +2533,31 @@ class EvaluateApplicationTest(TestCase):
 
         self.assertEqual(self.application.status, Application.QUESTION)
 
+    def test_immediately_sent(self):
+        """
+        Given a partner with the Partner.LINK authorization method,
+        an application flagged as APPROVED should update to SENT.
+        """
+        factory = RequestFactory()
+
+        self.application.status = Application.PENDING
+        self.application.save()
+
+        # Create an coordinator with a test client session
+        coordinator = EditorCraftRoom(self, Terms=True, Coordinator=True)
+
+        self.partner.coordinator = coordinator.user
+        self.partner.authorization_method = Partner.LINK
+        self.partner.save()
+
+        # Approve the application
+        response = self.client.post(self.url,
+            data={'status': Application.APPROVED},
+            follow=True)
+
+        # Verify status
+        self.application.refresh_from_db()
+        self.assertEqual(self.application.status, Application.SENT)
 
 
 class BatchEditTest(TestCase):

--- a/TWLight/emails/tasks.py
+++ b/TWLight/emails/tasks.py
@@ -33,7 +33,7 @@ from django.core.urlresolvers import reverse_lazy
 from django.db.models.signals import pre_save, post_save
 from django.dispatch import receiver
 from django.shortcuts import get_object_or_404
-
+from django.utils.translation import ugettext_lazy as _
 
 from TWLight.applications.models import Application
 from TWLight.applications.signals import Reminder

--- a/TWLight/emails/tasks.py
+++ b/TWLight/emails/tasks.py
@@ -209,10 +209,18 @@ def send_approval_notification_email(instance):
     # If, for some reason, we're trying to send an email to a user
     # who deleted their account, stop doing that.
     if instance.editor:
+        if instance.is_instantly_finalized():
+            user_instructions = instance.get_user_instructions()
+        else:
+            # Translators: This text goes into account approval emails in the case that we need to send the user's details to a publisher for manual account setup.
+            user_instructions = _("You can expect to receive access details "
+                "within a week or two once it has been processed.")
+
         email.send(instance.user.email,
             {'user': instance.user.editor.wp_username,
              'lang': instance.user.userprofile.lang,
-             'partner': instance.partner})
+             'partner': instance.partner,
+             'user_instructions': user_instructions})
     else:
         logger.error("Tried to send an email to an editor that doesn't "
             "exist, perhaps because their account is deleted.")
@@ -341,14 +349,14 @@ def send_authorization_emails(sender, instance, **kwargs):
 
             base_url = get_current_site(None).domain
 
-            access_code_instructions = instance.partner.access_code_instructions
+            user_instructions = instance.partner.user_instructions
             mail_instance = MagicMailBuilder()
 
             email = mail_instance.access_code_email(instance.authorization.authorized_user.email,
                 {'editor_wp_username': instance.authorization.authorized_user.editor.wp_username,
                  'partner': instance.partner,
                  'access_code': instance.code,
-                 'access_code_instructions': access_code_instructions
+                 'user_instructions': user_instructions
                  })
             email.send()
 

--- a/TWLight/emails/templates/emails/approval_notification-body-html.html
+++ b/TWLight/emails/templates/emails/approval_notification-body-html.html
@@ -4,7 +4,8 @@
 {% comment %} Translators: This email is sent to users when their application is approved. Don't translate Jinja variables in curly braces like {{ user }} or {{ partner }}; don't translate html tags either. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).{% endcomment %}
 {% blocktrans trimmed %}
   <p>Dear {{ user }},</p>
-  <p>Thank you for applying for access to {{ partner }} resources through The Wikipedia Library. We are happy to inform you that your application has been approved. You can expect to receive access details within a week or two once it has been processed.</p>
+  <p>Thank you for applying for access to {{ partner }} resources through The Wikipedia Library. We are happy to inform you that your application has been approved.</p>
+  <p>{{ user_instructions }}</p>
   <p>Cheers!</p>
   <p>The Wikipedia Library</p>
 {% endblocktrans %}

--- a/TWLight/emails/templates/emails/approval_notification-body-text.html
+++ b/TWLight/emails/templates/emails/approval_notification-body-text.html
@@ -5,8 +5,9 @@ Dear {{ user }},
 
 Thank you for applying for access to {{ partner }} resources through
 The Wikipedia Library. We are happy to inform you that your application has
-been approved. You can expect to receive access details within a week or 
-two once it has been processed.
+been approved.
+
+{{ user_instructions }}
 
 Cheers!
 

--- a/TWLight/resources/models.py
+++ b/TWLight/resources/models.py
@@ -177,6 +177,7 @@ class Partner(models.Model):
     CODES = 1
     PROXY = 2
     BUNDLE = 3
+    LINK = 4
 
     AUTHORIZATION_METHODS = (
         # Translators: This is the name of the authorization method whereby user accounts are set up by email.
@@ -187,6 +188,8 @@ class Partner(models.Model):
         (PROXY, _('Proxy')),
         # Translators: This is the name of the authorization method whereby users access resources automatically via the library bundle.
         (BUNDLE, _('Library Bundle')),
+        # Translators: This is the name of the authorization method whereby users are provided with a link through which they can create a free account.
+        (LINK, _('Link')),
     )
 
     status = models.IntegerField(choices=STATUS_CHOICES,
@@ -247,7 +250,8 @@ class Partner(models.Model):
             "'Email' means the accounts are set up via email, and is the default. "
             "Select 'Access Codes' if we send individual, or group, login details "
             "or access codes. 'Proxy' means access delivered directly via EZProxy, "
-            "and Library Bundle is automated proxy-based access."))
+            "and Library Bundle is automated proxy-based access. 'Link' is if we "
+            "send users a URL to use to create an account."))
 
     mutually_exclusive = models.NullBooleanField(
         blank=True, null=True,

--- a/TWLight/resources/models.py
+++ b/TWLight/resources/models.py
@@ -20,6 +20,7 @@ RESOURCE_LANGUAGES = copy.copy(settings.INTERSECTIONAL_LANGUAGES)
 
 RESOURCE_LANGUAGE_CODES = [lang[0] for lang in RESOURCE_LANGUAGES]
 
+
 def validate_language_code(code):
     """
     Takes a language code and verifies that it is the first element of a tuple
@@ -173,6 +174,7 @@ class Partner(models.Model):
         (WAITLIST, _('Waitlisted')),
     )
 
+    # Authorization methods, used in both Partner and Stream
     EMAIL = 0
     CODES = 1
     PROXY = 2
@@ -230,10 +232,13 @@ class Partner(models.Model):
         help_text=_("Optional instructions for sending application data to "
             "this partner."))
 
-    access_code_instructions = models.TextField(blank=True, null=True,
-        # Translators: In the administrator interface, this text is help text for a field where staff can provide email instructions to editors for using an access code to access a partner resource.
+    user_instructions = models.TextField(blank=True, null=True,
+        # Translators: In the administrator interface, this text is help text for a field where staff can provide email instructions to editors for accessing a partner resource.
         help_text=_("Optional instructions for editors to use access codes "
-            "for this partner. Sent via email upon access code assignment."))
+            "or free signup URLs for this partner. Sent via email upon "
+            "application approval (for links) or access code assignment. "
+            "If this partner has collections, fill out user instructions "
+            "on each collection instead."))
 
     excerpt_limit = models.PositiveSmallIntegerField(blank=True, null=True,
           # Translators: In the administrator interface, this text is help text for a field where staff can optionally provide a excerpt word limit per article.
@@ -416,6 +421,22 @@ class Stream(models.Model):
         help_text=_("Optional description of this stream's resources."))
 
     languages = models.ManyToManyField(Language, blank=True)
+
+    authorization_method = models.IntegerField(choices=Partner.AUTHORIZATION_METHODS,
+        default=Partner.EMAIL,
+        # Translators: In the administrator interface, this text is help text for a field where staff can specify which method of account distribution this collection uses.
+        help_text=_("Which authorization method does this collection use? "
+            "'Email' means the accounts are set up via email, and is the default. "
+            "Select 'Access Codes' if we send individual, or group, login details "
+            "or access codes. 'Proxy' means access delivered directly via EZProxy, "
+            "and Library Bundle is automated proxy-based access. 'Link' is if we "
+            "send users a URL to use to create an account."))
+
+    user_instructions = models.TextField(blank=True, null=True,
+        # Translators: In the administrator interface, this text is help text for a field where staff can provide email instructions to editors for accessing a collection.
+        help_text=_("Optional instructions for editors to use access codes "
+            "or free signup URLs for this collection. Sent via email upon "
+            "application approval (for links) or access code assignment."))
 
 
     def __unicode__(self):


### PR DESCRIPTION
For some partners we have a single set of instructions that is sent to all users, e.g. "Your application has been approved, please go to this link to create your free account: [link]" or "Here is the login that all approved editors use: [login details]". As such, if we store that standardised wording, we can simply send it to users automatically.

There were a few possible ways to do this here, and I think I've taken the easiest, though it may not be the most straightforward:
 - A new authorization method, `Partner.LINK` has been added. For this method, an APPROVED application is immediately updated to SENT upon being saved (`Partner.PROXY` also does this)
 - `access_code_instructions` is now `user_instructions`. It's still used for access code instructions for that authorization method, but it can now also be used to store instructions for the `Partner.LINK` method.
 - `user_instructions` was hooked into the approval email - it now defaults back to the "you'll hear more in 2-4 weeks" text in the case of `Partner.EMAIL` or `.CODES`, but in the case of `Partner.LINK` uses `user_instructions` following the generic "your account was approved" text. This saves us having to generate an entire new email template, signal, and task.
 - Because instructions are specific to the collection being applied to, I added identical `authorization_method` and `user_instructions` fields to collections, along with some application functions for figuring out which to use. This is the least tidy bit of this PR in my opinion. Going forward we still might want to consider moving Applications to being hooked to Streams by default, but that raised a bunch of questions about how the relation between Partners and Streams would work, so I went for this option for now.