### PR TITLE
fix the footer overlap on home page in a mobile view

### DIFF
--- a/TWLight/static/css/local.css
+++ b/TWLight/static/css/local.css
@@ -202,6 +202,7 @@ header {
   }
 }
 
+
 #top-nav {
   border-bottom: 1px solid #eee;
   margin-bottom: 20px;
@@ -214,6 +215,13 @@ header {
   position: absolute;
   bottom: 0;
   width: 100%;
+}
+
+@media (max-width:300px){
+  #footer{
+    position: relative;
+    top: 7px;
+  }
 }
 
 .nav-greeting {
@@ -774,9 +782,4 @@ CLEARING COLUMNS
   color: #fff;
 }
 
-@media (max-width:300px){
-  #footer{
-    position: relative;
-    top: 7px;
-  }
-}
+

--- a/TWLight/static/css/local.css
+++ b/TWLight/static/css/local.css
@@ -774,3 +774,9 @@ CLEARING COLUMNS
   color: #fff;
 }
 
+@media (max-width:300px){
+  #footer{
+    position: relative;
+    top: 7px;
+  }
+}


### PR DESCRIPTION
[//]: # (Thank you for uploading a PR to the Wikipedia Library!)

## Description
Footer was overlapping when the width changes to 300px on home page means in a mobile view footer was overlapping
So I have fixed it by adding a media query.

**Before Change:**

<img width="960" alt="2020-11-01" src="https://user-images.githubusercontent.com/69956695/97895740-2df19000-1d5a-11eb-9d5e-cc70a74b1cc4.png">

**After Change:**
<img width="960" alt="2020-11-01 (1)" src="https://user-images.githubusercontent.com/69956695/97895866-57122080-1d5a-11eb-915a-e81fccba5b4d.png">

I have also check this on the Partners page.
## Rationale
[//]: # (Why is this change required? What problem does it solve?)

## Phabricator Ticket
https://phabricator.wikimedia.org/T255794

## How Has This Been Tested?
[//]: # (- Did you add tests to your changes? Did you modify tests to accommodate your changes?)
[//]: # (- Can this change be tested manually? How?)

## Screenshots of your changes (if appropriate):
[//]: # (It can also be a GIF to prove that your changes are working)

## Types of changes
What types of changes does your code introduce? Add an `x` in all the boxes that apply:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
