### PR TITLE
Upgrade Django to 3.1

### DIFF
--- a/TWLight/applications/migrations/0001_initial_squashed_0029_remove_application_hidden.py
+++ b/TWLight/applications/migrations/0001_initial_squashed_0029_remove_application_hidden.py
@@ -222,7 +222,7 @@ class Migration(migrations.Migration):
         migrations.AddField(
             model_name="application",
             name="imported",
-            field=models.NullBooleanField(default=False),
+            field=models.BooleanField(default=False, null=True),
         ),
         migrations.AlterField(
             model_name="application",

--- a/TWLight/applications/models.py
+++ b/TWLight/applications/models.py
@@ -142,7 +142,7 @@ class Application(models.Model):
     )
 
     # Was this application imported via CLI?
-    imported = models.NullBooleanField(default=False)
+    imported = models.BooleanField(default=False, null=True)
 
     # If this Application is a renewal, the parent is the original Application
     # it was copied from.

--- a/TWLight/resources/migrations/0001_initial_squashed_0062_auto_20190220_1639.py
+++ b/TWLight/resources/migrations/0001_initial_squashed_0062_auto_20190220_1639.py
@@ -107,8 +107,9 @@ class Migration(migrations.Migration):
                 ),
                 (
                     "mutually_exclusive",
-                    models.NullBooleanField(
+                    models.BooleanField(
                         default=None,
+                        null=True,
                         help_text=b"If True, users can only apply for one Stream at a time from this Partner. If False, users can apply for multiple Streams at a time. This field must be filled in when Partners have multiple Streams, but may be left blank otherwise.",
                     ),
                 ),
@@ -881,8 +882,10 @@ class Migration(migrations.Migration):
         migrations.AddField(
             model_name="partner",
             name="bundle",
-            field=models.NullBooleanField(
-                default=False, help_text="Is this partner a part of the Bundle?"
+            field=models.BooleanField(
+                default=False,
+                null=True,
+                help_text="Is this partner a part of the Bundle?",
             ),
         ),
         migrations.AddField(

--- a/TWLight/resources/migrations/0063_auto_20190220_1639_squashed_0084_auto_20201019_1310.py
+++ b/TWLight/resources/migrations/0063_auto_20190220_1639_squashed_0084_auto_20201019_1310.py
@@ -605,8 +605,9 @@ class Migration(migrations.Migration):
         migrations.AlterField(
             model_name="partner",
             name="mutually_exclusive",
-            field=models.NullBooleanField(
+            field=models.BooleanField(
                 default=None,
+                null=True,
                 help_text="If True, users can only apply for one Stream at a time from this Partner. If False, users can apply for multiple Streams at a time. This field must be filled in when Partners have multiple Streams, but may be left blank otherwise.",
             ),
         ),

--- a/TWLight/resources/models.py
+++ b/TWLight/resources/models.py
@@ -294,7 +294,7 @@ class Partner(models.Model):
         "send users a URL to use to create an account.",
     )
 
-    mutually_exclusive = models.NullBooleanField(
+    mutually_exclusive = models.BooleanField(
         blank=True,
         null=True,
         default=None,

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,7 +1,7 @@
 black==20.8b1
 bleach==3.3.0
 defusedxml==0.7.1
-django==3.0.14
+django==3.1.8
 django-annoying==0.10.6
 django-autocomplete-light==3.8.2
 django-contrib-comments==2.0.0


### PR DESCRIPTION
## Description
Upgrade to Django 3.1

## Rationale
[//]: # (Why is this change required? What problem does it solve?)
In order to use `JSONFields` in MySQL, we need to upgrade our Django version.

## Phabricator Ticket
[//]: # (Link to the Phabricator ticket)
[T280697](https://phabricator.wikimedia.org/T280697)

## How Has This Been Tested?
[//]: # (- Did you add tests to your changes? Did you modify tests to accommodate your changes?)
[//]: # (- Can this change be tested manually? How?)

## Screenshots of your changes (if appropriate):
[//]: # (It can also be a GIF to prove that your changes are working)

## Types of changes
What types of changes does your code introduce? Add an `x` in all the boxes that apply:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Minor change (fix a typo, add a translation tag, add section to README, etc.)
