### PR TITLE
Add staff to be eligible for library bundle

### DIFF
--- a/TWLight/users/helpers/editor_data.py
+++ b/TWLight/users/helpers/editor_data.py
@@ -184,8 +184,11 @@ def editor_recent_edits(
     )
 
 
-def editor_bundle_eligible(wp_valid, wp_enough_recent_edits):
-    if wp_valid and wp_enough_recent_edits:
+def editor_bundle_eligible(editor):
+    enough_edits_and_valid = editor.wp_valid and editor.wp_enough_recent_edits
+    # Staff and superusers should be eligible for bundles for testing purposes
+    user_staff_or_superuser = editor.user.is_staff or editor.user.is_superuser
+    if enough_edits_and_valid or user_staff_or_superuser:
         return True
     else:
         return False

--- a/TWLight/users/management/commands/user_update_eligibility.py
+++ b/TWLight/users/management/commands/user_update_eligibility.py
@@ -40,6 +40,7 @@ class Command(BaseCommand):
         if options["datetime"]:
             wp_editcount_updated = datetime.fromisoformat(options["datetime"])
 
+        # Getting all editors that are currently eligible or are staff or are superusers
         editors = Editor.objects.filter(wp_bundle_eligible=True)
         for editor in editors:
             if options["global_userinfo"]:
@@ -49,7 +50,12 @@ class Command(BaseCommand):
                     editor.wp_username, editor.wp_sub, True
                 )
             if global_userinfo:
-                editor.wp_editcount_prev_updated, editor.wp_editcount_prev, editor.wp_editcount_recent, editor.wp_enough_recent_edits = editor_recent_edits(
+                (
+                    editor.wp_editcount_prev_updated,
+                    editor.wp_editcount_prev,
+                    editor.wp_editcount_recent,
+                    editor.wp_enough_recent_edits,
+                ) = editor_recent_edits(
                     global_userinfo["editcount"],
                     editor.wp_editcount_updated,
                     editor.wp_editcount_prev_updated,
@@ -69,9 +75,8 @@ class Command(BaseCommand):
                     editor.wp_not_blocked,
                     editor.ignore_wp_blocks,
                 )
-                editor.wp_bundle_eligible = editor_bundle_eligible(
-                    editor.wp_valid, editor.wp_enough_recent_edits
-                )
+                editor.wp_bundle_eligible = editor_bundle_eligible(editor)
+
                 editor.save()
 
                 editor.update_bundle_authorization()

--- a/TWLight/users/migrations/0061_make_staff_superusers_wp_eligible.py
+++ b/TWLight/users/migrations/0061_make_staff_superusers_wp_eligible.py
@@ -1,0 +1,16 @@
+from django.db import migrations
+
+
+def turn_staff_superusers_bundle_eligible(apps, schema_editor):
+    Editor = apps.get_model("users", "Editor")
+    for editor in Editor.objects.all():
+        if editor.user.is_staff or editor.user.is_superuser:
+            editor.wp_bundle_eligible = True
+            editor.save()
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [("users", "0060_auto_20200804_1634")]
+
+    operations = [migrations.RunPython(turn_staff_superusers_bundle_eligible)]

--- a/TWLight/users/models.py
+++ b/TWLight/users/models.py
@@ -455,9 +455,9 @@ class Editor(models.Model):
             self.wp_not_blocked,
             self.ignore_wp_blocks,
         )
-        self.wp_bundle_eligible = editor_bundle_eligible(
-            self.wp_valid, self.wp_enough_recent_edits
-        )
+
+        self.wp_bundle_eligible = editor_bundle_eligible(self)
+
         self.save()
 
         self.update_bundle_authorization()


### PR DESCRIPTION
[//]: # (Thank you for uploading a PR to the Wikipedia Library!)

## Description
Added the ability for all Wikipedia Library staff to access the Library Bundle from the management command `user_update_eligibility`.

## Rationale
[//]: # (Why is this change required? What problem does it solve?)
Since Wikipedia Library staff need to test the application's functionality, it is crucial that they have access to the library bundle so they can test it.

## Phabricator Ticket
[//]: # (Link to the Phabricator ticket)
[T252429](https://phabricator.wikimedia.org/T252429)

## How Has This Been Tested?
[//]: # (- Did you add tests to your changes? Did you modify tests to accommodate your changes?)
[//]: # (- Can this change be tested manually? How?)
Automatic tests have been added.

## Screenshots of your changes (if appropriate):
[//]: # (It can also be a GIF to prove that your changes are working)
N/A

## Types of changes
What types of changes does your code introduce? Add an `x` in all the boxes that apply:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
