### PR TITLE
May 21 fixes

### DIFF
--- a/TWLight/users/helpers/authorizations.py
+++ b/TWLight/users/helpers/authorizations.py
@@ -48,9 +48,8 @@ def get_valid_partner_authorizations(partner_pk, stream_pk=None):
         return Authorization.objects.none()
 
 
-def create_resource_dict(name, authorization, partner, stream):
+def create_resource_dict(authorization, partner, stream):
     resource_item = {
-        "name": name,
         "partner": partner,
         "authorization": authorization,
         "stream": stream,
@@ -79,27 +78,21 @@ def sort_authorizations_into_resource_list(authorizations):
     """
     Given a queryset of Authorization objects, return a
     list of dictionaries, sorted alphabetically by partner
-    or stream name, with additional data computed for ease
-    of display in the my_library template.
+    name, with additional data computed for ease of display
+    in the my_library template.
     """
     resource_list = []
     if authorizations:
         for authorization in authorizations:
             for partner in authorization.partners.all():
                 stream = authorization.stream
-                # Name this item according to whether this authorization is
-                # to a stream
-                if stream:
-                    name_string = stream.name
-                else:
-                    name_string = partner.company_name
 
                 resource_list.append(
-                    create_resource_dict(name_string, authorization, partner, stream)
+                    create_resource_dict(authorization, partner, stream)
                 )
 
         # Alphabetise by name
-        resource_list = sorted(resource_list, key=lambda i: i["name"])
+        resource_list = sorted(resource_list, key=lambda i: i["partner"].company_name)
 
         return resource_list
     else:

--- a/TWLight/users/helpers/authorizations.py
+++ b/TWLight/users/helpers/authorizations.py
@@ -92,7 +92,9 @@ def sort_authorizations_into_resource_list(authorizations):
                 )
 
         # Alphabetise by name
-        resource_list = sorted(resource_list, key=lambda i: i["partner"].company_name.lower())
+        resource_list = sorted(
+            resource_list, key=lambda i: i["partner"].company_name.lower()
+        )
 
         return resource_list
     else:

--- a/TWLight/users/helpers/authorizations.py
+++ b/TWLight/users/helpers/authorizations.py
@@ -92,7 +92,7 @@ def sort_authorizations_into_resource_list(authorizations):
                 )
 
         # Alphabetise by name
-        resource_list = sorted(resource_list, key=lambda i: i["partner"].company_name)
+        resource_list = sorted(resource_list, key=lambda i: i["partner"].company_name.lower())
 
         return resource_list
     else:


### PR DESCRIPTION
Just two small fixes here to the alphabetisation of My Library.
  - We were using stream name as the key on which to alphabetise, but that was confusing because we displayed the collection as `Partner name (Stream name)`, so I reverted that part to always sort on partner name.
  - `sorted()` was sorting capital letters before lowercase letters (i.e. BMJ before BioOne), so I adjusted the sort key to be based on lowercase strings.