### PR TITLE
WIP Add custom variable data to matomo via nginx logs

### DIFF
--- a/conf/local.nginx.conf
+++ b/conf/local.nginx.conf
@@ -7,10 +7,16 @@ log_format matomo  '{"ip": "$remote_addr",'
                    '"user_agent": "$http_user_agent",'
                    '"length": $bytes_sent,'
                    '"generation_time_milli": $request_time,'
+                   '"args": {"_cvar": {"1": ["Has-Session", $has_session]}},'
                    '"date": "$time_iso8601"}';
 
 # remote address is a joke here since we don't have x-forwarded-for
 limit_req_zone $binary_remote_addr zone=one:10m rate=500r/s;
+
+map $http_cookie $has_session {
+  default 0;
+  ~sessionid 1; # Django session cookie
+}
 
 upstream twlight {
   server twlight:80;

--- a/conf/production.nginx.conf
+++ b/conf/production.nginx.conf
@@ -7,6 +7,7 @@ log_format matomo  '{"ip": "$remote_addr",'
                    '"user_agent": "$http_user_agent",'
                    '"length": $bytes_sent,'
                    '"generation_time_milli": $request_time,'
+                   '"args": {"_cvar": {"1": ["Has-Session", $has_session]}},'
                    '"date": "$time_iso8601"}';
 
 map $http_x_forwarded_proto $web_proxy_scheme {
@@ -25,11 +26,15 @@ map $request_method $no_cache {
   POST 1; # POST requests aren't cached usually
 }
 
-## Testing for the session cookie being present. If there is then no
-## caching is to be done.
-map $http_cookie $no_cache {
+## Testing for the session cookie being present.
+map $http_cookie $has_session {
   default 0;
   ~sessionid 1; # Django session cookie
+}
+## If there is, then no caching is to be done.
+map $has_session $no_cache {
+  default 0;
+  $has_session 1;
 }
 
 ## proxy caching settings.

--- a/conf/staging.nginx.conf
+++ b/conf/staging.nginx.conf
@@ -7,6 +7,7 @@ log_format matomo  '{"ip": "$remote_addr",'
                    '"user_agent": "$http_user_agent",'
                    '"length": $bytes_sent,'
                    '"generation_time_milli": $request_time,'
+                   '"args": {"_cvar": {"1": ["Has-Session", $has_session]}},'
                    '"date": "$time_iso8601"}';
 
 map $http_x_forwarded_proto $web_proxy_scheme {
@@ -25,11 +26,16 @@ map $request_method $no_cache {
   POST 1; # POST requests aren't cached usually
 }
 
-## Testing for the session cookie being present. If there is then no
-## caching is to be done.
-map $http_cookie $no_cache {
+## Testing for the session cookie being present.
+map $http_cookie $has_session {
   default 0;
   ~sessionid 1; # Django session cookie
+}
+
+## If there is, then no caching is to be done.
+map $has_session $no_cache {
+  default 0;
+  $has_session 1;
 }
 
 ## proxy caching settings.

--- a/syslog/bin/import_logs.py
+++ b/syslog/bin/import_logs.py
@@ -2437,7 +2437,7 @@ class Parser:
                 is_robot=False,
                 is_error=False,
                 is_redirect=False,
-                args={},
+                args=format.get('args'),
             )
 
             if config.options.regex_group_to_page_cvars_map:


### PR DESCRIPTION
[//]: # (Thank you for uploading a PR to the Wikipedia Library!)

## Description
- Adds a `Has-Session` custom variable in the json access log emitted by nginx
- Updates syslog/bin/import_logs.py to use args from log source

## Rationale
We need to be able to tell the difference between authenticated and anonymous traffic in our log analysis

## Phabricator Ticket
https://phabricator.wikimedia.org/T282245

## How Has This Been Tested?
WIP - lots of manual fiddling so far

## Screenshots of your changes (if appropriate):
![Screenshot from 2021-05-07 14-14-49](https://user-images.githubusercontent.com/2986893/117497864-a2da9800-af3e-11eb-9010-d7de317976f6.png)
Note the `Has-Session` entry

## Types of changes
What types of changes does your code introduce? Add an `x` in all the boxes that apply:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Minor change (fix a typo, add a translation tag, add section to README, etc.)
