### PR TITLE
Increase truncate limit to account for wikicode

### DIFF
--- a/TWLight/templates/home.html
+++ b/TWLight/templates/home.html
@@ -105,7 +105,7 @@
               </div>
               <div class="col-md-9" style="display:inline-block;">
                 {% cache 31536000 partner_short_description LANGUAGE_CODE partner.pk %}
-                  {{ partner.short_description | twlight_wikicode2html | safe |truncatechars:200}}
+                  {{ partner.short_description | twlight_wikicode2html | safe |truncatechars:300}}
                 {% endcache %}
               </div>
             </div>


### PR DESCRIPTION
I didn't realise that `truncatechars` would also include the wikicode in its character count, so the home page partner descriptions are getting cut off way too early. 300 seems to be a reasonable increase, bringing us to ~3 lines at 1080p.