### PR TITLE
requested_access_duration boolean field comment

### DIFF
--- a/TWLight/applications/models.py
+++ b/TWLight/applications/models.py
@@ -109,7 +109,7 @@ class Application(models.Model):
     requested_access_duration = models.IntegerField(choices=REQUESTED_ACCESS_DURATION_CHOICES, blank=True, null=True,
                                                     # Translators: Shown in the administrator interface for editing applications directly. Labels the field that holds the account length for proxy partners.
                                                     help_text=_('User selection of when they\'d like their account to expire (in months). '
-                                                                'Only relevant if the applied partner/collection has authorization_method as \'proxy\'.'))
+                                                                'Required for proxied resources; optional otherwise.'))
 
     # Was this application imported via CLI?
     imported = models.NullBooleanField(default=False)

--- a/TWLight/resources/models.py
+++ b/TWLight/resources/models.py
@@ -331,10 +331,20 @@ class Partner(models.Model):
         # Translators: In the administrator interface, this text is help text for a check box where staff can select whether users must first register at the organisation's website before finishing their application.
         help_text=_("Mark as true if this partner requires applicants to have "
                     "already signed up at the partner website."))
+    
+    # Integrating a dropdown field to get the duration for which a user wishes to have his/her 
+    # access for without this boolean field isn't a problem for renewals. We want this 
+    # field to get along with the initial dynamic application form generation (applications/forms.py). 
+    # The way these optional fields (to get input from users) work, when different partners have 
+    # different requirements, optional or not is decided by these boolean fields. We could've 
+    # worked around that by checking the authorization_method, but not without a significant amount 
+    # of rework. This is plain and simple and adds one more teeny tiny step for superusers. As it 
+    # happens, this also gives us the unintended advantage of toggling the field on even when the 
+    # partner doesn't have proxy, but has account durations that can be manually set.    
     requested_access_duration = models.BooleanField(default=False,
-        # Translators: In the administrator interface, this text is help text for a check box where staff can select whether users must select the length of account they desire for proxy partners.
-        help_text=_("Mark as true if the authorization method of this partner is proxy "
-                    "and requires the duration of the access (expiry) be specified."))
+        # Translators: In the administrator interface, this text is help text for a check box where staff can select whether users must select the length of account they desire for proxy partners and sometimes for other authorization methods.
+        help_text=_("Must be checked if the authorization method of this partner is proxy; "
+                    "optional otherwise."))
 
 
     def __unicode__(self):


### PR DESCRIPTION
Added a comment to explain the purpose of the `requested_access_duration` boolean field and updated a couple help_texts ([more](https://wikimedia.slack.com/archives/GHBFH8VHN/p1571821304035500))