### PR TITLE
Delete bundle authorizations when users delete their data

### DIFF
--- a/TWLight/users/migrations/0062_delete_hanging_userless_bundle_auths.py
+++ b/TWLight/users/migrations/0062_delete_hanging_userless_bundle_auths.py
@@ -1,0 +1,16 @@
+from django.db import migrations
+
+
+def delete_hanging_bundle_auths(apps, schema_editor):
+    Authorization = apps.get_model("users", "Authorization")
+    Authorization.objects.filter(
+        user=None,
+        partners__authorization_method=3,  # using the actual number of Partner.BUNDLE
+    ).distinct()  # distinct() required because partners__authorization_method is ManyToMany
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [("users", "0061_make_staff_superusers_wp_eligible")]
+
+    operations = [migrations.RunPython(delete_hanging_bundle_auths)]

--- a/TWLight/users/views.py
+++ b/TWLight/users/views.py
@@ -562,6 +562,11 @@ class DeleteDataView(SelfOnly, DeleteView):
             user_authorization.date_expires = date.today() - timedelta(days=1)
             user_authorization.save()
 
+        # Delete any bundle authorizations.
+        bundle_auths = user.editor.get_bundle_authorization
+        if bundle_auths:
+            bundle_auths.delete()
+
         # Did the user authorize any authorizations?
         # If so, we need to retain their validity by shifting
         # the authorizer to TWL Team


### PR DESCRIPTION
[//]: # (Thank you for uploading a PR to the Wikipedia Library!)

## Description
Bundle authorizations were not being deleted when a user deleted their data. This caused authorizations to be without an attached user.

## Rationale
[//]: # (Why is this change required? What problem does it solve?)
A bundle authorization without an attached user is of no use in the database, so it would be best if we deleted it.

## Phabricator Ticket
[//]: # (Link to the Phabricator ticket)
[T258380](https://phabricator.wikimedia.org/T258380)

## How Has This Been Tested?
[//]: # (- Did you add tests to your changes? Did you modify tests to accommodate your changes?)
[//]: # (- Can this change be tested manually? How?)
Added a unit test

## Screenshots of your changes (if appropriate):
[//]: # (It can also be a GIF to prove that your changes are working)

## Types of changes
What types of changes does your code introduce? Add an `x` in all the boxes that apply:
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
