### PR TITLE
'Sent' in the cases where the application is to a publisher with the …

### DIFF
--- a/TWLight/applications/templates/applications/application_list_include.html
+++ b/TWLight/applications/templates/applications/application_list_include.html
@@ -9,9 +9,15 @@
 {% for app in object_list %}
   <div class="row">
     <div class="col-xs-4 col-sm-2">
+    {% if app.partner.authorization_method == 0 %}
       <span class="label label{{ app.get_bootstrap_class }} pull-right">
         {{ app.get_status_display }}
       </span>
+    {% else %}
+      <span class="label label{{ app.get_bootstrap_class }} pull-right">
+        Finalized
+      </span>
+    {% endif %}
     </div>    
     <div class="col-xs-8 col-sm-6">
       <h4>


### PR DESCRIPTION
…EMAIL authorization methods, and 'Finalized' when they have the CODES, PROXY, or LINK methods

[//]: # (Thank you for uploading a PR to the Wikipedia Library!)

## Description
As noted a number of times  'sent' (or 'sent to partner') is becoming a misnomer for the final status of an application on the Library Card platform. Of all our distribution workflows, it really only applies to the EMAIL distribution method. For access codes, proxy, and links, we don't send anything to the partner, and in fact approving an application marks it as 'sent' immediately.

We should rename all strings and variables from 'sent' to 'finalised'. In the EMAIL distribution method case, we could still show users the 'sent to partner' text, and show 'finalized' for other authorization methods.
## Rationale
[//]: # (Why is this change required? What problem does it solve?)

## Phabricator Ticket
https://phabricator.wikimedia.org/T237517

## How Has This Been Tested?
[//]: # (- Did you add tests to your changes? Did you modify tests to accommodate your changes?)
[//]: # (- Can this change be tested manually? How?)

## Screenshots of your changes (if appropriate):
[//]: # (It can also be a GIF to prove that your changes are working)

## Types of changes
What types of changes does your code introduce? Add an `x` in all the boxes that apply:
- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
