### PR TITLE
More staging bundle fixes

### DIFF
--- a/TWLight/resources/templates/resources/partner_detail.html
+++ b/TWLight/resources/templates/resources/partner_detail.html
@@ -473,7 +473,7 @@
                 {% if user.editor.wp_bundle_eligible %}
                   {% if partner.specific_stream %}
                     {% comment %} Translators: This text labels a button taking users to their library. {% endcomment %}
-                    <a class="btn btn-default btn-lg btn-block" href="{% url "users:my_library" %}">{% trans "My Library" %}</a><br />
+                    <a class="btn btn-primary btn-lg btn-block" href="{% url "users:my_library" %}">{% trans "My Library" %}</a><br />
                     <img src="{% static 'img/LibraryBundle.svg' %}" class="img-responsive pull-left" style="width:45px; height:45px; padding-right: 5px;" title="{% trans 'Library Bundle' %}" alt="
                     {% comment %} Translators: Alt text for the Library Bundle icon shown on the collection page. {% endcomment %}
                     {% trans "Library bundle access" %}
@@ -486,7 +486,7 @@
                     {% endblocktrans %}
                   {% else %}
                     {% comment %} Translators: This text labels a button authenticated, bundle eligible users can click to access the proxied resource. {% endcomment %}
-                    <a class="btn btn-default btn-lg btn-block" href="{{ partner.get_access_url }}">{% trans "Access Collection" %}</a><br />
+                    <a class="btn btn-primary btn-lg btn-block" href="{{ partner.get_access_url }}">{% trans "Access Collection" %}</a><br />
                     <img src="{% static 'img/LibraryBundle.svg' %}" class="img-responsive pull-left" style="width:45px; height:45px; padding-right: 5px;" title="{% trans 'Library Bundle' %}" alt="
                     {% comment %} Translators: Alt text for the Library Bundle icon shown on the collection page. {% endcomment %}
                     {% trans "Library bundle access" %}
@@ -499,7 +499,7 @@
                   {% endif %}
                 {% else %}
                   {% comment %} Translators: This text labels a button authenticated, bundle eligible users can click to access the proxied resource. {% endcomment %}
-                  <a class="btn btn-default btn-lg btn-block disabled">{% trans "Access Collection" %}</a><br />
+                  <a class="btn btn-primary btn-lg btn-block disabled">{% trans "Access Collection" %}</a><br />
                   <img src="{% static 'img/LibraryBundle.svg' %}" class="img-responsive pull-left" style="width:45px; height:45px; padding-right: 5px;" title="{% trans 'Library Bundle' %}" alt="
                   {% comment %} Translators: Alt text for the Library Bundle icon shown on the collection page. {% endcomment %}
                   {% trans "Library bundle access" %}
@@ -514,7 +514,7 @@
                 {% endif %}
               {% else %}
                 {% comment %} Translators: Buttton prompting users to log in. {% endcomment %}
-                <a class="btn btn-default btn-lg btn-block" href="{% url 'oauth_login' %}?next={{ request.path|urlencode }}">{% trans "Log in" %}</a><br />
+                <a class="btn btn-primary btn-lg btn-block" href="{% url 'oauth_login' %}?next={{ request.path|urlencode }}">{% trans "Log in" %}</a><br />
                 <img src="{% static 'img/LibraryBundle.svg' %}" class="img-responsive pull-left" style="width:45px; height:45px; padding-right: 5px;" title="{% trans 'Library Bundle' %}" alt="
                 {% comment %} Translators: Alt text for the Library Bundle icon shown on the collection page. {% endcomment %}
                 {% trans "Library bundle access" %}

--- a/TWLight/resources/tests.py
+++ b/TWLight/resources/tests.py
@@ -992,9 +992,7 @@ class BundlePartnerTest(TestCase):
         # give them an authorization to the Proxy partner.
 
         application = ApplicationFactory(
-            partner=self.proxy_partner_1,
-            editor=self.editor,
-            status=Application.PENDING
+            partner=self.proxy_partner_1, editor=self.editor, status=Application.PENDING
         )
 
         coordinator = EditorCraftRoom(self, Terms=True, Coordinator=True)
@@ -1007,7 +1005,7 @@ class BundlePartnerTest(TestCase):
         try:
             authorization = Authorization.objects.get(
                 user=self.editor.user,
-                partners=Partner.objects.filter(pk=self.proxy_partner_1.pk)
+                partners=Partner.objects.filter(pk=self.proxy_partner_1.pk),
             )
         except Authorization.DoesNotExist:
             self.fail("Authorization wasn't created in the first place.")

--- a/TWLight/resources/tests.py
+++ b/TWLight/resources/tests.py
@@ -812,9 +812,6 @@ class BundlePartnerTest(TestCase):
         self.editor = EditorFactory()
         self.editor.wp_bundle_eligible = True
         self.editor.save()
-        # This should create an authorization linked to
-        # bundle partners.
-        self.editor.update_bundle_authorization()
 
     def test_switching_partner_to_bundle_updates_auths(self):
         """
@@ -822,6 +819,10 @@ class BundlePartnerTest(TestCase):
         method to Bundle, existing bundle authorizations
         should be updated to include it.
         """
+        # This should create an authorization linked to
+        # bundle partners.
+        self.editor.update_bundle_authorization()
+
         bundle_authorization = Authorization.objects.filter(
             user=self.editor.user, partners__authorization_method=Partner.BUNDLE
         ).distinct()
@@ -839,6 +840,8 @@ class BundlePartnerTest(TestCase):
         method to non-Bundle, existing bundle authorizations
         should be updated to remove it.
         """
+        self.editor.update_bundle_authorization()
+
         bundle_authorization = Authorization.objects.filter(
             user=self.editor.user, partners__authorization_method=Partner.BUNDLE
         ).distinct()
@@ -856,6 +859,8 @@ class BundlePartnerTest(TestCase):
         not available, existing bundle authorizations
         should be updated to add it.
         """
+        self.editor.update_bundle_authorization()
+
         bundle_authorization = Authorization.objects.filter(
             user=self.editor.user, partners__authorization_method=Partner.BUNDLE
         ).distinct()
@@ -872,6 +877,8 @@ class BundlePartnerTest(TestCase):
         When a partner is marked as not available, existing bundle
         authorizations should be updated to add it.
         """
+        self.editor.update_bundle_authorization()
+
         bundle_authorization = Authorization.objects.filter(
             user=self.editor.user, partners__authorization_method=Partner.BUNDLE
         ).distinct()
@@ -888,6 +895,8 @@ class BundlePartnerTest(TestCase):
         Changing the availability of a PROXY partner should make no
         changes to bundle auths
         """
+        self.editor.update_bundle_authorization()
+
         bundle_authorization = Authorization.objects.filter(
             user=self.editor.user, partners__authorization_method=Partner.BUNDLE
         ).distinct()
@@ -905,6 +914,8 @@ class BundlePartnerTest(TestCase):
         to a non-bundle authorization should not make any changes
         to bundle auths
         """
+        self.editor.update_bundle_authorization()
+
         bundle_authorization = Authorization.objects.filter(
             user=self.editor.user, partners__authorization_method=Partner.BUNDLE
         ).distinct()
@@ -921,6 +932,8 @@ class BundlePartnerTest(TestCase):
         Creating a new partner with the BUNDLE authorization method
         immediately should add to existing Bundle authorizations.
         """
+        self.editor.update_bundle_authorization()
+
         bundle_authorization = Authorization.objects.filter(
             user=self.editor.user, partners__authorization_method=Partner.BUNDLE
         ).distinct()
@@ -938,6 +951,8 @@ class BundlePartnerTest(TestCase):
         Creating a new partner with the BUNDLE authorization method
         but NOT_AVAILABLE status should not change existing auths
         """
+        self.editor.update_bundle_authorization()
+
         bundle_authorization = Authorization.objects.filter(
             user=self.editor.user, partners__authorization_method=Partner.BUNDLE
         ).distinct()
@@ -955,6 +970,8 @@ class BundlePartnerTest(TestCase):
         Creating a new partner with the PROXY authorization method
         should make no change to existing Bundle authorizations
         """
+        self.editor.update_bundle_authorization()
+
         bundle_authorization = Authorization.objects.filter(
             user=self.editor.user, partners__authorization_method=Partner.BUNDLE
         ).distinct()
@@ -964,3 +981,45 @@ class BundlePartnerTest(TestCase):
         _ = PartnerFactory(authorization_method=Partner.PROXY, status=Partner.AVAILABLE)
 
         self.assertEqual(bundle_authorization.first().partners.count(), 2)
+
+    def test_switching_partner_to_bundle_deletes_previous_auths(self):
+        """
+        Users may have previously had an authorization to a partner that
+        we switch to Bundle. When switching a partner to Bundle, they
+        should be deleted and we should only have a single Bundle auth.
+        """
+        # Before we create the user's Bundle authorizations, let's
+        # give them an authorization to the Proxy partner.
+
+        application = ApplicationFactory(
+            partner=self.proxy_partner_1,
+            editor=self.editor,
+            status=Application.PENDING
+        )
+
+        coordinator = EditorCraftRoom(self, Terms=True, Coordinator=True)
+
+        application.status = Application.APPROVED
+        application.sent_by = coordinator.user
+        application.save()
+
+        # We should now have an auth for this user to this partner
+        try:
+            authorization = Authorization.objects.get(
+                user=self.editor.user,
+                partners=Partner.objects.filter(pk=self.proxy_partner_1.pk)
+            )
+        except Authorization.DoesNotExist:
+            self.fail("Authorization wasn't created in the first place.")
+
+        self.editor.update_bundle_authorization()
+
+        self.proxy_partner_1.authorization_method = Partner.BUNDLE
+        self.proxy_partner_1.save()
+
+        bundle_authorization = Authorization.objects.filter(
+            user=self.editor.user, partners__authorization_method=Partner.BUNDLE
+        ).distinct()
+
+        # Ultimately we should have one Bundle authorization
+        self.assertEqual(bundle_authorization.count(), 1)

--- a/TWLight/users/helpers/authorizations.py
+++ b/TWLight/users/helpers/authorizations.py
@@ -48,14 +48,14 @@ def get_valid_partner_authorizations(partner_pk, stream_pk=None):
         return Authorization.objects.none()
 
 
-def sort_authorizations_into_my_library_list(authorizations):
+def sort_authorizations_into_resource_list(authorizations):
     """
     Given a queryset of Authorization objects, return a
     list of dictionaries, sorted alphabetically by partner
     or stream name, with additional data computed for ease
     of display in the my_library template.
     """
-    authorization_list = []
+    resource_list = []
     if authorizations:
         for authorization in authorizations:
             for partner in authorization.partners.all():
@@ -66,8 +66,8 @@ def sort_authorizations_into_my_library_list(authorizations):
                     name_string = stream.name
                 else:
                     name_string = partner.company_name
-                authorization_list.append({"name": name_string})
-                this_item = authorization_list[-1]
+                resource_list.append({"name": name_string})
+                this_item = resource_list[-1]
 
                 this_item["partner"] = partner
                 this_item["authorization"] = authorization
@@ -83,8 +83,8 @@ def sort_authorizations_into_my_library_list(authorizations):
                 this_item['valid_authorization_with_access_url'] = access_url and valid_authorization and authorization.user.userprofile.terms_of_use
 
         # Alphabetise by name
-        authorization_list = sorted(authorization_list, key=lambda i: i["name"])
+        resource_list = sorted(resource_list, key=lambda i: i["name"])
 
-        return authorization_list
+        return resource_list
     else:
         return None

--- a/TWLight/users/helpers/authorizations.py
+++ b/TWLight/users/helpers/authorizations.py
@@ -46,3 +46,45 @@ def get_valid_partner_authorizations(partner_pk, stream_pk=None):
         return valid_authorizations
     except Authorization.DoesNotExist:
         return Authorization.objects.none()
+
+
+def sort_authorizations_into_my_library_list(authorizations):
+    """
+    Given a queryset of Authorization objects, return a
+    list of dictionaries, sorted alphabetically by partner
+    or stream name, with additional data computed for ease
+    of display in the my_library template.
+    """
+    authorization_list = []
+    if authorizations:
+        for authorization in authorizations:
+            for partner in authorization.partners.all():
+                # Name this item according to whether this authorization is
+                # to a stream
+                stream = authorization.stream
+                if stream:
+                    name_string = stream.name
+                else:
+                    name_string = partner.company_name
+                authorization_list.append({"name": name_string})
+                this_item = authorization_list[-1]
+
+                this_item["partner"] = partner
+                this_item["authorization"] = authorization
+                this_item["stream"] = stream
+                if stream:
+                    access_url = stream.get_access_url
+                else:
+                    access_url = partner.get_access_url
+                this_item["access_url"] = access_url
+
+                valid_authorization = authorization.is_valid
+                this_item['valid_proxy_authorization'] = partner.authorization_method == partner.PROXY and valid_authorization
+                this_item['valid_authorization_with_access_url'] = access_url and valid_authorization and authorization.user.userprofile.terms_of_use
+
+        # Alphabetise by name
+        authorization_list = sorted(authorization_list, key=lambda i: i["name"])
+
+        return authorization_list
+    else:
+        return None

--- a/TWLight/users/helpers/authorizations.py
+++ b/TWLight/users/helpers/authorizations.py
@@ -79,8 +79,15 @@ def sort_authorizations_into_resource_list(authorizations):
                 this_item["access_url"] = access_url
 
                 valid_authorization = authorization.is_valid
-                this_item['valid_proxy_authorization'] = partner.authorization_method == partner.PROXY and valid_authorization
-                this_item['valid_authorization_with_access_url'] = access_url and valid_authorization and authorization.user.userprofile.terms_of_use
+                this_item["valid_proxy_authorization"] = (
+                    partner.authorization_method == partner.PROXY
+                    and valid_authorization
+                )
+                this_item["valid_authorization_with_access_url"] = (
+                    access_url
+                    and valid_authorization
+                    and authorization.user.userprofile.terms_of_use
+                )
 
         # Alphabetise by name
         resource_list = sorted(resource_list, key=lambda i: i["name"])

--- a/TWLight/users/oauth.py
+++ b/TWLight/users/oauth.py
@@ -86,9 +86,11 @@ class OAuthBackend(object):
 
     def _meets_minimum_requirement(self, identity):
         """
+        If the user is not confirmed (or autoconfirmed), they are not allowed
+        to log in to the site at all.
         This needs to be reworked to actually check against global_userinfo.
         """
-        if "autoconfirmed" in identity["rights"]:
+        if "autoconfirmed" in identity["rights"] or "confirmed" in identity["rights"]:
             return True
 
         return False

--- a/TWLight/users/oauth.py
+++ b/TWLight/users/oauth.py
@@ -84,17 +84,6 @@ class OAuthBackend(object):
         # wiki userID should be unique, and limited to ASCII.
         return "{sub}".format(sub=identity["sub"])
 
-    def _meets_minimum_requirement(self, identity):
-        """
-        If the user is not confirmed (or autoconfirmed), they are not allowed
-        to log in to the site at all.
-        This needs to be reworked to actually check against global_userinfo.
-        """
-        if "autoconfirmed" in identity["rights"] or "confirmed" in identity["rights"]:
-            return True
-
-        return False
-
     def _create_user(self, identity):
         # This can't be super informative because we don't want to log
         # identities.

--- a/TWLight/users/templates/users/collection_tile.html
+++ b/TWLight/users/templates/users/collection_tile.html
@@ -9,62 +9,50 @@
 {% endcomment %}
 
 <div class="panel panel-default full-width">
-  <div class="panel-body top-border {% if each_authorization.about_to_expire %}expiry-warning{% endif %}">
-    {% if each_authorization.is_bundle %}
+  <div class="panel-body top-border {% if collection.authorization.about_to_expire %}expiry-warning{% endif %}">
+    {% if collection.authorization.is_bundle %}
       {% comment %} Translators: Title text for the Library Bundle icon shown on the collection page. {% endcomment %}
       <img src="{% static 'img/LibraryBundle.svg' %}" class="img-responsive no-padding-logo-collection-tiles" style="width:35px; height:30px;" title="{% trans 'Library Bundle' %}" alt="
       {% comment %} Translators: Alt text for the Library Bundle icon shown on the collection page. {% endcomment %}
       {% trans "Library bundle access" %}
       ">
     {% endif %}
-    {% if each_partner.authorization_method == each_partner.PROXY and each_authorization.is_valid %}
+    {% if collection.valid_proxy_authorization %}
       {% comment %} Translators: A button when clicked takes users to a confirmation page to return their access for a particular collection. {% endcomment %}
-      <a href="{% url 'users:return_authorization' each_authorization.id %}" class="btn btn-outline-danger fit-content no-padding-icon"><i class="fa fa-times fa-2x" title="{% trans 'Click to return this access' %}"></i></a>
+      <a href="{% url 'users:return_authorization' collection.authorization.id %}" class="btn btn-outline-danger fit-content no-padding-icon"><i class="fa fa-times fa-2x" title="{% trans 'Click to return this access' %}"></i></a>
     {% endif %}
-    {% if each_partner.logos.logo.url %}
+    {% if collection.partner.logos.logo.url %}
       <div class="partner-logo-container">
         <a href="
-          {% if each_partner.get_access_url and each_authorization.is_valid and each_authorization.user.userprofile.terms_of_use %}
-            {{ each_partner.get_access_url }}
-          {% elif each_authorization.stream.get_access_url and each_authorization.is_valid and each_authorization.user.userprofile.terms_of_use %}
-            {{ each_authorization.stream.get_access_url }}
+          {% if collection.valid_authorization_with_access_url %}
+            {{ collection.access_url }}
           {% else %}
-            {% url 'partners:detail' each_partner.pk %}
+            {% url 'partners:detail' collection.partner.pk %}
           {% endif %}
         ">
-          <img src="{{ each_partner.logos.logo.url }}" class="img-responsive partner-logo" title="
-            {% if each_partner.get_access_url and each_authorization.is_valid %}
-              {% comment %} Translators: Title for logo in tiles that are linked to an external website. Don't translate {{ each_partner }}. {% endcomment %}
-              {% blocktrans trimmed %}
-                 External link to {{ each_partner }}'s website
-              {% endblocktrans %}
-            {% elif each_authorization.stream.get_access_url and each_authorization.is_valid %}
-              {% comment %} Translators: Title for logo in tiles that are linked to an external website. Don't translate {{ stream }}. {% endcomment %}
-              {% blocktrans trimmed with each_authorization.stream as stream %}
-                 Link to {{ stream }}'s external website
+          <img src="{{ collection.partner.logos.logo.url }}" class="img-responsive partner-logo" title="
+            {% if collection.valid_authorization_with_access_url %}
+              {% comment %} Translators: Title for logo in tiles that are linked to an external website. Don't translate {{ name }}. {% endcomment %}
+              {% blocktrans trimmed with collection.name as name %}
+                 External link to {{ name }}'s website
               {% endblocktrans %}
             {% else %}
-              {% comment %} Translators: Title for logo in tiles that are linked to partner description  page. Don't translate {{ each_partner }}. {% endcomment %}
-              {% blocktrans trimmed %}
-                 Link to {{ each_partner }} signup page
+              {% comment %} Translators: Title for logo in tiles that are linked to partner description  page. Don't translate {{ name }}. {% endcomment %}
+              {% blocktrans trimmed with collection.name as name %}
+                 Link to {{ name }} signup page
               {% endblocktrans %}
             {% endif %}
             "
           alt="
-            {% if each_partner.get_access_url and each_authorization.is_valid %}
-              {% comment %} Translators: Alt text for publisher logos on the my library page. Don't translate {{ each_partner }}. {% endcomment %}
-              {% blocktrans trimmed %}
-                 Link to {{ each_partner }}'s external website
-              {% endblocktrans %}
-            {% elif each_authorization.stream.get_access_url and each_authorization.is_valid %}
-              {% comment %} Translators: Title for logo in tiles that are linked to an external website. Don't translate {{ stream }}. {% endcomment %}
-              {% blocktrans trimmed with each_authorization.stream as stream %}
-                 Link to {{ stream }}'s external website
+            {% if collection.valid_authorization_with_access_url %}
+              {% comment %} Translators: Alt text for publisher logos on the my library page. Don't translate {{ name }}. {% endcomment %}
+              {% blocktrans trimmed with collection.name as name %}
+                 Link to {{ name }}'s external website
               {% endblocktrans %}
             {% else %}
-              {% comment %} Translators: Alt text for publisher logos on the my library page. Don't translate {{ each_partner }}. {% endcomment %}
-              {% blocktrans trimmed %}
-                 Link to {{ each_partner }} signup page
+              {% comment %} Translators: Alt text for publisher logos on the my library page. Don't translate {{ name }}. {% endcomment %}
+              {% blocktrans trimmed with collection.name as name %}
+                 Link to {{ name }} signup page
               {% endblocktrans %}
             {% endif %}
           ">
@@ -72,20 +60,16 @@
       </div>
     {% endif %}
     <hr>
-    {% if each_authorization.is_valid and each_partner.get_access_url or each_authorization.stream.get_access_url %}
+    {% if collection.authorization.is_valid and collection.access_url %}
       <div style="text-align: center;">
         <a href="
-          {% if each_authorization.stream %}
-            {{ each_authorization.stream.get_access_url }}
-          {% else %}
-            {{ each_partner.get_access_url }}
-          {% endif %}
+          {{ collection.access_url }}
         " class="btn btn-primary
-        {% if not each_authorization.user.userprofile.terms_of_use %}
+        {% if not collection.authorization.user.userprofile.terms_of_use %}
           disabled
         {% endif %}
         " role="button">
-          {% if each_authorization.is_accessed_via_proxy %}
+          {% if collection.authorization.is_accessed_via_proxy %}
             {% comment %} Translators: Users can click this button to access a collection they have access to. {% endcomment %}
             {% trans 'Access collection' %}
           {% else %}
@@ -97,14 +81,14 @@
       <hr>
     {% endif %}
     <i class="fa fa-info-circle" aria-hidden="true" title="Partner description page"></i>
-    <strong><a href="{% url 'partners:detail' each_partner.pk %}">{{ each_partner }}</a></strong>
-    {% if each_authorization.stream %}({{ each_authorization.stream }}){% endif %}
-    {% if not each_authorization.is_bundle %}
-      {% if each_authorization.latest_sent_app and not each_authorization.open_app %}
+    <strong><a href="{% url 'partners:detail' collection.partner.pk %}">{{ collection.partner }}</a></strong>
+    {% if collection.stream %}({{ collection.stream }}){% endif %}
+    {% if not collection.authorization.is_bundle %}
+      {% if collection.authorization.latest_sent_app and not collection.authorization.open_app %}
         {% comment %} Translators: Hovertext for when renewals for a partner is not available and the renew button is disabled. {% endcomment %}
-        <span class="pull-right" {% if not each_partner.renewals_available %}title="{% trans 'Renewals are not available for this partner' %}"{% endif %}>
-          <a href="{% url 'applications:renew' each_authorization.latest_sent_app.pk %}" class="btn btn-default pull-right {% if not each_partner.renewals_available %}disabled{% endif %}" role="button">
-            {% if each_authorization.is_valid %}
+        <span class="pull-right" {% if not collection.partner.renewals_available %}title="{% trans 'Renewals are not available for this partner' %}"{% endif %}>
+          <a href="{% url 'applications:renew' collection.authorization.latest_sent_app.pk %}" class="btn btn-default pull-right {% if not collection.partner.renewals_available %}disabled{% endif %}" role="button">
+            {% if collection.authorization.is_valid %}
               {% comment %} Translators: Labels a button users can click to extend the duration of their access. {% endcomment %}
               {% trans 'Extend' %}
             {% else %}
@@ -114,9 +98,9 @@
           </a>
         </span>
         <div class="clearfix"></div>
-      {% elif each_partner.specific_title and not each_authorization.open_app %}
+      {% elif collection.partner.specific_title and not collection.authorization.open_app %}
         <span class="pull-right">
-          <a href="{% url 'applications:apply_single' each_partner.pk %}" class="btn btn-primary pull-right" role="button">
+          <a href="{% url 'applications:apply_single' collection.partner.pk %}" class="btn btn-primary pull-right" role="button">
             {% comment %} Translators: Labels the button users can click to apply for a resource. {% endcomment %}
             {% trans 'Apply' %}
           </a>
@@ -124,19 +108,19 @@
         <div class="clearfix"></div>
       {% endif %}
     {% endif %}
-    {% if each_authorization.open_app %}
+    {% if collection.authorization.open_app %}
       {% comment %} Translators: Labels a button users can click to view an application requesting access to a resource. {% endcomment %}
-      <a href="{% url 'applications:evaluate' each_authorization.open_app.pk %}" class="btn btn-primary pull-right" role="button">{% trans 'View application' %}</a><div class="clearfix"></div>
+      <a href="{% url 'applications:evaluate' collection.authorization.open_app.pk %}" class="btn btn-primary pull-right" role="button">{% trans 'View application' %}</a><div class="clearfix"></div>
     {% endif %}
-    {% if each_authorization.date_expires %}
-      <span class="pull-right" {% if each_authorization.about_to_expire %}style="color: #bf4d3d"{% endif %}>
+    {% if collection.authorization.date_expires %}
+      <span class="pull-right" {% if collection.authorization.about_to_expire %}style="color: #bf4d3d"{% endif %}>
         <small>
-          {% if not each_authorization.is_valid %}
+          {% if not collection.authorization.is_valid %}
             {% comment %} Translators: Text beside the date on which the authorization has expired. {% endcomment %}
-            {% trans 'Expired on' %}: {{ each_authorization.date_expires }}
+            {% trans 'Expired on' %}: {{ collection.authorization.date_expires }}
           {% else %}
             {% comment %} Translators: Text beside the date on which the authorization will expire. {% endcomment %}
-            {% trans 'Expires on' %}: {{ each_authorization.date_expires }}
+            {% trans 'Expires on' %}: {{ collection.authorization.date_expires }}
           {% endif %}
         </small>
       </span>

--- a/TWLight/users/templates/users/editor_detail_data.html
+++ b/TWLight/users/templates/users/editor_detail_data.html
@@ -82,7 +82,10 @@
       {% trans "Satisfies minimum account age?" %}
   </div>
   <div class="col-xs-12 col-sm-9">
-      {% if editor.wp_account_old_enough %}
+      {% if not editor.wp_editcount_prev %}
+          {% comment %} Translators: This text is shown next to a user's eligibility if they haven't logged in to the Library Card. In this case, we don't yet know if they're eligible. {% endcomment %}
+          <i>{% trans "Unknown (requires user login)" %}</i>
+      {% elif editor.wp_account_old_enough %}
           {% comment %} Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this shows if the user qualifies through the technical requirements. {% endcomment %}
           {% trans "Yes" %}
       {% else %}
@@ -96,7 +99,10 @@
       {% trans "Satisfies minimum edit count?" %}
   </div>
   <div class="col-xs-12 col-sm-9">
-      {% if editor.wp_enough_edits %}
+      {% if not editor.wp_editcount_prev %}
+          {% comment %} Translators: This text is shown next to a user's eligibility if they haven't logged in to the Library Card. In this case, we don't yet know if they're eligible. {% endcomment %}
+          <i>{% trans "Unknown (requires user login)" %}</i>
+      {% elif editor.wp_enough_edits %}
           {% comment %} Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this shows if the user qualifies through the technical requirements. {% endcomment %}
           {% trans "Yes" %}
       {% else %}
@@ -110,7 +116,10 @@
       {% trans "Is not blocked on any project?" %}
   </div>
   <div class="col-xs-12 col-sm-9">
-      {% if editor.wp_not_blocked %}
+      {% if not editor.wp_editcount_prev %}
+          {% comment %} Translators: This text is shown next to a user's eligibility if they haven't logged in to the Library Card. In this case, we don't yet know if they're eligible. {% endcomment %}
+          <i>{% trans "Unknown (requires user login)" %}</i>
+      {% elif editor.wp_not_blocked %}
           {% comment %} Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this shows if the user qualifies through the technical requirements. {% endcomment %}
           {% trans "Yes" %}
       {% else %}
@@ -140,7 +149,10 @@
         </p>
     </div>
     <div class="col-xs-12 col-sm-9">
-        {% if editor.wp_bundle_eligible %}
+        {% if not editor.wp_editcount_prev %}
+            {% comment %} Translators: This text is shown next to a user's eligibility if they haven't logged in to the Library Card. In this case, we don't yet know if they're eligible. {% endcomment %}
+            <i>{% trans "Unknown (requires user login)" %}</i>
+        {% elif editor.wp_bundle_eligible %}
             {% comment %} Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this shows if the user qualifies through the technical requirements for the Library Bundle. {% endcomment %}
             {% trans "Yes" %}
         {% else %}
@@ -154,7 +166,10 @@
         {% trans "Satisfies recent edit count?" %}
     </div>
     <div class="col-xs-12 col-sm-9">
-        {% if editor.wp_enough_recent_edits %}
+        {% if not editor.wp_editcount_prev %}
+            {% comment %} Translators: This text is shown next to a user's eligibility if they haven't logged in to the Library Card. In this case, we don't yet know if they're eligible. {% endcomment %}
+            <i>{% trans "Unknown (requires user login)" %}</i>
+        {% elif editor.wp_enough_recent_edits %}
             {% comment %} Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this shows if the user qualifies through the technical requirements for the Library Bundle. {% endcomment %}
             {% trans "Yes" %}
         {% else %}

--- a/TWLight/users/templates/users/my_library.html
+++ b/TWLight/users/templates/users/my_library.html
@@ -20,7 +20,7 @@
         {% comment %} Translators: Tab label (1 of 2) for the page listing all partners which can accessed either via proxy or via bundle (direct access). {% endcomment %}
         {% trans 'Instant access' %}
         <span class="badge">
-          {{ proxy_bundle_authorizations.count }}
+          {{ proxy_bundle_authorizations|length }}
         </span>
       </a>
     </li>
@@ -35,7 +35,7 @@
         {% comment %} Translators: Tab label (2 of 2) for the page listing all partners which can accessed manually. {% endcomment %}
         {% trans 'Individual access' %}
         <span class="badge">
-          {{ manual_authorizations.count }}
+          {{ manual_authorizations|length }}
         </span>
       </a>
     </li>
@@ -50,12 +50,10 @@
     ">
       <br>
       <div class="row row-flex">
-        {% for each_authorization in proxy_bundle_authorizations %}
-          {% for each_partner in each_authorization.partners.all %}
-            <div class="col-flex col-xs-12 col-sm-4 col-md-3">
-              {% include "users/collection_tile.html" %}
-            </div>
-          {% endfor %}
+        {% for collection in proxy_bundle_authorizations %}
+          <div class="col-flex col-xs-12 col-sm-4 col-md-3">
+            {% include "users/collection_tile.html" %}
+          </div>
         {% empty %}
           <div class="col-xs-12">
             {% comment %} Translators: On the collection page (proxy/bundle access tab), this text is displayed when the user has no active collections. {% endcomment %}
@@ -69,12 +67,10 @@
         <hr>
       {% endif %}
       <div class="row row-flex">
-        {% for each_authorization in proxy_bundle_authorizations_expired %}
-          {% for each_partner in each_authorization.partners.all %}
-            <div class="col-flex col-xs-12 col-sm-4 col-md-3">
-              {% include "users/collection_tile.html" %}
-            </div>
-          {% endfor %}
+        {% for collection in proxy_bundle_authorizations_expired %}
+          <div class="col-flex col-xs-12 col-sm-4 col-md-3">
+            {% include "users/collection_tile.html" %}
+          </div>
         {% endfor %}
       </div>
     </div>
@@ -87,12 +83,10 @@
     ">
       <br>
       <div class="row row-flex">
-        {% for each_authorization in manual_authorizations %}
-          {% for each_partner in each_authorization.partners.all %}
-            <div class="col-flex col-xs-12 col-sm-4 col-md-3">
-              {% include "users/collection_tile.html" %}
-            </div>
-          {% endfor %}
+        {% for collection in manual_authorizations %}
+          <div class="col-flex col-xs-12 col-sm-4 col-md-3">
+            {% include "users/collection_tile.html" %}
+          </div>
         {% empty %}
           <div class="col-xs-12">
             {% comment %} Translators: On the collection page (manual access tab), this text is displayed when the user has no active collections. {% endcomment %}
@@ -100,18 +94,16 @@
           </div>
         {% endfor %}
       </div>
-      {%  if manual_authorizations_expired %}
+      {% if manual_authorizations_expired %}
         {% comment %} Translators: Heading for the section which lists all of the user's expired collection. {% endcomment %}
         <h4>{% trans 'Expired' %}</h4>
         <hr>
       {% endif %}
       <div class="row row-flex">
-        {% for each_authorization in manual_authorizations_expired %}
-          {% for each_partner in each_authorization.partners.all %}
-            <div class="col-flex col-xs-12 col-sm-4 col-md-3">
-              {% include "users/collection_tile.html" %}
-            </div>
-          {% endfor %}
+        {% for collection in manual_authorizations_expired %}
+          <div class="col-flex col-xs-12 col-sm-4 col-md-3">
+            {% include "users/collection_tile.html" %}
+          </div>
         {% endfor %}
       </div>
     </div>

--- a/TWLight/users/templates/users/my_library.html
+++ b/TWLight/users/templates/users/my_library.html
@@ -50,9 +50,9 @@
     ">
       <br>
       <div class="row row-flex">
-        {% for collection in proxy_bundle_authorizations %}
+        {% for resource in proxy_bundle_authorizations %}
           <div class="col-flex col-xs-12 col-sm-4 col-md-3">
-            {% include "users/collection_tile.html" %}
+            {% include "users/resource_tile.html" %}
           </div>
         {% empty %}
           <div class="col-xs-12">
@@ -67,9 +67,9 @@
         <hr>
       {% endif %}
       <div class="row row-flex">
-        {% for collection in proxy_bundle_authorizations_expired %}
+        {% for resource in proxy_bundle_authorizations_expired %}
           <div class="col-flex col-xs-12 col-sm-4 col-md-3">
-            {% include "users/collection_tile.html" %}
+            {% include "users/resource_tile.html" %}
           </div>
         {% endfor %}
       </div>
@@ -83,9 +83,9 @@
     ">
       <br>
       <div class="row row-flex">
-        {% for collection in manual_authorizations %}
+        {% for resource in manual_authorizations %}
           <div class="col-flex col-xs-12 col-sm-4 col-md-3">
-            {% include "users/collection_tile.html" %}
+            {% include "users/resource_tile.html" %}
           </div>
         {% empty %}
           <div class="col-xs-12">
@@ -100,9 +100,9 @@
         <hr>
       {% endif %}
       <div class="row row-flex">
-        {% for collection in manual_authorizations_expired %}
+        {% for resource in manual_authorizations_expired %}
           <div class="col-flex col-xs-12 col-sm-4 col-md-3">
-            {% include "users/collection_tile.html" %}
+            {% include "users/resource_tile.html" %}
           </div>
         {% endfor %}
       </div>

--- a/TWLight/users/templates/users/my_library.html
+++ b/TWLight/users/templates/users/my_library.html
@@ -89,8 +89,8 @@
           </div>
         {% empty %}
           <div class="col-xs-12">
-            {% comment %} Translators: On the collection page (manual access tab), this text is displayed when the user has no active collections. {% endcomment %}
-            {% trans 'You have no active manual access collections.' %}
+            {% comment %} Translators: On the collection page (individual access tab), this text is displayed when the user has no active collections. {% endcomment %}
+            {% trans 'You have no active individual access collections.' %}
           </div>
         {% endfor %}
       </div>

--- a/TWLight/users/templates/users/resource_tile.html
+++ b/TWLight/users/templates/users/resource_tile.html
@@ -9,49 +9,49 @@
 {% endcomment %}
 
 <div class="panel panel-default full-width">
-  <div class="panel-body top-border {% if collection.authorization.about_to_expire %}expiry-warning{% endif %}">
-    {% if collection.authorization.is_bundle %}
+  <div class="panel-body top-border {% if resource.authorization.about_to_expire %}expiry-warning{% endif %}">
+    {% if resource.authorization.is_bundle %}
       {% comment %} Translators: Title text for the Library Bundle icon shown on the collection page. {% endcomment %}
       <img src="{% static 'img/LibraryBundle.svg' %}" class="img-responsive no-padding-logo-collection-tiles" style="width:35px; height:30px;" title="{% trans 'Library Bundle' %}" alt="
       {% comment %} Translators: Alt text for the Library Bundle icon shown on the collection page. {% endcomment %}
       {% trans "Library bundle access" %}
       ">
     {% endif %}
-    {% if collection.valid_proxy_authorization %}
-      {% comment %} Translators: A button when clicked takes users to a confirmation page to return their access for a particular collection. {% endcomment %}
-      <a href="{% url 'users:return_authorization' collection.authorization.id %}" class="btn btn-outline-danger fit-content no-padding-icon"><i class="fa fa-times fa-2x" title="{% trans 'Click to return this access' %}"></i></a>
+    {% if resource.valid_proxy_authorization %}
+      {% comment %} Translators: A button when clicked takes users to a confirmation page to return their access for a particular resource. {% endcomment %}
+      <a href="{% url 'users:return_authorization' resource.authorization.id %}" class="btn btn-outline-danger fit-content no-padding-icon"><i class="fa fa-times fa-2x" title="{% trans 'Click to return this access' %}"></i></a>
     {% endif %}
-    {% if collection.partner.logos.logo.url %}
+    {% if resource.partner.logos.logo.url %}
       <div class="partner-logo-container">
         <a href="
-          {% if collection.valid_authorization_with_access_url %}
-            {{ collection.access_url }}
+          {% if resource.valid_authorization_with_access_url %}
+            {{ resource.access_url }}
           {% else %}
-            {% url 'partners:detail' collection.partner.pk %}
+            {% url 'partners:detail' resource.partner.pk %}
           {% endif %}
         ">
-          <img src="{{ collection.partner.logos.logo.url }}" class="img-responsive partner-logo" title="
-            {% if collection.valid_authorization_with_access_url %}
+          <img src="{{ resource.partner.logos.logo.url }}" class="img-responsive partner-logo" title="
+            {% if resource.valid_authorization_with_access_url %}
               {% comment %} Translators: Title for logo in tiles that are linked to an external website. Don't translate {{ name }}. {% endcomment %}
-              {% blocktrans trimmed with collection.name as name %}
+              {% blocktrans trimmed with resource.name as name %}
                  External link to {{ name }}'s website
               {% endblocktrans %}
             {% else %}
               {% comment %} Translators: Title for logo in tiles that are linked to partner description  page. Don't translate {{ name }}. {% endcomment %}
-              {% blocktrans trimmed with collection.name as name %}
+              {% blocktrans trimmed with resource.name as name %}
                  Link to {{ name }} signup page
               {% endblocktrans %}
             {% endif %}
             "
           alt="
-            {% if collection.valid_authorization_with_access_url %}
+            {% if resource.valid_authorization_with_access_url %}
               {% comment %} Translators: Alt text for publisher logos on the my library page. Don't translate {{ name }}. {% endcomment %}
-              {% blocktrans trimmed with collection.name as name %}
+              {% blocktrans trimmed with resource.name as name %}
                  Link to {{ name }}'s external website
               {% endblocktrans %}
             {% else %}
               {% comment %} Translators: Alt text for publisher logos on the my library page. Don't translate {{ name }}. {% endcomment %}
-              {% blocktrans trimmed with collection.name as name %}
+              {% blocktrans trimmed with resource.name as name %}
                  Link to {{ name }} signup page
               {% endblocktrans %}
             {% endif %}
@@ -60,20 +60,20 @@
       </div>
     {% endif %}
     <hr>
-    {% if collection.authorization.is_valid and collection.access_url %}
+    {% if resource.authorization.is_valid and resource.access_url %}
       <div style="text-align: center;">
         <a href="
-          {{ collection.access_url }}
+          {{ resource.access_url }}
         " class="btn btn-primary
-        {% if not collection.authorization.user.userprofile.terms_of_use %}
+        {% if not resource.authorization.user.userprofile.terms_of_use %}
           disabled
         {% endif %}
         " role="button">
-          {% if collection.authorization.is_accessed_via_proxy %}
+          {% if resource.authorization.is_accessed_via_proxy %}
             {% comment %} Translators: Users can click this button to access a collection they have access to. {% endcomment %}
             {% trans 'Access collection' %}
           {% else %}
-            {% comment %} Translators: Users can click this button to be taken to the website for a collection. {% endcomment %}
+            {% comment %} Translators: Users can click this button to be taken to the website for a resource. {% endcomment %}
             {% trans 'Go to site' %}
           {% endif %}
         </a>
@@ -81,14 +81,14 @@
       <hr>
     {% endif %}
     <i class="fa fa-info-circle" aria-hidden="true" title="Partner description page"></i>
-    <strong><a href="{% url 'partners:detail' collection.partner.pk %}">{{ collection.partner }}</a></strong>
-    {% if collection.stream %}({{ collection.stream }}){% endif %}
-    {% if not collection.authorization.is_bundle %}
-      {% if collection.authorization.latest_sent_app and not collection.authorization.open_app %}
+    <strong><a href="{% url 'partners:detail' resource.partner.pk %}">{{ resource.partner }}</a></strong>
+    {% if resource.stream %}({{ resource.stream }}){% endif %}
+    {% if not resource.authorization.is_bundle %}
+      {% if resource.authorization.latest_sent_app and not resource.authorization.open_app %}
         {% comment %} Translators: Hovertext for when renewals for a partner is not available and the renew button is disabled. {% endcomment %}
-        <span class="pull-right" {% if not collection.partner.renewals_available %}title="{% trans 'Renewals are not available for this partner' %}"{% endif %}>
-          <a href="{% url 'applications:renew' collection.authorization.latest_sent_app.pk %}" class="btn btn-default pull-right {% if not collection.partner.renewals_available %}disabled{% endif %}" role="button">
-            {% if collection.authorization.is_valid %}
+        <span class="pull-right" {% if not resource.partner.renewals_available %}title="{% trans 'Renewals are not available for this partner' %}"{% endif %}>
+          <a href="{% url 'applications:renew' resource.authorization.latest_sent_app.pk %}" class="btn btn-default pull-right {% if not resource.partner.renewals_available %}disabled{% endif %}" role="button">
+            {% if resource.authorization.is_valid %}
               {% comment %} Translators: Labels a button users can click to extend the duration of their access. {% endcomment %}
               {% trans 'Extend' %}
             {% else %}
@@ -98,9 +98,9 @@
           </a>
         </span>
         <div class="clearfix"></div>
-      {% elif collection.partner.specific_title and not collection.authorization.open_app %}
+      {% elif resource.partner.specific_title and not resource.authorization.open_app %}
         <span class="pull-right">
-          <a href="{% url 'applications:apply_single' collection.partner.pk %}" class="btn btn-primary pull-right" role="button">
+          <a href="{% url 'applications:apply_single' resource.partner.pk %}" class="btn btn-primary pull-right" role="button">
             {% comment %} Translators: Labels the button users can click to apply for a resource. {% endcomment %}
             {% trans 'Apply' %}
           </a>
@@ -108,19 +108,19 @@
         <div class="clearfix"></div>
       {% endif %}
     {% endif %}
-    {% if collection.authorization.open_app %}
+    {% if resource.authorization.open_app %}
       {% comment %} Translators: Labels a button users can click to view an application requesting access to a resource. {% endcomment %}
-      <a href="{% url 'applications:evaluate' collection.authorization.open_app.pk %}" class="btn btn-primary pull-right" role="button">{% trans 'View application' %}</a><div class="clearfix"></div>
+      <a href="{% url 'applications:evaluate' resource.authorization.open_app.pk %}" class="btn btn-primary pull-right" role="button">{% trans 'View application' %}</a><div class="clearfix"></div>
     {% endif %}
-    {% if collection.authorization.date_expires %}
-      <span class="pull-right" {% if collection.authorization.about_to_expire %}style="color: #bf4d3d"{% endif %}>
+    {% if resource.authorization.date_expires %}
+      <span class="pull-right" {% if resource.authorization.about_to_expire %}style="color: #bf4d3d"{% endif %}>
         <small>
-          {% if not collection.authorization.is_valid %}
+          {% if not resource.authorization.is_valid %}
             {% comment %} Translators: Text beside the date on which the authorization has expired. {% endcomment %}
-            {% trans 'Expired on' %}: {{ collection.authorization.date_expires }}
+            {% trans 'Expired on' %}: {{ resource.authorization.date_expires }}
           {% else %}
             {% comment %} Translators: Text beside the date on which the authorization will expire. {% endcomment %}
-            {% trans 'Expires on' %}: {{ collection.authorization.date_expires }}
+            {% trans 'Expires on' %}: {{ resource.authorization.date_expires }}
           {% endif %}
         </small>
       </span>

--- a/TWLight/users/tests.py
+++ b/TWLight/users/tests.py
@@ -406,9 +406,9 @@ class ViewsTestCase(TestCase):
             "proxy_bundle_authorizations"
         ]
         response_proxy_bundle_partners = []
-        for each_authorization in response_proxy_bundle_auths:
-            self.assertEqual(each_authorization.user, self.user_editor)
-            partners = each_authorization.partners.all()
+        for collection in response_proxy_bundle_auths:
+            self.assertEqual(collection['authorization'].user, self.user_editor)
+            partners = collection['authorization'].partners.all()
             for partner in partners:
                 response_proxy_bundle_partners.append(partner)
 
@@ -424,9 +424,9 @@ class ViewsTestCase(TestCase):
         manual_partners = [partner3]
         response_manual_auths = response.context_data["manual_authorizations"]
         response_manual_partners = []
-        for each_authorization in response_manual_auths:
-            self.assertEqual(each_authorization.user, self.user_editor)
-            partners = each_authorization.partners.all()
+        for collection in response_manual_auths:
+            self.assertEqual(collection['authorization'].user, self.user_editor)
+            partners = collection['authorization'].partners.all()
             for partner in partners:
                 response_manual_partners.append(partner)
 

--- a/TWLight/users/tests.py
+++ b/TWLight/users/tests.py
@@ -407,8 +407,8 @@ class ViewsTestCase(TestCase):
         ]
         response_proxy_bundle_partners = []
         for collection in response_proxy_bundle_auths:
-            self.assertEqual(collection['authorization'].user, self.user_editor)
-            partners = collection['authorization'].partners.all()
+            self.assertEqual(collection["authorization"].user, self.user_editor)
+            partners = collection["authorization"].partners.all()
             for partner in partners:
                 response_proxy_bundle_partners.append(partner)
 
@@ -425,8 +425,8 @@ class ViewsTestCase(TestCase):
         response_manual_auths = response.context_data["manual_authorizations"]
         response_manual_partners = []
         for collection in response_manual_auths:
-            self.assertEqual(collection['authorization'].user, self.user_editor)
-            partners = collection['authorization'].partners.all()
+            self.assertEqual(collection["authorization"].user, self.user_editor)
+            partners = collection["authorization"].partners.all()
             for partner in partners:
                 response_manual_partners.append(partner)
 

--- a/TWLight/users/views.py
+++ b/TWLight/users/views.py
@@ -45,7 +45,7 @@ from .forms import (
     UserEmailForm,
     CoordinatorEmailForm,
 )
-from .helpers.authorizations import sort_authorizations_into_my_library_list
+from .helpers.authorizations import sort_authorizations_into_resource_list
 from .models import Editor, UserProfile, Authorization
 from .serializers import UserSerializer
 from TWLight.applications.models import Application
@@ -765,16 +765,16 @@ class CollectionUserView(SelfOnly, ListView):
                                 each_authorization.open_app = None
 
         # Sort the querysets into more useful lists
-        manual_authorizations_list = sort_authorizations_into_my_library_list(
+        manual_authorizations_list = sort_authorizations_into_resource_list(
             manual_authorizations
         )
-        manual_authorizations_expired_list = sort_authorizations_into_my_library_list(
+        manual_authorizations_expired_list = sort_authorizations_into_resource_list(
             manual_authorizations_expired
         )
-        proxy_bundle_authorizations_list = sort_authorizations_into_my_library_list(
+        proxy_bundle_authorizations_list = sort_authorizations_into_resource_list(
             proxy_bundle_authorizations
         )
-        proxy_bundle_authorizations_expired_list = sort_authorizations_into_my_library_list(
+        proxy_bundle_authorizations_expired_list = sort_authorizations_into_resource_list(
             proxy_bundle_authorizations_expired
         )
 

--- a/TWLight/users/views.py
+++ b/TWLight/users/views.py
@@ -45,6 +45,7 @@ from .forms import (
     UserEmailForm,
     CoordinatorEmailForm,
 )
+from .helpers.authorizations import sort_authorizations_into_my_library_list
 from .models import Editor, UserProfile, Authorization
 from .serializers import UserSerializer
 from TWLight.applications.models import Application
@@ -763,12 +764,26 @@ class CollectionUserView(SelfOnly, ListView):
                             except Application.DoesNotExist:
                                 each_authorization.open_app = None
 
-        context["proxy_bundle_authorizations"] = proxy_bundle_authorizations
+        # Sort the querysets into more useful lists
+        manual_authorizations_list = sort_authorizations_into_my_library_list(
+            manual_authorizations
+        )
+        manual_authorizations_expired_list = sort_authorizations_into_my_library_list(
+            manual_authorizations_expired
+        )
+        proxy_bundle_authorizations_list = sort_authorizations_into_my_library_list(
+            proxy_bundle_authorizations
+        )
+        proxy_bundle_authorizations_expired_list = sort_authorizations_into_my_library_list(
+            proxy_bundle_authorizations_expired
+        )
+
+        context["proxy_bundle_authorizations"] = proxy_bundle_authorizations_list
         context[
             "proxy_bundle_authorizations_expired"
-        ] = proxy_bundle_authorizations_expired
-        context["manual_authorizations"] = manual_authorizations
-        context["manual_authorizations_expired"] = manual_authorizations_expired
+        ] = proxy_bundle_authorizations_expired_list
+        context["manual_authorizations"] = manual_authorizations_list
+        context["manual_authorizations_expired"] = manual_authorizations_expired_list
         return context
 
 

--- a/TWLight/users/views.py
+++ b/TWLight/users/views.py
@@ -652,7 +652,7 @@ class TermsView(UpdateView):
                 )
 
             messages.add_message(self.request, messages.WARNING, fail_msg)
-            return reverse_lazy("users:home")
+            return reverse_lazy("homepage")
 
 
 class AuthorizedUsers(APIView):


### PR DESCRIPTION
  - Users are now redirected to the homepage after agreeing to the Terms of Use
  - Removed a piece of the login code that wasn't being used
  - When a partner is switched to Bundle, we now delete any previously existing authorizations to that partner, since they're no longer valid.
    - Added a test for this, which failed before my signal changes.
  - If we haven't collected Bundle eligibility data for a user yet (as determined by whether we've collected `editor.wp_editcount_prev`), display "Unknown" instead of "No" next to eligibility criteria on application review pages.
  - Instead of looping authorizations and partners in my_library, we now construct a list of dictionaries, one item per tile, bringing some of our logic out into view code.
    - This also fixes the authorization count on the tab when the user has a Bundle authorization.