### PR TITLE
Added a withdraw button which withdraw/delete the application 

### DIFF
--- a/TWLight/users/templates/users/my_applications.html
+++ b/TWLight/users/templates/users/my_applications.html
@@ -58,7 +58,7 @@
           {% trans 'Not yet reviewed.' %}
         {% endif %}
         <br />
-        <form action="{% url 'users:my_deletion' user.editor.pk app.pk%}" class="m-2" method="post">
+        <form action="{% url 'users:withdraw' user.editor.pk app.pk%}" class="m-2" method="post">
         {% csrf_token %}
         <input type="submit" value="Withdraw" class="btn btn-danger btn-sm">
         </form>

--- a/TWLight/users/templates/users/my_applications.html
+++ b/TWLight/users/templates/users/my_applications.html
@@ -3,89 +3,101 @@
 {% load l10n %}
 
 {% block content %}
-  {% comment %}Translators: Heading of the applications page where users can view all of their applications listed with other relevant info.{% endcomment %}
-  <h3 class="inline-header">{% trans 'My applications' %}</h3>
-    <a href="{% url 'users:my_library' %}" class="btn btn-default pull-right">
-    {% comment %}Translators: A button on the 'your applications' page which when clicked takes users their collection page.{% endcomment %}
-    {% trans "My Library" %}
-  </a>
-  <div class="clearfix"></div>
-  {% for app in object_list %}
-    <div class="row">
-      <div class="col-sm-2 hidden-xs">
-        <span class="label label{{ app.get_bootstrap_class }} pull-right">
-          {% if app.parent %}
-            Renewal -
-          {% endif %}
-          {{ app.get_status_display }}
-        </span>
-      </div>
-      <div class="col-xs-8 col-sm-6">
-        <h4>
-        <a href="{{ app.get_absolute_url }}">
-          {{ app.partner }}
-          {% if app.specific_stream %}
-            ({{ app.specific_stream }})
-          {% endif %}
-        </a>
-        </h4>
-        <div class="visible-xs">
-          <span class="label label{{ app.get_bootstrap_class }}">
-            {% if app.parent %}
-              Renewal -
-            {% endif %}
-            {{ app.get_status_display }}
-          </span>
-          <br /><br />
-        </div>
-        {% if app.imported %}
-          {% comment %}Translators: On the page listing applications, this shows next to an application which was imported to the website.{% endcomment %}
-          {% trans 'Imported application' %}
-        {% elif app.get_version_count > 1 %} {# first version is original submission, not later review #}
-          {% if app.get_latest_reviewer %}
-            {% comment %}Translators: On the page listing applications, this shows next to an application which was previously reviewed. Don't translate {{ reviewer }} or {{ review_date }}.{% endcomment %}
-            {% blocktrans trimmed with reviewer=app.get_latest_reviewer review_date=app.get_latest_review_date|localize %}
-              Last reviewed by {{ reviewer }} on {{ review_date }}
-            {% endblocktrans %}
-          {% else %}
-            {% comment %}Translators: On the page listing applications, this shows next to an application which was previously reviewed. Don't translate {{ review_date }}.{% endcomment %}
-            {% blocktrans trimmed with review_date=app.get_latest_review_date|localize %}
-              Last reviewed on {{ review_date }}
-            {% endblocktrans %}
-          {% endif %}
-        {% else %}
-          {% comment %}Translators: On the page listing applications, this shows next to an application which has not yet been reviewed.{% endcomment %}
-          {% trans 'Not yet reviewed.' %}
-        {% endif %}
-        <br />
-        <form action="{% url 'users:withdraw' user.editor.pk app.pk%}" class="m-2" method="post">
-        {% csrf_token %}
-        <input type="submit" value="Withdraw" class="btn btn-danger btn-sm">
-        </form>
-      </div>
-      {% ifequal app.editor.user.pk user.pk %}
-        {% if app.status == app.SENT %}
-          <div class="col-xs-8 col-xs-offset-4 col-sm-4 col-sm-offset-0">
-            {% comment %}Translators: On the page listing applications, this text labels an area where users can either request for renewals, or be shown a message of why they cannot renew.{% endcomment %}
-            <strong>{% trans "Has your account expired?" %}</strong> <br />
-            {% if app.is_renewable %}
-              {% comment %}Translators: On the page listing applications, this text labels a link which users can click to request a renewal of their application.{% endcomment %}
-              <a class="btn btn-default btn-sm" href="{% url 'applications:renew' app.pk %}">{% trans "Request renewal" %}</a>
-            {% else %}
-              {% comment %}Translators: On the page listing applications, this text explains a user they cannot renew their application since they've already requested a renewal or there aren't any renewals available.{% endcomment %}
-              <em>{% trans "Renewals are either not required, not available right now, or you have already requested a renewal." %}</em>
-            {% endif %}
-          </div>
-        {% endif %}
-      {% endifequal %}
-      {% if not forloop.last %}
-        <div class="col-sm-10 col-sm-offset-2 col-xs-12">
-          <hr />
-        </div>
+{% comment %}Translators: Heading of the applications page where users can view all of their applications listed with
+other relevant info.{% endcomment %}
+<h3 class="inline-header">{% trans 'My applications' %}</h3>
+<a href="{% url 'users:my_library' %}" class="btn btn-default pull-right">
+  {% comment %}Translators: A button on the 'your applications' page which when clicked takes users their collection
+  page.{% endcomment %}
+  {% trans "My Library" %}
+</a>
+<div class="clearfix"></div>
+{% for app in object_list %}
+<div class="row">
+  <div class="col-sm-2 hidden-xs">
+    <span class="label label{{ app.get_bootstrap_class }} pull-right">
+      {% if app.parent %}
+      Renewal -
       {% endif %}
+      {{ app.get_status_display }}
+    </span>
+  </div>
+  <div class="col-xs-8 col-sm-6">
+    <h4>
+      <a href="{{ app.get_absolute_url }}">
+        {{ app.partner }}
+        {% if app.specific_stream %}
+        ({{ app.specific_stream }})
+        {% endif %}
+      </a>
+    </h4>
+    <div class="visible-xs">
+      <span class="label label{{ app.get_bootstrap_class }}">
+        {% if app.parent %}
+        Renewal -
+        {% endif %}
+        {{ app.get_status_display }}
+      </span>
+      <br /><br />
     </div>
-  {% empty %}
-    {% comment %}Translators: On the page listing applications, this text is displayed when there aren't any applications to list.{% endcomment %}
-    {% trans 'No applications right now.' %}
-  {% endfor %}
+    {% if app.imported %}
+    {% comment %}Translators: On the page listing applications, this shows next to an application which was imported to
+    the website.{% endcomment %}
+    {% trans 'Imported application' %}
+    {% elif app.get_version_count > 1 %} {# first version is original submission, not later review #}
+    {% if app.get_latest_reviewer %}
+    {% comment %}Translators: On the page listing applications, this shows next to an application which was previously
+    reviewed. Don't translate {{ reviewer }} or {{ review_date }}.{% endcomment %}
+    {% blocktrans trimmed with reviewer=app.get_latest_reviewer review_date=app.get_latest_review_date|localize %}
+    Last reviewed by {{ reviewer }} on {{ review_date }}
+    {% endblocktrans %}
+    {% else %}
+    {% comment %}Translators: On the page listing applications, this shows next to an application which was previously
+    reviewed. Don't translate {{ review_date }}.{% endcomment %}
+    {% blocktrans trimmed with review_date=app.get_latest_review_date|localize %}
+    Last reviewed on {{ review_date }}
+    {% endblocktrans %}
+    {% endif %}
+    {% else %}
+    {% comment %}Translators: On the page listing applications, this shows next to an application which has not yet been
+    reviewed.{% endcomment %}
+    {% trans 'Not yet reviewed.' %}
+    {% endif %}
+    <br />
+    {% if app.status != app.INVALID %}
+    <form action="{% url 'users:withdraw' user.editor.pk app.pk%}" class="m-2" method="post">
+      {% csrf_token %}
+      <input type="submit" value="Withdraw" class="btn btn-danger btn-sm">
+    </form>
+    {% endif %}
+  </div>
+  {% ifequal app.editor.user.pk user.pk %}
+  {% if app.status == app.SENT %}
+  <div class="col-xs-8 col-xs-offset-4 col-sm-4 col-sm-offset-0">
+    {% comment %}Translators: On the page listing applications, this text labels an area where users can either request
+    for renewals, or be shown a message of why they cannot renew.{% endcomment %}
+    <strong>{% trans "Has your account expired?" %}</strong> <br />
+    {% if app.is_renewable %}
+    {% comment %}Translators: On the page listing applications, this text labels a link which users can click to request
+    a renewal of their application.{% endcomment %}
+    <a class="btn btn-default btn-sm" href="{% url 'applications:renew' app.pk %}">{% trans "Request renewal" %}</a>
+    {% else %}
+    {% comment %}Translators: On the page listing applications, this text explains a user they cannot renew their
+    application since they've already requested a renewal or there aren't any renewals available.{% endcomment %}
+    <em>{% trans "Renewals are either not required, not available right now, or you have already requested a renewal." %}</em>
+    {% endif %}
+  </div>
+  {% endif %}
+  {% endifequal %}
+  {% if not forloop.last %}
+  <div class="col-sm-10 col-sm-offset-2 col-xs-12">
+    <hr />
+  </div>
+  {% endif %}
+</div>
+{% empty %}
+{% comment %}Translators: On the page listing applications, this text is displayed when there aren't any applications to
+list.{% endcomment %}
+{% trans 'No applications right now.' %}
+{% endfor %}
 {% endblock %}

--- a/TWLight/users/templates/users/my_applications.html
+++ b/TWLight/users/templates/users/my_applications.html
@@ -3,101 +3,91 @@
 {% load l10n %}
 
 {% block content %}
-{% comment %}Translators: Heading of the applications page where users can view all of their applications listed with
-other relevant info.{% endcomment %}
-<h3 class="inline-header">{% trans 'My applications' %}</h3>
-<a href="{% url 'users:my_library' %}" class="btn btn-default pull-right">
-  {% comment %}Translators: A button on the 'your applications' page which when clicked takes users their collection
-  page.{% endcomment %}
-  {% trans "My Library" %}
-</a>
-<div class="clearfix"></div>
-{% for app in object_list %}
-<div class="row">
-  <div class="col-sm-2 hidden-xs">
-    <span class="label label{{ app.get_bootstrap_class }} pull-right">
-      {% if app.parent %}
-      Renewal -
+  {% comment %}Translators: Heading of the applications page where users can view all of their applications listed with other relevant info.{% endcomment %}
+  <h3 class="inline-header">{% trans 'My applications' %}</h3>
+    <a href="{% url 'users:my_library' %}" class="btn btn-default pull-right">
+    {% comment %}Translators: A button on the 'your applications' page which when clicked takes users their collection page.{% endcomment %}
+    {% trans "My Library" %}
+  </a>
+  <div class="clearfix"></div>
+  {% for app in object_list %}
+    <div class="row">
+      <div class="col-sm-2 hidden-xs">
+        <span class="label label{{ app.get_bootstrap_class }} pull-right">
+          {% if app.parent %}
+            Renewal -
+          {% endif %}
+          {{ app.get_status_display }}
+        </span>
+      </div>
+      <div class="col-xs-8 col-sm-6">
+        <h4>
+        <a href="{{ app.get_absolute_url }}">
+          {{ app.partner }}
+          {% if app.specific_stream %}
+            ({{ app.specific_stream }})
+          {% endif %}
+        </a>
+        </h4>
+        <div class="visible-xs">
+          <span class="label label{{ app.get_bootstrap_class }}">
+            {% if app.parent %}
+              Renewal -
+            {% endif %}
+            {{ app.get_status_display }}
+          </span>
+          <br /><br />
+        </div>
+        {% if app.imported %}
+          {% comment %}Translators: On the page listing applications, this shows next to an application which was imported to the website.{% endcomment %}
+          {% trans 'Imported application' %}
+        {% elif app.get_version_count > 1 %} {# first version is original submission, not later review #}
+          {% if app.get_latest_reviewer %}
+            {% comment %}Translators: On the page listing applications, this shows next to an application which was previously reviewed. Don't translate {{ reviewer }} or {{ review_date }}.{% endcomment %}
+            {% blocktrans trimmed with reviewer=app.get_latest_reviewer review_date=app.get_latest_review_date|localize %}
+              Last reviewed by {{ reviewer }} on {{ review_date }}
+            {% endblocktrans %}
+          {% else %}
+            {% comment %}Translators: On the page listing applications, this shows next to an application which was previously reviewed. Don't translate {{ review_date }}.{% endcomment %}
+            {% blocktrans trimmed with review_date=app.get_latest_review_date|localize %}
+              Last reviewed on {{ review_date }}
+            {% endblocktrans %}
+          {% endif %}
+        {% else %}
+          {% comment %}Translators: On the page listing applications, this shows next to an application which has not yet been reviewed.{% endcomment %}
+          {% trans 'Not yet reviewed.' %}
+        {% endif %}
+        <br />
+        {% if app.status != app.INVALID %}
+          <form action="{% url 'users:withdraw' user.editor.pk app.pk%}" class="m-2" method="post">
+          {% csrf_token %}
+          <input type="submit" value="Withdraw" class="btn btn-danger btn-sm">
+          </form>
+        {% endif %}
+      </div>
+      {% ifequal app.editor.user.pk user.pk %}
+        {% if app.status == app.SENT %}
+          <div class="col-xs-8 col-xs-offset-4 col-sm-4 col-sm-offset-0">
+            {% comment %}Translators: On the page listing applications, this text labels an area where users can either request for renewals, or be shown a message of why they cannot renew.{% endcomment %}
+            <strong>{% trans "Has your account expired?" %}</strong> <br />
+            {% if app.is_renewable %}
+              {% comment %}Translators: On the page listing applications, this text labels a link which users can click to request a renewal of their application.{% endcomment %}
+              <a class="btn btn-default btn-sm" href="{% url 'applications:renew' app.pk %}">{% trans "Request renewal" %}</a>
+            {% else %}
+              {% comment %}Translators: On the page listing applications, this text explains a user they cannot renew their application since they've already requested a renewal or there aren't any renewals available.{% endcomment %}
+              <em>{% trans "Renewals are either not required, not available right now, or you have already requested a renewal." %}</em>
+            {% endif %}
+          </div>
+        {% endif %}
+      {% endifequal %}
+      {% if not forloop.last %}
+        <div class="col-sm-10 col-sm-offset-2 col-xs-12">
+          <hr />
+        </div>
       {% endif %}
-      {{ app.get_status_display }}
-    </span>
-  </div>
-  <div class="col-xs-8 col-sm-6">
-    <h4>
-      <a href="{{ app.get_absolute_url }}">
-        {{ app.partner }}
-        {% if app.specific_stream %}
-        ({{ app.specific_stream }})
-        {% endif %}
-      </a>
-    </h4>
-    <div class="visible-xs">
-      <span class="label label{{ app.get_bootstrap_class }}">
-        {% if app.parent %}
-        Renewal -
-        {% endif %}
-        {{ app.get_status_display }}
-      </span>
-      <br /><br />
     </div>
-    {% if app.imported %}
-    {% comment %}Translators: On the page listing applications, this shows next to an application which was imported to
-    the website.{% endcomment %}
-    {% trans 'Imported application' %}
-    {% elif app.get_version_count > 1 %} {# first version is original submission, not later review #}
-    {% if app.get_latest_reviewer %}
-    {% comment %}Translators: On the page listing applications, this shows next to an application which was previously
-    reviewed. Don't translate {{ reviewer }} or {{ review_date }}.{% endcomment %}
-    {% blocktrans trimmed with reviewer=app.get_latest_reviewer review_date=app.get_latest_review_date|localize %}
-    Last reviewed by {{ reviewer }} on {{ review_date }}
-    {% endblocktrans %}
-    {% else %}
-    {% comment %}Translators: On the page listing applications, this shows next to an application which was previously
-    reviewed. Don't translate {{ review_date }}.{% endcomment %}
-    {% blocktrans trimmed with review_date=app.get_latest_review_date|localize %}
-    Last reviewed on {{ review_date }}
-    {% endblocktrans %}
-    {% endif %}
-    {% else %}
-    {% comment %}Translators: On the page listing applications, this shows next to an application which has not yet been
-    reviewed.{% endcomment %}
-    {% trans 'Not yet reviewed.' %}
-    {% endif %}
-    <br />
-    {% if app.status != app.INVALID %}
-    <form action="{% url 'users:withdraw' user.editor.pk app.pk%}" class="m-2" method="post">
-      {% csrf_token %}
-      <input type="submit" value="Withdraw" class="btn btn-danger btn-sm">
-    </form>
-    {% endif %}
-  </div>
-  {% ifequal app.editor.user.pk user.pk %}
-  {% if app.status == app.SENT %}
-  <div class="col-xs-8 col-xs-offset-4 col-sm-4 col-sm-offset-0">
-    {% comment %}Translators: On the page listing applications, this text labels an area where users can either request
-    for renewals, or be shown a message of why they cannot renew.{% endcomment %}
-    <strong>{% trans "Has your account expired?" %}</strong> <br />
-    {% if app.is_renewable %}
-    {% comment %}Translators: On the page listing applications, this text labels a link which users can click to request
-    a renewal of their application.{% endcomment %}
-    <a class="btn btn-default btn-sm" href="{% url 'applications:renew' app.pk %}">{% trans "Request renewal" %}</a>
-    {% else %}
-    {% comment %}Translators: On the page listing applications, this text explains a user they cannot renew their
-    application since they've already requested a renewal or there aren't any renewals available.{% endcomment %}
-    <em>{% trans "Renewals are either not required, not available right now, or you have already requested a renewal." %}</em>
-    {% endif %}
-  </div>
-  {% endif %}
-  {% endifequal %}
-  {% if not forloop.last %}
-  <div class="col-sm-10 col-sm-offset-2 col-xs-12">
-    <hr />
-  </div>
-  {% endif %}
-</div>
-{% empty %}
-{% comment %}Translators: On the page listing applications, this text is displayed when there aren't any applications to
-list.{% endcomment %}
-{% trans 'No applications right now.' %}
-{% endfor %}
+  {% empty %}
+    {% comment %}Translators: On the page listing applications, this text is displayed when there aren't any applications to list.{% endcomment %}
+    {% trans 'No applications right now.' %}
+  {% endfor %}
 {% endblock %}

--- a/TWLight/users/templates/users/my_applications.html
+++ b/TWLight/users/templates/users/my_applications.html
@@ -58,6 +58,10 @@
           {% trans 'Not yet reviewed.' %}
         {% endif %}
         <br />
+        <form action="{% url 'users:my_deletion' user.editor.pk app.pk%}" class="m-2" method="post">
+        {% csrf_token %}
+        <input type="submit" value="Withdraw" class="btn btn-danger btn-sm">
+        </form>
       </div>
       {% ifequal app.editor.user.pk user.pk %}
         {% if app.status == app.SENT %}

--- a/TWLight/users/tests.py
+++ b/TWLight/users/tests.py
@@ -103,6 +103,7 @@ class ViewsTestCase(TestCase):
     def setUp(self):
         super(ViewsTestCase, self).setUp()
         self.client = Client()
+        
 
         # User 1: regular Editor
         self.username1 = "alice"
@@ -285,8 +286,21 @@ class ViewsTestCase(TestCase):
             partner=PartnerFactory(authorization_method=Partner.BUNDLE),
             editor=self.user_editor.editor,
         )
+        app8 = ApplicationFactory(
+            status = Application.PENDING,
+            partner=PartnerFactory(authorization_method=Partner.BUNDLE),
+            editor=self.user_editor.editor,
+        )
 
         factory = RequestFactory()
+        request = factory.get(
+            reverse("users:withdraw", kwargs={"pk": self.editor1.pk, "id":app8.pk})
+        )
+        request.user = self.user_editor
+        response = views.WithdrawApplication.as_view()(request,pk=self.editor1.pk, id=app8.pk)
+        
+        self.assertEqual(app8.status,Application.INVALID)
+        
         request = factory.get(
             reverse("users:my_applications", kwargs={"pk": self.editor1.pk})
         )

--- a/TWLight/users/tests.py
+++ b/TWLight/users/tests.py
@@ -103,7 +103,6 @@ class ViewsTestCase(TestCase):
     def setUp(self):
         super(ViewsTestCase, self).setUp()
         self.client = Client()
-        
 
         # User 1: regular Editor
         self.username1 = "alice"
@@ -286,21 +285,8 @@ class ViewsTestCase(TestCase):
             partner=PartnerFactory(authorization_method=Partner.BUNDLE),
             editor=self.user_editor.editor,
         )
-        app8 = ApplicationFactory(
-            status = Application.PENDING,
-            partner=PartnerFactory(authorization_method=Partner.BUNDLE),
-            editor=self.user_editor.editor,
-        )
 
         factory = RequestFactory()
-        request = factory.get(
-            reverse("users:withdraw", kwargs={"pk": self.editor1.pk, "id":app8.pk})
-        )
-        request.user = self.user_editor
-        response = views.WithdrawApplication.as_view()(request,pk=self.editor1.pk, id=app8.pk)
-        
-        self.assertEqual(app8.status,Application.INVALID)
-        
         request = factory.get(
             reverse("users:my_applications", kwargs={"pk": self.editor1.pk})
         )
@@ -324,6 +310,23 @@ class ViewsTestCase(TestCase):
         # We can't use assertTemplateUsed with RequestFactory (only with
         # Client), and testing that the rendered content is equal to an
         # expected string is too fragile.
+
+    def test_withdraw_application(self):
+        app = ApplicationFactory(
+            status=Application.PENDING,
+            partner=PartnerFactory(authorization_method=Partner.BUNDLE),
+            editor=self.user_editor.editor,
+        )
+        factory = RequestFactory()
+        request = factory.get(
+            reverse("users:withdraw", kwargs={"pk": self.editor1.pk, "id": app.pk})
+        )
+        request.user = self.user_editor
+        response = views.WithdrawApplication.as_view()(
+            request, pk=self.editor1.pk, id=app.pk
+        )
+        app.refresh_from_db()
+        self.assertEqual(app.status, Application.INVALID)
 
     def test_my_library_page_has_authorizations(self):
 

--- a/TWLight/users/urls.py
+++ b/TWLight/users/urls.py
@@ -53,8 +53,8 @@ urlpatterns = [
         name="my_collection",
     ),
     url(
-        r"^deletion/(?P<pk>\d+)/(?P<id>\d+)/$",
-        login_required(views.DeleteApplication.as_view()),
-        name="my_deletion",
+        r"^withdraw/(?P<pk>\d+)/(?P<id>\d+)/$",
+        login_required(views.WithdrawApplication.as_view()),
+        name="withdraw",
     ),
 ]

--- a/TWLight/users/urls.py
+++ b/TWLight/users/urls.py
@@ -52,4 +52,9 @@ urlpatterns = [
         views.LibraryRedirectView.as_view(),
         name="my_collection",
     ),
+    url(
+        r"^deletion/(?P<pk>\d+)/(?P<id>\d+)/$",
+        login_required(views.DeleteApplication.as_view()),
+        name="my_deletion",
+    ),
 ]

--- a/TWLight/users/views.py
+++ b/TWLight/users/views.py
@@ -854,10 +854,9 @@ class DeleteApplication(RedirectView):
     url = "/"
 
     def get_redirect_url(self, *args, **kwargs):
-        del_id = kwargs['id']
-        application_id = kwargs['pk']
+        del_id = kwargs["id"]
+        application_id = kwargs["pk"]
         Application.objects.get(pk=del_id).delete()
         message = f"Your application has been withdrawn successfully. Head over to <a href='/users/my_applications/{application_id}'>My Applications</a> to view the status."
         messages.add_message(self.request, messages.SUCCESS, message)
         return super().get_redirect_url(*args, **kwargs)
-

--- a/TWLight/users/views.py
+++ b/TWLight/users/views.py
@@ -850,13 +850,13 @@ class LibraryRedirectView(RedirectView):
     url = reverse_lazy("users:my_library")
 
 
-class DeleteApplication(RedirectView):
+class WithdrawApplication(RedirectView):
     url = "/"
 
     def get_redirect_url(self, *args, **kwargs):
-        del_id = kwargs["id"]
+        withdraw_id = kwargs["id"]
         application_id = kwargs["pk"]
-        Application.objects.get(pk=del_id).delete()
+        Application.objects.filter(pk=withdraw_id).update(status=Application.INVALID)
         message = f"Your application has been withdrawn successfully. Head over to <a href='/users/my_applications/{application_id}'>My Applications</a> to view the status."
         messages.add_message(self.request, messages.SUCCESS, message)
         return super().get_redirect_url(*args, **kwargs)

--- a/TWLight/users/views.py
+++ b/TWLight/users/views.py
@@ -848,3 +848,16 @@ class AuthorizationReturnView(SelfOnly, UpdateView):
 class LibraryRedirectView(RedirectView):
     permanent = True
     url = reverse_lazy("users:my_library")
+
+
+class DeleteApplication(RedirectView):
+    url = "/"
+
+    def get_redirect_url(self, *args, **kwargs):
+        del_id = kwargs['id']
+        application_id = kwargs['pk']
+        Application.objects.get(pk=del_id).delete()
+        message = f"Your application has been withdrawn successfully. Head over to <a href='/users/my_applications/{application_id}'>My Applications</a> to view the status."
+        messages.add_message(self.request, messages.SUCCESS, message)
+        return super().get_redirect_url(*args, **kwargs)
+


### PR DESCRIPTION
[//]: # (Thank you for uploading a PR to the Wikipedia Library!)

## Description
I had created a withdraw button which withdraw the application and redirect user to the home page.
When user will click on the button the application will be deleted and user will redirect to the home page
with a message as shown in the figure..


<img width="960" alt="2020-10-07" src="https://user-images.githubusercontent.com/69956695/95364597-a6e20100-08ee-11eb-9aa5-ad46a484c36b.png">





## Rationale
[//]: # (Why is this change required? What problem does it solve?)

## Phabricator Ticket
 https://phabricator.wikimedia.org/T243137

## How Has This Been Tested?
[//]: # (- Did you add tests to your changes? Did you modify tests to accommodate your changes?)
[//]: # (- Can this change be tested manually? How?)

## Screenshots of your changes (if appropriate):
<img width="960" alt="2020-10-07 (2)" src="https://user-images.githubusercontent.com/69956695/95365119-5028f700-08ef-11eb-8bcd-14a4aa6e3500.png">
   
## Types of changes
What types of changes does your code introduce? Add an `x` in all the boxes that apply:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
