### PR TITLE
library bundle eligibility check T235262 

### DIFF
--- a/TWLight/users/factories.py
+++ b/TWLight/users/factories.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-from datetime import datetime, date
+from datetime import datetime
 import factory
 import json
 import random
@@ -65,7 +65,6 @@ class EditorFactory(factory.django.DjangoModelFactory):
     affiliation = "Institut Pasteur"
     wp_username = factory.Faker("name", locale=random.choice(settings.FAKER_LOCALES))
     wp_editcount = 42
-    wp_editcount_date_updated = date.today()
     wp_registered = datetime.today()
     # Increment counter each time we create an editor so that we don't fail
     # the wp_sub + home_wiki uniqueness constraint on Editor.

--- a/TWLight/users/factories.py
+++ b/TWLight/users/factories.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-from datetime import datetime
+from datetime import datetime, date
 import factory
 import json
 import random
@@ -65,6 +65,7 @@ class EditorFactory(factory.django.DjangoModelFactory):
     affiliation = "Institut Pasteur"
     wp_username = factory.Faker("name", locale=random.choice(settings.FAKER_LOCALES))
     wp_editcount = 42
+    wp_editcount_date_updated = date.today()
     wp_registered = datetime.today()
     # Increment counter each time we create an editor so that we don't fail
     # the wp_sub + home_wiki uniqueness constraint on Editor.

--- a/TWLight/users/models.py
+++ b/TWLight/users/models.py
@@ -146,7 +146,7 @@ def editor_account_old_enough(wp_registered):
     return datetime.today().date() - timedelta(days=182) >= wp_registered
 
 
-def editor_valid(username, enough_edits, account_old_enough, not_blocked):
+def editor_valid(enough_edits, account_old_enough, not_blocked):
     """
     Check for the eligibility criteria laid out in the terms of service.
     Note that we won't prohibit signups or applications on this basis.
@@ -155,7 +155,6 @@ def editor_valid(username, enough_edits, account_old_enough, not_blocked):
     if enough_edits and account_old_enough and not_blocked:
         return True
     else:
-        logger.info("Editor {username} was not valid.".format(username=username))
         return False
 
 
@@ -526,7 +525,6 @@ class Editor(models.Model):
         self.wp_enough_edits = editor_enough_edits(global_userinfo)
         self.wp_not_blocked = editor_not_blocked(identity)
         self.wp_valid = editor_valid(
-            self.wp_username,
             self.wp_enough_edits,
             self.wp_account_old_enough,
             self.wp_not_blocked,

--- a/TWLight/users/models.py
+++ b/TWLight/users/models.py
@@ -150,11 +150,6 @@ def editor_account_old_enough(wp_registered):
 def editor_valid(username, enough_edits, account_old_enough, not_blocked):
     """
     Check for the eligibility criteria laid out in the terms of service.
-    To wit, users must:
-    * Have >= 500 edits
-    * Be active for >= 6 months
-    * Not be blocked on any projects
-
     Note that we won't prohibit signups or applications on this basis.
     Coordinators have discretion to approve people who are near the cutoff.
     """
@@ -207,6 +202,12 @@ def editor_recent_edits(
         wp_editcount_recent,
         wp_enough_recent_edits,
     )
+
+def editor_bundle_eligible(wp_valid, wp_enough_recent_edits):
+    if wp_valid and wp_enough_recent_edits:
+        return True
+    else:
+        return False
 
 
 class Editor(models.Model):
@@ -334,6 +335,16 @@ class Editor(models.Model):
         editable=False,
         help_text=_("Recent Wikipedia edit count"),
     )
+    wp_bundle_eligible = models.BooleanField(
+        default=False,
+        editable=False,
+        # Translators: Help text asking whether the user met all requirements for access to the library card bundle the last time they logged in (when their information was last updated).
+        help_text=_(
+            "At their last login, did this user meet the criteria for access to the library card bundle?"
+        ),
+    )
+
+
 
     # ~~~~~~~~~~~~~~~~~~~~~~~~~~~ User-entered data ~~~~~~~~~~~~~~~~~~~~~~~~~~~
     contributions = models.TextField(
@@ -416,12 +427,6 @@ class Editor(models.Model):
             return json.loads(self.wp_groups)
         else:
             return None
-
-    def bundle_eligible(self):
-        if self.wp_valid and self.wp_enough_recent_edits:
-            return True
-        else:
-            return False
 
     def get_global_userinfo(self, identity):
         """
@@ -531,6 +536,7 @@ class Editor(models.Model):
             self.wp_account_old_enough,
             self.wp_not_blocked,
         )
+        self.wp_bundle_eligible = editor_bundle_eligible(self.wp_valid, self.wp_enough_recent_edits)
         self.user.save()
 
         # Add language if the user hasn't selected one

--- a/TWLight/users/models.py
+++ b/TWLight/users/models.py
@@ -159,6 +159,8 @@ def editor_valid(enough_edits, account_old_enough, not_blocked):
 
 
 def editor_recent_edits(
+    global_userinfo_editcount,
+    wp_editcount_date_updated,
     wp_editcount,
     wp_editcount_prev_date_updated,
     wp_editcount_prev,
@@ -168,7 +170,7 @@ def editor_recent_edits(
     # If we have historical data, see how many days have passed and how many edits have been made since the last check.
     if wp_editcount_prev_date_updated:
         editcount_update_delta = date.today() - wp_editcount_prev_date_updated
-        editcount_delta = wp_editcount - wp_editcount_prev
+        editcount_delta = global_userinfo_editcount - wp_editcount_prev
         if (
             # If the editor didn't have enough recent edits yet
             # update the counts if it's been 30 days or sooner if they have now have enough edits.
@@ -179,14 +181,14 @@ def editor_recent_edits(
             or (wp_enough_recent_edits and editcount_update_delta.days >= 30)
         ):
             wp_editcount_prev = wp_editcount
-            wp_editcount_prev_date_updated = date.today()
-            wp_editcount_recent = editcount_delta
+            wp_editcount_prev_date_updated = wp_editcount_date_updated
+            wp_editcount_recent = global_userinfo_editcount - wp_editcount_prev
 
     # If we don't have any historical editcount data, let all edits to date count.
     # Editor.wp_editcount_prev defaults to 0, so we don't need to worry about changing it.
     else:
         wp_editcount_prev_date_updated = date.today()
-        wp_editcount_recent = wp_editcount
+        wp_editcount_recent = global_userinfo_editcount
 
     # Perform the check for enough recent edits.
     if wp_editcount_recent >= 10:
@@ -242,6 +244,14 @@ class Editor(models.Model):
     # Translators: The total number of edits this user has made to all Wikipedia projects
     wp_editcount = models.IntegerField(
         help_text=_("Wikipedia edit count"), blank=True, null=True
+    )
+    wp_editcount_date_updated = models.DateField(
+        default=None,
+        null=True,
+        blank=True,
+        editable=False,
+        # Translators: The date that wp_editcount was updated from Wikipedia.
+        help_text=_("When the editcount was updated from Wikipedia"),
     )
     # Translators: The date this user registered their Wikipedia account
     wp_registered = models.DateField(
@@ -502,12 +512,15 @@ class Editor(models.Model):
         if global_userinfo:
             self.wp_editcount_prev_date_updated, self.wp_editcount_prev, self.wp_editcount_recent, self.wp_enough_recent_edits = editor_recent_edits(
                 global_userinfo["editcount"],
+                self.wp_editcount_date_updated,
+                self.wp_editcount,
                 self.wp_editcount_prev_date_updated,
                 self.wp_editcount_prev,
                 self.wp_editcount_recent,
                 self.wp_enough_recent_edits,
             )
             self.wp_editcount = global_userinfo["editcount"]
+            self.wp_editcount_date_updated = date.today()
 
         # This will be True the first time the user logs in, since use_wp_email
         # defaults to True. Therefore we will initialize the email field if

--- a/TWLight/users/models.py
+++ b/TWLight/users/models.py
@@ -263,8 +263,8 @@ class Editor(models.Model):
         else:
             return None
 
-    @property
-    def is_bundle_eligible(self, identity, global_userinfo):
+    @cached_property
+    def bundle_eligible(self, identity, global_userinfo):
 
         # prev_editcount is set to 0 for the first 30 days, all edits get counted here for new users.
         recent_edits = self.wp_editcount - self.prev_editcount
@@ -273,6 +273,30 @@ class Editor(models.Model):
             return True
         else:
             return False
+
+    def account_old_enough(self, identity, global_userinfo):
+        # Check: registered >= 6 months ago
+        # Try oauth registration date first. If it's not valid,
+        # try the global_userinfo date
+        try:
+            reg_date = datetime.strptime(identity["registered"], "%Y%m%d%H%M%S").date()
+        except:
+            reg_date = datetime.strptime(
+                global_userinfo["registration"], "%Y-%m-%dT%H:%M:%SZ"
+            ).date()
+        return datetime.today().date() - timedelta(days=182) >= reg_date
+
+    def enough_edits(self, global_userinfo):
+        # If, for some reason, this information hasn't come through,
+        # default to user not being valid.
+        if not global_userinfo:
+            return False
+        # Check: >= 500 edits
+        return int(global_userinfo["editcount"]) >= 500
+
+    def not_blocked(self, identity):
+        # Check: not blocked
+        return identity["blocked"] == False
 
     def _is_user_valid(self, identity, global_userinfo):
         """
@@ -285,28 +309,12 @@ class Editor(models.Model):
         Note that we won't prohibit signups or applications on this basis.
         Coordinators have discretion to approve people who are near the cutoff.
         """
-        # If, for some reason, this information hasn't come through,
-        # default to user not being valid.
-        if not global_userinfo:
-            return False
-        # Check: >= 500 edits
-        enough_edits = int(global_userinfo["editcount"]) >= 500
 
-        # Check: registered >= 6 months ago
-        # Try oauth registration date first. If it's not valid,
-        # try the global_userinfo date
-        try:
-            reg_date = datetime.strptime(identity["registered"], "%Y%m%d%H%M%S").date()
-        except:
-            reg_date = datetime.strptime(
-                global_userinfo["registration"], "%Y-%m-%dT%H:%M:%SZ"
-            ).date()
-        account_old_enough = datetime.today().date() - timedelta(days=182) >= reg_date
-
-        # Check: not blocked
-        not_blocked = identity["blocked"] == False
-
-        if enough_edits and account_old_enough and not_blocked:
+        if (
+            self.enough_edits(global_userinfo)
+            and self.account_old_enough(identity, global_userinfo)
+            and self.not_blocked(identity)
+        ):
             return True
         else:
             logger.info(

--- a/TWLight/users/models.py
+++ b/TWLight/users/models.py
@@ -116,7 +116,6 @@ def editor_reg_date(identity, global_userinfo):
             ).date()
         except (TypeError, ValueError):
             reg_date = None
-            pass
     return reg_date
 
 
@@ -454,12 +453,10 @@ class Editor(models.Model):
             except AssertionError:
                 logger.exception("Could not fetch global_userinfo for User.")
                 return None
-                pass
 
         except:
             logger.exception("Could not fetch global_userinfo for User.")
             return None
-            pass
 
     def update_from_wikipedia(self, identity, lang):
         """
@@ -523,7 +520,6 @@ class Editor(models.Model):
                 # Email isn't guaranteed to be present in identity - don't do
                 # anything if we can't find it.
                 logger.exception("Unable to get Editor email address from Wikipedia.")
-                pass
 
         self.wp_registered = editor_reg_date(identity, global_userinfo)
         self.wp_account_old_enough = editor_account_old_enough(self.wp_registered)

--- a/TWLight/users/models.py
+++ b/TWLight/users/models.py
@@ -105,19 +105,6 @@ def create_user_profile(sender, instance, created, **kwargs):
 models.signals.post_save.connect(create_user_profile, sender=settings.AUTH_USER_MODEL)
 
 
-def editor_account_old_enough(identity, global_userinfo):
-    # Check: registered >= 6 months ago
-    # Try oauth registration date first. If it's not valid,
-    # try the global_userinfo date
-    try:
-        reg_date = datetime.strptime(identity["registered"], "%Y%m%d%H%M%S").date()
-    except:
-        reg_date = datetime.strptime(
-            global_userinfo["registration"], "%Y-%m-%dT%H:%M:%SZ"
-        ).date()
-    return datetime.today().date() - timedelta(days=182) >= reg_date
-
-
 def editor_enough_edits(global_userinfo):
     # If, for some reason, this information hasn't come through,
     # default to user not being valid.
@@ -156,22 +143,6 @@ class Editor(models.Model):
         # Translators: The date the user's profile was created on the website (not on Wikipedia).
         help_text=_("When this profile was first created"),
     )
-    # Set as non-editable.
-    date_prev_editcount_updated = models.DateField(
-        default=None,
-        null=True,
-        blank=True,
-        editable=False,
-        help_text=_("When the previous editcount was last updated from Wikipedia"),
-    )
-    # Translators: The number of edits this user has made to all Wikipedia projects 30 days ago
-    prev_editcount = models.IntegerField(
-        default=0,
-        null=True,
-        blank=True,
-        editable=False,
-        help_text=_("30-day-old Wikipedia edit count"),
-    )
 
     # ~~~~~~~~~~~~~~~~~~~~~~~ Data from Wikimedia OAuth ~~~~~~~~~~~~~~~~~~~~~~~#
     # Uses same field names as OAuth, but with wp_ prefixed.
@@ -199,13 +170,68 @@ class Editor(models.Model):
     wp_groups = models.TextField(help_text=_("Wikipedia groups"), blank=True)
     # Translators: Lists the individual user rights permissions the editor has on Wikipedia. e.g. sendemail, createpage, move
     wp_rights = models.TextField(help_text=_("Wikipedia user rights"), blank=True)
+
+    # ~~~~~~~~~~~~~~~~~~~~~~~ Non-editable data computed from Wikimedia OAuth ~~~~~~~~~~~~~~~~~~~~~~~#
     wp_valid = models.BooleanField(
         default=False,
-        # Translators: Help text asking whether the user met the requirements for access (see https://wikipedialibrary.wmflabs.org/about/) the last time they logged in (when their information was last updated).
+        editable=False,
+        # Translators: Help text asking whether the user met all requirements for access (see https://wikipedialibrary.wmflabs.org/about/) the last time they logged in (when their information was last updated).
         help_text=_(
             "At their last login, did this user meet the criteria in "
             "the terms of use?"
         ),
+    )
+    wp_account_old_enough = models.BooleanField(
+        default=False,
+        editable=False,
+        # Translators: Help text asking whether the user met the account age requirement for access (see https://wikipedialibrary.wmflabs.org/about/) the last time they logged in (when their information was last updated).
+        help_text=_(
+            "At their last login, did this user meet the account age criterion in "
+            "the terms of use?"
+        ),
+    )
+    wp_enough_edits = models.BooleanField(
+        default=False,
+        editable=False,
+        # Translators: Help text asking whether the user met the total editcount requirement for access (see https://wikipedialibrary.wmflabs.org/about/) the last time they logged in (when their information was last updated).
+        help_text=_(
+            "At their last login, did this user meet the total editcount criterion in "
+            "the terms of use?"
+        ),
+    )
+    wp_enough_recent_edits = models.BooleanField(
+        default=False,
+        editable=False,
+        # Translators: Help text asking whether the user met the recent editcount requirement for access (see https://wikipedialibrary.wmflabs.org/about/) the last time they logged in (when their information was last updated).
+        help_text=_(
+            "At their last login, did this user meet the recent editcount criterion in "
+            "the terms of use?"
+        ),
+    )
+    wp_not_blocked = models.BooleanField(
+        default=False,
+        editable=False,
+        # Translators: Help text asking whether the user met the 'not currently blocked' requirement for access (see https://wikipedialibrary.wmflabs.org/about/) the last time they logged in (when their information was last updated).
+        help_text=_(
+            "At their last login, did this user meet the 'not currently blocked' criterion in "
+            "the terms of use?"
+        ),
+    )
+    wp_editcount_prev_date_updated = models.DateField(
+        default=None,
+        null=True,
+        blank=True,
+        editable=False,
+        help_text=_("When the previous editcount was last updated from Wikipedia"),
+    )
+    # wp_editcount_prev is initially set to 0 so that all edits get counted as recent edits for new users.
+    # Translators: The number of edits this user has made to all Wikipedia projects 30 days ago
+    wp_editcount_prev = models.IntegerField(
+        default=0,
+        null=True,
+        blank=True,
+        editable=False,
+        help_text=_("30-day-old Wikipedia edit count"),
     )
 
     # ~~~~~~~~~~~~~~~~~~~~~~~~~~~ User-entered data ~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -290,15 +316,32 @@ class Editor(models.Model):
         else:
             return None
 
-    def bundle_eligible(self, identity, global_userinfo):
+    def editor_account_old_enough(self):
+        # Check: registered >= 6 months ago
+        return datetime.today().date() - timedelta(days=182) >= self.wp_registered
 
-        # prev_editcount is set to 0 for the first 30 days, all edits get counted here for new users.
-        recent_edits = self.wp_editcount - self.prev_editcount
-
-        if self._is_user_valid(identity, global_userinfo) and recent_edits >= 10:
+    def bundle_eligible(self):
+        if self.wp_valid and self.wp_enough_recent_edits:
             return True
         else:
             return False
+
+    def _set_recent_edits(self):
+        # If it's been 30 days or more since we last updated historical editcount,
+        # copy wp_editcount to wp_editcount_prev before updating wp_editcount.
+        # This allows us track recent edits for bundle eligibility.
+        if self.wp_editcount_prev_date_updated:
+            editcount_update_delta = date.today() - self.wp_editcount_prev_date_updated
+            if editcount_update_delta.days >= 30:
+                self.wp_editcount_prev = self.wp_editcount
+                self.wp_editcount_prev_date_updated = date.today()
+                recent_edits = self.wp_editcount - self.wp_editcount_prev
+                if recent_edits >= 10:
+                    self.wp_enough_recent_edits = True
+                else:
+                    self.wp_enough_recent_edits = False
+        else:
+            self.wp_editcount_prev_date_updated = date.today()
 
     def _is_user_valid(self, identity, global_userinfo):
         """
@@ -314,7 +357,7 @@ class Editor(models.Model):
 
         if (
             editor_enough_edits(global_userinfo)
-            and editor_account_old_enough(identity, global_userinfo)
+            and self.editor_account_old_enough
             and editor_not_blocked(identity)
         ):
             return True
@@ -401,13 +444,7 @@ class Editor(models.Model):
         self.wp_rights = json.dumps(identity["rights"])
         self.wp_groups = json.dumps(identity["groups"])
         if global_userinfo:
-            # If it's been 30 days or more since we last updated historical editcount,
-            # copy wp_editcount to prev_editcount before updating wp_editcount.
-            # This allows us track recent edits for bundle eligibility.
-            if self.date_prev_editcount_updated:
-                editcount_update_delta = date.today() - self.date_prev_editcount_updated
-                if editcount_update_delta.days >= 30:
-                    self.prev_editcount = self.wp_editcount
+            self._set_recent_edits()
             self.wp_editcount = global_userinfo["editcount"]
         # Try oauth registration date first.  If it's not valid, try the global_userinfo date
         try:
@@ -422,8 +459,9 @@ class Editor(models.Model):
                 pass
 
         self.wp_registered = reg_date
+        self.wp_enough_edits = editor_enough_edits(global_userinfo)
+        self.wp_not_blocked = editor_not_blocked(identity)
         self.wp_valid = self._is_user_valid(identity, global_userinfo)
-        self.date_prev_editcount_updated = now()
         self.save()
 
         # This will be True the first time the user logs in, since use_wp_email

--- a/TWLight/users/models.py
+++ b/TWLight/users/models.py
@@ -129,6 +129,22 @@ class Editor(models.Model):
         # Translators: The date the user's profile was created on the website (not on Wikipedia).
         help_text=_("When this profile was first created"),
     )
+    # Set as non-editable.
+    date_prev_editcount_updated = models.DateField(
+        default=None,
+        null=True,
+        blank=True,
+        editable=False,
+        help_text=_("When the previous editcount was last updated from Wikipedia"),
+    )
+    # Translators: The number of edits this user has made to all Wikipedia projects 30 days ago
+    prev_editcount = models.IntegerField(
+        default=0,
+        null=True,
+        blank=True,
+        editable=False,
+        help_text=_("30-day-old Wikipedia edit count"),
+    )
 
     # ~~~~~~~~~~~~~~~~~~~~~~~ Data from Wikimedia OAuth ~~~~~~~~~~~~~~~~~~~~~~~#
     # Uses same field names as OAuth, but with wp_ prefixed.
@@ -247,6 +263,17 @@ class Editor(models.Model):
         else:
             return None
 
+    @property
+    def is_bundle_eligible(self, identity, global_userinfo):
+
+        # prev_editcount is set to 0 for the first 30 days, all edits get counted here for new users.
+        recent_edits = self.wp_editcount - self.prev_editcount
+
+        if self._is_user_valid(identity, global_userinfo) and recent_edits >= 10:
+            return True
+        else:
+            return False
+
     def _is_user_valid(self, identity, global_userinfo):
         """
         Check for the eligibility criteria laid out in the terms of service.
@@ -364,6 +391,13 @@ class Editor(models.Model):
         self.wp_rights = json.dumps(identity["rights"])
         self.wp_groups = json.dumps(identity["groups"])
         if global_userinfo:
+            # If it's been 30 days or more since we last updated historical editcount,
+            # copy wp_editcount to prev_editcount before updating wp_editcount.
+            # This allows us track recent edits for bundle eligibility.
+            if self.date_prev_editcount_updated:
+                editcount_update_delta = date.today() - self.date_prev_editcount_updated
+                if editcount_update_delta.days >= 30:
+                    self.prev_editcount = self.wp_editcount
             self.wp_editcount = global_userinfo["editcount"]
         # Try oauth registration date first.  If it's not valid, try the global_userinfo date
         try:
@@ -379,6 +413,7 @@ class Editor(models.Model):
 
         self.wp_registered = reg_date
         self.wp_valid = self._is_user_valid(identity, global_userinfo)
+        self.date_prev_editcount_updated = now()
         self.save()
 
         # This will be True the first time the user logs in, since use_wp_email

--- a/TWLight/users/models.py
+++ b/TWLight/users/models.py
@@ -167,18 +167,18 @@ def editor_recent_edits(
     wp_editcount_recent,
     wp_enough_recent_edits,
 ):
+
     # If we have historical data, see how many days have passed and how many edits have been made since the last check.
     if wp_editcount_prev_updated and wp_editcount_updated:
         editcount_update_delta = now() - wp_editcount_prev_updated
         editcount_delta = global_userinfo_editcount - wp_editcount_prev
         if (
-            # If the editor didn't have enough recent edits yet
-            # update the counts if it's been 30 days or sooner if they have now have enough edits.
-            # This grants them eligibility as soon as possible.
-            (not wp_enough_recent_edits)
-            and (editcount_update_delta.days >= 30 or editcount_delta >= 10)
+            # If the editor didn't have enough recent edits but they do now, update the counts immediately.
+            # This recognizes their eligibility as soon as possible.
+            (not wp_enough_recent_edits and editcount_delta >= 10)
             # If the user had enough edits, just update the counts after 30 days.
-            or (wp_enough_recent_edits and editcount_update_delta.days >= 30)
+            # This means that eligibility always lasts at least 30 days.
+            or (wp_enough_recent_edits and editcount_update_delta.days > 30)
         ):
             wp_editcount_prev = wp_editcount
             wp_editcount_prev_updated = wp_editcount_updated

--- a/TWLight/users/models.py
+++ b/TWLight/users/models.py
@@ -525,9 +525,7 @@ class Editor(models.Model):
         self.wp_enough_edits = editor_enough_edits(global_userinfo)
         self.wp_not_blocked = editor_not_blocked(identity)
         self.wp_valid = editor_valid(
-            self.wp_enough_edits,
-            self.wp_account_old_enough,
-            self.wp_not_blocked,
+            self.wp_enough_edits, self.wp_account_old_enough, self.wp_not_blocked
         )
         self.wp_bundle_eligible = editor_bundle_eligible(
             self.wp_valid, self.wp_enough_recent_edits

--- a/TWLight/users/models.py
+++ b/TWLight/users/models.py
@@ -289,15 +289,6 @@ class Editor(models.Model):
             "the terms of use?"
         ),
     )
-    wp_enough_recent_edits = models.BooleanField(
-        default=False,
-        editable=False,
-        # Translators: Help text asking whether the user met the recent editcount requirement for access (see https://wikipedialibrary.wmflabs.org/about/) the last time they logged in (when their information was last updated).
-        help_text=_(
-            "At their last login, did this user meet the recent editcount criterion in "
-            "the terms of use?"
-        ),
-    )
     wp_not_blocked = models.BooleanField(
         default=False,
         editable=False,
@@ -307,31 +298,40 @@ class Editor(models.Model):
             "the terms of use?"
         ),
     )
-    # Translators: The date that wp_editcount_prev was updated from Wikipedia.
+    wp_enough_recent_edits = models.BooleanField(
+        default=False,
+        editable=False,
+        # Translators: Help text asking whether the user met the recent editcount requirement for access to the library card bundle the last time they logged in (when their information was last updated).
+        help_text=_(
+            "At their last login, did this user meet the recent editcount criterion in "
+            "the terms of use?"
+        ),
+    )
     wp_editcount_prev_date_updated = models.DateField(
         default=None,
         null=True,
         blank=True,
         editable=False,
+        # Translators: The date that wp_editcount_prev was updated from Wikipedia.
         help_text=_("When the previous editcount was last updated from Wikipedia"),
     )
     # wp_editcount_prev is initially set to 0 so that all edits get counted as recent edits for new users.
-    # Translators: The number of edits this user made to all Wikipedia projects at a previous date.
     wp_editcount_prev = models.IntegerField(
         default=0,
         null=True,
         blank=True,
         editable=False,
+        # Translators: The number of edits this user made to all Wikipedia projects at a previous date.
         help_text=_("Previous Wikipedia edit count"),
     )
 
     # wp_editcount_recent is computed by selectively subtracting wp_editcount_prev from wp_editcount.
-    # Translators: The number of edits this user recently made to all Wikipedia projects.
     wp_editcount_recent = models.IntegerField(
         default=0,
         null=True,
         blank=True,
         editable=False,
+        # Translators: The number of edits this user recently made to all Wikipedia projects.
         help_text=_("Recent Wikipedia edit count"),
     )
     wp_bundle_eligible = models.BooleanField(

--- a/TWLight/users/models.py
+++ b/TWLight/users/models.py
@@ -203,6 +203,7 @@ def editor_recent_edits(
         wp_enough_recent_edits,
     )
 
+
 def editor_bundle_eligible(wp_valid, wp_enough_recent_edits):
     if wp_valid and wp_enough_recent_edits:
         return True
@@ -343,8 +344,6 @@ class Editor(models.Model):
             "At their last login, did this user meet the criteria for access to the library card bundle?"
         ),
     )
-
-
 
     # ~~~~~~~~~~~~~~~~~~~~~~~~~~~ User-entered data ~~~~~~~~~~~~~~~~~~~~~~~~~~~
     contributions = models.TextField(
@@ -536,7 +535,9 @@ class Editor(models.Model):
             self.wp_account_old_enough,
             self.wp_not_blocked,
         )
-        self.wp_bundle_eligible = editor_bundle_eligible(self.wp_valid, self.wp_enough_recent_edits)
+        self.wp_bundle_eligible = editor_bundle_eligible(
+            self.wp_valid, self.wp_enough_recent_edits
+        )
         self.user.save()
 
         # Add language if the user hasn't selected one

--- a/TWLight/users/templates/users/editor_detail_data.html
+++ b/TWLight/users/templates/users/editor_detail_data.html
@@ -1,208 +1,244 @@
 {% load i18n %}
 
-  <p>
+<p>
     {% comment %} Translators: This is shown on editor profiles, under the heading for Wikipedia editor data. {% endcomment %}
     {% blocktrans trimmed %}
-      This information is updated automatically from your Wikimedia account 
-      each time you log in, except for the Contributions field, where you 
-      can describe your Wikimedia editing history.
+        This information is updated automatically from your Wikimedia account
+        each time you log in, except for the Contributions field, where you
+        can describe your Wikimedia editing history.
     {% endblocktrans %}
-  </p>
+</p>
 
-  <hr />
+<hr/>
 
-  <div class="row clearfix">
+<div class="row clearfix">
     <div class="col-xs-12 col-sm-3">
-      {% comment %} Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this labels the user's username. {% endcomment %}
-      <strong>{% trans "Username *" %}</strong>
+        {% comment %} Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this labels the user's username. {% endcomment %}
+        <strong>{% trans "Username *" %}</strong>
     </div>
     <div class="col-xs-12 col-sm-9">
-      {{ editor.wp_username }}
-      {% if editor.wp_link_central_auth %}
-        <br />
-        {% comment %} Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this is a button for viewing a Wikipedian's account information through https://meta.wikimedia.org/wiki/Special:CentralAuth/) {% endcomment %}
-        <a href="{{ editor.wp_link_central_auth }}">({% trans "CentralAuth" %})</a>
-      {% endif %}
+        {{ editor.wp_username }}
+        {% if editor.wp_link_central_auth %}
+            <br/>
+            {% comment %} Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this is a button for viewing a Wikipedian's account information through https://meta.wikimedia.org/wiki/Special:CentralAuth/) {% endcomment %}
+            <a href="{{ editor.wp_link_central_auth }}">({% trans "CentralAuth" %})</a>
+        {% endif %}
     </div>
-  </div>
+</div>
 
-  <hr />
+<hr/>
 
-  <div class="row clearfix">
+<div class="row clearfix">
     <div class="col-xs-12 col-sm-3">
-      {% comment %} Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this labels the user's description of their Wikipedia edits. {% endcomment %}
-      <strong>{% trans "Contributions" %}</strong>
+        {% comment %} Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this labels the user's description of their Wikipedia edits. {% endcomment %}
+        <strong>{% trans "Contributions" %}</strong>
     </div>
     <div class="col-xs-12 col-sm-9">
-      {% if editor.contributions %}
-        {{ editor.contributions }}
-      {% endif %}
-      {% ifequal editor.user user %}
-        <br />
-        {% comment %} Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this is a button for updating a user's description of themself. {% endcomment %}
-         <a href="{% url 'users:editor_update' editor.pk %}">{% trans "(update)" %}</a>
-      {% endifequal %}
-      <br />
+        {% if editor.contributions %}
+            {{ editor.contributions }}
+        {% endif %}
+        {% ifequal editor.user user %}
+            <br/>
+            {% comment %} Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this is a button for updating a user's description of themself. {% endcomment %}
+            <a href="{% url 'users:editor_update' editor.pk %}">{% trans "(update)" %}</a>
+        {% endifequal %}
+        <br/>
     </div>
-  </div>
+</div>
 
-  <hr />
+<hr/>
 
-  <div class="row clearfix">
+<div class="row clearfix">
     <div class="col-xs-12 col-sm-3">
-      {% comment %} Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this is the heading for a Yes/No ToU question. {% endcomment %}
-      <strong>{% trans "Satisfies terms of use?" %}</strong>
-      <p>
-        {% comment %} Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this question has a Yes or No answer. {% endcomment %}
-        {% blocktrans trimmed %}
-          At their last login, did this user meet the criteria set forth in the
-          terms of use?
-        {% endblocktrans %}
-      </p>
-    </div>
-    <div class="col-xs-12 col-sm-9">
-      {% if editor.wp_valid %}
-        {% comment %} Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this shows if the user qualifies through the technical requirements. {% endcomment %}
-        {% trans "Yes" %}
-      {% else %}
-        <p class="bg-danger"><strong class="warning">{% trans "No" %}</strong></p>
+        {% comment %} Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this is the heading for a Yes/No ToU question. {% endcomment %}
+        <strong>{% trans "Satisfies terms of use?" %}</strong>
         <p>
-          {% comment %} Translators: When viewing a user's profile in an application, this message shows if the software doesn't think that the user is eligible for access. Don't translate {{ username }}.{% endcomment %}
-          {% blocktrans trimmed with username=editor.wp_username %}
-            {{ username }} may still be eligible for access grants at the
-            coordinators' discretion.
-          {% endblocktrans %}
+            {% comment %} Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this question has a Yes or No answer. {% endcomment %}
+            {% blocktrans trimmed %}
+                At their last login, did this user meet the criteria set forth in the
+                terms of use?
+            {% endblocktrans %}
         </p>
-      {% endif %}
-    </div>
-  </div>
-
-  <hr />
-
-  <div class="row clearfix">
-    <div class="col-xs-12 col-sm-3">
-      {% comment %} Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this labels the edit count of the user across all Wikimedia projects. Don't remove the * {% endcomment %}
-      <strong>{% trans "Global edit count *" %}</strong>
     </div>
     <div class="col-xs-12 col-sm-9">
-      {{ editor.wp_editcount }}
-      {% if editor.wp_link_guc %}
-        <br />
-        {# Translators: this links to a Tools page with edit stats for a given wikipedia editor. #}
-        <a href="{{ editor.wp_link_guc }}">{% trans "(view global user contributions)" %}</a>
-      {% endif %}
+        {% if editor.wp_valid %}
+            {% comment %} Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this shows if the user qualifies through the technical requirements. {% endcomment %}
+            {% trans "Yes" %}
+        {% else %}
+            <p class="bg-danger"><strong class="warning">{% trans "No" %}</strong></p>
+            <p>
+                {% comment %} Translators: When viewing a user's profile in an application, this message shows if the software doesn't think that the user is eligible for access. Don't translate {{ username }}.{% endcomment %}
+                {% blocktrans trimmed with username=editor.wp_username %}
+                    {{ username }} may still be eligible for access grants at the
+                    coordinators' discretion.
+                {% endblocktrans %}
+            </p>
+        {% endif %}
     </div>
-  </div>
-
-  <hr />
-
-  <div class="row clearfix">
     <div class="col-xs-12 col-sm-3">
-      {% comment %} Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this labels the date the user registered their Meta-wiki account or the date their account was merged by the SUL merge process. Don't remove the * {% endcomment %}
-      <strong>{% trans "Meta-Wiki registration or SUL merge date *" %}</strong>
+        {% comment %} Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this is the heading for a Yes/No ToU question. {% endcomment %}
+        {% trans "Satisfies minimum account age?" %}
     </div>
     <div class="col-xs-12 col-sm-9">
-      {{ editor.wp_registered }}
+        {% if editor.wp_account_old_enough %}
+            {% comment %} Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this shows if the user qualifies through the technical requirements. {% endcomment %}
+            {% trans "Yes" %}
+        {% else %}
+            <strong class="warning">{% trans "No" %}</strong>
+        {% endif %}
     </div>
-  </div>
-
-  <hr />
-
-  <div class="row clearfix">
     <div class="col-xs-12 col-sm-3">
-      {% comment %} Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this labels the user's Wikipedia User ID. Don't remove the * {% endcomment %}
-      <strong>{% trans "Wikipedia user ID *" %}</strong>
+        {% comment %} Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this is the heading for a Yes/No ToU question. {% endcomment %}
+        {% trans "Satisfies minimum edit count?" %}
     </div>
     <div class="col-xs-12 col-sm-9">
-      {{ editor.wp_sub }}
+        {% if editor.wp_enough_edits %}
+            {% comment %} Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this shows if the user qualifies through the technical requirements. {% endcomment %}
+            {% trans "Yes" %}
+        {% else %}
+            <strong class="warning">{% trans "No" %}</strong>
+        {% endif %}
     </div>
-  </div>
+    <div class="col-xs-12 col-sm-3">
+        {% comment %} Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this is the heading for a Yes/No ToU question. {% endcomment %}
+        {% trans "Is not blocked on any project?" %}
+    </div>
+    <div class="col-xs-12 col-sm-9">
+        {% if editor.wp_not_blocked %}
+            {% comment %} Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this shows if the user qualifies through the technical requirements. {% endcomment %}
+            {% trans "Yes" %}
+        {% else %}
+            <strong class="warning">{% trans "No" %}</strong>
+        {% endif %}
+    </div>
+</div>
 
-  {# The following is personal data and must ONLY be displayed to its owner. #}
-  {% ifequal editor.user user %}
-    <hr />
+<hr/>
+
+<div class="row clearfix">
+    <div class="col-xs-12 col-sm-3">
+        {% comment %} Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this labels the edit count of the user across all Wikimedia projects. Don't remove the * {% endcomment %}
+        <strong>{% trans "Global edit count *" %}</strong>
+    </div>
+    <div class="col-xs-12 col-sm-9">
+        {{ editor.wp_editcount }}
+        {% if editor.wp_link_guc %}
+            <br/>
+            {# Translators: this links to a Tools page with edit stats for a given wikipedia editor. #}
+            <a href="{{ editor.wp_link_guc }}">{% trans "(view global user contributions)" %}</a>
+        {% endif %}
+    </div>
+</div>
+
+<hr/>
+
+<div class="row clearfix">
+    <div class="col-xs-12 col-sm-3">
+        {% comment %} Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this labels the date the user registered their Meta-wiki account or the date their account was merged by the SUL merge process. Don't remove the * {% endcomment %}
+        <strong>{% trans "Meta-Wiki registration or SUL merge date *" %}</strong>
+    </div>
+    <div class="col-xs-12 col-sm-9">
+        {{ editor.wp_registered }}
+    </div>
+</div>
+
+<hr/>
+
+<div class="row clearfix">
+    <div class="col-xs-12 col-sm-3">
+        {% comment %} Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this labels the user's Wikipedia User ID. Don't remove the * {% endcomment %}
+        <strong>{% trans "Wikipedia user ID *" %}</strong>
+    </div>
+    <div class="col-xs-12 col-sm-9">
+        {{ editor.wp_sub }}
+    </div>
+</div>
+
+{# The following is personal data and must ONLY be displayed to its owner. #}
+{% ifequal editor.user user %}
+    <hr/>
 
     <h3>Personal data</h3>
 
     <p>
-      <span class="glyphicon glyphicon-info-sign"></span>
-      {% comment %} Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this text is in the 'Personal data' section. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).{% endcomment %}
-      {% blocktrans trimmed %}
-        The following information is visible only to you, site administrators,
-        publishing partners (where required), and volunteer Wikipedia Library
-        coordinators (who have signed a Non-Disclosure Agreement).
-      {% endblocktrans %}
+        <span class="glyphicon glyphicon-info-sign"></span>
+        {% comment %} Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this text is in the 'Personal data' section. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).{% endcomment %}
+        {% blocktrans trimmed %}
+            The following information is visible only to you, site administrators,
+            publishing partners (where required), and volunteer Wikipedia Library
+            coordinators (who have signed a Non-Disclosure Agreement).
+        {% endblocktrans %}
     </p>
 
     <p>
-      {% url 'users:pii_update' as update_url %}
-      {% comment %} Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this labels a button which users can click to update or remove their personal information. Don't translate {{ update_url }}.{% endcomment %}
-      {% blocktrans trimmed %}
-        You may <a href="{{ update_url }}">update or delete</a>
-        your data at any time.
-      {% endblocktrans %}
+        {% url 'users:pii_update' as update_url %}
+        {% comment %} Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this labels a button which users can click to update or remove their personal information. Don't translate {{ update_url }}.{% endcomment %}
+        {% blocktrans trimmed %}
+            You may <a href="{{ update_url }}">update or delete</a>
+            your data at any time.
+        {% endblocktrans %}
     </p>
 
-    <hr />
+    <hr/>
 
     <div class="row clearfix">
-      <div class="col-xs-12 col-sm-3">
-        {% comment %} Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this labels the user's email. Don't remove the *. {% endcomment %}
-        <strong>{% trans "Email *" %}</strong>
-      </div>
-      <div class="col-xs-12 col-sm-9">
-	      {{ editor.user.email }}<br />
-        <a href="{% url 'users:email_change' %}">{% trans "(update)" %}</a>
-      </div>
+        <div class="col-xs-12 col-sm-3">
+            {% comment %} Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this labels the user's email. Don't remove the *. {% endcomment %}
+            <strong>{% trans "Email *" %}</strong>
+        </div>
+        <div class="col-xs-12 col-sm-9">
+            {{ editor.user.email }}<br/>
+            <a href="{% url 'users:email_change' %}">{% trans "(update)" %}</a>
+        </div>
     </div>
 
-    <hr />
+    <hr/>
 
     <div class="row clearfix">
-      <div class="col-xs-12 col-sm-3">
-        {% comment %} Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this labels the user's real name. {% endcomment %}
-        <strong>{% trans "Real name" %}</strong>
-      </div>
-      <div class="col-xs-12 col-sm-9">
-        {{ editor.real_name }}
-      </div>
+        <div class="col-xs-12 col-sm-3">
+            {% comment %} Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this labels the user's real name. {% endcomment %}
+            <strong>{% trans "Real name" %}</strong>
+        </div>
+        <div class="col-xs-12 col-sm-9">
+            {{ editor.real_name }}
+        </div>
     </div>
 
-    <hr />
+    <hr/>
 
     <div class="row clearfix">
-      <div class="col-xs-12 col-sm-3">
-        {% comment %} Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this labels the country in which the user lives. {% endcomment %}
-        <strong>{% trans "Country of residence" %}</strong>
-      </div>
-      <div class="col-xs-12 col-sm-9">
-        {{ editor.country_of_residence }}
-      </div>
+        <div class="col-xs-12 col-sm-3">
+            {% comment %} Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this labels the country in which the user lives. {% endcomment %}
+            <strong>{% trans "Country of residence" %}</strong>
+        </div>
+        <div class="col-xs-12 col-sm-9">
+            {{ editor.country_of_residence }}
+        </div>
     </div>
 
-    <hr />
+    <hr/>
 
     <div class="row clearfix">
-      <div class="col-xs-12 col-sm-3">
-        {% comment %} Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this labels the user's occupation. {% endcomment %}
-        <strong>{% trans "Occupation" %}</strong>
-      </div>
-      <div class="col-xs-12 col-sm-9">
-        {{ editor.occupation }}
-      </div>
+        <div class="col-xs-12 col-sm-3">
+            {% comment %} Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this labels the user's occupation. {% endcomment %}
+            <strong>{% trans "Occupation" %}</strong>
+        </div>
+        <div class="col-xs-12 col-sm-9">
+            {{ editor.occupation }}
+        </div>
     </div>
 
-    <hr />
+    <hr/>
 
     <div class="row clearfix">
-      <div class="col-xs-12 col-sm-3">
-        {% comment %} Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this labels the user's institutional affiliation (e.g. university) {% endcomment %}
-        <strong>{% trans "Institutional affiliation" %}</strong>
-      </div>
-      <div class="col-xs-12 col-sm-9">
-        {{ editor.affiliation }}
-      </div>
+        <div class="col-xs-12 col-sm-3">
+            {% comment %} Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this labels the user's institutional affiliation (e.g. university) {% endcomment %}
+            <strong>{% trans "Institutional affiliation" %}</strong>
+        </div>
+        <div class="col-xs-12 col-sm-9">
+            {{ editor.affiliation }}
+        </div>
     </div>
 
-    <hr />
-  {% endifequal %}
+    <hr/>
+{% endifequal %}

--- a/TWLight/users/templates/users/editor_detail_data.html
+++ b/TWLight/users/templates/users/editor_detail_data.html
@@ -173,36 +173,9 @@
     <div class="col-xs-12 col-sm-3">
         {% comment %} Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this labels the recent edit count of the user across all Wikimedia projects. Don't remove the * {% endcomment %}
         <strong>{% trans "Recent global edit count *" %}</strong>
-        <p>
-            {% comment %} translators: when viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this describes the method used to determine recent editcount. {% endcomment %}
-            {% blocktrans trimmed %}
-                Recent global edit count is computed by periodically recording the current global edit count and retaining a previous value.
-                1 current value and 1 previous value are kept in order to determine recent activity over a period of up to 30 days.
-            {% endblocktrans %}
-        </p>
     </div>
     <div class="col-xs-12 col-sm-9">
         {{ editor.wp_editcount_recent }}
-    </div>
-</div>
-
-<div class="row clearfix">
-    <div class="col-xs-12 col-sm-3">
-        {% comment %} Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this labels the previous edit count of the user across all Wikimedia projects. Don't remove the * {% endcomment %}
-        {% trans "Previous global edit count *" %}
-    </div>
-    <div class="col-xs-12 col-sm-9">
-        {{ editor.wp_editcount_prev }}
-    </div>
-</div>
-
-<div class="row clearfix">
-    <div class="col-xs-12 col-sm-3">
-        {% comment %} Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this labels the date the previous edit count of the user across all Wikimedia projects was collected. Don't remove the * {% endcomment %}
-        {% trans "Previous global edit count date *" %}
-    </div>
-    <div class="col-xs-12 col-sm-9">
-        {{ editor.wp_editcount_prev_date_updated }}
     </div>
 </div>
 

--- a/TWLight/users/templates/users/editor_detail_data.html
+++ b/TWLight/users/templates/users/editor_detail_data.html
@@ -134,6 +134,8 @@
             <p class="bg-danger"><strong class="warning">{% trans "No" %}</strong></p>
         {% endif %}
     </div>
+</div>
+<div class="row clearfix">
     <div class="col-xs-12 col-sm-3">
         {% comment %} Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this is the heading for a Yes/No program eligibility question. {% endcomment %}
         {% trans "Satisfies recent edit count?" %}

--- a/TWLight/users/templates/users/editor_detail_data.html
+++ b/TWLight/users/templates/users/editor_detail_data.html
@@ -117,6 +117,41 @@
 
 <div class="row clearfix">
     <div class="col-xs-12 col-sm-3">
+        {% comment %} Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this is the heading for a Yes/No program eligibility question. {% endcomment %}
+        <strong>{% trans "Eligible for Bundle?" %}</strong>
+        <p>
+            {% comment %} Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this question has a Yes or No answer. {% endcomment %}
+            {% blocktrans trimmed %}
+                At their last login, did this user meet the criteria set forth in the Library Bundle? Note that satisfying terms of use is a prerequisite to bundle eligibility.
+            {% endblocktrans %}
+        </p>
+    </div>
+    <div class="col-xs-12 col-sm-9">
+        {% if editor.wp_bundle_eligible %}
+            {% comment %} Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this shows if the user qualifies through the technical requirements for the Library Bundle. {% endcomment %}
+            {% trans "Yes" %}
+        {% else %}
+            <p class="bg-danger"><strong class="warning">{% trans "No" %}</strong></p>
+        {% endif %}
+    </div>
+    <div class="col-xs-12 col-sm-3">
+        {% comment %} Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this is the heading for a Yes/No program eligibility question. {% endcomment %}
+        {% trans "Satisfies recent edit count?" %}
+    </div>
+    <div class="col-xs-12 col-sm-9">
+        {% if editor.enough_recent_edits %}
+            {% comment %} Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this shows if the user qualifies through the technical requirements for the Library Bundle. {% endcomment %}
+            {% trans "Yes" %}
+        {% else %}
+            <strong class="warning">{% trans "No" %}</strong>
+        {% endif %}
+    </div>
+</div>
+
+<hr/>
+
+<div class="row clearfix">
+    <div class="col-xs-12 col-sm-3">
         {% comment %} Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this labels the edit count of the user across all Wikimedia projects. Don't remove the * {% endcomment %}
         <strong>{% trans "Global edit count *" %}</strong>
     </div>

--- a/TWLight/users/templates/users/editor_detail_data.html
+++ b/TWLight/users/templates/users/editor_detail_data.html
@@ -53,9 +53,9 @@
         {% comment %} Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this is the heading for a Yes/No ToU question. {% endcomment %}
         <strong>{% trans "Satisfies terms of use?" %}</strong>
         <p>
-            {% comment %} Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this question has a Yes or No answer. {% endcomment %}
+            {% comment %} translators: when viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this question has a yes or no answer. {% endcomment %}
             {% blocktrans trimmed %}
-                At their last login, did this user meet the criteria set forth in the
+                at their last login, did this user meet the criteria set forth in the
                 terms of use?
             {% endblocktrans %}
         </p>
@@ -152,8 +152,8 @@
 
 <div class="row clearfix">
     <div class="col-xs-12 col-sm-3">
-        {% comment %} Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this labels the edit count of the user across all Wikimedia projects. Don't remove the * {% endcomment %}
-        <strong>{% trans "Global edit count *" %}</strong>
+        {% comment %} Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this labels the edit current count of the user across all Wikimedia projects. Don't remove the * {% endcomment %}
+        <strong>{% trans "Current global edit count *" %}</strong>
     </div>
     <div class="col-xs-12 col-sm-9">
         {{ editor.wp_editcount }}
@@ -162,6 +162,45 @@
             {# Translators: this links to a Tools page with edit stats for a given wikipedia editor. #}
             <a href="{{ editor.wp_link_guc }}">{% trans "(view global user contributions)" %}</a>
         {% endif %}
+    </div>
+</div>
+
+<hr/>
+
+<div class="row clearfix">
+    <div class="col-xs-12 col-sm-3">
+        {% comment %} Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this labels the recent edit count of the user across all Wikimedia projects. Don't remove the * {% endcomment %}
+        <strong>{% trans "Recent global edit count *" %}</strong>
+        <p>
+            {% comment %} translators: when viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this describes the method used to determine recent editcount. {% endcomment %}
+            {% blocktrans trimmed %}
+                Recent global edit count is computed by periodically recording the current global edit count and retaining a previous value.
+                1 current value and 1 previous value are kept in order to determine recent activity over a period of up to 30 days.
+            {% endblocktrans %}
+        </p>
+    </div>
+    <div class="col-xs-12 col-sm-9">
+        {{ editor.wp_editcount_recent }}
+    </div>
+</div>
+
+<div class="row clearfix">
+    <div class="col-xs-12 col-sm-3">
+        {% comment %} Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this labels the previous edit count of the user across all Wikimedia projects. Don't remove the * {% endcomment %}
+        {% trans "Previous global edit count *" %}
+    </div>
+    <div class="col-xs-12 col-sm-9">
+        {{ editor.wp_editcount_prev }}
+    </div>
+</div>
+
+<div class="row clearfix">
+    <div class="col-xs-12 col-sm-3">
+        {% comment %} Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this labels the date the previous edit count of the user across all Wikimedia projects was collected. Don't remove the * {% endcomment %}
+        {% trans "Previous global edit count date *" %}
+    </div>
+    <div class="col-xs-12 col-sm-9">
+        {{ editor.wp_editcount_prev_date_updated }}
     </div>
 </div>
 

--- a/TWLight/users/tests.py
+++ b/TWLight/users/tests.py
@@ -750,11 +750,11 @@ class EditorModelTestCase(TestCase):
         self.assertTrue(valid)
 
         # 1st time bundle check should always pass for a valid user.
-        self.test_editor.wp_editcount_prev_date_updated, self.test_editor.wp_editcount_prev, self.test_editor.wp_editcount_recent, self.test_editor.wp_enough_recent_edits = editor_recent_edits(
+        self.test_editor.wp_editcount_prev_updated, self.test_editor.wp_editcount_prev, self.test_editor.wp_editcount_recent, self.test_editor.wp_enough_recent_edits = editor_recent_edits(
             global_userinfo["editcount"],
-            self.test_editor.wp_editcount_date_updated,
+            self.test_editor.wp_editcount_updated,
             self.test_editor.wp_editcount,
-            self.test_editor.wp_editcount_prev_date_updated,
+            self.test_editor.wp_editcount_prev_updated,
             self.test_editor.wp_editcount_prev,
             self.test_editor.wp_editcount_recent,
             self.test_editor.wp_enough_recent_edits,
@@ -765,11 +765,11 @@ class EditorModelTestCase(TestCase):
         self.assertTrue(bundle_eligible)
 
         # A valid user should pass 30 days after their first login, even if they haven't made anymore edits.
-        self.test_editor.wp_editcount_prev_date_updated, self.test_editor.wp_editcount_prev, self.test_editor.wp_editcount_recent, self.test_editor.wp_enough_recent_edits = editor_recent_edits(
+        self.test_editor.wp_editcount_prev_updated, self.test_editor.wp_editcount_prev, self.test_editor.wp_editcount_recent, self.test_editor.wp_enough_recent_edits = editor_recent_edits(
             global_userinfo["editcount"],
-            self.test_editor.wp_editcount_date_updated,
+            self.test_editor.wp_editcount_updated,
             self.test_editor.wp_editcount,
-            self.test_editor.wp_editcount_prev_date_updated - timedelta(days=30),
+            self.test_editor.wp_editcount_prev_updated - timedelta(days=30),
             self.test_editor.wp_editcount_prev,
             self.test_editor.wp_editcount_recent,
             self.test_editor.wp_enough_recent_edits,
@@ -780,11 +780,11 @@ class EditorModelTestCase(TestCase):
         self.assertTrue(bundle_eligible)
 
         # A valid user should fail 31 days after their first login, if they haven't made any more edits.
-        self.test_editor.wp_editcount_prev_date_updated, self.test_editor.wp_editcount_prev, self.test_editor.wp_editcount_recent, self.test_editor.wp_enough_recent_edits = editor_recent_edits(
+        self.test_editor.wp_editcount_prev_updated, self.test_editor.wp_editcount_prev, self.test_editor.wp_editcount_recent, self.test_editor.wp_enough_recent_edits = editor_recent_edits(
             global_userinfo["editcount"],
-            self.test_editor.wp_editcount_date_updated,
+            self.test_editor.wp_editcount_updated,
             self.test_editor.wp_editcount,
-            self.test_editor.wp_editcount_prev_date_updated - timedelta(days=31),
+            self.test_editor.wp_editcount_prev_updated - timedelta(days=31),
             self.test_editor.wp_editcount_prev,
             self.test_editor.wp_editcount_recent,
             self.test_editor.wp_enough_recent_edits,
@@ -795,11 +795,11 @@ class EditorModelTestCase(TestCase):
         self.assertFalse(bundle_eligible)
 
         # A valid user should pass 31 days after their first login if they have made enough edits.
-        self.test_editor.wp_editcount_prev_date_updated, self.test_editor.wp_editcount_prev, self.test_editor.wp_editcount_recent, self.test_editor.wp_enough_recent_edits = editor_recent_edits(
+        self.test_editor.wp_editcount_prev_updated, self.test_editor.wp_editcount_prev, self.test_editor.wp_editcount_recent, self.test_editor.wp_enough_recent_edits = editor_recent_edits(
             global_userinfo["editcount"] + 10,
-            self.test_editor.wp_editcount_date_updated,
+            self.test_editor.wp_editcount_updated,
             self.test_editor.wp_editcount,
-            self.test_editor.wp_editcount_prev_date_updated - timedelta(days=31),
+            self.test_editor.wp_editcount_prev_updated - timedelta(days=31),
             self.test_editor.wp_editcount_prev,
             self.test_editor.wp_editcount_recent,
             self.test_editor.wp_enough_recent_edits,
@@ -813,11 +813,11 @@ class EditorModelTestCase(TestCase):
         identity["blocked"] = True
         not_blocked = editor_not_blocked(identity)
         valid = editor_valid(enough_edits, account_old_enough, not_blocked)
-        self.test_editor.wp_editcount_prev_date_updated, self.test_editor.wp_editcount_prev, self.test_editor.wp_editcount_recent, self.test_editor.wp_enough_recent_edits = editor_recent_edits(
+        self.test_editor.wp_editcount_prev_updated, self.test_editor.wp_editcount_prev, self.test_editor.wp_editcount_recent, self.test_editor.wp_enough_recent_edits = editor_recent_edits(
             global_userinfo["editcount"] + 10,
-            self.test_editor.wp_editcount_date_updated,
+            self.test_editor.wp_editcount_updated,
             self.test_editor.wp_editcount,
-            self.test_editor.wp_editcount_prev_date_updated - timedelta(days=31),
+            self.test_editor.wp_editcount_prev_updated - timedelta(days=31),
             self.test_editor.wp_editcount_prev,
             self.test_editor.wp_editcount_recent,
             self.test_editor.wp_enough_recent_edits,

--- a/TWLight/users/tests.py
+++ b/TWLight/users/tests.py
@@ -653,31 +653,14 @@ class EditorModelTestCase(TestCase):
         expected_text = ["sysops", "bureaucrats"]
         self.assertEqual(expected_text, self.test_editor.get_wp_groups_display)
 
-    @patch("urllib.request.urlopen")
-    def test_is_user_valid(self, mock_urlopen):
+    def test_is_user_valid(self):
         """
         Users must:
         * Have >= 500 edits
         * Be active for >= 6 months
         * Have Special:Email User enabled
         * Not be blocked on any projects
-
-        This checks everything except Special:Email. (Checking that requires
-        another http request, so we're going to mock a successful request here
-        in order to check all the other criteria, and check for the failure case
-        in the next test.)
         """
-        mock_response = Mock()
-
-        oauth_data = FAKE_IDENTITY_DATA
-
-        global_userinfo_data = FAKE_GLOBAL_USERINFO
-
-        # This goes to an iterator; we need to return the expected data
-        # enough times to power all the calls to read() in this function.
-        mock_response.read.side_effect = [json.dumps(oauth_data)] * 7
-
-        mock_urlopen.return_value = mock_response
 
         identity = copy.copy(FAKE_IDENTITY)
         global_userinfo = copy.copy(FAKE_GLOBAL_USERINFO)
@@ -762,24 +745,12 @@ class EditorModelTestCase(TestCase):
         # Valid users with enough recent edits are eligible.
         self.assertTrue(editor_bundle_eligible(True, True))
 
-    @patch("urllib.request.urlopen")
-    def test_is_user_bundle_eligible(self, mock_urlopen):
+    def test_is_user_bundle_eligible(self):
         """
         Users must:
         * Be valid
         * Have made 10 edits in the last 30 days (with some wiggle room, as you will see)
         """
-        mock_response = Mock()
-
-        oauth_data = FAKE_IDENTITY_DATA
-
-        global_userinfo_data = FAKE_GLOBAL_USERINFO
-
-        # This goes to an iterator; we need to return the expected data
-        # enough times to power all the calls to read() in this function.
-        mock_response.read.side_effect = [json.dumps(oauth_data)] * 7
-
-        mock_urlopen.return_value = mock_response
 
         identity = copy.copy(FAKE_IDENTITY)
         global_userinfo = copy.copy(FAKE_GLOBAL_USERINFO)

--- a/TWLight/users/tests.py
+++ b/TWLight/users/tests.py
@@ -671,7 +671,7 @@ class EditorModelTestCase(TestCase):
         enough_edits = editor_enough_edits(global_userinfo)
         not_blocked = editor_not_blocked(identity)
         valid = editor_valid(
-            self.test_editor.wp_username, enough_edits, account_old_enough, not_blocked
+            enough_edits, account_old_enough, not_blocked
         )
         self.assertTrue(valid)
 
@@ -679,7 +679,7 @@ class EditorModelTestCase(TestCase):
         global_userinfo["editcount"] = 500
         enough_edits = editor_enough_edits(global_userinfo)
         valid = editor_valid(
-            self.test_editor.wp_username, enough_edits, account_old_enough, not_blocked
+            enough_edits, account_old_enough, not_blocked
         )
         self.assertTrue(valid)
 
@@ -687,7 +687,7 @@ class EditorModelTestCase(TestCase):
         global_userinfo["editcount"] = 499
         enough_edits = editor_enough_edits(global_userinfo)
         valid = editor_valid(
-            self.test_editor.wp_username, enough_edits, account_old_enough, not_blocked
+            enough_edits, account_old_enough, not_blocked
         )
         self.assertFalse(valid)
 
@@ -698,7 +698,7 @@ class EditorModelTestCase(TestCase):
         account_old_enough = editor_account_old_enough(registered)
         enough_edits = editor_enough_edits(global_userinfo)
         valid = editor_valid(
-            self.test_editor.wp_username, enough_edits, account_old_enough, not_blocked
+            enough_edits, account_old_enough, not_blocked
         )
         self.assertFalse(valid)
 
@@ -708,7 +708,7 @@ class EditorModelTestCase(TestCase):
         registered = editor_reg_date(identity, global_userinfo)
         account_old_enough = editor_account_old_enough(registered)
         valid = editor_valid(
-            self.test_editor.wp_username, enough_edits, account_old_enough, not_blocked
+            enough_edits, account_old_enough, not_blocked
         )
         self.assertTrue(valid)
 
@@ -718,7 +718,7 @@ class EditorModelTestCase(TestCase):
         registered = editor_reg_date(identity, global_userinfo)
         account_old_enough = editor_account_old_enough(registered)
         valid = editor_valid(
-            self.test_editor.wp_username, enough_edits, account_old_enough, not_blocked
+            enough_edits, account_old_enough, not_blocked
         )
         self.assertTrue(valid)
 
@@ -726,7 +726,7 @@ class EditorModelTestCase(TestCase):
         identity["blocked"] = True
         not_blocked = editor_not_blocked(identity)
         valid = editor_valid(
-            self.test_editor.wp_username, enough_edits, account_old_enough, not_blocked
+            enough_edits, account_old_enough, not_blocked
         )
         self.assertFalse(valid)
 
@@ -761,7 +761,7 @@ class EditorModelTestCase(TestCase):
         enough_edits = editor_enough_edits(global_userinfo)
         not_blocked = editor_not_blocked(identity)
         valid = editor_valid(
-            self.test_editor.wp_username, enough_edits, account_old_enough, not_blocked
+            enough_edits, account_old_enough, not_blocked
         )
         self.assertTrue(valid)
 
@@ -821,7 +821,7 @@ class EditorModelTestCase(TestCase):
         identity["blocked"] = True
         not_blocked = editor_not_blocked(identity)
         valid = editor_valid(
-            self.test_editor.wp_username, enough_edits, account_old_enough, not_blocked
+            enough_edits, account_old_enough, not_blocked
         )
         self.test_editor.wp_editcount_prev_date_updated, self.test_editor.wp_editcount_prev, self.test_editor.wp_editcount_recent, self.test_editor.wp_enough_recent_edits = editor_recent_edits(
             global_userinfo["editcount"] + 10,

--- a/TWLight/users/tests.py
+++ b/TWLight/users/tests.py
@@ -25,7 +25,16 @@ from .authorization import OAuthBackend
 from .helpers.wiki_list import WIKIS, LANGUAGE_CODES
 from .factories import EditorFactory, UserFactory
 from .groups import get_coordinators, get_restricted
-from .models import UserProfile, Editor, Authorization
+from .models import (
+    UserProfile,
+    Editor,
+    Authorization,
+    editor_valid,
+    editor_account_old_enough,
+    editor_enough_edits,
+    editor_not_blocked,
+    editor_reg_date,
+)
 
 FAKE_IDENTITY_DATA = {"query": {"userinfo": {"options": {"disablemail": 0}}}}
 
@@ -672,41 +681,76 @@ class EditorModelTestCase(TestCase):
         global_userinfo = copy.copy(FAKE_GLOBAL_USERINFO)
 
         # Valid data
-        self.assertTrue(self.test_editor._is_user_valid(identity, global_userinfo))
+        registered = editor_reg_date(identity, global_userinfo)
+        account_old_enough = editor_account_old_enough(registered)
+        enough_edits = editor_enough_edits(global_userinfo)
+        not_blocked = editor_not_blocked(identity)
+        valid = editor_valid(
+            self.test_editor.wp_username, enough_edits, account_old_enough, not_blocked
+        )
+        self.assertTrue(valid)
 
         # Edge case
         global_userinfo["editcount"] = 500
-        self.assertTrue(self.test_editor._is_user_valid(identity, global_userinfo))
+        enough_edits = editor_enough_edits(global_userinfo)
+        valid = editor_valid(
+            self.test_editor.wp_username, enough_edits, account_old_enough, not_blocked
+        )
+        self.assertTrue(valid)
 
         # Too few edits
         global_userinfo["editcount"] = 499
-        self.assertFalse(self.test_editor._is_user_valid(identity, global_userinfo))
+        enough_edits = editor_enough_edits(global_userinfo)
+        valid = editor_valid(
+            self.test_editor.wp_username, enough_edits, account_old_enough, not_blocked
+        )
+        self.assertFalse(valid)
 
         # Account created too recently
         global_userinfo["editcount"] = 500
         identity["registered"] = datetime.today().strftime("%Y%m%d%H%M%S")
-        self.assertFalse(self.test_editor._is_user_valid(identity, global_userinfo))
+        registered = editor_reg_date(identity, global_userinfo)
+        account_old_enough = editor_account_old_enough(registered)
+        enough_edits = editor_enough_edits(global_userinfo)
+        valid = editor_valid(
+            self.test_editor.wp_username, enough_edits, account_old_enough, not_blocked
+        )
+        self.assertFalse(valid)
 
         # Edge case: this shouldn't.
         almost_6_months_ago = datetime.today() - timedelta(days=183)
         identity["registered"] = almost_6_months_ago.strftime("%Y%m%d%H%M%S")
-        self.assertTrue(self.test_editor._is_user_valid(identity, global_userinfo))
+        registered = editor_reg_date(identity, global_userinfo)
+        account_old_enough = editor_account_old_enough(registered)
+        valid = editor_valid(
+            self.test_editor.wp_username, enough_edits, account_old_enough, not_blocked
+        )
+        self.assertTrue(valid)
 
         # Edge case: this should work.
         almost_6_months_ago = datetime.today() - timedelta(days=182)
         identity["registered"] = almost_6_months_ago.strftime("%Y%m%d%H%M%S")
-        self.assertTrue(self.test_editor._is_user_valid(identity, global_userinfo))
+        registered = editor_reg_date(identity, global_userinfo)
+        account_old_enough = editor_account_old_enough(registered)
+        valid = editor_valid(
+            self.test_editor.wp_username, enough_edits, account_old_enough, not_blocked
+        )
+        self.assertTrue(valid)
 
         # Bad editor! No biscuit.
         identity["blocked"] = True
-        self.assertFalse(self.test_editor._is_user_valid(identity, global_userinfo))
+        not_blocked = editor_not_blocked(identity)
+        valid = editor_valid(
+            self.test_editor.wp_username, enough_edits, account_old_enough, not_blocked
+        )
+        self.assertFalse(valid)
 
     @patch.object(Editor, "get_global_userinfo")
-    @patch.object(Editor, "_is_user_valid")
-    def test_update_from_wikipedia(self, mock_validity, mock_global_userinfo):
+    # @patch.object(Editor, "_is_user_valid")
+    def test_update_from_wikipedia(self, mock_global_userinfo):
         # update_from_wikipedia calls _is_user_valid, which generates an API
         # call to Wikipedia that we don't actually want to do in testing.
-        mock_validity.return_value = True
+        # mock_validity.return_value = True
 
         identity = {}
         identity["username"] = "evil_dr_porkchop"
@@ -720,6 +764,8 @@ class EditorModelTestCase(TestCase):
         identity["email"] = "porkchop@example.com"
         identity["iss"] = "zh-classical.wikipedia.org"
         identity["registered"] = "20130205230142"
+        # validity
+        identity["blocked"] = False
 
         global_userinfo = {}
         global_userinfo["home"] = "zh_classicalwiki"

--- a/TWLight/users/tests.py
+++ b/TWLight/users/tests.py
@@ -752,6 +752,8 @@ class EditorModelTestCase(TestCase):
         # 1st time bundle check should always pass for a valid user.
         self.test_editor.wp_editcount_prev_date_updated, self.test_editor.wp_editcount_prev, self.test_editor.wp_editcount_recent, self.test_editor.wp_enough_recent_edits = editor_recent_edits(
             global_userinfo["editcount"],
+            self.test_editor.wp_editcount_date_updated,
+            self.test_editor.wp_editcount,
             self.test_editor.wp_editcount_prev_date_updated,
             self.test_editor.wp_editcount_prev,
             self.test_editor.wp_editcount_recent,
@@ -765,6 +767,8 @@ class EditorModelTestCase(TestCase):
         # A valid user should pass 30 days after their first login, even if they haven't made anymore edits.
         self.test_editor.wp_editcount_prev_date_updated, self.test_editor.wp_editcount_prev, self.test_editor.wp_editcount_recent, self.test_editor.wp_enough_recent_edits = editor_recent_edits(
             global_userinfo["editcount"],
+            self.test_editor.wp_editcount_date_updated,
+            self.test_editor.wp_editcount,
             self.test_editor.wp_editcount_prev_date_updated - timedelta(days=30),
             self.test_editor.wp_editcount_prev,
             self.test_editor.wp_editcount_recent,
@@ -778,6 +782,8 @@ class EditorModelTestCase(TestCase):
         # A valid user should fail 31 days after their first login, if they haven't made any more edits.
         self.test_editor.wp_editcount_prev_date_updated, self.test_editor.wp_editcount_prev, self.test_editor.wp_editcount_recent, self.test_editor.wp_enough_recent_edits = editor_recent_edits(
             global_userinfo["editcount"],
+            self.test_editor.wp_editcount_date_updated,
+            self.test_editor.wp_editcount,
             self.test_editor.wp_editcount_prev_date_updated - timedelta(days=31),
             self.test_editor.wp_editcount_prev,
             self.test_editor.wp_editcount_recent,
@@ -791,6 +797,8 @@ class EditorModelTestCase(TestCase):
         # A valid user should pass 31 days after their first login if they have made enough edits.
         self.test_editor.wp_editcount_prev_date_updated, self.test_editor.wp_editcount_prev, self.test_editor.wp_editcount_recent, self.test_editor.wp_enough_recent_edits = editor_recent_edits(
             global_userinfo["editcount"] + 10,
+            self.test_editor.wp_editcount_date_updated,
+            self.test_editor.wp_editcount,
             self.test_editor.wp_editcount_prev_date_updated - timedelta(days=31),
             self.test_editor.wp_editcount_prev,
             self.test_editor.wp_editcount_recent,
@@ -807,6 +815,8 @@ class EditorModelTestCase(TestCase):
         valid = editor_valid(enough_edits, account_old_enough, not_blocked)
         self.test_editor.wp_editcount_prev_date_updated, self.test_editor.wp_editcount_prev, self.test_editor.wp_editcount_recent, self.test_editor.wp_enough_recent_edits = editor_recent_edits(
             global_userinfo["editcount"] + 10,
+            self.test_editor.wp_editcount_date_updated,
+            self.test_editor.wp_editcount,
             self.test_editor.wp_editcount_prev_date_updated - timedelta(days=31),
             self.test_editor.wp_editcount_prev,
             self.test_editor.wp_editcount_recent,

--- a/TWLight/users/tests.py
+++ b/TWLight/users/tests.py
@@ -13,6 +13,7 @@ from django.core.urlresolvers import resolve, reverse
 from django.test import TestCase, Client, RequestFactory
 from django.utils.translation import get_language
 from django.utils.html import escape
+from django.utils.timezone import now
 from TWLight.applications.factories import ApplicationFactory
 from TWLight.applications.models import Application
 from TWLight.resources.factories import PartnerFactory
@@ -742,6 +743,8 @@ class EditorModelTestCase(TestCase):
         global_userinfo = copy.copy(FAKE_GLOBAL_USERINFO)
 
         # Valid data
+        global_userinfo["editcount"] = 500
+        self.test_editor.wp_editcount = 500
         registered = editor_reg_date(identity, global_userinfo)
         account_old_enough = editor_account_old_enough(registered)
         enough_edits = editor_enough_edits(global_userinfo)
@@ -750,6 +753,25 @@ class EditorModelTestCase(TestCase):
         self.assertTrue(valid)
 
         # 1st time bundle check should always pass for a valid user.
+        self.test_editor.wp_editcount_prev_updated, self.test_editor.wp_editcount_prev, self.test_editor.wp_editcount_recent, self.test_editor.wp_enough_recent_edits = editor_recent_edits(
+            global_userinfo["editcount"],
+            None,
+            self.test_editor.wp_editcount,
+            None,
+            self.test_editor.wp_editcount_prev,
+            self.test_editor.wp_editcount_recent,
+            self.test_editor.wp_enough_recent_edits,
+        )
+        bundle_eligible = editor_bundle_eligible(
+            valid, self.test_editor.wp_enough_recent_edits
+        )
+        self.assertTrue(bundle_eligible)
+
+        # A valid user should pass 30 days after their first login, even if they haven't made anymore edits.
+        self.test_editor.wp_editcount_updated = now() - timedelta(days=30)
+        self.test_editor.wp_editcount_prev_updated = (
+            self.test_editor.wp_editcount_prev_updated - timedelta(days=30)
+        )
         self.test_editor.wp_editcount_prev_updated, self.test_editor.wp_editcount_prev, self.test_editor.wp_editcount_recent, self.test_editor.wp_enough_recent_edits = editor_recent_edits(
             global_userinfo["editcount"],
             self.test_editor.wp_editcount_updated,
@@ -764,27 +786,16 @@ class EditorModelTestCase(TestCase):
         )
         self.assertTrue(bundle_eligible)
 
-        # A valid user should pass 30 days after their first login, even if they haven't made anymore edits.
-        self.test_editor.wp_editcount_prev_updated, self.test_editor.wp_editcount_prev, self.test_editor.wp_editcount_recent, self.test_editor.wp_enough_recent_edits = editor_recent_edits(
-            global_userinfo["editcount"],
-            self.test_editor.wp_editcount_updated,
-            self.test_editor.wp_editcount,
-            self.test_editor.wp_editcount_prev_updated - timedelta(days=30),
-            self.test_editor.wp_editcount_prev,
-            self.test_editor.wp_editcount_recent,
-            self.test_editor.wp_enough_recent_edits,
-        )
-        bundle_eligible = editor_bundle_eligible(
-            valid, self.test_editor.wp_enough_recent_edits
-        )
-        self.assertTrue(bundle_eligible)
-
         # A valid user should fail 31 days after their first login, if they haven't made any more edits.
+        self.test_editor.wp_editcount_updated = now() - timedelta(days=31)
+        self.test_editor.wp_editcount_prev_updated = (
+            self.test_editor.wp_editcount_prev_updated - timedelta(days=31)
+        )
         self.test_editor.wp_editcount_prev_updated, self.test_editor.wp_editcount_prev, self.test_editor.wp_editcount_recent, self.test_editor.wp_enough_recent_edits = editor_recent_edits(
             global_userinfo["editcount"],
             self.test_editor.wp_editcount_updated,
             self.test_editor.wp_editcount,
-            self.test_editor.wp_editcount_prev_updated - timedelta(days=31),
+            self.test_editor.wp_editcount_prev_updated,
             self.test_editor.wp_editcount_prev,
             self.test_editor.wp_editcount_recent,
             self.test_editor.wp_enough_recent_edits,
@@ -799,7 +810,57 @@ class EditorModelTestCase(TestCase):
             global_userinfo["editcount"] + 10,
             self.test_editor.wp_editcount_updated,
             self.test_editor.wp_editcount,
-            self.test_editor.wp_editcount_prev_updated - timedelta(days=31),
+            self.test_editor.wp_editcount_prev_updated,
+            self.test_editor.wp_editcount_prev,
+            self.test_editor.wp_editcount_recent,
+            self.test_editor.wp_enough_recent_edits,
+        )
+        bundle_eligible = editor_bundle_eligible(
+            valid, self.test_editor.wp_enough_recent_edits
+        )
+        self.test_editor.wp_editcount_updated = now()
+        self.assertTrue(bundle_eligible)
+
+        # Bad editor! No biscuit, even if you have enough edits.
+        identity["blocked"] = True
+        not_blocked = editor_not_blocked(identity)
+        valid = editor_valid(enough_edits, account_old_enough, not_blocked)
+        self.test_editor.wp_editcount_updated = now() - timedelta(days=31)
+        self.test_editor.wp_editcount_prev_updated = (
+            self.test_editor.wp_editcount_prev_updated - timedelta(days=31)
+        )
+        self.test_editor.wp_editcount_prev_updated, self.test_editor.wp_editcount_prev, self.test_editor.wp_editcount_recent, self.test_editor.wp_enough_recent_edits = editor_recent_edits(
+            global_userinfo["editcount"] + 10,
+            self.test_editor.wp_editcount_updated,
+            self.test_editor.wp_editcount,
+            self.test_editor.wp_editcount_prev_updated,
+            self.test_editor.wp_editcount_prev,
+            self.test_editor.wp_editcount_recent,
+            self.test_editor.wp_enough_recent_edits,
+        )
+        bundle_eligible = editor_bundle_eligible(
+            valid, self.test_editor.wp_enough_recent_edits
+        )
+        self.test_editor.wp_editcount_updated = now()
+        self.assertFalse(bundle_eligible)
+
+        # Currently, a valid user will pass 60 days after their first login if they have 10 more edits,
+        # even if we're not sure whether they made those edits in the last 30 days.
+        # TODO: add management command to be executed as a cron job to periodically update editors' recent edit counts.
+        # That way the time delta used to calculate recent edits is never greater than 30 days.
+        identity["blocked"] = False
+        not_blocked = editor_not_blocked(identity)
+        valid = editor_valid(enough_edits, account_old_enough, not_blocked)
+
+        self.test_editor.wp_editcount_updated = now() - timedelta(days=60)
+        self.test_editor.wp_editcount_prev_updated = (
+            self.test_editor.wp_editcount_prev_updated - timedelta(days=60)
+        )
+        self.test_editor.wp_editcount_prev_updated, self.test_editor.wp_editcount_prev, self.test_editor.wp_editcount_recent, self.test_editor.wp_enough_recent_edits = editor_recent_edits(
+            global_userinfo["editcount"] + 10,
+            self.test_editor.wp_editcount_updated,
+            self.test_editor.wp_editcount,
+            self.test_editor.wp_editcount_prev_updated,
             self.test_editor.wp_editcount_prev,
             self.test_editor.wp_editcount_recent,
             self.test_editor.wp_enough_recent_edits,
@@ -808,24 +869,6 @@ class EditorModelTestCase(TestCase):
             valid, self.test_editor.wp_enough_recent_edits
         )
         self.assertTrue(bundle_eligible)
-
-        # Bad editor! No biscuit, even if you have enough edits.
-        identity["blocked"] = True
-        not_blocked = editor_not_blocked(identity)
-        valid = editor_valid(enough_edits, account_old_enough, not_blocked)
-        self.test_editor.wp_editcount_prev_updated, self.test_editor.wp_editcount_prev, self.test_editor.wp_editcount_recent, self.test_editor.wp_enough_recent_edits = editor_recent_edits(
-            global_userinfo["editcount"] + 10,
-            self.test_editor.wp_editcount_updated,
-            self.test_editor.wp_editcount,
-            self.test_editor.wp_editcount_prev_updated - timedelta(days=31),
-            self.test_editor.wp_editcount_prev,
-            self.test_editor.wp_editcount_recent,
-            self.test_editor.wp_enough_recent_edits,
-        )
-        bundle_eligible = editor_bundle_eligible(
-            valid, self.test_editor.wp_enough_recent_edits
-        )
-        self.assertFalse(bundle_eligible)
 
     @patch.object(Editor, "get_global_userinfo")
     def test_update_from_wikipedia(self, mock_global_userinfo):

--- a/TWLight/users/tests.py
+++ b/TWLight/users/tests.py
@@ -833,6 +833,37 @@ class EditorModelTestCase(TestCase):
         )
         self.assertFalse(bundle_eligible)
 
+        # A valid user should pass 31 days after their first login if they have made enough edits.
+        self.test_editor.wp_editcount_prev_date_updated, self.test_editor.wp_editcount_prev, self.test_editor.wp_editcount_recent, self.test_editor.wp_enough_recent_edits = editor_recent_edits(
+            global_userinfo["editcount"] + 10,
+            self.test_editor.wp_editcount_prev_date_updated - timedelta(days=31),
+            self.test_editor.wp_editcount_prev,
+            self.test_editor.wp_editcount_recent,
+            self.test_editor.wp_enough_recent_edits,
+        )
+        bundle_eligible = editor_bundle_eligible(
+            valid, self.test_editor.wp_enough_recent_edits
+        )
+        self.assertTrue(bundle_eligible)
+
+        # Bad editor! No biscuit, even if you have enough edits.
+        identity["blocked"] = True
+        not_blocked = editor_not_blocked(identity)
+        valid = editor_valid(
+            self.test_editor.wp_username, enough_edits, account_old_enough, not_blocked
+        )
+        self.test_editor.wp_editcount_prev_date_updated, self.test_editor.wp_editcount_prev, self.test_editor.wp_editcount_recent, self.test_editor.wp_enough_recent_edits = editor_recent_edits(
+            global_userinfo["editcount"] + 10,
+            self.test_editor.wp_editcount_prev_date_updated - timedelta(days=31),
+            self.test_editor.wp_editcount_prev,
+            self.test_editor.wp_editcount_recent,
+            self.test_editor.wp_enough_recent_edits,
+        )
+        bundle_eligible = editor_bundle_eligible(
+            valid, self.test_editor.wp_enough_recent_edits
+        )
+        self.assertFalse(bundle_eligible)
+
     @patch.object(Editor, "get_global_userinfo")
     def test_update_from_wikipedia(self, mock_global_userinfo):
         identity = {}

--- a/TWLight/users/tests.py
+++ b/TWLight/users/tests.py
@@ -751,16 +751,16 @@ class EditorModelTestCase(TestCase):
         # Start out with basic validation of the eligibility functions.
 
         # Invalid users without enough recent edits are not eligible.
-        self.asertFalse(editor_bundle_eligible(False, False))
+        self.assertFalse(editor_bundle_eligible(False, False))
 
         # Invalid users with enough recent edits are not eligible.
-        self.asertFalse(editor_bundle_eligible(False, True))
+        self.assertFalse(editor_bundle_eligible(False, True))
 
         # Valid users without enough recent edits are not eligible.
-        self.asertFalse(editor_bundle_eligible(True, False))
+        self.assertFalse(editor_bundle_eligible(True, False))
 
         # Valid users with enough recent edits are eligible.
-        self.asertTrue(editor_bundle_eligible(True, True))
+        self.assertTrue(editor_bundle_eligible(True, True))
 
     @patch("urllib.request.urlopen")
     def test_is_user_bundle_eligible(self, mock_urlopen):

--- a/TWLight/users/tests.py
+++ b/TWLight/users/tests.py
@@ -746,12 +746,7 @@ class EditorModelTestCase(TestCase):
         self.assertFalse(valid)
 
     @patch.object(Editor, "get_global_userinfo")
-    # @patch.object(Editor, "_is_user_valid")
     def test_update_from_wikipedia(self, mock_global_userinfo):
-        # update_from_wikipedia calls _is_user_valid, which generates an API
-        # call to Wikipedia that we don't actually want to do in testing.
-        # mock_validity.return_value = True
-
         identity = {}
         identity["username"] = "evil_dr_porkchop"
         # Users' unique WP IDs should not change across API calls, but are

--- a/TWLight/users/tests.py
+++ b/TWLight/users/tests.py
@@ -670,25 +670,19 @@ class EditorModelTestCase(TestCase):
         account_old_enough = editor_account_old_enough(registered)
         enough_edits = editor_enough_edits(global_userinfo)
         not_blocked = editor_not_blocked(identity)
-        valid = editor_valid(
-            enough_edits, account_old_enough, not_blocked
-        )
+        valid = editor_valid(enough_edits, account_old_enough, not_blocked)
         self.assertTrue(valid)
 
         # Edge case
         global_userinfo["editcount"] = 500
         enough_edits = editor_enough_edits(global_userinfo)
-        valid = editor_valid(
-            enough_edits, account_old_enough, not_blocked
-        )
+        valid = editor_valid(enough_edits, account_old_enough, not_blocked)
         self.assertTrue(valid)
 
         # Too few edits
         global_userinfo["editcount"] = 499
         enough_edits = editor_enough_edits(global_userinfo)
-        valid = editor_valid(
-            enough_edits, account_old_enough, not_blocked
-        )
+        valid = editor_valid(enough_edits, account_old_enough, not_blocked)
         self.assertFalse(valid)
 
         # Account created too recently
@@ -697,9 +691,7 @@ class EditorModelTestCase(TestCase):
         registered = editor_reg_date(identity, global_userinfo)
         account_old_enough = editor_account_old_enough(registered)
         enough_edits = editor_enough_edits(global_userinfo)
-        valid = editor_valid(
-            enough_edits, account_old_enough, not_blocked
-        )
+        valid = editor_valid(enough_edits, account_old_enough, not_blocked)
         self.assertFalse(valid)
 
         # Edge case: this shouldn't.
@@ -707,9 +699,7 @@ class EditorModelTestCase(TestCase):
         identity["registered"] = almost_6_months_ago.strftime("%Y%m%d%H%M%S")
         registered = editor_reg_date(identity, global_userinfo)
         account_old_enough = editor_account_old_enough(registered)
-        valid = editor_valid(
-            enough_edits, account_old_enough, not_blocked
-        )
+        valid = editor_valid(enough_edits, account_old_enough, not_blocked)
         self.assertTrue(valid)
 
         # Edge case: this should work.
@@ -717,17 +707,13 @@ class EditorModelTestCase(TestCase):
         identity["registered"] = almost_6_months_ago.strftime("%Y%m%d%H%M%S")
         registered = editor_reg_date(identity, global_userinfo)
         account_old_enough = editor_account_old_enough(registered)
-        valid = editor_valid(
-            enough_edits, account_old_enough, not_blocked
-        )
+        valid = editor_valid(enough_edits, account_old_enough, not_blocked)
         self.assertTrue(valid)
 
         # Bad editor! No biscuit.
         identity["blocked"] = True
         not_blocked = editor_not_blocked(identity)
-        valid = editor_valid(
-            enough_edits, account_old_enough, not_blocked
-        )
+        valid = editor_valid(enough_edits, account_old_enough, not_blocked)
         self.assertFalse(valid)
 
     def test_editor_eligibility_functions(self):
@@ -760,9 +746,7 @@ class EditorModelTestCase(TestCase):
         account_old_enough = editor_account_old_enough(registered)
         enough_edits = editor_enough_edits(global_userinfo)
         not_blocked = editor_not_blocked(identity)
-        valid = editor_valid(
-            enough_edits, account_old_enough, not_blocked
-        )
+        valid = editor_valid(enough_edits, account_old_enough, not_blocked)
         self.assertTrue(valid)
 
         # 1st time bundle check should always pass for a valid user.
@@ -820,9 +804,7 @@ class EditorModelTestCase(TestCase):
         # Bad editor! No biscuit, even if you have enough edits.
         identity["blocked"] = True
         not_blocked = editor_not_blocked(identity)
-        valid = editor_valid(
-            enough_edits, account_old_enough, not_blocked
-        )
+        valid = editor_valid(enough_edits, account_old_enough, not_blocked)
         self.test_editor.wp_editcount_prev_date_updated, self.test_editor.wp_editcount_prev, self.test_editor.wp_editcount_recent, self.test_editor.wp_enough_recent_edits = editor_recent_edits(
             global_userinfo["editcount"] + 10,
             self.test_editor.wp_editcount_prev_date_updated - timedelta(days=31),


### PR DESCRIPTION
As talked about in the description of:
https://phabricator.wikimedia.org/T235262

In addition to adding editor object attributes for bundle eligibility, this PR breaks up the individual requirements for an account as specified in [our terms](https://wikipedialibrary.wmflabs.org/terms/) into separate attrs as well.

There are lots of other places where we're using props instead of attrs in order to keep our db schema as clean as we can. In this case, I thought attrs were better because:

- we can directly work against editor querysets that are filtered on elements of eligibility
- the data used to determine eligibility only changes upon user oauth login. Nothing the user does after login will impact the freshness of these attributes

Note that this PR doesn't currently include a cron task to update the recent edit count for editors. That means that if a user is eligible upon a given login, makes 10 edits, and then waits 60 days before logging in again, that they would be flagged as eligible. We'll want that cron task, but I thought it would be best for us to sort out the way the checks worked and how things were stored in the db first.

This PR also doesn't include any kind of display for the added fields. We'll probably want those. 