### PR TITLE
Fix requested_access_duration check and knock-on test failures

### DIFF
--- a/TWLight/applications/factories.py
+++ b/TWLight/applications/factories.py
@@ -3,6 +3,7 @@
 import factory
 
 from TWLight.resources.factories import PartnerFactory
+from TWLight.resources.models import Partner
 from TWLight.users.factories import EditorFactory
 
 from TWLight.applications.models import Application
@@ -15,3 +16,7 @@ class ApplicationFactory(factory.django.DjangoModelFactory):
 
     editor = factory.SubFactory(EditorFactory)
     partner = factory.SubFactory(PartnerFactory)
+
+    # This needs to be set for applications to resources with the
+    # PROXY authorization_method.
+    requested_access_duration = None

--- a/TWLight/applications/models.py
+++ b/TWLight/applications/models.py
@@ -511,7 +511,7 @@ def post_revision_commit(sender, instance, **kwargs):
         # to one year from now
         if (
             instance.partner.authorization_method == Partner.PROXY
-            and instance.requested_access_duration is False
+            and instance.partner.requested_access_duration is False
         ):
             one_year_from_now = date.today() + timedelta(days=365)
             authorization.date_expires = one_year_from_now

--- a/TWLight/applications/models.py
+++ b/TWLight/applications/models.py
@@ -511,7 +511,7 @@ def post_revision_commit(sender, instance, **kwargs):
         # to one year from now
         if (
             instance.partner.authorization_method == Partner.PROXY
-            and instance.requested_access_duration is None
+            and instance.requested_access_duration is False
         ):
             one_year_from_now = date.today() + timedelta(days=365)
             authorization.date_expires = one_year_from_now

--- a/TWLight/applications/tests.py
+++ b/TWLight/applications/tests.py
@@ -2051,6 +2051,7 @@ class RenewApplicationTest(BaseApplicationViewTest):
             partner=partner,
             status=Application.SENT,  # proxy applications are directly marked SENT
             editor=editor1,
+            requested_access_duration=12,
         )
 
         renewal_url = reverse("applications:renew", kwargs={"pk": app1.pk})
@@ -2395,7 +2396,9 @@ class ApplicationModelTest(TestCase):
         partner = PartnerFactory(
             authorization_method=Partner.PROXY, requested_access_duration=True
         )
-        application = ApplicationFactory(partner=partner, status=Application.PENDING)
+        application = ApplicationFactory(
+            partner=partner, status=Application.PENDING, requested_access_duration=12
+        )
         coordinator = EditorCraftRoom(self, Terms=True, Coordinator=True)
         application.partner.coordinator = coordinator.user
         application.partner.save()

--- a/TWLight/graphs/tests.py
+++ b/TWLight/graphs/tests.py
@@ -115,12 +115,24 @@ class GraphsTestCase(TestCase):
         editor2 = EditorFactory()
 
         parent_app = ApplicationFactory(
-            status=Application.SENT, partner=partner1, editor=editor1
+            status=Application.SENT,
+            partner=partner1,
+            editor=editor1,
+            requested_access_duration=12,
         )
         ApplicationFactory(
-            status=Application.SENT, partner=partner1, editor=editor1, parent=parent_app
+            status=Application.SENT,
+            partner=partner1,
+            editor=editor1,
+            parent=parent_app,
+            requested_access_duration=12,
         )
-        ApplicationFactory(status=Application.SENT, partner=partner2, editor=editor2)
+        ApplicationFactory(
+            status=Application.SENT,
+            partner=partner2,
+            editor=editor2,
+            requested_access_duration=12,
+        )
 
         request = self.factory.get(reverse("csv:proxy_authorizations"))
         request.user = self.user

--- a/TWLight/resources/factories.py
+++ b/TWLight/resources/factories.py
@@ -16,6 +16,16 @@ class PartnerFactory(factory.django.DjangoModelFactory):
     )
     terms_of_use = factory.Faker("uri", locale=random.choice(settings.FAKER_LOCALES))
     status = Partner.AVAILABLE  # not the default, but usually wanted in tests
+    authorization_method = Partner.EMAIL
+
+    # PROXY partners need requested_access_duration to be True, so we ensure
+    # that field is set even if a test doesn't set it explicitly.
+    @factory.lazy_attribute
+    def requested_access_duration(self):
+        if self.authorization_method == Partner.PROXY:
+            return True
+        else:
+            return False
 
 
 class StreamFactory(factory.django.DjangoModelFactory):

--- a/TWLight/tests.py
+++ b/TWLight/tests.py
@@ -2,6 +2,7 @@ import random
 
 from unittest.mock import patch
 from datetime import date, timedelta
+from dateutil.relativedelta import relativedelta
 from faker import Faker
 from django.contrib.auth.models import User
 from django.conf import settings
@@ -493,13 +494,22 @@ class AuthorizationBaseTestCase(TestCase):
             editor=self.editor3, partner=self.partner1, status=Application.PENDING
         )
         self.app4 = ApplicationFactory(
-            editor=self.editor1, partner=self.partner2, status=Application.PENDING
+            editor=self.editor1,
+            partner=self.partner2,
+            status=Application.PENDING,
+            requested_access_duration=12,
         )
         self.app5 = ApplicationFactory(
-            editor=self.editor2, partner=self.partner2, status=Application.PENDING
+            editor=self.editor2,
+            partner=self.partner2,
+            status=Application.PENDING,
+            requested_access_duration=12,
         )
         self.app6 = ApplicationFactory(
-            editor=self.editor3, partner=self.partner2, status=Application.PENDING
+            editor=self.editor3,
+            partner=self.partner2,
+            status=Application.PENDING,
+            requested_access_duration=12,
         )
         self.app7 = ApplicationFactory(
             editor=self.editor1, partner=self.partner3, status=Application.PENDING
@@ -773,7 +783,7 @@ class AuthorizationTestCase(AuthorizationBaseTestCase):
         # For a proxy partner we should set the expiry
         # date correctly for its authorizations.
 
-        expected_expiry = date.today() + timedelta(days=365)
+        expected_expiry = date.today() + relativedelta(months=12)
         self.assertEqual(self.auth_app4.date_expires, expected_expiry)
 
     def test_authorization_backfill_expiry_date_on_partner_save(self):

--- a/TWLight/users/tests.py
+++ b/TWLight/users/tests.py
@@ -298,7 +298,10 @@ class ViewsTestCase(TestCase):
         editor = EditorCraftRoom(self, Terms=True, Coordinator=False)
         partner = PartnerFactory(authorization_method=Partner.PROXY)
         app = ApplicationFactory(
-            status=Application.SENT, editor=editor, partner=partner
+            status=Application.SENT,
+            editor=editor,
+            partner=partner,
+            requested_access_duration=12,
         )
         authorization = Authorization.objects.get(user=editor.user, partner=partner)
         self.assertEqual(authorization.get_latest_app(), app)


### PR DESCRIPTION
When generating authorizations we were checking for `requested_access_duration is None` on the submitted application. Users can't submit applications with `None` data for that field on a proxy partner unless the partner has `requested_access_duration is False`*, so we should check for that directly.

I made that change and then discovered this had a knock-on effect of causing failures on a bunch of tests because they weren't setting the application `requested_access_duration` field on app submission (they were sending `None`), so I went through and updated those applications to send the correct data.

*We should name those fields differently, it's very confusing.