### PR TITLE
Add a note to the multiple-partner application page about Bundle part…

### DIFF
--- a/TWLight/applications/templates/applications/request_for_application.html
+++ b/TWLight/applications/templates/applications/request_for_application.html
@@ -19,11 +19,12 @@
 
 {% comment %}Translators: We are asking editors which publishers' resources they want access to. They may request more than one publisher.{% endcomment %}
 <h1>{% trans 'What resources do you want to access?' %}</h1>
- <div class="well well-sm">
-      {% blocktrans trimmed %}
+<div class="well well-sm">
+  {% comment %}Translators: This text explains that Library Bundle partners are not shown in this list.{% endcomment %}
+    {% blocktrans trimmed %}
       Library Bundle partners are not shown as eligibility is determined automatically.
     {% endblocktrans %}
-  </div>
+</div>
 
 
 <form method="post">

--- a/TWLight/applications/templates/applications/request_for_application.html
+++ b/TWLight/applications/templates/applications/request_for_application.html
@@ -19,6 +19,12 @@
 
 {% comment %}Translators: We are asking editors which publishers' resources they want access to. They may request more than one publisher.{% endcomment %}
 <h1>{% trans 'What resources do you want to access?' %}</h1>
+ <div class="well well-sm">
+      {% blocktrans trimmed %}
+      Library Bundle partners are not shown as eligibility is determined automatically.
+    {% endblocktrans %}
+  </div>
+
 
 <form method="post">
   {% csrf_token %}


### PR DESCRIPTION

## Description
When users navigate to https://wikipedialibrary.wmflabs.org/applications/request/ it may not be clear why some partners from the previous page don't show up in the list. So I have added one statement in that page.

<img width="960" alt="2020-11-06" src="https://user-images.githubusercontent.com/69956695/98286908-ac546900-1fca-11eb-90a4-12df0b1d0caa.png">


## Rationale
[//]: # (Why is this change required? What problem does it solve?)

## Phabricator Ticket
https://phabricator.wikimedia.org/T252510

## How Has This Been Tested?
[//]: # (- Did you add tests to your changes? Did you modify tests to accommodate your changes?)
[//]: # (- Can this change be tested manually? How?)

## Screenshots of your changes (if appropriate):
[//]: # (It can also be a GIF to prove that your changes are working)

## Types of changes
What types of changes does your code introduce? Add an `x` in all the boxes that apply:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
