### PR TITLE
Don't send two separate emails when access code applications are appr…

### DIFF
--- a/TWLight/emails/tasks.py
+++ b/TWLight/emails/tasks.py
@@ -61,6 +61,10 @@ class CommentNotificationEmailOthers(template_mail.TemplateMail):
     name = "comment_notification_others"
 
 
+class ApprovalNotification(template_mail.TemplateMail):
+    name = "approval_notification"
+
+
 class WaitlistNotification(template_mail.TemplateMail):
     name = "waitlist_notification"
 
@@ -312,6 +316,32 @@ def send_comment_notification_emails(sender, **kwargs):
             )
 
 
+def send_approval_notification_email(instance):
+    base_url = get_current_site(None).domain
+    path = reverse_lazy("users:my_library")
+    link = "https://{base}{path}".format(base=base_url, path=path)
+    email = ApprovalNotification()
+
+    # If, for some reason, we're trying to send an email to a user
+    # who deleted their account, stop doing that.
+    if instance.editor and instance.partner.authorization_method!=1:
+        email.send(
+            instance.user.email,
+            {
+                "user": instance.user.editor.wp_username,
+                "lang": instance.user.userprofile.lang,
+                "partner": instance.partner,
+                "link": link,
+                "user_instructions": instance.get_user_instructions(),
+            },
+        )
+    else:
+        logger.error(
+            "Tried to send an email to an editor that doesn't "
+            "exist, perhaps because their account is deleted."
+        )
+
+
 def send_waitlist_notification_email(instance):
     base_url = get_current_site(None).domain
     path = reverse_lazy("partners:filter")
@@ -388,6 +418,7 @@ def update_app_status_on_save(sender, instance, **kwargs):
     """
     # Maps status indicators to the correct email handling function.
     handlers = {
+        Application.APPROVED: send_approval_notification_email,
         Application.NOT_APPROVED: send_rejection_notification_email,
         # We can't use Partner.WAITLIST as the key, because that's actually an
         # integer, and it happens to be the same as Application.APPROVED. If

--- a/TWLight/emails/templates/emails/access_code_email-body-text.html
+++ b/TWLight/emails/templates/emails/access_code_email-body-text.html
@@ -1,9 +1,17 @@
 {% load i18n %}
 {% comment %}Translators: This email is sent to users with their access code. Don't translate Jinja variables in curly braces like {{ user }} or {{ partner }}. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).{% endcomment %}
 {% blocktrans trimmed %}
+Dear {{ editor_wp_username }},
+
 Your approved application to {{ partner }} has now been finalised. Your access code or login details can be found below:
 
-{{ access_code }}
+{{ access_code }}.
 
-{{ access_code_instructions }}
+User instructions are {{user_instructions}}.
+
+You can view the collections you're authorized to access at My Library: {{ link }}
+
+Cheers!
+
+The Wikipedia Library
 {% endblocktrans %}


### PR DESCRIPTION
[//]: # (Thank you for uploading a PR to the Wikipedia Library!)

## Description
We send users an email when their account is approved. We also send them an email when their application is marked as 'Sent'. In the case of access code applications, these two actions can happen very soon after each other - we already have the access codes so there's no need to send the user's details over to some external partner. We can approve their application, and then head over to the Send interface to assign access codes. Ideally, therefore, we should only send the user one email in the access codes case - when their application is marked Sent with the corresponding access code.

## Rationale
[//]: # (Why is this change required? What problem does it solve?)

## Phabricator Ticket
https://phabricator.wikimedia.org/T262521

## How Has This Been Tested?
[//]: # (- Did you add tests to your changes? Did you modify tests to accommodate your changes?)
[//]: # (- Can this change be tested manually? How?)

## Screenshots of your changes (if appropriate):
[//]: # (It can also be a GIF to prove that your changes are working)

## Types of changes
What types of changes does your code introduce? Add an `x` in all the boxes that apply:
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
