### PR TITLE
scrub glitchtip event data

### DIFF
--- a/TWLight/settings/helpers.py
+++ b/TWLight/settings/helpers.py
@@ -1,0 +1,76 @@
+import re
+from typing import Any
+
+
+def sentry_before_send(event: dict, hint: dict):
+    """
+    Callback for sentry's client-side event filtering.
+    We're using it to mask sensitive data.
+    https://docs.sentry.io/platforms/python/configuration/filtering/#filtering-error-events
+    Parameters
+    ----------
+    event : dict
+        Sentry event dictionary object
+    hint : dict
+        Source data dictionary used to create the event.
+        https://docs.sentry.io/platforms/python/configuration/filtering/#using-hints
+    Returns
+    -------
+    dict
+        The modified event.
+    """
+    # We catch any exception, because if we don't, the event is dropped.
+    # We want to keep passing them on so we can continually improve our scrubbing
+    # while still sending events.
+    # noinspection PyBroadException
+    try:
+        event = _scrub_event(event)
+    except:
+        pass
+
+    return event
+
+
+def _mask(dirty: str):
+    """
+    Masks out known sensitive data from string.
+    Parameters
+    ----------
+    dirty : str
+        Input that may contain sensitive information.
+    Returns
+    -------
+    str
+        Output with any known sensitive information masked out.
+    """
+    # DB credentials as found in called processes.
+    pattern = re.compile("([' ])--(user|password)=.+([' ])")
+    clean = pattern.sub(r"\1--\2=*****\3", dirty)
+
+    return clean
+
+
+def _scrub_event(event_data: Any):
+    """
+    Recursively traverses sentry event data returns a scrubbed version.
+    Parameters
+    ----------
+    event_data : Any
+        Input that may contain sensitive information.
+    Returns
+    -------
+    Any
+        Output with any known sensitive information masked out.
+    """
+    # Basically cribbed from stackoverflow:
+    # https://stackoverflow.com/a/38970181
+    if isinstance(event_data, dict):
+        items = event_data.items()
+    elif isinstance(event_data, (list, tuple)):
+        items = enumerate(event_data)
+    else:
+        return _mask(str(event_data))
+
+    for key, value in items:
+        event_data[key] = _scrub_event(value)
+    return event_data

--- a/TWLight/settings/production.py
+++ b/TWLight/settings/production.py
@@ -9,6 +9,7 @@ Settings file intended for use in production, on WMF servers.  This file:
 import sys
 import sentry_sdk
 from sentry_sdk.integrations.django import DjangoIntegration
+from TWLight.settings.helpers import sentry_before_send
 
 from .base import *
 
@@ -48,4 +49,5 @@ CACHES = {
 sentry_sdk.init(
     dsn="https://50e927aaca194181afe5c4b8e790d004@glitchtip-wikipedialibrary.wmflabs.org/1",
     integrations=[DjangoIntegration()],
+    before_send=sentry_before_send,
 )

--- a/TWLight/settings/staging.py
+++ b/TWLight/settings/staging.py
@@ -9,6 +9,7 @@ Settings file intended for use in staging, on WMF servers.  This file:
 import sys
 import sentry_sdk
 from sentry_sdk.integrations.django import DjangoIntegration
+from TWLight.settings.helpers import sentry_before_send
 
 from .base import *
 
@@ -32,4 +33,5 @@ CACHES = {
 sentry_sdk.init(
     dsn="https://50e927aaca194181afe5c4b8e790d004@glitchtip-wikipedialibrary.wmflabs.org/1",
     integrations=[DjangoIntegration()],
+    before_send=sentry_before_send,
 )


### PR DESCRIPTION
[//]: # (Thank you for uploading a PR to the Wikipedia Library!)

## Description
This is a quick fix (note the lack of unit tests) that I almost hotfixed in , but I thought could use a second set of eyes.

## Rationale
Since we're no longer using Django's builtin error logging, we no longer get the benefit of the builtin data scrubbing. So, we'll scrub it ourselves!

## Phabricator Ticket
https://phabricator.wikimedia.org/T275521

## How Has This Been Tested?
I did the following manual test:
- pulled down some event json from glitchtip
- imported the new callback into my interactive python shell
- fed the event to the callback
- checked the output data, which was now masked at several levels

## Screenshots of your changes (if appropriate):
N/A

## Types of changes
What types of changes does your code introduce? Add an `x` in all the boxes that apply:
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
