### PR TITLE
In /admin default language is selected to english on resource pages

### DIFF
--- a/TWLight/resources/models.py
+++ b/TWLight/resources/models.py
@@ -101,6 +101,7 @@ class Language(models.Model):
         max_length=8,
         validators=[validate_language_code],
         unique=True,
+        default=RESOURCE_LANGUAGES[16]
     )
 
     def save(self, *args, **kwargs):

--- a/TWLight/resources/models.py
+++ b/TWLight/resources/models.py
@@ -101,7 +101,7 @@ class Language(models.Model):
         max_length=8,
         validators=[validate_language_code],
         unique=True,
-        default=RESOURCE_LANGUAGES[16]
+        default=RESOURCE_LANGUAGES[16],
     )
 
     def save(self, *args, **kwargs):


### PR DESCRIPTION
[//]: # (Thank you for uploading a PR to the Wikipedia Library!)

## Description
In the admin interface, on resource pages, staff can select the language of fields they want to edit. 90% of the time we want to edit the English versions, so I have added English language as selected in the drop down by default.

**Before Change:**

<img width="960" alt="2020-11-07 (1)" src="https://user-images.githubusercontent.com/69956695/98415215-dda06800-20a2-11eb-95e3-01cd9090f7b3.png">

**After Change:** 

<img width="960" alt="2020-11-07" src="https://user-images.githubusercontent.com/69956695/98415242-ebee8400-20a2-11eb-854b-1864f9dfbcb6.png">


## Rationale
[//]: # (Why is this change required? What problem does it solve?)

## Phabricator Ticket
https://phabricator.wikimedia.org/T240170

## How Has This Been Tested?
[//]: # (- Did you add tests to your changes? Did you modify tests to accommodate your changes?)
[//]: # (- Can this change be tested manually? How?)

## Screenshots of your changes (if appropriate):
[//]: # (It can also be a GIF to prove that your changes are working)

## Types of changes
What types of changes does your code introduce? Add an `x` in all the boxes that apply:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
