### PR TITLE
Add condition to check user is current coordinator

### DIFF
--- a/TWLight/emails/tasks.py
+++ b/TWLight/emails/tasks.py
@@ -241,6 +241,7 @@ def send_comment_notification_emails(sender, **kwargs):
     app_versions = Version.objects.get_for_object(app)
 
     # 'First' app version is the most recent
+
     recent_app_coordinator = app_versions.first().revision.user
     if recent_app_coordinator and recent_app_coordinator != current_comment.user:
         if recent_app_coordinator != app.partner.coordinator and not (

--- a/TWLight/emails/tests.py
+++ b/TWLight/emails/tests.py
@@ -180,6 +180,7 @@ class ApplicationCommentTest(TestCase):
 
     def test_comment_email_sending_6(self):
         """
+
         In case the coordinator is changed for a Partner, then the 
         previous coordinator should not receive comment notification email.
         Also now the new coordinator should receive the email.


### PR DESCRIPTION
## Description
We should do a check before sending a comment notification email that the coordinator we're about to email is also the current coordinator of the partner.

## Phabricator Ticket
[T226369](https://phabricator.wikimedia.org/T226369)

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
