### PR TITLE
avoid docker warnings for empty continuation lines

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ RUN apk add --update \
     libxslt-dev \
     mariadb-dev \
     # Python, duh.
-    python py-pip ;\
+    python py-pip
     pip install virtualenv
 
 FROM twlight_base as twlight_build
@@ -21,9 +21,9 @@ RUN apk add \
     libxml2-dev \
     musl-dev \
     python-dev \
-    zlib-dev ;\
-    virtualenv /venv ;\
-    source /venv/bin/activate ;\
+    zlib-dev
+    virtualenv /venv
+    source /venv/bin/activate
     pip install -r /requirements/wmf.txt
 
 FROM twlight_base
@@ -43,12 +43,12 @@ RUN apk add --update \
     # since we just use it to generate a css file.
     nodejs \
     npm \
-    tar ;\
+    tar
     # CSS Janus is the thing actually used to generate the rtl css.
-    npm install cssjanus ;\
+    npm install cssjanus
     # Pandoc is used for rendering wikicode resource descriptions
     # into html for display. We do need this on the live image.
-    wget https://github.com/jgm/pandoc/releases/download/2.7.1/pandoc-2.7.1-linux.tar.gz -P /tmp ;\
+    wget https://github.com/jgm/pandoc/releases/download/2.7.1/pandoc-2.7.1-linux.tar.gz -P /tmp
     tar -xf /tmp/pandoc-2.7.1-linux.tar.gz --directory /opt
 
 # Utility scripts that run in the virtual environment.

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,8 +4,7 @@ RUN apk add --update \
     libjpeg-turbo \
     libxslt-dev \
     mariadb-dev \
-    # Python, duh.
-    python py-pip
+    python py-pip ;\
     pip install virtualenv
 
 FROM twlight_base as twlight_build
@@ -21,9 +20,9 @@ RUN apk add \
     libxml2-dev \
     musl-dev \
     python-dev \
-    zlib-dev
-    virtualenv /venv
-    source /venv/bin/activate
+    zlib-dev ;\
+    virtualenv /venv ;\
+    source /venv/bin/activate ;\
     pip install -r /requirements/wmf.txt
 
 FROM twlight_base
@@ -31,24 +30,24 @@ COPY --from=twlight_build /venv /venv
 ENV PATH="${PATH}:/opt/pandoc-2.7.1/bin" TWLIGHT_HOME=/app PYTHONUNBUFFERED=1 PYTHONPATH="/app:/usr/lib/python2.7"
 
 # Runtime dependencies.
+# Refactoring shell code could remove bash dependency
+# mariadb-client Not needed by the running app, but by the backup/restore shell scripts.
+# Node stuff for rtl support. This and subsequent node things
+# should all be moved out of the running container
+# since we just use it to generate a css file.
+# CSS Janus is the thing actually used to generate the rtl css.
+# Pandoc is used for rendering wikicode resource descriptions
+# into html for display. We do need this on the live image.
 RUN apk add --update \
-    # Refactoring shell code could remove this dependency
     bash \
     gettext \
     git \
-    # Not needed by the running app, but by the backup/restore shell scripts.
     mariadb-client \
-    # Node stuff for rtl support. This and subsequent node things
-    # should all be moved out of the running container
-    # since we just use it to generate a css file.
     nodejs \
     npm \
-    tar
-    # CSS Janus is the thing actually used to generate the rtl css.
-    npm install cssjanus
-    # Pandoc is used for rendering wikicode resource descriptions
-    # into html for display. We do need this on the live image.
-    wget https://github.com/jgm/pandoc/releases/download/2.7.1/pandoc-2.7.1-linux.tar.gz -P /tmp
+    tar ;\
+    npm install cssjanus ;\
+    wget https://github.com/jgm/pandoc/releases/download/2.7.1/pandoc-2.7.1-linux.tar.gz -P /tmp ;\
     tar -xf /tmp/pandoc-2.7.1-linux.tar.gz --directory /opt
 
 # Utility scripts that run in the virtual environment.


### PR DESCRIPTION
docker doesn't like comments in the middle of continued lines within a command, so I consolidated the comments ahead of the commands in question.