### PR TITLE
Fix bug with bundle eligibility after first month

### DIFF
--- a/TWLight/users/helpers/editor_data.py
+++ b/TWLight/users/helpers/editor_data.py
@@ -119,7 +119,6 @@ def editor_valid(enough_edits, account_old_enough, not_blocked, ignore_wp_blocks
 def editor_recent_edits(
     global_userinfo_editcount,
     wp_editcount_updated,
-    wp_editcount,
     wp_editcount_prev_updated,
     wp_editcount_prev,
     wp_editcount_recent,
@@ -138,13 +137,13 @@ def editor_recent_edits(
             # This means that eligibility always lasts at least 30 days.
             or (wp_enough_recent_edits and editcount_update_delta.days > 30)
         ):
-            wp_editcount_prev = wp_editcount
-            wp_editcount_prev_updated = wp_editcount_updated
             wp_editcount_recent = global_userinfo_editcount - wp_editcount_prev
+            wp_editcount_prev = global_userinfo_editcount
+            wp_editcount_prev_updated = wp_editcount_updated
 
-    # If we don't have any historical editcount data, let all edits to date count.
-    # Editor.wp_editcount_prev defaults to 0, so we don't need to worry about changing it.
+    # If we don't have any historical editcount data, let all edits to date count
     else:
+        wp_editcount_prev = global_userinfo_editcount
         wp_editcount_prev_updated = now()
         wp_editcount_recent = global_userinfo_editcount
 

--- a/TWLight/users/models.py
+++ b/TWLight/users/models.py
@@ -406,7 +406,6 @@ class Editor(models.Model):
             self.wp_editcount_prev_updated, self.wp_editcount_prev, self.wp_editcount_recent, self.wp_enough_recent_edits = editor_recent_edits(
                 global_userinfo["editcount"],
                 self.wp_editcount_updated,
-                self.wp_editcount,
                 self.wp_editcount_prev_updated,
                 self.wp_editcount_prev,
                 self.wp_editcount_recent,

--- a/TWLight/users/tests.py
+++ b/TWLight/users/tests.py
@@ -882,7 +882,6 @@ class EditorModelTestCase(TestCase):
         self.test_editor.wp_editcount_prev_updated, self.test_editor.wp_editcount_prev, self.test_editor.wp_editcount_recent, self.test_editor.wp_enough_recent_edits = editor_recent_edits(
             global_userinfo["editcount"],
             None,
-            self.test_editor.wp_editcount,
             None,
             self.test_editor.wp_editcount_prev,
             self.test_editor.wp_editcount_recent,
@@ -901,7 +900,6 @@ class EditorModelTestCase(TestCase):
         self.test_editor.wp_editcount_prev_updated, self.test_editor.wp_editcount_prev, self.test_editor.wp_editcount_recent, self.test_editor.wp_enough_recent_edits = editor_recent_edits(
             global_userinfo["editcount"],
             self.test_editor.wp_editcount_updated,
-            self.test_editor.wp_editcount,
             self.test_editor.wp_editcount_prev_updated,
             self.test_editor.wp_editcount_prev,
             self.test_editor.wp_editcount_recent,
@@ -920,7 +918,6 @@ class EditorModelTestCase(TestCase):
         self.test_editor.wp_editcount_prev_updated, self.test_editor.wp_editcount_prev, self.test_editor.wp_editcount_recent, self.test_editor.wp_enough_recent_edits = editor_recent_edits(
             global_userinfo["editcount"],
             self.test_editor.wp_editcount_updated,
-            self.test_editor.wp_editcount,
             self.test_editor.wp_editcount_prev_updated,
             self.test_editor.wp_editcount_prev,
             self.test_editor.wp_editcount_recent,
@@ -935,7 +932,6 @@ class EditorModelTestCase(TestCase):
         self.test_editor.wp_editcount_prev_updated, self.test_editor.wp_editcount_prev, self.test_editor.wp_editcount_recent, self.test_editor.wp_enough_recent_edits = editor_recent_edits(
             global_userinfo["editcount"] + 10,
             self.test_editor.wp_editcount_updated,
-            self.test_editor.wp_editcount,
             self.test_editor.wp_editcount_prev_updated,
             self.test_editor.wp_editcount_prev,
             self.test_editor.wp_editcount_recent,
@@ -960,7 +956,6 @@ class EditorModelTestCase(TestCase):
         self.test_editor.wp_editcount_prev_updated, self.test_editor.wp_editcount_prev, self.test_editor.wp_editcount_recent, self.test_editor.wp_enough_recent_edits = editor_recent_edits(
             global_userinfo["editcount"] + 10,
             self.test_editor.wp_editcount_updated,
-            self.test_editor.wp_editcount,
             self.test_editor.wp_editcount_prev_updated,
             self.test_editor.wp_editcount_prev,
             self.test_editor.wp_editcount_recent,
@@ -1027,7 +1022,6 @@ class EditorModelTestCase(TestCase):
         self.test_editor.wp_editcount_prev_updated, self.test_editor.wp_editcount_prev, self.test_editor.wp_editcount_recent, self.test_editor.wp_enough_recent_edits = editor_recent_edits(
             self.test_editor.wp_editcount,
             self.test_editor.wp_editcount_updated,
-            self.test_editor.wp_editcount,
             self.test_editor.wp_editcount_prev_updated,
             self.test_editor.wp_editcount_prev,
             self.test_editor.wp_editcount_recent,


### PR DESCRIPTION
This fixes an issue with incorrect bundle eligibility after the first month.

We were using `wp_editcount` before saving it for the current login attempt, and therefore comparing the current edit count to an arbitrary time in the past (when the user last logged in). This PR re-orders the check and fixes the comparison such that we're comparing the current edit count to the last recorded one, and before we overwrite that previous value.

It also updates the first-month logic to record current edit count, rather than setting it to 0, so that we're making consistent comparisons in subsequent months.