### PR TITLE
All authorized editors are members of the 'Default' ezproxy group

### DIFF
--- a/TWLight/ezproxy/views.py
+++ b/TWLight/ezproxy/views.py
@@ -83,6 +83,9 @@ class EZProxyTicket(object):
                 "EZProxy Configuration Error: shared secret cannot be empty."
             )
 
+        # All allowed editors get the "Default" group.
+        groups.append("Default")
+
         packet = "$u" + repr(timegm(gmtime()))
         packet += "$g" + "+".join(groups)
         packet += "$e"


### PR DESCRIPTION
[//]: # (Thank you for uploading a PR to the Wikipedia Library!)

## Description
All authorized editors are members of the 'Default' ezproxy group. This used to be our behavior, which we are now reverting to.

## Rationale
To keep ezproxy users in proxied sessions across resources, we need to proxy doi.org in the default proxy group. That way, clicking a doi link that resolves to a paywalled resource will allow for access if possible.

## Phabricator Ticket
https://phabricator.wikimedia.org/T277676

## How Has This Been Tested?
Manual testing

## Screenshots of your changes (if appropriate):
N/A

## Types of changes
What types of changes does your code introduce? Add an `x` in all the boxes that apply:
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Minor change (fix a typo, add a translation tag, add section to README, etc.)
