### PR TITLE
Handle OAuth login errors better

### DIFF
--- a/TWLight/templates/base.html
+++ b/TWLight/templates/base.html
@@ -180,7 +180,7 @@
         <div class="alert alert-{{ message.tags }}">{{ message|safe }}</div>
       {% endfor %}
     {% endif %}
-    {% if not user.email and not user.is_anonymous %}
+    {% if user.is_authenticated and not user.email %}
       <div class="alert alert-warning">
         {% url 'users:email_change' as email_url %}
         {% url 'contact' as contact_us_url %}
@@ -203,7 +203,7 @@
         {% endblocktrans %}
       </div>
     {% endif %}
-    {% if not user.userprofile.terms_of_use and not user.is_anonymous %}
+    {% if user.is_authenticated and not user.userprofile.terms_of_use %}
       <div class="alert alert-warning">
         {% url 'terms' as terms_url %}
         {% comment %}Translators: Shown if the current user has not agreed to the terms of use. {% endcomment %}

--- a/TWLight/urls.py
+++ b/TWLight/urls.py
@@ -30,6 +30,7 @@ from TWLight.ezproxy.urls import urlpatterns as ezproxy_urls
 
 from .views import LanguageWhiteListView, HomePageView
 
+handler400 = "TWLight.views.bad_request"
 
 urlpatterns = [
     # Built-in -----------------------------------------------------------------

--- a/TWLight/users/oauth.py
+++ b/TWLight/users/oauth.py
@@ -7,7 +7,7 @@ from django.conf import settings
 from django.contrib import messages
 from django.contrib.auth import login, authenticate
 from django.contrib.auth.models import User
-from django.core.exceptions import PermissionDenied, DisallowedHost, SuspiciousOperation
+from django.core.exceptions import DisallowedHost, SuspiciousOperation
 from django.urls import reverse_lazy
 from django.http import HttpResponseRedirect
 from django.http.request import QueryDict
@@ -176,7 +176,7 @@ class OAuthBackend(object):
                     editor = self._create_editor(user, identity)
                     created = True
                 except:
-                    raise PermissionDenied
+                    raise SuspiciousOperation
 
         except User.DoesNotExist:
             logger.info("Can't find user; creating one.")
@@ -198,8 +198,8 @@ class OAuthBackend(object):
 
         try:
             assert isinstance(access_token, AccessToken)
-        except AssertionError:
-            logger.exception("Did not have a properly formed AccessToken")
+        except AssertionError as e:
+            logger.exception(e)
             return None
 
         # Get identifying information about the user. This doubles as a way
@@ -209,17 +209,15 @@ class OAuthBackend(object):
         logger.info("Identifying user...")
         try:
             identity = handshaker.identify(access_token, 15)
-        except OAuthException:
-            logger.warning(
-                "Someone tried to log in but presented an invalid access token."
-            )
+        except OAuthException as e:
+            logger.exception(e)
             messages.add_message(
                 request,
                 messages.WARNING,
                 # Translators: This error message is shown when there's a problem with the authenticated login process.
                 _("You tried to log in but presented an invalid access token."),
             )
-            raise PermissionDenied
+            raise SuspiciousOperation
 
         # Get or create the user.
         logger.info("User has been identified; getting or creating user.")
@@ -245,8 +243,8 @@ class OAuthBackend(object):
     def get_user(self, user_id):
         try:
             return User.objects.get(pk=user_id)
-        except User.DoesNotExist:
-            logger.warning("There is no user {user_id}".format(user_id=user_id))
+        except User.DoesNotExist as e:
+            logger.exception(e)
             return None
 
 
@@ -264,22 +262,22 @@ class OAuthInitializeView(View):
         domain = self.request.get_host()
         try:
             assert domain in settings.ALLOWED_HOSTS  # safety first!
-        except (AssertionError, DisallowedHost):
-            logger.exception()
+        except (AssertionError, DisallowedHost) as e:
+            logger.exception(e)
             messages.add_message(
                 request,
                 messages.WARNING,
                 # Translators: This message is shown when the OAuth login process fails because the request came from the wrong website. Don't translate {domain}.
                 _("{domain} is not an allowed host.").format(domain=domain),
             )
-            raise PermissionDenied
+            raise SuspiciousOperation
 
         # Try to capture the relevant page state, including desired destination
         try:
             request.session["get"] = request.GET
             logger.info("Found get parameters for post-login redirection.")
-        except:
-            logger.warning("No get parameters for post-login redirection.")
+        except Exception as e:
+            logger.warning(e)
             pass
 
         # If the user has already logged in, let's not spam the OAuth provider.
@@ -304,12 +302,9 @@ class OAuthInitializeView(View):
                     "User is already authenticated. Sending them on "
                     'for post-login redirection per "next" parameter.'
                 )
-            except KeyError:
+            except KeyError as e:
                 return_url = reverse_lazy("homepage")
-                logger.warning(
-                    'User already authenticated. No "next" '
-                    "parameter for post-login redirection."
-                )
+                logger.warning(e)
 
             return HttpResponseRedirect(return_url)
         else:
@@ -319,8 +314,14 @@ class OAuthInitializeView(View):
 
             try:
                 redirect, request_token = handshaker.initiate()
-            except OAuthException:
-                logger.exception("Handshaker not initiated.")
+            except OAuthException as e:
+                logger.exception(e)
+                messages.add_message(
+                    request,
+                    messages.WARNING,
+                    # Translators: This warning message is shown to users when OAuth handshaker can't be initiated.
+                    _("Handshaker not initiated, please try logging in again."),
+                )
                 raise SuspiciousOperation
 
             local_redirect = _localize_oauth_redirect(redirect)
@@ -349,43 +350,43 @@ class OAuthCallbackView(View):
             response_qs_parsed = urllib.parse.parse_qs(response_qs)
             assert "oauth_token" in response_qs_parsed
             assert "oauth_verifier" in response_qs_parsed
-        except (AssertionError, TypeError):
-            logger.exception("Did not receive a valid oauth response.")
+        except (AssertionError, TypeError) as e:
+            logger.exception(e)
             messages.add_message(
                 request,
                 messages.WARNING,
                 # Translators: This warning message is shown to users when the response received from Wikimedia OAuth servers is not a valid one.
                 _("Did not receive a valid oauth response."),
             )
-            raise PermissionDenied
+            raise SuspiciousOperation
 
         # Get the handshaker. It should have already been constructed by
         # OAuthInitializeView.
         domain = self.request.get_host()
         try:
             assert domain in settings.ALLOWED_HOSTS
-        except (AssertionError, DisallowedHost):
-            logger.exception("Domain is not an allowed host")
+        except (AssertionError, DisallowedHost) as e:
+            logger.exception(e)
             messages.add_message(
                 request,
                 messages.WARNING,
                 # Translators: This message is shown when the OAuth login process fails because the request came from the wrong website. Don't translate {domain}.
                 _("{domain} is not an allowed host.").format(domain=domain),
             )
-            raise PermissionDenied
+            raise SuspiciousOperation
 
         try:
             handshaker = _get_handshaker()
-        except AssertionError:
+        except AssertionError as e:
             # get_handshaker will throw AssertionErrors for invalid data.
-            logger.exception("Could not find handshaker")
+            logger.exception(e)
             messages.add_message(
                 request,
                 messages.WARNING,
                 # Translators: This message is shown when the OAuth login process fails.
                 _("Could not find handshaker."),
             )
-            raise PermissionDenied
+            raise SuspiciousOperation
 
         # Get the session token placed by OAuthInitializeView.
         session_token = request.session.pop("request_token", None)
@@ -398,33 +399,33 @@ class OAuthCallbackView(View):
                 # Translators: This message is shown when the OAuth login process fails.
                 _("No session token."),
             )
-            raise PermissionDenied
+            raise SuspiciousOperation
 
         # Rehydrate it into a request token.
         request_token = _rehydrate_token(session_token)
 
         if not request_token:
-            logger.info("No request token.")
+            logger.exception("No request token.")
             messages.add_message(
                 request,
                 messages.WARNING,
                 # Translators: This message is shown when the OAuth login process fails.
                 _("No request token."),
             )
-            raise PermissionDenied
+            raise SuspiciousOperation
 
         # See if we can complete the OAuth process.
         try:
             access_token = handshaker.complete(request_token, response_qs)
-        except:
-            logger.exception("Access token generation failed.")
+        except OAuthException as e:
+            logger.exception(e)
             messages.add_message(
                 request,
                 messages.WARNING,
                 # Translators: This message is shown when the OAuth login process fails.
                 _("Access token generation failed."),
             )
-            raise PermissionDenied
+            raise SuspiciousOperation
 
         user = authenticate(
             request=request, access_token=access_token, handshaker=handshaker
@@ -490,12 +491,9 @@ class OAuthCallbackView(View):
                             "User authenticated. Sending them on for "
                             'post-login redirection per "next" parameter.'
                         )
-                    except KeyError:
+                    except KeyError as e:
                         return_url = reverse_lazy("homepage")
-                        logger.warning(
-                            'User authenticated. No "next" parameter '
-                            "for post-login redirection."
-                        )
+                        logger.warning(e)
                 else:
                     return_url = reverse_lazy("terms")
         else:

--- a/TWLight/users/views.py
+++ b/TWLight/users/views.py
@@ -286,7 +286,7 @@ class UserHomeView(View):
     @classonlymethod
     def as_view(cls):
         def _get_view(request, *args, **kwargs):
-            if request.user.is_anonymous:
+            if not request.user.is_authenticated:
                 # We can't use something like django-braces LoginRequiredMixin
                 # here, because as_view applies at an earlier point in the
                 # process.

--- a/TWLight/views.py
+++ b/TWLight/views.py
@@ -4,6 +4,7 @@ import json
 from django.views.generic import TemplateView
 from django.views import View
 from django.conf import settings
+from django.contrib.messages import get_messages
 from django.http import HttpResponse
 from django.utils.translation import gettext_lazy as _
 
@@ -108,5 +109,6 @@ def bad_request(request, exception, template_name=ERROR_400_TEMPLATE_NAME):
             content_type="text/html",
         )
     # In django core, no exception content is passed to the template, to not disclose any sensitive information.
-    # We go ahead and include the request data so that we can pass in messages.
-    return HttpResponseBadRequest(template.render(request=request))
+    # We pass in messages fetched from request data, but leave the rest behind.
+    messages = get_messages(request)
+    return HttpResponseBadRequest(template.render({"messages": messages}))

--- a/TWLight/views.py
+++ b/TWLight/views.py
@@ -1,18 +1,22 @@
 # -*- coding: utf-8 -*-
 import json
 
-from django.urls import reverse_lazy
 from django.views.generic import TemplateView
 from django.views import View
 from django.conf import settings
 from django.http import HttpResponse
 from django.utils.translation import gettext_lazy as _
 
-from TWLight.applications.models import Application
 from TWLight.resources.models import Partner
-from TWLight.users.models import Editor
+
+from django.http import HttpResponseBadRequest
+from django.template import TemplateDoesNotExist, loader
+from django.views.decorators.csrf import requires_csrf_token
+from django.views.decorators.debug import sensitive_variables
 
 import logging
+
+from django.views.defaults import ERROR_400_TEMPLATE_NAME, ERROR_PAGE_TEMPLATE
 
 logger = logging.getLogger(__name__)
 
@@ -83,3 +87,26 @@ class HomePageView(TemplateView):
         context["featured_partners"] = Partner.objects.filter(featured=True)[:3]
 
         return context
+
+
+@sensitive_variables()
+@requires_csrf_token
+def bad_request(request, exception, template_name=ERROR_400_TEMPLATE_NAME):
+    """
+    400 error handler.
+    Templates: :template:`400.html`
+    Context: None
+    """
+    try:
+        template = loader.get_template(template_name)
+    except TemplateDoesNotExist:
+        if template_name != ERROR_400_TEMPLATE_NAME:
+            # Reraise if it's a missing custom template.
+            raise
+        return HttpResponseBadRequest(
+            ERROR_PAGE_TEMPLATE % {"title": "Bad Request (400)", "details": ""},
+            content_type="text/html",
+        )
+    # In django core, no exception content is passed to the template, to not disclose any sensitive information.
+    # We go ahead and include the request data so that we can pass in messages.
+    return HttpResponseBadRequest(template.render(request=request))


### PR DESCRIPTION
[//]: # (Thank you for uploading a PR to the Wikipedia Library!)

## Description
Moves a bunch of exceptions over to suspicious operation exceptions and updates the 400 error handler to use a slightly modified view that allows the django messages framework to function for 400 errors. Adds a "please try again" message when users encounter the handshaker problem we've been seeing in the logs.

## Rationale
Our unhandled oauth exceptions are unhelpful to users and are blowing up our inboxes with error messages.

## Phabricator Ticket
https://phabricator.wikimedia.org/T255431

## How Has This Been Tested?
I manually raised various exceptions in different parts of the oauth code block to verify the behavior. Oauth exchange is a big black hole in our test suite, and I wasn't about to open that can of worms to fix this annoyance.

## Screenshots of your changes (if appropriate):
This turns out to be a hassle to get good screenshots of for a variety of reasons. Know that the current result is a 500 error, and the PR gives a 400 bad request error with a call to action.

## Types of changes
What types of changes does your code introduce? Add an `x` in all the boxes that apply:
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
