### PR TITLE
Replace docker.io with quay.io for wikipedialibrary images

### DIFF
--- a/.travis/deploy.sh
+++ b/.travis/deploy.sh
@@ -33,7 +33,7 @@ then
 fi
 
 # Push docker image if is build was fired from a push to master, staging, or production and there are no missing migrations or changed translations.
-if [ "${TRAVIS_PULL_REQUEST}" = "false" ] && [ -z "${TRAVIS_TAG}" ] && [ "${TRAVIS_BRANCH}" = "master" ] || [ "${TRAVIS_BRANCH}" = "staging" ] || [ "${TRAVIS_BRANCH}" = "production" ] && [ -n "${DOCKER_USERNAME+isset}" ] && [ -n "${DOCKER_PASSWORD+isset}" ] && [ -n "${TWLIGHT_MISSING_MIGRATIONS+isset}" ] && [ "${TWLIGHT_MISSING_MIGRATIONS}" -eq 0 ] && [ "${TWLIGHT_TRANSLATION_FILES_CHANGED}" -eq 0 ]
+if [ "${TRAVIS_PULL_REQUEST}" = "false" ] && [ -z "${TRAVIS_TAG}" ] && [ "${TRAVIS_BRANCH}" = "master" ] || [ "${TRAVIS_BRANCH}" = "staging" ] || [ "${TRAVIS_BRANCH}" = "production" ] && [ -n "${cr_server+isset}" ] && [ -n "${cr_username+isset}" ] && [ -n "${cr_password+isset}" ] && [ -n "${TWLIGHT_MISSING_MIGRATIONS+isset}" ] && [ "${TWLIGHT_MISSING_MIGRATIONS}" -eq 0 ] && [ "${TWLIGHT_TRANSLATION_FILES_CHANGED}" -eq 0 ]
 then
    TWLIGHT_MISSING_MIGRATIONS=${TWLIGHT_MISSING_MIGRATIONS} TWLIGHT_TRANSLATION_FILES_CHANGED=${TWLIGHT_TRANSLATION_FILES_CHANGED} .travis/./docker_push.sh
 fi

--- a/.travis/docker_compose.sh
+++ b/.travis/docker_compose.sh
@@ -1,11 +1,13 @@
 #!/usr/bin/env bash
 
+# Pull alpine base image from docker hub, but then retag it for $cr_server for reuse.
 docker pull "library/alpine:3.11" || true
+docker tag "library/alpine:3.11" "${cr_server}/wikipedialibrary/alpine:3.11"
 docker pull "${cr_server}/wikipedialibrary/twlight_base:${BRANCH_TAG}" || true
 docker pull "${cr_server}/wikipedialibrary/twlight_build:${BRANCH_TAG}" || true
 docker pull "${cr_server}/wikipedialibrary/twlight:${BRANCH_TAG}" || true
 
-docker build --cache-from "library/alpine:3.11" \
+docker build --cache-from "${cr_server}/wikipedialibrary/alpine:3.11" \
              --cache-from "${cr_server}/wikipedialibrary/twlight_base:${BRANCH_TAG}" \
              --target twlight_base \
              --tag "${cr_server}/wikipedialibrary/twlight_base:${COMMIT_TAG}"  \

--- a/.travis/docker_compose.sh
+++ b/.travis/docker_compose.sh
@@ -1,8 +1,10 @@
 #!/usr/bin/env bash
 
-# Pull alpine base image from docker hub, but then retag it for $cr_server for reuse.
-docker pull "library/alpine:3.11" || true
-docker tag "library/alpine:3.11" "${cr_server}/wikipedialibrary/alpine:3.11"
+# Pull alpine base image from docker hub, but then retag it for $cr_server for reuse and mirroring.
+docker pull "docker.io/library/alpine:3.11" || true
+docker tag "docker.io/library/alpine:3.11" "${cr_server}/wikipedialibrary/alpine:3.11"
+
+# Build images with caching and then run the stack in docker-compose.
 docker pull "${cr_server}/wikipedialibrary/twlight_base:${BRANCH_TAG}" || true
 docker pull "${cr_server}/wikipedialibrary/twlight_build:${BRANCH_TAG}" || true
 docker pull "${cr_server}/wikipedialibrary/twlight:${BRANCH_TAG}" || true

--- a/.travis/docker_compose.sh
+++ b/.travis/docker_compose.sh
@@ -1,8 +1,10 @@
 #!/usr/bin/env bash
 
-# Pull alpine base image from docker hub, but then retag it for $cr_server for reuse and mirroring.
+# Pull images from docker hub, but then retag for $cr_server for reuse and mirroring.
 docker pull "docker.io/library/alpine:3.11" || true
 docker tag "docker.io/library/alpine:3.11" "${cr_server}/wikipedialibrary/alpine:3.11"
+docker pull "docker.io/library/mariadb:10" || true
+docker tag "docker.io/library/mariadb:10" "${cr_server}/wikipedialibrary/mariadb:10"
 
 # Build images with caching and then run the stack in docker-compose.
 docker pull "${cr_server}/wikipedialibrary/twlight_base:${BRANCH_TAG}" || true

--- a/.travis/docker_compose.sh
+++ b/.travis/docker_compose.sh
@@ -1,29 +1,29 @@
 #!/usr/bin/env bash
 
-docker pull "library/alpine:latest" || true
-docker pull "wikipedialibrary/twlight_base:${BRANCH_TAG}" || true
-docker pull "wikipedialibrary/twlight_build:${BRANCH_TAG}" || true
-docker pull "wikipedialibrary/twlight:${BRANCH_TAG}" || true
+docker pull "library/alpine:3.11" || true
+docker pull "${cr_server}/wikipedialibrary/twlight_base:${BRANCH_TAG}" || true
+docker pull "${cr_server}/wikipedialibrary/twlight_build:${BRANCH_TAG}" || true
+docker pull "${cr_server}/wikipedialibrary/twlight:${BRANCH_TAG}" || true
 
-docker build --cache-from "library/alpine:latest" \
-             --cache-from "wikipedialibrary/twlight_base:${BRANCH_TAG}" \
+docker build --cache-from "library/alpine:3.11" \
+             --cache-from "${cr_server}/wikipedialibrary/twlight_base:${BRANCH_TAG}" \
              --target twlight_base \
-             --tag "wikipedialibrary/twlight_base:${COMMIT_TAG}"  \
-             --tag "wikipedialibrary/twlight_base:${BRANCH_TAG}"  \
-             --tag "wikipedialibrary/twlight_base:${BUILD_TAG}" \
+             --tag "${cr_server}/wikipedialibrary/twlight_base:${COMMIT_TAG}"  \
+             --tag "${cr_server}/wikipedialibrary/twlight_base:${BRANCH_TAG}"  \
+             --tag "${cr_server}/wikipedialibrary/twlight_base:${BUILD_TAG}" \
              . && \
-docker build --cache-from "wikipedialibrary/twlight_base:${BRANCH_TAG}" \
-             --cache-from "wikipedialibrary/twlight_build:${BRANCH_TAG}" \
+docker build --cache-from "${cr_server}/wikipedialibrary/twlight_base:${BRANCH_TAG}" \
+             --cache-from "${cr_server}/wikipedialibrary/twlight_build:${BRANCH_TAG}" \
              --target twlight_build \
-             --tag "wikipedialibrary/twlight_build:${COMMIT_TAG}" \
-             --tag "wikipedialibrary/twlight_build:${BRANCH_TAG}" \
-             --tag "wikipedialibrary/twlight_build:${BUILD_TAG}" \
+             --tag "${cr_server}/wikipedialibrary/twlight_build:${COMMIT_TAG}" \
+             --tag "${cr_server}/wikipedialibrary/twlight_build:${BRANCH_TAG}" \
+             --tag "${cr_server}/wikipedialibrary/twlight_build:${BUILD_TAG}" \
              . && \
-docker build --cache-from "wikipedialibrary/twlight_base:${BRANCH_TAG}" \
-             --cache-from "wikipedialibrary/twlight_build:${BRANCH_TAG}" \
-             --cache-from "wikipedialibrary/twlight:${BRANCH_TAG}"  \
-             --tag "wikipedialibrary/twlight:${COMMIT_TAG}" \
-             --tag "wikipedialibrary/twlight:${BRANCH_TAG}" \
-             --tag "wikipedialibrary/twlight:${BUILD_TAG}" \
+docker build --cache-from "${cr_server}/wikipedialibrary/twlight_base:${BRANCH_TAG}" \
+             --cache-from "${cr_server}/wikipedialibrary/twlight_build:${BRANCH_TAG}" \
+             --cache-from "${cr_server}/wikipedialibrary/twlight:${BRANCH_TAG}"  \
+             --tag "${cr_server}/wikipedialibrary/twlight:${COMMIT_TAG}" \
+             --tag "${cr_server}/wikipedialibrary/twlight:${BRANCH_TAG}" \
+             --tag "${cr_server}/wikipedialibrary/twlight:${BUILD_TAG}" \
              . && \
 docker-compose -f docker-compose.yml -f docker-compose.travis.yml up -d db twlight

--- a/.travis/docker_compose.sh
+++ b/.travis/docker_compose.sh
@@ -5,6 +5,8 @@ docker pull "docker.io/library/alpine:3.11" || true
 docker tag "docker.io/library/alpine:3.11" "${cr_server}/wikipedialibrary/alpine:3.11"
 docker pull "docker.io/library/mariadb:10" || true
 docker tag "docker.io/library/mariadb:10" "${cr_server}/wikipedialibrary/mariadb:10"
+docker pull "docker.io/library/nginx:latest" || true
+docker tag "docker.io/library/nginx:latest" "${cr_server}/wikipedialibrary/nginx:latest"
 
 # Build images with caching and then run the stack in docker-compose.
 docker pull "${cr_server}/wikipedialibrary/twlight_base:${BRANCH_TAG}" || true

--- a/.travis/docker_push.sh
+++ b/.travis/docker_push.sh
@@ -15,6 +15,7 @@ then
   echo "$cr_password" | docker login $cr_server -u "$cr_username" --password-stdin
 
   docker push ${cr_server}/wikipedialibrary/alpine:3.11
+  docker push ${cr_server}/wikipedialibrary/mariadb:10
 
   docker push ${cr_server}/wikipedialibrary/twlight_base:${COMMIT_TAG}
   docker push ${cr_server}/wikipedialibrary/twlight_base:${BRANCH_TAG}

--- a/.travis/docker_push.sh
+++ b/.travis/docker_push.sh
@@ -13,6 +13,9 @@ echo "TWLIGHT_TRANSLATION_FILES_CHANGED: ${TWLIGHT_TRANSLATION_FILES_CHANGED}"
 if [ "${TRAVIS_PULL_REQUEST}" = "false" ] && [ -z "${TRAVIS_TAG}" ] && [ -n "${cr_server+isset}" && [ -n "${cr_username+isset}" ] && [ -n "${cr_password+isset}" ] && [ -n "${TWLIGHT_MISSING_MIGRATIONS+isset}" ] && [ "${TWLIGHT_MISSING_MIGRATIONS}" -eq 0 ] && [ "${TWLIGHT_TRANSLATION_FILES_CHANGED}" -eq 0 ]
 then
   echo "$cr_password" | docker login $cr_server -u "$cr_username" --password-stdin
+
+  docker push ${cr_server}/wikipedialibrary/alpine:3.11
+
   docker push ${cr_server}/wikipedialibrary/twlight_base:${COMMIT_TAG}
   docker push ${cr_server}/wikipedialibrary/twlight_base:${BRANCH_TAG}
   docker push ${cr_server}/wikipedialibrary/twlight_base:${BUILD_TAG}

--- a/.travis/docker_push.sh
+++ b/.travis/docker_push.sh
@@ -16,6 +16,7 @@ then
 
   docker push ${cr_server}/wikipedialibrary/alpine:3.11
   docker push ${cr_server}/wikipedialibrary/mariadb:10
+  docker push ${cr_server}/wikipedialibrary/nginx:latest
 
   docker push ${cr_server}/wikipedialibrary/twlight_base:${COMMIT_TAG}
   docker push ${cr_server}/wikipedialibrary/twlight_base:${BRANCH_TAG}

--- a/.travis/docker_push.sh
+++ b/.travis/docker_push.sh
@@ -10,18 +10,18 @@ echo "TWLIGHT_TRANSLATION_FILES_CHANGED: ${TWLIGHT_TRANSLATION_FILES_CHANGED}"
 
 
 # Only act if this is build was fired from a push and there are no missing migrations or changed translations.
-if [ "${TRAVIS_PULL_REQUEST}" = "false" ] && [ -z "${TRAVIS_TAG}" ] && [ -n "${DOCKER_USERNAME+isset}" ] && [ -n "${DOCKER_PASSWORD+isset}" ] && [ -n "${TWLIGHT_MISSING_MIGRATIONS+isset}" ] && [ "${TWLIGHT_MISSING_MIGRATIONS}" -eq 0 ] && [ "${TWLIGHT_TRANSLATION_FILES_CHANGED}" -eq 0 ]
+if [ "${TRAVIS_PULL_REQUEST}" = "false" ] && [ -z "${TRAVIS_TAG}" ] && [ -n "${cr_server+isset}" && [ -n "${cr_username+isset}" ] && [ -n "${cr_password+isset}" ] && [ -n "${TWLIGHT_MISSING_MIGRATIONS+isset}" ] && [ "${TWLIGHT_MISSING_MIGRATIONS}" -eq 0 ] && [ "${TWLIGHT_TRANSLATION_FILES_CHANGED}" -eq 0 ]
 then
-  echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
-  docker push wikipedialibrary/twlight_base:${COMMIT_TAG}
-  docker push wikipedialibrary/twlight_base:${BRANCH_TAG}
-  docker push wikipedialibrary/twlight_base:${BUILD_TAG}
+  echo "$cr_password" | docker login $cr_server -u "$cr_username" --password-stdin
+  docker push ${cr_server}/wikipedialibrary/twlight_base:${COMMIT_TAG}
+  docker push ${cr_server}/wikipedialibrary/twlight_base:${BRANCH_TAG}
+  docker push ${cr_server}/wikipedialibrary/twlight_base:${BUILD_TAG}
 
-  docker push wikipedialibrary/twlight_build:${COMMIT_TAG}
-  docker push wikipedialibrary/twlight_build:${BRANCH_TAG}
-  docker push wikipedialibrary/twlight_build:${BUILD_TAG}
+  docker push ${cr_server}/wikipedialibrary/twlight_build:${COMMIT_TAG}
+  docker push ${cr_server}/wikipedialibrary/twlight_build:${BRANCH_TAG}
+  docker push ${cr_server}/wikipedialibrary/twlight_build:${BUILD_TAG}
 
-  docker push wikipedialibrary/twlight:${COMMIT_TAG}
-  docker push wikipedialibrary/twlight:${BRANCH_TAG}
-  docker push wikipedialibrary/twlight:${BUILD_TAG}
+  docker push ${cr_server}/wikipedialibrary/twlight:${COMMIT_TAG}
+  docker push ${cr_server}/wikipedialibrary/twlight:${BRANCH_TAG}
+  docker push ${cr_server}/wikipedialibrary/twlight:${BUILD_TAG}
 fi

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM library/alpine:3.11 as twlight_base
+FROM quay.io/wikipedialibrary/alpine:3.11 as twlight_base
 # Base dependencies.
 RUN apk add --update \
     libjpeg-turbo \

--- a/bin/debian_swarm_deploy.sh
+++ b/bin/debian_swarm_deploy.sh
@@ -82,7 +82,7 @@ echo "Setting up crontab. *WARNING* This will create duplicate jobs if run repea
 (crontab -l 2>/dev/null; echo "# Run django_cron tasks.") | crontab -
 (crontab -l 2>/dev/null; echo '*/5 * * * *  docker exec -t \$(docker ps -q -f name=${TWLIGHT_STACK_ENV}_twlight) /app/bin/twlight_docker_entrypoint.sh python manage.py runcrons') | crontab -
 (crontab -l 2>/dev/null; echo "# Update the running TWLight service if there is a new image. The initial pull is just to verify that the image is valid. Otherwise an inaccessible image could break the service.") | crontab -
-(crontab -l 2>/dev/null; echo '*/5 * * * *  docker pull wikipedialibrary/twlight:branch_${TWLIGHT_GIT_BRANCH} >/dev/null && docker service update --image wikipedialibrary/twlight:branch_${TWLIGHT_GIT_BRANCH} ${TWLIGHT_STACK_ENV}_twlight') | crontab -
+(crontab -l 2>/dev/null; echo '*/5 * * * *  docker pull quay.io/wikipedialibrary/twlight:branch_${TWLIGHT_GIT_BRANCH} >/dev/null && docker service update --image quay.io/wikipedialibrary/twlight:branch_${TWLIGHT_GIT_BRANCH} ${TWLIGHT_STACK_ENV}_twlight') | crontab -
 
 EOF
 sudo su --login twlight /usr/bin/env bash -c "${TWLIGHT}"

--- a/bin/twlight_docker_deploy.sh
+++ b/bin/twlight_docker_deploy.sh
@@ -14,15 +14,15 @@ tag=${2}
 # Move into the repository.
 cd /srv/TWLight
 # Check for newer image
-pull=$(docker pull wikipedialibrary/twlight:${tag})
+pull=$(docker pull quay.io/wikipedialibrary/twlight:${tag})
 
 # Pull swarm config updates and update the stack if there is a new image.
-if echo ${pull} | grep "Status: Downloaded newer image for wikipedialibrary/twlight:${tag}" >/dev/null
+if echo ${pull} | grep "Status: Downloaded newer image for quay.io/wikipedialibrary/twlight:${tag}" >/dev/null
 then
     git pull
     docker stack deploy -c docker-compose.yml -c docker-compose.${env}.yml ${env}
 # Report if the local image is already up to date.
-elif echo ${pull} | grep "Status: Image is up to date for wikipedialibrary/twlight:${tag}" >/dev/null
+elif echo ${pull} | grep "Status: Image is up to date for quay.io/wikipedialibrary/twlight:${tag}" >/dev/null
 then
    echo "Up to date"
 # Fail in any other circumstance.

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -31,7 +31,7 @@ services:
     ports:
       - "3306:3306"
   twlight:
-    image: wikipedialibrary/twlight:local
+    image: quay.io/wikipedialibrary/twlight:local
     env_file:
       - ./conf/local.twlight.env
     # Local environment should mount things from the code directory

--- a/docker-compose.production.yml
+++ b/docker-compose.production.yml
@@ -22,7 +22,7 @@ secrets:
 
 services:
   migrate:
-    image: wikipedialibrary/twlight:branch_production
+    image: quay.io/wikipedialibrary/twlight:branch_production
     command: bash -c "/app/bin/twlight_backup.sh && /app/bin/virtualenv_migrate.sh"
     restart: on-failure
     env_file:

--- a/docker-compose.staging.yml
+++ b/docker-compose.staging.yml
@@ -22,7 +22,7 @@ secrets:
 
 services:
   migrate:
-    image: wikipedialibrary/twlight:branch_staging
+    image: quay.io/wikipedialibrary/twlight:branch_staging
     command: bash -c "/app/bin/twlight_backup.sh && /app/bin/virtualenv_migrate.sh"
     restart: on-failure
     env_file:

--- a/docker-compose.travis.yml
+++ b/docker-compose.travis.yml
@@ -29,12 +29,12 @@ services:
         source: ./conf/db/local.d
         target: /etc/mysql/conf.d
   twlight:
-    image: wikipedialibrary/twlight:${BRANCH_TAG}
+    image: ${cr_server}/wikipedialibrary/twlight:${BRANCH_TAG}
     build:
       cache_from:
-        - wikipedialibrary/twlight_base:${BRANCH_TAG}
-        - wikipedialibrary/twlight_build:${BRANCH_TAG}
-        - wikipedialibrary/twlight:${BRANCH_TAG}
+        - ${cr_server}/wikipedialibrary/twlight_base:${BRANCH_TAG}
+        - ${cr_server}/wikipedialibrary/twlight_build:${BRANCH_TAG}
+        - ${cr_server}/wikipedialibrary/twlight:${BRANCH_TAG}
     env_file:
       - ./conf/travis.twlight.env
     environment:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -42,7 +42,7 @@ services:
       - TWLIGHT_OAUTH_CONSUMER_SECRET
       - TWLIGHT_EZPROXY_SECRET
   web:
-    image: nginx:latest
+    image: quay.io/wikipedialibrary/nginx:latest
     volumes:
       - type: bind
         source: ./media

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,7 @@ volumes:
 
 services:
   db:
-    image: mariadb:10
+    image: quay.io/wikipedialibrary/mariadb:10
     volumes:
       - mysql:/var/lib/mysql
       - type: bind


### PR DESCRIPTION
## Description
Replace docker.io with quay.io for wikipedialibrary images.

## Rationale
The newly enforced docker hub pull rate limits make our deployment pipeline too unpredictable
https://www.docker.com/increase-rate-limits

## Phabricator Ticket
https://phabricator.wikimedia.org/T269784

## How Has This Been Tested?
Our testing capabilities on this are limited since this is an in-band change to our deployment infrastructure.

## Screenshots of your changes (if appropriate):
N/A

## Types of changes
What types of changes does your code introduce? Add an `x` in all the boxes that apply:
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
