### PR TITLE
Show proposer name on suggestion page

### DIFF
--- a/TWLight/resources/templates/resources/suggest.html
+++ b/TWLight/resources/templates/resources/suggest.html
@@ -119,4 +119,7 @@
       $.get(upvoteURL);
     });
   </script>
+  <script>
+    function viewUpvoters(e,suggestion,box){}
+  </script>
 {% endblock javascript %}

--- a/TWLight/resources/templates/resources/suggest.html
+++ b/TWLight/resources/templates/resources/suggest.html
@@ -64,7 +64,7 @@
                 </p>
                 {% comment %}Translators: This is the text that appears before the URL of every partner suggestion. {% endcomment %}
                 <p><strong>{% trans 'URL' %}:</strong> <a href="{{ each_suggestion.company_url }}">{{ each_suggestion.company_url }}</a></p>
-                <p><strong>{% trans 'Proposer' %}:</strong><a href="{{each_suggestion.author.wp_link_central_auth}}">{{each_suggestion.author}}</a></p>
+                <p><strong>{% trans 'Proposer' %}:</strong> <a href="{{ each_suggestion.author.editor.wp_link_central_auth }}">{{ each_suggestion.author.editor.wp_username }}</a></p>
               </div>
               {% if user.is_authenticated %}
                 <div class="col-md-2 pull-right" style="text-align: right;">

--- a/TWLight/resources/templates/resources/suggest.html
+++ b/TWLight/resources/templates/resources/suggest.html
@@ -64,6 +64,7 @@
                 </p>
                 {% comment %}Translators: This is the text that appears before the URL of every partner suggestion. {% endcomment %}
                 <p><strong>{% trans 'URL' %}:</strong> <a href="{{ each_suggestion.company_url }}">{{ each_suggestion.company_url }}</a></p>
+                <p><strong>{% trans 'Proposer' %}:</strong><a href="{{each_suggestion.author.wp_link_central_auth}}">{{each_suggestion.author}}</a></p>
               </div>
               {% if user.is_authenticated %}
                 <div class="col-md-2 pull-right" style="text-align: right;">
@@ -80,7 +81,7 @@
                     </span>
                     <span class="count badge">{{ each_suggestion.upvoted_users.count }}</span>
                   </a>
-                </div>
+                </div>           
               {% endif %}
             </div>
           </div>


### PR DESCRIPTION
[//]: # (Thank you for uploading a PR to the Wikipedia Library!)

## Description
Added proposer name.

The suggest page now shows the user name of the proposer of each suggested partner.
It also links to the user's CentralAuth page via user.wp_link_central_auth.
## Rationale
[//]: # (Why is this change required? What problem does it solve?)
## Phabricator Ticket
[//]: # (Link to the Phabricator ticket)
https://phabricator.wikimedia.org/T218849
## How Has This Been Tested?
[//]: # (- Did you add tests to your changes? Did you modify tests to accommodate your changes?)
[//]: # (- Can this change be tested manually? How?)
Tested offline with the sample data.

## Screenshots of your changes (if appropriate):
[//]: # (It can also be a GIF to prove that your changes are working)
![image](https://user-images.githubusercontent.com/53284888/93362730-f68b5a80-f863-11ea-9b59-e6187873e7f9.png)


## Types of changes
What types of changes does your code introduce? Add an `x` in all the boxes that apply:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
