### PR TITLE
Fix creating authorizations via batch edit

### DIFF
--- a/TWLight/applications/helpers.py
+++ b/TWLight/applications/helpers.py
@@ -206,7 +206,7 @@ def get_accounts_available(app):
 
 
 def is_proxy_and_application_approved(status, app):
-    if (app.partner.authorization_method == Partner.PROXY or (app.specific_stream.authorization_method == Partner.PROXY if app.specific_stream else False)) and int(status) == Application.APPROVED:
+    if (app.partner.authorization_method == Partner.PROXY or (app.specific_stream.authorization_method == Partner.PROXY if app.specific_stream else False)) and status == Application.APPROVED:
         return True
     else:
         return False

--- a/TWLight/applications/tests.py
+++ b/TWLight/applications/tests.py
@@ -3101,6 +3101,30 @@ class BatchEditTest(TestCase):
         self.application.refresh_from_db()
         self.assertEqual(self.application.date_closed, date.today())
 
+    def test_batch_edit_creates_authorization(self):
+        # Make sure that if we batch edit, authorizations are created
+        # as expected.
+        factory = RequestFactory()
+
+        self.application.status = Application.PENDING
+        self.application.date_created = date.today() - timedelta(days=3)
+        self.application.save()
+
+        # Create an coordinator with a test client session
+        coordinator = EditorCraftRoom(self, Terms=True, Coordinator=True)
+
+        # Approve the application
+        response = self.client.post(self.url,
+                                    data={'applications': self.application.pk,
+                                          'batch_status': Application.SENT},
+                                    follow=True)
+
+        authorization_exists = Authorization.objects.filter(
+            authorized_user=self.application.user,
+            partner=self.application.partner
+        ).exists()
+
+        self.assertTrue(authorization_exists)
 
 # posting to batch edit without app or status fails appropriately?
 

--- a/TWLight/applications/views.py
+++ b/TWLight/applications/views.py
@@ -831,8 +831,8 @@ class BatchEditView(CoordinatorsOnly, ToURequired, View):
         try:
             assert 'batch_status' in request.POST
 
-            status = request.POST['batch_status']
-            assert int(status) in [Application.PENDING,
+            status = int(request.POST['batch_status'])
+            assert status in [Application.PENDING,
                                    Application.QUESTION,
                                    Application.APPROVED,
                                    Application.NOT_APPROVED,
@@ -950,11 +950,11 @@ class BatchEditView(CoordinatorsOnly, ToURequired, View):
                 if app.partner.status != Partner.WAITLIST:
                     if app.specific_stream is not None and streams_distribution_flag[app.specific_stream.pk] is True:
                         batch_update_success.append(app_pk)
-                        app.status = int(status)
+                        app.status = status
                         app.save()
                     elif partners_distribution_flag[app.partner.pk] is True:
                         batch_update_success.append(app_pk)
-                        app.status = int(status)
+                        app.status = status
                         app.save()
                     else:
                         batch_update_failed.append(app_pk)


### PR DESCRIPTION
We had one place where we were comparing a unicode application status to an integer which caused this to fail. I've set `status` to an int explicitly higher up the chain.