### PR TITLE
exclude bots from Matomo analytics

### DIFF
--- a/syslog/bin/import_logs.py
+++ b/syslog/bin/import_logs.py
@@ -100,6 +100,7 @@ EXCLUDED_USER_AGENTS = (
     'netcraftsurvey',
     'panopta',
     'pingdom.com_bot_',
+    'python-requests/',
     'robot',
     'spider',
     'surveybot',

--- a/syslog/bin/import_logs.py
+++ b/syslog/bin/import_logs.py
@@ -80,6 +80,7 @@ DOWNLOAD_EXTENSIONS = set((
 # https://github.com/matomo-org/device-detector/blob/master/regexes/bots.yml
 # user agents must be lowercase
 EXCLUDED_USER_AGENTS = (
+    'apache-httpclient',
     'adsbot-google',
     'ask jeeves',
     'baidubot',

--- a/syslog/bin/matomo.sh
+++ b/syslog/bin/matomo.sh
@@ -8,7 +8,9 @@ while IFS= read -r line; do
     echo ${line} | /srv/syslog/bin/import_logs.py \
     --url=https://${MATOMO_FQDN}/ --token-auth=${MATOMO_AUTH_TOKEN} \
     --idsite=${MATOMO_SITEID} --recorders=4 \
-    --enable-http-errors --enable-http-redirects --enable-bots \
+    --enable-http-errors \
+    --enable-http-redirects \
+    --enable-bots \
     --log-format-name=nginx_json -
   fi
 done

--- a/syslog/bin/matomo.sh
+++ b/syslog/bin/matomo.sh
@@ -10,7 +10,6 @@ while IFS= read -r line; do
     --idsite=${MATOMO_SITEID} --recorders=4 \
     --enable-http-errors \
     --enable-http-redirects \
-    --enable-bots \
     --log-format-name=nginx_json -
   fi
 done


### PR DESCRIPTION
## Description
Adds more user agents to the bot list and filters all bot traffic out from matomo analyitcs

## Rationale
We're trying to improve the signal:noise ratio in matomo

## Phabricator Ticket
https://phabricator.wikimedia.org/T282714

## How Has This Been Tested?
I verified that this works locally by connecting my dev environment to matomo and setting the user-agent string in curl.
I'll need to update the visitor segments in matomo, because the `Bot` and `Not-Bot` variables are used in those, but will no longer be populated.

## Screenshots of your changes (if appropriate):
N/A

## Types of changes
What types of changes does your code introduce? Add an `x` in all the boxes that apply:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Minor change (fix a typo, add a translation tag, add section to README, etc.)
