### PR TITLE
Even more Bundle fixes

### DIFF
--- a/TWLight/resources/models.py
+++ b/TWLight/resources/models.py
@@ -498,17 +498,6 @@ class Partner(models.Model):
                     ]
                 }
             )
-        if (
-            self.authorization_method in [self.PROXY, self.BUNDLE]
-            and not self.target_url
-        ):
-            raise ValidationError(
-                {
-                    "target_url": [
-                        "For partners accessed via proxy, a target URL is required."
-                    ]
-                }
-            )
 
     def get_absolute_url(self):
         return reverse_lazy("partners:detail", kwargs={"pk": self.pk})

--- a/TWLight/tests.py
+++ b/TWLight/tests.py
@@ -917,7 +917,9 @@ class AuthorizationTestCase(AuthorizationBaseTestCase):
             post_save_partner2_auths_with_expiry_count,
         )
 
-    def test_authorization_backfill_expiry_date_on_partner_save_with_coordinator_deletion(self):
+    def test_authorization_backfill_expiry_date_on_partner_save_with_coordinator_deletion(
+        self
+    ):
         # As above, but this should still work in the case that an authorization's
         # coordinator deleted their data after authorizing a user.
         initial_partner2_auths_no_expiry_count = 0
@@ -978,7 +980,9 @@ class AuthorizationTestCase(AuthorizationBaseTestCase):
             post_save_partner2_auths_with_expiry_count,
         )
 
-    def test_authorization_backfill_expiry_date_on_partner_save_with_new_coordinator(self):
+    def test_authorization_backfill_expiry_date_on_partner_save_with_new_coordinator(
+        self
+    ):
         # As above, but this should still work in the case that the coordinator
         # for a partner has changed, so Authorizer is no longer in the coordinators
         # user group.

--- a/TWLight/tests.py
+++ b/TWLight/tests.py
@@ -940,7 +940,7 @@ class AuthorizationTestCase(AuthorizationBaseTestCase):
                 partner2_auth.date_expires = None
                 partner2_auth.save()
 
-        # Now have a user with an authorization to partner2 delete their data
+        # Now have partner2's coordinator delete their data
         delete_url = reverse("users:delete_data", kwargs={"pk": self.editor4.user.pk})
 
         # Need a password so we can login
@@ -1002,6 +1002,7 @@ class AuthorizationTestCase(AuthorizationBaseTestCase):
                 partner2_auth.date_expires = None
                 partner2_auth.save()
 
+        # editor4 stops being a coordinator
         get_coordinators().user_set.remove(self.editor4.user)
 
         # Save partner 2

--- a/TWLight/users/forms.py
+++ b/TWLight/users/forms.py
@@ -58,7 +58,7 @@ class AuthorizationUserChoiceForm(forms.ModelChoiceField):
 
 class AuthorizationAdminForm(forms.ModelForm):
     """
-    This override only exists to run custom validation for ManyToMany Partner relationship.
+    This override only exists to run custom validation.
     """
 
     class Meta:

--- a/TWLight/users/forms.py
+++ b/TWLight/users/forms.py
@@ -12,7 +12,7 @@ from django import forms
 from django.db import models
 from django.utils.translation import ugettext as _
 
-from .helpers.validation import validate_partners
+from .helpers.validation import validate_partners, validate_authorizer
 from .models import Editor, UserProfile, Authorization
 from .groups import get_restricted
 
@@ -68,6 +68,10 @@ class AuthorizationAdminForm(forms.ModelForm):
     def clean_partners(self):
         validate_partners(self.cleaned_data["partners"])
         return self.cleaned_data["partners"]
+
+    def clean_authorizer(self):
+        validate_authorizer(self.cleaned_data["authorizer"])
+        return self.cleaned_data["authorizer"]
 
 
 class AuthorizationInlineForm(forms.ModelForm):

--- a/TWLight/users/helpers/authorizations.py
+++ b/TWLight/users/helpers/authorizations.py
@@ -53,7 +53,7 @@ def create_resource_dict(name, authorization, partner, stream):
         "name": name,
         "partner": partner,
         "authorization": authorization,
-        "stream": stream
+        "stream": stream,
     }
 
     if stream:
@@ -64,13 +64,12 @@ def create_resource_dict(name, authorization, partner, stream):
 
     valid_authorization = authorization.is_valid
     resource_item["valid_proxy_authorization"] = (
-            partner.authorization_method == partner.PROXY
-            and valid_authorization
+        partner.authorization_method == partner.PROXY and valid_authorization
     )
     resource_item["valid_authorization_with_access_url"] = (
-            access_url
-            and valid_authorization
-            and authorization.user.userprofile.terms_of_use
+        access_url
+        and valid_authorization
+        and authorization.user.userprofile.terms_of_use
     )
 
     return resource_item
@@ -88,9 +87,7 @@ def sort_authorizations_into_resource_list(authorizations):
         for authorization in authorizations:
             for partner in authorization.partners.all():
                 stream = authorization.stream
-                partner_streams = Stream.objects.filter(
-                    partner=partner
-                )
+                partner_streams = Stream.objects.filter(partner=partner)
                 if partner_streams and not stream:
                     # If this authorization wasn't to a specific stream, but the
                     # partner has streams, we assume that means all streams
@@ -100,10 +97,8 @@ def sort_authorizations_into_resource_list(authorizations):
                     for stream in partner_streams:
                         resource_list.append(
                             create_resource_dict(
-                                stream.name,
-                                authorization,
-                                partner,
-                                stream)
+                                stream.name, authorization, partner, stream
+                            )
                         )
                 else:
                     # Name this item according to whether this authorization is
@@ -115,10 +110,7 @@ def sort_authorizations_into_resource_list(authorizations):
 
                     resource_list.append(
                         create_resource_dict(
-                            name_string,
-                            authorization,
-                            partner,
-                            stream
+                            name_string, authorization, partner, stream
                         )
                     )
 

--- a/TWLight/users/helpers/authorizations.py
+++ b/TWLight/users/helpers/authorizations.py
@@ -87,32 +87,18 @@ def sort_authorizations_into_resource_list(authorizations):
         for authorization in authorizations:
             for partner in authorization.partners.all():
                 stream = authorization.stream
-                partner_streams = Stream.objects.filter(partner=partner)
-                if partner_streams and not stream:
-                    # If this authorization wasn't to a specific stream, but the
-                    # partner has streams, we assume that means all streams
-                    # need to be included, with the same auth method.
-                    # This is specifically useful for Bundle authorizations to
-                    # partners with multiple streams.
-                    for stream in partner_streams:
-                        resource_list.append(
-                            create_resource_dict(
-                                stream.name, authorization, partner, stream
-                            )
-                        )
+                # Name this item according to whether this authorization is
+                # to a stream
+                if stream:
+                    name_string = stream.name
                 else:
-                    # Name this item according to whether this authorization is
-                    # to a stream
-                    if stream:
-                        name_string = stream.name
-                    else:
-                        name_string = partner.company_name
+                    name_string = partner.company_name
 
-                    resource_list.append(
-                        create_resource_dict(
-                            name_string, authorization, partner, stream
-                        )
+                resource_list.append(
+                    create_resource_dict(
+                        name_string, authorization, partner, stream
                     )
+                )
 
         # Alphabetise by name
         resource_list = sorted(resource_list, key=lambda i: i["name"])

--- a/TWLight/users/helpers/authorizations.py
+++ b/TWLight/users/helpers/authorizations.py
@@ -2,7 +2,7 @@ import datetime
 
 from django.db.models import Q
 
-from TWLight.resources.models import Partner, Stream
+from TWLight.resources.models import Partner
 from TWLight.users.models import Authorization
 
 

--- a/TWLight/users/helpers/authorizations.py
+++ b/TWLight/users/helpers/authorizations.py
@@ -95,9 +95,7 @@ def sort_authorizations_into_resource_list(authorizations):
                     name_string = partner.company_name
 
                 resource_list.append(
-                    create_resource_dict(
-                        name_string, authorization, partner, stream
-                    )
+                    create_resource_dict(name_string, authorization, partner, stream)
                 )
 
         # Alphabetise by name

--- a/TWLight/users/helpers/validation.py
+++ b/TWLight/users/helpers/validation.py
@@ -3,7 +3,9 @@ from django.db.models import QuerySet
 from django.core.exceptions import ValidationError
 from django.utils.translation import ugettext_lazy as _
 from modeltranslation.manager import MultilingualQuerySet
+
 from TWLight.resources.models import Partner
+from TWLight.users.groups import get_coordinators
 
 
 def validate_partners(partners: Union[QuerySet, MultilingualQuerySet]):
@@ -23,3 +25,16 @@ def validate_partners(partners: Union[QuerySet, MultilingualQuerySet]):
             raise ValidationError(
                 _("Only Bundle Partners support shared Authorization.")
             )
+
+
+def validate_authorizer(authorizer):
+    coordinators = get_coordinators()
+    authorizer_is_coordinator = authorizer in coordinators.user_set.all()
+    if not authorizer or not (
+        authorizer_is_coordinator
+        or authorizer.is_staff
+        or authorizer.username == "TWL Team"
+    ):
+        raise ValidationError(
+            "Authorization authorizer must be a coordinator or staff."
+        )

--- a/TWLight/users/models.py
+++ b/TWLight/users/models.py
@@ -46,7 +46,7 @@ from django.utils.functional import cached_property
 from django.utils.translation import ugettext_lazy as _
 from TWLight.resources.models import Partner, Stream
 from TWLight.users.groups import get_coordinators
-from TWLight.users.helpers.validation import validate_partners
+from TWLight.users.helpers.validation import validate_partners, validate_authorizer
 
 from TWLight.users.helpers.editor_data import (
     editor_global_userinfo,
@@ -779,19 +779,6 @@ class Authorization(models.Model):
         else:
             return False
 
-    def validate_authorizer(self):
-        authorizer = self.authorizer
-        coordinators = get_coordinators()
-        authorizer_is_coordinator = authorizer in coordinators.user_set.all()
-        if not authorizer or not (
-            authorizer_is_coordinator
-            or authorizer.is_staff
-            or authorizer.username == "TWL Team"
-        ):
-            raise ValidationError(
-                "Authorization authorizer must be a coordinator or staff."
-            )
-
     def clean(self):
         """
         Run custom validations for Authorization objects, both when the
@@ -809,4 +796,4 @@ class Authorization(models.Model):
         # A user can stop being in one of these groups later, so we
         # only verify this on object creation.
         else:
-            self.validate_authorizer()
+            validate_authorizer(self.authorizer)

--- a/TWLight/users/models.py
+++ b/TWLight/users/models.py
@@ -567,12 +567,6 @@ class Authorization(models.Model):
         blank=False,
         null=True,
         on_delete=models.SET_NULL,
-        # Really this should be limited to superusers or the associated partner coordinator instead of any coordinator. This object structure needs to change a bit for that to be possible.
-        limit_choices_to=(
-            models.Q(is_superuser=True)
-            | models.Q(groups__name="coordinators")
-            | models.Q(username="TWL Team")
-        ),
         # Translators: In the administrator interface, this text is help text for a field where staff can specify the user who authorized the editor.
         help_text=_("The authorizing user."),
     )

--- a/TWLight/users/signals.py
+++ b/TWLight/users/signals.py
@@ -114,22 +114,20 @@ def update_existing_bundle_authorizations(sender, instance, **kwargs):
     # New data for this partner for readability
     now_bundle = instance.authorization_method == Partner.BUNDLE
     now_available = instance.status == Partner.AVAILABLE
-    now_not_available = instance.status == Partner.NOT_AVAILABLE
 
     # Previous data for this partner for readability
     previously_available = previous_data.status == Partner.AVAILABLE
-    previously_not_available = previous_data.status == Partner.NOT_AVAILABLE
     previously_bundle = previous_data.authorization_method == Partner.BUNDLE
 
     if now_available:
         if now_bundle:
-            if previously_not_available or not previously_bundle:
+            if not previously_available or not previously_bundle:
                 add_to_auths = True
         else:
             if previously_bundle:
                 remove_from_auths = True
 
-    elif now_not_available:
+    elif not now_available:
         if previously_available and previously_bundle:
             remove_from_auths = True
 

--- a/TWLight/users/views.py
+++ b/TWLight/users/views.py
@@ -557,6 +557,16 @@ class DeleteDataView(SelfOnly, DeleteView):
             user_authorization.date_expires = date.today() - timedelta(days=1)
             user_authorization.save()
 
+        # Did the user authorize any authorizations?
+        # If so, we need to retain their validity by shifting
+        # the authorizer to TWL Team
+        twl_team = User.objects.get(username="TWL Team")
+        for authorization in Authorization.objects.filter(
+            authorizer=user
+        ):
+            authorization.authorizer = twl_team
+            authorization.save()
+
         user.delete()
 
         return HttpResponseRedirect(self.success_url)

--- a/TWLight/users/views.py
+++ b/TWLight/users/views.py
@@ -645,22 +645,6 @@ class TermsView(UpdateView):
             self.get_object().terms_of_use_date = None
             self.get_object().save()
 
-            if self.request.user in coordinators.user_set.all():
-                # Translators: This message is shown if the user (who is also a coordinator) does not accept to the Terms of Use when signing up. They can browse the website but cannot apply for or evaluate applications for access to resources.
-                fail_msg = _(
-                    "You may explore the site, but you will not be "
-                    "able to apply for access to materials or evaluate "
-                    "applications unless you agree with the terms of use."
-                )
-            else:
-                # Translators: This message is shown if the user does not accept to the Terms of Use when signing up. They can browse the website but cannot apply for access to resources.
-                fail_msg = _(
-                    "You may explore the site, but you will not be "
-                    "able to apply for access unless you agree with "
-                    "the terms of use."
-                )
-
-            messages.add_message(self.request, messages.WARNING, fail_msg)
             return reverse_lazy("homepage")
 
 

--- a/TWLight/users/views.py
+++ b/TWLight/users/views.py
@@ -561,9 +561,7 @@ class DeleteDataView(SelfOnly, DeleteView):
         # If so, we need to retain their validity by shifting
         # the authorizer to TWL Team
         twl_team = User.objects.get(username="TWL Team")
-        for authorization in Authorization.objects.filter(
-            authorizer=user
-        ):
+        for authorization in Authorization.objects.filter(authorizer=user):
             authorization.authorizer = twl_team
             authorization.save()
 


### PR DESCRIPTION
- Coordinators can stop being coordinators in two ways - either they're no longer in the coordinator user group or they delete their data. Both cases were leading to server errors when we tried to do things with the related Partner or Authorization objects.
  - ~~We now no longer require an Authorization's `authorizer` to be a coordinator, because a coordinator might have authorized a user and then stopped being a coordinator.~~
    - Actually, we still do this validation but only when the object is created.
  - When a user deletes their data, if they're a coordinator we need to shift the `authorizer` to TWL Team so that the authorization is still valid (i.e. `is_valid` returns True)
- ~~When an authorization doesn't have a specific stream attached, but the partner has streams, the user should be authorized for all streams and have them show up individually in their library.~~
- Don't send a message after not agreeing to ToU, because we always show a very similar message anyway.
- Reverted my target URL + proxy validation on partner resources. We want to be able to set auth method at the resource level even when target URLs are only configured on streams.
- I had excluded Waitlist status from our resource signal considerations when updating Bundle authorizations. That didn't make much sense because we needed to update auths if, for example, switching a previously waitlisted partner to available + bundle in one go. We now basically consider waitlist to be synonymous with not_available for those purposes.