### PR TITLE
Fix server error when coordinators view their own application

### DIFF
--- a/TWLight/view_mixins.py
+++ b/TWLight/view_mixins.py
@@ -80,6 +80,10 @@ def test_func_partner_coordinator(obj, user):
             # Return true if the object is an application to a
             # partner for whom the user is a designated coordinator
             elif isinstance(obj, Application):
+                # When coordinators view their own application
+                # Return none if the partner has no coordinator
+                if obj.partner.coordinator is None:
+                    return None
                 obj_partner_coordinator_test = obj.partner.coordinator.pk == user.pk
             # Return true if the object is a partner for whom the user is a designated coordinator
             elif isinstance(obj, Partner):


### PR DESCRIPTION
## Description
When coordinators view their own application to a Partner which
has no coordinator then we need to return None

## Phabricator Ticket
https://phabricator.wikimedia.org/T262248

## How Has This Been Tested?
I have not tested it.

## Types of changes
What types of changes does your code introduce? Add an `x` in all the boxes that apply:
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
