### PR TITLE
Show recently filed applications and their date

### DIFF
--- a/TWLight/applications/templates/applications/application_evaluation.html
+++ b/TWLight/applications/templates/applications/application_evaluation.html
@@ -218,25 +218,46 @@
     {% endif %}    
   </div>
 
-  {% comment %}Translators: This is the title of the section of an application page which contains the Recent Applications made by the applicant{% endcomment %}
-  <h2>{% trans 'Recent Applications' %}</h2>
+  {% comment %}Translators: This is the title of the section of an application page which contains the Recent Applications made by the applicant in the last 90 days.{% endcomment %}
+  <h2>{% trans 'Recent Applications (last 90 days)' %}</h2>
   
-  <div class="row">
-    {% for app in recent_apps %}
-      <div class="col-xs-12 col-sm-4">
-        {% if app.partner.coordinator == request.user or app.partner.coordinator == app.editor.user %}
-          <a href="{{ app.get_absolute_url }}">
-            <strong>{{ app.partner }}</strong>
-          </a>
-        {% else %}
-          <strong>{{ app.partner }}</strong>
-        {% endif %}
-      </div>
-      <div class="col-xs-12 col-sm-8">
-        <span class="label label{{ app.get_bootstrap_class }} label-lg">{{ app.get_status_display }}</span>
-      </div>
-    {% endfor %}
-  </div>
+  {% if recent_apps|length > 0 %}
+    <div class="table-responsive">
+      <table class="table table-hover">
+        <thead>
+          <tr>
+            <th scope="col">Partner</th>
+            <th scope="col">Status</th>
+            <th scope="col">Date Created</th>
+          </tr>
+        </thead>
+        <tbody>
+          {% for app in recent_apps %}
+          <tr>
+            <td>
+              {% if app.partner.coordinator == request.user or app.partner.coordinator == app.editor.user %}
+              <a href="{{ app.get_absolute_url }}">
+                <strong>{{ app.partner }}</strong>
+              </a>
+              {% else %}
+                <strong>{{ app.partner }}</strong>
+              {% endif %}
+            </td>
+            <td>
+              <span class="label label{{ app.get_bootstrap_class }} label-lg">{{ app.get_status_display }}</span>
+            </td>
+            <td>
+              <span>{{ app.date_created }}</span>
+            </td>
+          </tr>
+          {% endfor %}
+        </tbody>
+      </table>
+    </div>
+  {% else %}
+    {% comment %}Translators: This text is shown to Coordinators when applicant has not made any application in the last 90 days. {% endcomment %}
+    <i>{% trans "No applications were made in last 90 days by the applicant" %}</i>
+{% endif %}
 
   {% comment %}Translators: This is the title of the section of an application page which contains the comment thread between the user and account coordinator.{% endcomment %}
   <h2>{% trans 'Discussion' %}</h2>

--- a/TWLight/applications/views.py
+++ b/TWLight/applications/views.py
@@ -9,6 +9,7 @@ import urllib.error
 import urllib.parse
 import urllib.request
 from urllib.parse import urlparse
+from datetime import datetime, timedelta
 
 import bleach
 from crispy_forms.helper import FormHelper
@@ -960,12 +961,17 @@ class EvaluateApplicationView(
         if app.parent and existing_authorization:
             context["previous_auth_expiry_date"] = existing_authorization.date_expires
 
-        # Get 5 recent applications
+        # Add recent applications in context
+        # get applications opened by editor in last 3 months
         # also exclude current app if it is present in recent apps
+
         recent_apps = (
-            Application.objects.filter(editor=self.object.editor)
+            Application.objects.filter(
+                editor=self.object.editor,
+                date_created__gte=datetime.today() - timedelta(days=90),
+            )
             .exclude(pk=app.pk)
-            .order_by("-id")[:5]
+            .order_by("-id")
         )
         context["recent_apps"] = recent_apps
 


### PR DESCRIPTION
## Description
Show all applications filed in last 3 months and their submission date, on application evaluation page.

## Rationale
Before this we used to show 5 recent applications on evaluation page. But we need to display more applications on that page so coordinators can decide if a user is applying indiscriminately.

## Phabricator Ticket
[T262904](https://phabricator.wikimedia.org/T262904)

## How Has This Been Tested?
I have added 2 new tests for this behaviour. Also removed a test which was previously used to test rendering of 5 recent applications only.
This change can be tested manually by going on application evaluation page and checking recent applications section.

## Screenshots of your changes:
![Screen Shot 2020-09-18 at 6 31 53 PM](https://user-images.githubusercontent.com/31045288/93601662-24e17500-f9df-11ea-8a9e-e032bd80d55e.png)

## Types of changes
What types of changes does your code introduce? Add an `x` in all the boxes that apply:
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
