### PR TITLE
Remove unused server-erroring code

### DIFF
--- a/TWLight/resources/views.py
+++ b/TWLight/resources/views.py
@@ -104,11 +104,6 @@ class PartnersDetailView(DetailView):
         else:
             context["median_days"] = None
 
-        # To restrict the graph from rendering, if there's only a week's worth of data
-        earliest_date = get_earliest_creation_date(
-            Application.objects.filter(partner=partner)
-        )
-
         # Find out if current user has applications and change the Apply
         # button behaviour accordingly
         if (


### PR DESCRIPTION
We were getting server errors on Civilica because all imported applications had the same date. There's an underlying issue here of `get_earliest_creation_date` not returning something sensible when all apps have the same date, but this code was unused on the partner detail page anyway, so this is a quick fix for now.