### PR TITLE
Block /admin login page in production & staging

### DIFF
--- a/TWLight/settings/base.py
+++ b/TWLight/settings/base.py
@@ -44,6 +44,9 @@ TWLIGHT_HOME = os.path.dirname(
 
 TWLIGHT_ENV = os.environ.get("TWLIGHT_ENV")
 
+# To Block/Unblock /admin login page in production & staging
+ADMIN_ENABLED = False
+
 # An atypical way of setting django languages for TranslateWiki integration:
 # https://translatewiki.net/wiki/Thread:Support/_The_following_issue_is_unconfirmed,_still_to_be_investigated._Adding_TheWikipediaLibrary_Card_Platform_TranslateWiki
 

--- a/TWLight/settings/local.py
+++ b/TWLight/settings/local.py
@@ -12,6 +12,9 @@ from .base import *
 
 DEFAULT_FROM_EMAIL = "<twlight.local@localhost.localdomain>"
 
+# To Block/Unblock /admin login page in production & staging
+ADMIN_ENABLED = True
+
 # TEST CONFIGURATION
 # ------------------------------------------------------------------------------
 

--- a/TWLight/tests.py
+++ b/TWLight/tests.py
@@ -1263,3 +1263,38 @@ class AuthorizedUsersAPITestCase(AuthorizationBaseTestCase):
         expected_json = [{"wp_username": self.editor1.wp_username}]
 
         self.assertEqual(response.data, expected_json)
+
+
+class AdminEnableTestCase(TestCase):
+    def test_admin_enabled(self):
+        """
+        Test behaviour when ADMIN_ENABLED set to True
+        """
+
+        # check ADMIN_ENABLED value
+        self.assertEqual(settings.ADMIN_ENABLED, True)
+
+        # check homepage
+        response = self.client.get(reverse("homepage"))
+        self.assertEqual(response.status_code, 200)
+
+        # Check admin page
+        response = self.client.get("/admin/")
+        self.assertRedirects(response, "/admin/login/?next=/admin/")
+        self.assertEqual(response.status_code, 302)
+
+    def test_admin_disabled(self):
+        """
+        Test behaviour when ADMIN_ENABLED set to True
+        """
+        # override settings and update ADMIN_ENABLED
+        with self.settings(ADMIN_ENABLED=False):
+            # check ADMIN_ENABLED value
+            self.assertEqual(settings.ADMIN_ENABLED, False)
+
+            # check homepage
+            response = self.client.get(reverse("homepage"))
+            self.assertEqual(response.status_code, 200)
+            # Check admin
+            response = self.client.get("/admin/")
+            self.assertEqual(response.status_code, 404)

--- a/TWLight/urls.py
+++ b/TWLight/urls.py
@@ -11,6 +11,7 @@ from django.contrib.auth import views as auth_views
 from django.contrib.auth.decorators import login_required
 from django.views.generic import TemplateView
 from django.views.decorators.cache import cache_page
+from django.conf import settings
 
 from TWLight.api.urls import urlpatterns as api_urls
 from TWLight.applications.urls import urlpatterns as applications_urls
@@ -34,7 +35,6 @@ from .views import LanguageWhiteListView, HomePageView
 urlpatterns = [
     # Built-in -----------------------------------------------------------------
     url(r"^admin/doc", include(admindocs)),
-    url(r"^admin/", admin.site.urls),
     url(r"^accounts/login/", auth_views.LoginView.as_view(), name="auth_login"),
     url(
         r"^accounts/logout/",
@@ -96,3 +96,6 @@ urlpatterns = [
     url(r"^$", HomePageView.as_view(), name="homepage"),
     url(r"^about/$", TemplateView.as_view(template_name="about.html"), name="about"),
 ]
+
+if settings.ADMIN_ENABLED:
+    urlpatterns += [url(r"^admin/", admin.site.urls)]


### PR DESCRIPTION


## Description
No one should allowed to log in via /admin directly, so we should remove that from URLs

## Phabricator Ticket
[//]: # https://phabricator.wikimedia.org/T245268

## How Has This Been Tested?
[//]: # (- Did you add tests to your changes? Did you modify tests to accommodate your changes?)
No
[//]: # (- Can this change be tested manually? How?)

## Screenshots of your changes (if appropriate):
[//]: # (It can also be a GIF to prove that your changes are working)

## Types of changes
What types of changes does your code introduce? Add an `x` in all the boxes that apply:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
