### PR TITLE
per-language nginx response cache for anonymous users

### DIFF
--- a/conf/production.nginx.conf
+++ b/conf/production.nginx.conf
@@ -10,6 +10,25 @@ map $http_user_agent $limit_bots {
   ~*(GoogleBot|bingbot|YandexBot|mj12bot|Apache-HttpClient) $binary_remote_addr;
 }
 
+## Testing the request method. Only GET and HEAD are caching safe.
+map $request_method $no_cache {
+  default 0;
+  POST 1; # POST requests aren't cached usually
+}
+
+## Testing for the session cookie being present. If there is then no
+## caching is to be done.
+map $http_cookie $no_cache {
+  default 0;
+  ~sessionid 1; # Django session cookie
+}
+
+## proxy caching settings.
+proxy_cache_path /var/lib/nginx/cache levels=1:2 keys_zone=cache:8m max_size=10g inactive=10m;
+proxy_cache_key "$scheme$proxy_host$uri$is_args$args$http_accept_language";
+proxy_cache_lock on;
+proxy_cache_use_stale error timeout invalid_header updating http_500 http_502 http_503 http_504;
+
 # remote address is a joke here since we don't have x-forwarded-for
 limit_req_zone $limit_bots zone=bots:10m rate=1r/s;
 limit_req_zone $binary_remote_addr zone=one:10m rate=500r/s;
@@ -31,6 +50,12 @@ server {
     keepalive_timeout 5;
 
     root /app;
+
+    proxy_cache_valid 200 301 302 401 403 404 5m;
+    proxy_cache_bypass $no_cache $http_cache_control;
+    proxy_cache_revalidate  on;
+    proxy_cache cache;
+    add_header X-Cache-Status $upstream_cache_status;
 
     location / {
       # Redirects any http requests to https.

--- a/conf/staging.nginx.conf
+++ b/conf/staging.nginx.conf
@@ -10,6 +10,25 @@ map $http_user_agent $limit_bots {
   ~*(GoogleBot|bingbot|YandexBot|mj12bot|Apache-HttpClient) $binary_remote_addr;
 }
 
+## Testing the request method. Only GET and HEAD are caching safe.
+map $request_method $no_cache {
+  default 0;
+  POST 1; # POST requests aren't cached usually
+}
+
+## Testing for the session cookie being present. If there is then no
+## caching is to be done.
+map $http_cookie $no_cache {
+  default 0;
+  ~sessionid 1; # Django session cookie
+}
+
+## proxy caching settings.
+proxy_cache_path /var/lib/nginx/cache levels=1:2 keys_zone=cache:8m max_size=10g inactive=10m;
+proxy_cache_key "$scheme$proxy_host$uri$is_args$args$http_accept_language";
+proxy_cache_lock on;
+proxy_cache_use_stale error timeout invalid_header updating http_500 http_502 http_503 http_504;
+
 # remote address is a joke here since we don't have x-forwarded-for
 limit_req_zone $limit_bots zone=bots:10m rate=1r/s;
 limit_req_zone $binary_remote_addr zone=one:10m rate=500r/s;
@@ -31,6 +50,12 @@ server {
     keepalive_timeout 5;
 
     root /app;
+
+    proxy_cache_valid 200 301 302 401 403 404 5m;
+    proxy_cache_bypass $no_cache $http_cache_control;
+    proxy_cache_revalidate  on;
+    proxy_cache cache;
+    add_header X-Cache-Status $upstream_cache_status;
 
     location / {
       # Redirects any http requests to https.

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -22,14 +22,6 @@ secrets:
     file: ./secrets/TWLIGHT_EZPROXY_SECRET
 
 services:
-  db:
-    # Local environment should accomodate a variety of host OSes
-    volumes:
-      - type: bind
-        source: ./conf/db/local.d
-        target: /etc/mysql/conf.d
-    ports:
-      - "3306:3306"
   twlight:
     image: quay.io/wikipedialibrary/twlight:local
     env_file:
@@ -44,5 +36,3 @@ services:
       - type: bind
         source: ./conf/local.nginx.conf
         target: /etc/nginx/conf.d/default.conf
-    ports:
-      - "80:80"

--- a/docker-compose.production.yml
+++ b/docker-compose.production.yml
@@ -44,9 +44,6 @@ services:
       - TWLIGHT_OAUTH_CONSUMER_KEY
       - TWLIGHT_OAUTH_CONSUMER_SECRET
       - TWLIGHT_EZPROXY_SECRET
-  db:
-    ports:
-      - "3306:3306"
   twlight:
     image: quay.io/wikipedialibrary/twlight:branch_production
     command: /app/bin/twlight_docker_entrypoint.sh "python manage.py collectstatic --noinput && /venv/bin/gunicorn TWLight.wsgi"
@@ -65,5 +62,3 @@ services:
       - type: bind
         source: ./conf/production.nginx.conf
         target: /etc/nginx/conf.d/default.conf
-    ports:
-      - "80:80"

--- a/docker-compose.production.yml
+++ b/docker-compose.production.yml
@@ -60,6 +60,8 @@ services:
       - 'migrate'
   web:
     volumes:
+      - type: volume
+        target: /var/lib/nginx/cache
       - type: bind
         source: ./conf/production.nginx.conf
         target: /etc/nginx/conf.d/default.conf

--- a/docker-compose.staging.yml
+++ b/docker-compose.staging.yml
@@ -60,6 +60,8 @@ services:
       - 'migrate'
   web:
     volumes:
+      - type: volume
+        target: /var/lib/nginx/cache
       - type: bind
         source: ./conf/staging.nginx.conf
         target: /etc/nginx/conf.d/default.conf

--- a/docker-compose.staging.yml
+++ b/docker-compose.staging.yml
@@ -44,9 +44,6 @@ services:
       - TWLIGHT_OAUTH_CONSUMER_KEY
       - TWLIGHT_OAUTH_CONSUMER_SECRET
       - TWLIGHT_EZPROXY_SECRET
-  db:
-    ports:
-      - "3306:3306"
   twlight:
     image: quay.io/wikipedialibrary/twlight:branch_staging
     command: /app/bin/twlight_staging_entrypoint.sh "python manage.py collectstatic --noinput && /venv/bin/gunicorn TWLight.wsgi"
@@ -65,5 +62,3 @@ services:
       - type: bind
         source: ./conf/staging.nginx.conf
         target: /etc/nginx/conf.d/default.conf
-    ports:
-      - "80:80"

--- a/docker-compose.travis.yml
+++ b/docker-compose.travis.yml
@@ -22,12 +22,6 @@ secrets:
     file: ./secrets/TWLIGHT_EZPROXY_SECRET
 
 services:
-  db:
-    # Local environment should accommodate a variety of host OSes
-    volumes:
-      - type: bind
-        source: ./conf/db/local.d
-        target: /etc/mysql/conf.d
   twlight:
     image: ${cr_server}/wikipedialibrary/twlight:${BRANCH_TAG}
     build:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,6 +7,8 @@ volumes:
 
 services:
   db:
+    ports:
+      - "3306:3306"
     image: quay.io/wikipedialibrary/mariadb:10
     volumes:
       - mysql:/var/lib/mysql
@@ -42,6 +44,8 @@ services:
       - TWLIGHT_OAUTH_CONSUMER_SECRET
       - TWLIGHT_EZPROXY_SECRET
   web:
+    ports:
+      - "80:80"
     image: quay.io/wikipedialibrary/nginx:latest
     volumes:
       - type: bind


### PR DESCRIPTION
## Description
Adds per-language nginx response cache for anonymous users in staging and production environments, along with an instrumentation header, `X-Cache-Status`

## Rationale
This will reduce the load on the platform when a large number of anonymous users are browsing the site simultaneously.

## Phabricator Ticket
https://phabricator.wikimedia.org/T278932

## How Has This Been Tested?
I manually added this to the local nginx config and browsed the site both anonymously and logged in, with various accept-language settings in my browser.

## Screenshots of your changes (if appropriate):
N/A

## Types of changes
What types of changes does your code introduce? Add an `x` in all the boxes that apply:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Minor change (fix a typo, add a translation tag, add section to README, etc.)
