### PR TITLE
Remove description and short_description from Partner model

### DIFF
--- a/TWLight/resources/admin.py
+++ b/TWLight/resources/admin.py
@@ -61,7 +61,9 @@ class PartnerLogoInline(admin.TabularInline):
     model = PartnerLogo
 
 
-class PartnerAdmin(TabbedExternalJqueryTranslationAdmin):
+class PartnerAdmin(admin.ModelAdmin):
+    model = Partner
+
     class CustomModelChoiceField(forms.ModelChoiceField):
         """
         This lets us relabel the users in the dropdown with their recognizable
@@ -91,7 +93,7 @@ class PartnerAdmin(TabbedExternalJqueryTranslationAdmin):
     language_strings.short_description = "Languages"
 
     search_fields = ("company_name",)
-    list_display = ("company_name", "short_description", "id", "language_strings")
+    list_display = ("company_name", "id", "language_strings")
     inlines = [ContactInline, VideoInline, PartnerLogoInline]
 
 

--- a/TWLight/resources/management/commands/resources_example_data.py
+++ b/TWLight/resources/management/commands/resources_example_data.py
@@ -41,9 +41,6 @@ class Command(BaseCommand):
             partner = PartnerFactory(
                 company_location=random.choice(list(countries)),
                 renewals_available=random.choice([True, False]),
-                short_description=Faker(
-                    random.choice(settings.FAKER_LOCALES)
-                ).paragraph(nb_sentences=4),
                 send_instructions=Faker(
                     random.choice(settings.FAKER_LOCALES)
                 ).paragraph(nb_sentences=2),

--- a/TWLight/resources/models.py
+++ b/TWLight/resources/models.py
@@ -241,21 +241,6 @@ class Partner(models.Model):
         "terms of use to get access; optional otherwise.",
     )
 
-    short_description = models.TextField(
-        max_length=1000,
-        blank=True,
-        null=True,
-        help_text="Optional short description of this partner's resources.",
-    )
-
-    description = models.TextField(
-        "long description",
-        blank=True,
-        help_text="Optional detailed description in addition to the short "
-        "description such as collections, instructions, notes, special "
-        "requirements, alternate access options, unique features, citations notes.",
-    )
-
     send_instructions = models.TextField(
         blank=True,
         null=True,
@@ -466,20 +451,6 @@ class Partner(models.Model):
                 raise ValidationError(
                     "Error trying to insert a tag: the JSON is invalid"
                 )
-        """Invalidate this partner's pandoc-rendered html from cache"""
-        for code in RESOURCE_LANGUAGE_CODES:
-            short_description_cache_key = make_template_fragment_key(
-                "partner_short_description", [code, self.pk]
-            )
-            description_cache_key = make_template_fragment_key(
-                "partner_description", [code, self.pk]
-            )
-            send_instructions_cache_key = make_template_fragment_key(
-                "partner_send_instructions", [code, self.pk]
-            )
-            cache.delete(short_description_cache_key)
-            cache.delete(description_cache_key)
-            cache.delete(send_instructions_cache_key)
 
     @property
     def get_languages(self):

--- a/TWLight/resources/translation.py
+++ b/TWLight/resources/translation.py
@@ -1,13 +1,8 @@
 from modeltranslation.translator import translator, TranslationOptions
 
-from .models import Partner, Stream, TextFieldTag
+from .models import Stream, TextFieldTag
 
 # See https://django-modeltranslation.readthedocs.io/en/latest/registration.html
-class PartnerTranslationOptions(TranslationOptions):
-    fields = ("short_description", "description", "send_instructions")
-
-
-translator.register(Partner, PartnerTranslationOptions)
 
 
 class StreamTranslationOptions(TranslationOptions):
@@ -34,6 +29,5 @@ translator.register(TextFieldTag, MultilingualTagTO)
 # https://github.com/deschler/django-modeltranslation/issues/455
 # Should be removed as soon as bug is resolved
 
-Partner._meta.base_manager_name = None
 Stream._meta.base_manager_name = None
 TextFieldTag._meta.base_manager_name = None


### PR DESCRIPTION
[//]: # (Thank you for uploading a PR to the Wikipedia Library!)

## Description
Remove `description` and `short_description` from `Partner` model, along with the related caching, modeltranslation, and admin bits.

## Rationale
This is housekeeping to avoid confusion in django admin and to reduce the width of our db tables

## Phabricator Ticket
https://phabricator.wikimedia.org/T278339

## How Has This Been Tested?
 - I clicked around and verified that the site templates were still rendering correctly and that partner admin works
 - The test suite passes, and we've already verified that the new partner descriptions work

## Screenshots of your changes (if appropriate):
NA

## Types of changes
What types of changes does your code introduce? Add an `x` in all the boxes that apply:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Minor change (fix a typo, add a translation tag, add section to README, etc.)
