### PR TITLE
Handle 404 on non-int tag value in /partners/ filter

### DIFF
--- a/TWLight/resources/views.py
+++ b/TWLight/resources/views.py
@@ -58,7 +58,7 @@ class PartnersFilterView(FilterView):
         try:
             filter_data = kwargs.pop("filter").data
             tag_id = filter_data.get("tags")
-            if tag_id and isinstance(tag_id, int):
+            if tag_id:
                 context["tag"] = TextFieldTag.objects.get(id=tag_id)
         except (KeyError, ValueError, TextFieldTag.DoesNotExist):
             pass

--- a/TWLight/resources/views.py
+++ b/TWLight/resources/views.py
@@ -58,9 +58,9 @@ class PartnersFilterView(FilterView):
         try:
             filter_data = kwargs.pop("filter").data
             tag_id = filter_data.get("tags")
-            if tag_id:
+            if tag_id and isinstance(tag_id, int):
                 context["tag"] = TextFieldTag.objects.get(id=tag_id)
-        except (KeyError, TextFieldTag.DoesNotExist):
+        except (KeyError, ValueError, TextFieldTag.DoesNotExist):
             pass
         return context
 


### PR DESCRIPTION
Something that was missed in #384 and now included here, is we check for `ValueError`s