### PR TITLE
T265146 housekkeeping

### DIFF
--- a/TWLight/users/management/commands/user_update_eligibility.py
+++ b/TWLight/users/management/commands/user_update_eligibility.py
@@ -89,6 +89,7 @@ class Command(BaseCommand):
             # `global_userinfo` data may be overridden.
             if options["global_userinfo"]:
                 global_userinfo = options["global_userinfo"]
+                editor.check_sub(global_userinfo["id"])
             # Default behavior is to fetch live `global_userinfo`
             else:
                 global_userinfo = editor_global_userinfo(editor.wp_sub)

--- a/TWLight/users/management/commands/user_update_eligibility.py
+++ b/TWLight/users/management/commands/user_update_eligibility.py
@@ -111,6 +111,9 @@ class Command(BaseCommand):
                 editor.wp_bundle_eligible = editor_bundle_eligible(editor)
                 # Save editor.
                 editor.save()
-                editor.prune_editcount(current_datetime=datetime_override)
+                # Prune EditorLogs, with daily_prune_range set to only check the previous day to improve performance.
+                editor.prune_editcount(
+                    current_datetime=datetime_override, daily_prune_range=2
+                )
                 # Update bundle authorizations.
                 editor.update_bundle_authorization()

--- a/TWLight/users/management/commands/user_update_eligibility.py
+++ b/TWLight/users/management/commands/user_update_eligibility.py
@@ -2,7 +2,7 @@ from datetime import timedelta
 import logging
 from django.utils.timezone import now
 from django.core.management.base import BaseCommand
-from TWLight.users.models import Editor, EditorLog
+from TWLight.users.models import Editor
 
 from TWLight.users.helpers.editor_data import (
     editor_global_userinfo,
@@ -91,9 +91,7 @@ class Command(BaseCommand):
                 global_userinfo = options["global_userinfo"]
             # Default behavior is to fetch live `global_userinfo`
             else:
-                global_userinfo = editor_global_userinfo(
-                    editor.wp_username, editor.wp_sub, True
-                )
+                global_userinfo = editor_global_userinfo(editor.wp_sub)
             if global_userinfo:
                 editor.update_editcount(global_userinfo["editcount"], datetime_override)
                 # Determine editor validity.

--- a/TWLight/users/models.py
+++ b/TWLight/users/models.py
@@ -375,8 +375,7 @@ class Editor(models.Model):
             self.wp_enough_recent_edits = True
 
     def prune_editcount(
-        self,
-        current_datetime: timezone = None,
+        self, current_datetime: timezone = None, daily_prune_range: int = 30
     ):
         """
         Removes extraneous and outdated EditorLogs related to this editor.
@@ -384,7 +383,8 @@ class Editor(models.Model):
         ----------
         current_datetime : timezone
             optional timezone-aware timestamp override that represents now()
-
+        daily_prune_range : int
+            optional number of days to check for and prune excess daily counts. Defaults to 30.
         Returns
         -------
         None
@@ -398,12 +398,12 @@ class Editor(models.Model):
         ).delete()
 
         # Prune EditorLogs that:
-        # have a timestamp between 12am 30 days ago and 12am yesterday.
-        # are not the earliest EditorLog for that day.
+        # have a timestamp between 12am `daily_prune_range` days ago and 12am yesterday
+        # and are not the earliest EditorLog for that day.
         current_date = timezone.localtime(current_datetime).replace(
             hour=0, minute=0, second=0, microsecond=0
         )
-        for day in range(1, 30):
+        for day in range(1, daily_prune_range):
             start_time = current_date - timedelta(days=day + 1)
             end_time = current_date - timedelta(days=day)
             extra_logs = EditorLog.objects.filter(

--- a/TWLight/users/tests.py
+++ b/TWLight/users/tests.py
@@ -1557,7 +1557,7 @@ class ManagementCommandsTestCase(TestCase):
 
         self.global_userinfo_editor = {
             "home": "enwiki",
-            "id": 567823,
+            "id": self.editor.wp_sub,
             "registration": "2015-11-06T15:46:29Z",  # Well before first commit.
             "name": "user328",
             "editcount": 5000,
@@ -1582,6 +1582,7 @@ class ManagementCommandsTestCase(TestCase):
                 datetime=datetime.isoformat(
                     self.editor.wp_editcount_updated + timedelta(days=1)
                 ),
+                wp_username=self.editor.wp_username,
                 global_userinfo=self.global_userinfo_editor,
             )
         self.editor.refresh_from_db()
@@ -1679,6 +1680,7 @@ class ManagementCommandsTestCase(TestCase):
             datetime=datetime.isoformat(
                 self.editor.wp_editcount_updated + timedelta(days=1)
             ),
+            wp_username=self.editor.wp_username,
             global_userinfo=self.global_userinfo_editor,
         )
 

--- a/TWLight/users/tests.py
+++ b/TWLight/users/tests.py
@@ -8,7 +8,11 @@ from urllib.parse import urlparse
 
 from django.conf import settings
 from django.contrib.auth.models import User, AnonymousUser
-from django.core.exceptions import PermissionDenied, ValidationError
+from django.core.exceptions import (
+    PermissionDenied,
+    SuspiciousOperation,
+    ValidationError,
+)
 from django.urls import resolve, reverse
 from django.core.management import call_command
 from django.test import TestCase, Client, RequestFactory
@@ -1342,7 +1346,7 @@ class EditorModelTestCase(TestCase):
         # Now check what happens if their wikipedia ID number has changed - this
         # should throw an error as we can no longer verify they're the same
         # editor.
-        with self.assertRaises(AssertionError):
+        with self.assertRaises(SuspiciousOperation):
             new_identity["sub"] = new_editor.wp_sub + 1
             new_global_userinfo["id"] = new_identity["sub"]
             new_editor.update_from_wikipedia(


### PR DESCRIPTION
## Description
Some post-recent-editcount-revamp housekeeping
- global userinfo requests use wp_sub only
- cleaner wp_sub validation
- small change to the prune_editcount method for better performance

## Rationale
We saw a few errors and some slow performance from user_update_eligibility after revamping recent editcount code.

## Phabricator Ticket
https://phabricator.wikimedia.org/T265146

## How Has This Been Tested?
Updated unit tests

## Screenshots of your changes (if appropriate):
NA

## Types of changes
What types of changes does your code introduce? Add an `x` in all the boxes that apply:
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
