### PR TITLE
Remove unnecessary space from a message

### DIFF
--- a/TWLight/resources/templates/resources/partner_detail.html
+++ b/TWLight/resources/templates/resources/partner_detail.html
@@ -532,8 +532,8 @@
                 {% url 'about' as about %}
                 {% comment %}Translators: Text shown to unauthenticated users when they visit a Bundle partner page. {% endcomment %}
                 {% blocktrans trimmed %}
-                  This resource is part of our <a href="{{ about }}">Library Bundle</a>
-                  , which you can access if you meet our minimum eligibility criteria.
+                  This resource is part of our <a href="{{ about }}">Library Bundle</a>,
+                  which you can access if you meet our minimum eligibility criteria.
                   Log in to find out if you are eligible.
                 {% endblocktrans %}
               {% endif %}


### PR DESCRIPTION
[//]: # (Thank you for uploading a PR to the Wikipedia Library!)

## Description
Describe your changes in detail following the [commit message guidelines](https://www.mediawiki.org/wiki/Gerrit/Commit_message_guidelines)

Move a comma from the beginning of the line to the end of the previous line.

## Rationale
[//]: # (Why is this change required? What problem does it solve?)

In #624, an unnecessary word was removed, but as a result the comma
moved to the beginning of the line, and this adds a space before it.
There shouldn't be a space before a comma.

## Phabricator Ticket
[//]: # (Link to the Phabricator ticket)

## How Has This Been Tested?
[//]: # (- Did you add tests to your changes? Did you modify tests to accommodate your changes?)
[//]: # (- Can this change be tested manually? How?)

## Screenshots of your changes (if appropriate):
[//]: # (It can also be a GIF to prove that your changes are working)

## Types of changes
What types of changes does your code introduce? Add an `x` in all the boxes that apply:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
