### PR TITLE
Lutrome - T242196 - Reword 'I accept' button to 'Submit' on Terms of Use page

### DIFF
--- a/TWLight/users/forms.py
+++ b/TWLight/users/forms.py
@@ -182,8 +182,8 @@ class TermsForm(forms.ModelForm):
 
         self.helper.layout = Layout(
             "terms_of_use",
-            # Translators: this 'I accept' is referenced in the terms of use and should be translated the same way both places.
-            Submit("submit", _("I accept"), css_class="btn btn-default"),
+            # Translators: this 'Submit' is referenced in the terms of use and should be translated the same way both places.
+            Submit("submit", _("Submit"), css_class="btn btn-default"),
         )
 
 

--- a/TWLight/users/templates/users/terms.html
+++ b/TWLight/users/templates/users/terms.html
@@ -297,7 +297,7 @@ wikipedialibrary@wikimedia.org
     <p>
     {% comment %}Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library. {% endcomment %}
     {% blocktrans trimmed %}
-       By checking this box and clicking “I Accept”, you agree that you have read the above terms and that you will adhere to the terms of use in your application to and use of the The Wikipedia Library, and the publishers’ services to which you gain access through The Wikipedia Library program.
+       By checking this box and clicking “Submit”, you agree that you have read the above terms and that you will adhere to the terms of use in your application to and use of the The Wikipedia Library, and the publishers’ services to which you gain access through The Wikipedia Library program.
     {% endblocktrans %}
     </p>
     {% crispy form %}


### PR DESCRIPTION
[//]: # (Thank you for uploading a PR to the Wikipedia Library!)

## Description
    - Change "I Accept" on TWLight\users\forms.py#L185-186 to "Submit".
    - Change "I Accept" on TWLight\users\templates\users\forms.html#L300 to "Submit".
    - Change "I Accept" on all TWLight\locale\*\django.po files.

## Rationale
[//]: The fact that there is both a checkbox and "I Accept" button on the Terms of Use page is confusing to users, so it makes more sense to change the "I accept" text in the ToU and in the button to "Submit", making it more clear to the user what it does, and the users will understand that the checkbox has to be checked first before clicking the button.
I also changed "I Accept" to "Submit" across the translator comments in all locale files so the translators can begin working on the change as well.

## Phabricator Ticket
[//]: # https://phabricator.wikimedia.org/T242196

## How Has This Been Tested?
[//]: No tests have been added or modified.
[//]: I tested this change by changing the text "I Accept" to "Submit" in the terms.html and forms.py file, then going through the account creation process to confirm the button works as intended.

## Types of changes
What types of changes does your code introduce? Add an `x` in all the boxes that apply:
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
