### PR TITLE
Correctly assign sent_by on evaluate view

### DIFF
--- a/TWLight/applications/tests.py
+++ b/TWLight/applications/tests.py
@@ -2653,6 +2653,24 @@ class EvaluateApplicationTest(TestCase):
         # The email should contain user_instructions
         self.assertTrue(stream.user_instructions in mail.outbox[0].body)
 
+    def test_sent_by_assignment(self):
+        # sent_by wasn't being set when applications were marked as sent
+        # from the evaluate view. This checks that's working correctly.
+        factory = RequestFactory()
+
+        # Create an coordinator with a test client session
+        coordinator = EditorCraftRoom(self, Terms=True, Coordinator=True)
+        self.partner.coordinator = coordinator.user
+        self.partner.save()
+
+        # Send the application
+        response = self.client.post(self.url,
+            data={'status': Application.SENT},
+            follow=True)
+
+        self.application.refresh_from_db()
+        self.assertEqual(self.application.sent_by, coordinator.user)
+
 
 class BatchEditTest(TestCase):
     def setUp(self):

--- a/TWLight/applications/views.py
+++ b/TWLight/applications/views.py
@@ -767,6 +767,9 @@ class EvaluateApplicationView(NotDeleted, CoordinatorOrSelf, ToURequired, Update
     success_url = reverse_lazy('applications:list')
 
     def form_valid(self, form):
+        if self.object.status == Application.SENT:
+            self.object.sent_by = self.request.user
+            self.object.save()
         with reversion.create_revision():
             reversion.set_user(self.request.user)
             try:


### PR DESCRIPTION
We weren't assigning `sent_by` if an application was marked Sent in the evaluate view, only on the Mark as Sent page. Added a test.