### PR TITLE
Link new homepage to root of project

### DIFF
--- a/TWLight/templates/login_partial.html
+++ b/TWLight/templates/login_partial.html
@@ -50,7 +50,7 @@
 <div class="row">
     <div class="col-lg-6 col-md-12 col-sm-12 homepage-login">
       {% comment %}Translators: Button that logs editors in via Wikipedia.{% endcomment %}
-      <a  class="btn btn-lg btn-light homepage-login-button" href="{% url 'oauth_login' %}?next={% url 'homepage' %}">
+      <a  class="btn btn-light homepage-login-button" href="{% url 'oauth_login' %}?next={% url 'home' %}">
         {% trans "Login via Wikipedia" %}
       </a>
     </div>

--- a/TWLight/templates/login_partial.html
+++ b/TWLight/templates/login_partial.html
@@ -50,7 +50,7 @@
 <div class="row">
     <div class="col-lg-6 col-md-12 col-sm-12 homepage-login">
       {% comment %}Translators: Button that logs editors in via Wikipedia.{% endcomment %}
-      <a  class="btn btn-light homepage-login-button" href="{% url 'oauth_login' %}?next={% url 'home' %}">
+      <a  class="btn btn-lg btn-light homepage-login-button" href="{% url 'oauth_login' %}?next={% url 'home' %}">
         {% trans "Login via Wikipedia" %}
       </a>
     </div>

--- a/TWLight/templates/partner_carousel.html
+++ b/TWLight/templates/partner_carousel.html
@@ -8,9 +8,9 @@
     <ul class="nav justify-content-center">
       <li class="nav-item">
         {% if not selected %}
-          <a class="nav-link more-item active" href="{% url 'new_homepage' %}?tags=">
+          <a class="nav-link more-item active" href="{% url 'homepage' %}?tags=">
         {% else %}
-          <a class="nav-link more-item" href="{% url 'new_homepage' %}?tags=">
+          <a class="nav-link more-item" href="{% url 'homepage' %}?tags=">
         {% endif %}
           {% comment %}Translators: This is a filter of featured collections of The Wikipedia Library.{% endcomment %}
           {% blocktranslate %}
@@ -21,9 +21,9 @@
       {% for tag_key, tag_value in tags.items %}
           <li class="nav-item">
             {% if selected and tag_key == selected %}
-              <a class="nav-link more-item active" href="{% url 'new_homepage' %}?tags={{tag_key}}">
+              <a class="nav-link more-item active" href="{% url 'homepage' %}?tags={{tag_key}}">
             {% else %}
-              <a class="nav-link more-item" href="{% url 'new_homepage' %}?tags={{tag_key}}">
+              <a class="nav-link more-item" href="{% url 'homepage' %}?tags={{tag_key}}">
             {% endif %}
               {{ tag_value }}
             </a>
@@ -48,7 +48,7 @@
             </a>
             <div class="dropdown-menu">
               {% for a_tag_key, a_tag_value in more_tags.items %}
-                <a class="dropdown-item more-item" href="{% url 'new_homepage' %}?tags={{a_tag_key}}">
+                <a class="dropdown-item more-item" href="{% url 'homepage' %}?tags={{a_tag_key}}">
                   {{ a_tag_value }}
                 </a>
               {% endfor %}

--- a/TWLight/tests.py
+++ b/TWLight/tests.py
@@ -4,7 +4,8 @@ from datetime import date, timedelta
 from faker import Faker
 from testdata import wrap_testdata
 
-from django.contrib.auth.models import User
+from django.contrib.auth import logout
+from django.contrib.auth.models import User, AnonymousUser
 from django.conf import settings
 from django.core import mail
 from django.core.exceptions import PermissionDenied, ValidationError
@@ -26,6 +27,8 @@ from TWLight.users.factories import UserFactory, EditorFactory
 from TWLight.users.groups import get_coordinators
 from TWLight.users.models import Authorization
 import TWLight.users.views
+
+from . import views as base_views
 
 from .view_mixins import (
     PartnerCoordinatorOrSelf,
@@ -1267,3 +1270,99 @@ class AuthorizedUsersAPITestCase(AuthorizationBaseTestCase):
         expected_json = [{"wp_username": self.editor1.wp_username}]
 
         self.assertEqual(response.data, expected_json)
+
+
+class TestBaseViews(TestCase):
+    @classmethod
+    @wrap_testdata
+    def setUpTestData(cls):
+        super().setUpTestData()
+        cls.partner1 = PartnerFactory(
+            authorization_method=Partner.PROXY,
+            status=Partner.AVAILABLE,
+            featured=True,
+            new_tags={"tags": ["music_tag"]},
+        )
+        cls.partner2 = PartnerFactory(
+            authorization_method=Partner.PROXY,
+            status=Partner.AVAILABLE,
+            requested_access_duration=True,
+            new_tags={"tags": ["art_tag"]},
+        )
+        cls.partner3 = PartnerFactory(
+            authorization_method=Partner.CODES,
+            status=Partner.AVAILABLE,
+            featured=True,
+            new_tags={"tags": ["music_tag"]},
+        )
+        cls.partner4 = PartnerFactory(
+            authorization_method=Partner.PROXY,
+            status=Partner.AVAILABLE,
+            featured=True,
+            new_tags={"tags": ["art_tag"]},
+        )
+        cls.partner5 = PartnerFactory(
+            authorization_method=Partner.PROXY,
+            status=Partner.AVAILABLE,
+            specific_stream=True,
+            new_tags={"tags": ["multidisciplinary_tag"]},
+        )
+        cls.user_editor = UserFactory(username="Jon Snow")
+        cls.editor1 = EditorFactory(user=cls.user_editor)
+        cls.editor1.wp_bundle_eligible = True
+        cls.editor1.save()
+
+    def test_featured_partners(self):
+        factory = RequestFactory()
+        request = factory.get(reverse("homepage"))
+        request.user = AnonymousUser()
+        response = base_views.NewHomePageView.as_view()(request)
+
+        self.assertEqual(response.status_code, 200)
+
+        content = response.content.decode("utf-8")
+
+        self.assertIn(self.partner1.company_name, content)
+        self.assertIn(self.partner3.company_name, content)
+        self.assertIn(self.partner4.company_name, content)
+
+        self.assertNotIn(self.partner2.company_name, content)
+        self.assertNotIn(self.partner5.company_name, content)
+
+    def test_filter_partners_carousel_music(self):
+        factory = RequestFactory()
+        url = reverse("homepage")
+        param_url = "{url}?tags=music_tag".format(url=url)
+        request = factory.get(param_url)
+        request.user = AnonymousUser()
+        response = base_views.NewHomePageView.as_view()(request)
+
+        self.assertEqual(response.status_code, 200)
+
+        content = response.content.decode("utf-8")
+
+        self.assertIn(self.partner1.company_name, content)
+        self.assertIn(self.partner3.company_name, content)
+        self.assertIn(self.partner5.company_name, content)
+
+        self.assertNotIn(self.partner2.company_name, content)
+        self.assertNotIn(self.partner4.company_name, content)
+
+    def test_filter_partners_carousel_art(self):
+        factory = RequestFactory()
+        url = reverse("homepage")
+        param_url = "{url}?tags=art_tag".format(url=url)
+        request = factory.get(param_url)
+        request.user = AnonymousUser()
+        response = base_views.NewHomePageView.as_view()(request)
+
+        self.assertEqual(response.status_code, 200)
+
+        content = response.content.decode("utf-8")
+
+        self.assertIn(self.partner2.company_name, content)
+        self.assertIn(self.partner4.company_name, content)
+        self.assertIn(self.partner5.company_name, content)
+
+        self.assertNotIn(self.partner1.company_name, content)
+        self.assertNotIn(self.partner3.company_name, content)

--- a/TWLight/tests.py
+++ b/TWLight/tests.py
@@ -14,6 +14,7 @@ from django.urls import reverse
 from django.http import HttpResponseRedirect
 from django.test import TestCase, RequestFactory, Client
 from django.utils import timezone
+from django.utils.html import escape
 
 from rest_framework.test import APIRequestFactory, force_authenticate
 
@@ -1327,12 +1328,12 @@ class TestBaseViews(TestCase):
 
         content = response.content.decode("utf-8")
 
-        self.assertIn(self.partner1.company_name, content)
-        self.assertIn(self.partner3.company_name, content)
-        self.assertIn(self.partner4.company_name, content)
+        self.assertIn(escape(self.partner1.company_name), content)
+        self.assertIn(escape(self.partner3.company_name), content)
+        self.assertIn(escape(self.partner4.company_name), content)
 
-        self.assertNotIn(self.partner2.company_name, content)
-        self.assertNotIn(self.partner5.company_name, content)
+        self.assertNotIn(escape(self.partner2.company_name), content)
+        self.assertNotIn(escape(self.partner5.company_name), content)
 
     def test_filter_partners_carousel_music(self):
         """
@@ -1351,12 +1352,12 @@ class TestBaseViews(TestCase):
 
         content = response.content.decode("utf-8")
 
-        self.assertIn(self.partner1.company_name, content)
-        self.assertIn(self.partner3.company_name, content)
-        self.assertIn(self.partner5.company_name, content)
+        self.assertIn(escape(self.partner1.company_name), content)
+        self.assertIn(escape(self.partner3.company_name), content)
+        self.assertIn(escape(self.partner5.company_name), content)
 
-        self.assertNotIn(self.partner2.company_name, content)
-        self.assertNotIn(self.partner4.company_name, content)
+        self.assertNotIn(escape(self.partner2.company_name), content)
+        self.assertNotIn(escape(self.partner4.company_name), content)
 
     def test_filter_partners_carousel_art(self):
         """
@@ -1375,9 +1376,9 @@ class TestBaseViews(TestCase):
 
         content = response.content.decode("utf-8")
 
-        self.assertIn(self.partner2.company_name, content)
-        self.assertIn(self.partner4.company_name, content)
-        self.assertIn(self.partner5.company_name, content)
+        self.assertIn(escape(self.partner2.company_name), content)
+        self.assertIn(escape(self.partner4.company_name), content)
+        self.assertIn(escape(self.partner5.company_name), content)
 
-        self.assertNotIn(self.partner1.company_name, content)
-        self.assertNotIn(self.partner3.company_name, content)
+        self.assertNotIn(escape(self.partner1.company_name), content)
+        self.assertNotIn(escape(self.partner3.company_name), content)

--- a/TWLight/tests.py
+++ b/TWLight/tests.py
@@ -1313,6 +1313,11 @@ class TestBaseViews(TestCase):
         cls.editor1.save()
 
     def test_featured_partners(self):
+        """
+        Test to determine that the carousel filters are working properly.
+        When an anonymous user navigates to the homepage, only the featured
+        partners should appear in the carousel.
+        """
         factory = RequestFactory()
         request = factory.get(reverse("homepage"))
         request.user = AnonymousUser()
@@ -1330,6 +1335,11 @@ class TestBaseViews(TestCase):
         self.assertNotIn(self.partner5.company_name, content)
 
     def test_filter_partners_carousel_music(self):
+        """
+        Test to determine that the carousel filters are working properly.
+        When an anonymous user filters by a tag, only partners with that tag and
+        the "multidisciplinary_tag" should appear
+        """
         factory = RequestFactory()
         url = reverse("homepage")
         param_url = "{url}?tags=music_tag".format(url=url)
@@ -1349,6 +1359,11 @@ class TestBaseViews(TestCase):
         self.assertNotIn(self.partner4.company_name, content)
 
     def test_filter_partners_carousel_art(self):
+        """
+        Test to determine that the carousel filters are working properly.
+        When an anonymous user filters by a tag, only partners with that tag and
+        the "multidisciplinary_tag" should appear
+        """
         factory = RequestFactory()
         url = reverse("homepage")
         param_url = "{url}?tags=art_tag".format(url=url)

--- a/TWLight/urls.py
+++ b/TWLight/urls.py
@@ -88,7 +88,7 @@ urlpatterns = [
     ),
     # For contact us form
     url(r"^contact/$", ContactUsView.as_view(), name="contact"),
-    url(r"^$", HomePageView.as_view(), name="homepage"),
+    url(r"^$", NewHomePageView.as_view(), name="homepage"),
     url(r"^about/$", TemplateView.as_view(template_name="about.html"), name="about"),
-    url(r"^homepage/$", NewHomePageView.as_view(), name="new_homepage"),
+    url(r"^home/$", login_required(HomePageView.as_view()), name="home"),
 ]

--- a/TWLight/views.py
+++ b/TWLight/views.py
@@ -13,7 +13,7 @@ from django.template import TemplateDoesNotExist, loader
 from django.views.decorators.csrf import requires_csrf_token
 from django.views.decorators.debug import sensitive_variables
 
-from TWLight.resources.models import Partner
+from TWLight.resources.models import Partner, PartnerLogo
 from TWLight.resources.helpers import get_partner_description, get_tag_dict
 
 import logging
@@ -166,11 +166,15 @@ class NewHomePageView(TemplateView):
             partner_descriptions = get_partner_description(
                 language_code, partner_short_description_key, partner_description_key
             )
+            try:
+                partner_logo = partner.logos.logo.url
+            except PartnerLogo.DoesNotExist:
+                partner_logo = None
             partners_obj.append(
                 {
                     "pk": partner.pk,
                     "partner_name": partner.company_name,
-                    "partner_logo": partner.logos.logo.url,
+                    "partner_logo": partner_logo,
                     "short_description": partner_descriptions["short_description"],
                     "description": partner_descriptions["description"],
                 }

--- a/TWLight/views.py
+++ b/TWLight/views.py
@@ -181,7 +181,7 @@ class NewHomePageView(TemplateView):
 
     def get(self, request):
         if request.user.is_authenticated:
-            return redirect("/")
+            return redirect("/home")
         else:
             context = self.get_context_data()
             return render(request, "homepage.html", context)


### PR DESCRIPTION
## Description
Link new homepage to root of TWLight and create new tests for the new view.

## Rationale
[//]: # (Why is this change required? What problem does it solve?)
Currently, the redesigned Wikipedia Library homepage is located at /homepage instead of the root of the project. This PR will replace the old homepage with the new one.

Additionally, the new homepage view did not have tests, so tests were added in this PR.

## Phabricator Ticket
[//]: # (Link to the Phabricator ticket)
[T285822](https://phabricator.wikimedia.org/T285822)

## How Has This Been Tested?
[//]: # (- Did you add tests to your changes? Did you modify tests to accommodate your changes?)
[//]: # (- Can this change be tested manually? How?)
- Created automated tests to check if filters are working properly.
- Manual tests

## Screenshots of your changes (if appropriate):
[//]: # (It can also be a GIF to prove that your changes are working)

## Types of changes
What types of changes does your code introduce? Add an `x` in all the boxes that apply:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Minor change (fix a typo, add a translation tag, add section to README, etc.)
