### PR TITLE
Handle modification of application status from INVALID to anything else

### DIFF
--- a/TWLight/applications/tests.py
+++ b/TWLight/applications/tests.py
@@ -2520,6 +2520,7 @@ class EvaluateApplicationTest(TestCase):
         response = self.client.post(
             self.url, data={"status": Application.APPROVED}, follow=True
         )
+
         self.application.refresh_from_db()
         self.assertEqual(self.application.status, Application.APPROVED)
 

--- a/TWLight/applications/views.py
+++ b/TWLight/applications/views.py
@@ -930,6 +930,19 @@ class EvaluateApplicationView(NotDeleted, CoordinatorOrSelf, ToURequired, Update
 
         return form
 
+    def post(self, request, *args, **kwargs):
+        app = self.get_object()
+        if app.status == Application.INVALID:
+            messages.add_message(
+                self.request,
+                messages.ERROR,
+                _("Status of INVALID applications can't get changed."),
+            )
+            return HttpResponseRedirect(
+                reverse("applications:evaluate", kwargs={"pk": app.pk})
+            )
+        return super(EvaluateApplicationView, self).post(request, *args, **kwargs)
+
 
 class BatchEditView(CoordinatorsOnly, ToURequired, View):
     http_method_names = ["post"]

--- a/TWLight/applications/views.py
+++ b/TWLight/applications/views.py
@@ -936,7 +936,8 @@ class EvaluateApplicationView(NotDeleted, CoordinatorOrSelf, ToURequired, Update
             messages.add_message(
                 self.request,
                 messages.ERROR,
-                _("Status of INVALID applications can't get changed."),
+                # Translators: this message is shown to coordinators who attempt to change an application's Status from INVALID to any other Status.
+                _("Status of INVALID applications Cannot be changed."),
             )
             return HttpResponseRedirect(
                 reverse("applications:evaluate", kwargs={"pk": app.pk})


### PR DESCRIPTION
If a coordinator tries to modify application status from INVALID to anything else
then return the coordinator back to the app with an error message

Bug: T239503