### PR TITLE
Use truncatechars_html for consistent description length

### DIFF
--- a/TWLight/templates/home.html
+++ b/TWLight/templates/home.html
@@ -105,7 +105,7 @@
               </div>
               <div class="col-md-9" style="display:inline-block;">
                 {% cache 31536000 partner_short_description LANGUAGE_CODE partner.pk %}
-                  {{ partner.short_description | twlight_wikicode2html | safe |truncatechars:300}}
+                  {{ partner.short_description | twlight_wikicode2html | safe |truncatechars_html:300}}
                 {% endcache %}
               </div>
             </div>


### PR DESCRIPTION
We have a bunch of markup (converted to html) in short descriptions. `truncatechars` made these very inconsistent in length on the new homepage, but it turns out we can just use `truncatechars_html` to truncate based on the rendered text rather than the html.