### PR TITLE
Fix application objects taking way too long to load (potentially to a 500) in admin

### DIFF
--- a/TWLight/applications/admin.py
+++ b/TWLight/applications/admin.py
@@ -9,7 +9,7 @@ class ApplicationAdmin(VersionAdmin):
     search_fields = ('partner__company_name', 'editor__wp_username')
     list_display = ('id', 'partner', 'editor',)
     list_filter = ('status', 'partner')
-    raw_id_fields = ('editor',)
+    raw_id_fields = ('editor', 'sent_by', 'specific_stream', 'parent', 'partner', )
 
     # reversion options
     history_latest_first = True


### PR DESCRIPTION
Tweaking applications from admin is not the norm, rather the exception. Hence not necessary to load every single foreign key on an application object.