### PR TITLE
Flag renewals on Send to partners page

### DIFF
--- a/TWLight/applications/templates/applications/send_partner.html
+++ b/TWLight/applications/templates/applications/send_partner.html
@@ -130,7 +130,16 @@
                   </div>
                   <div class="media-body">
                   <label for="app_{{ app.pk }}">
-                    <h4 class="media-heading">{{ app }}</h4>
+                    <h4 class="media-heading">{{ app }}
+                
+                    <!--Flag renewals on Send to partners page-->                    
+                    {% if app.parent %}
+                    <span class="label label-info">
+                      {% comment %}Translators: Displayed if an application is a renewal.{% endcomment %}
+                      {% trans "Renewal" %}
+                    </span>
+                  {% endif %}</h4>
+                  
                     <ul class="list-unstyled pull-left">
                       {% for key, send_data in output.items %}
                         <li><strong>{{ send_data.label }}</strong> &mdash; {{ send_data.data }}</li>


### PR DESCRIPTION
[//]: # (Thank you for uploading a PR to the Wikipedia Library!)

## Description
Add (renewal) if app.parent is True in send_partner.html

## Rationale
Applications which are renewal requests are currently flagged in the Review interface, but not the 'Send to partners' interface. There are some partners for which renewals are processed differently from new accounts, so seeing the renewal flag on the Send page would be helpful.

## Phabricator Ticket
[Phabricator Ticket](https://phabricator.wikimedia.org/T240092)


## How Has This Been Tested?
[//]: # (- Did you add tests to your changes? Did you modify tests to accommodate your changes?)
I have tested the changes manually and it is working as expected.

[//]: # (- Can this change be tested manually? How?)

I have tested the changes by running the example data scripts by which I was able to get a superuser account locally to see the pages and then I edited application's status and it showed me renewal, written on the application name, where it was required.

## Screenshots of your changes (if appropriate):
[Screenshot](https://lab.gdy.club/~saloni/Renewal.png)


## Types of changes
What types of changes does your code introduce? Add an `x` in all the boxes that apply:
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
