### PR TITLE
Add non-public API for authorized users

### DIFF
--- a/TWLight/api/urls.py
+++ b/TWLight/api/urls.py
@@ -1,0 +1,8 @@
+from django.conf.urls import url
+
+from TWLight.users import views
+
+urlpatterns = [
+    url(r'^(?P<version>(v1))/users/authorizations/partner/(?P<pk>\d+)/$',
+        views.AuthorizedUsers.as_view())
+    ]

--- a/TWLight/api/urls.py
+++ b/TWLight/api/urls.py
@@ -3,6 +3,6 @@ from django.conf.urls import url
 from TWLight.users import views
 
 urlpatterns = [
-    url(r'^(?P<version>(v1))/users/authorizations/partner/(?P<pk>\d+)/$',
+    url(r'^(?P<version>(v0))/users/authorizations/partner/(?P<pk>\d+)/$',
         views.AuthorizedUsers.as_view())
     ]

--- a/TWLight/settings/base.py
+++ b/TWLight/settings/base.py
@@ -113,6 +113,7 @@ TWLIGHT_APPS = [
     'TWLight.emails',
     'TWLight.graphs',
     'TWLight.comments',
+    'TWLight.api',
 ]
 
 # dal (autocomplete_light) and modeltranslation must go before django.contrib.admin.
@@ -124,6 +125,12 @@ CRON_CLASSES = [
     'TWLight.crons.BackupCronJob',
     'TWLight.crons.SendCoordinatorRemindersCronJob',
 ]
+
+# REST FRAMEWORK CONFIG
+# ------------------------------------------------------------------------------
+REST_FRAMEWORK = {
+    'DEFAULT_VERSIONING_CLASS': 'rest_framework.versioning.NamespaceVersioning'
+}
 
 # MIDDLEWARE CONFIGURATION
 # ------------------------------------------------------------------------------

--- a/TWLight/settings/base.py
+++ b/TWLight/settings/base.py
@@ -101,6 +101,8 @@ THIRD_PARTY_APPS = [
     # django-request, the user analytics package.
     'request',
     'django_countries',
+    'rest_framework',
+    'rest_framework.authtoken',
 ]
 
 TWLIGHT_APPS = [

--- a/TWLight/urls.py
+++ b/TWLight/urls.py
@@ -17,6 +17,7 @@ import django
 
 import TWLight.i18n.views
 import TWLight.i18n.urls
+from TWLight.api.urls import urlpatterns as api_urls
 from TWLight.applications.urls import urlpatterns as applications_urls
 from TWLight.emails.views import ContactUsView
 from TWLight.graphs.urls import csv_urlpatterns as csv_urls
@@ -54,6 +55,7 @@ urlpatterns = [
     # TWLight apps -------------------------------------------------------------
     # This makes our custom set language form  available.
     url(r'^i18n/', include('TWLight.i18n.urls')),
+    url(r'^api/', include(api_urls, namespace="api")),
     url(r'^users/', include(users_urls, namespace="users")),
     url(r'^applications/', include(applications_urls, namespace="applications")),
     url(r'^partners/', include(partners_urls, namespace="partners")),

--- a/TWLight/users/models.py
+++ b/TWLight/users/models.py
@@ -393,7 +393,7 @@ class Authorization(models.Model):
     # Users may have multiple authorizations.
     authorized_user = models.ForeignKey(settings.AUTH_USER_MODEL, blank=False, null=True,
         on_delete=models.SET_NULL,
-        related_name="+",
+        related_name="authorizations",
         # Translators: In the administrator interface, this text is help text for a field where staff can specify the username of the authorized editor.
         help_text=_('The authorized user.'))
 

--- a/TWLight/users/serializers.py
+++ b/TWLight/users/serializers.py
@@ -1,0 +1,10 @@
+from django.contrib.auth.models import User
+from rest_framework import serializers
+
+
+class UserSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = User
+        # Since we only care about one field we could probably return data in a more
+        # sensible format, but this is totally functional.
+        fields = ('username',)

--- a/TWLight/users/tests.py
+++ b/TWLight/users/tests.py
@@ -10,7 +10,6 @@ from django.conf import settings
 from django.contrib.auth.models import User, AnonymousUser
 from django.core.exceptions import PermissionDenied
 from django.core.urlresolvers import resolve, reverse
-from django.template.loader import render_to_string
 from django.test import TestCase, Client, RequestFactory
 from django.utils.translation import get_language
 
@@ -19,7 +18,6 @@ from TWLight.applications.models import Application
 
 from TWLight.resources.factories import PartnerFactory
 from TWLight.resources.models import Partner
-from TWLight.resources.tests import EditorCraftRoom
 
 from . import views
 from .authorization import OAuthBackend
@@ -27,6 +25,8 @@ from .helpers.wiki_list import WIKIS, LANGUAGE_CODES
 from .factories import EditorFactory, UserFactory
 from .groups import get_coordinators, get_restricted
 from .models import UserProfile, Editor
+
+from rest_framework.test import APIRequestFactory, force_authenticate
 
 FAKE_IDENTITY_DATA = {'query': {
     'userinfo': {
@@ -794,3 +794,111 @@ class HelpersTestCase(TestCase):
         LANGUAGES = set(LANGUAGE_CODES.keys())
 
         self.assertEqual(WIKIS_LANGUAGES, LANGUAGES)
+
+
+class AuthorizedUsersAPITestCase(TestCase):
+    """
+    Tests for the AuthorizedUsers view and API.
+    """
+    def setUp(self):
+        super(AuthorizedUsersAPITestCase, self).setUp()
+
+        self.partner1 = PartnerFactory(
+            authorization_method=Partner.EMAIL
+        )
+        self.partner2 = PartnerFactory(
+            authorization_method=Partner.PROXY
+        )
+
+        self.editor1 = EditorFactory()
+        self.editor2 = EditorFactory()
+        self.editor3 = EditorFactory()
+        self.editor4 = EditorFactory()
+
+        self.base_api_url = "https://localhost/users/authorized_users"
+
+    def test_authorized_users_api_denied(self):
+        """
+        Test that, if no credentials are supplied, the API returns no data.
+        """
+        factory = APIRequestFactory()
+        request = factory.get('/users/authorized_users/1')
+
+        response = views.AuthorizedUsers.as_view()(request, self.partner1.pk)
+
+        self.assertEqual(response.status_code, 401)
+
+    def test_authorized_users_api_success(self):
+        """
+        Test that, if credentials are supplied, the API returns a 200 status code.
+        """
+        factory = APIRequestFactory()
+        request = factory.get('/users/authorized_users/1')
+        force_authenticate(request, user=self.editor1.user)
+
+        response = views.AuthorizedUsers.as_view()(request, self.partner1.pk)
+
+        self.assertEqual(response.status_code, 200)
+
+    def test_authorized_users_api_applications(self):
+        """
+        In the case of a non-proxy partner, we should return all users with
+        a sent application.
+        """
+        _ = ApplicationFactory(
+            editor=self.editor1,
+            partner=self.partner1,
+            status=Application.SENT
+        )
+        _ = ApplicationFactory(
+            editor=self.editor2,
+            partner=self.partner1,
+            status=Application.APPROVED
+        )
+        _ = ApplicationFactory(
+            editor=self.editor3,
+            partner=self.partner1,
+            status=Application.SENT
+        )
+
+        factory = APIRequestFactory()
+        request = factory.get('/users/authorized_users/1')
+        force_authenticate(request, user=self.editor1.user)
+
+        response = views.AuthorizedUsers.as_view()(request, self.partner1.pk)
+
+        expected_json = [{"username": self.editor1.user.username},
+                         {"username": self.editor3.user.username}]
+
+        self.assertEqual(response.data, expected_json)
+
+    def test_authorized_users_api_authorizations(self):
+        """
+        In the case of a proxy partner, we should return all active authorizations
+        for that partner.
+        """
+        _ = ApplicationFactory(
+            editor=self.editor1,
+            partner=self.partner2,
+            status=Application.SENT
+        )
+        _ = ApplicationFactory(
+            editor=self.editor2,
+            partner=self.partner2,
+            status=Application.SENT
+        )
+        _ = ApplicationFactory(
+            editor=self.editor3,
+            partner=self.partner2,
+            status=Application.PENDING
+        )
+        factory = APIRequestFactory()
+        request = factory.get('/users/authorized_users/1')
+        force_authenticate(request, user=self.editor1.user)
+
+        response = views.AuthorizedUsers.as_view()(request, self.partner2.pk)
+
+        expected_json = [{"username": self.editor1.user.username},
+                         {"username": self.editor2.user.username}]
+
+        self.assertEqual(response.data, expected_json)

--- a/TWLight/users/tests.py
+++ b/TWLight/users/tests.py
@@ -815,14 +815,12 @@ class AuthorizedUsersAPITestCase(TestCase):
         self.editor3 = EditorFactory()
         self.editor4 = EditorFactory()
 
-        self.base_api_url = "https://localhost/users/authorized_users"
-
     def test_authorized_users_api_denied(self):
         """
         Test that, if no credentials are supplied, the API returns no data.
         """
         factory = APIRequestFactory()
-        request = factory.get('/users/authorized_users/1')
+        request = factory.get('/api/v1/users/authorizations/partner/1')
 
         response = views.AuthorizedUsers.as_view()(request, self.partner1.pk)
 
@@ -833,7 +831,7 @@ class AuthorizedUsersAPITestCase(TestCase):
         Test that, if credentials are supplied, the API returns a 200 status code.
         """
         factory = APIRequestFactory()
-        request = factory.get('/users/authorized_users/1')
+        request = factory.get('/api/v1/users/authorizations/partner/1')
         force_authenticate(request, user=self.editor1.user)
 
         response = views.AuthorizedUsers.as_view()(request, self.partner1.pk)
@@ -862,7 +860,7 @@ class AuthorizedUsersAPITestCase(TestCase):
         )
 
         factory = APIRequestFactory()
-        request = factory.get('/users/authorized_users/1')
+        request = factory.get('/api/v1/users/authorizations/partner/1')
         force_authenticate(request, user=self.editor1.user)
 
         response = views.AuthorizedUsers.as_view()(request, self.partner1.pk)
@@ -893,7 +891,7 @@ class AuthorizedUsersAPITestCase(TestCase):
             status=Application.PENDING
         )
         factory = APIRequestFactory()
-        request = factory.get('/users/authorized_users/1')
+        request = factory.get('/api/v1/users/authorizations/partner/1')
         force_authenticate(request, user=self.editor1.user)
 
         response = views.AuthorizedUsers.as_view()(request, self.partner2.pk)

--- a/TWLight/users/tests.py
+++ b/TWLight/users/tests.py
@@ -820,7 +820,7 @@ class AuthorizedUsersAPITestCase(TestCase):
         Test that, if no credentials are supplied, the API returns no data.
         """
         factory = APIRequestFactory()
-        request = factory.get('/api/v1/users/authorizations/partner/1')
+        request = factory.get('/api/v0/users/authorizations/partner/1')
 
         response = views.AuthorizedUsers.as_view()(request, self.partner1.pk)
 
@@ -831,7 +831,7 @@ class AuthorizedUsersAPITestCase(TestCase):
         Test that, if credentials are supplied, the API returns a 200 status code.
         """
         factory = APIRequestFactory()
-        request = factory.get('/api/v1/users/authorizations/partner/1')
+        request = factory.get('/api/v0/users/authorizations/partner/1')
         force_authenticate(request, user=self.editor1.user)
 
         response = views.AuthorizedUsers.as_view()(request, self.partner1.pk)
@@ -860,7 +860,7 @@ class AuthorizedUsersAPITestCase(TestCase):
         )
 
         factory = APIRequestFactory()
-        request = factory.get('/api/v1/users/authorizations/partner/1')
+        request = factory.get('/api/v0/users/authorizations/partner/1')
         force_authenticate(request, user=self.editor1.user)
 
         response = views.AuthorizedUsers.as_view()(request, self.partner1.pk)
@@ -891,7 +891,7 @@ class AuthorizedUsersAPITestCase(TestCase):
             status=Application.PENDING
         )
         factory = APIRequestFactory()
-        request = factory.get('/api/v1/users/authorizations/partner/1')
+        request = factory.get('/api/v0/users/authorizations/partner/1')
         force_authenticate(request, user=self.editor1.user)
 
         response = views.AuthorizedUsers.as_view()(request, self.partner2.pk)

--- a/TWLight/users/urls.py
+++ b/TWLight/users/urls.py
@@ -25,4 +25,6 @@ urlpatterns = [
     url(r'^delete_data/(?P<pk>\d+)/$',
        login_required(views.DeleteDataView.as_view()),
         name='delete_data'),
+    url(r'^authorized_users/(?P<pk>\d+)/$',
+        views.AuthorizedUsers.as_view())
 ]

--- a/TWLight/users/urls.py
+++ b/TWLight/users/urls.py
@@ -25,6 +25,4 @@ urlpatterns = [
     url(r'^delete_data/(?P<pk>\d+)/$',
        login_required(views.DeleteDataView.as_view()),
         name='delete_data'),
-    url(r'^authorized_users/(?P<pk>\d+)/$',
-        views.AuthorizedUsers.as_view())
 ]

--- a/TWLight/users/views.py
+++ b/TWLight/users/views.py
@@ -42,7 +42,7 @@ coordinators = get_coordinators()
 restricted = get_restricted()
 
 import logging
-logger = logging.getLogger('django')
+logger = logging.getLogger(__name__)
 
 def _is_real_url(url):
     """
@@ -549,6 +549,7 @@ class AuthorizedUsers(APIView):
     uses the full list of sent applications.
     """
     authentication_classes = (TokenAuthentication,)
+    # TODO: We might want to set up more granular permissions for future APIs.
     permission_classes = (IsAuthenticated,)
 
     def get(self, request, pk, format=None):

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -13,6 +13,7 @@ django-premailer
 django-request==1.5.4
 django-reversion==3.0.3
 django-taggit==0.23.0
+djangorestframework==3.9.4
 djmail==1.1.0
 docutils==0.14
 factory_boy>=2.10.0,<3.0


### PR DESCRIPTION
Adds an API via the Django REST Framework at `/users/authorized_users/` for retrieving the list of users with active authorizations (in the case of proxy partners) or sent applications (in all other cases), for use in the Wikilink tool (https://wikilink.wmflabs.org/). Requires an API token.

I know we talked about having Wikilink be in containers alongside Library Card itself, but I felt more confident going this way. Does this make sense? First time I've made an API.