### PR TITLE
T265146: Recent edit count isn't updating correctly for some users

### DIFF
--- a/TWLight/users/helpers/editor_data.py
+++ b/TWLight/users/helpers/editor_data.py
@@ -229,9 +229,9 @@ def editor_recent_edits(
         current_datetime = timezone.now()
 
     # If we have historical data, see how many days have passed and how many edits have been made since the last check.
-    if wp_editcount_prev_updated and wp_editcount_updated:
-        editcount_update_delta = current_datetime - wp_editcount_prev_updated
-        editcount_delta = global_userinfo_editcount - wp_editcount_prev
+    if wp_editcount and wp_editcount_updated:
+        editcount_update_delta = current_datetime - wp_editcount_updated
+        editcount_delta = global_userinfo_editcount - wp_editcount
         if (
             # If the editor didn't have enough recent edits but they do now, update the counts immediately.
             # This recognizes their eligibility as soon as possible.

--- a/TWLight/users/tests.py
+++ b/TWLight/users/tests.py
@@ -1716,7 +1716,9 @@ class ManagementCommandsTestCase(TestCase):
             global_userinfo=self.global_userinfo_editor,
         )
         self.editor.refresh_from_db()
-        self.assertEqual(self.editor.wp_editcount, self.editor.wp_editcount_prev)
+        self.assertEqual(self.editor.wp_editcount, 5000)
+        self.assertEqual(self.editor.wp_editcount_prev, 42)
+        self.assertEqual(self.editor.wp_editcount_recent, 4958)
         self.assertTrue(self.editor.wp_bundle_eligible)
 
         # A valid editor should pass 31 days after their last update, so long as they made enough edits.


### PR DESCRIPTION
[//]: # (Thank you for uploading a PR to the Wikipedia Library!)

## Description
use globaluserinfo editcount and current date along with editor.wp_editcount and editor.wp_editcount_updated when determining the update delta for checking bundle eligibility and determining whether or not to update the counts.

## Rationale
The previous PR for this issue made a change to which fields current and previous editcounts were stored in.
Since then we've been storing good data.  However, we were using the old fields to decide when to update the counts. This updates those date fields.

## Phabricator Ticket
https://phabricator.wikimedia.org/T265146

## How Has This Been Tested?
More detailed editor tests added, which is how I located the problem.

## Screenshots of your changes (if appropriate):
NA

## Types of changes
What types of changes does your code introduce? Add an `x` in all the boxes that apply:
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
