### PR TITLE
fix the bug in a message which was appearing when user return the aut…

### DIFF
--- a/TWLight/users/views.py
+++ b/TWLight/users/views.py
@@ -840,7 +840,7 @@ class AuthorizationReturnView(SelfOnly, UpdateView):
             self.request,
             messages.SUCCESS,
             # Translators: This message is shown once the access to a partner has successfully been returned.
-            _("Access to {} has been returned.").format(authorization.partners),
+            _("Access to {} has been returned.").format(authorization.partners.get()),
         )
         return HttpResponseRedirect(reverse("users:my_library"))
 


### PR DESCRIPTION
…horization

[//]: # (Thank you for uploading a PR to the Wikipedia Library!)

## Description
Users can return an authorization, expiring it and freeing up a space for other users, on their My Library page. Doing so sends them a system message, which currently appears to be broken. 
Before solving the message was looking like as show in the image:

<img width="960" alt="2020-10-10 (3)" src="https://user-images.githubusercontent.com/69956695/95653087-762ee100-0b13-11eb-8f96-d593c025dc32.png">

So, I have fix this bug.



## Rationale
[//]: # (Why is this change required? What problem does it solve?)

## Phabricator Ticket
https://phabricator.wikimedia.org/T264999

## How Has This Been Tested?
[//]: # (- Did you add tests to your changes? Did you modify tests to accommodate your changes?)
[//]: # (- Can this change be tested manually? How?)

## Screenshots of your changes (if appropriate):
[//]: # (It can also be a GIF to prove that your changes are working)
<img width="960" alt="2020-10-10 (2)" src="https://user-images.githubusercontent.com/69956695/95653174-34eb0100-0b14-11eb-9b13-a2d13bdb7f0b.png">


## Types of changes
What types of changes does your code introduce? Add an `x` in all the boxes that apply:
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
