### PR TITLE
Provide a more informative error message when navigating to Not Available able resources

### DIFF
--- a/TWLight/resources/tests.py
+++ b/TWLight/resources/tests.py
@@ -162,7 +162,8 @@ class PartnerModelTests(TestCase):
 
         request = RequestFactory().get(detail_url)
         request.user = editor.user
-        with self.assertRaises(Http404):
+        # This must raise a PermissionDenied exception
+        with self.assertRaises(PermissionDenied):
             # We must explicitly pass kwargs to the view even though they are
             # implied by the URL.
             _ = PartnersDetailView.as_view()(request, pk=partner.pk)

--- a/TWLight/resources/views.py
+++ b/TWLight/resources/views.py
@@ -230,6 +230,24 @@ class PartnersDetailView(DetailView):
 
         return partner_list
 
+    def get(self, request, *args, **kwargs):
+        try:
+            partner = self.get_object()
+        except Http404:
+            # If partner object does not exists check if the partner's status is NOT_AVAILABLE.
+            partner_pk = self.kwargs.get("pk")
+            if Partner.even_not_available.filter(pk=partner_pk).exists():
+                messages.add_message(
+                    self.request,
+                    messages.ERROR,
+                    # Translators: This message is shown when user tries to access a NOT_AVAILABLE Partner
+                    _("This partner is currently not open for applications"),
+                )
+                raise PermissionDenied
+
+        # In all other cases call the default get method.
+        return super(PartnersDetailView, self).get(request, *args, **kwargs)
+
 
 class PartnersToggleWaitlistView(CoordinatorsOnly, View):
     def post(self, request, *args, **kwargs):


### PR DESCRIPTION

when navigating to a Not Available partner. Instead of raising a generic "Not found" error, we should explain that this partner isn't currently open for applications.

Bug: T212767