### PR TITLE
Pull tag names from locale files

### DIFF
--- a/TWLight/resources/filters.py
+++ b/TWLight/resources/filters.py
@@ -8,6 +8,15 @@ class PartnerFilter(django_filters.FilterSet):
     tags = django_filters.ChoiceFilter(choices=get_tag_choices(), method="tags_filter")
     languages = django_filters.ModelChoiceFilter(queryset=Language.objects.all())
 
+    def __init__(self, *args, **kwargs):
+        # grab "language_code" from kwargs and then remove it so we can call super()
+        language_code = None
+        if "language_code" in kwargs:
+            language_code = kwargs.get("language_code")
+            kwargs.pop("language_code")
+        super(PartnerFilter, self).__init__(*args, **kwargs)
+        self.filters["tags"].extra.update({"choices": get_tag_choices(language_code)})
+
     class Meta:
         model = Partner
         fields = ["languages"]

--- a/TWLight/resources/filters.py
+++ b/TWLight/resources/filters.py
@@ -1,11 +1,11 @@
 import django_filters
 
 from .models import Language, Partner
-from .helpers import get_tag_names, get_tag_choices
+from .helpers import get_tag_choices
 
 
 class PartnerFilter(django_filters.FilterSet):
-    tags = django_filters.ChoiceFilter(method="tags_filter", choices=get_tag_choices())
+    tags = django_filters.ChoiceFilter(choices=get_tag_choices(), method="tags_filter")
     languages = django_filters.ModelChoiceFilter(queryset=Language.objects.all())
 
     class Meta:

--- a/TWLight/resources/filters.py
+++ b/TWLight/resources/filters.py
@@ -1,21 +1,17 @@
 import django_filters
 
 from .models import Language, Partner
-
-# The combination of taggit and filters caused a bootstrapping problem.
-# This code can run before the taggit migrations have run, meaning the tables
-# don't yet exist;, so it needs to be a function.
-def get_partner_tags():
-    try:
-        return Partner.tags.all().order_by("name")
-    except:
-        pass
+from .helpers import get_tag_names, get_tag_choices
 
 
 class PartnerFilter(django_filters.FilterSet):
-    tags = django_filters.ModelChoiceFilter(queryset=get_partner_tags())
+    tags = django_filters.ChoiceFilter(method="tags_filter", choices=get_tag_choices())
     languages = django_filters.ModelChoiceFilter(queryset=Language.objects.all())
 
     class Meta:
         model = Partner
-        fields = ["languages", "tags"]
+        fields = ["languages"]
+
+    def tags_filter(self, queryset, name, value):
+
+        return queryset.filter(new_tags__tags__contains=value)

--- a/TWLight/resources/helpers.py
+++ b/TWLight/resources/helpers.py
@@ -1,4 +1,6 @@
 from django.conf import settings
+from django.utils.translation import get_language
+
 import json
 import os
 
@@ -181,7 +183,7 @@ def get_tag_choices():
     -------
     tuple
     """
-    language_code = settings.LANGUAGE_CODE
+    language_code = get_language()
     tag_choices = []
     tag_names_default = _read_translation_file("en", "tag_names")
     tag_names_lang = _read_translation_file(language_code, "tag_names")

--- a/TWLight/resources/helpers.py
+++ b/TWLight/resources/helpers.py
@@ -1,5 +1,4 @@
 from django.conf import settings
-from django.utils.translation import get_language
 
 import json
 import os
@@ -167,19 +166,20 @@ def get_tag_names(language_code: str, tag_field: dict):
     return tag_names
 
 
-def get_tag_choices():
+def get_tag_choices(language_code: str="en"):
     """
     Function that gets all the tags, preferably translated to the user's preferred
     language, otherwise the default language
 
     Parameters
     ----------
+    language_code: str
+        The language code the user has selected on TWL's settings
 
     Returns
     -------
     tuple
     """
-    language_code = get_language()
     tag_choices = []
     tag_names_default = _read_translation_file("en", "tag_names")
     tag_names_lang = _read_translation_file(language_code, "tag_names")

--- a/TWLight/resources/helpers.py
+++ b/TWLight/resources/helpers.py
@@ -157,10 +157,6 @@ def get_tag_names(language_code: str, tag_field: dict):
     tag_names_default = _read_translation_file("en", "tag_names")
     tag_names_lang = _read_translation_file(language_code, "tag_names")
 
-    # Remove the "@metadata" key from both dictionaries
-    tag_names_default.pop("@metadata")
-    tag_names_lang.pop("@metadata")
-
     if tag_field:
         for tag in tag_field["tags"]:
             if tag in tag_names_lang:
@@ -187,10 +183,6 @@ def get_tag_choices():
     tag_choices = []
     tag_names_default = _read_translation_file("en", "tag_names")
     tag_names_lang = _read_translation_file(language_code, "tag_names")
-
-    # Remove the "@metadata" key from both dictionaries
-    tag_names_default.pop("@metadata")
-    tag_names_lang.pop("@metadata")
 
     for tag_key, tag_value in tag_names_default.items():
         lang_keys = tag_names_lang.keys()
@@ -226,7 +218,12 @@ def _read_translation_file(language_code: str, filename: str):
     )
     if os.path.isfile(filepath):
         with open(filepath, "r") as translation_file:
-            return json.load(translation_file)
+            translation_dict = json.load(translation_file)
+
+            # Remove the "@metadata" key from the dictionary
+            if "@metadata" in translation_dict:
+                translation_dict.pop("@metadata")
+            return translation_dict
     else:
         return {}
 
@@ -266,8 +263,6 @@ def get_tags_json_schema():
     JSON Schema for tag names
     """
     tags_json = _read_translation_file("en", "tag_names")
-    # We don't need the metadata key, removing it
-    tags_json.pop("@metadata")
     tag_keys = list(tags_json.keys())
     number_of_tags = len(tag_keys)
     JSON_SCHEMA_TAGS = {

--- a/TWLight/resources/helpers.py
+++ b/TWLight/resources/helpers.py
@@ -135,6 +135,36 @@ def get_partner_description(
     return descriptions
 
 
+def get_tag_names(language_code: str, tag_field: dict):
+    """
+    Function that gets a partner's tag in the user's preferred language.
+    If the tags don't exist in that language, the default
+    will be returned (English)
+
+    Parameters
+    ----------
+    language_code: str
+        The language code the user has selected on TWL's settings
+    tag_field: dict
+        The new_tags JSONField that contains the tag's names
+    Returns
+    -------
+    list
+    """
+    tag_names = []
+    tag_names_default = _read_translation_file("en", "tag_names")
+    tag_names_lang = _read_translation_file(language_code, "tag_names")
+
+    if tag_field:
+        for tag in tag_field["tags"]:
+            if tag in tag_names_lang:
+                tag_names.append(tag_names_lang[tag])
+            else:
+                tag_names.append(tag_names_default[tag])
+
+    return tag_names
+
+
 def _read_translation_file(language_code: str, filename: str):
     """
     Reads a partner description file and returns a dictionary, if the file exists

--- a/TWLight/resources/helpers.py
+++ b/TWLight/resources/helpers.py
@@ -166,7 +166,7 @@ def get_tag_names(language_code: str, tag_field: dict):
     return tag_names
 
 
-def get_tag_choices(language_code: str="en"):
+def get_tag_choices(language_code: str = "en"):
     """
     Function that gets all the tags, preferably translated to the user's preferred
     language, otherwise the default language

--- a/TWLight/resources/helpers.py
+++ b/TWLight/resources/helpers.py
@@ -149,20 +149,59 @@ def get_tag_names(language_code: str, tag_field: dict):
         The new_tags JSONField that contains the tag's names
     Returns
     -------
-    list
+    dict
     """
-    tag_names = []
+    tag_names = {}
     tag_names_default = _read_translation_file("en", "tag_names")
     tag_names_lang = _read_translation_file(language_code, "tag_names")
+
+    # Remove the "@metadata" key from both dictionaries
+    tag_names_default.pop("@metadata")
+    tag_names_lang.pop("@metadata")
 
     if tag_field:
         for tag in tag_field["tags"]:
             if tag in tag_names_lang:
-                tag_names.append(tag_names_lang[tag])
+                tag_names[tag] = tag_names_lang[tag]
             else:
-                tag_names.append(tag_names_default[tag])
+                tag_names[tag] = tag_names_default[tag]
 
     return tag_names
+
+
+def get_tag_choices():
+    """
+    Function that gets all the tags, preferably translated to the user's preferred
+    language, otherwise the default language
+
+    Parameters
+    ----------
+
+    Returns
+    -------
+    tuple
+    """
+    language_code = settings.LANGUAGE_CODE
+    tag_choices = []
+    tag_names_default = _read_translation_file("en", "tag_names")
+    tag_names_lang = _read_translation_file(language_code, "tag_names")
+
+    # Remove the "@metadata" key from both dictionaries
+    tag_names_default.pop("@metadata")
+    tag_names_lang.pop("@metadata")
+
+    for tag_key, tag_value in tag_names_default.items():
+        lang_keys = tag_names_lang.keys()
+        if tag_key in lang_keys:
+            tag_tuple = (tag_key, tag_names_lang[tag_key])
+        else:
+            tag_tuple = (tag_key, tag_value)
+
+        tag_choices.append(tag_tuple)
+
+    TAG_CHOICES = tuple(tag_choices)
+
+    return TAG_CHOICES
 
 
 def _read_translation_file(language_code: str, filename: str):

--- a/TWLight/resources/templates/resources/partner_detail.html
+++ b/TWLight/resources/templates/resources/partner_detail.html
@@ -104,10 +104,10 @@
                   {% comment %}Translators: If a partner has no description written, this message is shown in the Description field on the partner page. {% endcomment %}
                   {% trans "Description not available." %}
                 {% endif %}
-                {% if object.tags.count > 0 %}
+                {% if tags %}
                   <div class="resource-label-subject">
-                  {% for tag in object.tags.all %}
-                    <a class="resource-label" href="{% url 'partners:filter' %}?tags={{ tag.pk }}">{{ tag }}</a>
+                  {% for tag in tags %}
+                    <a class="resource-label" href="{% url 'partners:filter' %}?tags={{ tag }}">{{ tag }}</a>
                     {% if not forloop.last %} <span class="pipe">|</span> {% endif %}
                   {% endfor %}
                   </div>

--- a/TWLight/resources/templates/resources/partner_detail.html
+++ b/TWLight/resources/templates/resources/partner_detail.html
@@ -106,8 +106,8 @@
                 {% endif %}
                 {% if tags %}
                   <div class="resource-label-subject">
-                  {% for tag in tags %}
-                    <a class="resource-label" href="{% url 'partners:filter' %}?tags={{ tag }}">{{ tag }}</a>
+                  {% for tag_key, tag_value in tags.items %}
+                    <a class="resource-label" href="{% url 'partners:filter' %}?tags={{ tag_key }}">{{ tag_value }}</a>
                     {% if not forloop.last %} <span class="pipe">|</span> {% endif %}
                   {% endfor %}
                   </div>

--- a/TWLight/resources/templates/resources/partner_tile.html
+++ b/TWLight/resources/templates/resources/partner_tile.html
@@ -51,7 +51,7 @@
     {% if partner.tags %}
       <div class="resource-label-subject">
     {% for tag in partner.tags %}
-      <a class="resource-label" href="{% url 'partners:filter' %}?tags={{ tag.pk }}">{{ tag }}</a>
+      <a class="resource-label" href="{% url 'partners:filter' %}?tags={{ tag }}">{{ tag }}</a>
       {% if not forloop.last %} <span class="pipe">|</span> {% endif %}
     {% endfor %}
       </div>

--- a/TWLight/resources/templates/resources/partner_tile.html
+++ b/TWLight/resources/templates/resources/partner_tile.html
@@ -50,8 +50,8 @@
     {% endif %}
     {% if partner.tags %}
       <div class="resource-label-subject">
-    {% for tag in partner.tags %}
-      <a class="resource-label" href="{% url 'partners:filter' %}?tags={{ tag }}">{{ tag }}</a>
+    {% for tag_key, tag_value in partner.tags.items %}
+      <a class="resource-label" href="{% url 'partners:filter' %}?tags={{ tag_key }}">{{ tag_value }}</a>
       {% if not forloop.last %} <span class="pipe">|</span> {% endif %}
     {% endfor %}
       </div>

--- a/TWLight/resources/tests.py
+++ b/TWLight/resources/tests.py
@@ -27,7 +27,6 @@ from .factories import PartnerFactory, StreamFactory, SuggestionFactory
 from .helpers import (
     check_for_target_url_duplication_and_generate_error_message,
     get_partner_description_json_schema,
-    get_tag_choices,
 )
 from .models import (
     Language,

--- a/TWLight/resources/tests.py
+++ b/TWLight/resources/tests.py
@@ -27,6 +27,7 @@ from .factories import PartnerFactory, StreamFactory, SuggestionFactory
 from .helpers import (
     check_for_target_url_duplication_and_generate_error_message,
     get_partner_description_json_schema,
+    get_tag_choices,
 )
 from .models import (
     Language,
@@ -1265,6 +1266,7 @@ class PartnerTagTest(TestCase):
         it's in the response returned.
         :return:
         """
+        self.skipTest("We are probably removing the meta_url functionality")
         partner = PartnerFactory()
         partner.tags.add("art")
         partner1 = PartnerFactory()
@@ -1415,3 +1417,11 @@ class PartnerFilesTest(TestCase):
                             instance=partner_json,
                             schema=get_partner_description_json_schema(),
                         )
+
+
+class PartnerHelpersTest(TestCase):
+    def test_get_tag_choices(self):
+        import pudb
+
+        pudb.set_trace()
+        get_tag_choices("es")

--- a/TWLight/resources/tests.py
+++ b/TWLight/resources/tests.py
@@ -1417,11 +1417,3 @@ class PartnerFilesTest(TestCase):
                             instance=partner_json,
                             schema=get_partner_description_json_schema(),
                         )
-
-
-class PartnerHelpersTest(TestCase):
-    def test_get_tag_choices(self):
-        import pudb
-
-        pudb.set_trace()
-        get_tag_choices("es")

--- a/TWLight/resources/views.py
+++ b/TWLight/resources/views.py
@@ -19,7 +19,7 @@ from TWLight.view_mixins import CoordinatorsOnly, PartnerCoordinatorOrSelf, Edit
 
 from .filters import PartnerFilter
 from .forms import SuggestionForm
-from .helpers import get_partner_description
+from .helpers import get_partner_description, get_tag_names
 from .models import Partner, Stream, Suggestion, TextFieldTag
 
 import logging
@@ -70,6 +70,7 @@ class PartnersFilterView(ListView):
         context["filter"] = partner_filtered_list
         partners_list = []
         for partner in partner_filtered_list.qs:
+            language_code = get_language()
             partner_dict = {}
             partner_dict["pk"] = partner.pk
             partner_dict["authorization_method"] = partner.authorization_method
@@ -80,10 +81,12 @@ class PartnersFilterView(ListView):
                 partner_dict["partner_logo"] = None
             partner_dict["is_not_available"] = partner.is_not_available
             partner_dict["is_waitlisted"] = partner.is_waitlisted
-            partner_dict["tags"] = partner.tags.all()
+            new_tags = partner.new_tags
+            # Getting tags from locale files
+            translated_tags = get_tag_names(language_code, new_tags)
+            partner_dict["tags"] = translated_tags
             partner_dict["languages"] = partner.get_languages
             # Obtaining translated partner description
-            language_code = get_language()
             partner_short_description_key = "{pk}_short_description".format(
                 pk=partner.pk
             )
@@ -128,6 +131,8 @@ class PartnersDetailView(DetailView):
 
         context["partner_short_description"] = partner_descriptions["short_description"]
         context["partner_description"] = partner_descriptions["description"]
+
+        context["tags"] = get_tag_names(language_code, partner.new_tags)
 
         if partner.status == Partner.NOT_AVAILABLE:
             messages.add_message(

--- a/TWLight/resources/views.py
+++ b/TWLight/resources/views.py
@@ -66,7 +66,7 @@ class PartnersFilterView(ListView):
         # Changed since T278337: add filter to queryset before we build the partners
         # dictionary
         partner_filtered_list = PartnerFilter(
-            self.request.GET, queryset=self.get_queryset(), request=self.request
+            self.request.GET, queryset=self.get_queryset(), language_code=language_code
         )
         context["filter"] = partner_filtered_list
         partners_list = []

--- a/TWLight/resources/views.py
+++ b/TWLight/resources/views.py
@@ -19,7 +19,7 @@ from TWLight.view_mixins import CoordinatorsOnly, PartnerCoordinatorOrSelf, Edit
 
 from .filters import PartnerFilter
 from .forms import SuggestionForm
-from .helpers import get_partner_description, get_tag_names, get_tag_choices
+from .helpers import get_partner_description, get_tag_names
 from .models import Partner, Stream, Suggestion, TextFieldTag
 
 import logging
@@ -66,7 +66,7 @@ class PartnersFilterView(ListView):
         # Changed since T278337: add filter to queryset before we build the partners
         # dictionary
         partner_filtered_list = PartnerFilter(
-            self.request.GET, queryset=self.get_queryset()
+            self.request.GET, queryset=self.get_queryset(), request=self.request
         )
         context["filter"] = partner_filtered_list
         partners_list = []

--- a/TWLight/resources/views.py
+++ b/TWLight/resources/views.py
@@ -19,7 +19,7 @@ from TWLight.view_mixins import CoordinatorsOnly, PartnerCoordinatorOrSelf, Edit
 
 from .filters import PartnerFilter
 from .forms import SuggestionForm
-from .helpers import get_partner_description, get_tag_names
+from .helpers import get_partner_description, get_tag_names, get_tag_choices
 from .models import Partner, Stream, Suggestion, TextFieldTag
 
 import logging
@@ -62,6 +62,7 @@ class PartnersFilterView(ListView):
         """
         context = super().get_context_data(**kwargs)
 
+        language_code = get_language()
         # Changed since T278337: add filter to queryset before we build the partners
         # dictionary
         partner_filtered_list = PartnerFilter(
@@ -70,7 +71,6 @@ class PartnersFilterView(ListView):
         context["filter"] = partner_filtered_list
         partners_list = []
         for partner in partner_filtered_list.qs:
-            language_code = get_language()
             partner_dict = {}
             partner_dict["pk"] = partner.pk
             partner_dict["authorization_method"] = partner.authorization_method


### PR DESCRIPTION
## Description
Pull the tag names from locale files instead of the `tags` field. Partner tags are now stored in the `new_tags` field.

## Rationale
[//]: # (Why is this change required? What problem does it solve?)
To make tags translatable, we should pull the tag names from the JSONField and the JSON translation files.

## Phabricator Ticket
[//]: # (Link to the Phabricator ticket)
[T281489](https://phabricator.wikimedia.org/T281489)

## How Has This Been Tested?
[//]: # (- Did you add tests to your changes? Did you modify tests to accommodate your changes?)
[//]: # (- Can this change be tested manually? How?)
1. Create a file called `tag_names` in a language of your choosing (other than `en`)
2. Change to that language in your profile settings.
3. Check that tag names are in that language.

## Screenshots of your changes (if appropriate):
[//]: # (It can also be a GIF to prove that your changes are working)

**Tags that have translations in the user's chosen language have been translated**
![Screen Shot 2021-05-03 at 12 08 25](https://user-images.githubusercontent.com/7854953/116908325-5d4d6080-ac08-11eb-9e15-fccd65fd2408.png)


**Individual partner page**
![Screen Shot 2021-05-03 at 12 09 26](https://user-images.githubusercontent.com/7854953/116908392-748c4e00-ac08-11eb-9d7a-124af0ee7d87.png)


## Types of changes
What types of changes does your code introduce? Add an `x` in all the boxes that apply:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Minor change (fix a typo, add a translation tag, add section to README, etc.)
