### PR TITLE
Add management command to migrate tags to `new_tags` field

### DIFF
--- a/TWLight/resources/management/commands/migrate_tags_to_new_tags.py
+++ b/TWLight/resources/management/commands/migrate_tags_to_new_tags.py
@@ -1,0 +1,29 @@
+from django.core.management.base import BaseCommand
+
+from TWLight.resources.models import Partner
+
+
+class Command(BaseCommand):
+    help = "Migrates content from the tags column to the new_tags column"
+
+    def handle(self, *args, **options):
+        partners = Partner.objects.all()
+
+        for partner in partners:
+            new_tags_dict = {}
+            tag_names = []
+            tags = partner.tags.all()
+            for tag in tags:
+                if tag.name == "sciences" or tag.name == "social":
+                    tag_name = "social-sciences_tag"
+                else:
+                    tag_name = "{tag_name}_tag".format(tag_name=tag.name)
+
+                if tag_name not in tag_names:
+                    tag_names.append(tag_name)
+
+            new_tags_dict["tags"] = tag_names
+
+            partner.new_tags = new_tags_dict
+
+            partner.save()


### PR DESCRIPTION
## Description
Created a management command that will migrate the contents of the `tags` field into the `new_tags` field structure.

## Rationale
[//]: # (Why is this change required? What problem does it solve?)
This is another step into making our tags translatable.

## Phabricator Ticket
[//]: # (Link to the Phabricator ticket)
[T281322](https://phabricator.wikimedia.org/T281322)

## How Has This Been Tested?
[//]: # (- Did you add tests to your changes? Did you modify tests to accommodate your changes?)
[//]: # (- Can this change be tested manually? How?)
Tested manually

## Screenshots of your changes (if appropriate):
[//]: # (It can also be a GIF to prove that your changes are working)

**Before running the command**
![Screen Shot 2021-04-27 at 17 26 45](https://user-images.githubusercontent.com/7854953/116323675-23053e80-a784-11eb-9e2f-9e8e35aaa6cc.png)


**After running the command**
![Screen Shot 2021-04-27 at 17 40 15](https://user-images.githubusercontent.com/7854953/116323690-2c8ea680-a784-11eb-8bf3-d79f2d5971b1.png)


**Special case: `social` and `sciences` tags were merged into `social-sciences` tag**
![Screen Shot 2021-04-27 at 17 43 06](https://user-images.githubusercontent.com/7854953/116323732-45975780-a784-11eb-96e4-c23e47ba715d.png)



## Types of changes
What types of changes does your code introduce? Add an `x` in all the boxes that apply:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Minor change (fix a typo, add a translation tag, add section to README, etc.)
