### PR TITLE
support streams to partner consolidation

### DIFF
--- a/TWLight/applications/__init__.py
+++ b/TWLight/applications/__init__.py
@@ -1,0 +1,1 @@
+default_app_config = "TWLight.applications.app.Config"

--- a/TWLight/applications/app.py
+++ b/TWLight/applications/app.py
@@ -1,0 +1,10 @@
+from django.apps import AppConfig
+from django.utils.translation import ugettext_lazy as _
+
+
+class Config(AppConfig):
+    name = "TWLight.applications"
+    verbose_name = _("applications")
+
+    def ready(self):
+        import TWLight.applications.signals

--- a/TWLight/applications/signals.py
+++ b/TWLight/applications/signals.py
@@ -1,10 +1,13 @@
 import logging
-
+from datetime import date, datetime, timedelta
+from dateutil.relativedelta import relativedelta
+from django.db.models.signals import pre_save, post_save
 from django.dispatch import receiver, Signal
+from django.utils.timezone import localtime, now
 from django_comments.signals import comment_was_posted
-
 from TWLight.resources.models import Partner
-from .models import Application
+from TWLight.applications.models import Application
+from TWLight.users.models import Authorization
 
 no_more_accounts = Signal(providing_args=["partner_pk"])
 
@@ -64,3 +67,141 @@ def set_partner_status(sender, **kwargs):
             " partner {pk} does not exist - unable to set"
             " partner status".format(pk=partner_pk)
         )
+
+
+# IMPORTANT: pre_save is not sent by Queryset.update(), so *none of this
+# behavior will happen on if you update() an Application queryset*.
+# That is sometimes okay, but it is not always okay.
+# Errors caused by days_open not existing when expected to
+# exist can show up in weird parts of the application (for example, template
+# rendering failing when get_num_days_open returns None but its output is
+# passed to a template filter that needs an integer).
+@receiver(pre_save, sender=Application)
+def update_app_status_on_save(sender, instance, **kwargs):
+
+    # Make sure not using a mix of dates and datetimes
+    if instance.date_created and isinstance(instance.date_created, datetime):
+        instance.date_created = instance.date_created.date()
+
+    # Make sure not using a mix of dates and datetimes
+    if instance.date_closed and isinstance(instance.date_closed, datetime):
+        instance.date_closed = instance.date_closed.date()
+
+    if instance.id:
+        orig_app = Application.include_invalid.get(pk=instance.id)
+        orig_status = orig_app.status
+        if all(
+            [
+                orig_status not in Application.FINAL_STATUS_LIST,
+                int(instance.status) in Application.FINAL_STATUS_LIST,
+                not bool(instance.date_closed),
+            ]
+        ):
+
+            instance.date_closed = localtime(now()).date()
+            instance.days_open = (instance.date_closed - instance.date_created).days
+
+    else:
+        # If somehow we've created an Application whose status is final
+        # at the moment of creation, set its date-closed-type parameters
+        # too.
+        if (
+            instance.status in Application.FINAL_STATUS_LIST
+            and not instance.date_closed
+        ):
+
+            instance.date_closed = localtime(now()).date()
+            instance.days_open = 0
+
+
+@receiver(post_save, sender=Application)
+def post_revision_commit(sender, instance, **kwargs):
+
+    # For some authorization methods, we can skip the manual Approved->Sent
+    # step and just immediately take an Approved application and give it
+    # a finalised status.
+    skip_approved = (
+        instance.status == Application.APPROVED and instance.is_instantly_finalized()
+    )
+
+    if skip_approved:
+        instance.status = Application.SENT
+        instance.save()
+
+    # Renewals are for applications that are approved/sent.
+    # Having a parent for NOT_APPROVED apps hinders us from
+    # correctly renewing the parent. So, we unset the parent
+    # if the status is NOT_APPROVED and the app already has
+    # a parent.
+    if instance.status == Application.NOT_APPROVED and instance.parent:
+        instance.parent = None
+        instance.save()
+
+    # Authorize editor to access resource after an application is saved as sent.
+
+    if instance.status == Application.SENT:
+        # Check if an authorization already exists.
+        if instance.specific_stream:
+            existing_authorization = Authorization.objects.filter(
+                user=instance.user,
+                partner=instance.partner,
+                stream=instance.specific_stream,
+            )
+        else:
+            existing_authorization = Authorization.objects.filter(
+                user=instance.user, partner=instance.partner
+            )
+
+        authorized_user = instance.user
+        authorizer = instance.sent_by
+
+        # In the case that there is no existing authorization, create a new one
+        if existing_authorization.count() == 0:
+            authorization = Authorization()
+        # If an authorization already existed (such as in the case of a
+        # renewal), we'll simply update that one.
+        elif existing_authorization.count() == 1:
+            authorization = existing_authorization[0]
+        else:
+            logger.error(
+                "Found more than one authorization object for "
+                "{user} - {partner}".format(
+                    user=instance.user, partner=instance.partner
+                )
+            )
+            return
+
+        if instance.specific_stream:
+            authorization.stream = instance.specific_stream
+
+        authorization.user = authorized_user
+        authorization.authorizer = authorizer
+        authorization.partner = instance.partner
+
+        # If this is a proxy partner, and the requested_access_duration
+        # field is set to false, set (or reset) the expiry date
+        # to one year from now
+        if (
+            instance.partner.authorization_method == Partner.PROXY
+            and instance.requested_access_duration is None
+        ):
+            one_year_from_now = date.today() + timedelta(days=365)
+            authorization.date_expires = one_year_from_now
+        # If this is a proxy partner, and the requested_access_duration
+        # field is set to true, set (or reset) the expiry date
+        # to 1, 3, 6 or 12 months from today based on user input
+        elif (
+            instance.partner.authorization_method == Partner.PROXY
+            and instance.partner.requested_access_duration is True
+        ):
+            custom_expiry_date = date.today() + relativedelta(
+                months=instance.requested_access_duration
+            )
+            authorization.date_expires = custom_expiry_date
+        # Alternatively, if this partner has a specified account_length,
+        # we'll use that to set the expiry.
+        elif instance.partner.account_length:
+            # account_length should be a timedelta
+            authorization.date_expires = date.today() + instance.partner.account_length
+
+        authorization.save()

--- a/TWLight/resources/__init__.py
+++ b/TWLight/resources/__init__.py
@@ -1,0 +1,1 @@
+default_app_config = "TWLight.resources.app.Config"

--- a/TWLight/resources/app.py
+++ b/TWLight/resources/app.py
@@ -1,0 +1,10 @@
+from django.apps import AppConfig
+from django.utils.translation import ugettext_lazy as _
+
+
+class Config(AppConfig):
+    name = "TWLight.resources"
+    verbose_name = _("resources")
+
+    def ready(self):
+        import TWLight.resources.signals

--- a/TWLight/resources/models.py
+++ b/TWLight/resources/models.py
@@ -14,8 +14,6 @@ from django.core.urlresolvers import reverse_lazy, reverse
 from django.db import models
 from django.utils.translation import ugettext_lazy as _
 from django_countries.fields import CountryField
-from django.dispatch import receiver
-from django.db.models.signals import post_delete
 
 
 RESOURCE_LANGUAGES = copy.copy(settings.INTERSECTIONAL_LANGUAGES)
@@ -672,18 +670,6 @@ class Stream(models.Model):
         elif self.target_url:
             access_url = self.target_url
         return access_url
-
-
-@receiver(post_delete, sender=Stream)
-def set_partner_specific_stream_false_if_no_streams(sender, instance, **kwargs):
-    """
-    Set parent partner's specific_stream to False when the last stream is deleted.
-    """
-
-    partner = instance.partner
-    if partner.specific_stream and Stream.objects.filter(partner=partner).count() == 0:
-        partner.specific_stream = False
-        partner.save()
 
 
 class Contact(models.Model):

--- a/TWLight/resources/models.py
+++ b/TWLight/resources/models.py
@@ -681,7 +681,7 @@ def set_partner_specific_stream_false_if_no_streams(sender, instance, **kwargs):
     """
 
     partner = instance.partner
-    if Stream.objects.filter(partner=partner).count() == 0:
+    if partner.specific_stream and Stream.objects.filter(partner=partner).count() == 0:
         partner.specific_stream = False
         partner.save()
 

--- a/TWLight/resources/models.py
+++ b/TWLight/resources/models.py
@@ -14,6 +14,9 @@ from django.core.urlresolvers import reverse_lazy, reverse
 from django.db import models
 from django.utils.translation import ugettext_lazy as _
 from django_countries.fields import CountryField
+from django.dispatch import receiver
+from django.db.models.signals import post_delete
+
 
 RESOURCE_LANGUAGES = copy.copy(settings.INTERSECTIONAL_LANGUAGES)
 
@@ -669,6 +672,18 @@ class Stream(models.Model):
         elif self.target_url:
             access_url = self.target_url
         return access_url
+
+
+@receiver(post_delete, sender=Stream)
+def set_partner_specific_stream_false_if_no_streams(sender, instance, **kwargs):
+    """
+    Set parent partner's specific_stream to False when the last stream is deleted.
+    """
+
+    partner = instance.partner
+    if Stream.objects.filter(partner=partner).count() == 0:
+        partner.specific_stream = False
+        partner.save()
 
 
 class Contact(models.Model):

--- a/TWLight/resources/signals.py
+++ b/TWLight/resources/signals.py
@@ -1,0 +1,15 @@
+from django.dispatch import receiver
+from django.db.models.signals import post_delete
+from TWLight.resources.models import Stream
+
+
+@receiver(post_delete, sender=Stream)
+def set_partner_specific_stream_false_if_no_streams(sender, instance, **kwargs):
+    """
+    Set parent partner's specific_stream to False when the last stream is deleted.
+    """
+
+    partner = instance.partner
+    if partner.specific_stream and Stream.objects.filter(partner=partner).count() == 0:
+        partner.specific_stream = False
+        partner.save()

--- a/TWLight/tests.py
+++ b/TWLight/tests.py
@@ -743,13 +743,13 @@ class AuthorizationTestCase(AuthorizationBaseTestCase):
     def test_handle_stream_post_delete(self):
 
         partner5_authorizations = Authorization.objects.filter(
-            partner=self.partner5, stream__isnull=True
+            partner=self.partner5, user=self.editor1.user, stream__isnull=True
         )
         stream1_authorizations = Authorization.objects.filter(
-            stream=self.partner5_stream1
+            partner=self.partner5, user=self.editor1.user, stream=self.partner5_stream1
         )
         stream2_authorizations = Authorization.objects.filter(
-            stream=self.partner5_stream2
+            partner=self.partner5, user=self.editor1.user, stream=self.partner5_stream2
         )
         # Verifying that we only have stream-specific auths.
         self.assertTrue(self.partner5.specific_stream)

--- a/TWLight/users/__init__.py
+++ b/TWLight/users/__init__.py
@@ -1,0 +1,1 @@
+default_app_config = "TWLight.users.app.Config"

--- a/TWLight/users/app.py
+++ b/TWLight/users/app.py
@@ -1,0 +1,10 @@
+from django.apps import AppConfig
+from django.utils.translation import ugettext_lazy as _
+
+
+class Config(AppConfig):
+    name = "TWLight.users"
+    verbose_name = _("users")
+
+    def ready(self):
+        import TWLight.users.signals

--- a/TWLight/users/models.py
+++ b/TWLight/users/models.py
@@ -115,15 +115,6 @@ class UserProfile(models.Model):
     )
 
 
-# Create user profiles automatically when users are created.
-def create_user_profile(sender, instance, created, **kwargs):
-    if created:
-        UserProfile.objects.create(user=instance)
-
-
-models.signals.post_save.connect(create_user_profile, sender=settings.AUTH_USER_MODEL)
-
-
 class Editor(models.Model):
     """
     This model is for storing data related to people's accounts on Wikipedia.

--- a/TWLight/users/signals.py
+++ b/TWLight/users/signals.py
@@ -75,9 +75,9 @@ def delete_all_but_latest_partner_authorizations(sender, instance, **kwargs):
     authorizations = Authorization.objects.filter(partner=partner, stream__isnull=True)
     users = User.objects.filter(authorization__in=authorizations)
     for user in users:
-        partner_authorizations = authorizations.filter(user=user)
-        if partner_authorizations.count() > 1:
-            latest_partner_authorization = partner_authorizations.latest(
+        user_authorizations = authorizations.filter(user=user)
+        if user_authorizations.count() > 1:
+            latest_authorization = user_authorizations.latest(
                 "date_authorized"
             )
-            partner_authorizations.exclude(pk=latest_partner_authorization.pk).delete()
+            user_authorizations.exclude(pk=latest_authorization.pk).delete()

--- a/TWLight/users/signals.py
+++ b/TWLight/users/signals.py
@@ -3,7 +3,7 @@ from django.contrib.auth.models import User
 from django.dispatch import receiver, Signal
 from django.db.models.signals import post_save, post_delete
 from TWLight.users.models import Authorization
-from .models import Partner, Stream
+from TWLight.resources.models import Partner, Stream
 
 
 class Notice(object):

--- a/TWLight/users/signals.py
+++ b/TWLight/users/signals.py
@@ -72,13 +72,10 @@ def delete_all_but_latest_partner_authorizations(sender, instance, **kwargs):
     """
 
     partner = instance.partner
-    authorizations = Authorization.objects.filter(partner=partner)
+    authorizations = Authorization.objects.filter(partner=partner, stream__isnull=True)
     users = User.objects.filter(authorization__in=authorizations)
-
     for user in users:
-        partner_authorizations = Authorization.objects.filter(
-            user=user, partner=partner, stream__isnull=True
-        )
+        partner_authorizations = authorizations.filter(user=user)
         if partner_authorizations.count() > 1:
             latest_partner_authorization = partner_authorizations.latest(
                 "date_authorized"


### PR DESCRIPTION
Adds some signal receivers to handle authorization de-duplication and partner configuration after collection deletion. Needs tests.