### PR TITLE
Fix Authorizer not being set for PROXY/LINK partners

### DIFF
--- a/TWLight/applications/models.py
+++ b/TWLight/applications/models.py
@@ -313,20 +313,6 @@ class Application(models.Model):
         # view.
         return self.editor.user
 
-
-    @property
-    def latest_reviewer(self):
-        revision = self.get_latest_revision()
-
-        if revision:
-            try:
-                return revision.user
-            except AttributeError:
-                return None
-        else:
-            return None
-
-
     @property
     def is_renewable(self):
         """
@@ -387,8 +373,6 @@ def post_revision_commit(sender, instance, **kwargs):
         instance.is_instantly_finalized())
 
     if skip_approved:
-        # The latest reviewer is the effective sender.
-        instance.sent_by = instance.latest_reviewer
         instance.status = Application.SENT
         instance.save()
 

--- a/TWLight/applications/views.py
+++ b/TWLight/applications/views.py
@@ -748,15 +748,14 @@ class EvaluateApplicationView(NotDeleted, CoordinatorOrSelf, ToURequired, Update
 
     def form_valid(self, form):
         app = self.object
-        status = form.cleaned_data['status']
-        
+
         # Correctly assign sent_by.
-        if app.status == Application.SENT:
+        if app.status == Application.SENT or (app.is_instantly_finalized() and app.status == Application.APPROVED):
             app.sent_by = self.request.user
             app.save()
         
         # The logic below hard limits coordinators from approving applications when a particular proxy partner has run out of accounts.
-        if is_proxy_and_application_approved(status, app):
+        if is_proxy_and_application_approved(app.status, app):
             if app.partner.status == Partner.WAITLIST:
                 # Translators: After a coordinator has changed the status of an application to APPROVED, if the corresponding partner/collection is waitlisted this message appears.
                 messages.add_message(self.request, messages.ERROR,
@@ -956,21 +955,13 @@ class BatchEditView(CoordinatorsOnly, ToURequired, View):
                     if app.specific_stream is not None and streams_distribution_flag[app.specific_stream.pk] is True:
                         batch_update_success.append(app_pk)
                         app.status = status
+                        app.sent_by = request.user
                         app.save()
-                        # After the app is saved, we set sent_by if we sent the app.
-                        # Necessary because of instantly finalized apps.
-                        if app.status == Application.SENT and not app.sent_by:
-                            app.sent_by = request.user
-                            app.save()
                     elif partners_distribution_flag[app.partner.pk] is True:
                         batch_update_success.append(app_pk)
                         app.status = status
+                        app.sent_by = request.user
                         app.save()
-                        # After the app is saved, we set sent_by if we sent the app.
-                        # Necessary because of instantly finalized apps.
-                        if app.status == Application.SENT and not app.sent_by:
-                            app.sent_by = request.user
-                            app.save()
                     else:
                         batch_update_failed.append(app_pk)
                 else:
@@ -978,12 +969,9 @@ class BatchEditView(CoordinatorsOnly, ToURequired, View):
             else:
                 batch_update_success.append(app_pk)
                 app.status = status
-                app.save()
-                # After the app is saved, we set sent_by if we sent the app.
-                # Necessary because of instantly finalized apps.
-                if app.status == Application.SENT and not app.sent_by:
+                if app.is_instantly_finalized() and app.status in [Application.APPROVED, Application.SENT]:
                     app.sent_by = request.user
-                    app.save()
+                app.save()
 
         # We manually send the signals to waitlist the partners with corresponding 'True' values.
         # This could be tweaked in the future to also waitlist partners with collections. We don't do that


### PR DESCRIPTION
Corresponding Phab task: [T233508](https://phabricator.wikimedia.org/T233508#5666202) 

What we were trying to do is set `app.sent_by` by retrieving it from the application we were operating on. The object not having `sent_by`, returned `None` on `app.latest_reviewer`, overwriting whatever value was in `sent_by`, thus blanking the field, making `sent_by` assignments from `EvaluateApplicationView` pointless. 

Also in `BatchEditView` we were effectively trying to call `post_revision_commit` twice since `app.latest_reviewer` blanked `sent_by` the first time (`if skip_approved:` was false the second time). 