### PR TITLE
T234552: Users who are blocked on any project should require manual review for Bundle approval

### DIFF
--- a/TWLight/users/helpers/editor_data.py
+++ b/TWLight/users/helpers/editor_data.py
@@ -1,0 +1,108 @@
+from datetime import datetime, date, timedelta
+from django.utils.timezone import now
+
+
+def editor_reg_date(identity, global_userinfo):
+    # Try oauth registration date first.  If it's not valid, try the global_userinfo date
+    try:
+        reg_date = datetime.strptime(identity["registered"], "%Y%m%d%H%M%S").date()
+    except (TypeError, ValueError):
+        try:
+            reg_date = datetime.strptime(
+                global_userinfo["registration"], "%Y-%m-%dT%H:%M:%SZ"
+            ).date()
+        except (TypeError, ValueError):
+            reg_date = None
+    return reg_date
+
+
+def editor_enough_edits(global_userinfo):
+    # If, for some reason, this information hasn't come through,
+    # default to user not being valid.
+    if not global_userinfo:
+        return False
+    # Check: >= 500 edits
+    return int(global_userinfo["editcount"]) >= 500
+
+
+def editor_not_blocked(identity):
+    # If, for some reason, this information hasn't come through,
+    # default to user not being valid.
+    if not identity:
+        return False
+    # Check: not blocked
+    return identity["blocked"] == False
+
+
+def editor_account_old_enough(wp_registered):
+    # If, for some reason, this information hasn't come through,
+    # default to user not being valid.
+    if not wp_registered:
+        return False
+    # Check: registered >= 6 months ago
+    return datetime.today().date() - timedelta(days=182) >= wp_registered
+
+
+def editor_valid(enough_edits, account_old_enough, not_blocked):
+    """
+    Check for the eligibility criteria laid out in the terms of service.
+    Note that we won't prohibit signups or applications on this basis.
+    Coordinators have discretion to approve people who are near the cutoff.
+    """
+    if enough_edits and account_old_enough and not_blocked:
+        return True
+    else:
+        return False
+
+
+def editor_recent_edits(
+    global_userinfo_editcount,
+    wp_editcount_updated,
+    wp_editcount,
+    wp_editcount_prev_updated,
+    wp_editcount_prev,
+    wp_editcount_recent,
+    wp_enough_recent_edits,
+):
+
+    # If we have historical data, see how many days have passed and how many edits have been made since the last check.
+    if wp_editcount_prev_updated and wp_editcount_updated:
+        editcount_update_delta = now() - wp_editcount_prev_updated
+        editcount_delta = global_userinfo_editcount - wp_editcount_prev
+        if (
+            # If the editor didn't have enough recent edits but they do now, update the counts immediately.
+            # This recognizes their eligibility as soon as possible.
+            (not wp_enough_recent_edits and editcount_delta >= 10)
+            # If the user had enough edits, just update the counts after 30 days.
+            # This means that eligibility always lasts at least 30 days.
+            or (wp_enough_recent_edits and editcount_update_delta.days > 30)
+        ):
+            wp_editcount_prev = wp_editcount
+            wp_editcount_prev_updated = wp_editcount_updated
+            wp_editcount_recent = global_userinfo_editcount - wp_editcount_prev
+
+    # If we don't have any historical editcount data, let all edits to date count.
+    # Editor.wp_editcount_prev defaults to 0, so we don't need to worry about changing it.
+    else:
+        wp_editcount_prev_updated = now()
+        wp_editcount_recent = global_userinfo_editcount
+
+    # Perform the check for enough recent edits.
+    if wp_editcount_recent >= 10:
+        wp_enough_recent_edits = True
+    else:
+        wp_enough_recent_edits = False
+    # Return a tuple containing all recent-editcount-related results.
+    return (
+        wp_editcount_prev_updated,
+        wp_editcount_prev,
+        wp_editcount_recent,
+        wp_enough_recent_edits,
+    )
+
+
+def editor_bundle_eligible(wp_valid, wp_enough_recent_edits):
+    if wp_valid and wp_enough_recent_edits:
+        return True
+    else:
+        return False

--- a/TWLight/users/helpers/editor_data.py
+++ b/TWLight/users/helpers/editor_data.py
@@ -106,13 +106,13 @@ def editor_account_old_enough(wp_registered):
     return datetime.today().date() - timedelta(days=182) >= wp_registered
 
 
-def editor_valid(enough_edits, account_old_enough, not_blocked):
+def editor_valid(enough_edits, account_old_enough, not_blocked, ignore_wp_blocks):
     """
     Check for the eligibility criteria laid out in the terms of service.
     Note that we won't prohibit signups or applications on this basis.
     Coordinators have discretion to approve people who are near the cutoff.
     """
-    if enough_edits and account_old_enough and not_blocked:
+    if enough_edits and account_old_enough and (not_blocked or ignore_wp_blocks):
         return True
     else:
         return False

--- a/TWLight/users/helpers/editor_data.py
+++ b/TWLight/users/helpers/editor_data.py
@@ -86,13 +86,15 @@ def editor_enough_edits(global_userinfo):
     return int(global_userinfo["editcount"]) >= 500
 
 
-def editor_not_blocked(identity):
+def editor_not_blocked(merged: list):
     # If, for some reason, this information hasn't come through,
     # default to user not being valid.
-    if not identity:
+    if not merged:
         return False
-    # Check: not blocked
-    return identity["blocked"] == False
+    else:
+        # Check: not blocked on any merged account.
+        # Note that this looks funny since we're inverting the truthiness returned by the check for blocks.
+        return False if any("blocked" in account for account in merged) else True
 
 
 def editor_account_old_enough(wp_registered):

--- a/TWLight/users/helpers/editor_data.py
+++ b/TWLight/users/helpers/editor_data.py
@@ -1,9 +1,12 @@
 from datetime import datetime, timedelta
 import json
+import logging
 import typing
 import urllib.request, urllib.error, urllib.parse
 from django.conf import settings
 from django.utils.timezone import now
+
+logger = logging.getLogger(__name__)
 
 
 def editor_global_userinfo(
@@ -14,13 +17,17 @@ def editor_global_userinfo(
     )
 
     results = json.loads(urllib.request.urlopen(endpoint).read())
-    global_userinfo = results["query"]["globaluserinfo"]
-    # If the user isn't found global_userinfo contains the empty key "missing"
-    assert "missing" not in global_userinfo
-    if strict:
-        # Verify that the numerical account ID matches, not just the user's handle.
-        assert isinstance(wp_sub, int)
-        assert wp_sub == global_userinfo["id"]
+    try:
+        global_userinfo = results["query"]["globaluserinfo"]
+        # If the user isn't found global_userinfo contains the empty key "missing"
+        assert "missing" not in global_userinfo
+        if strict:
+            # Verify that the numerical account ID matches, not just the user's handle.
+            assert isinstance(wp_sub, int)
+            assert wp_sub == global_userinfo["id"]
+    except (KeyError, AssertionError):
+        global_userinfo = None
+        logger.exception("Could not fetch global_userinfo for User.")
     return global_userinfo
 
 

--- a/TWLight/users/helpers/editor_data.py
+++ b/TWLight/users/helpers/editor_data.py
@@ -77,13 +77,8 @@ def editor_reg_date(identity, global_userinfo):
     return reg_date
 
 
-def editor_enough_edits(global_userinfo):
-    # If, for some reason, this information hasn't come through,
-    # default to user not being valid.
-    if not global_userinfo:
-        return False
-    # Check: >= 500 edits
-    return int(global_userinfo["editcount"]) >= 500
+def editor_enough_edits(editcount: int):
+    return editcount >= 500
 
 
 def editor_not_blocked(merged: list):

--- a/TWLight/users/helpers/editor_data.py
+++ b/TWLight/users/helpers/editor_data.py
@@ -78,6 +78,10 @@ def editor_reg_date(identity, global_userinfo):
 
 
 def editor_enough_edits(editcount: int):
+    # If, for some reason, this information hasn't come through,
+    # default to user not being valid.
+    if not editcount:
+        return False
     return editcount >= 500
 
 

--- a/TWLight/users/helpers/editor_data.py
+++ b/TWLight/users/helpers/editor_data.py
@@ -12,11 +12,13 @@ logger = logging.getLogger(__name__)
 def editor_global_userinfo(
     wp_username: str, wp_sub: typing.Optional[int], strict: bool
 ):
-    endpoint = "{base}/w/api.php?action=query&meta=globaluserinfo&guiuser={name}&format=json&formatversion=2".format(
-        base=settings.TWLIGHT_OAUTH_PROVIDER_URL, name=urllib.parse.quote(wp_username)
+    endpoint = settings.TWLIGHT_OAUTH_PROVIDER_URL + "/w/api.php"
+    guiuser = urllib.parse.quote(wp_username)
+    query = "{endpoint}?action=query&meta=globaluserinfo&guiuser={guiuser}&guiprop=merged|unattached&format=json&formatversion=2".format(
+        endpoint=endpoint, guiuser=guiuser
     )
 
-    results = json.loads(urllib.request.urlopen(endpoint).read())
+    results = json.loads(urllib.request.urlopen(query).read())
     try:
         global_userinfo = results["query"]["globaluserinfo"]
         # If the user isn't found global_userinfo contains the empty key "missing"

--- a/TWLight/users/helpers/editor_data.py
+++ b/TWLight/users/helpers/editor_data.py
@@ -14,7 +14,7 @@ def editor_global_userinfo(
 ):
     endpoint = settings.TWLIGHT_OAUTH_PROVIDER_URL + "/w/api.php"
     guiuser = urllib.parse.quote(wp_username)
-    query = "{endpoint}?action=query&meta=globaluserinfo&guiuser={guiuser}&guiprop=merged&format=json&formatversion=2".format(
+    query = "{endpoint}?action=query&meta=globaluserinfo&guiuser={guiuser}&guiprop=editcount|merged&format=json&formatversion=2".format(
         endpoint=endpoint, guiuser=guiuser
     )
 
@@ -43,7 +43,8 @@ def editor_global_userinfo(
                     "reason": ""
                 }
                 ... # Continues ad nauseam
-            ]
+            ],
+            "editcount": account['editcount']           # global editcount
         }
      }
     }

--- a/TWLight/users/helpers/editor_data.py
+++ b/TWLight/users/helpers/editor_data.py
@@ -14,11 +14,41 @@ def editor_global_userinfo(
 ):
     endpoint = settings.TWLIGHT_OAUTH_PROVIDER_URL + "/w/api.php"
     guiuser = urllib.parse.quote(wp_username)
-    query = "{endpoint}?action=query&meta=globaluserinfo&guiuser={guiuser}&guiprop=merged|unattached&format=json&formatversion=2".format(
+    query = "{endpoint}?action=query&meta=globaluserinfo&guiuser={guiuser}&guiprop=merged&format=json&formatversion=2".format(
         endpoint=endpoint, guiuser=guiuser
     )
 
     results = json.loads(urllib.request.urlopen(query).read())
+    """
+    Expected data:
+    {
+    "batchcomplete": true,
+     "query": {
+        "globaluserinfo": {                         # Global account
+            "home": "enwiki",                           # Wiki used to determine the name of the global account. See https://www.mediawiki.org/wiki/SUL_finalisation
+            "id": account['id'],                        # Wikipedia ID
+            "registration": "YYYY-MM-DDTHH:mm:ssZ",     # Date registered
+            "name": account['name'],                    # wikipedia username
+            "merged": [                                 # Individual project accounts attached to the global account.
+                {
+                    "wiki": "enwiki",
+                    "url": "https://en.wikipedia.org",
+                    "timestamp": "YYYY-MM-DDTHH:mm:ssZ",
+                    "method": "login",
+                    "editcount": account['editcount']           # editcount for this project
+                    "registration": "YYYY-MM-DDTHH:mm:ssZ",     # Date registered for this project
+                    "groups": ["extendedconfirmed"],
+                    "blocked": {                                # Only exists if the user has blocks for this project.
+                    "expiry": "infinity",
+                    "reason": ""
+                }
+                ... # Continues ad nauseam
+            ]
+        }
+     }
+    }
+    """
+
     try:
         global_userinfo = results["query"]["globaluserinfo"]
         # If the user isn't found global_userinfo contains the empty key "missing"

--- a/TWLight/users/management/commands/user_update_eligibility.py
+++ b/TWLight/users/management/commands/user_update_eligibility.py
@@ -12,6 +12,7 @@ from TWLight.users.helpers.editor_data import (
     editor_valid,
     editor_enough_edits,
     editor_recent_edits,
+    editor_not_blocked,
     editor_bundle_eligible,
 )
 
@@ -60,6 +61,7 @@ class Command(BaseCommand):
                 editor.wp_editcount = global_userinfo["editcount"]
                 editor.wp_editcount_updated = wp_editcount_updated
                 editor.wp_enough_edits = editor_enough_edits(global_userinfo)
+                editor.wp_not_blocked = editor_not_blocked(global_userinfo["merged"])
                 editor.wp_valid = editor_valid(
                     editor.wp_enough_edits,
                     # We could recalculate this, but we would only need to do that if upped the minimum required account age.

--- a/TWLight/users/management/commands/user_update_eligibility.py
+++ b/TWLight/users/management/commands/user_update_eligibility.py
@@ -68,6 +68,7 @@ class Command(BaseCommand):
                     editor.wp_account_old_enough,
                     # editor.wp_not_blocked can only be rechecked on login, so we're going with the existing value.
                     editor.wp_not_blocked,
+                    editor.ignore_wp_blocks,
                 )
                 editor.wp_bundle_eligible = editor_bundle_eligible(
                     editor.wp_valid, editor.wp_enough_recent_edits

--- a/TWLight/users/management/commands/user_update_eligibility.py
+++ b/TWLight/users/management/commands/user_update_eligibility.py
@@ -60,7 +60,7 @@ class Command(BaseCommand):
                 )
                 editor.wp_editcount = global_userinfo["editcount"]
                 editor.wp_editcount_updated = wp_editcount_updated
-                editor.wp_enough_edits = editor_enough_edits(global_userinfo["editcount"])
+                editor.wp_enough_edits = editor_enough_edits(editor.wp_editcount)
                 editor.wp_not_blocked = editor_not_blocked(global_userinfo["merged"])
                 editor.wp_valid = editor_valid(
                     editor.wp_enough_edits,

--- a/TWLight/users/management/commands/user_update_eligibility.py
+++ b/TWLight/users/management/commands/user_update_eligibility.py
@@ -5,12 +5,13 @@ import urllib.request, urllib.error, urllib.parse
 
 from django.utils.timezone import now
 from django.core.management.base import BaseCommand
-from TWLight.users.models import (
-    Editor,
+from TWLight.users.models import Editor
+
+from TWLight.users.helpers.editor_data import (
+    editor_valid,
+    editor_enough_edits,
     editor_recent_edits,
     editor_bundle_eligible,
-    editor_enough_edits,
-    editor_valid,
 )
 
 logger = logging.getLogger(__name__)

--- a/TWLight/users/management/commands/user_update_eligibility.py
+++ b/TWLight/users/management/commands/user_update_eligibility.py
@@ -60,7 +60,7 @@ class Command(BaseCommand):
                 )
                 editor.wp_editcount = global_userinfo["editcount"]
                 editor.wp_editcount_updated = wp_editcount_updated
-                editor.wp_enough_edits = editor_enough_edits(global_userinfo)
+                editor.wp_enough_edits = editor_enough_edits(global_userinfo["editcount"])
                 editor.wp_not_blocked = editor_not_blocked(global_userinfo["merged"])
                 editor.wp_valid = editor_valid(
                     editor.wp_enough_edits,

--- a/TWLight/users/models.py
+++ b/TWLight/users/models.py
@@ -359,9 +359,8 @@ class Editor(models.Model):
         else:
             return None
 
-    @property
     def get_global_userinfo(self, identity):
-        return editor_global_userinfo(identity["username"], identity["id"], True)
+        return editor_global_userinfo(identity["username"], identity["sub"], True)
 
     def update_from_wikipedia(self, identity, lang):
         """

--- a/TWLight/users/models.py
+++ b/TWLight/users/models.py
@@ -427,8 +427,7 @@ class Editor(models.Model):
 
         self.wp_registered = editor_reg_date(identity, global_userinfo)
         self.wp_account_old_enough = editor_account_old_enough(self.wp_registered)
-        # TODO: update this function to simply take editcount.
-        self.wp_enough_edits = editor_enough_edits(global_userinfo["editcount"])
+        self.wp_enough_edits = editor_enough_edits(self.wp_editcount)
         self.wp_valid = editor_valid(
             self.wp_enough_edits,
             self.wp_account_old_enough,

--- a/TWLight/users/models.py
+++ b/TWLight/users/models.py
@@ -415,6 +415,7 @@ class Editor(models.Model):
                 self.wp_enough_recent_edits,
             )
             self.wp_editcount = global_userinfo["editcount"]
+            self.wp_not_blocked = editor_not_blocked(global_userinfo["merged"])
             self.wp_editcount_updated = now()
 
         self.save()
@@ -433,7 +434,6 @@ class Editor(models.Model):
         self.wp_registered = editor_reg_date(identity, global_userinfo)
         self.wp_account_old_enough = editor_account_old_enough(self.wp_registered)
         self.wp_enough_edits = editor_enough_edits(global_userinfo)
-        self.wp_not_blocked = editor_not_blocked(identity)
         self.wp_valid = editor_valid(
             self.wp_enough_edits, self.wp_account_old_enough, self.wp_not_blocked
         )

--- a/TWLight/users/models.py
+++ b/TWLight/users/models.py
@@ -46,6 +46,7 @@ from TWLight.resources.models import Partner, Stream
 from TWLight.users.groups import get_coordinators
 
 from TWLight.users.helpers.editor_data import (
+    editor_global_userinfo,
     editor_valid,
     editor_account_old_enough,
     editor_enough_edits,
@@ -358,37 +359,9 @@ class Editor(models.Model):
         else:
             return None
 
+    @property
     def get_global_userinfo(self, identity):
-        """
-        Grab global user information from the API, which we'll use to overlay
-        somme local wiki user info returned by OAuth.  Returns a dict like:
-
-        global_userinfo:
-          home:         "zhwikisource"
-          id:           27666025
-          registration: "2013-05-05T16:00:09Z"
-          name:         "Example"
-          editcount:    10
-        """
-        try:
-            endpoint = "{base}/w/api.php?action=query&meta=globaluserinfo&guiuser={username}&guiprop=editcount&format=json&formatversion=2".format(
-                base=identity["iss"], username=urllib.parse.quote(identity["username"])
-            )
-
-            results = json.loads(urllib.request.urlopen(endpoint).read())
-            global_userinfo = results["query"]["globaluserinfo"]
-
-            try:
-                assert "missing" not in global_userinfo
-                logger.info("Fetched global_userinfo for User.")
-                return global_userinfo
-            except AssertionError:
-                logger.exception("Could not fetch global_userinfo for User.")
-                return None
-
-        except:
-            logger.exception("Could not fetch global_userinfo for User.")
-            return None
+        return editor_global_userinfo(identity["username"], identity["id"], True)
 
     def update_from_wikipedia(self, identity, lang):
         """

--- a/TWLight/users/models.py
+++ b/TWLight/users/models.py
@@ -195,7 +195,7 @@ class Editor(models.Model):
     # Translators: Lists the individual user rights permissions the editor has on Wikipedia. e.g. sendemail, createpage, move
     wp_rights = models.TextField(help_text=_("Wikipedia user rights"), blank=True)
 
-    # ~~~~~~~~~~~~~~~~~~~~~~~ Non-editable data computed from Wikimedia OAuth ~~~~~~~~~~~~~~~~~~~~~~~#
+    # ~~~~~~~~~~~~~~~~~~~~~~~ Non-editable data computed from Wikimedia OAuth / API Query ~~~~~~~~~~~~~~~~~~~~~~~#
     wp_valid = models.BooleanField(
         default=False,
         editable=False,
@@ -275,6 +275,13 @@ class Editor(models.Model):
         help_text=_(
             "At their last login, did this user meet the criteria for access to the library card bundle?"
         ),
+    )
+
+    # ~~~~~~~~~~~~~~~~~~~~~~~~~~~ Staff-entered data ~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    ignore_wp_blocks = models.BooleanField(
+        default=False,
+        # Translators: Help text asking whether to ignore the 'not currently blocked' requirement for access.
+        help_text=_("Ignore the 'not currently blocked' criterion for access?"),
     )
 
     # ~~~~~~~~~~~~~~~~~~~~~~~~~~~ User-entered data ~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -435,7 +442,10 @@ class Editor(models.Model):
         self.wp_account_old_enough = editor_account_old_enough(self.wp_registered)
         self.wp_enough_edits = editor_enough_edits(global_userinfo)
         self.wp_valid = editor_valid(
-            self.wp_enough_edits, self.wp_account_old_enough, self.wp_not_blocked
+            self.wp_enough_edits,
+            self.wp_account_old_enough,
+            self.wp_not_blocked,
+            self.ignore_wp_blocks,
         )
         self.wp_bundle_eligible = editor_bundle_eligible(
             self.wp_valid, self.wp_enough_recent_edits

--- a/TWLight/users/models.py
+++ b/TWLight/users/models.py
@@ -428,7 +428,7 @@ class Editor(models.Model):
         self.wp_registered = editor_reg_date(identity, global_userinfo)
         self.wp_account_old_enough = editor_account_old_enough(self.wp_registered)
         # TODO: update this function to simply take editcount.
-        self.wp_enough_edits = editor_enough_edits(global_userinfo)
+        self.wp_enough_edits = editor_enough_edits(global_userinfo["editcount"])
         self.wp_valid = editor_valid(
             self.wp_enough_edits,
             self.wp_account_old_enough,

--- a/TWLight/users/models.py
+++ b/TWLight/users/models.py
@@ -425,6 +425,19 @@ class Editor(models.Model):
             self.wp_not_blocked = editor_not_blocked(global_userinfo["merged"])
             self.wp_editcount_updated = now()
 
+        self.wp_registered = editor_reg_date(identity, global_userinfo)
+        self.wp_account_old_enough = editor_account_old_enough(self.wp_registered)
+        # TODO: update this function to simply take editcount.
+        self.wp_enough_edits = editor_enough_edits(global_userinfo)
+        self.wp_valid = editor_valid(
+            self.wp_enough_edits,
+            self.wp_account_old_enough,
+            self.wp_not_blocked,
+            self.ignore_wp_blocks,
+        )
+        self.wp_bundle_eligible = editor_bundle_eligible(
+            self.wp_valid, self.wp_enough_recent_edits
+        )
         self.save()
 
         # This will be True the first time the user logs in, since use_wp_email
@@ -438,18 +451,6 @@ class Editor(models.Model):
                 # anything if we can't find it.
                 logger.exception("Unable to get Editor email address from Wikipedia.")
 
-        self.wp_registered = editor_reg_date(identity, global_userinfo)
-        self.wp_account_old_enough = editor_account_old_enough(self.wp_registered)
-        self.wp_enough_edits = editor_enough_edits(global_userinfo)
-        self.wp_valid = editor_valid(
-            self.wp_enough_edits,
-            self.wp_account_old_enough,
-            self.wp_not_blocked,
-            self.ignore_wp_blocks,
-        )
-        self.wp_bundle_eligible = editor_bundle_eligible(
-            self.wp_valid, self.wp_enough_recent_edits
-        )
         self.user.save()
 
         # Add language if the user hasn't selected one

--- a/TWLight/users/models.py
+++ b/TWLight/users/models.py
@@ -45,6 +45,16 @@ from django.utils.translation import ugettext_lazy as _
 from TWLight.resources.models import Partner, Stream
 from TWLight.users.groups import get_coordinators
 
+from TWLight.users.helpers.editor_data import (
+    editor_valid,
+    editor_account_old_enough,
+    editor_enough_edits,
+    editor_not_blocked,
+    editor_reg_date,
+    editor_recent_edits,
+    editor_bundle_eligible,
+)
+
 logger = logging.getLogger(__name__)
 
 
@@ -122,112 +132,6 @@ def create_user_profile(sender, instance, created, **kwargs):
 
 
 models.signals.post_save.connect(create_user_profile, sender=settings.AUTH_USER_MODEL)
-
-
-def editor_reg_date(identity, global_userinfo):
-    # Try oauth registration date first.  If it's not valid, try the global_userinfo date
-    try:
-        reg_date = datetime.strptime(identity["registered"], "%Y%m%d%H%M%S").date()
-    except (TypeError, ValueError):
-        try:
-            reg_date = datetime.strptime(
-                global_userinfo["registration"], "%Y-%m-%dT%H:%M:%SZ"
-            ).date()
-        except (TypeError, ValueError):
-            reg_date = None
-    return reg_date
-
-
-def editor_enough_edits(global_userinfo):
-    # If, for some reason, this information hasn't come through,
-    # default to user not being valid.
-    if not global_userinfo:
-        return False
-    # Check: >= 500 edits
-    return int(global_userinfo["editcount"]) >= 500
-
-
-def editor_not_blocked(identity):
-    # If, for some reason, this information hasn't come through,
-    # default to user not being valid.
-    if not identity:
-        return False
-    # Check: not blocked
-    return identity["blocked"] == False
-
-
-def editor_account_old_enough(wp_registered):
-    # If, for some reason, this information hasn't come through,
-    # default to user not being valid.
-    if not wp_registered:
-        return False
-    # Check: registered >= 6 months ago
-    return datetime.today().date() - timedelta(days=182) >= wp_registered
-
-
-def editor_valid(enough_edits, account_old_enough, not_blocked):
-    """
-    Check for the eligibility criteria laid out in the terms of service.
-    Note that we won't prohibit signups or applications on this basis.
-    Coordinators have discretion to approve people who are near the cutoff.
-    """
-    if enough_edits and account_old_enough and not_blocked:
-        return True
-    else:
-        return False
-
-
-def editor_recent_edits(
-    global_userinfo_editcount,
-    wp_editcount_updated,
-    wp_editcount,
-    wp_editcount_prev_updated,
-    wp_editcount_prev,
-    wp_editcount_recent,
-    wp_enough_recent_edits,
-):
-
-    # If we have historical data, see how many days have passed and how many edits have been made since the last check.
-    if wp_editcount_prev_updated and wp_editcount_updated:
-        editcount_update_delta = now() - wp_editcount_prev_updated
-        editcount_delta = global_userinfo_editcount - wp_editcount_prev
-        if (
-            # If the editor didn't have enough recent edits but they do now, update the counts immediately.
-            # This recognizes their eligibility as soon as possible.
-            (not wp_enough_recent_edits and editcount_delta >= 10)
-            # If the user had enough edits, just update the counts after 30 days.
-            # This means that eligibility always lasts at least 30 days.
-            or (wp_enough_recent_edits and editcount_update_delta.days > 30)
-        ):
-            wp_editcount_prev = wp_editcount
-            wp_editcount_prev_updated = wp_editcount_updated
-            wp_editcount_recent = global_userinfo_editcount - wp_editcount_prev
-
-    # If we don't have any historical editcount data, let all edits to date count.
-    # Editor.wp_editcount_prev defaults to 0, so we don't need to worry about changing it.
-    else:
-        wp_editcount_prev_updated = now()
-        wp_editcount_recent = global_userinfo_editcount
-
-    # Perform the check for enough recent edits.
-    if wp_editcount_recent >= 10:
-        wp_enough_recent_edits = True
-    else:
-        wp_enough_recent_edits = False
-    # Return a tuple containing all recent-editcount-related results.
-    return (
-        wp_editcount_prev_updated,
-        wp_editcount_prev,
-        wp_editcount_recent,
-        wp_enough_recent_edits,
-    )
-
-
-def editor_bundle_eligible(wp_valid, wp_enough_recent_edits):
-    if wp_valid and wp_enough_recent_edits:
-        return True
-    else:
-        return False
 
 
 class Editor(models.Model):

--- a/TWLight/users/tests.py
+++ b/TWLight/users/tests.py
@@ -785,15 +785,15 @@ class EditorModelTestCase(TestCase):
         )
         self.assertFalse(valid)
 
-        # Edge case: this shouldn't.
-        almost_6_months_ago = datetime.today() - timedelta(days=183)
+        # Edge case: this shouldn't work.
+        almost_6_months_ago = datetime.today() - timedelta(days=181)
         identity["registered"] = almost_6_months_ago.strftime("%Y%m%d%H%M%S")
         registered = editor_reg_date(identity, global_userinfo)
         account_old_enough = editor_account_old_enough(registered)
         valid = editor_valid(
             enough_edits, account_old_enough, not_blocked, ignore_wp_blocks
         )
-        self.assertTrue(valid)
+        self.assertFalse(valid)
 
         # Edge case: this should work.
         almost_6_months_ago = datetime.today() - timedelta(days=182)
@@ -812,6 +812,15 @@ class EditorModelTestCase(TestCase):
             enough_edits, account_old_enough, not_blocked, ignore_wp_blocks
         )
         self.assertFalse(valid)
+
+        # Aw, you're not that bad. Have a cookie.
+        global_userinfo["merged"] = copy.copy(FAKE_MERGED_ACCOUNTS_BLOCKED)
+        not_blocked = editor_not_blocked(global_userinfo["merged"])
+        ignore_wp_blocks = True
+        valid = editor_valid(
+            enough_edits, account_old_enough, not_blocked, ignore_wp_blocks
+        )
+        self.assertTrue(valid)
 
     def test_editor_eligibility_functions(self):
         # Start out with basic validation of the eligibility functions.

--- a/TWLight/users/tests.py
+++ b/TWLight/users/tests.py
@@ -758,19 +758,26 @@ class EditorModelTestCase(TestCase):
         account_old_enough = editor_account_old_enough(registered)
         enough_edits = editor_enough_edits(global_userinfo)
         not_blocked = editor_not_blocked(global_userinfo["merged"])
-        valid = editor_valid(enough_edits, account_old_enough, not_blocked)
+        ignore_wp_blocks = False
+        valid = editor_valid(
+            enough_edits, account_old_enough, not_blocked, ignore_wp_blocks
+        )
         self.assertTrue(valid)
 
         # Edge case
         global_userinfo["editcount"] = 500
         enough_edits = editor_enough_edits(global_userinfo)
-        valid = editor_valid(enough_edits, account_old_enough, not_blocked)
+        valid = editor_valid(
+            enough_edits, account_old_enough, not_blocked, ignore_wp_blocks
+        )
         self.assertTrue(valid)
 
         # Too few edits
         global_userinfo["editcount"] = 499
         enough_edits = editor_enough_edits(global_userinfo)
-        valid = editor_valid(enough_edits, account_old_enough, not_blocked)
+        valid = editor_valid(
+            enough_edits, account_old_enough, not_blocked, ignore_wp_blocks
+        )
         self.assertFalse(valid)
 
         # Account created too recently
@@ -779,7 +786,9 @@ class EditorModelTestCase(TestCase):
         registered = editor_reg_date(identity, global_userinfo)
         account_old_enough = editor_account_old_enough(registered)
         enough_edits = editor_enough_edits(global_userinfo)
-        valid = editor_valid(enough_edits, account_old_enough, not_blocked)
+        valid = editor_valid(
+            enough_edits, account_old_enough, not_blocked, ignore_wp_blocks
+        )
         self.assertFalse(valid)
 
         # Edge case: this shouldn't.
@@ -787,7 +796,9 @@ class EditorModelTestCase(TestCase):
         identity["registered"] = almost_6_months_ago.strftime("%Y%m%d%H%M%S")
         registered = editor_reg_date(identity, global_userinfo)
         account_old_enough = editor_account_old_enough(registered)
-        valid = editor_valid(enough_edits, account_old_enough, not_blocked)
+        valid = editor_valid(
+            enough_edits, account_old_enough, not_blocked, ignore_wp_blocks
+        )
         self.assertTrue(valid)
 
         # Edge case: this should work.
@@ -795,13 +806,17 @@ class EditorModelTestCase(TestCase):
         identity["registered"] = almost_6_months_ago.strftime("%Y%m%d%H%M%S")
         registered = editor_reg_date(identity, global_userinfo)
         account_old_enough = editor_account_old_enough(registered)
-        valid = editor_valid(enough_edits, account_old_enough, not_blocked)
+        valid = editor_valid(
+            enough_edits, account_old_enough, not_blocked, ignore_wp_blocks
+        )
         self.assertTrue(valid)
 
         # Bad editor! No biscuit.
         global_userinfo["merged"] = copy.copy(FAKE_MERGED_ACCOUNTS_BLOCKED)
         not_blocked = editor_not_blocked(global_userinfo["merged"])
-        valid = editor_valid(enough_edits, account_old_enough, not_blocked)
+        valid = editor_valid(
+            enough_edits, account_old_enough, not_blocked, ignore_wp_blocks
+        )
         self.assertFalse(valid)
 
     def test_editor_eligibility_functions(self):
@@ -836,7 +851,10 @@ class EditorModelTestCase(TestCase):
         account_old_enough = editor_account_old_enough(registered)
         enough_edits = editor_enough_edits(global_userinfo)
         not_blocked = editor_not_blocked(global_userinfo["merged"])
-        valid = editor_valid(enough_edits, account_old_enough, not_blocked)
+        ignore_wp_blocks = False
+        valid = editor_valid(
+            enough_edits, account_old_enough, not_blocked, ignore_wp_blocks
+        )
         self.assertTrue(valid)
 
         # 1st time bundle check should always pass for a valid user.
@@ -911,7 +929,9 @@ class EditorModelTestCase(TestCase):
         # Bad editor! No biscuit, even if you have enough edits.
         global_userinfo["merged"] = copy.copy(FAKE_MERGED_ACCOUNTS_BLOCKED)
         not_blocked = editor_not_blocked(global_userinfo["merged"])
-        valid = editor_valid(enough_edits, account_old_enough, not_blocked)
+        valid = editor_valid(
+            enough_edits, account_old_enough, not_blocked, ignore_wp_blocks
+        )
         self.test_editor.wp_editcount_updated = now() - timedelta(days=31)
         self.test_editor.wp_editcount_prev_updated = (
             self.test_editor.wp_editcount_prev_updated - timedelta(days=31)
@@ -946,6 +966,7 @@ class EditorModelTestCase(TestCase):
             self.test_editor.wp_enough_edits,
             self.test_editor.wp_account_old_enough,
             self.test_editor.wp_not_blocked,
+            self.test_editor.ignore_wp_blocks,
         )
         self.test_editor.wp_editcount_updated = now() - timedelta(days=60)
         self.test_editor.wp_editcount_prev_updated = (

--- a/TWLight/users/tests.py
+++ b/TWLight/users/tests.py
@@ -54,13 +54,40 @@ FAKE_IDENTITY = {
     "username": "alice",
 }
 
+FAKE_MERGED_ACCOUNTS = [
+    {
+        "wiki": "enwiki",
+        "url": "https://en.wikipedia.org",
+        "timestamp": "2015-11-06T15:46:29Z",
+        "method": "login",
+        "editcount": 100,
+        "registration": "2015-11-06T15:46:29Z",
+        "groups": ["extendedconfirmed"],
+    }
+]
+
+FAKE_MERGED_ACCOUNTS_BLOCKED = [
+    {
+        "wiki": "enwiki",
+        "url": "https://en.wikipedia.org",
+        "timestamp": "2015-11-06T15:46:29Z",
+        "method": "login",
+        "editcount": 100,
+        "registration": "2015-11-06T15:46:29Z",
+        "groups": ["extendedconfirmed"],
+        "blocked": {"expiry": "infinity", "reason": "bad editor!"},
+    }
+]
+
 FAKE_GLOBAL_USERINFO = {
     "home": "enwiki",
     "id": 567823,
     "registration": "2015-11-06T15:46:29Z",  # Well before first commit.
     "name": "alice",
     "editcount": 5000,
+    "merged": copy.copy(FAKE_MERGED_ACCOUNTS),
 }
+
 
 # CSRF middleware is helpful for site security, but not helpful for testing
 # the rendered output of a page.
@@ -730,7 +757,7 @@ class EditorModelTestCase(TestCase):
         registered = editor_reg_date(identity, global_userinfo)
         account_old_enough = editor_account_old_enough(registered)
         enough_edits = editor_enough_edits(global_userinfo)
-        not_blocked = editor_not_blocked(identity)
+        not_blocked = editor_not_blocked(global_userinfo["merged"])
         valid = editor_valid(enough_edits, account_old_enough, not_blocked)
         self.assertTrue(valid)
 
@@ -772,8 +799,8 @@ class EditorModelTestCase(TestCase):
         self.assertTrue(valid)
 
         # Bad editor! No biscuit.
-        identity["blocked"] = True
-        not_blocked = editor_not_blocked(identity)
+        global_userinfo["merged"] = copy.copy(FAKE_MERGED_ACCOUNTS_BLOCKED)
+        not_blocked = editor_not_blocked(global_userinfo["merged"])
         valid = editor_valid(enough_edits, account_old_enough, not_blocked)
         self.assertFalse(valid)
 
@@ -808,7 +835,7 @@ class EditorModelTestCase(TestCase):
         registered = editor_reg_date(identity, global_userinfo)
         account_old_enough = editor_account_old_enough(registered)
         enough_edits = editor_enough_edits(global_userinfo)
-        not_blocked = editor_not_blocked(identity)
+        not_blocked = editor_not_blocked(global_userinfo["merged"])
         valid = editor_valid(enough_edits, account_old_enough, not_blocked)
         self.assertTrue(valid)
 
@@ -882,8 +909,8 @@ class EditorModelTestCase(TestCase):
         self.assertTrue(bundle_eligible)
 
         # Bad editor! No biscuit, even if you have enough edits.
-        identity["blocked"] = True
-        not_blocked = editor_not_blocked(identity)
+        global_userinfo["merged"] = copy.copy(FAKE_MERGED_ACCOUNTS_BLOCKED)
+        not_blocked = editor_not_blocked(global_userinfo["merged"])
         valid = editor_valid(enough_edits, account_old_enough, not_blocked)
         self.test_editor.wp_editcount_updated = now() - timedelta(days=31)
         self.test_editor.wp_editcount_prev_updated = (
@@ -909,12 +936,12 @@ class EditorModelTestCase(TestCase):
 
         # Valid data for first time logging in after bundle was launched. 60 days ago.
         global_userinfo["editcount"] = 500
-        identity["blocked"] = False
+        global_userinfo["merged"] = copy.copy(FAKE_MERGED_ACCOUNTS)
         self.test_editor.wp_editcount = global_userinfo["editcount"]
         self.test_editor.wp_registered = editor_reg_date(identity, global_userinfo)
         self.test_editor.wp_account_old_enough = editor_account_old_enough(registered)
         self.test_editor.wp_enough_edits = editor_enough_edits(global_userinfo)
-        self.test_editor.wp_not_blocked = editor_not_blocked(identity)
+        self.test_editor.wp_not_blocked = editor_not_blocked(global_userinfo["merged"])
         self.test_editor.wp_valid = editor_valid(
             self.test_editor.wp_enough_edits,
             self.test_editor.wp_account_old_enough,
@@ -991,6 +1018,8 @@ class EditorModelTestCase(TestCase):
         global_userinfo["name"] = identity["username"]
         # We should now be using the global_userinfo editcount
         global_userinfo["editcount"] = 960
+
+        global_userinfo["merged"] = copy.copy(FAKE_MERGED_ACCOUNTS_BLOCKED)
 
         # update_from_wikipedia calls get_global_userinfo, which generates an
         # API call to Wikipedia that we don't actually want to do in testing.

--- a/TWLight/users/tests.py
+++ b/TWLight/users/tests.py
@@ -753,10 +753,10 @@ class EditorModelTestCase(TestCase):
 
         # Valid data
         global_userinfo["editcount"] = 500
-        self.test_editor.wp_editcount = 500
+        self.test_editor.wp_editcount = global_userinfo["editcount"]
+        enough_edits = editor_enough_edits(self.test_editor.wp_editcount)
         registered = editor_reg_date(identity, global_userinfo)
         account_old_enough = editor_account_old_enough(registered)
-        enough_edits = editor_enough_edits(global_userinfo["editcount"])
         not_blocked = editor_not_blocked(global_userinfo["merged"])
         ignore_wp_blocks = False
         valid = editor_valid(
@@ -764,17 +764,10 @@ class EditorModelTestCase(TestCase):
         )
         self.assertTrue(valid)
 
-        # Edge case
-        global_userinfo["editcount"] = 500
-        enough_edits = editor_enough_edits(global_userinfo["editcount"])
-        valid = editor_valid(
-            enough_edits, account_old_enough, not_blocked, ignore_wp_blocks
-        )
-        self.assertTrue(valid)
-
         # Too few edits
         global_userinfo["editcount"] = 499
-        enough_edits = editor_enough_edits(global_userinfo["editcount"])
+        self.test_editor.wp_editcount = global_userinfo["editcount"]
+        enough_edits = editor_enough_edits(self.test_editor.wp_editcount)
         valid = editor_valid(
             enough_edits, account_old_enough, not_blocked, ignore_wp_blocks
         )
@@ -782,10 +775,11 @@ class EditorModelTestCase(TestCase):
 
         # Account created too recently
         global_userinfo["editcount"] = 500
+        self.test_editor.wp_editcount = global_userinfo["editcount"]
+        enough_edits = editor_enough_edits(self.test_editor.wp_editcount)
         identity["registered"] = datetime.today().strftime("%Y%m%d%H%M%S")
         registered = editor_reg_date(identity, global_userinfo)
         account_old_enough = editor_account_old_enough(registered)
-        enough_edits = editor_enough_edits(global_userinfo["editcount"])
         valid = editor_valid(
             enough_edits, account_old_enough, not_blocked, ignore_wp_blocks
         )
@@ -846,10 +840,10 @@ class EditorModelTestCase(TestCase):
 
         # Valid data
         global_userinfo["editcount"] = 500
-        self.test_editor.wp_editcount = 500
+        self.test_editor.wp_editcount = global_userinfo["editcount"]
+        enough_edits = editor_enough_edits(self.test_editor.wp_editcount)
         registered = editor_reg_date(identity, global_userinfo)
         account_old_enough = editor_account_old_enough(registered)
-        enough_edits = editor_enough_edits(global_userinfo["editcount"])
         not_blocked = editor_not_blocked(global_userinfo["merged"])
         ignore_wp_blocks = False
         valid = editor_valid(
@@ -955,12 +949,15 @@ class EditorModelTestCase(TestCase):
         # even if we're not sure whether they made those edits in the last 30 days.
 
         # Valid data for first time logging in after bundle was launched. 60 days ago.
-        global_userinfo["editcount"] = 500
         global_userinfo["merged"] = copy.copy(FAKE_MERGED_ACCOUNTS)
+        global_userinfo["editcount"] = 500
+        self.test_editor.wp_editcount = global_userinfo["editcount"]
+        self.test_editor.wp_enough_edits = editor_enough_edits(
+            self.test_editor.wp_editcount
+        )
         self.test_editor.wp_editcount = global_userinfo["editcount"]
         self.test_editor.wp_registered = editor_reg_date(identity, global_userinfo)
         self.test_editor.wp_account_old_enough = editor_account_old_enough(registered)
-        self.test_editor.wp_enough_edits = editor_enough_edits(global_userinfo["editcount"])
         self.test_editor.wp_not_blocked = editor_not_blocked(global_userinfo["merged"])
         self.test_editor.wp_valid = editor_valid(
             self.test_editor.wp_enough_edits,

--- a/TWLight/users/tests.py
+++ b/TWLight/users/tests.py
@@ -27,10 +27,9 @@ from .authorization import OAuthBackend
 from .helpers.wiki_list import WIKIS, LANGUAGE_CODES
 from .factories import EditorFactory, UserFactory
 from .groups import get_coordinators, get_restricted
-from .models import (
-    UserProfile,
-    Editor,
-    Authorization,
+from .models import UserProfile, Editor, Authorization
+
+from TWLight.users.helpers.editor_data import (
     editor_valid,
     editor_account_old_enough,
     editor_enough_edits,

--- a/TWLight/users/tests.py
+++ b/TWLight/users/tests.py
@@ -756,7 +756,7 @@ class EditorModelTestCase(TestCase):
         self.test_editor.wp_editcount = 500
         registered = editor_reg_date(identity, global_userinfo)
         account_old_enough = editor_account_old_enough(registered)
-        enough_edits = editor_enough_edits(global_userinfo)
+        enough_edits = editor_enough_edits(global_userinfo["editcount"])
         not_blocked = editor_not_blocked(global_userinfo["merged"])
         ignore_wp_blocks = False
         valid = editor_valid(
@@ -766,7 +766,7 @@ class EditorModelTestCase(TestCase):
 
         # Edge case
         global_userinfo["editcount"] = 500
-        enough_edits = editor_enough_edits(global_userinfo)
+        enough_edits = editor_enough_edits(global_userinfo["editcount"])
         valid = editor_valid(
             enough_edits, account_old_enough, not_blocked, ignore_wp_blocks
         )
@@ -774,7 +774,7 @@ class EditorModelTestCase(TestCase):
 
         # Too few edits
         global_userinfo["editcount"] = 499
-        enough_edits = editor_enough_edits(global_userinfo)
+        enough_edits = editor_enough_edits(global_userinfo["editcount"])
         valid = editor_valid(
             enough_edits, account_old_enough, not_blocked, ignore_wp_blocks
         )
@@ -785,7 +785,7 @@ class EditorModelTestCase(TestCase):
         identity["registered"] = datetime.today().strftime("%Y%m%d%H%M%S")
         registered = editor_reg_date(identity, global_userinfo)
         account_old_enough = editor_account_old_enough(registered)
-        enough_edits = editor_enough_edits(global_userinfo)
+        enough_edits = editor_enough_edits(global_userinfo["editcount"])
         valid = editor_valid(
             enough_edits, account_old_enough, not_blocked, ignore_wp_blocks
         )
@@ -849,7 +849,7 @@ class EditorModelTestCase(TestCase):
         self.test_editor.wp_editcount = 500
         registered = editor_reg_date(identity, global_userinfo)
         account_old_enough = editor_account_old_enough(registered)
-        enough_edits = editor_enough_edits(global_userinfo)
+        enough_edits = editor_enough_edits(global_userinfo["editcount"])
         not_blocked = editor_not_blocked(global_userinfo["merged"])
         ignore_wp_blocks = False
         valid = editor_valid(
@@ -960,7 +960,7 @@ class EditorModelTestCase(TestCase):
         self.test_editor.wp_editcount = global_userinfo["editcount"]
         self.test_editor.wp_registered = editor_reg_date(identity, global_userinfo)
         self.test_editor.wp_account_old_enough = editor_account_old_enough(registered)
-        self.test_editor.wp_enough_edits = editor_enough_edits(global_userinfo)
+        self.test_editor.wp_enough_edits = editor_enough_edits(global_userinfo["editcount"])
         self.test_editor.wp_not_blocked = editor_not_blocked(global_userinfo["merged"])
         self.test_editor.wp_valid = editor_valid(
             self.test_editor.wp_enough_edits,


### PR DESCRIPTION
https://phabricator.wikimedia.org/T234552

Okay, we had to pay a bit of technical debt to add this functionality.

In this PR, I've factored the many implementations of get_global_userinfo out to a single static function and moved it along with all of the recent editor eligibility/validity functions out to a helper module.

We previously were only getting blocked status for the SUL "home" project account rather than global blocks. We're now getting a list of local project accounts with block status for each one as part of global_userinfo. The block check essentially works the same as before, except it's now checking for a block in *any* account attached to the global user.

There is a new Editor.ignore_wp_blocks Boolean property that allows users to be treated as if they had no blocks, even if they do. Basically, this overrides the check for blocks while calculated Editor.is_valid.

On the editor profile, the editor should show as failing the block check, but being valid anyway.

There is currently no UI for setting ignore_wp_blocks, so that will need to be done in admin by a superuser for now.