### PR TITLE
fix pluralized strings in cooridnator reminder notifications.

### DIFF
--- a/TWLight/emails/templates/emails/coordinator_reminder_notification-body-html.html
+++ b/TWLight/emails/templates/emails/coordinator_reminder_notification-body-html.html
@@ -13,7 +13,7 @@
 {% if pending_count %}
   {% comment %}Translators: This text is part of a scheduled reminder email sent to coordinators who have applications requiring action. Don't translate Jinja variables in curly braces like {{ counter }}.{% endcomment %}
   {% blocktrans count counter=pending_count trimmed%}
-    One pending application.
+    {{ counter }} pending application.
   {% plural %}
     {{ counter }} pending applications.
   {% endblocktrans %}
@@ -21,7 +21,7 @@
 {% if question_count %}
   {% comment %}Translators: This text is part of a scheduled reminder email sent to coordinators who have applications requiring action. Don't translate Jinja variables in curly braces like {{ counter }}.{% endcomment %}
   {% blocktrans count counter=question_count trimmed%}
-    One under discussion application.
+    {{ counter }} under discussion application.
   {% plural %}
     {{ counter }} under discussion applications.
   {% endblocktrans %}
@@ -29,7 +29,7 @@
 {% if approved_count %}
   {% comment %}Translators: This text is part of a scheduled reminder email sent to coordinators who have applications requiring action. Don't translate Jinja variables in curly braces like {{ counter }}.{% endcomment %}
   {% blocktrans count counter=approved_count trimmed %}
-    {{ approved_count }} approved applications.
+    {{ counter }} approved application.
   {% plural %}
     {{ counter }} approved applications.
   {% endblocktrans %}

--- a/TWLight/emails/templates/emails/coordinator_reminder_notification-body-text.html
+++ b/TWLight/emails/templates/emails/coordinator_reminder_notification-body-text.html
@@ -12,7 +12,7 @@ have a total of {{ total_apps }} applications.
 {% if pending_count %}
   {% comment %}Translators: This text is part of a scheduled reminder email sent to coordinators who have applications requiring action. Don't translate Jinja variables in curly braces like {{ counter }}.{% endcomment %}
   {% blocktrans count counter=pending_count trimmed%}
-    One pending application.
+    {{ counter }} pending application.
   {% plural %}
     {{ counter }} pending applications.
   {% endblocktrans %}
@@ -20,7 +20,7 @@ have a total of {{ total_apps }} applications.
 {% comment %}Translators: This text is part of a scheduled reminder email sent to coordinators who have applications requiring action. Don't translate Jinja variables in curly braces like {{ counter }}.{% endcomment %}
 {% if question_count %}
   {% blocktrans count counter=question_count trimmed%}
-    One under discussion application.
+    {{ counter }} under discussion application.
   {% plural %}
     {{ counter }} under discussion applications.
   {% endblocktrans %}
@@ -28,7 +28,7 @@ have a total of {{ total_apps }} applications.
 {% if approved_count %}
   {% comment %}Translators: This text is part of a scheduled reminder email sent to coordinators who have applications requiring action. Don't translate Jinja variables in curly braces like {{ counter }}.{% endcomment %}
   {% blocktrans count counter=approved_count trimmed %}
-    One approved application.
+    {{ counter }} approved application.
   {% plural %}
     {{ counter }} approved applications.
   {% endblocktrans %}

--- a/TWLight/emails/tests.py
+++ b/TWLight/emails/tests.py
@@ -605,9 +605,9 @@ class CoordinatorReminderEmailTest(TestCase):
         # has enabled reminders only for QUESTION, we send a
         # reminder only when we have an app of status: QUESTION,
         # but include info on all apps in the email.
-        self.assertNotIn("One pending application", mail.outbox[0].body)
-        self.assertIn("One under discussion application", mail.outbox[0].body)
-        self.assertNotIn("One approved application", mail.outbox[0].body)
+        self.assertNotIn("1 pending application", mail.outbox[0].body)
+        self.assertIn("1 under discussion application", mail.outbox[0].body)
+        self.assertNotIn("1 approved application", mail.outbox[0].body)
 
         ApplicationFactory(
             partner=self.partner, status=Application.APPROVED, editor=self.user2.editor
@@ -628,9 +628,9 @@ class CoordinatorReminderEmailTest(TestCase):
 
         call_command("send_coordinator_reminders")
         self.assertEqual(len(mail.outbox), 1)
-        self.assertIn("One pending application", mail.outbox[0].body)
-        self.assertIn("One under discussion application", mail.outbox[0].body)
-        self.assertIn("One approved application", mail.outbox[0].body)
+        self.assertIn("1 pending application", mail.outbox[0].body)
+        self.assertIn("1 under discussion application", mail.outbox[0].body)
+        self.assertIn("1 approved application", mail.outbox[0].body)
 
 
 class ProjectPage2021LaunchTest(TestCase):


### PR DESCRIPTION
[//]: # (Thank you for uploading a PR to the Wikipedia Library!)

## Description
Corrects errors in our pluralization handling for coordinator reminder emails.

## Rationale
This is preventing some of the translatewiki localization work from being used in the platform.

## Phabricator Ticket
https://phabricator.wikimedia.org/T286728

## How Has This Been Tested?
I've run individual i18n commands in django as well as our translation script and examined the output.
Note that this will cause the related i18n messages to no longer match, so there will be some followup translation updates required.

## Screenshots of your changes (if appropriate):
N/A

## Types of changes
What types of changes does your code introduce? Add an `x` in all the boxes that apply:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Minor change (fix a typo, add a translation tag, add section to README, etc.)
