### PR TITLE
fixed T238915: Switch "Proxy/Bundle access" and "Manual access" tabs on "Your collection" page

### DIFF
--- a/TWLight/users/templates/users/my_collection.html
+++ b/TWLight/users/templates/users/my_collection.html
@@ -9,13 +9,40 @@
     {% trans "Your applications" %}
   </a>
   <ul class="nav nav-tabs">
-    {% comment %} Translators: Tab label (1 of 2) for the page listing all partners which can accessed manually. {% endcomment %}
-    <li {% if manual_authorizations or manual_authorizations_expired %}class="active"{% elif not proxy_bundle_authorizations and not proxy_bundle_authorizations_expired %}class="active"{% endif %}><a data-toggle="tab" href="#manual">{%  trans 'Manual access' %} <span class="badge">{{ manual_authorizations.count }}</span></a></li>
-    {% comment %} Translators: Tab label (2 of 2) for the page listing all partners which can accessed either via proxy or via bundle (direct access). {% endcomment %}
-    <li {% if proxy_bundle_authorizations or proxy_bundle_authorizations_expired %}{% if not manual_authorizations and not manual_authorizations_expired %}class="active"{% endif %}{% endif %}><a data-toggle="tab" href="#proxy">{%  trans 'Proxy/bundle access' %} <span class="badge">{{ proxy_bundle_authorizations.count }}</span></a></li>
+    {% comment %} Translators: Tab label (1 of 2) for the page listing all partners which can accessed either via proxy or via bundle (direct access). {% endcomment %}
+    <li {% if proxy_bundle_authorizations or proxy_bundle_authorizations_expired %}class="active"{% elif not manual_authorizations and not manual_authorizations_expired %}class="active"{% endif %}><a data-toggle="tab" href="#proxy">{%  trans 'Proxy/bundle access' %} <span class="badge">{{ proxy_bundle_authorizations.count }}</span></a></li>
+    {% comment %} Translators: Tab label (2 of 2) for the page listing all partners which can accessed manually. {% endcomment %}
+    <li {% if manual_authorizations or manual_authorizations_expired %}{% if not proxy_bundle_authorizations and not proxy_bundle_authorizations_expired %}class="active"{% endif %}{% endif %}><a data-toggle="tab" href="#manual">{%  trans 'Manual access' %} <span class="badge">{{ manual_authorizations.count }}</span></a></li>
   </ul>
   <div class="tab-content">
-    <div id="manual" class="tab-pane fade {% if manual_authorizations or manual_authorizations_expired %}in active{% elif not proxy_bundle_authorizations and not proxy_bundle_authorizations_expired %}in active{% endif %}">
+    <div id="proxy" class="tab-pane fade {% if proxy_bundle_authorizations or proxy_bundle_authorizations_expired %}in active{% elif not manual_authorizations and not manual_authorizations_expired %}in active{% endif %}">
+      <br>
+      <div class="row row-flex">
+        {% for each_authorization in proxy_bundle_authorizations %}
+          <div class="col-flex col-xs-12 col-sm-4 col-md-3">
+            {% include "users/collection_tile.html" %}
+          </div>
+        {% empty %}
+          <div class="col-xs-12">
+            {% comment %} Translators: On the collection page (proxy/bundle access tab), this text is displayed when the user has no active collections. {% endcomment %}
+            {% trans 'You have no active proxy/bundle collections.' %}
+          </div>
+        {% endfor %}
+      </div>
+      {%  if proxy_bundle_authorizations_expired %}
+        {% comment %} Translators: Heading for the section which lists all of the user's expired collection. {% endcomment %}
+        <h4>{% trans 'Expired' %}</h4>
+        <hr>
+      {% endif %}
+      <div class="row row-flex">
+        {% for each_authorization in proxy_bundle_authorizations_expired %}
+          <div class="col-flex col-xs-12 col-sm-4 col-md-3">
+            {% include "users/collection_tile.html" %}
+          </div>
+        {% endfor %}
+      </div>
+    </div>
+    <div id="manual" class="tab-pane fade {% if manual_authorizations or manual_authorizations_expired %}{% if not proxy_bundle_authorizations and not proxy_bundle_authorizations_expired %}in active{% endif %}{% endif %}">
       <br>
       <div class="row row-flex">
         {% for each_authorization in manual_authorizations %}
@@ -42,32 +69,5 @@
         {% endfor %}
       </div>
     </div>
-    <div id="proxy" class="tab-pane fade {% if proxy_bundle_authorizations or proxy_bundle_authorizations_expired %}{% if not manual_authorizations and not manual_authorizations_expired %}in active{% endif %}{% endif %}">
-      <br>
-      <div class="row row-flex">
-        {% for each_authorization in proxy_bundle_authorizations %}
-          <div class="col-flex col-xs-12 col-sm-4 col-md-3">
-            {% include "users/collection_tile.html" %}
-          </div>
-        {% empty %}
-          <div class="col-xs-12">
-            {% comment %} Translators: On the collection page (proxy/bundle access tab), this text is displayed when the user has no active collections. {% endcomment %}
-            {% trans 'You have no active proxy/bundle collections.' %}
-          </div>
-        {% endfor %}
-      </div>
-      {%  if proxy_bundle_authorizations_expired %}
-        {% comment %} Translators: Heading for the section which lists all of the user's expired collection. {% endcomment %}
-        <h4>{% trans 'Expired' %}</h4>
-        <hr>
-      {% endif %}
-      <div class="row row-flex">
-        {% for each_authorization in proxy_bundle_authorizations_expired %}
-          <div class="col-flex col-xs-12 col-sm-4 col-md-3">
-            {% include "users/collection_tile.html" %}
-          </div>
-        {% endfor %}
-      </div>
-     </div>
   </div>
 {% endblock %}


### PR DESCRIPTION
[https://phabricator.wikimedia.org/T238915](url)

"Proxy/Bundle access" made default access
![image](https://user-images.githubusercontent.com/40785645/71898217-bcb76f80-317e-11ea-870d-6ef66507f96b.png)

![image](https://user-images.githubusercontent.com/40785645/71898301-fdaf8400-317e-11ea-9040-71b0a708488a.png)
