### PR TITLE
Dev accept

### DIFF
--- a/TWLight/users/forms.py
+++ b/TWLight/users/forms.py
@@ -183,7 +183,7 @@ class TermsForm(forms.ModelForm):
         self.helper.layout = Layout(
             "terms_of_use",
             # Translators: this 'I accept' is referenced in the terms of use and should be translated the same way both places.
-            Submit("submit", _("I Submit"), css_class="btn btn-default"),
+            Submit("submit", _("Submit"), css_class="btn btn-default"),
         )
 
 

--- a/TWLight/users/forms.py
+++ b/TWLight/users/forms.py
@@ -183,7 +183,7 @@ class TermsForm(forms.ModelForm):
         self.helper.layout = Layout(
             "terms_of_use",
             # Translators: this 'I accept' is referenced in the terms of use and should be translated the same way both places.
-            Submit("submit", _("I accept"), css_class="btn btn-default"),
+            Submit("submit", _("I Submit"), css_class="btn btn-default"),
         )
 
 

--- a/TWLight/users/templates/users/terms.html
+++ b/TWLight/users/templates/users/terms.html
@@ -297,7 +297,7 @@ wikipedialibrary@wikimedia.org
     <p>
     {% comment %}Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library. {% endcomment %}
     {% blocktrans trimmed %}
-       By checking this box and clicking “I Accept”, you agree that you have read the above terms and that you will adhere to the terms of use in your application to and use of the The Wikipedia Library, and the publishers’ services to which you gain access through The Wikipedia Library program.
+       By checking this box and clicking “Submit”, you agree that you have read the above terms and that you will adhere to the terms of use in your application to and use of the The Wikipedia Library, and the publishers’ services to which you gain access through The Wikipedia Library program.
     {% endblocktrans %}
     </p>
     {% crispy form %}


### PR DESCRIPTION
## Why these changes
It's confusing to users that the form on the Terms of Use page has both a check box and an "I Accept" button. Users expect that the button is sufficient to accept, without the check box. Additionally, users can un-accept the terms, to do which they need to un-check the box and then click... "I Accept".
I re-word the button to 'Submit' so that it's more obvious the check box should be selected first.

## Phabricator Ticket
[Phabricator Ticket](https://phabricator.wikimedia.org/T242196)
 
## Types of changes
What types of changes does your code introduce? Add an `x` in all the boxes that apply:
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
