### PR TITLE
Fix and test setting authorization expiry date

### DIFF
--- a/TWLight/applications/models.py
+++ b/TWLight/applications/models.py
@@ -360,12 +360,12 @@ def post_revision_commit(sender, instance, **kwargs):
         # If this is a proxy partner, set (or reset) the expiry date
         # to one year from now
         if instance.partner.authorization_method == Partner.PROXY:
-            one_year_from_now = datetime.date.today() + timedelta(years=1)
+            one_year_from_now = date.today() + timedelta(days=365)
             authorization.date_expires = one_year_from_now
         # Alternatively, if this partner has a specified account_length,
         # we'll use that to set the expiry.
         elif instance.partner.account_length:
             # account_length should be a timedelta
-            authorization.date_expires = datetime.date.today() + instance.partner.account_length
+            authorization.date_expires = date.today() + instance.partner.account_length
 
         authorization.save()

--- a/TWLight/applications/tests.py
+++ b/TWLight/applications/tests.py
@@ -3137,3 +3137,42 @@ class MarkSentTest(TestCase):
 
         # The email should contain the assigned access code.
         self.assertTrue(self.access_code.code in mail.outbox[0].body)
+
+    def test_authorization_expiry_date(self):
+        # For a partner with a set account length we should set the expiry
+        # date correctly for its authorizations.
+        self.partner.account_length = timedelta(days=180)
+        self.partner.save()
+
+        request = RequestFactory().post(self.url,
+            data={'applications': [self.app1.pk]})
+        request.user = self.user
+
+        _ = views.SendReadyApplicationsView.as_view()(
+            request, pk=self.partner.pk)
+
+        authorization_object = Authorization.objects.get(
+            authorized_user=self.app1.user,
+            partner=self.app1.partner,
+        )
+
+        expected_expiry = date.today() + self.partner.account_length
+        self.assertEqual(authorization_object.date_expires, expected_expiry)
+
+    def test_authorization_expiry_date_proxy(self):
+        # For a proxy partner we should set the expiry
+        # date correctly for its authorizations.
+        self.partner.authorization_method = Partner.PROXY
+        self.partner.save()
+
+        self.app1.status = Application.SENT
+        self.app1.save()
+
+        authorization_object = Authorization.objects.get(
+            authorized_user=self.app1.user,
+            partner=self.app1.partner,
+        )
+
+        expected_expiry = date.today() + timedelta(days=365)
+        self.assertEqual(authorization_object.date_expires, expected_expiry)
+


### PR DESCRIPTION
Turns out we weren't setting authorization object expiry date properly (by which I mean server errors), and didn't have any tests for the functionality. Now we do :)