### PR TITLE
T265146: user_update_eligibility should correctly update editcount for bundle eligibility.

### DIFF
--- a/TWLight/users/helpers/editor_data.py
+++ b/TWLight/users/helpers/editor_data.py
@@ -4,7 +4,7 @@ import logging
 import typing
 import urllib.request, urllib.error, urllib.parse
 from django.conf import settings
-from django.utils.timezone import now
+from django.utils import timezone
 
 logger = logging.getLogger(__name__)
 
@@ -220,6 +220,7 @@ def editor_recent_edits(
     wp_editcount_prev: int,
     wp_editcount_recent: int,
     wp_enough_recent_edits: bool,
+    current_datetime: timezone = None,
 ):
     """
     Checks current global_userinfo editcount against stored editor data and returns updated data.
@@ -231,15 +232,19 @@ def editor_recent_edits(
     wp_editcount_prev : int
     wp_editcount_recent : int
     wp_enough_recent_edits : bool
+    current_datetime : timezone
 
     Returns
     -------
     tuple
         Contains recent-editcount-related results.
     """
+    if not current_datetime:
+        current_datetime = timezone.now()
+
     # If we have historical data, see how many days have passed and how many edits have been made since the last check.
     if wp_editcount_prev_updated and wp_editcount_updated:
-        editcount_update_delta = now() - wp_editcount_prev_updated
+        editcount_update_delta = current_datetime - wp_editcount_prev_updated
         editcount_delta = global_userinfo_editcount - wp_editcount_prev
         if (
             # If the editor didn't have enough recent edits but they do now, update the counts immediately.
@@ -256,7 +261,7 @@ def editor_recent_edits(
     # If we don't have any historical editcount data, let all edits to date count
     else:
         wp_editcount_prev = global_userinfo_editcount
-        wp_editcount_prev_updated = now()
+        wp_editcount_prev_updated = current_datetime
         wp_editcount_recent = global_userinfo_editcount
 
     # Perform the check for enough recent edits.

--- a/TWLight/users/helpers/editor_data.py
+++ b/TWLight/users/helpers/editor_data.py
@@ -33,7 +33,7 @@ def editor_global_userinfo(
     return global_userinfo
 
 
-def _get_user_info_request(wp_param_name, wp_param):
+def _get_user_info_request(wp_param_name: str, wp_param: str):
     """
     This function queries the mediawiki api to get users' Wikipedia information
 
@@ -85,7 +85,7 @@ def _get_user_info_request(wp_param_name, wp_param):
     return json.loads(urllib.request.urlopen(query).read())
 
 
-def editor_reg_date(identity, global_userinfo):
+def editor_reg_date(identity: dict, global_userinfo: dict):
     # Try oauth registration date first.  If it's not valid, try the global_userinfo date
     try:
         reg_date = datetime.strptime(identity["registered"], "%Y%m%d%H%M%S").date()
@@ -118,7 +118,7 @@ def editor_not_blocked(merged: list):
         return False if any("blocked" in account for account in merged) else True
 
 
-def editor_account_old_enough(wp_registered):
+def editor_account_old_enough(wp_registered: datetime.date):
     # If, for some reason, this information hasn't come through,
     # default to user not being valid.
     if not wp_registered:
@@ -127,7 +127,12 @@ def editor_account_old_enough(wp_registered):
     return datetime.today().date() - timedelta(days=182) >= wp_registered
 
 
-def editor_valid(enough_edits, account_old_enough, not_blocked, ignore_wp_blocks):
+def editor_valid(
+    enough_edits: bool,
+    account_old_enough: bool,
+    not_blocked: bool,
+    ignore_wp_blocks: bool,
+):
     """
     Check for the eligibility criteria laid out in the terms of service.
     Note that we won't prohibit signups or applications on this basis.
@@ -140,12 +145,12 @@ def editor_valid(enough_edits, account_old_enough, not_blocked, ignore_wp_blocks
 
 
 def editor_recent_edits(
-    global_userinfo_editcount,
-    wp_editcount_updated,
-    wp_editcount_prev_updated,
-    wp_editcount_prev,
-    wp_editcount_recent,
-    wp_enough_recent_edits,
+    global_userinfo_editcount: int,
+    wp_editcount_updated: datetime.date,
+    wp_editcount_prev_updated: datetime.date,
+    wp_editcount_prev: int,
+    wp_editcount_recent: int,
+    wp_enough_recent_edits: bool,
 ):
 
     # If we have historical data, see how many days have passed and how many edits have been made since the last check.
@@ -184,7 +189,7 @@ def editor_recent_edits(
     )
 
 
-def editor_bundle_eligible(editor):
+def editor_bundle_eligible(editor: "Editor"):
     enough_edits_and_valid = editor.wp_valid and editor.wp_enough_recent_edits
     # Staff and superusers should be eligible for bundles for testing purposes
     user_staff_or_superuser = editor.user.is_staff or editor.user.is_superuser

--- a/TWLight/users/helpers/editor_data.py
+++ b/TWLight/users/helpers/editor_data.py
@@ -205,7 +205,7 @@ def editor_valid(
     Returns
     -------
     bool
-        The editor's validity.
+        Answer to the question: is the editor account valid?
     """
     if enough_edits and account_old_enough and (not_blocked or ignore_wp_blocks):
         return True
@@ -284,7 +284,7 @@ def editor_bundle_eligible(editor: "Editor"):
     Returns
     -------
     bool
-        The editor's eligibility.
+        Answer to the question: is the editor account eligible for Bundle?
     """
     enough_edits_and_valid = editor.wp_valid and editor.wp_enough_recent_edits
     # Staff and superusers should be eligible for bundles for testing purposes

--- a/TWLight/users/helpers/editor_data.py
+++ b/TWLight/users/helpers/editor_data.py
@@ -17,13 +17,17 @@ def editor_global_userinfo(
     Parameters
     ----------
     wp_username : str
+        Global Wikipedia username, used for guiuser parameter in globaluserinfo calls.
     wp_sub : int
+        Global Wikipedia User ID, used for guiid parameter in globaluserinfo calls.
     strict : bool
+        Verify that guiuser and guiid match. This precludes library account takeover via wikipedia username changes,
+        but also precludes updates to accounts upon username change.
 
     Returns
     -------
     dict
-        Contains the editor's globaluserinfo as returned by the mediawiki api.
+        The editor's globaluserinfo as returned by the mediawiki api.
     """
     guiuser = urllib.parse.quote(wp_username)
     # Trying to get global user info with the username
@@ -60,36 +64,8 @@ def _get_user_info_request(wp_param_name: str, wp_param: str):
     Returns
     -------
     dict
-        A dictionary like the one below or a dictionary with a "missing" key
-
-    Expected data:
-    {
-    "batchcomplete": true,
-     "query": {
-        "globaluserinfo": {                         # Global account
-            "home": "enwiki",                           # Wiki used to determine the name of the global account. See https://www.mediawiki.org/wiki/SUL_finalisation
-            "id": account['id'],                        # Wikipedia ID
-            "registration": "YYYY-MM-DDTHH:mm:ssZ",     # Date registered
-            "name": account['name'],                    # wikipedia username
-            "merged": [                                 # Individual project accounts attached to the global account.
-                {
-                    "wiki": "enwiki",
-                    "url": "https://en.wikipedia.org",
-                    "timestamp": "YYYY-MM-DDTHH:mm:ssZ",
-                    "method": "login",
-                    "editcount": account['editcount']           # editcount for this project
-                    "registration": "YYYY-MM-DDTHH:mm:ssZ",     # Date registered for this project
-                    "groups": ["extendedconfirmed"],
-                    "blocked": {                                # Only exists if the user has blocks for this project.
-                    "expiry": "infinity",
-                    "reason": ""
-                }
-                ... # Continues ad nauseam
-            ],
-            "editcount": account['editcount']           # global editcount
-        }
-     }
-    }
+        The globaluserinfo api query response as described in the MediaWiki API globaluserinfo documentation:
+        https://www.mediawiki.org/w/api.php?action=help&modules=query%2Bglobaluserinfo
     """
     endpoint = settings.TWLIGHT_API_PROVIDER_ENDPOINT
     query = "{endpoint}?action=query&meta=globaluserinfo&{wp_param_name}={wp_param}&guiprop=editcount|merged&format=json&formatversion=2".format(
@@ -264,7 +240,6 @@ def editor_recent_edits(
             # This means that eligibility always lasts at least 30 days.
             or (wp_enough_recent_edits and editcount_update_delta.days > 30)
         ):
-            # recent edits = global userinfo editcount - stored editcount.
             wp_editcount_recent = global_userinfo_editcount - wp_editcount
             # Shift the currently stored counts into the "prev" fields for use in future checks.
             wp_editcount_prev = wp_editcount

--- a/TWLight/users/helpers/editor_data.py
+++ b/TWLight/users/helpers/editor_data.py
@@ -215,6 +215,7 @@ def editor_valid(
 
 def editor_recent_edits(
     global_userinfo_editcount: int,
+    wp_editcount: int,
     wp_editcount_updated: datetime.date,
     wp_editcount_prev_updated: datetime.date,
     wp_editcount_prev: int,
@@ -227,12 +228,21 @@ def editor_recent_edits(
     Parameters
     ----------
     global_userinfo_editcount : int
+        editcount returned by globaluserinfo.
+    wp_editcount : int
+        editcount currently stored in database.
     wp_editcount_updated : datetime.date
+        timestamp for stored editcount
     wp_editcount_prev_updated : datetime.date
+        timestamp for stored previous editcount
     wp_editcount_prev : int
+        historical editcount used to calculate recent edits
     wp_editcount_recent : int
+        recent editcount used to determine bundle eligibility
     wp_enough_recent_edits : bool
+        current recent edit status as stored in database
     current_datetime : timezone
+        optional timezone-aware timestamp override that represents now()
 
     Returns
     -------
@@ -254,8 +264,10 @@ def editor_recent_edits(
             # This means that eligibility always lasts at least 30 days.
             or (wp_enough_recent_edits and editcount_update_delta.days > 30)
         ):
-            wp_editcount_recent = global_userinfo_editcount - wp_editcount_prev
-            wp_editcount_prev = global_userinfo_editcount
+            # recent edits = global userinfo editcount - stored editcount.
+            wp_editcount_recent = global_userinfo_editcount - wp_editcount
+            # Shift the currently stored counts into the "prev" fields for use in future checks.
+            wp_editcount_prev = wp_editcount
             wp_editcount_prev_updated = wp_editcount_updated
 
     # If we don't have any historical editcount data, let all edits to date count

--- a/TWLight/users/management/commands/user_update_eligibility.py
+++ b/TWLight/users/management/commands/user_update_eligibility.py
@@ -56,9 +56,9 @@ class Command(BaseCommand):
             datetime_override = datetime.fromisoformat(options["datetime"])
             wp_editcount_updated = datetime_override
 
-        # Getting all editors that are currently eligible and have not been recently updated.
+        # Get all editors who have not been updated in more than 30 days.
         editors = Editor.objects.filter(
-            wp_bundle_eligible=True, wp_editcount_updated__lt=now() - timedelta(days=30)
+            wp_editcount_updated__lt=now() - timedelta(days=30)
         )
         for editor in editors:
             # `global_userinfo` data may be overridden.

--- a/TWLight/users/management/commands/user_update_eligibility.py
+++ b/TWLight/users/management/commands/user_update_eligibility.py
@@ -37,8 +37,11 @@ class Command(BaseCommand):
 
     def handle(self, *args, **options):
         wp_editcount_updated = now()
+        datetime_override = None
+
         if options["datetime"]:
-            wp_editcount_updated = datetime.fromisoformat(options["datetime"])
+            datetime_override = datetime.fromisoformat(options["datetime"])
+            wp_editcount_updated = datetime_override
 
         # Getting all editors that are currently eligible or are staff or are superusers
         editors = Editor.objects.filter(wp_bundle_eligible=True)
@@ -62,6 +65,7 @@ class Command(BaseCommand):
                     editor.wp_editcount_prev,
                     editor.wp_editcount_recent,
                     editor.wp_enough_recent_edits,
+                    datetime_override,
                 )
                 editor.wp_editcount = global_userinfo["editcount"]
                 editor.wp_editcount_updated = wp_editcount_updated

--- a/TWLight/users/management/commands/user_update_eligibility.py
+++ b/TWLight/users/management/commands/user_update_eligibility.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import datetime, timedelta
 import logging
 from django.utils.timezone import now
 from django.core.management.base import BaseCommand
@@ -56,8 +56,10 @@ class Command(BaseCommand):
             datetime_override = datetime.fromisoformat(options["datetime"])
             wp_editcount_updated = datetime_override
 
-        # Getting all editors that are currently eligible or are staff or are superusers
-        editors = Editor.objects.filter(wp_bundle_eligible=True)
+        # Getting all editors that are currently eligible and have not been recently updated.
+        editors = Editor.objects.filter(
+            wp_bundle_eligible=True, wp_editcount_updated__lt=now() - timedelta(days=30)
+        )
         for editor in editors:
             # `global_userinfo` data may be overridden.
             if options["global_userinfo"]:

--- a/TWLight/users/management/commands/user_update_eligibility.py
+++ b/TWLight/users/management/commands/user_update_eligibility.py
@@ -48,17 +48,17 @@ class Command(BaseCommand):
         """
 
         # Default behavior is to use current datetime for timestamps.
-        wp_editcount_updated = now()
+        now_or_datetime = now()
         datetime_override = None
 
         # This may be overridden so that values may be treated as if they were valid for an arbitrary datetime.
         if options["datetime"]:
-            datetime_override = datetime.fromisoformat(options["datetime"])
-            wp_editcount_updated = datetime_override
+            datetime_override = now_or_datetime.fromisoformat(options["datetime"])
+            now_or_datetime = datetime_override
 
         # Get all editors who have not been updated in more than 30 days.
         editors = Editor.objects.filter(
-            wp_editcount_updated__lt=now() - timedelta(days=30)
+            wp_editcount_updated__lt=now_or_datetime - timedelta(days=30)
         )
         for editor in editors:
             # `global_userinfo` data may be overridden.
@@ -87,7 +87,7 @@ class Command(BaseCommand):
                 )
                 # Set current editcount.
                 editor.wp_editcount = global_userinfo["editcount"]
-                editor.wp_editcount_updated = wp_editcount_updated
+                editor.wp_editcount_updated = now_or_datetime
                 # Determine editor validity.
                 editor.wp_enough_edits = editor_enough_edits(editor.wp_editcount)
                 editor.wp_not_blocked = editor_not_blocked(global_userinfo["merged"])

--- a/TWLight/users/management/commands/user_update_eligibility.py
+++ b/TWLight/users/management/commands/user_update_eligibility.py
@@ -78,6 +78,7 @@ class Command(BaseCommand):
                     editor.wp_enough_recent_edits,
                 ) = editor_recent_edits(
                     global_userinfo["editcount"],
+                    editor.wp_editcount,
                     editor.wp_editcount_updated,
                     editor.wp_editcount_prev_updated,
                     editor.wp_editcount_prev,

--- a/TWLight/users/models.py
+++ b/TWLight/users/models.py
@@ -436,6 +436,7 @@ class Editor(models.Model):
                 self.wp_enough_recent_edits,
             ) = editor_recent_edits(
                 global_userinfo["editcount"],
+                self.wp_editcount,
                 self.wp_editcount_updated,
                 self.wp_editcount_prev_updated,
                 self.wp_editcount_prev,

--- a/TWLight/users/tests.py
+++ b/TWLight/users/tests.py
@@ -1157,9 +1157,10 @@ class EditorModelTestCase(TestCase):
         self.assertTrue(bundle_eligible)
 
         # Bad editor! No biscuit, even if you have enough edits.
+        global_userinfo["editcount"] = 510
         global_userinfo["merged"] = copy.copy(FAKE_MERGED_ACCOUNTS_BLOCKED)
         not_blocked = editor_not_blocked(global_userinfo["merged"])
-        valid = editor_valid(
+        self.test_editor.wp_valid = editor_valid(
             enough_edits, account_old_enough, not_blocked, ignore_wp_blocks
         )
         self.test_editor.wp_editcount_updated = now() - timedelta(days=31)
@@ -1172,7 +1173,7 @@ class EditorModelTestCase(TestCase):
             self.test_editor.wp_editcount_recent,
             self.test_editor.wp_enough_recent_edits,
         ) = editor_recent_edits(
-            global_userinfo["editcount"] + 10,
+            global_userinfo["editcount"],
             self.test_editor.wp_editcount,
             self.test_editor.wp_editcount_updated,
             self.test_editor.wp_editcount_prev_updated,
@@ -1181,7 +1182,11 @@ class EditorModelTestCase(TestCase):
             self.test_editor.wp_enough_recent_edits,
         )
         bundle_eligible = editor_bundle_eligible(self.test_editor)
+        self.test_editor.wp_editcount = global_userinfo["editcount"]
         self.test_editor.wp_editcount_updated = now()
+
+        self.assertEqual(self.test_editor.wp_editcount, 510)
+        self.assertEqual(self.test_editor.wp_editcount_prev, 500)
         self.assertFalse(bundle_eligible)
 
         # Without a scheduled management command, a valid user will pass 60 days after their first login if they have 10 more edits,


### PR DESCRIPTION
## Description
This limits the scope of editors that may be modified by the command, which should protect us against overrun errors and also reduce the runtime of the command.

## Rationale
Testing revealed that the command incorrectly updates edit counts even if the user has already been updated. This reduces the intended time period used to calculate recent edit counts, effectively making bundle eligibility tougher to keep than it should be.

## Phabricator Ticket
https://phabricator.wikimedia.org/T265146

## How Has This Been Tested?
I finished out the partial timestamp override code so that I could run the command in the test suite against specified dates. I was able to reproduce the issue we saw in production with a failing test, and then get the test passing by updating the command as well as the underlying helper function.

## Screenshots of your changes (if appropriate):
NA

## Types of changes
What types of changes does your code introduce? Add an `x` in all the boxes that apply:
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
