### PR TITLE
Add blank flag to `new_tags` field

### DIFF
--- a/TWLight/resources/models.py
+++ b/TWLight/resources/models.py
@@ -323,7 +323,7 @@ class Partner(models.Model):
     tags = TaggableManager(through=TaggedTextField, blank=True)
 
     # New tag model that uses JSONField instead of Taggit to make tags translatable
-    new_tags = models.JSONField(null=True, default=None)
+    new_tags = models.JSONField(null=True, default=None, blank=True)
 
     # Non-universal form fields
     # --------------------------------------------------------------------------


### PR DESCRIPTION
## Description
Add a `blank=True` flag to the `new_tags` field.

## Rationale
[//]: # (Why is this change required? What problem does it solve?)
We could not update partners if the `new_tags` field was null. This should be possible.
 
## Phabricator Ticket
[//]: # (Link to the Phabricator ticket)
N/A

## How Has This Been Tested?
[//]: # (- Did you add tests to your changes? Did you modify tests to accommodate your changes?)
[//]: # (- Can this change be tested manually? How?)

## Screenshots of your changes (if appropriate):
[//]: # (It can also be a GIF to prove that your changes are working)

## Types of changes
What types of changes does your code introduce? Add an `x` in all the boxes that apply:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Minor change (fix a typo, add a translation tag, add section to README, etc.)
