### PR TITLE
Add extra option in types of changes section

### DIFF
--- a/docs/pull_request_template.md
+++ b/docs/pull_request_template.md
@@ -21,3 +21,4 @@ What types of changes does your code introduce? Add an `x` in all the boxes that
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
+- [ ] Minor change (fix a typo, add a translation tag, add section to README, etc.)


### PR DESCRIPTION
[//]: # (Thank you for uploading a PR to the Wikipedia Library!)

## Description
Added a `Minor change` option in the `Types of changes` section of the PR template.

## Rationale
[//]: # (Why is this change required? What problem does it solve?)
A lot of first contributions from users are minor changes

## Phabricator Ticket
[//]: # (Link to the Phabricator ticket)
N/A

## How Has This Been Tested?
[//]: # (- Did you add tests to your changes? Did you modify tests to accommodate your changes?)
[//]: # (- Can this change be tested manually? How?)

## Screenshots of your changes (if appropriate):
[//]: # (It can also be a GIF to prove that your changes are working)

## Types of changes
What types of changes does your code introduce? Add an `x` in all the boxes that apply:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
(See, this is why we need a minor change option)
