### PR TITLE
Change `suggested_company_name` factory var to `pystr`

### DIFF
--- a/TWLight/resources/factories.py
+++ b/TWLight/resources/factories.py
@@ -32,9 +32,7 @@ class SuggestionFactory(factory.django.DjangoModelFactory):
         model = Suggestion
         strategy = factory.CREATE_STRATEGY
 
-    suggested_company_name = factory.Faker(
-        "company", locale=random.choice(settings.FAKER_LOCALES)
-    )
+    suggested_company_name = factory.Faker("pystr", max_chars=40)
     company_url = factory.Faker("url", locale=random.choice(settings.FAKER_LOCALES))
 
 


### PR DESCRIPTION
## Description
Since we are still having problems with the `SuggestionFactory.suggested_company_name` variable, we switched from Faker.company_name to Faker.pystr that has a `max_chars` parameter.

## Rationale
[//]: # (Why is this change required? What problem does it solve?)
This will stop our builds from failing because of Faker creating a suggested company name that has more than 40 characters.

## Phabricator Ticket
[//]: # (Link to the Phabricator ticket)
[T280201](https://phabricator.wikimedia.org/T280201)

## How Has This Been Tested?
[//]: # (- Did you add tests to your changes? Did you modify tests to accommodate your changes?)
[//]: # (- Can this change be tested manually? How?)

## Screenshots of your changes (if appropriate):
[//]: # (It can also be a GIF to prove that your changes are working)

## Types of changes
What types of changes does your code introduce? Add an `x` in all the boxes that apply:
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Minor change (fix a typo, add a translation tag, add section to README, etc.)
