### PR TITLE
Show Error on 'Mark as Sent' page for automatic-send partners

### DIFF
--- a/TWLight/applications/templates/applications/send_partner.html
+++ b/TWLight/applications/templates/applications/send_partner.html
@@ -185,8 +185,6 @@
         {% comment %} Translators: When viewing the list of applications ready to be sent for a particular partner, this labels the button coordinators press to change the status of applications to 'sent'.{% endcomment %}
         <input type="submit" class="btn btn-primary" value="{% trans "Mark as sent" %}"></input>
       </form>
-    {% else %}
-      This partner's authorization method has been set to proxy or bundle, but these features aren't supported yet.
     {% endif %}
   {% else %}
     {% comment %} Translators: When viewing the list of applications ready to be sent for a particular partner, this message shows when there are none to show the coordinator.{% endcomment %}

--- a/TWLight/applications/tests.py
+++ b/TWLight/applications/tests.py
@@ -3760,18 +3760,16 @@ class MarkSentTest(TestCase):
         # Expected success condition: redirect back to the original page.
         self.assertEqual(response.status_code, 302)
         self.assertEqual(response.url, self.url)
-    
+
     def test_email_authorization_method(self):
         # If partner's authroization method is EMAIL
-        # then partner's 'mark as sent' page should 
-        # display list of approved applications 
+        # then partner's 'mark as sent' page should
+        # display list of approved applications
 
         self.partner.authorization_method = Partner.EMAIL
         self.partner.save()
 
-        request = RequestFactory().get(
-            self.url
-        )
+        request = RequestFactory().get(self.url)
         request.user = self.user
         response = views.SendReadyApplicationsView.as_view()(
             request, pk=self.partner.pk
@@ -3779,7 +3777,7 @@ class MarkSentTest(TestCase):
 
         # Expected success condition: coordinator may access the page
         self.assertEqual(response.status_code, 200)
-    
+
     def test_proxy_authorization_method(self):
         # If partner's authroization method is PROXY
         # then partner's 'mark as sent' page should raise 404
@@ -3787,12 +3785,9 @@ class MarkSentTest(TestCase):
         self.partner.authorization_method = Partner.PROXY
         self.partner.save()
 
-        request = RequestFactory().get(
-            self.url,
-        )
+        request = RequestFactory().get(self.url)
         request.user = self.user
 
         # Expected success condition: raise a 404 not found page
         with self.assertRaises(Http404):
-            _ = views.SendReadyApplicationsView.as_view()(
-            request, pk=self.partner.pk)
+            _ = views.SendReadyApplicationsView.as_view()(request, pk=self.partner.pk)

--- a/TWLight/applications/tests.py
+++ b/TWLight/applications/tests.py
@@ -3760,3 +3760,39 @@ class MarkSentTest(TestCase):
         # Expected success condition: redirect back to the original page.
         self.assertEqual(response.status_code, 302)
         self.assertEqual(response.url, self.url)
+    
+    def test_email_authorization_method(self):
+        # If partner's authroization method is EMAIL
+        # then partner's 'mark as sent' page should 
+        # display list of approved applications 
+
+        self.partner.authorization_method = Partner.EMAIL
+        self.partner.save()
+
+        request = RequestFactory().get(
+            self.url
+        )
+        request.user = self.user
+        response = views.SendReadyApplicationsView.as_view()(
+            request, pk=self.partner.pk
+        )
+
+        # Expected success condition: coordinator may access the page
+        self.assertEqual(response.status_code, 200)
+    
+    def test_proxy_authorization_method(self):
+        # If partner's authroization method is PROXY
+        # then partner's 'mark as sent' page should raise 404
+
+        self.partner.authorization_method = Partner.PROXY
+        self.partner.save()
+
+        request = RequestFactory().get(
+            self.url,
+        )
+        request.user = self.user
+
+        # Expected success condition: raise a 404 not found page
+        with self.assertRaises(Http404):
+            _ = views.SendReadyApplicationsView.as_view()(
+            request, pk=self.partner.pk)

--- a/TWLight/applications/views.py
+++ b/TWLight/applications/views.py
@@ -1169,7 +1169,7 @@ class SendReadyApplicationsView(PartnerCoordinatorOnly, DetailView):
                 request, *args, **kwargs
             )
         else:
-            raise Http404("Application's for this Partner are sent automatically")
+            raise Http404("Applications for this Partner are sent automatically")
 
     def get_context_data(self, **kwargs):
         context = super(SendReadyApplicationsView, self).get_context_data(**kwargs)

--- a/TWLight/applications/views.py
+++ b/TWLight/applications/views.py
@@ -1161,6 +1161,14 @@ class SendReadyApplicationsView(PartnerCoordinatorOnly, DetailView):
     model = Partner
     template_name = "applications/send_partner.html"
 
+    def dispatch(self, request, *args, **kwargs):
+        partner = self.get_object()
+        auth_method = partner.authorization_method
+        if auth_method == Partner.EMAIL or auth_method == Partner.CODES:
+            return super(SendReadyApplicationsView, self).dispatch(request, *args, **kwargs)
+        else:
+            raise Http404("Application's for this Partner are sent automatically")
+
     def get_context_data(self, **kwargs):
         context = super(SendReadyApplicationsView, self).get_context_data(**kwargs)
         apps = (

--- a/TWLight/applications/views.py
+++ b/TWLight/applications/views.py
@@ -1165,7 +1165,9 @@ class SendReadyApplicationsView(PartnerCoordinatorOnly, DetailView):
         partner = self.get_object()
         auth_method = partner.authorization_method
         if auth_method == Partner.EMAIL or auth_method == Partner.CODES:
-            return super(SendReadyApplicationsView, self).dispatch(request, *args, **kwargs)
+            return super(SendReadyApplicationsView, self).dispatch(
+                request, *args, **kwargs
+            )
         else:
             raise Http404("Application's for this Partner are sent automatically")
 


### PR DESCRIPTION
If a Partner's authorization method is Link, Proxy or Bundle
then the applications are sent automatically. So the 'Mark as Sent'
page is no longer needed for that Partner.

Bug: T234551
