### PR TITLE
Anchored the Library bundle 'Learn More' button to the Library

### DIFF
--- a/TWLight/templates/about.html
+++ b/TWLight/templates/about.html
@@ -165,7 +165,7 @@
     {% endblocktrans %}
   </p>
 
-  <h3>Library Bundle</h3>
+  <h3 id="bundle-section">Library Bundle</h3>
 
   <p>
     {% comment %}Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/) {% endcomment %}

--- a/TWLight/templates/home.html
+++ b/TWLight/templates/home.html
@@ -87,7 +87,7 @@
           </div>
         {% else %}
 				  {% comment %}Translators: On the main page of the website (https://wikipedialibrary.wmflabs.org/), the 'Learn more' button takes users to the 'About' page. {% endcomment %}
-          <a href="{% url 'about' %}" class="btn btn-default btn-block read-more">{% trans "Learn more" %} </a>
+          <a href="{% url 'about' %}#bundle-section" class="btn btn-default btn-block read-more">{% trans "Learn more" %} </a>
         {% endif %}
       </div>
 	  </div>


### PR DESCRIPTION
[//]: # (Thank you for uploading a PR to the Wikipedia Library!)

## Description
When a user was clicking on the Learn More button in the Library Bundle information box, instead of taking to that section it used to take it to about page only. SO I wrote the code so it will navigate to the Library bundle section on the About page.

## Rationale
[//]: # (Why is this change required? What problem does it solve?)

## Phabricator Ticket
https://phabricator.wikimedia.org/T252511

## How Has This Been Tested?
[//]: # (- Did you add tests to your changes? Did you modify tests to accommodate your changes?)
[//]: # (- Can this change be tested manually? How?)

## Screenshots of your changes (if appropriate):
[//]: # (It can also be a GIF to prove that your changes are working)

## Types of changes
What types of changes does your code introduce? Add an `x` in all the boxes that apply:
- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
