### PR TITLE
Clear 'reminder email sent' field when authorization is renewed

### DIFF
--- a/TWLight/applications/signals.py
+++ b/TWLight/applications/signals.py
@@ -210,6 +210,12 @@ def post_revision_commit(sender, instance, **kwargs):
         authorization.save()
         authorization.partners.add(instance.partner)
 
+        # If we just finalised a renewal, reset reminder_email_sent
+        # so that we can send further reminders.
+        if instance.parent and authorization.reminder_email_sent:
+            authorization.reminder_email_sent = False
+            authorization.save()
+
 
 @receiver(post_save, sender=Partner)
 @receiver(post_save, sender=Stream)


### PR DESCRIPTION
https://phabricator.wikimedia.org/T246396

- When an application is marked as sent, we check in the Application `post_save` signal whether this was a renewal for which we had previously marked `reminder_email_sent` as True. If so, reset it to False so we can send future reminder emails about this authorization.

The test here is a bit hacky. I took the quick route rather than the probably-ideal fix of going back up and creating an Authorization in a sensible Application-first way in the setup.