### PR TITLE
Fix invalid apps trying to modify status on comment

### DIFF
--- a/TWLight/applications/signals.py
+++ b/TWLight/applications/signals.py
@@ -29,14 +29,21 @@ def under_discussion(sender, comment, request, **kwargs):
     When coordinators post a comment on an application which currently has the
     PENDING status, automatically set it to 'Under discussion' (QUESTION).
     """
-    application_object = Application.objects.get(pk=comment.object_pk)
-
-    if (
-        application_object.status == Application.PENDING
-        and application_object.editor.user.username != request.user.username
-    ):
-        application_object.status = Application.QUESTION
-        application_object.save()
+    try:
+        application_object = Application.objects.get(pk=comment.object_pk)
+        if (
+            application_object.status == Application.PENDING
+            and application_object.editor.user.username != request.user.username
+        ):
+            application_object.status = Application.QUESTION
+            application_object.save()
+    except Application.DoesNotExist:
+        logger.info(
+            "Status of invalid application not changed on comment {}.".format(
+                comment.object_pk
+            )
+        )
+        pass
 
 
 @receiver(no_more_accounts)


### PR DESCRIPTION
Invalid apps aren't returned on object.get(), resulting in a server error, and comments on invalid apps shouldn't modify the status of the apps anyways. Continue with the existing logic if we get an app object, if not handle the error gracefully.