### PR TITLE
Withdraw button will appear only to the status which are PENDING,APPR…

### DIFF
--- a/TWLight/users/templates/users/my_applications.html
+++ b/TWLight/users/templates/users/my_applications.html
@@ -58,7 +58,7 @@
           {% trans 'Not yet reviewed.' %}
         {% endif %}
         <br />
-        {% if app.status != app.INVALID %}
+        {% if app.status == app.APPROVED or app.status == app.PENDING or app.status == app.QUESTION %}
           <form action="{% url 'users:withdraw' user.editor.pk app.pk%}" class="m-2" method="post">
           {% csrf_token %}
           <input type="submit" value="Withdraw" class="btn btn-danger btn-sm">

--- a/TWLight/users/tests.py
+++ b/TWLight/users/tests.py
@@ -312,8 +312,18 @@ class ViewsTestCase(TestCase):
         # expected string is too fragile.
 
     def test_withdraw_application(self):
-        app = ApplicationFactory(
+        app1 = ApplicationFactory(
             status=Application.PENDING,
+            partner=PartnerFactory(authorization_method=Partner.BUNDLE),
+            editor=self.user_editor.editor,
+        )
+        app2 = ApplicationFactory(
+            status=Application.APPROVED,
+            partner=PartnerFactory(authorization_method=Partner.BUNDLE),
+            editor=self.user_editor.editor,
+        )
+        app3 = ApplicationFactory(
+            status=Application.QUESTION,
             partner=PartnerFactory(authorization_method=Partner.BUNDLE),
             editor=self.user_editor.editor,
         )
@@ -326,7 +336,9 @@ class ViewsTestCase(TestCase):
             request, pk=self.editor1.pk, id=app.pk
         )
         app.refresh_from_db()
-        self.assertEqual(app.status, Application.INVALID)
+        self.assertEqual(app1.status, Application.INVALID)
+        self.assertEqual(app2.status, Application.INVALID)
+        self.assertEqual(app3.status, Application.INVALID)
 
     def test_my_library_page_has_authorizations(self):
 

--- a/TWLight/users/tests.py
+++ b/TWLight/users/tests.py
@@ -329,7 +329,7 @@ class ViewsTestCase(TestCase):
         app.refresh_from_db()
         self.assertEqual(app.status, Application.INVALID)
 
-    def test_withdraw_sent_application(self):
+    def test_sent_application(self):
         app = ApplicationFactory(
             status=Application.SENT,
             partner=PartnerFactory(authorization_method=Partner.BUNDLE),
@@ -339,14 +339,14 @@ class ViewsTestCase(TestCase):
 
         factory = RequestFactory()
         request = factory.get(
-            reverse("users:withdraw", kwargs={"pk": self.editor1.pk, "id": app.pk})
+            reverse("users:my_applications", kwargs={"pk": self.editor1.pk})
         )
         request.user = self.user_editor
-        response = views.WithdrawApplication.as_view()(
-            request, pk=self.editor1.pk, id=app.pk
+        response = views. ListApplicationsUserView.as_view()(
+            request, pk=self.editor1.pk,
         )
         app.refresh_from_db()
-        self.assertNotIn(app.status, response.render().content.decode("utf-8"))
+        self.assertNotIn("Withdraw", response.render().content.decode("utf-8"))
 
     def test_my_library_page_has_authorizations(self):
 

--- a/TWLight/users/tests.py
+++ b/TWLight/users/tests.py
@@ -342,8 +342,9 @@ class ViewsTestCase(TestCase):
             reverse("users:my_applications", kwargs={"pk": self.editor1.pk})
         )
         request.user = self.user_editor
-        response = views. ListApplicationsUserView.as_view()(
-            request, pk=self.editor1.pk,
+        response = views.ListApplicationsUserView.as_view()(
+            request,
+            pk=self.editor1.pk,
         )
         app.refresh_from_db()
         self.assertNotIn("Withdraw", response.render().content.decode("utf-8"))

--- a/TWLight/users/tests.py
+++ b/TWLight/users/tests.py
@@ -312,21 +312,12 @@ class ViewsTestCase(TestCase):
         # expected string is too fragile.
 
     def test_withdraw_application(self):
-        app1 = ApplicationFactory(
-            status=Application.PENDING,
+        app = ApplicationFactory(
+            status=Application.SENT,
             partner=PartnerFactory(authorization_method=Partner.BUNDLE),
             editor=self.user_editor.editor,
         )
-        app2 = ApplicationFactory(
-            status=Application.APPROVED,
-            partner=PartnerFactory(authorization_method=Partner.BUNDLE),
-            editor=self.user_editor.editor,
-        )
-        app3 = ApplicationFactory(
-            status=Application.QUESTION,
-            partner=PartnerFactory(authorization_method=Partner.BUNDLE),
-            editor=self.user_editor.editor,
-        )
+
         factory = RequestFactory()
         request = factory.get(
             reverse("users:withdraw", kwargs={"pk": self.editor1.pk, "id": app.pk})
@@ -336,9 +327,8 @@ class ViewsTestCase(TestCase):
             request, pk=self.editor1.pk, id=app.pk
         )
         app.refresh_from_db()
-        self.assertEqual(app1.status, Application.INVALID)
-        self.assertEqual(app2.status, Application.INVALID)
-        self.assertEqual(app3.status, Application.INVALID)
+        # self.assertEqual(app.status, Application.INVALID)
+        self.assertNotIn(app.status, response.render().content.decode("utf-8"))
 
     def test_my_library_page_has_authorizations(self):
 

--- a/TWLight/users/tests.py
+++ b/TWLight/users/tests.py
@@ -313,7 +313,7 @@ class ViewsTestCase(TestCase):
 
     def test_withdraw_application(self):
         app = ApplicationFactory(
-            status=Application.SENT,
+            status=Application.PENDING,
             partner=PartnerFactory(authorization_method=Partner.BUNDLE),
             editor=self.user_editor.editor,
         )
@@ -327,7 +327,25 @@ class ViewsTestCase(TestCase):
             request, pk=self.editor1.pk, id=app.pk
         )
         app.refresh_from_db()
-        # self.assertEqual(app.status, Application.INVALID)
+        self.assertEqual(app.status, Application.INVALID)
+
+    def test_withdraw_sent_application(self):
+        app = ApplicationFactory(
+            status=Application.SENT,
+            partner=PartnerFactory(authorization_method=Partner.BUNDLE),
+            editor=self.user_editor.editor,
+            sent_by=self.user_coordinator,
+        )
+
+        factory = RequestFactory()
+        request = factory.get(
+            reverse("users:withdraw", kwargs={"pk": self.editor1.pk, "id": app.pk})
+        )
+        request.user = self.user_editor
+        response = views.WithdrawApplication.as_view()(
+            request, pk=self.editor1.pk, id=app.pk
+        )
+        app.refresh_from_db()
         self.assertNotIn(app.status, response.render().content.decode("utf-8"))
 
     def test_my_library_page_has_authorizations(self):


### PR DESCRIPTION

[//]: # (Thank you for uploading a PR to the Wikipedia Library!)

## Description
Withdraw was appearing to all the status except invalid. I make a change in it. Now it will appear to only  PENDING, APPROVED and  UNDER DISCUSSION status.

## Rationale
[//]: # (Why is this change required? What problem does it solve?)

## Phabricator Ticket
https://phabricator.wikimedia.org/T268449

## How Has This Been Tested?
[//]: # (- Did you add tests to your changes? Did you modify tests to accommodate your changes?)
[//]: # (- Can this change be tested manually? How?)

## Screenshots of your changes (if appropriate):
[//]: # (It can also be a GIF to prove that your changes are working)

## Types of changes
What types of changes does your code introduce? Add an `x` in all the boxes that apply:
- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
