### PR TITLE
Consistency in user library/application page names

### DIFF
--- a/TWLight/applications/views.py
+++ b/TWLight/applications/views.py
@@ -411,7 +411,7 @@ class SubmitApplicationView(_BaseSubmitApplicationView):
             # Translators: When a user applies for a set of resources, they receive this message if their application was filed successfully.
             _(
                 "Your application has been submitted for review. "
-                'Head over to <a href="{applications_url}">Your Applications'
+                'Head over to <a href="{applications_url}">My Applications'
                 "</a> to view the status.".format(
                     applications_url=reverse_lazy(
                         "users:my_applications",
@@ -472,7 +472,7 @@ class SubmitSingleApplicationView(_BaseSubmitApplicationView):
             messages.SUCCESS,
             _(
                 "Your application has been submitted for review. "
-                'Head over to <a href="{applications_url}">Your Applications'
+                'Head over to <a href="{applications_url}">My Applications'
                 "</a> to view the status.".format(
                     applications_url=reverse_lazy(
                         "users:my_applications",

--- a/TWLight/resources/templates/resources/partner_detail.html
+++ b/TWLight/resources/templates/resources/partner_detail.html
@@ -52,9 +52,9 @@
         <div class="panel panel-default visible-xs">
           <div class="panel-body top-border">
             {% if has_auths %}
-              {% comment %} Translators: This message is shown when a user has authorizations, linking to their respective collections page. {% endcomment %}
+              {% comment %} Translators: This text refers to the page containing the content a user is authorized to access. {% endcomment %}
               {% blocktrans trimmed %}
-                View the status of your access(es) in <strong><a href="{{ library_url }}">Your Library</a></strong> page.
+                View the status of your access(es) in <strong><a href="{{ library_url }}">My Library</a></strong> page.
               {% endblocktrans %}
               {% if has_open_apps %}
                 <hr />
@@ -63,7 +63,7 @@
             {% if has_open_apps %}
               {% comment %} Translators: This message is shown when a user has open applications, linking to their respective applications page. {% endcomment %}
               {% blocktrans trimmed %}
-                View the status of your application(s) in <strong><a href="{{ applications_url }}">Your Applications</a></strong> page.
+                View the status of your application(s) on your <strong><a href="{{ applications_url }}">My Applications</a></strong> page.
               {% endblocktrans %}
             {% endif %}
           </div>
@@ -401,7 +401,7 @@
                   {% if has_auths %}
                     {% comment %} Translators: This message is shown when a user has authorizations, linking to their respective collections page. {% endcomment %}
                     {% blocktrans trimmed %}
-                      View the status of your access(es) in <strong><a href="{{ library_url }}">Your Library</a></strong> page.
+                      View the status of your access(es) on your <strong><a href="{{ library_url }}">My Library</a></strong> page.
                     {% endblocktrans %}
                     {% if has_open_apps %}
                       <hr />
@@ -410,7 +410,7 @@
                   {% if has_open_apps %}
                     {% comment %} Translators: This message is shown when a user has open applications, linking to their respective applications page. {% endcomment %}
                     {% blocktrans trimmed %}
-                      View the status of your application(s) in <strong><a href="{{ applications_url }}">Your Applications</a></strong> page.
+                      View the status of your application(s) on your <strong><a href="{{ applications_url }}">My Applications</a></strong> page.
                     {% endblocktrans %}
                   {% endif %}
                 </div>

--- a/TWLight/templates/home.html
+++ b/TWLight/templates/home.html
@@ -21,7 +21,7 @@
       {% if user.is_authenticated %}
         <a href="{% url 'users:my_library' %}" class="btn btn-primary btn-block">
           {% comment %} Translators: On the homepage, this message labels a button users can click to go to the 'My Library' page, which lists their available collections. {% endcomment %}
-          {% trans "Your Library" %}
+          {% trans "My Library" %}
         </a>
       {% else %}
         <a href="{% url 'oauth_login' %}" class="btn btn-primary btn-block">
@@ -81,7 +81,7 @@
             {% url 'users:my_library' as library_url %}
             {% comment %} Translators: This message is shown on the homepage to users who meet the technical eligibility criteria for the Library Bundle. {% endcomment %}
             {% blocktrans %}
-              You meet the eligibility criteria! Check out <a href="{{ library_url }}">Your Library</a> to see what you have access to.
+              You meet the eligibility criteria! Check out <a href="{{ library_url }}">My Library</a> to see what you have access to.
             {% endblocktrans %}
           </div>
         {% else %}

--- a/TWLight/users/templates/users/editor_detail.html
+++ b/TWLight/users/templates/users/editor_detail.html
@@ -18,7 +18,7 @@
       <a href="{% url 'users:my_library' %}" class="btn btn-default btn-lg btn-block btn-extra-large"><i class="fa fa-folder-open-o fa-4x pull-left" aria-hidden="true"></i>
         <p class="app-list"  style="font-size:25px; float:left">
           {% comment %} Translators: Line one of two in a button on users' profile page which when clicked takes users to their collection page. {% endcomment %}
-          {% trans 'Your Library' %}
+          {% trans 'My Library' %}
         </p><br>
         <p class="app-list hidden-xs pull-left" style="font-size:15px; float:left">
           {% comment %} Translators: Line two of two, explaining the purpose of the page in a button on users' profile page which when clicked takes users to a page with their available collections. {% endcomment %}
@@ -30,7 +30,7 @@
       <a href="{% url 'users:my_applications' editor.pk %}" class="btn btn-default btn-lg btn-block btn-extra-large"><i class="fa fa-file-text-o fa-4x pull-left" aria-hidden="true"></i>
         <p class="app-list"  style="font-size:25px; float:left">
           {% comment %} Translators: Line one of two in a button on users' profile page which when clicked takes users to their applications page. {% endcomment %}
-          {% trans 'Your applications' %}
+          {% trans 'My applications' %}
         </p><br>
         <p class="app-list hidden-xs" style="font-size:15px; float:left">
           {% comment %} Translators: Line two of two, explaining the purpose of the page in a button on users' profile page which when clicked takes users to a page with their collection. {% endcomment %}

--- a/TWLight/users/templates/users/my_applications.html
+++ b/TWLight/users/templates/users/my_applications.html
@@ -4,7 +4,7 @@
 
 {% block content %}
   {% comment %} Translators: Heading of the applications page where users can view all of their applications listed with other relevant info. {% endcomment %}
-  <h3 class="inline-header">{% trans 'Your applications' %}</h3>
+  <h3 class="inline-header">{% trans 'My applications' %}</h3>
     <a href="{% url 'users:my_library' %}" class="btn btn-default pull-right">
     {% comment %} Translators: A button on the 'your applications' page which when clicked takes users their collection page. {% endcomment %}
     {% trans "My Library" %}

--- a/TWLight/users/templates/users/my_library.html
+++ b/TWLight/users/templates/users/my_library.html
@@ -3,10 +3,10 @@
 
 {% block content %}
   {% comment %} Translators: Heading of the collection page where users can view all partners they are authorized to access with other relevant information. {% endcomment %}
-  <h3 class="inline-header">{% trans 'Your Library' %}</h3>
+  <h3 class="inline-header">{% trans 'My Library' %}</h3>
   <a href="{% url 'users:my_applications' user.editor.pk %}" class="btn btn-default pull-right">
-    {% comment %} Translators: A button on the 'your library' page which when clicked takes users their applications page. {% endcomment %}
-    {% trans "Your applications" %}
+    {% comment %} Translators: A button on the 'my library' page which when clicked takes users their applications page. {% endcomment %}
+    {% trans "My applications" %}
   </a>
   <ul class="nav nav-tabs">
     <li


### PR DESCRIPTION
We were being inconsistent about 'My' vs 'Your' Library and Applications. Made that consistent around 'My'.