### PR TITLE
Update About page text to clarify Library Bundle requirements

### DIFF
--- a/TWLight/templates/about.html
+++ b/TWLight/templates/about.html
@@ -60,7 +60,7 @@
       </li>
       <li>
         {% comment %}Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/). {% endcomment %}
-        {% trans "You have made a minimum of 500 edits" %}
+        {% trans "You have made a minimum of 500 edits to Wikimedia projects" %}
       </li>
       <li>
         {% comment %}Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/). {% endcomment %}


### PR DESCRIPTION
[//]: # (Thank you for uploading a PR to the Wikipedia Library!)

## Description
I have updated About page text to clarify Library Bundle requirements by replacing one of the requirements as "You have made a minimum of 500 edits" with "You have made a minimum of 500 edits to Wikimedia projects".

## Rationale
On the About page ([https://wikipedialibrary.wmflabs.org/about/](https://wikipedialibrary.wmflabs.org/about/)) we write one of the requirements as "You have made a minimum of 500 edits". This was confusing to at least one user, since it doesn't match directly with "You have made at least 10 edits to Wikimedia projects in the last month". We should add "to Wikimedia projects to the former.

## Phabricator Ticket
[Phabricator Ticket](https://phabricator.wikimedia.org/T261605)

## How Has This Been Tested?
I have tested the changes manually by running the project on localhost and it is working as expected.

## Screenshots of your changes (if appropriate):
[Screenshot](https://gist.github.com/saloniig/ad4b5d75c82df336b37e18640d730637)

## Types of changes
What types of changes does your code introduce? Add an `x` in all the boxes that apply:
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
