### PR TITLE
Change base docker image, stop mirroring images on every travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,8 +12,10 @@ language: minimal
 services:
   - docker
 
-# Build and run containers.
 install:
+  # Conditionally mirror images from docker.io to ${cr_server}.
+  - .travis/./docker_mirror.sh
+  # Build and run containers.
   - .travis/./docker_compose.sh
 
 # Initalize the app and test it.

--- a/.travis/deploy.sh
+++ b/.travis/deploy.sh
@@ -14,32 +14,32 @@ TWLIGHT_TRANSLATION_FILES_CHANGED=$((TWLIGHT_TRANSLATION_FILES_ADDED+TWLIGHT_TRA
 
 
 # Print Travis environment variables and migration count.
-echo "TRAVIS_PULL_REQUEST: ${TRAVIS_PULL_REQUEST}"
+echo "TRAVIS_EVENT_TYPE: ${TRAVIS_EVENT_TYPE}"
 echo "TRAVIS_TAG: ${TRAVIS_TAG}"
 echo "TRAVIS_BRANCH: ${TRAVIS_BRANCH}"
 echo "TWLIGHT_MISSING_MIGRATIONS: ${TWLIGHT_MISSING_MIGRATIONS}"
 echo "TWLIGHT_TRANSLATION_FILES_CHANGED: ${TWLIGHT_TRANSLATION_FILES_CHANGED}"
 
 # Sync back to remote if is build was fired from a push to master or staging and there are missing migrations.
-if [ "${TRAVIS_PULL_REQUEST}" = "false" ] && [ -z "${TRAVIS_TAG}" ] && [ "${TRAVIS_BRANCH}" = "master" ] || [ "${TRAVIS_BRANCH}" = "staging" ] && [ -n "${gh_bot_username+isset}" ] && [ -n "${gh_bot_token+isset}" ] && [ -n "${TWLIGHT_MISSING_MIGRATIONS+isset}" ] && [ "${TWLIGHT_MISSING_MIGRATIONS}" -gt 0 ]
+if [ "${TRAVIS_EVENT_TYPE}" = "push" ] && [ -z "${TRAVIS_TAG}" ] && [ "${TRAVIS_BRANCH}" = "master" ] || [ "${TRAVIS_BRANCH}" = "staging" ] && [ -n "${gh_bot_username+isset}" ] && [ -n "${gh_bot_token+isset}" ] && [ -n "${TWLIGHT_MISSING_MIGRATIONS+isset}" ] && [ "${TWLIGHT_MISSING_MIGRATIONS}" -gt 0 ]
 then
    TWLIGHT_MISSING_MIGRATIONS=${TWLIGHT_MISSING_MIGRATIONS} .travis/./migrations.sh
 fi
 
 # Sync back to remote if this is build was fired from a push to master or staging and there are changed translations.
-if [ "${TRAVIS_PULL_REQUEST}" = "false" ] && [ -z "${TRAVIS_TAG}" ] && [ "${TRAVIS_BRANCH}" = "master" ] || [ "${TRAVIS_BRANCH}" = "staging" ] && [ -n "${gh_bot_username+isset}" ] && [ -n "${gh_bot_token+isset}" ] && [ -n "${TWLIGHT_TRANSLATION_FILES_CHANGED+isset}" ] && [ "${TWLIGHT_TRANSLATION_FILES_CHANGED}" -gt 0 ]
+if [ "${TRAVIS_EVENT_TYPE}" = "push" ] && [ -z "${TRAVIS_TAG}" ] && [ "${TRAVIS_BRANCH}" = "master" ] || [ "${TRAVIS_BRANCH}" = "staging" ] && [ -n "${gh_bot_username+isset}" ] && [ -n "${gh_bot_token+isset}" ] && [ -n "${TWLIGHT_TRANSLATION_FILES_CHANGED+isset}" ] && [ "${TWLIGHT_TRANSLATION_FILES_CHANGED}" -gt 0 ]
 then
    TWLIGHT_TRANSLATION_FILES_CHANGED=${TWLIGHT_TRANSLATION_FILES_CHANGED} .travis/./translations.sh
 fi
 
 # Push docker image if is build was fired from a push to master, staging, or production and there are no missing migrations or changed translations.
-if [ "${TRAVIS_PULL_REQUEST}" = "false" ] && [ -z "${TRAVIS_TAG}" ] && [ "${TRAVIS_BRANCH}" = "master" ] || [ "${TRAVIS_BRANCH}" = "staging" ] || [ "${TRAVIS_BRANCH}" = "production" ] && [ -n "${cr_server+isset}" ] && [ -n "${cr_username+isset}" ] && [ -n "${cr_password+isset}" ] && [ -n "${TWLIGHT_MISSING_MIGRATIONS+isset}" ] && [ "${TWLIGHT_MISSING_MIGRATIONS}" -eq 0 ] && [ "${TWLIGHT_TRANSLATION_FILES_CHANGED}" -eq 0 ]
+if [ "${TRAVIS_EVENT_TYPE}" = "push" ] && [ -z "${TRAVIS_TAG}" ] && [ "${TRAVIS_BRANCH}" = "master" ] || [ "${TRAVIS_BRANCH}" = "staging" ] || [ "${TRAVIS_BRANCH}" = "production" ] && [ -n "${cr_server+isset}" ] && [ -n "${cr_username+isset}" ] && [ -n "${cr_password+isset}" ] && [ -n "${TWLIGHT_MISSING_MIGRATIONS+isset}" ] && [ "${TWLIGHT_MISSING_MIGRATIONS}" -eq 0 ] && [ "${TWLIGHT_TRANSLATION_FILES_CHANGED}" -eq 0 ]
 then
    TWLIGHT_MISSING_MIGRATIONS=${TWLIGHT_MISSING_MIGRATIONS} TWLIGHT_TRANSLATION_FILES_CHANGED=${TWLIGHT_TRANSLATION_FILES_CHANGED} .travis/./docker_push.sh
 fi
 
 # Deploy to production if is build was fired from a push to master and there are no missing migrations or changed translations.
-if [ "${TRAVIS_PULL_REQUEST}" = "false" ] && [ -z "${TRAVIS_TAG}" ] && [ "${TRAVIS_BRANCH}" = "master" ] && [ -n "${gh_bot_username+isset}" ] && [ -n "${gh_bot_token+isset}" ] && [ -n "${TWLIGHT_MISSING_MIGRATIONS+isset}" ] && [ "${TWLIGHT_MISSING_MIGRATIONS}" -eq 0 ] && [ "${TWLIGHT_TRANSLATION_FILES_CHANGED}" -eq 0 ]
+if [ "${TRAVIS_EVENT_TYPE}" = "push" ] && [ -z "${TRAVIS_TAG}" ] && [ "${TRAVIS_BRANCH}" = "master" ] && [ -n "${gh_bot_username+isset}" ] && [ -n "${gh_bot_token+isset}" ] && [ -n "${TWLIGHT_MISSING_MIGRATIONS+isset}" ] && [ "${TWLIGHT_MISSING_MIGRATIONS}" -eq 0 ] && [ "${TWLIGHT_TRANSLATION_FILES_CHANGED}" -eq 0 ]
 then
    TWLIGHT_MISSING_MIGRATIONS=${TWLIGHT_MISSING_MIGRATIONS} TWLIGHT_TRANSLATION_FILES_CHANGED=${TWLIGHT_TRANSLATION_FILES_CHANGED} .travis/./production.sh
 fi

--- a/.travis/docker_compose.sh
+++ b/.travis/docker_compose.sh
@@ -2,15 +2,15 @@
 export DOCKER_BUILDKIT=1 # enable buildkit for parallel builds
 export COMPOSE_DOCKER_CLI_BUILD=1 # use docker cli for building
 
-docker-compose build twlight_base
+docker-compose -f docker-compose.travis.yml build twlight_base
 docker tag "quay.io/wikipedialibrary/twlight_base:local" "quay.io/wikipedialibrary/twlight_base:${BRANCH_TAG}"
 docker tag "quay.io/wikipedialibrary/twlight_base:local" "quay.io/wikipedialibrary/twlight_base:${BUILD_TAG}"
 docker tag "quay.io/wikipedialibrary/twlight_base:local" "quay.io/wikipedialibrary/twlight_base:${COMMIT_TAG}"
-docker-compose build twlight_build
+docker-compose -f docker-compose.travis.yml build twlight_build
 docker tag "quay.io/wikipedialibrary/twlight_build:local" "quay.io/wikipedialibrary/twlight_build:${BRANCH_TAG}"
 docker tag "quay.io/wikipedialibrary/twlight_build:local" "quay.io/wikipedialibrary/twlight_build:${BUILD_TAG}"
 docker tag "quay.io/wikipedialibrary/twlight_build:local" "quay.io/wikipedialibrary/twlight_build:${COMMIT_TAG}"
-docker-compose build twlight
+docker-compose -f docker-compose.travis.yml build twlight
 docker tag "quay.io/wikipedialibrary/twlight:local" "quay.io/wikipedialibrary/twlight:${BRANCH_TAG}"
 docker tag "quay.io/wikipedialibrary/twlight:local" "quay.io/wikipedialibrary/twlight:${BUILD_TAG}"
 docker tag "quay.io/wikipedialibrary/twlight:local" "quay.io/wikipedialibrary/twlight:${COMMIT_TAG}"

--- a/.travis/docker_compose.sh
+++ b/.travis/docker_compose.sh
@@ -2,22 +2,6 @@
 export DOCKER_BUILDKIT=1 # enable buildkit for parallel builds
 export COMPOSE_DOCKER_CLI_BUILD=1 # use docker cli for building
 
-# Pull images from docker hub, but then retag for $cr_server for reuse and mirroring.
-docker pull "docker.io/library/alpine:3.11" || true
-docker tag "docker.io/library/alpine:3.11" "quay.io/wikipedialibrary/alpine:3.11"
-docker pull "docker.io/library/debian:buster-slim" || true
-docker tag "docker.io/library/debian:buster-slim" "quay.io/wikipedialibrary/debian:buster-slim"
-docker pull "docker.io/library/mariadb:10" || true
-docker tag "docker.io/library/mariadb:10" "quay.io/wikipedialibrary/mariadb:10"
-docker pull "docker.io/library/nginx:latest" || true
-docker tag "docker.io/library/nginx:latest" "quay.io/wikipedialibrary/nginx:latest"
-
-# Build images with caching and then run the stack in docker-compose.
-docker pull "quay.io/wikipedialibrary/twlight_base:branch_production" || true
-docker pull "quay.io/wikipedialibrary/twlight_build:branch_production" || true
-docker pull "quay.io/wikipedialibrary/twlight:branch_production" || true
-docker pull "quay.io/wikipedialibrary/twlight_syslog:branch_production" || true
-
 docker-compose build twlight_base
 docker tag "quay.io/wikipedialibrary/twlight_base:local" "quay.io/wikipedialibrary/twlight_base:${BRANCH_TAG}"
 docker tag "quay.io/wikipedialibrary/twlight_base:local" "quay.io/wikipedialibrary/twlight_base:${BUILD_TAG}"

--- a/.travis/docker_compose.sh
+++ b/.travis/docker_compose.sh
@@ -5,6 +5,8 @@ export COMPOSE_DOCKER_CLI_BUILD=1 # use docker cli for building
 # Pull images from docker hub, but then retag for $cr_server for reuse and mirroring.
 docker pull "docker.io/library/alpine:3.11" || true
 docker tag "docker.io/library/alpine:3.11" "quay.io/wikipedialibrary/alpine:3.11"
+docker pull "docker.io/library/debian:buster-slim" || true
+docker tag "docker.io/library/debian:buster-slim" "quay.io/wikipedialibrary/debian:buster-slim"
 docker pull "docker.io/library/mariadb:10" || true
 docker tag "docker.io/library/mariadb:10" "quay.io/wikipedialibrary/mariadb:10"
 docker pull "docker.io/library/nginx:latest" || true

--- a/.travis/docker_mirror.sh
+++ b/.travis/docker_mirror.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+
+# Print Travis environment variables and migration count.
+echo "TRAVIS_EVENT_TYPE: ${TRAVIS_EVENT_TYPE}"
+
+# Only act if this is build was fired from cron and we have container registry credentials
+if [ "${TRAVIS_EVENT_TYPE}" = "cron" ] && [ -n "${cr_server+isset}" ] && [ -n "${cr_username+isset}" ] && [ -n "${cr_password+isset}" ]
+then
+  echo "$cr_password" | docker login $cr_server -u "$cr_username" --password-stdin
+
+  # Pull images from docker hub, then retag for $cr_server for reuse and mirroring.
+  declare -a images=("alpine:3.11" "debian:buster-slim" "mariadb:10" "nginx:latest" "python:3.7-slim-buster")
+  for image in $images
+  do
+    docker pull docker.io/library/${image}
+    docker tag docker.io/library/${image} ${cr_server}/wikipedialibrary/${image}
+    docker push ${cr_server}/wikipedialibrary/${image}
+  done
+fi

--- a/.travis/docker_push.sh
+++ b/.travis/docker_push.sh
@@ -1,36 +1,23 @@
 #!/usr/bin/env bash
 
 # Print Travis environment variables and migration count.
-echo "TRAVIS_PULL_REQUEST: ${TRAVIS_PULL_REQUEST}"
+echo "TRAVIS_EVENT_TYPE: ${TRAVIS_EVENT_TYPE}"
 echo "TRAVIS_TAG: ${TRAVIS_TAG}"
 echo "TRAVIS_BRANCH: ${TRAVIS_BRANCH}"
 echo "TWLIGHT_MISSING_MIGRATIONS: ${TWLIGHT_MISSING_MIGRATIONS}"
 echo "TWLIGHT_TRANSLATION_FILES_CHANGED: ${TWLIGHT_TRANSLATION_FILES_CHANGED}"
 
-
-
 # Only act if this is build was fired from a push and there are no missing migrations or changed translations.
-if [ "${TRAVIS_PULL_REQUEST}" = "false" ] && [ -z "${TRAVIS_TAG}" ] && [ -n "${cr_server+isset}" ] && [ -n "${cr_username+isset}" ] && [ -n "${cr_password+isset}" ] && [ -n "${TWLIGHT_MISSING_MIGRATIONS+isset}" ] && [ "${TWLIGHT_MISSING_MIGRATIONS}" -eq 0 ] && [ "${TWLIGHT_TRANSLATION_FILES_CHANGED}" -eq 0 ]
+if [ "${TRAVIS_EVENT_TYPE}" = "push" ] && [ -z "${TRAVIS_TAG}" ] && [ -n "${cr_server+isset}" ] && [ -n "${cr_username+isset}" ] && [ -n "${cr_password+isset}" ] && [ -n "${TWLIGHT_MISSING_MIGRATIONS+isset}" ] && [ "${TWLIGHT_MISSING_MIGRATIONS}" -eq 0 ] && [ "${TWLIGHT_TRANSLATION_FILES_CHANGED}" -eq 0 ]
 then
   echo "$cr_password" | docker login $cr_server -u "$cr_username" --password-stdin
 
-  docker push ${cr_server}/wikipedialibrary/alpine:3.11
-  docker push ${cr_server}/wikipedialibrary/mariadb:10
-  docker push ${cr_server}/wikipedialibrary/nginx:latest
-
-  docker push ${cr_server}/wikipedialibrary/twlight_base:${COMMIT_TAG}
-  docker push ${cr_server}/wikipedialibrary/twlight_base:${BRANCH_TAG}
-  docker push ${cr_server}/wikipedialibrary/twlight_base:${BUILD_TAG}
-
-  docker push ${cr_server}/wikipedialibrary/twlight_build:${COMMIT_TAG}
-  docker push ${cr_server}/wikipedialibrary/twlight_build:${BRANCH_TAG}
-  docker push ${cr_server}/wikipedialibrary/twlight_build:${BUILD_TAG}
-
-  docker push ${cr_server}/wikipedialibrary/twlight:${COMMIT_TAG}
-  docker push ${cr_server}/wikipedialibrary/twlight:${BRANCH_TAG}
-  docker push ${cr_server}/wikipedialibrary/twlight:${BUILD_TAG}
-
-  docker push ${cr_server}/wikipedialibrary/twlight_syslog:${COMMIT_TAG}
-  docker push ${cr_server}/wikipedialibrary/twlight_syslog:${BRANCH_TAG}
-  docker push ${cr_server}/wikipedialibrary/twlight_syslog:${BUILD_TAG}
+  # Push built images to ${cr_server}
+  declare -a repositories=("twlight_base" "twlight_build" "twlight" "twlight_syslog")
+  for repository in repositories
+  do
+    docker push ${cr_server}/wikipedialibrary/${repository}:${COMMIT_TAG}
+    docker push ${cr_server}/wikipedialibrary/${repository}:${BRANCH_TAG}
+    docker push ${cr_server}/wikipedialibrary/${repository}:${BUILD_TAG}
+  done
 fi

--- a/.travis/migrations.sh
+++ b/.travis/migrations.sh
@@ -1,13 +1,13 @@
 #!/usr/bin/env bash
 
 # Print Travis environment variables and migration count.
-echo "TRAVIS_PULL_REQUEST: ${TRAVIS_PULL_REQUEST}"
+echo "TRAVIS_EVENT_TYPE: ${TRAVIS_EVENT_TYPE}"
 echo "TRAVIS_TAG: ${TRAVIS_TAG}"
 echo "TRAVIS_BRANCH: ${TRAVIS_BRANCH}"
 echo "TWLIGHT_MISSING_MIGRATIONS: ${TWLIGHT_MISSING_MIGRATIONS}"
 
 # Only act if this is build was fired from a push to branch and there are missing migrations.
-if [ "${TRAVIS_PULL_REQUEST}" = "false" ] && [ -z "${TRAVIS_TAG}" ] && [ -n "${gh_bot_username+isset}" ] && [ -n "${gh_bot_token+isset}" ] && [ -n "${TWLIGHT_MISSING_MIGRATIONS+isset}" ] && [ "${TWLIGHT_MISSING_MIGRATIONS}" -gt 0 ]
+if [ "${TRAVIS_EVENT_TYPE}" = "push" ] && [ -z "${TRAVIS_TAG}" ] && [ -n "${gh_bot_username+isset}" ] && [ -n "${gh_bot_token+isset}" ] && [ -n "${TWLIGHT_MISSING_MIGRATIONS+isset}" ] && [ "${TWLIGHT_MISSING_MIGRATIONS}" -gt 0 ]
 then
     # Configure git.
     git_config() {

--- a/.travis/production.sh
+++ b/.travis/production.sh
@@ -1,14 +1,14 @@
 #!/usr/bin/env bash
 
 # Print Travis environment variables and migration count.
-echo "TRAVIS_PULL_REQUEST: ${TRAVIS_PULL_REQUEST}"
+echo "TRAVIS_EVENT_TYPE: ${TRAVIS_EVENT_TYPE}"
 echo "TRAVIS_TAG: ${TRAVIS_TAG}"
 echo "TRAVIS_BRANCH: ${TRAVIS_BRANCH}"
 echo "TWLIGHT_MISSING_MIGRATIONS: ${TWLIGHT_MISSING_MIGRATIONS}"
 echo "TWLIGHT_TRANSLATION_FILES_CHANGED: ${TWLIGHT_TRANSLATION_FILES_CHANGED}"
 
 # Only act if this is build was fired from a push to master and there are no missing migrations or changed translations.
-if [ "${TRAVIS_PULL_REQUEST}" = "false" ] && [ -z "${TRAVIS_TAG}" ] && [ "${TRAVIS_BRANCH}" = "master" ] && [ -n "${gh_bot_username+isset}" ] && [ -n "${gh_bot_token+isset}" ] && [ -n "${TWLIGHT_MISSING_MIGRATIONS+isset}" ]  && [ "${TWLIGHT_MISSING_MIGRATIONS}" -eq 0 ] && [ "${TWLIGHT_TRANSLATION_FILES_CHANGED}" -eq 0 ]
+if [ "${TRAVIS_EVENT_TYPE}" = "push" ] && [ -z "${TRAVIS_TAG}" ] && [ "${TRAVIS_BRANCH}" = "master" ] && [ -n "${gh_bot_username+isset}" ] && [ -n "${gh_bot_token+isset}" ] && [ -n "${TWLIGHT_MISSING_MIGRATIONS+isset}" ]  && [ "${TWLIGHT_MISSING_MIGRATIONS}" -eq 0 ] && [ "${TWLIGHT_TRANSLATION_FILES_CHANGED}" -eq 0 ]
 then
     # Configure git.
     git_config() {

--- a/.travis/translations.sh
+++ b/.travis/translations.sh
@@ -1,13 +1,13 @@
 #!/usr/bin/env bash
 
 # Print Travis environment variables and changed translation count.
-echo "TRAVIS_PULL_REQUEST: ${TRAVIS_PULL_REQUEST}"
+echo "TRAVIS_EVENT_TYPE: ${TRAVIS_EVENT_TYPE}"
 echo "TRAVIS_TAG: ${TRAVIS_TAG}"
 echo "TRAVIS_BRANCH: ${TRAVIS_BRANCH}"
 echo "TWLIGHT_TRANSLATION_FILES_CHANGED: ${TWLIGHT_TRANSLATION_FILES_CHANGED}"
 
 # Only act if this is build was fired from a push and there are changed translations.
-if [ "${TRAVIS_PULL_REQUEST}" = "false" ] && [ -z "${TRAVIS_TAG}" ] && [ -n "${gh_bot_username+isset}" ] && [ -n "${gh_bot_token+isset}" ] && [ -n "${TWLIGHT_TRANSLATION_FILES_CHANGED+isset}" ] && [ "${TWLIGHT_TRANSLATION_FILES_CHANGED}" -gt 0 ]
+if [ "${TRAVIS_EVENT_TYPE}" = "push" ] && [ -z "${TRAVIS_TAG}" ] && [ -n "${gh_bot_username+isset}" ] && [ -n "${gh_bot_token+isset}" ] && [ -n "${TWLIGHT_TRANSLATION_FILES_CHANGED+isset}" ] && [ "${TWLIGHT_TRANSLATION_FILES_CHANGED}" -gt 0 ]
 then
     # Configure git.
     git_config() {

--- a/bin/twlight_i18n_lint.pl
+++ b/bin/twlight_i18n_lint.pl
@@ -1,4 +1,4 @@
-#!/usr/bin/perl
+#!/usr/bin/env perl
 
 # Checks for localization issues.
 # https://phabricator.wikimedia.org/T255167

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -28,7 +28,7 @@ services:
       context: .
       target: twlight_base
       cache_from:
-        - quay.io/wikipedialibrary/alpine:3.11
+        - quay.io/wikipedialibrary/debian:buster-slim
         - quay.io/wikipedialibrary/twlight_base:branch_production
   twlight_build:
     image: quay.io/wikipedialibrary/twlight_build:local

--- a/docker-compose.travis.yml
+++ b/docker-compose.travis.yml
@@ -22,24 +22,47 @@ secrets:
     file: ./secrets/TWLIGHT_EZPROXY_SECRET
 
 services:
+  twlight_base:
+    image: quay.io/wikipedialibrary/twlight_base:local
+    build:
+      context: .
+      target: twlight_base
+      cache_from:
+        - quay.io/wikipedialibrary/twlight_base:branch_production
+  twlight_build:
+    image: quay.io/wikipedialibrary/twlight_build:local
+    build:
+      context: .
+      target: twlight_build
+      cache_from:
+        - quay.io/wikipedialibrary/twlight_base:local
+        - quay.io/wikipedialibrary/twlight_base:branch_production
+        - quay.io/wikipedialibrary/twlight_build:branch_production
   twlight:
     image: quay.io/wikipedialibrary/twlight:local
     build:
       context: .
       cache_from:
+        - quay.io/wikipedialibrary/twlight_base:local
         - quay.io/wikipedialibrary/twlight_base:branch_production
+        - quay.io/wikipedialibrary/twlight_build:local
         - quay.io/wikipedialibrary/twlight_build:branch_production
     env_file:
-      - ./conf/local.twlight.env
+      - ./conf/travis.twlight.env
+    environment:
+      - TRAVIS_JOB_ID
+      - TRAVIS_BRANCH
+      - COVERALLS_REPO_TOKEN
     # Local environment should mount things from the code directory
     volumes:
       - type: bind
         source: .
         target: /app
-  web:
-    volumes:
-      - type: bind
-        source: ./conf/local.nginx.conf
-        target: /etc/nginx/conf.d/default.conf
   syslog:
-    image: quay.io/wikipedialibrary/twlight_syslog:local
+    build:
+      context: syslog
+      cache_from:
+        - quay.io/wikipedialibrary/twlight_syslog:branch_production
+    environment:
+      - MATOMO_FQDN=analytics-wikipedialibrary.wmflabs.org
+

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -67,7 +67,6 @@ services:
     build:
       context: syslog
       cache_from:
-        - quay.io/wikipedialibrary/alpine:3.11
         - quay.io/wikipedialibrary/twlight_syslog:branch_production
     environment:
       - MATOMO_FQDN=analytics-wikipedialibrary.wmflabs.org

--- a/perl/Dockerfile
+++ b/perl/Dockerfile
@@ -1,0 +1,19 @@
+FROM quay.io/wikipedialibrary/debian:buster-slim as perl_build
+ENV PERL_VERSION=5.32.1
+# Base dependencies; split out to create cachable layer.
+RUN apt update; \
+    apt install -y \
+    build-essential \
+    gcc \
+    wget ; \
+    apt clean ; \
+    wget https://www.cpan.org/src/5.0/perl-${PERL_VERSION}.tar.gz ; \
+    tar -xvf perl-${PERL_VERSION}.tar.gz ; \
+    cd perl-${PERL_VERSION} ; \
+    ./Configure -des -Dprefix=/opt/perl ; \
+    make && make test && make install
+
+FROM quay.io/wikipedialibrary/debian:buster-slim
+COPY --from=perl_build /opt/perl /opt/perl
+
+ENTRYPOINT ["/opt/perl/bin/perl"]

--- a/tests/shunit/twlight_i18n_lint_test.sh
+++ b/tests/shunit/twlight_i18n_lint_test.sh
@@ -6,7 +6,7 @@ testBadPyNewlines() {
     prefix=${TWLIGHT_HOME}/tests/shunit/data/bad_i18n_newline_
     for i in ${prefix}*.py
     do
-        assertFalse "${file} should cause an error." "perl ${TWLIGHT_HOME}/bin/twlight_i18n_lint.pl ${i}"
+        assertFalse "${file} should cause an error." "${TWLIGHT_HOME}/bin/twlight_i18n_lint.pl ${i}"
     done
 }
 
@@ -14,7 +14,7 @@ testGoodPy() {
     prefix=${TWLIGHT_HOME}/tests/shunit/data/good_i18n_
     for i in ${prefix}*.py
     do
-        assertTrue "${file} should not cause an error." "perl ${TWLIGHT_HOME}/bin/twlight_i18n_lint.pl ${i}" ||:
+        assertTrue "${file} should not cause an error." "${TWLIGHT_HOME}/bin/twlight_i18n_lint.pl ${i}" ||:
     done
 }
 
@@ -22,7 +22,7 @@ testBadPyComments() {
     prefix=${TWLIGHT_HOME}/tests/shunit/data/bad_i18n_comment_
     for i in ${prefix}*.py
     do
-        assertFalse "${file} should cause an error." "perl ${TWLIGHT_HOME}/bin/twlight_i18n_lint.pl ${i}"
+        assertFalse "${file} should cause an error." "${TWLIGHT_HOME}/bin/twlight_i18n_lint.pl ${i}"
     done
 }
 


### PR DESCRIPTION
## Description
- changes base image from alpine:3.11 to python:3.7-slim-buster
- limits docker.io => quay.io mirroring to builds fired by cron

## Rationale
Our travis builds can be painfully slow

## Phabricator Ticket
https://phabricator.wikimedia.org/T282593

## How Has This Been Tested?

- Many many many local docker pulls/builds/pushes and travis builds
- I've run the backup, restore, migrate, test, translate, and css janus scripts to verify that stuff still works

## Screenshots of your changes (if appropriate):
N/A

## Types of changes
What types of changes does your code introduce? Add an `x` in all the boxes that apply:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Minor change (fix a typo, add a translation tag, add section to README, etc.)
