### PR TITLE
add python:3.8-buster to docker_mirror.sh

### DIFF
--- a/.travis/docker_mirror.sh
+++ b/.travis/docker_mirror.sh
@@ -9,7 +9,7 @@ then
   echo "$cr_password" | docker login $cr_server -u "$cr_username" --password-stdin
 
   # Pull images from docker hub, then retag for $cr_server for reuse and mirroring.
-  declare -a images=("alpine:3.11" "debian:buster-slim" "mariadb:10" "nginx:latest" "python:3.7-slim-buster")
+  declare -a images=("alpine:3.11" "debian:buster-slim" "mariadb:10" "nginx:latest" "python:3.8-buster" "python:3.7-slim-buster")
   for image in "${images[@]}"
   do
     docker pull docker.io/library/${image}


### PR DESCRIPTION
## Description
adds python:3.8-buster to our docker mirror list

## Rationale
So externallinks can have an updated base image

## Phabricator Ticket
N/A

## How Has This Been Tested?
N/A

## Screenshots of your changes (if appropriate):
N/A

## Types of changes
What types of changes does your code introduce? Add an `x` in all the boxes that apply:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Minor change (fix a typo, add a translation tag, add section to README, etc.)
