### PR TITLE
Fix bug preventing saving users with Bundle authorizations

### DIFF
--- a/TWLight/users/admin.py
+++ b/TWLight/users/admin.py
@@ -58,13 +58,6 @@ class UserProfileInline(admin.StackedInline):
     )
 
 
-class AuthorizationInline(admin.StackedInline):
-    form = AuthorizationInlineForm
-    model = Authorization
-    fk_name = "user"
-    extra = 0
-
-
 class AuthorizationAdmin(admin.ModelAdmin):
     list_display = (
         "id",
@@ -111,6 +104,13 @@ class AuthorizationAdmin(admin.ModelAdmin):
 
 
 admin.site.register(Authorization, AuthorizationAdmin)
+
+
+class AuthorizationInline(admin.StackedInline):
+    form = AuthorizationAdminForm
+    model = Authorization
+    fk_name = "user"
+    extra = 0
 
 
 class UserAdmin(AuthUserAdmin):


### PR DESCRIPTION
## Description
AuthorizationInline should use the same custom form as AuthorizationAdmin to allow for authorizations generated by `TWL Team`.

## Rationale
Editors with `TWL Team` authorizations can't currently be modified in the admin site.

## Phabricator Ticket
https://phabricator.wikimedia.org/T272459

## How Has This Been Tested?
Manually tested saving editors with `TWL Team` authorizations in the admin site.

## Screenshots of your changes (if appropriate):
N/A

## Types of changes
What types of changes does your code introduce? Add an `x` in all the boxes that apply:
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
