### PR TITLE
Fix bug where user is not eligible for 6+ months criteria despite account creation in 2006

### DIFF
--- a/TWLight/users/factories.py
+++ b/TWLight/users/factories.py
@@ -64,7 +64,7 @@ class EditorFactory(factory.django.DjangoModelFactory):
     occupation = "Cat floofer"
     affiliation = "Institut Pasteur"
     wp_username = factory.Faker("name", locale=random.choice(settings.FAKER_LOCALES))
-    wp_registered = datetime.today()
+    wp_registered = datetime.today().date()
     # Increment counter each time we create an editor so that we don't fail
     # the wp_sub + home_wiki uniqueness constraint on Editor.
     wp_sub = factory.Sequence(lambda n: n)

--- a/TWLight/users/helpers/editor_data.py
+++ b/TWLight/users/helpers/editor_data.py
@@ -140,7 +140,7 @@ def editor_account_old_enough(wp_registered: datetime.date):
     """
     # If, for some reason, this information hasn't come through,
     # default to user not being valid.
-    if not wp_registered:
+    if wp_registered is None:
         return False
     # Check: registered >= 6 months ago
     return datetime.today().date() - timedelta(days=182) >= wp_registered

--- a/TWLight/users/management/commands/user_update_eligibility.py
+++ b/TWLight/users/management/commands/user_update_eligibility.py
@@ -98,9 +98,14 @@ class Command(BaseCommand):
                 # Determine editor validity.
                 editor.wp_enough_edits = editor_enough_edits(editor.wp_editcount)
                 editor.wp_not_blocked = editor_not_blocked(global_userinfo["merged"])
+                # We will only check if the account is old enough if the value is False
+                # Accounts that are already old enough will never cease to be old enough
+                if not editor.wp_account_old_enough:
+                    editor.wp_account_old_enough = editor_account_old_enough(
+                        editor.wp_registered
+                    )
                 editor.wp_valid = editor_valid(
                     editor.wp_enough_edits,
-                    # We could recalculate this, but we would only need to do that if upped the minimum required account age.
                     editor.wp_account_old_enough,
                     # editor.wp_not_blocked can only be rechecked on login, so we're going with the existing value.
                     editor.wp_not_blocked,

--- a/TWLight/users/models.py
+++ b/TWLight/users/models.py
@@ -648,8 +648,13 @@ class Editor(models.Model):
             )
             self.wp_not_blocked = editor_not_blocked(global_userinfo["merged"])
 
-        self.wp_registered = editor_reg_date(identity, global_userinfo)
-        self.wp_account_old_enough = editor_account_old_enough(self.wp_registered)
+        if self.wp_registered is None:
+            self.wp_registered = editor_reg_date(identity, global_userinfo)
+        # if the account is already old enough, we shouldn't run this check everytime
+        # since this flag should never return back to False
+        if not self.wp_account_old_enough:
+            self.wp_account_old_enough = editor_account_old_enough(self.wp_registered)
+
         self.wp_enough_edits = editor_enough_edits(self.wp_editcount)
         self.wp_valid = editor_valid(
             self.wp_enough_edits,

--- a/TWLight/users/tests.py
+++ b/TWLight/users/tests.py
@@ -980,6 +980,7 @@ class EditorModelTestCase(TestCase):
             wp_username="editor_model_test",
             wp_rights=json.dumps(["cat floofing", "the big red button"]),
             wp_groups=json.dumps(["sysops", "bureaucrats"]),
+            wp_registered=None,
         )
         self.editor.user.userprofile.terms_of_use = True
         self.editor.user.userprofile.save()
@@ -1346,7 +1347,7 @@ class EditorModelTestCase(TestCase):
 
         # Don't change self.editor, or other tests will fail! Make a new one
         # to test instead.
-        new_editor = EditorFactory()
+        new_editor = EditorFactory(wp_registered=None)
         new_identity = dict(identity)
         new_global_userinfo = dict(global_userinfo)
         new_identity["sub"] = new_editor.wp_sub


### PR DESCRIPTION
## Description
This PR now checks whether a user's account is already over 6 months old before trying to update it since this criterion should only be checked if it's false (once it's true, it should remain true).

## Rationale
[//]: # (Why is this change required? What problem does it solve?)
We believe the reason a user with an account created in 2006 is not eligible was because of something going wrong in the login process that made the `wp_account_old_enough`  attribute False. Now, if `wp_account_old_enough` is True, it will never be evaluated again. This attribute will also be checked in the `user_update_eligibility` command that runs every day when it is False.

## Phabricator Ticket
[//]: # (Link to the Phabricator ticket)
[T274625](https://phabricator.wikimedia.org/T274625)

## How Has This Been Tested?
[//]: # (- Did you add tests to your changes? Did you modify tests to accommodate your changes?)
[//]: # (- Can this change be tested manually? How?)
Tested using previous tests to make sure nothing got broken.

## Screenshots of your changes (if appropriate):
[//]: # (It can also be a GIF to prove that your changes are working)
N/A

## Types of changes
What types of changes does your code introduce? Add an `x` in all the boxes that apply:
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
