### PR TITLE
Proxy/Bundle UX fixes

### DIFF
--- a/TWLight/applications/views.py
+++ b/TWLight/applications/views.py
@@ -414,8 +414,8 @@ class SubmitApplicationView(_BaseSubmitApplicationView):
                 'Head over to <a href="{applications_url}">Your Applications'
                 "</a> to view the status.".format(
                     applications_url=reverse_lazy(
-                        "users:my_applications",
-                        kwargs={"pk": self.request.user.pk})
+                        "users:my_applications", kwargs={"pk": self.request.user.pk}
+                    )
                 )
             ),
         )
@@ -474,8 +474,8 @@ class SubmitSingleApplicationView(_BaseSubmitApplicationView):
                 'Head over to <a href="{applications_url}">Your Applications'
                 "</a> to view the status.".format(
                     applications_url=reverse_lazy(
-                        "users:my_applications",
-                        kwargs={"pk": self.request.user.pk})
+                        "users:my_applications", kwargs={"pk": self.request.user.pk}
+                    )
                 )
             ),
         )

--- a/TWLight/applications/views.py
+++ b/TWLight/applications/views.py
@@ -411,7 +411,12 @@ class SubmitApplicationView(_BaseSubmitApplicationView):
             # Translators: When a user applies for a set of resources, they receive this message if their application was filed successfully.
             _(
                 "Your application has been submitted for review. "
-                "You can check the status of your applications on this page."
+                'Head over to <a href="{applications_url}">Your Applications'
+                "</a> to view the status.".format(
+                    applications_url=reverse_lazy(
+                        "users:my_applications",
+                        kwargs={"pk": self.request.user.pk})
+                )
             ),
         )
         user_home = reverse(
@@ -466,7 +471,12 @@ class SubmitSingleApplicationView(_BaseSubmitApplicationView):
             messages.SUCCESS,
             _(
                 "Your application has been submitted for review. "
-                "You can check the status of your applications on this page."
+                'Head over to <a href="{applications_url}">Your Applications'
+                "</a> to view the status.".format(
+                    applications_url=reverse_lazy(
+                        "users:my_applications",
+                        kwargs={"pk": self.request.user.pk})
+                )
             ),
         )
         user_home = self._get_partners()[0].get_absolute_url()

--- a/TWLight/resources/models.py
+++ b/TWLight/resources/models.py
@@ -661,7 +661,7 @@ class Stream(models.Model):
         ezproxy_url = settings.TWLIGHT_EZPROXY_URL
         access_url = None
         if (
-            self.authorization_method == Partner.PROXY
+            self.authorization_method in [Partner.PROXY, Partner.BUNDLE]
             and ezproxy_url
             and self.target_url
         ):

--- a/TWLight/resources/models.py
+++ b/TWLight/resources/models.py
@@ -534,7 +534,11 @@ class Partner(models.Model):
     def get_access_url(self):
         ezproxy_url = settings.TWLIGHT_EZPROXY_URL
         access_url = None
-        if self.authorization_method == self.PROXY and ezproxy_url and self.target_url:
+        if(
+            self.authorization_method in [self.PROXY, self.BUNDLE]
+            and ezproxy_url
+            and self.target_url
+        ):
             access_url = ezproxy_url + "/login?url=" + self.target_url
         elif self.target_url:
             access_url = self.target_url

--- a/TWLight/resources/models.py
+++ b/TWLight/resources/models.py
@@ -534,7 +534,7 @@ class Partner(models.Model):
     def get_access_url(self):
         ezproxy_url = settings.TWLIGHT_EZPROXY_URL
         access_url = None
-        if(
+        if (
             self.authorization_method in [self.PROXY, self.BUNDLE]
             and ezproxy_url
             and self.target_url

--- a/TWLight/resources/templates/resources/partner_detail.html
+++ b/TWLight/resources/templates/resources/partner_detail.html
@@ -471,17 +471,32 @@
             <div class="panel-body top-border">
               {% if user.is_authenticated %}
                 {% if user.editor.wp_bundle_eligible %}
-                  {% comment %} Translators: This text labels a button authenticated, bundle eligible users can click to access the proxied resource. {% endcomment %}
-                  <a class="btn btn-default btn-lg btn-block" href="{{ partner.get_access_url }}">{% trans "Access Collection" %}</a><br />
-                  <img src="{% static 'img/LibraryBundle.svg' %}" class="img-responsive pull-left" style="width:45px; height:45px; padding-right: 5px;" title="{% trans 'Library Bundle' %}" alt="
-                  {% comment %} Translators: Alt text for the Library Bundle icon shown on the collection page. {% endcomment %}
-                  {% trans "Library bundle access" %}
-                  ">
-                  {% comment %} Translators: Text shown to authenticated, bundle eligible users when they visit a Bundle partner page. {% endcomment %}
-                  {% blocktrans trimmed %}
-                    You are eligible to access Library Bundle partners.
-                    Click the above button to access the collection.
-                  {% endblocktrans %}
+                  {% if partner.specific_stream %}
+                    {% comment %} Translators: This text labels a button taking users to their library. {% endcomment %}
+                    <a class="btn btn-default btn-lg btn-block" href="{% url "users:my_library" %}">{% trans "My Library" %}</a><br />
+                    <img src="{% static 'img/LibraryBundle.svg' %}" class="img-responsive pull-left" style="width:45px; height:45px; padding-right: 5px;" title="{% trans 'Library Bundle' %}" alt="
+                    {% comment %} Translators: Alt text for the Library Bundle icon shown on the collection page. {% endcomment %}
+                    {% trans "Library bundle access" %}
+                    ">
+                    {% comment %} Translators: Text shown to authenticated, bundle eligible users when they need to visit My Library to access collections. {% endcomment %}
+                    {% blocktrans trimmed %}
+                      You are eligible to access Library Bundle partners.
+                      Click the button above to go to your Library and browse
+                      collections from this partner.
+                    {% endblocktrans %}
+                  {% else %}
+                    {% comment %} Translators: This text labels a button authenticated, bundle eligible users can click to access the proxied resource. {% endcomment %}
+                    <a class="btn btn-default btn-lg btn-block" href="{{ partner.get_access_url }}">{% trans "Access Collection" %}</a><br />
+                    <img src="{% static 'img/LibraryBundle.svg' %}" class="img-responsive pull-left" style="width:45px; height:45px; padding-right: 5px;" title="{% trans 'Library Bundle' %}" alt="
+                    {% comment %} Translators: Alt text for the Library Bundle icon shown on the collection page. {% endcomment %}
+                    {% trans "Library bundle access" %}
+                    ">
+                    {% comment %} Translators: Text shown to authenticated, bundle eligible users when they visit a Bundle partner page. {% endcomment %}
+                    {% blocktrans trimmed %}
+                      You are eligible to access Library Bundle partners.
+                      Click the button above to access the collection.
+                    {% endblocktrans %}
+                  {% endif %}
                 {% else %}
                   {% comment %} Translators: This text labels a button authenticated, bundle eligible users can click to access the proxied resource. {% endcomment %}
                   <a class="btn btn-default btn-lg btn-block disabled">{% trans "Access Collection" %}</a><br />

--- a/TWLight/templates/home.html
+++ b/TWLight/templates/home.html
@@ -25,7 +25,7 @@
         </a>
       {% else %}
         <a href="{% url 'oauth_login' %}" class="btn btn-primary btn-block">
-          <span class="glyphicon glyphicon-off"></span>&nbsp
+          <span class="glyphicon glyphicon-off"></span>&nbsp;
           {% comment %} Translators: This message is shown on the button users click to log in to the website. {% endcomment %}
           {% trans "Log in" %}
         </a>

--- a/TWLight/templates/home.html
+++ b/TWLight/templates/home.html
@@ -2,6 +2,8 @@
 {% load staticfiles %}
 {% load i18n %}
 {% load l10n %}
+{% load cache %}
+{% load twlight_wikicode2html %}
 
 {% block content %}
   <div class="lead">
@@ -98,11 +100,13 @@
         {% for partner in featured_partners %}
           <div class="row">
             <div class="featured-partner">
-              <div class="col-md-4">
+              <div class="col-md-3">
                 <a href="{% url 'partners:detail' partner.pk %}"><img src="{{ partner.logos.logo.url }}" alt="{{ partner }} logo" class="featured-partner-logo"></a>
               </div>
-              <div class="col-md-8" style="display:inline-block;">
-                {{ partner.short_description |truncatechars:200 }}
+              <div class="col-md-9" style="display:inline-block;">
+                {% cache 31536000 partner_short_description LANGUAGE_CODE object.pk %}
+                  {{ partner.short_description | twlight_wikicode2html | safe |truncatechars:200}}
+                {% endcache %}
               </div>
             </div>
           </div>

--- a/TWLight/templates/home.html
+++ b/TWLight/templates/home.html
@@ -2,7 +2,6 @@
 {% load staticfiles %}
 {% load i18n %}
 {% load l10n %}
-{% load cache %}
 {% load twlight_wikicode2html %}
 
 {% block content %}
@@ -104,9 +103,7 @@
                 <a href="{% url 'partners:detail' partner.pk %}"><img src="{{ partner.logos.logo.url }}" alt="{{ partner }} logo" class="featured-partner-logo"></a>
               </div>
               <div class="col-md-9" style="display:inline-block;">
-                {% cache 31536000 partner_short_description LANGUAGE_CODE object.pk %}
-                  {{ partner.short_description | twlight_wikicode2html | safe |truncatechars:200}}
-                {% endcache %}
+                {{ partner.short_description | twlight_wikicode2html | safe |truncatechars:200}}
               </div>
             </div>
           </div>

--- a/TWLight/templates/home.html
+++ b/TWLight/templates/home.html
@@ -2,6 +2,7 @@
 {% load staticfiles %}
 {% load i18n %}
 {% load l10n %}
+{% load cache %}
 {% load twlight_wikicode2html %}
 
 {% block content %}
@@ -24,7 +25,7 @@
         </a>
       {% else %}
         <a href="{% url 'oauth_login' %}" class="btn btn-primary btn-block">
-          <span class="glyphicon glyphicon-off"></span>&nbsp;
+          <span class="glyphicon glyphicon-off"></span>&nbsp
           {% comment %} Translators: This message is shown on the button users click to log in to the website. {% endcomment %}
           {% trans "Log in" %}
         </a>
@@ -103,7 +104,9 @@
                 <a href="{% url 'partners:detail' partner.pk %}"><img src="{{ partner.logos.logo.url }}" alt="{{ partner }} logo" class="featured-partner-logo"></a>
               </div>
               <div class="col-md-9" style="display:inline-block;">
-                {{ partner.short_description | twlight_wikicode2html | safe |truncatechars:200}}
+                {% cache 31536000 partner_short_description LANGUAGE_CODE partner.pk %}
+                  {{ partner.short_description | twlight_wikicode2html | safe |truncatechars:200}}
+                {% endcache %}
               </div>
             </div>
           </div>

--- a/TWLight/users/models.py
+++ b/TWLight/users/models.py
@@ -698,7 +698,6 @@ class Authorization(models.Model):
         or stream and False otherwise.
         """
         authorization_method = self.get_authorization_method()
-        logger.info(authorization_method)
 
         if authorization_method == Partner.BUNDLE:
             return True

--- a/TWLight/users/models.py
+++ b/TWLight/users/models.py
@@ -680,19 +680,27 @@ class Authorization(models.Model):
         else:
             return False
 
-    def is_renewable(self):
-        partner = self.partner
-        if (
-            # We consider an authorization renewable, if the partner is PROXY and
-            # about to expire or has already expired (is_valid returns false on expiry)
-            # or if the partner isn't PROXY or BUNDLE, in which case the authorization
-            # would have an empty date_expires field. The first would check still cover for
-            # non-PROXY and non-BUNDLE partners with expiry dates.
-            self.about_to_expire()
-            or not self.is_valid
-            or not partner.authorization_method == partner.PROXY
-            and not partner.authorization_method == partner.BUNDLE
-        ):
+    def get_authorization_method(self):
+        """
+        For this authorization, returns the linked authorization
+        method of the partner or stream, as applicable
+        """
+        if self.stream:
+            authorization_method = self.stream.authorization_method
+        else:
+            authorization_method = self.partner.authorization_method
+
+        return authorization_method
+
+    def is_bundle(self):
+        """
+        Returns True if this authorization is to a Bundle partner
+        or stream and False otherwise.
+        """
+        authorization_method = self.get_authorization_method()
+        logger.info(authorization_method)
+
+        if authorization_method == Partner.BUNDLE:
             return True
         else:
             return False
@@ -702,10 +710,7 @@ class Authorization(models.Model):
         Do users access the collection for this authorization via the proxy, or not?
         Returns True if the partner or stream has an authorization_method of Proxy or Bundle.
         """
-        if self.stream:
-            authorization_method = self.stream.authorization_method
-        else:
-            authorization_method = self.partner.authorization_method
+        authorization_method = self.get_authorization_method()
 
         if authorization_method in [Partner.PROXY, Partner.BUNDLE]:
             return True

--- a/TWLight/users/templates/users/collection_tile.html
+++ b/TWLight/users/templates/users/collection_tile.html
@@ -10,7 +10,7 @@
 
 <div class="panel panel-default full-width">
   <div class="panel-body top-border {% if each_authorization.about_to_expire %}expiry-warning{% endif %}">
-    {% if each_authorization.partner.authorization_method == each_authorization.partner.BUNDLE %}
+    {% if each_authorization.is_bundle %}
       {% comment %} Translators: Title text for the Library Bundle icon shown on the collection page. {% endcomment %}
       <img src="{% static 'img/LibraryBundle.svg' %}" class="img-responsive no-padding-logo-collection-tiles" style="width:35px; height:30px;" title="{% trans 'Library Bundle' %}" alt="
       {% comment %} Translators: Alt text for the Library Bundle icon shown on the collection page. {% endcomment %}

--- a/TWLight/users/templates/users/collection_tile.html
+++ b/TWLight/users/templates/users/collection_tile.html
@@ -93,28 +93,30 @@
     <i class="fa fa-info-circle" aria-hidden="true" title="Partner description page"></i>
     <strong><a href="{% url 'partners:detail' each_authorization.partner.pk %}">{{ each_authorization.partner }}</a></strong>
     {% if each_authorization.stream %}({{ each_authorization.stream }}){% endif %}
-    {% if each_authorization.latest_sent_app and not each_authorization.open_app %}
-      {% comment %} Translators: Hovertext for when renewals for a partner is not available and the renew button is disabled. {% endcomment %}
-      <span class="pull-right" {% if not each_authorization.partner.renewals_available %}title="{% trans 'Renewals are not available for this partner' %}"{% endif %}>
-        <a href="{% url 'applications:renew' each_authorization.latest_sent_app.pk %}" class="btn btn-default pull-right {% if not each_authorization.partner.renewals_available %}disabled{% endif %}" role="button">
-          {% if each_authorization.is_valid %}
-            {% comment %} Translators: Labels a button users can click to extend the duration of their access. {% endcomment %}
-            {% trans 'Extend' %}
-          {% else %}
-            {% comment %} Translators: Labels a button users can click to renew an expired account. {% endcomment %}
-            {% trans 'Renew' %}
-          {% endif %}
-        </a>
-      </span>
-      <div class="clearfix"></div>
-    {% elif each_authorization.partner.specific_title and not each_authorization.open_app %}
-      <span class="pull-right">
-        <a href="{% url 'applications:apply_single' each_authorization.partner.pk %}" class="btn btn-primary pull-right" role="button">
-          {% comment %} Translators: Labels the button users can click to apply for a resource. {% endcomment %}
-          {% trans 'Apply' %}
-        </a>
-      </span>
-      <div class="clearfix"></div>
+    {% if not each_authorization.is_bundle %}
+      {% if each_authorization.latest_sent_app and not each_authorization.open_app %}
+        {% comment %} Translators: Hovertext for when renewals for a partner is not available and the renew button is disabled. {% endcomment %}
+        <span class="pull-right" {% if not each_authorization.partner.renewals_available %}title="{% trans 'Renewals are not available for this partner' %}"{% endif %}>
+          <a href="{% url 'applications:renew' each_authorization.latest_sent_app.pk %}" class="btn btn-default pull-right {% if not each_authorization.partner.renewals_available %}disabled{% endif %}" role="button">
+            {% if each_authorization.is_valid %}
+              {% comment %} Translators: Labels a button users can click to extend the duration of their access. {% endcomment %}
+              {% trans 'Extend' %}
+            {% else %}
+              {% comment %} Translators: Labels a button users can click to renew an expired account. {% endcomment %}
+              {% trans 'Renew' %}
+            {% endif %}
+          </a>
+        </span>
+        <div class="clearfix"></div>
+      {% elif each_authorization.partner.specific_title and not each_authorization.open_app %}
+        <span class="pull-right">
+          <a href="{% url 'applications:apply_single' each_authorization.partner.pk %}" class="btn btn-primary pull-right" role="button">
+            {% comment %} Translators: Labels the button users can click to apply for a resource. {% endcomment %}
+            {% trans 'Apply' %}
+          </a>
+        </span>
+        <div class="clearfix"></div>
+      {% endif %}
     {% endif %}
     {% if each_authorization.open_app %}
       {% comment %} Translators: Labels a button users can click to view an application requesting access to a resource. {% endcomment %}


### PR DESCRIPTION
A handful of fixes based on the UI/UX PRs that just went up on staging:
 - Reduced logo size on the homepage
 - Did wikicode->html properly for partner descriptions on homepage
 - Fixed adding proxy URL for Bundle partners/streams
 - Reworded the successful-application message to point to a more appropriate place
 - Hid the Extend button in My Library for Bundle authorizations
 - Refactored Authorization functions to remove unused `is_renewable`, adding `is_bundle`