### PR TITLE
Task T277148 completed

### DIFF
--- a/TWLight/users/templates/users/preferences.html
+++ b/TWLight/users/templates/users/preferences.html
@@ -66,7 +66,8 @@
              {% trans "Update" %}
           </button>
           </br>
-          </br> Last updated at : {{ user.userprofile.terms_of_use_date }} {{ user.userprofile.terms_of_use_date | time:"H:i" }}
+          {% comment %} Translators: This text labels the date for when the terms of use were most recently changed. {% endcomment %}
+          </br> {% trans 'Last updated at:' %} {{ user.userprofile.terms_of_use_date }} {{ user.userprofile.terms_of_use_date | time:"H:i" }}
           {% comment %} Translators: This link is to the site's terms of use. {% endcomment %}
           </br><a href="{% url 'terms' %}"> {% trans "View Terms of Use" %}</a>
         </form>


### PR DESCRIPTION
[//]: # (Thank you for uploading a PR to the Wikipedia Library!)

## Description
Describe your changes in detail following the [commit message guidelines](https://www.mediawiki.org/wiki/Gerrit/Commit_message_guidelines)
The string contains "Last updated at" on user's profile has not been marked for translation at line 69 in the preferences.html
and also it had been written in the task description to add the following translate comment {% comment %} Translators: This text labels the date for when the terms of use were most recently changed. {% endcomment %} just above the line number 69.

## Rationale
[//]: # (Why is this change required? What problem does it solve?)
This change is required to mark the "Last updated at" string for translation.

## Phabricator Ticket
[//]: # (Link to the Phabricator ticket)
https://phabricator.wikimedia.org/T277148

## How Has This Been Tested?
[//]: # (- Did you add tests to your changes? Did you modify tests to accommodate your changes?)
[//]: # (- Can this change be tested manually? How?)


## Screenshots of your changes (if appropriate):
[//]: # (It can also be a GIF to prove that your changes are working)

## Types of changes
What types of changes does your code introduce? Add an `x` in all the boxes that apply:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
