### PR TITLE
Always allow users to extend lifetime of an authorization (T238671)

### DIFF
--- a/TWLight/applications/models.py
+++ b/TWLight/applications/models.py
@@ -333,6 +333,23 @@ class Application(models.Model):
                 )
         return user_instructions
 
+    def get_authorization(self):
+        """
+        For a given application, find an authorization for this partner-stream-editor, if possible.
+        """
+        authorization = Authorization.objects.filter(
+                partner=self.partner, user=self.editor.user
+            )
+        if self.specific_stream:
+            authorization = authorization.filter(
+                stream=self.specific_stream
+            )
+
+        if authorization.exists():
+            return authorization[0]
+        else:
+            return None
+
     def is_instantly_finalized(self):
         """
         Check if this application is to a partner or collection for which

--- a/TWLight/applications/models.py
+++ b/TWLight/applications/models.py
@@ -337,18 +337,19 @@ class Application(models.Model):
         """
         For a given application, find an authorization for this partner-stream-editor, if possible.
         """
-        authorization = Authorization.objects.filter(
-                partner=self.partner, user=self.editor.user
-            )
-        if self.specific_stream:
-            authorization = authorization.filter(
-                stream=self.specific_stream
-            )
-
-        if authorization.exists():
-            return authorization[0]
-        else:
+        try:
+            if self.specific_stream:
+                authorization = Authorization.objects.get(
+                    partner=self.partner, user=self.editor.user, stream=self.specific_stream
+                )
+            else:
+                authorization = Authorization.objects.get(
+                    partner=self.partner, user=self.editor.user
+                )
+        except Authorization.DoesNotExist:
             return None
+
+        return authorization
 
     def is_instantly_finalized(self):
         """

--- a/TWLight/applications/templates/applications/application_evaluation.html
+++ b/TWLight/applications/templates/applications/application_evaluation.html
@@ -194,6 +194,17 @@
         {% trans 'No' %}
       {% endif %}
     </div>
+
+    {% if object.parent and object.parent.get_authorization %}
+      <div class="col-xs-12 col-sm-4">
+        {% comment %} Translators: This labels the section of the application showing the length of access remaining on the user's previous authorization.{% endcomment %}
+        <strong>{% trans 'Previous access expiry date' %}</strong>
+      </div>
+      <div class="col-xs-12 col-sm-8">
+        {{ previous_auth_expiry_date }}
+      </div>
+    {% endif %}
+
     {% if object.comments %}
       <div class="col-xs-12 col-sm-4">
         {% comment %} Translators: This labels the section of an application containing the additional comments submitted by the user when applying.{% endcomment %}

--- a/TWLight/applications/views.py
+++ b/TWLight/applications/views.py
@@ -897,6 +897,9 @@ class EvaluateApplicationView(NotDeleted, CoordinatorOrSelf, ToURequired, Update
         partner_coordinator = self.request.user == self.object.partner.coordinator
         superuser = self.request.user.is_superuser
         context["partner_coordinator"] = partner_coordinator or superuser
+        existing_authorization = app.get_authorization()
+        if app.parent and existing_authorization:
+            context["previous_auth_expiry_date"] = existing_authorization.date_expires
 
         return context
 

--- a/TWLight/users/models.py
+++ b/TWLight/users/models.py
@@ -422,7 +422,7 @@ class Authorization(models.Model):
         app_label = "users"
         verbose_name = "authorization"
         verbose_name_plural = "authorizations"
-        unique_together = ("user", "partner", "stream", "date_authorized")
+        unique_together = ("user", "partner", "stream")
 
     coordinators = get_coordinators()
 

--- a/TWLight/users/templates/users/collection_tile.html
+++ b/TWLight/users/templates/users/collection_tile.html
@@ -68,18 +68,21 @@
       <hr>
     {% endif %}
     <i class="fa fa-info-circle" aria-hidden="true" title="Partner description page"></i> <strong><a href="{% url 'partners:detail' each_authorization.partner.pk %}">{{ each_authorization.partner }}</a></strong>
-    {% if each_authorization.is_renewable %}
       {% if each_authorization.latest_app and not each_authorization.open_app %}
         {% comment %} Translators: Hovertext for when renewals for a partner is not available and the renew button is disabled. {% endcomment %}
         <span class="pull-right" {% if not each_authorization.partner.renewals_available %}title="{% trans 'Renewals are not available for this partner' %}"{% endif %}>
           <a href="{% url 'applications:renew' each_authorization.latest_app.pk %}" class="btn btn-primary pull-right {% if not each_authorization.partner.renewals_available %}disabled{% endif %}" role="button">
-            {% comment %} Translators: Labels the button that links to the renewal url. {% endcomment %}
-            {% trans 'Renew' %}
+            {% if each_authorization.is_valid %}
+              {% comment %} Translators: Labels a button users can click to extend the duration of their access. {% endcomment %}
+              {% trans 'Extend' %}
+            {% else %}
+              {% comment %} Translators: Labels a button users can click to renew an expired account. {% endcomment %}
+              {% trans 'Renew' %}
+            {% endif %}
           </a>
         </span>
         <div class="clearfix"></div>
       {% endif %}
-    {% endif %}
     {% if each_authorization.open_app %}
       {% comment %} Translators: Labels the button that links to the application page itself if the applications is already renewed. {% endcomment %}
       <a href="{% url 'applications:evaluate' each_authorization.open_app.pk %}" class="btn btn-primary pull-right" role="button">{% trans 'View application' %}</a><div class="clearfix"></div>

--- a/TWLight/users/templates/users/collection_tile.html
+++ b/TWLight/users/templates/users/collection_tile.html
@@ -84,7 +84,7 @@
         <div class="clearfix"></div>
       {% endif %}
     {% if each_authorization.open_app %}
-      {% comment %} Translators: Labels the button that links to the application page itself if the applications is already renewed. {% endcomment %}
+      {% comment %} Translators: Labels a button users can click to view an application requesting access to a resource. {% endcomment %}
       <a href="{% url 'applications:evaluate' each_authorization.open_app.pk %}" class="btn btn-primary pull-right" role="button">{% trans 'View application' %}</a><div class="clearfix"></div>
     {% endif %}
     {% if each_authorization.date_expires %}
@@ -94,7 +94,7 @@
             {% comment %} Translators: Text beside the date on which the authorization has expired. {% endcomment %}
             {% trans 'Expired on' %}: {{ each_authorization.date_expires }}
           {% else %}
-            {% comment %} Translators: Text beside the date on which the authorization will expired. {% endcomment %}
+            {% comment %} Translators: Text beside the date on which the authorization will expire. {% endcomment %}
             {% trans 'Expires on' %}: {{ each_authorization.date_expires }}
           {% endif %}
         </small>


### PR DESCRIPTION
Shuffles the logic a bit so we never hide the Renew button, instead always displaying it with the (in my opinion) slightly clearer text 'Extend'. If the authorization expires, we switch back to 'Renew'.