### PR TITLE
Update AuthorizedUsers API and tests

### DIFF
--- a/TWLight/tests.py
+++ b/TWLight/tests.py
@@ -1225,8 +1225,6 @@ class AuthorizedUsersAPITestCase(AuthorizationBaseTestCase):
             request, self.partner5.pk, 0
         )
 
-        expected_json = [
-            {"wp_username": self.editor1.wp_username},
-        ]
+        expected_json = [{"wp_username": self.editor1.wp_username}]
 
         self.assertEqual(response.data, expected_json)

--- a/TWLight/users/views.py
+++ b/TWLight/users/views.py
@@ -670,9 +670,7 @@ class AuthorizedUsers(APIView):
         # We're ignoring streams here, because the API operates at the partner
         # level. This is fine for the use case we built it for (Wikilink tool)
         valid_partner_auths = get_valid_partner_authorizations(pk)
-        users = User.objects.filter(
-            authorizations__in=valid_partner_auths
-        ).distinct()
+        users = User.objects.filter(authorizations__in=valid_partner_auths).distinct()
 
         serializer = UserSerializer(users, many=True)
         return Response(serializer.data)


### PR DESCRIPTION
The API used by the Wikilink tool for user reference addition tracking needed updating to function with Bundle authorizations correctly. Helpfully we already had a helper function to get the valid authorizations for a partner, and switching the previous view logic out to use that instead works as expected.

Added a couple of extra tests to cover Bundle partners and those with streams.