### PR TITLE
Anchored the Library bundle 'Learn More' button to the Library Bundle…

### DIFF
--- a/TWLight/templates/about.html
+++ b/TWLight/templates/about.html
@@ -165,7 +165,7 @@
     {% endblocktrans %}
   </p>
 
-  <h3>Library Bundle</h3>
+  <h3 id="anchor">Library Bundle</h3>
 
   <p>
     {% comment %}Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/) {% endcomment %}

--- a/TWLight/templates/home.html
+++ b/TWLight/templates/home.html
@@ -1,3 +1,4 @@
+{#need to edit line 90 for about#}
 {% extends "base.html" %}
 {% load static %}
 {% load i18n %}
@@ -87,7 +88,8 @@
           </div>
         {% else %}
 				  {% comment %}Translators: On the main page of the website (https://wikipedialibrary.wmflabs.org/), the 'Learn more' button takes users to the 'About' page. {% endcomment %}
-          <a href="{% url 'about' %}" class="btn btn-default btn-block read-more">{% trans "Learn more" %} </a>
+          <a href="{% url 'about' %}#anchor" class="btn btn-default btn-block read-more">{% trans "Learn more" %} </a>
+{#          need to edit this#}
         {% endif %}
       </div>
 	  </div>


### PR DESCRIPTION
… section of the About page

[//]: # (Thank you for uploading a PR to the Wikipedia Library!)

## Description
When a user was clicking on the Learn More button in the Library Bundle information box, instead of taking to that section it used to take it to about page only. SO I wrote the code so it will navigate to the Library bundle section on the About page.


## Phabricator Ticket
[//]: #  https://phabricator.wikimedia.org/T252511



## Types of changes
What types of changes does your code introduce? Add an `x` in all the boxes that apply:
- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
