### PR TITLE
Fix navbar options when unauthenticated

### DIFF
--- a/TWLight/templates/header_partial_b3.html
+++ b/TWLight/templates/header_partial_b3.html
@@ -50,20 +50,19 @@
           </a>
         </li>
         <li role="separator" class="divider"></li>
-        {% if user %}
-        <li role="presentation" class="mobile-menu nav-item">
-          <a class="btn user-button" href="{% url 'users:home' %}">
-            {{ user.editor.wp_username }}
-          </a>
-        </li>
-
+        {% if user and user.is_authenticated %}
+          <li role="presentation" class="mobile-menu nav-item">
+            <a class="btn user-button" href="{% url 'users:home' %}">
+              {{ user.editor.wp_username }}
+            </a>
+          </li>
+          <li role="presentation" class="mobile-menu nav-item">
+            {% comment %}Translators: Shown in the top bar to let users log out of The Wikipedia Library. {% endcomment %}
+            <a class="nav-links" href="{% url 'auth_logout' %}?next=/">
+              {% trans "Log out" %}
+            </a>
+          </li>
         {% endif %}
-        <li role="presentation" class="mobile-menu nav-item">
-          {% comment %}Translators: Shown in the top bar to let users log out of The Wikipedia Library. {% endcomment %}
-          <a class="nav-links" href="{% url 'auth_logout' %}?next=/">
-            {% trans "Log out" %}
-          </a>
-        </li>
       </ul>
     </div><!-- /.navbar-collapse -->
   </div><!-- /.container-fluid -->

--- a/TWLight/templates/header_partial_b4.html
+++ b/TWLight/templates/header_partial_b4.html
@@ -45,19 +45,19 @@
         </a>
       </li>
       <div class="dropdown-divider"></div>
-      {% if user %}
-      <li role="presentation" class="mobile-menu align-middle nav-item">
-        <a class="btn user-button" href="{% url 'users:home' %}">
-          {{ user.editor.wp_username }}
-        </a>
-      </li>
+      {% if user and user.is_authenticated %}
+        <li role="presentation" class="mobile-menu align-middle nav-item">
+          <a class="btn user-button" href="{% url 'users:home' %}">
+            {{ user.editor.wp_username }}
+          </a>
+        </li>
+        <li role="presentation" class="mobile-menu align-middle nav-item">
+          {% comment %}Translators: Shown in the top bar to let users log out of The Wikipedia Library. {% endcomment %}
+          <a class="nav-link nav-links" href="{% url 'auth_logout' %}?next=/">
+            {% trans "Log out" %}
+          </a>
+        </li>
       {% endif %}
-      <li role="presentation" class="mobile-menu align-middle nav-item">
-        {% comment %}Translators: Shown in the top bar to let users log out of The Wikipedia Library. {% endcomment %}
-        <a class="nav-link nav-links" href="{% url 'auth_logout' %}?next=/">
-          {% trans "Log out" %}
-        </a>
-      </li>
     </ul>
   </div>
 </nav>


### PR DESCRIPTION
To show the Log Out and Profile/Settings option in the header

[//]: # (Thank you for uploading a PR to the Wikipedia Library!)

## Description
Add a clause to check if a user is authenticated in order to show some navbar options like `Log out` and `Profile/Settings`

## Rationale
[//]: # (Why is this change required? What problem does it solve?)
It doesn't make sense to show these options when a user is logged out of the application.

## Phabricator Ticket
[//]: # (Link to the Phabricator ticket)
[T286734](https://phabricator.wikimedia.org/T286734)

## How Has This Been Tested?
[//]: # (- Did you add tests to your changes? Did you modify tests to accommodate your changes?)
[//]: # (- Can this change be tested manually? How?)
1. Log out of TWL
2. Go to a page where a user can go unauthenticated, like the `Contact Us` page.
3. Check that the `Log out` option does not show

## Screenshots of your changes (if appropriate):
[//]: # (It can also be a GIF to prove that your changes are working)

**Before the fix**
![Screen Shot 2021-07-15 at 19 23 43](https://user-images.githubusercontent.com/7854953/125873777-325d35b4-73e0-4064-879b-c9d8d4c58d98.png)


**After the fix**
![Screen Shot 2021-07-15 at 19 23 56](https://user-images.githubusercontent.com/7854953/125873803-098bb572-052a-4b36-9490-8ce5cf63c7f1.png)


## Types of changes
What types of changes does your code introduce? Add an `x` in all the boxes that apply:
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Minor change (fix a typo, add a translation tag, add section to README, etc.)
