### PR TITLE
Add editor_account_old_enough to imports in user_update_eligibility

### DIFF
--- a/TWLight/users/management/commands/user_update_eligibility.py
+++ b/TWLight/users/management/commands/user_update_eligibility.py
@@ -10,6 +10,7 @@ from TWLight.users.helpers.editor_data import (
     editor_enough_edits,
     editor_not_blocked,
     editor_bundle_eligible,
+    editor_account_old_enough,
 )
 
 logger = logging.getLogger(__name__)


### PR DESCRIPTION
## Description
Forgot to add an import to the management command

## Rationale
[//]: # (Why is this change required? What problem does it solve?)
This will break the `user_update_eligibility` command if not merged

## Phabricator Ticket
[//]: # (Link to the Phabricator ticket)
Related to [T274625](https://phabricator.wikimedia.org/T274625)

## How Has This Been Tested?
[//]: # (- Did you add tests to your changes? Did you modify tests to accommodate your changes?)
[//]: # (- Can this change be tested manually? How?)
Ran command manually to check that it's working

## Screenshots of your changes (if appropriate):
[//]: # (It can also be a GIF to prove that your changes are working)

## Types of changes
What types of changes does your code introduce? Add an `x` in all the boxes that apply:
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
