### PR TITLE
 Refactor editor_global_userinfo

### DIFF
--- a/TWLight/users/helpers/editor_data.py
+++ b/TWLight/users/helpers/editor_data.py
@@ -58,7 +58,7 @@ def editor_global_userinfo(
             assert wp_sub == global_userinfo["id"]
     except (KeyError, AssertionError):
         global_userinfo = None
-        logger.exception("Could not fetch global_userinfo for User.")
+        logger.exception(f"Could not fetch global_userinfo for User {guiuser}")
     return global_userinfo
 
 

--- a/TWLight/users/helpers/editor_data.py
+++ b/TWLight/users/helpers/editor_data.py
@@ -13,11 +13,42 @@ def editor_global_userinfo(
     wp_username: str, wp_sub: typing.Optional[int], strict: bool
 ):
     guiuser = urllib.parse.quote(wp_username)
-    query = "{endpoint}?action=query&meta=globaluserinfo&guiuser={guiuser}&guiprop=editcount|merged&format=json&formatversion=2".format(
-        endpoint=settings.TWLIGHT_API_PROVIDER_ENDPOINT, guiuser=guiuser
-    )
-    results = json.loads(urllib.request.urlopen(query).read())
+    # Trying to get global user info with the username
+    results = _get_user_info_request("guiuser", guiuser)
+
+    try:
+        global_userinfo = results["query"]["globaluserinfo"]
+        # If the user isn't found global_userinfo contains the empty key "missing"
+        if "missing" in global_userinfo:
+            # querying again, this time using wp_sub
+            results = _get_user_info_request("guiid", wp_sub)
+            global_userinfo = results["query"]["globaluserinfo"]
+        if strict:
+            # Verify that the numerical account ID matches, not just the user's handle.
+            assert isinstance(wp_sub, int)
+            assert wp_sub == global_userinfo["id"]
+    except (KeyError, AssertionError):
+        global_userinfo = None
+        logger.exception(f"Could not fetch global_userinfo for User {guiuser}")
+    return global_userinfo
+
+
+def _get_user_info_request(wp_param_name, wp_param):
     """
+    This function queries the mediawiki api to get users' Wikipedia information
+
+    Parameters
+    ----------
+    wp_param_name : str
+        The name of the parameter we want to query by. Can be guiuser or guiid
+    wp_param : str
+        The value of that parameter we want to query by wp_username or wp_sub.
+
+    Returns
+    -------
+    dict
+        A dictionary like the one below or a dictionary with a "missing" key
+
     Expected data:
     {
     "batchcomplete": true,
@@ -47,19 +78,11 @@ def editor_global_userinfo(
      }
     }
     """
-
-    try:
-        global_userinfo = results["query"]["globaluserinfo"]
-        # If the user isn't found global_userinfo contains the empty key "missing"
-        assert "missing" not in global_userinfo
-        if strict:
-            # Verify that the numerical account ID matches, not just the user's handle.
-            assert isinstance(wp_sub, int)
-            assert wp_sub == global_userinfo["id"]
-    except (KeyError, AssertionError):
-        global_userinfo = None
-        logger.exception(f"Could not fetch global_userinfo for User {guiuser}")
-    return global_userinfo
+    endpoint = settings.TWLIGHT_API_PROVIDER_ENDPOINT
+    query = "{endpoint}?action=query&meta=globaluserinfo&{wp_param_name}={wp_param}&guiprop=editcount|merged&format=json&formatversion=2".format(
+        endpoint=endpoint, wp_param_name=wp_param_name, wp_param=wp_param
+    )
+    return json.loads(urllib.request.urlopen(query).read())
 
 
 def editor_reg_date(identity, global_userinfo):


### PR DESCRIPTION
[//]: # (Thank you for uploading a PR to the Wikipedia Library!)

## Description
Describe your changes in detail following the [commit message guidelines](https://www.mediawiki.org/wiki/Gerrit/Commit_message_guidelines)
Refactor editor_global_userinfo so that it also queries by wp_sub when the query by username does not return a user's information.

Add the username to the message when a user is not found.

## Rationale
[//]: # (Why is this change required? What problem does it solve?)
If a Wikipedia user changes their username, whenever the Wikipedia Library queries for that user with their old username, the user is never found. By adding a query of the user by their id, we can guarantee a user is returned. The only way a user is not returned is if that account has been deleted. 

## Phabricator Ticket
[//]: # (Link to the Phabricator ticket)
[T258613](https://phabricator.wikimedia.org/T258613)

## How Has This Been Tested?
[//]: # (- Did you add tests to your changes? Did you modify tests to accommodate your changes?)
[//]: # (- Can this change be tested manually? How?)
Since this function is run whenever a user logs in, I tried logging in and out with different accounts. There are also tests that cover this function. 

## Screenshots of your changes (if appropriate):
[//]: # (It can also be a GIF to prove that your changes are working)
N/A

## Types of changes
What types of changes does your code introduce? Add an `x` in all the boxes that apply:
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
