### PR TITLE
Improve the profile page view in mobile

### DIFF
--- a/TWLight/users/templates/users/editor_detail.html
+++ b/TWLight/users/templates/users/editor_detail.html
@@ -14,7 +14,7 @@
   </p>
   <hr>
   <div class="row">
-    <div class="col-md-5 col-lg-4">
+    <div class="col-md-5 col-lg-4" style="margin-bottom: 14px;">
       <a href="{% url 'users:my_library' %}" class="btn btn-default btn-lg btn-block btn-extra-large"><i class="fa fa-folder-open-o fa-4x pull-left" aria-hidden="true"></i>
         <p class="app-list"  style="font-size:25px; float:left">
           {% comment %}Translators: Line one of two in a button on users' profile page which when clicked takes users to their collection page.{% endcomment %}


### PR DESCRIPTION
[//]: # (Thank you for uploading a PR to the Wikipedia Library!)

## Description
I added some margin to the profile page when user open it in mobile.

**Before Change:**

<img width="960" alt="2020-10-13 (4)" src="https://user-images.githubusercontent.com/69956695/95859794-c492e880-0d7c-11eb-835d-74966466f64b.png">

**After Change:**

<img width="960" alt="2020-10-13 (3)" src="https://user-images.githubusercontent.com/69956695/95860029-176ca000-0d7d-11eb-9024-428d555d1f9e.png">
 

## Rationale
[//]: # (Why is this change required? What problem does it solve?)

## Phabricator Ticket
[//]: # (Link to the Phabricator ticket)

## How Has This Been Tested?
[//]: # (- Did you add tests to your changes? Did you modify tests to accommodate your changes?)
[//]: # (- Can this change be tested manually? How?)

## Screenshots of your changes (if appropriate):
[//]: # (It can also be a GIF to prove that your changes are working)

## Types of changes
What types of changes does your code introduce? Add an `x` in all the boxes that apply:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
