### PR TITLE
Restrict access to users that have not accepted terms of use

### DIFF
--- a/TWLight/resources/templates/resources/partner_detail.html
+++ b/TWLight/resources/templates/resources/partner_detail.html
@@ -476,7 +476,7 @@
           {% else %}
             <div class="panel-body top-border">
               {% if user.is_authenticated %}
-                {% if user.editor.wp_bundle_eligible and user.userprofile.terms_of_use %}
+                {% if user.editor.wp_bundle_eligible %}
                   {% if partner.specific_stream %}
                     {% comment %}Translators: This text labels a button taking users to their library. {% endcomment %}
                     <a class="btn btn-primary btn-lg btn-block" href="{% url "users:my_library" %}">{% trans "My Library" %}</a><br />

--- a/TWLight/resources/templates/resources/partner_detail.html
+++ b/TWLight/resources/templates/resources/partner_detail.html
@@ -136,7 +136,7 @@
                   </p>
                 {% endif %}
               </div>
-            </div>      
+            </div>
           </li>
           {% if object.videos.all %}
             <li class="timeline-inverted">
@@ -476,7 +476,7 @@
           {% else %}
             <div class="panel-body top-border">
               {% if user.is_authenticated %}
-                {% if user.editor.wp_bundle_eligible %}
+                {% if user.editor.wp_bundle_eligible and user.userprofile.terms_of_use %}
                   {% if partner.specific_stream %}
                     {% comment %}Translators: This text labels a button taking users to their library. {% endcomment %}
                     <a class="btn btn-primary btn-lg btn-block" href="{% url "users:my_library" %}">{% trans "My Library" %}</a><br />
@@ -542,7 +542,7 @@
       </div>
     </div>
   </div>
-  
+
 
 {% comment %}
   other stuff to do:

--- a/TWLight/resources/views.py
+++ b/TWLight/resources/views.py
@@ -146,7 +146,13 @@ class PartnersDetailView(DetailView):
                     # but link to collection page
                     if not partner.specific_title:
                         context["apply"] = False
-                    context["has_auths"] = True
+                    # User fulfills initial authorization
+                    fulfills_auth = True
+                    # Checking if user has agreed to terms and conditions, otherwise
+                    # they shouldn't be authorized to access the collection
+                    user_agreed_terms = user.userprofile.terms_of_use
+                    final_auth = fulfills_auth and user_agreed_terms
+                    context["has_auths"] = final_auth
                 except Authorization.DoesNotExist:
                     pass
                 except Authorization.MultipleObjectsReturned:
@@ -171,7 +177,13 @@ class PartnersDetailView(DetailView):
                     # User has correct number of auths, don't show 'apply',
                     # but link to collection page
                     context["apply"] = False
-                    context["has_auths"] = True
+                    # User fulfills initial authorization
+                    fulfills_auth = True
+                    # Checking if user has agreed to terms and conditions, otherwise
+                    # they shouldn't be authorized to access the collection
+                    user_agreed_terms = user.userprofile.terms_of_use
+                    final_auth = fulfills_auth and user_agreed_terms
+                    context["has_auths"] = final_auth
                     if apps.count() > 0:
                         # User has open apps, link to apps page
                         context["has_open_apps"] = True
@@ -182,8 +194,14 @@ class PartnersDetailView(DetailView):
                         if each_authorization.stream in partner_streams:
                             auth_streams.append(each_authorization.stream)
                     if auth_streams:
+                        # User fulfills initial authorization
+                        fulfills_auth = True
+                        # Checking if user has agreed to terms and conditions, otherwise
+                        # they shouldn't be authorized to access the collection
+                        user_agreed_terms = user.userprofile.terms_of_use
+                        final_auth = fulfills_auth and user_agreed_terms
                         # User has authorizations, link to collection page
-                        context["has_auths"] = True
+                        context["has_auths"] = final_auth
                     no_auth_streams = partner_streams.exclude(
                         name__in=auth_streams
                     )  # streams with no corresponding authorizations – we'll want to know if these have apps

--- a/TWLight/users/helpers/editor_data.py
+++ b/TWLight/users/helpers/editor_data.py
@@ -188,7 +188,9 @@ def editor_bundle_eligible(editor):
     enough_edits_and_valid = editor.wp_valid and editor.wp_enough_recent_edits
     # Staff and superusers should be eligible for bundles for testing purposes
     user_staff_or_superuser = editor.user.is_staff or editor.user.is_superuser
-    if enough_edits_and_valid or user_staff_or_superuser:
+    # Users must accept the terms of use in order to be eligible for bundle access
+    user_accepted_terms = editor.user.userprofile.terms_of_use
+    if (enough_edits_and_valid or user_staff_or_superuser) and user_accepted_terms:
         return True
     else:
         return False

--- a/TWLight/users/migrations/0063_check_terms_and_bundle_eligibility.py
+++ b/TWLight/users/migrations/0063_check_terms_and_bundle_eligibility.py
@@ -1,0 +1,20 @@
+from django.db import migrations
+
+
+def remove_bundle_eligibility_on_users_with_unaccepted_terms(apps, schema_editor):
+    Editor = apps.get_model("users", "Editor")
+    for editor in Editor.objects.all():
+        # If a user has not accepted the terms of use and has bundle eligibility,
+        # remove the eligibility until user accepts the terms of use
+        if not editor.user.userprofile.terms_of_use and editor.wp_bundle_eligible:
+            editor.wp_bundle_eligible = False
+            editor.save()
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [("users", "0062_delete_hanging_userless_bundle_auths")]
+
+    operations = [
+        migrations.RunPython(remove_bundle_eligibility_on_users_with_unaccepted_terms)
+    ]

--- a/TWLight/users/views.py
+++ b/TWLight/users/views.py
@@ -33,6 +33,7 @@ from TWLight.view_mixins import (
 )
 from TWLight.users.groups import get_coordinators, get_restricted
 from TWLight.users.helpers.authorizations import get_valid_partner_authorizations
+from TWLight.users.helpers.editor_data import editor_bundle_eligible
 
 from rest_framework import status
 from rest_framework.authentication import TokenAuthentication
@@ -638,6 +639,13 @@ class TermsView(UpdateView):
         return kwargs
 
     def get_success_url(self):
+
+        # Check if user is still eligible for bundle based on if they agreed to
+        # the terms of use or not
+        self.request.user.editor.wp_bundle_eligible = editor_bundle_eligible(
+            self.request.user.editor
+        )
+        self.request.user.editor.save()
 
         if self.get_object().terms_of_use:
             # If they agreed with the terms, awesome. Send them where they were


### PR DESCRIPTION
[//]: # (Thank you for uploading a PR to the Wikipedia Library!)

## Description
Describe your changes in detail following the [commit message guidelines](https://www.mediawiki.org/wiki/Gerrit/Commit_message_guidelines)
Added a condition to check if a user has agreed to the terms of service in order to get any access to the library's collections.

## Rationale
[//]: # (Why is this change required? What problem does it solve?)
The button for an individual partner is not greyed-out when a user has not accepted the terms of service, which shouldn't be happening. 

## Phabricator Ticket
[//]: # (Link to the Phabricator ticket)
[T260229](https://phabricator.wikimedia.org/T260229)

## How Has This Been Tested?
[//]: # (- Did you add tests to your changes? Did you modify tests to accommodate your changes?)
[//]: # (- Can this change be tested manually? How?)
A test was added to check the correct functionality of the `user_update_eligibility` management command and made manual tests to check that access is being granted or denied based on acceptance of the terms of use.

### Manual test instructions:

Manual test 1:
1. If a user is bundle eligible, has agreed to the terms of use, and is logged in, they should be able to access the collections. 
2. Go to the terms of use page and opt-out of the terms.
3. Navigate to the bundle library. Buttons should be greyed-out.
4. Click on one of the bundle partners. The `Access Collection` button should be greyed-out. 
5. Go to the terms of use page and accept the terms again. 
6. User should have access to bundle items again

Manual test 2:
1. If a user is bundle eligible, has agreed to the terms of use, and is logged in, they should be able to access the collections. 
2. Go to the terms of use page and opt-out of the terms.
3. Log out of your session.
4. Log back in and, without agreeing to the terms of service, navigate to the library bundle page. 
5. User should see library bundle permission is expired.
6. Go to the terms of use page and accept the terms again. 
7. Log out and log back in. User should again have access to the library bundle collections.

## Screenshots of your changes (if appropriate):
[//]: # (It can also be a GIF to prove that your changes are working)

### User is bundle eligible and has agreed to the terms of use
![Screen Shot 2020-08-13 at 19 19 01](https://user-images.githubusercontent.com/7854953/90199706-247c0b80-dd9b-11ea-82c3-6ceb12bc4588.png)

![Screen Shot 2020-08-13 at 19 19 15](https://user-images.githubusercontent.com/7854953/90199735-3362be00-dd9b-11ea-9cdb-7a3a80842087.png)


### User is bundle eligible but has not agreed to the terms of use
![Screen Shot 2020-08-13 at 19 19 42](https://user-images.githubusercontent.com/7854953/90199757-437a9d80-dd9b-11ea-968e-f8ee728a1979.png)

![Screen Shot 2020-08-13 at 19 19 51](https://user-images.githubusercontent.com/7854953/90199769-483f5180-dd9b-11ea-9a70-76cf56b0c242.png)

### User is bundle eligible, has not agreed to the terms of use, logged out and logged back in
![Screen Shot 2020-08-13 at 19 21 05](https://user-images.githubusercontent.com/7854953/90199824-5f7e3f00-dd9b-11ea-8c13-335fe34d8084.png)

## Types of changes
What types of changes does your code introduce? Add an `x` in all the boxes that apply:
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
