### PR TITLE
Remove a space from inside a link in a message

### DIFF
--- a/TWLight/templates/about.html
+++ b/TWLight/templates/about.html
@@ -206,8 +206,7 @@
     {% url 'contact' as contact_url %}
     {% comment %}Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).{% endcomment %}
     {% blocktrans trimmed %}
-      If you have questions, need help, or want to volunteer to help, please see our <a href="{{ contact_url }}">
-      contact page</a>.
+      If you have questions, need help, or want to volunteer to help, please see our <a href="{{ contact_url }}">contact page</a>.
     {% endblocktrans %}
   </p>
 


### PR DESCRIPTION
[//]: # (Thank you for uploading a PR to the Wikipedia Library!)

## Description
Describe your changes in detail following the [commit message guidelines](https://www.mediawiki.org/wiki/Gerrit/Commit_message_guidelines)

Remove space in a message inside an HTML element.

## Rationale
[//]: # (Why is this change required? What problem does it solve?)

The current code adds an unnecessary space to an already-non-trivial translatable message. Without the space it will be easier to translate.