### PR TITLE
Fix footer to bottom of page

### DIFF
--- a/TWLight/static/css/local.css
+++ b/TWLight/static/css/local.css
@@ -2,8 +2,26 @@
 ----------------------------------------------------------------------------
 BODY
 --------------------------------------------------------------------------*/
+html {
+  position: relative;
+  min-height: 100%;
+}
+
 body {
   background-color: white;
+}
+
+/* Different buffers for the footer based on screen size */
+@media (max-width: 767px) {
+  body {
+    margin-bottom: 200px;
+  }
+}
+
+@media (min-width: 768px) {
+  body {
+    margin-bottom: 130px;
+  }
 }
 
 /*
@@ -191,9 +209,10 @@ header {
 #footer {
   background-color: #f8f8f8;
   border-top: 1px solid #eee;
-  margin-top: 20px;
-  padding-top: 20px;
-  padding-bottom: 20px;
+  padding: 20px 40px 15px 40px;
+  position: absolute;
+  bottom: 0;
+  width: 100%;
 }
 
 .nav-greeting {

--- a/TWLight/templates/base.html
+++ b/TWLight/templates/base.html
@@ -227,32 +227,12 @@
  </div>
   <footer id="footer">
     <div class="row">
-      <div class="col-xs-12">
-        <p>
-          {% comment %} Translators: This text is at the bottom of every page. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library). { %endcomment %}
-          {% blocktrans trimmed %}
-            The Wikipedia Library Card Platform is a project of 
-            <a href="https://meta.wikimedia.org/wiki/The_Wikipedia_Library">
-            The Wikipedia Library</a>.
-          {% endblocktrans %}
-        </p>
-        <p>
-          <a rel="license" href="http://creativecommons.org/licenses/by-sa/4.0/">
-          <img alt="Creative Commons License" style="border-width:0" src="https://i.creativecommons.org/l/by-sa/4.0/88x31.png" />
-      </a>
-        </p>
-        <p>
-          {% comment %} Translators: This text is at the bottom of every page. Don't translate "Creative Commons Attribution-ShareAlike 4.0 International". {% endcomment %}
-          {% blocktrans trimmed %}
-            This work is licensed under a
-            <a rel="license" href="http://creativecommons.org/licenses/by-sa/4.0/">Creative Commons Attribution-ShareAlike 4.0 International License</a>.
-          {% endblocktrans %}
-        </p>
-        
-    <hr />
-    </div>
-      
-    <div class="col-xs-12">
+        {% comment %} Translators: This text is at the bottom of every page. Don't translate "Creative Commons Attribution-ShareAlike 4.0 International". {% endcomment %}
+        {% blocktrans trimmed %}
+          This work is licensed under a
+          <a rel="license" href="http://creativecommons.org/licenses/by-sa/4.0/">Creative Commons Attribution-ShareAlike 4.0 International License</a>.
+        {% endblocktrans %}
+
         <ul class="list-inline pull-right">
           <li>
             <a href="{% url 'about' %}">
@@ -294,7 +274,6 @@
             </a>
           </li>
         </ul>
-      </div>
     </div>
   </footer>
 


### PR DESCRIPTION
This PR shuffles some HTML and CSS such that the footer is always at the bottom of the page, even when there's not enough other content to fill the window. The footer is now one line, with copyright notice on the left and list on the right.

I also removed some extraneous footer content that had actually been lost to due a malformed comment close (`{ %endcomment %}`).

Tested extensively by visiting various pages on different screen widths. Would still appreciate some review because I always feel like I'm flailing around in the dark with CSS.

I based this off Staging out of habit but I guess it could go direct to Master. It's not a priority task though, so if it's easier just to leave it on staging that's fine by me.