### PR TITLE
Applications set_null for specific_stream

### DIFF
--- a/TWLight/applications/models.py
+++ b/TWLight/applications/models.py
@@ -119,7 +119,11 @@ class Application(models.Model):
     rationale = models.TextField(blank=True)
     specific_title = models.CharField(max_length=128, blank=True)
     specific_stream = models.ForeignKey(
-        Stream, related_name="applications", blank=True, null=True
+        Stream,
+        related_name="applications",
+        blank=True,
+        null=True,
+        on_delete=models.SET_NULL
     )
     comments = models.TextField(blank=True)
     agreement_with_terms_of_use = models.BooleanField(default=False)

--- a/TWLight/applications/models.py
+++ b/TWLight/applications/models.py
@@ -123,7 +123,7 @@ class Application(models.Model):
         related_name="applications",
         blank=True,
         null=True,
-        on_delete=models.SET_NULL
+        on_delete=models.SET_NULL,
     )
     comments = models.TextField(blank=True)
     agreement_with_terms_of_use = models.BooleanField(default=False)

--- a/TWLight/applications/tests.py
+++ b/TWLight/applications/tests.py
@@ -2442,7 +2442,9 @@ class ApplicationModelTest(TestCase):
         editor = EditorFactory(user=user)
         coordinator = UserFactory()
         get_coordinators().user_set.add(coordinator)
-        partner = PartnerFactory(specific_stream=True, authorization_method=Partner.EMAIL)
+        partner = PartnerFactory(
+            specific_stream=True, authorization_method=Partner.EMAIL
+        )
         stream = StreamFactory(partner=partner, authorization_method=Partner.EMAIL)
         app = ApplicationFactory(
             rationale="Because I said so",
@@ -2458,13 +2460,25 @@ class ApplicationModelTest(TestCase):
             sent_by=coordinator,
         )
         # This app should show up in stream specific queries.
-        self.assertEqual(Application.objects.filter(pk=app.pk, specific_stream=stream.pk, editor=editor).count(), 1)
+        self.assertEqual(
+            Application.objects.filter(
+                pk=app.pk, specific_stream=stream.pk, editor=editor
+            ).count(),
+            1,
+        )
         # Delete the stream.
         stream.delete()
         # This app should no longer show up in stream specific queries.
-        self.assertEqual(Application.objects.filter(pk=app.pk, specific_stream=stream.pk, editor=editor).count(), 0)
+        self.assertEqual(
+            Application.objects.filter(
+                pk=app.pk, specific_stream=stream.pk, editor=editor
+            ).count(),
+            0,
+        )
         # But it should still be there.
-        self.assertEqual(Application.objects.filter(pk=app.pk, editor=editor).count(), 1)
+        self.assertEqual(
+            Application.objects.filter(pk=app.pk, editor=editor).count(), 1
+        )
 
     def test_get_authorization(self):
         # Approve an application so that we create an authorization

--- a/TWLight/applications/tests.py
+++ b/TWLight/applications/tests.py
@@ -2467,11 +2467,12 @@ class ApplicationModelTest(TestCase):
             1,
         )
         # Delete the stream.
+        stream_pk = stream.pk
         stream.delete()
         # This app should no longer show up in stream specific queries.
         self.assertEqual(
             Application.objects.filter(
-                pk=app.pk, specific_stream=stream.pk, editor=editor
+                pk=app.pk, specific_stream=stream_pk, editor=editor
             ).count(),
             0,
         )


### PR DESCRIPTION
If we `on_delete=SET_NULL` on the `specific_stream` field of Applications, then we should be able to move partners from collections-based to a single partner and have everything continue as expected without further required work.

I'll do a bit more investigation before actually deleting anything, but setting this field should have no negative effects in the meantime.