### PR TITLE
Add proxy/bundle management command and associated launch email

### DIFF
--- a/TWLight/emails/tasks.py
+++ b/TWLight/emails/tasks.py
@@ -179,12 +179,7 @@ def send_proxy_bundle_launch_notice(sender, **kwargs):
 
     email = ProxyBundleEmail()
 
-    email.send(
-        user_email,
-        {
-            "username": user_wp_username,
-        },
-    )
+    email.send(user_email, {"username": user_wp_username})
 
 
 @receiver(comment_was_posted)

--- a/TWLight/emails/tasks.py
+++ b/TWLight/emails/tasks.py
@@ -39,7 +39,7 @@ from TWLight.applications.signals import Reminder
 from TWLight.emails.signals import ContactUs
 from TWLight.resources.models import AccessCode, Partner
 from TWLight.users.groups import get_restricted
-from TWLight.users.signals import Notice
+from TWLight.users.signals import Notice, ProxyBundleLaunch
 
 
 logger = logging.getLogger(__name__)
@@ -79,6 +79,10 @@ class CoordinatorReminderNotification(template_mail.TemplateMail):
 
 class UserRenewalNotice(template_mail.TemplateMail):
     name = "user_renewal_notice"
+
+
+class ProxyBundleEmail(template_mail.TemplateMail):
+    name = "proxy_bundle_email"
 
 
 @receiver(Reminder.coordinator_reminder)
@@ -160,6 +164,25 @@ def send_user_renewal_notice_emails(sender, **kwargs):
             "lang": user_lang,
             "partner_name": partner_name,
             "partner_link": partner_link,
+        },
+    )
+
+
+@receiver(ProxyBundleLaunch.launch_notice)
+def send_proxy_bundle_launch_notice(sender, **kwargs):
+    """
+    Sends the email to notify users that the proxy & bundle features
+    have launched. Will only need to be sent once as-is.
+    """
+    user_wp_username = kwargs["user_wp_username"]
+    user_email = kwargs["user_email"]
+
+    email = ProxyBundleEmail()
+
+    email.send(
+        user_email,
+        {
+            "username": user_wp_username,
         },
     )
 

--- a/TWLight/emails/templates/emails/proxy_bundle_email-body-html.html
+++ b/TWLight/emails/templates/emails/proxy_bundle_email-body-html.html
@@ -1,0 +1,22 @@
+<html>
+<body>
+<p>Hi {{ username }},</p>
+
+<p>The Wikipedia Library is pleased to announce the implementation of EZProxy access and the Library Bundle!</p>
+
+<p>EZProxy is a proxy server used to authenticate your access. Instead of managing individual logins for each collection to which you have been approved, you can now access all EZProxy-supported content simply by logging in to your Library Card account and clicking through to the website. To access EZProxy collections, simply visit the Library Card platform, go to the My Library page at https://wikipedialibrary.wmflabs.org/users/my_library, and click on ‘Access collection’ for the content you wish to access under the ‘Instant access’ tab.</p>
+
+<p>If you had active accounts before now, please take the time to review the My Library page to verify how you need to access those accounts going forward. Collections in the 'Instant Access' tab must now be accessed via EZProxy. Collections in the 'Individual Access' tab should be accessed as before.</p>
+
+<p>Until now, all access via The Wikipedia Library required that you apply to and be approved for individual collections. The Library Bundle changes that workflow by making some collections immediately available to everyone who meets the experience requirements outlined in our Terms of Use. As long as you continue to meet those requirements (which include 10 edits within the past month and not being blocked), you will have on-demand access to Library Bundle collections via the Library Card without needing to make an application or renewal request.</p>
+
+<p>You can verify whether you meet the criteria to access Library Bundle collections on the Library Card homepage - https://wikipedialibrary.wmflabs.org. If you are eligible, collections will be accessible via the 'Instant Access' tab of My Library.</p>
+
+<p>You may notice when accessing resources via EZProxy that URLs are dynamically rewritten. Note that use of EZProxy requires you to enable cookies. If you are having problems you should also try clearing your cache and restarting your browser. Please be aware that existing individual logins for EZProxy-enabled collections (including the Library Bundle) will soon be deactivated, so this will be your only means of access for these collections. Any collections in the ‘Individual access’ tab in My Library will function as before.</p>
+
+<p>Along with the launch of these new access methods, we are happy to announce several major new partnerships, including large multidisciplinary collections from Springer Nature and ProQuest. Visit XXX to learn more about the new partners as well as the changes we’re making and how they can help improve your research workflow. Please let us know if you have any questions.</p>
+
+<p>Best,</p>
+<p>The Wikipedia Library Team</p>
+</body>
+</html>

--- a/TWLight/emails/templates/emails/proxy_bundle_email-body-html.html
+++ b/TWLight/emails/templates/emails/proxy_bundle_email-body-html.html
@@ -16,9 +16,7 @@
 
   <p>You may notice when accessing resources via EZProxy that URLs are dynamically rewritten. Note that use of EZProxy requires you to enable cookies. If you are having problems you should also try clearing your cache and restarting your browser. Please be aware that existing individual logins for EZProxy-enabled collections (including the Library Bundle) will soon be deactivated, so this will be your only means of access for these collections. Any collections in the ‘Individual access’ tab in My Library will function as before.</p>
 
-  <p>Along with the launch of these new access methods, we are happy to announce several major new partnerships, including large multidisciplinary collections from Springer Nature and ProQuest. Visit XXX to learn more about the new partners as well as the changes we’re making and how they can help improve your research workflow.</p>
-
-  <p>You can read more at https://meta.wikimedia.org/wiki/Library_Card_platform/Authentication-based_access. If you have any questions please post on the talk page.</p>
+  <p>Along with the launch of these new access methods, we are happy to announce several major new partnerships, including large multidisciplinary collections from Springer Nature and ProQuest.</p>
 
   <p>Best,</p>
   <p>The Wikipedia Library Team</p>

--- a/TWLight/emails/templates/emails/proxy_bundle_email-body-html.html
+++ b/TWLight/emails/templates/emails/proxy_bundle_email-body-html.html
@@ -16,7 +16,9 @@
 
   <p>You may notice when accessing resources via EZProxy that URLs are dynamically rewritten. Note that use of EZProxy requires you to enable cookies. If you are having problems you should also try clearing your cache and restarting your browser. Please be aware that existing individual logins for EZProxy-enabled collections (including the Library Bundle) will soon be deactivated, so this will be your only means of access for these collections. Any collections in the ‘Individual access’ tab in My Library will function as before.</p>
 
-  <p>Along with the launch of these new access methods, we are happy to announce several major new partnerships, including large multidisciplinary collections from Springer Nature and ProQuest. Visit XXX to learn more about the new partners as well as the changes we’re making and how they can help improve your research workflow. Please let us know if you have any questions.</p>
+  <p>Along with the launch of these new access methods, we are happy to announce several major new partnerships, including large multidisciplinary collections from Springer Nature and ProQuest. Visit XXX to learn more about the new partners as well as the changes we’re making and how they can help improve your research workflow.</p>
+
+  <p>You can read more at https://meta.wikimedia.org/wiki/Library_Card_platform/Authentication-based_access. If you have any questions please post on the talk page.</p>
 
   <p>Best,</p>
   <p>The Wikipedia Library Team</p>

--- a/TWLight/emails/templates/emails/proxy_bundle_email-body-html.html
+++ b/TWLight/emails/templates/emails/proxy_bundle_email-body-html.html
@@ -1,22 +1,25 @@
+{% load i18n %}
 <html>
 <body>
-<p>Hi {{ username }},</p>
+{% blocktrans trimmed %}
+  <p>Hi {{ username }},</p>
 
-<p>The Wikipedia Library is pleased to announce the implementation of EZProxy access and the Library Bundle!</p>
+  <p>The Wikipedia Library is pleased to announce the implementation of EZProxy access and the Library Bundle!</p>
 
-<p>EZProxy is a proxy server used to authenticate your access. Instead of managing individual logins for each collection to which you have been approved, you can now access all EZProxy-supported content simply by logging in to your Library Card account and clicking through to the website. To access EZProxy collections, simply visit the Library Card platform, go to the My Library page at https://wikipedialibrary.wmflabs.org/users/my_library, and click on ‘Access collection’ for the content you wish to access under the ‘Instant access’ tab.</p>
+  <p>EZProxy is a proxy server used to authenticate your access. Instead of managing individual logins for each collection to which you have been approved, you can now access all EZProxy-supported content simply by logging in to your Library Card account and clicking through to the website. To access EZProxy collections, simply visit the Library Card platform, go to the My Library page at https://wikipedialibrary.wmflabs.org/users/my_library, and click on ‘Access collection’ for the content you wish to access under the ‘Instant access’ tab.</p>
 
-<p>If you had active accounts before now, please take the time to review the My Library page to verify how you need to access those accounts going forward. Collections in the 'Instant Access' tab must now be accessed via EZProxy. Collections in the 'Individual Access' tab should be accessed as before.</p>
+  <p>If you had active accounts before now, please take the time to review the My Library page to verify how you need to access those accounts going forward. Collections in the 'Instant Access' tab must now be accessed via EZProxy. Collections in the 'Individual Access' tab should be accessed as before.</p>
 
-<p>Until now, all access via The Wikipedia Library required that you apply to and be approved for individual collections. The Library Bundle changes that workflow by making some collections immediately available to everyone who meets the experience requirements outlined in our Terms of Use. As long as you continue to meet those requirements (which include 10 edits within the past month and not being blocked), you will have on-demand access to Library Bundle collections via the Library Card without needing to make an application or renewal request.</p>
+  <p>Until now, all access via The Wikipedia Library required that you apply to and be approved for individual collections. The Library Bundle changes that workflow by making some collections immediately available to everyone who meets the experience requirements outlined in our Terms of Use. As long as you continue to meet those requirements (which include 10 edits within the past month and not being blocked), you will have on-demand access to Library Bundle collections via the Library Card without needing to make an application or renewal request.</p>
 
-<p>You can verify whether you meet the criteria to access Library Bundle collections on the Library Card homepage - https://wikipedialibrary.wmflabs.org. If you are eligible, collections will be accessible via the 'Instant Access' tab of My Library.</p>
+  <p>You can verify whether you meet the criteria to access Library Bundle collections on the Library Card homepage - https://wikipedialibrary.wmflabs.org. If you are eligible, collections will be accessible via the 'Instant Access' tab of My Library.</p>
 
-<p>You may notice when accessing resources via EZProxy that URLs are dynamically rewritten. Note that use of EZProxy requires you to enable cookies. If you are having problems you should also try clearing your cache and restarting your browser. Please be aware that existing individual logins for EZProxy-enabled collections (including the Library Bundle) will soon be deactivated, so this will be your only means of access for these collections. Any collections in the ‘Individual access’ tab in My Library will function as before.</p>
+  <p>You may notice when accessing resources via EZProxy that URLs are dynamically rewritten. Note that use of EZProxy requires you to enable cookies. If you are having problems you should also try clearing your cache and restarting your browser. Please be aware that existing individual logins for EZProxy-enabled collections (including the Library Bundle) will soon be deactivated, so this will be your only means of access for these collections. Any collections in the ‘Individual access’ tab in My Library will function as before.</p>
 
-<p>Along with the launch of these new access methods, we are happy to announce several major new partnerships, including large multidisciplinary collections from Springer Nature and ProQuest. Visit XXX to learn more about the new partners as well as the changes we’re making and how they can help improve your research workflow. Please let us know if you have any questions.</p>
+  <p>Along with the launch of these new access methods, we are happy to announce several major new partnerships, including large multidisciplinary collections from Springer Nature and ProQuest. Visit XXX to learn more about the new partners as well as the changes we’re making and how they can help improve your research workflow. Please let us know if you have any questions.</p>
 
-<p>Best,</p>
-<p>The Wikipedia Library Team</p>
+  <p>Best,</p>
+  <p>The Wikipedia Library Team</p>
+{% endblocktrans %}
 </body>
 </html>

--- a/TWLight/emails/templates/emails/proxy_bundle_email-body-text.html
+++ b/TWLight/emails/templates/emails/proxy_bundle_email-body-text.html
@@ -1,0 +1,18 @@
+Hi {{ username }},
+
+The Wikipedia Library is pleased to announce the implementation of EZProxy access and the Library Bundle!
+
+EZProxy is a proxy server used to authenticate your access. Instead of managing individual logins for each collection to which you have been approved, you can now access all EZProxy-supported content simply by logging in to your Library Card account and clicking through to the website. To access EZProxy collections, simply visit the Library Card platform, go to the My Library page at https://wikipedialibrary.wmflabs.org/users/my_library, and click on ‘Access collection’ for the content you wish to access under the ‘Instant access’ tab.
+
+If you had active accounts before now, please take the time to review the My Library page to verify how you need to access those accounts going forward. Collections in the 'Instant Access' tab must now be accessed via EZProxy. Collections in the 'Individual Access' tab should be accessed as before.
+
+Until now, all access via The Wikipedia Library required that you apply to and be approved for individual collections. The Library Bundle changes that workflow by making some collections immediately available to everyone who meets the experience requirements outlined in our Terms of Use. As long as you continue to meet those requirements (which include 10 edits within the past month and not being blocked), you will have on-demand access to Library Bundle collections via the Library Card without needing to make an application or renewal request.
+
+You can verify whether you meet the criteria to access Library Bundle collections on the Library Card homepage - https://wikipedialibrary.wmflabs.org. If you are eligible, collections will be accessible via the 'Instant Access' tab of My Library.
+
+You may notice when accessing resources via EZProxy that URLs are dynamically rewritten. Note that use of EZProxy requires you to enable cookies. If you are having problems you should also try clearing your cache and restarting your browser. Please be aware that existing individual logins for EZProxy-enabled collections (including the Library Bundle) will soon be deactivated, so this will be your only means of access for these collections. Any collections in the ‘Individual access’ tab in My Library will function as before.
+
+Along with the launch of these new access methods, we are happy to announce several major new partnerships, including large multidisciplinary collections from Springer Nature and ProQuest. Visit XXX to learn more about the new partners as well as the changes we’re making and how they can help improve your research workflow. Please let us know if you have any questions.
+
+Best,
+The Wikipedia Library Team

--- a/TWLight/emails/templates/emails/proxy_bundle_email-body-text.html
+++ b/TWLight/emails/templates/emails/proxy_bundle_email-body-text.html
@@ -14,7 +14,9 @@ You can verify whether you meet the criteria to access Library Bundle collection
 
 You may notice when accessing resources via EZProxy that URLs are dynamically rewritten. Note that use of EZProxy requires you to enable cookies. If you are having problems you should also try clearing your cache and restarting your browser. Please be aware that existing individual logins for EZProxy-enabled collections (including the Library Bundle) will soon be deactivated, so this will be your only means of access for these collections. Any collections in the ‘Individual access’ tab in My Library will function as before.
 
-Along with the launch of these new access methods, we are happy to announce several major new partnerships, including large multidisciplinary collections from Springer Nature and ProQuest. Visit XXX to learn more about the new partners as well as the changes we’re making and how they can help improve your research workflow. Please let us know if you have any questions.
+Along with the launch of these new access methods, we are happy to announce several major new partnerships, including large multidisciplinary collections from Springer Nature and ProQuest. Visit XXX to learn more about the new partners as well as the changes we’re making and how they can help improve your research workflow.
+
+You can read more at https://meta.wikimedia.org/wiki/Library_Card_platform/Authentication-based_access. If you have any questions please post on the talk page.
 
 Best,
 The Wikipedia Library Team

--- a/TWLight/emails/templates/emails/proxy_bundle_email-body-text.html
+++ b/TWLight/emails/templates/emails/proxy_bundle_email-body-text.html
@@ -1,3 +1,5 @@
+{% load i18n %}
+{% blocktrans trimmed %}
 Hi {{ username }},
 
 The Wikipedia Library is pleased to announce the implementation of EZProxy access and the Library Bundle!
@@ -16,3 +18,4 @@ Along with the launch of these new access methods, we are happy to announce seve
 
 Best,
 The Wikipedia Library Team
+{% endblocktrans %}

--- a/TWLight/emails/templates/emails/proxy_bundle_email-body-text.html
+++ b/TWLight/emails/templates/emails/proxy_bundle_email-body-text.html
@@ -14,7 +14,7 @@ You can verify whether you meet the criteria to access Library Bundle collection
 
 You may notice when accessing resources via EZProxy that URLs are dynamically rewritten. Note that use of EZProxy requires you to enable cookies. If you are having problems you should also try clearing your cache and restarting your browser. Please be aware that existing individual logins for EZProxy-enabled collections (including the Library Bundle) will soon be deactivated, so this will be your only means of access for these collections. Any collections in the ‘Individual access’ tab in My Library will function as before.
 
-Along with the launch of these new access methods, we are happy to announce several major new partnerships, including large multidisciplinary collections from Springer Nature and ProQuest. Visit XXX to learn more about the new partners as well as the changes we’re making and how they can help improve your research workflow.
+Along with the launch of these new access methods, we are happy to announce several major new partnerships, including large multidisciplinary collections from Springer Nature and ProQuest.
 
 You can read more at https://meta.wikimedia.org/wiki/Library_Card_platform/Authentication-based_access. If you have any questions please post on the talk page.
 

--- a/TWLight/emails/templates/emails/proxy_bundle_email-subject.html
+++ b/TWLight/emails/templates/emails/proxy_bundle_email-subject.html
@@ -1,0 +1,1 @@
+The Wikipedia Library - new platform features and publishers now available!

--- a/TWLight/emails/templates/emails/proxy_bundle_email-subject.html
+++ b/TWLight/emails/templates/emails/proxy_bundle_email-subject.html
@@ -1,1 +1,3 @@
-The Wikipedia Library - new platform features and publishers now available!
+{% load i18n %}
+
+{% trans 'The Wikipedia Library - new platform features and publishers now available!' %}

--- a/TWLight/emails/tests.py
+++ b/TWLight/emails/tests.py
@@ -30,6 +30,7 @@ from .tasks import (
     send_approval_notification_email,
     send_rejection_notification_email,
     send_user_renewal_notice_emails,
+    send_proxy_bundle_launch_notice,
     contact_us_emails,
 )
 
@@ -525,3 +526,29 @@ class CoordinatorReminderEmailTest(TestCase):
         self.assertIn("One pending application", mail.outbox[0].body)
         self.assertIn("One under discussion application", mail.outbox[0].body)
         self.assertIn("One approved application", mail.outbox[0].body)
+
+
+class ProxyBundleLaunchTest(TestCase):
+    def setUp(self):
+        super(ProxyBundleLaunchTest, self).setUp()
+        editor = EditorFactory(user__email="editor@example.com")
+        self.user = editor.user
+
+    def test_proxy_bundle_launch_email_1(self):
+        """
+        With one user, calling the proxy/bundle launch command
+        should send a single email, to that user.
+        """
+        call_command("proxy_bundle_launch")
+
+        self.assertEqual(len(mail.outbox), 1)
+        self.assertEqual(mail.outbox[0].to, [self.user.email])
+
+    def test_proxy_bundle_launch_email_2(self):
+        """
+        Adding another user should result in two sent emails.
+        """
+        _ = EditorFactory(user__email="editor@example.com")
+        call_command("proxy_bundle_launch")
+
+        self.assertEqual(len(mail.outbox), 2)

--- a/TWLight/emails/tests.py
+++ b/TWLight/emails/tests.py
@@ -552,3 +552,28 @@ class ProxyBundleLaunchTest(TestCase):
         call_command("proxy_bundle_launch")
 
         self.assertEqual(len(mail.outbox), 2)
+
+    def test_proxy_bundle_launch_email_3(self):
+        """
+        The proxy/bundle launch command should record the
+        email was sent
+        """
+        self.assertFalse(self.user.userprofile.proxy_notification_sent)
+
+        call_command("proxy_bundle_launch")
+
+        self.user.userprofile.refresh_from_db()
+        self.assertTrue(self.user.userprofile.proxy_notification_sent)
+
+    def test_proxy_bundle_launch_email_4(self):
+        """
+        The proxy/bundle launch command should not send
+        to a user we recorded as having received the email
+        already.
+        """
+        self.user.userprofile.proxy_notification_sent = True
+        self.user.userprofile.save()
+
+        call_command("proxy_bundle_launch")
+
+        self.assertEqual(len(mail.outbox), 0)

--- a/TWLight/users/management/commands/proxy_bundle_launch.py
+++ b/TWLight/users/management/commands/proxy_bundle_launch.py
@@ -1,0 +1,17 @@
+from django.core.management.base import BaseCommand
+
+from TWLight.users.signals import ProxyBundleLaunch
+from TWLight.users.models import User
+
+
+class Command(BaseCommand):
+    help = "Sends emails to all users notifying them of the Proxy/Bundle rollout, and drops active user sessions."
+
+    def handle(self, *args, **options):
+        all_users = User.objects.all()
+        for user in all_users:
+            ProxyBundleLaunch.launch_notice.send(
+                sender=self.__class__,
+                user_wp_username=user.editor.wp_username,
+                user_email=user.email,
+            )

--- a/TWLight/users/management/commands/proxy_bundle_launch.py
+++ b/TWLight/users/management/commands/proxy_bundle_launch.py
@@ -10,8 +10,12 @@ class Command(BaseCommand):
     def handle(self, *args, **options):
         all_users = User.objects.all()
         for user in all_users:
-            ProxyBundleLaunch.launch_notice.send(
-                sender=self.__class__,
-                user_wp_username=user.editor.wp_username,
-                user_email=user.email,
-            )
+            # Ensure we didn't already send this user an email.
+            if not user.userprofile.proxy_notification_sent:
+                ProxyBundleLaunch.launch_notice.send(
+                    sender=self.__class__,
+                    user_wp_username=user.editor.wp_username,
+                    user_email=user.email,
+                )
+                user.userprofile.proxy_notification_sent = True
+                user.userprofile.save()

--- a/TWLight/users/management/commands/proxy_bundle_launch.py
+++ b/TWLight/users/management/commands/proxy_bundle_launch.py
@@ -5,7 +5,7 @@ from TWLight.users.models import User
 
 
 class Command(BaseCommand):
-    help = "Sends emails to all users notifying them of the Proxy/Bundle rollout, and drops active user sessions."
+    help = "Sends emails to all users notifying them of the Proxy/Bundle rollout."
 
     def handle(self, *args, **options):
         all_users = User.objects.all()

--- a/TWLight/users/models.py
+++ b/TWLight/users/models.py
@@ -113,6 +113,8 @@ class UserProfile(models.Model):
         # Translators: Description of the option coordinators have to enable or disable to receive (or not) reminder emails for approved applications
         help_text=_("Does this coordinator want approved app reminder notices?"),
     )
+    # Temporary field to track sending of proxy launch email to prevent duplication in case of error.
+    proxy_notification_sent = models.BooleanField(default=False)
 
 
 class Editor(models.Model):

--- a/TWLight/users/signals.py
+++ b/TWLight/users/signals.py
@@ -18,6 +18,15 @@ class Notice(object):
     )
 
 
+class ProxyBundleLaunch(object):
+    launch_notice = Signal(
+        providing_args=[
+            "user_wp_username",
+            "user_email",
+        ]
+    )
+
+
 @receiver(post_save, sender=settings.AUTH_USER_MODEL)
 def create_user_profile(sender, instance, created, **kwargs):
     """Create user profiles automatically when users are created."""

--- a/TWLight/users/signals.py
+++ b/TWLight/users/signals.py
@@ -19,12 +19,7 @@ class Notice(object):
 
 
 class ProxyBundleLaunch(object):
-    launch_notice = Signal(
-        providing_args=[
-            "user_wp_username",
-            "user_email",
-        ]
-    )
+    launch_notice = Signal(providing_args=["user_wp_username", "user_email"])
 
 
 @receiver(post_save, sender=settings.AUTH_USER_MODEL)


### PR DESCRIPTION
- Added a new management command, `proxy_bundle_launch`.
- Command sends all users a one-off email about the proxy/bundle launch
- Tracks, via a model field, which users we sent the email to, in case we need to restart the command due to an error or somesuch.

We can now add the session-dropping part to the same command (Jason to do)