### PR TITLE
Fix "'msgid' and 'msgstr' entries do not both begin with '\n'" translation errors

### DIFF
--- a/TWLight/applications/templates/applications/application_evaluation.html
+++ b/TWLight/applications/templates/applications/application_evaluation.html
@@ -127,9 +127,9 @@
       <strong>
         {% url 'terms' as terms_url %}
         {% comment %}Translators: This labels the section of an application showing whether the user had agreed to the terms of use or not.{% endcomment %}
-        {% blocktrans trimmed %}
+        {% blocktranslate trimmed %}
           Has agreed to the site's <a href="{{ terms_url }}">terms of use</a>?
-        {% endblocktrans %}
+        {% endblocktranslate %}
       </strong>
     </div>
     <div class="col-xs-12 col-sm-8">
@@ -187,9 +187,9 @@
       {% if object.parent %}
         {% with object.parent.get_absolute_url as parent_url %}
           {% comment %}Translators: This message is shown next to the 'Renewal of existing access grant?' label if the application is a renewal. Don't translate HTML tags or {{ parent_url }}.{% endcomment %}
-          {% blocktrans trimmed %}
+          {% blocktranslate trimmed %}
             Yes (<a href="{{ parent_url }}">previous application</a>)
-          {% endblocktrans %}
+          {% endblocktranslate %}
         {% endwith %}
       {% else %}
         {% comment %}Translators: This message is shown next to the 'Renewal of existing access grant?' label if the application is not a renewal.{% endcomment %}
@@ -289,10 +289,10 @@
 
   <p>
     {% comment %}Translators: On an application page, this text tells users that the comments posted on the application are visible to coordinators and the submitting user only.{% endcomment %}
-    {% blocktrans trimmed %}
+    {% blocktranslate trimmed %}
       Comments are visible to all
       coordinators and to the editor who submitted this application.
-    {% endblocktrans %}
+    {% endblocktranslate %}
   </p>
 
   {% comment %}Translators: This is the title of the section of an application page which lists information about the user who submitted the application.{% endcomment %}
@@ -317,14 +317,14 @@
                   {% with review_date=version.revision.date_created|localize %}
                     {% if submit_user %}
                       {% comment %}Translators: Applications have a revision history section. This message denotes when the application was submitted and who submitted it. Don't translate {{ submit_user }} or {{ review_date }}.{% endcomment %}
-                      {% blocktrans trimmed %}
+                      {% blocktranslate trimmed %}
                         Submitted by {{ submit_user }} on {{ review_date }}
-                      {% endblocktrans %}
+                      {% endblocktranslate %}
                     {% else %}
                       {% comment %}Translators: Applications have a revision history section. This message denotes when the application was submitted for review. Don't translate {{ review_date }}.{% endcomment %}
-                      {% blocktrans trimmed %}
+                      {% blocktranslate trimmed %}
                         Submitted on {{ review_date }}
-                      {% endblocktrans %}
+                      {% endblocktranslate %}
                     {% endif %}
                   {% endwith %}
                 {% endwith %}
@@ -333,14 +333,14 @@
                   {% with review_date=version.revision.date_created|localize %}
                     {% if review_user %}
                       {% comment %}Translators: Applications have a revision history section. This message denotes when the application was reviewed and who reviewed it. Don't translate {{ review_user }} or {{ review_date }}.{% endcomment %}
-                      {% blocktrans trimmed %}
+                      {% blocktranslate trimmed %}
                         Reviewed by {{ review_user }} on {{ review_date }}
-                      {% endblocktrans %}
+                      {% endblocktranslate %}
                     {% else %}
                       {% comment %}Translators: Applications have a revision history section. This message denotes when the application was reviewed by an account coordinator. Don't translate {{ review_date }}.{% endcomment %}
-                      {% blocktrans trimmed %}
+                      {% blocktranslate trimmed %}
                         Reviewed on {{ review_date }}
-                      {% endblocktrans %}
+                      {% endblocktranslate %}
                     {% endif %}
                   {% endwith %}
                 {% endwith %}

--- a/TWLight/applications/templates/applications/application_list_include.html
+++ b/TWLight/applications/templates/applications/application_list_include.html
@@ -34,14 +34,14 @@
       {% elif app.get_version_count > 1 %} {# first version is original submission, not later review #}
         {% if app.get_latest_reviewer %}
           {% comment %}Translators: On the page listing applications, this shows next to an application which was previously reviewed. Don't translate {{ reviewer }} or {{ review_date }}.{% endcomment %}
-          {% blocktrans trimmed with reviewer=app.get_latest_reviewer review_date=app.get_latest_review_date|localize %}
+          {% blocktranslate trimmed with reviewer=app.get_latest_reviewer review_date=app.get_latest_review_date|localize %}
             Last reviewed by {{ reviewer }} on {{ review_date }}
-          {% endblocktrans %}
+          {% endblocktranslate %}
         {% else %}
           {% comment %}Translators: On the page listing applications, this shows next to an application which was previously reviewed. Don't translate {{ review_date }}.{% endcomment %}
-          {% blocktrans trimmed with review_date=app.get_latest_review_date|localize %}
+          {% blocktranslate trimmed with review_date=app.get_latest_review_date|localize %}
             Last reviewed on {{ review_date }}
-          {% endblocktrans %}
+          {% endblocktranslate %}
         {% endif %}
       {% else %}
         {% comment %}Translators: On the page listing applications, this shows next to an application which has not yet been reviewed.{% endcomment %}

--- a/TWLight/applications/templates/applications/application_list_reviewable_include.html
+++ b/TWLight/applications/templates/applications/application_list_reviewable_include.html
@@ -41,14 +41,14 @@
             {% if app.get_version_count > 1 %} {# first version is original submission, not later review #}
               {% if app.get_latest_reviewer %}
                 {% comment %}Translators: If an application was previously reviewed by a coordinator, this text displays the date and the name of the coordinator.{% endcomment %}
-                {% blocktrans trimmed with reviewer=app.get_latest_reviewer review_date=app.get_latest_review_date|localize %}
+                {% blocktranslate trimmed with reviewer=app.get_latest_reviewer review_date=app.get_latest_review_date|localize %}
                   Last reviewed by {{ reviewer }} on {{ review_date }}
-                {% endblocktrans %}
+                {% endblocktranslate %}
               {% else %}
                 {% comment %}Translators: If an application was previously reviewed, this text displays the date of the review.{% endcomment %}
-                {% blocktrans trimmed with review_date=app.get_latest_review_date|localize %}
+                {% blocktranslate trimmed with review_date=app.get_latest_review_date|localize %}
                   Last reviewed on {{ review_date }}
-                {% endblocktrans %}
+                {% endblocktranslate %}
               {% endif %}
             {% else %}
               {% comment %}Translators: If an application wasn't previously reviewed, this text is displayed.{% endcomment %}

--- a/TWLight/applications/templates/applications/confirm_renewal.html
+++ b/TWLight/applications/templates/applications/confirm_renewal.html
@@ -10,9 +10,9 @@
       <div class="form-group">
         <label class="control-label col-lg-3">
           {% comment %}Translators: This message is displayed on the page where users can confirm their renewal. Please do not translate {{  partner }}. {% endcomment %}
-          {% blocktrans trimmed %}
+          {% blocktranslate trimmed %}
             Click 'confirm' to renew your application for {{ partner }}
-          {% endblocktrans %}
+          {% endblocktranslate %}
         </label>
         <div class="col-lg-offset-1 col-lg-1 controls">
           {% comment %}Translators: Labels the submit button requesting confirmation of application renewal. {% endcomment %}

--- a/TWLight/applications/templates/applications/request_for_application.html
+++ b/TWLight/applications/templates/applications/request_for_application.html
@@ -21,9 +21,9 @@
 <h1>{% trans 'What resources do you want to access?' %}</h1>
 <div class="well well-sm">
   {% comment %}Translators: This text explains that Library Bundle partners are not shown in this list.{% endcomment %}
-    {% blocktrans trimmed %}
+    {% blocktranslate trimmed %}
       Library Bundle partners are not shown as eligibility is determined automatically.
-    {% endblocktrans %}
+    {% endblocktranslate %}
 </div>
 
 
@@ -70,10 +70,10 @@
 {% if any_waitlisted %}
   <div class="well well-sm">
     {# Translators: the HTML is so that the word 'waitlisted' will look the same as it does in the page above; please translate 'waitlisted' the same way you did elsewhere in this file. #}
-    {% blocktrans trimmed %}
+    {% blocktranslate trimmed %}
       You can apply to <span class="label label-warning">Waitlisted</span>
       partners, but they don't have access grants available right now. We will process those applications when access becomes available.
-    {% endblocktrans %}
+    {% endblocktranslate %}
   </div>
 {% endif %}
 

--- a/TWLight/applications/templates/applications/send_partner.html
+++ b/TWLight/applications/templates/applications/send_partner.html
@@ -36,7 +36,7 @@
 {% block content %}
   <h2>
     {% comment %}Translators: When viewing the list of applications ready to be sent for a particular partner, this is the title of the page, where {{ object }} will be the name of the partner. Don't translate {{ object }}.{% endcomment %}
-    {% blocktrans trimmed %}Application data for {{ object }}{% endblocktrans %}
+    {% blocktranslate trimmed %}Application data for {{ object }}{% endblocktranslate %}
   </h2>
 
   <div class="alert alert-info">
@@ -48,13 +48,13 @@
   {% if unavailable_streams %}
     <div class="well hidden-xs">
       {% comment %}Translators: This message is shown when applications exceed the number of accounts available for each collection. {% endcomment %}
-      {% blocktrans trimmed %}Applications for <strong>{{ unavailable_streams }}</strong> if sent, will exceed the total available accounts for the collections. Please proceed at your own discretion.{% endblocktrans %}
+      {% blocktranslate trimmed %}Applications for <strong>{{ unavailable_streams }}</strong> if sent, will exceed the total available accounts for the collections. Please proceed at your own discretion.{% endblocktranslate %}
     </div>
   {% elif total_apps_approved_or_sent %}
         {% if object.accounts_available < total_apps_approved_or_sent %}
           <div class="well hidden-xs">
             {% comment %}Translators: This message is shown when applications exceed the number of accounts available. {% endcomment %}
-            {% blocktrans trimmed %}Application(s) for {{ object }}, if sent, will exceed the total available accounts for the partner. Please proceed at your own discretion.{% endblocktrans %}
+            {% blocktranslate trimmed %}Application(s) for {{ object }}, if sent, will exceed the total available accounts for the partner. Please proceed at your own discretion.{% endblocktranslate %}
           </div>
         {% endif %}
   {% endif %}
@@ -82,11 +82,11 @@
   {% if object.authorization_method == object.EMAIL %}
     <h3>
       {% comment %}Translators: When viewing the list of applications ready to be sent for a particular partner, this is the title of the section containing contact information for the people applications should be sent to.{% endcomment %}
-      {% blocktrans trimmed count object.contacts.all|length as counter %}
+      {% blocktranslate trimmed count object.contacts.all|length as counter %}
         Contact
       {% plural %}
         Contacts
-      {% endblocktrans %}
+      {% endblocktranslate %}
     </h3>
 
     {% for contact in object.contacts.all %}
@@ -159,10 +159,10 @@
     {% elif object.authorization_method == object.CODES %}
       <p>
       {% comment %}Translators: This text guides coordinators in using the code sending interface for approved applications. {% endcomment %}
-      {% blocktrans trimmed %}
+      {% blocktranslate trimmed %}
         Use the dropdown menus to denote which editor will receive each code.
         Access codes will be sent to users automatically.
-      {% endblocktrans %}
+      {% endblocktranslate %}
       </p>
       <form method="POST">
         {% csrf_token %}

--- a/TWLight/emails/templates/emails/access_code_email-body-html.html
+++ b/TWLight/emails/templates/emails/access_code_email-body-html.html
@@ -2,13 +2,13 @@
 <html>
 <body>
 {% comment %}Translators: This email is sent to users with their access code. Don't translate Jinja variables in curly braces like {{ user }} or {{ partner }}. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).{% endcomment %}
-{% blocktrans trimmed %}
+{% blocktranslate trimmed %}
   <p>Your approved application to {{ partner }} has now been finalised. Your access code or login details can be found below:</p>
 
   <p><b>{{ access_code }}</b></p>
 
   <p>{{ access_code_instructions }}</p>
 
-{% endblocktrans %}
+{% endblocktranslate %}
 </body>
 </html>

--- a/TWLight/emails/templates/emails/access_code_email-body-text.html
+++ b/TWLight/emails/templates/emails/access_code_email-body-text.html
@@ -1,9 +1,9 @@
 {% load i18n %}
 {% comment %}Translators: This email is sent to users with their access code. Don't translate Jinja variables in curly braces like {{ user }} or {{ partner }}. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).{% endcomment %}
-{% blocktrans trimmed %}
+{% blocktranslate trimmed %}
 Your approved application to {{ partner }} has now been finalised. Your access code or login details can be found below:
 
 {{ access_code }}
 
 {{ access_code_instructions }}
-{% endblocktrans %}
+{% endblocktranslate %}

--- a/TWLight/emails/templates/emails/access_code_email-subject.html
+++ b/TWLight/emails/templates/emails/access_code_email-subject.html
@@ -1,5 +1,5 @@
 {% load i18n %}
 {% comment %}Translators: This is the subject line of an email sent to users with their access code.{% endcomment %}
-{% blocktrans trimmed %}
+{% blocktranslate trimmed %}
 Your Wikipedia Library access code
-{% endblocktrans %}
+{% endblocktranslate %}

--- a/TWLight/emails/templates/emails/approval_notification-body-html.html
+++ b/TWLight/emails/templates/emails/approval_notification-body-html.html
@@ -2,13 +2,13 @@
 <html>
 <body>
 {% comment %}Translators: This email is sent to users when their application is approved. Don't translate Jinja variables in curly braces like {{ user }} or {{ partner }}; don't translate html tags either. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).{% endcomment %}
-{% blocktrans trimmed %}
+{% blocktranslate trimmed %}
   <p>Dear {{ user }},</p>
   <p>Thank you for applying for access to {{ partner }} resources through The Wikipedia Library. We are happy to inform you that your application has been approved.</p>
   <p>{{ user_instructions }}</p>
   <p>You can view the collections you're authorized to access at My Library: {{ link }}</p>
   <p>Cheers!</p>
   <p>The Wikipedia Library</p>
-{% endblocktrans %}
+{% endblocktranslate %}
 </body>
 <html>

--- a/TWLight/emails/templates/emails/approval_notification-body-text.html
+++ b/TWLight/emails/templates/emails/approval_notification-body-text.html
@@ -1,6 +1,6 @@
 {% load i18n %}
 {% comment %}Translators: This email is sent to users when their application is approved. Don't translate Jinja variables in curly braces like {{ user }} or {{ partner }}. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).{% endcomment %}
-{% blocktrans trimmed %}
+{% blocktranslate trimmed %}
 Dear {{ user }},
 
 Thank you for applying for access to {{ partner }} resources through
@@ -14,4 +14,4 @@ You can view the collections you're authorized to access at My Library: {{ link 
 Cheers!
 
 The Wikipedia Library
-{% endblocktrans %}
+{% endblocktranslate %}

--- a/TWLight/emails/templates/emails/comment_notification_coordinator-body-html.html
+++ b/TWLight/emails/templates/emails/comment_notification_coordinator-body-html.html
@@ -2,12 +2,12 @@
 <html>
 <body>
 {% comment %}Translators: This email is sent to coordinators when a comment is left on an application they are processing. Don't translate Jinja variables in curly braces like {{ user }} or {{ partner }}. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).{% endcomment %}
-{% blocktrans trimmed  %}
+{% blocktranslate trimmed  %}
   <p style="color: #500050">{{ submit_date }} - {{ commenter }}</p>
   <blockquote><p>{{ comment }}</p></blockquote>
   <p>Please reply to these at: <a href="{{ app_url }}">{{ app_url }}</a></p>
   <p>Best,</p>
   <p>The Wikipedia Library</p>
-{% endblocktrans %}
+{% endblocktranslate %}
 </body>
 </html>

--- a/TWLight/emails/templates/emails/comment_notification_coordinator-body-text.html
+++ b/TWLight/emails/templates/emails/comment_notification_coordinator-body-text.html
@@ -1,6 +1,6 @@
 {% load i18n %}
 {% comment %}Translators: This email is sent to coordinators when a comment is left on an application they are processing. Don't translate Jinja variables in curly braces like {{ user }} or {{ partner }}. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).{% endcomment %}
-{% blocktrans trimmed %}
+{% blocktranslate trimmed %}
 
 {{ submit_date }} - {{ commenter }}
 {{ comment }}
@@ -11,4 +11,4 @@ Please reply to this at:
 Best,
 
 The Wikipedia Library
-{% endblocktrans %}
+{% endblocktranslate %}

--- a/TWLight/emails/templates/emails/comment_notification_editors-body-html.html
+++ b/TWLight/emails/templates/emails/comment_notification_editors-body-html.html
@@ -2,12 +2,12 @@
 <html>
 <body>
 {% comment %}Translators: This email is sent to users when they receive a comment on their application. Don't translate Jinja variables in curly braces like {{ user }} or {{ partner }}; don't translate html tags either. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).{% endcomment %}
-{% blocktrans trimmed  %}
+{% blocktranslate trimmed  %}
 <p style="color: #500050">{{ submit_date }} - {{ commenter }}</p>
 <blockquote><p>{{ comment }}</p></blockquote>
 <p>Please reply to these at <a href="{{ app_url }}">{{ app_url }}</a> so we can evaluate your application.</p>
 <p>Best,</p>
 <p>The Wikipedia Library</p>
-{% endblocktrans %}
+{% endblocktranslate %}
 </body>
 </html>

--- a/TWLight/emails/templates/emails/comment_notification_editors-body-text.html
+++ b/TWLight/emails/templates/emails/comment_notification_editors-body-text.html
@@ -1,6 +1,6 @@
 {% load i18n %}
 {% comment %}Translators: This email is sent to users when they receive a comment on their application. Don't translate Jinja variables in curly braces like {{ user }} or {{ partner }}. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).{% endcomment %}
-{% blocktrans trimmed %}
+{% blocktranslate trimmed %}
 {{ submit_date }} - {{ commenter }}
 {{ comment }}
 
@@ -11,4 +11,4 @@ so we can evaluate your application.
 Best,
 
 The Wikipedia Library
-{% endblocktrans %}
+{% endblocktranslate %}

--- a/TWLight/emails/templates/emails/comment_notification_others-body-html.html
+++ b/TWLight/emails/templates/emails/comment_notification_others-body-html.html
@@ -2,7 +2,7 @@
 <body>
 {% load i18n %}
 {% comment %}Translators: This email is sent to users when an application they commented on receives another comment. Don't translate Jinja variables in curly braces like {{ app_url }}; don't translate html tags either. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).{% endcomment %}
-{% blocktrans trimmed %}
+{% blocktranslate trimmed %}
 <p style="color: #500050">{{ submit_date }} - {{ commenter }}</p>
 <blockquote><p>{{ comment }}</p></blockquote>
 
@@ -10,6 +10,6 @@ See it at
 <a href="{{ app_url }}">{{ app_url }}</a>.
 
 Thanks for helping review Wikipedia Library applications!
-{% endblocktrans %}
+{% endblocktranslate %}
 </body>
 </html>

--- a/TWLight/emails/templates/emails/comment_notification_others-body-text.html
+++ b/TWLight/emails/templates/emails/comment_notification_others-body-text.html
@@ -1,6 +1,6 @@
 {% load i18n %}
 {% comment %}Translators: This email is sent to users when an application they commented on receives another comment. Don't translate Jinja variables in curly braces like {{ app_url }}. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).{% endcomment %}
-{% blocktrans trimmed %}
+{% blocktranslate trimmed %}
 {{ submit_date }} - {{ commenter }}
 {{ comment }}
 
@@ -8,4 +8,4 @@ See it at:
 {{ app_url }}
 
 Thanks for helping review Wikipedia Library applications!
-{% endblocktrans %}
+{% endblocktranslate %}

--- a/TWLight/emails/templates/emails/contact.html
+++ b/TWLight/emails/templates/emails/contact.html
@@ -27,7 +27,7 @@
           <div class="pull-right">
             {% url 'suggest' as suggest %}
             {% comment %}Translators: This is the text that appears at the bottom of the contact us form directing users to the suggestions form.{% endcomment %}
-            {% blocktrans trimmed %}(If you would like to suggest a partner, <a href="{{ suggest }}"><strong>go here</strong></a>.){% endblocktrans %}
+            {% blocktranslate trimmed %}(If you would like to suggest a partner, <a href="{{ suggest }}"><strong>go here</strong></a>.){% endblocktranslate %}
           </div>
         </div>
       </div>

--- a/TWLight/emails/templates/emails/contact_us_email-subject.html
+++ b/TWLight/emails/templates/emails/contact_us_email-subject.html
@@ -1,5 +1,5 @@
 {% load i18n %}
 {% comment %}Translators: This is the subject line of an email sent to the Library Card platform admins from the contact us form.{% endcomment %}
-{% blocktrans trimmed %}
+{% blocktranslate trimmed %}
 Wikipedia Library Card Platform message from {{ editor_wp_username }}
-{% endblocktrans %}
+{% endblocktranslate %}

--- a/TWLight/emails/templates/emails/coordinator_reminder_notification-body-html.html
+++ b/TWLight/emails/templates/emails/coordinator_reminder_notification-body-html.html
@@ -2,45 +2,45 @@
 <html>
 <body>
 {% comment %}Translators: This text is part of a scheduled reminder email sent to coordinators who have applications requiring action. Don't translate Jinja variables in curly braces like {{ total_apps }}, or {{ user }}.{% endcomment %}
-{% blocktrans trimmed %}
+{% blocktranslate trimmed %}
   <p>Dear {{ user }},</p>
   <p>Our records indicate that you are the designated coordinator for partners that
      have a total of {{ total_apps }} applications.</p>
-{% endblocktrans %}
+{% endblocktranslate %}
 {% comment %}Translators: Breakdown as in 'cost breakdown'; analysis.{% endcomment %}
 <strong>{% trans "Breakdown" %}</strong><br />
 {% comment %}We make use of the text below to test the behaviour of reminder emails. If you plan to change any of the 'breakdown' text, you'd also need to change the corresponding tests in emails.tests.CoordinatorReminderEmailTest.{% endcomment %}
 {% if pending_count %}
   {% comment %}Translators: This text is part of a scheduled reminder email sent to coordinators who have applications requiring action. Don't translate Jinja variables in curly braces like {{ counter }}.{% endcomment %}
-  {% blocktrans count counter=pending_count trimmed%}
+  {% blocktranslate count counter=pending_count trimmed %}
     {{ counter }} pending application.
   {% plural %}
     {{ counter }} pending applications.
-  {% endblocktrans %}
+  {% endblocktranslate %}
 {% endif %}
 {% if question_count %}
   {% comment %}Translators: This text is part of a scheduled reminder email sent to coordinators who have applications requiring action. Don't translate Jinja variables in curly braces like {{ counter }}.{% endcomment %}
-  {% blocktrans count counter=question_count trimmed%}
+  {% blocktranslate count counter=question_count trimmed %}
     {{ counter }} under discussion application.
   {% plural %}
     {{ counter }} under discussion applications.
-  {% endblocktrans %}
+  {% endblocktranslate %}
 {% endif %}
 {% if approved_count %}
   {% comment %}Translators: This text is part of a scheduled reminder email sent to coordinators who have applications requiring action. Don't translate Jinja variables in curly braces like {{ counter }}.{% endcomment %}
-  {% blocktrans count counter=approved_count trimmed %}
+  {% blocktranslate count counter=approved_count trimmed %}
     {{ counter }} approved application.
   {% plural %}
     {{ counter }} approved applications.
-  {% endblocktrans %}
+  {% endblocktranslate %}
 {% endif %}
 {% comment %}Translators: This text is part of a scheduled reminder email sent to coordinators who have applications requiring action. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library). Don't translate Jinja variables in curly braces like {{ link }}; don't translate email addresses or html tags either.{% endcomment %}
-{% blocktrans trimmed %}
+{% blocktranslate trimmed %}
 	<p>This is a gentle reminder that you may review applications at <a href="{{ link }}">{{ link }}</a>.</p>
   <p>You can customise your reminders under 'preferences' in your user profile.</p>
   <p>If you received this message in error, drop us a line at
      wikipedialibrary@wikimedia.org.</p>
   <p>Thanks for helping review Wikipedia Library applications!</p>
-{% endblocktrans %}
+{% endblocktranslate %}
 </body>
 </html>

--- a/TWLight/emails/templates/emails/coordinator_reminder_notification-body-text.html
+++ b/TWLight/emails/templates/emails/coordinator_reminder_notification-body-text.html
@@ -1,40 +1,40 @@
 {% load i18n %}
 {% comment %}Translators: This text is part of a scheduled reminder email sent to coordinators who have applications requiring action. Don't translate Jinja variables in curly braces like {{ total_apps }}, or {{ user }}.{% endcomment %}
-{% blocktrans trimmed %}
+{% blocktranslate trimmed %}
 Dear {{ user }},
 
 Our records indicate that you are the designated coordinator for partners that 
 have a total of {{ total_apps }} applications.
-{% endblocktrans %}
+{% endblocktranslate %}
 {% comment %}Translators: Breakdown as in 'cost breakdown'; analysis.{% endcomment %}
 {% trans "Breakdown" %}:
 {% comment %}We make use of the text below to test the behaviour of reminder emails. If you plan to change any of the 'breakdown' text, you'd also need to change the corresponding tests in emails.tests.CoordinatorReminderEmailTest.{% endcomment %}
 {% if pending_count %}
   {% comment %}Translators: This text is part of a scheduled reminder email sent to coordinators who have applications requiring action. Don't translate Jinja variables in curly braces like {{ counter }}.{% endcomment %}
-  {% blocktrans count counter=pending_count trimmed%}
+  {% blocktranslate count counter=pending_count trimmed %}
     {{ counter }} pending application.
   {% plural %}
     {{ counter }} pending applications.
-  {% endblocktrans %}
+  {% endblocktranslate %}
 {% endif %}
 {% comment %}Translators: This text is part of a scheduled reminder email sent to coordinators who have applications requiring action. Don't translate Jinja variables in curly braces like {{ counter }}.{% endcomment %}
 {% if question_count %}
-  {% blocktrans count counter=question_count trimmed%}
+  {% blocktranslate count counter=question_count trimmed %}
     {{ counter }} under discussion application.
   {% plural %}
     {{ counter }} under discussion applications.
-  {% endblocktrans %}
+  {% endblocktranslate %}
 {% endif %}
 {% if approved_count %}
   {% comment %}Translators: This text is part of a scheduled reminder email sent to coordinators who have applications requiring action. Don't translate Jinja variables in curly braces like {{ counter }}.{% endcomment %}
-  {% blocktrans count counter=approved_count trimmed %}
+  {% blocktranslate count counter=approved_count trimmed %}
     {{ counter }} approved application.
   {% plural %}
     {{ counter }} approved applications.
-  {% endblocktrans %}
+  {% endblocktranslate %}
 {% endif %}
 {% comment %}Translators: This text is part of a scheduled reminder email sent to coordinators who have applications requiring action. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library). Don't translate Jinja variables in curly braces like {{ link }}; don't translate the email address either.{% endcomment %}
-{% blocktrans trimmed %}
+{% blocktranslate trimmed %}
 This is a gentle reminder that you may review applications at:
 {{ link }}.
 
@@ -44,4 +44,4 @@ If you received this message in error, drop us a line at:
 wikipedialibrary@wikimedia.org
 
 Thanks for helping review Wikipedia Library applications!
-{% endblocktrans %}
+{% endblocktranslate %}

--- a/TWLight/emails/templates/emails/rejection_notification-body-html.html
+++ b/TWLight/emails/templates/emails/rejection_notification-body-html.html
@@ -2,13 +2,13 @@
 <html>
 <body>
 {% comment %}Translators: This email is sent to users when their application is rejected. Don't translate Jinja variables in curly braces like {{ user }} or {{ partner }}; don't translate html tags either. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).{% endcomment %}
-{% blocktrans trimmed %}
+{% blocktranslate trimmed %}
   <p>Dear {{ user }},</p>
   <p>Thank you for applying for access to {{ partner }} resources through The Wikipedia Library.
 	   Unfortunately at this time your application has not been approved.
 		 You can view your application and review comments at <a href="{{ app_url }}">{{ app_url }}</a>.</p>
 	<p>Best,</p>
 	<p>The Wikipedia Library</p>
-{% endblocktrans %}
+{% endblocktranslate %}
 </body>
 </html>

--- a/TWLight/emails/templates/emails/rejection_notification-body-text.html
+++ b/TWLight/emails/templates/emails/rejection_notification-body-text.html
@@ -1,6 +1,6 @@
 {% load i18n %}
 {% comment %}Translators: This email is sent to users when their application is rejected. Don't translate Jinja variables in curly braces like {{ user }} or {{ partner }}. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).{% endcomment %}
-{% blocktrans trimmed %}
+{% blocktranslate trimmed %}
 Dear {{ user }},
 
 Thank you for applying for access to {{ partner }} resources through
@@ -11,4 +11,4 @@ approved. You can view your application and review comments at:
 Best,
 
 The Wikipedia Library
-{% endblocktrans %}
+{% endblocktranslate %}

--- a/TWLight/emails/templates/emails/user_renewal_notice-body-html.html
+++ b/TWLight/emails/templates/emails/user_renewal_notice-body-html.html
@@ -2,13 +2,13 @@
 <html>
 <body>
 {% comment %}Translators: This email is sent to users when they have an account that is soon to expire. Don't translate Jinja variables in curly braces like {{ partner_name }} or {{ partner_link }}; don't translate html tags either. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).{% endcomment %}
-{% blocktrans trimmed %}
+{% blocktranslate trimmed %}
   <p>Dear {{ user }},</p>
 	<p>According to our records, your access to {{ partner_name }} will soon expire and you may lose access.
    If you want to continue making use of your free account, you can request renewal of your account by clicking the Renew button at {{ partner_link }}.</p>
 	<p>Best,</p>
 	<p>The Wikipedia Library</p>
   <p>You can disable these emails in your user page preferences: https://wikipedialibrary.wmflabs.org/users/</p>
-{% endblocktrans %}
+{% endblocktranslate %}
 </body>
 </html>

--- a/TWLight/emails/templates/emails/user_renewal_notice-body-text.html
+++ b/TWLight/emails/templates/emails/user_renewal_notice-body-text.html
@@ -1,6 +1,6 @@
 {% load i18n %}
 {% comment %}Translators: This email is sent to users when they have an account that is soon to expire. Don't translate Jinja variables in curly braces like {{ partner_name }} or {{ partner_link }}; don't translate html tags either. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).{% endcomment %}
-{% blocktrans trimmed %}
+{% blocktranslate trimmed %}
 Dear {{ user }},
 
 According to our records, your access to {{ partner_name }} will soon expire and you may lose access.
@@ -11,4 +11,4 @@ Best,
 The Wikipedia Library
 
 You can disable these emails in your user page preferences: https://wikipedialibrary.wmflabs.org/users/
-{% endblocktrans %}
+{% endblocktranslate %}

--- a/TWLight/emails/templates/emails/waitlist_notification-body-html.html
+++ b/TWLight/emails/templates/emails/waitlist_notification-body-html.html
@@ -2,7 +2,7 @@
 <html>
 <body>
 {% comment %}Translators: This email is sent to users when their application is waitlisted because there are no more accounts available. Don't translate Jinja variables in curly braces like {{ user }} or {{ partner }}; don't translate html tags either. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).{% endcomment %}
-{% blocktrans trimmed %}
+{% blocktranslate trimmed %}
   <p>Dear {{ user }},</p>
 	<p>Thank you for applying for access to {{ partner }} resources through The Wikipedia Library.
 	   There are no accounts currently available so your application has been waitlisted.
@@ -10,6 +10,6 @@
 		 You can see all available resources at <a href="{{ link }}">{{ link }}</a>.</p>
 	<p>Best,</p>
 	<p>The Wikipedia Library</p>
-{% endblocktrans %}
+{% endblocktranslate %}
 </body>
 </html>

--- a/TWLight/emails/templates/emails/waitlist_notification-body-text.html
+++ b/TWLight/emails/templates/emails/waitlist_notification-body-text.html
@@ -1,6 +1,6 @@
 {% load i18n %}
 {% comment %}Translators: This email is sent to users when their application is waitlisted because there are no more accounts available. Don't translate Jinja variables in curly braces like {{ user }} or {{ partner }}. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).{% endcomment %}
-{% blocktrans trimmed %}
+{% blocktranslate trimmed %}
 Dear {{ user }},
 
 Thank you for applying for access to {{ partner }} resources through
@@ -12,4 +12,4 @@ more accounts become available. You can see all available resources at:
 Best,
 
 The Wikipedia Library
-{% endblocktrans %}
+{% endblocktranslate %}

--- a/TWLight/resources/templates/resources/partner_detail.html
+++ b/TWLight/resources/templates/resources/partner_detail.html
@@ -22,11 +22,11 @@
        <span class="resource-label">{% trans "Waitlisted" %}</span>
        <p>
        {% comment %}Translators: If we have no available accounts for a partner, the coordinator can change the application system to a waiting list. {% endcomment %}
-       {% blocktrans trimmed %}
+       {% blocktranslate trimmed %}
        There are no access grants available for this partner
        at this time. You can still apply for access; applications will
        be processed when access is available.
-       {% endblocktrans %}
+       {% endblocktranslate %}
        </p>
     </div>
     {% endif %}
@@ -34,11 +34,11 @@
       <div class="alert alert-info visible-xs">
         <p>
           {% comment %}Translators: This text links to the minimum user requirements and terms of use on the partner page. {% endcomment %}
-          {% blocktrans trimmed %}
+          {% blocktranslate trimmed %}
             Before applying, please review the
             <strong><a href="{{ about }}#req">minimum requirements</a></strong> for access
             and our <strong><a href="{{ terms }}">terms of use</a></strong>.
-          {% endblocktrans %}
+          {% endblocktranslate %}
         </p>
       </div>
     {% endif %}
@@ -55,18 +55,18 @@
           <div class="panel-body top-border">
             {% if has_auths %}
               {% comment %}Translators: This text refers to the page containing the content a user is authorized to access. {% endcomment %}
-              {% blocktrans trimmed %}
+              {% blocktranslate trimmed %}
                 View the status of your access in <strong><a href="{{ library_url }}">My Library</a></strong> page.
-              {% endblocktrans %}
+              {% endblocktranslate %}
               {% if has_open_apps %}
                 <hr />
               {% endif %}
             {% endif %}
             {% if has_open_apps %}
               {% comment %}Translators: This message is shown when a user has open applications, linking to their respective applications page. {% endcomment %}
-              {% blocktrans trimmed %}
+              {% blocktranslate trimmed %}
                 View the status of your application(s) on your <strong><a href="{{ applications_url }}">My Applications</a></strong> page.
-              {% endblocktrans %}
+              {% endblocktranslate %}
             {% endif %}
           </div>
         </div>
@@ -179,23 +179,23 @@
                     {% if excerpt_limit_percentage and excerpt_limit %}
                       <li>
                         {% comment %}Translators: If a partner has specified the excerpt limit both in words and percentage, this message will display the percentage of words and the number of words on the partner page. {% endcomment %}
-                        {% blocktrans trimmed %}
+                        {% blocktranslate trimmed %}
                           {{ object }} allows a maximum of {{ excerpt_limit }} words or {{ excerpt_limit_percentage }}% of an article be excerpted into a Wikipedia article.
-                        {% endblocktrans %}
+                        {% endblocktranslate %}
                       </li>
                     {% elif excerpt_limit %}
                       <li>
                         {% comment %}Translators: If a partner has specified the excerpt limit in words, this message will display the number of words on the partner page. {% endcomment %}
-                        {% blocktrans trimmed %}
+                        {% blocktranslate trimmed %}
                           {{ object }} allows a maximum of {{ excerpt_limit }} words be excerpted into a Wikipedia article.
-                        {% endblocktrans %}
+                        {% endblocktranslate %}
                       </li>
                     {% elif excerpt_limit_percentage %}
                       <li>
                         {% comment %}Translators: If a partner has specified the excerpt limit in percentage, this message will display the percentage of words on the partner page. {% endcomment %}
-                        {% blocktrans trimmed %}
+                        {% blocktranslate trimmed %}
                           {{ object }} allows a maximum of {{ excerpt_limit_percentage }}% of an article be excerpted into a Wikipedia article.
-                        {% endblocktrans %}
+                        {% endblocktranslate %}
                       </li>
                     {% endif %}
                   </ul>
@@ -220,66 +220,66 @@
                     {% if object.agreement_with_terms_of_use %}
                       <li>
                         {% comment %}Translators: If a user must agree to a Terms of Use document, they see this message, and must enter the name of the resource. Don't translate {{ publisher }} or {{ url }}. {% endcomment %}
-                        {% blocktrans trimmed with publisher=object.company_name url=object.terms_of_use %}
+                        {% blocktranslate trimmed with publisher=object.company_name url=object.terms_of_use %}
                           {{ publisher }} requires that you agree with its <a href="{{ url }}">terms
                           of use</a>.
-                        {% endblocktrans %}
+                        {% endblocktranslate %}
                       </li>
                     {% endif %}
 
                     {% if object.real_name %}
                       <li>
                         {% comment %}Translators: If a user must provide their real name to apply to a partner, they see this message, and must enter the name of the resource. Don't translate {{ publisher }}. {% endcomment %}
-                        {% blocktrans trimmed with publisher=object.company_name %}
+                        {% blocktranslate trimmed with publisher=object.company_name %}
                           {{ publisher }} requires that you provide your real name.
-                        {% endblocktrans %}
+                        {% endblocktranslate %}
                       </li>
                     {% endif %}
 
                     {% if object.country_of_residence %}
                       <li>
                         {% comment %}Translators: If a user must provide the name of the country where they currently live to apply to a partner, they see this message, and must enter the name of the resource. Don't translate {{ publisher }}. {% endcomment %}
-                        {% blocktrans trimmed with publisher=object.company_name %}
+                        {% blocktranslate trimmed with publisher=object.company_name %}
                           {{ publisher }} requires that you provide your country of residence.
-                        {% endblocktrans %}
+                        {% endblocktranslate %}
                       </li>
                     {% endif %}
 
                     {% if object.occupation %}
                       <li>
                         {% comment %}Translators: If a user must provide their occupation to apply to a partner, they see this message, and must enter the name of the resource. Don't translate {{ publisher }}. {% endcomment %}
-                        {% blocktrans trimmed with publisher=object.company_name %}
+                        {% blocktranslate trimmed with publisher=object.company_name %}
                           {{ publisher }} requires that you provide your occupation.
-                        {% endblocktrans %}
+                        {% endblocktranslate %}
                       </li>
                     {% endif %}
 
                     {% if object.affiliation %}
                       <li>
                         {% comment %}Translators: If a user must provide their institutional affiliation (e.g. university) to apply to a partner, they see this message, and must enter the name of the resource. Don't translate {{ publisher }}. {% endcomment %}
-                        {% blocktrans trimmed with publisher=object.company_name %}
+                        {% blocktranslate trimmed with publisher=object.company_name %}
                           {{ publisher }} requires that you provide your institutional affiliation.
-                        {% endblocktrans %}
+                        {% endblocktranslate %}
                       </li>
                     {% endif %}
 
                     {% if object.specific_title %}
                       <li>
                         {% comment %}Translators: If a user must select a specific resource to apply for, they see this message, and must enter the name of the resource. Don't translate {{ publisher }}. {% endcomment %}
-                        {% blocktrans trimmed with publisher=object.company_name %}
+                        {% blocktranslate trimmed with publisher=object.company_name %}
                           {{ publisher }} requires that you specify a particular title that you want
                           to access.
-                        {% endblocktrans %}
+                        {% endblocktranslate %}
                       </li>
                     {% endif %}
 
                     {% if object.account_email %}
                       <li>
                         {% comment %}Translators: If a user must register on the partner website before applying, they see this message. Don't translate {{ partner }}. {% endcomment %}
-                        {% blocktrans trimmed with publisher=object.company_name %}
+                        {% blocktranslate trimmed with publisher=object.company_name %}
                           {{ publisher }} requires that you sign up for an account before applying
                           for access.
-                        {% endblocktrans %}
+                        {% endblocktranslate %}
                       </li>
                     {% endif %}
                   </ul>
@@ -354,11 +354,11 @@
             <span class="resource-label">{% trans "Waitlisted" %}</span>
             <p>
             {% comment %}Translators: If we have no available accounts for a partner, the coordinator can change the application system to a waiting list. {% endcomment %}
-            {% blocktrans trimmed %}
+            {% blocktranslate trimmed %}
             There are no access grants available for this partner
             at this time. You can still apply for access; applications will
             be processed when access is available.
-            {% endblocktrans %}
+            {% endblocktranslate %}
             </p>
           </div>
           {% endif %}
@@ -366,11 +366,11 @@
             <div class="alert alert-info hidden-xs">
               <p>
                 {% comment %}Translators: This text links to the minimum user requirements and terms of use on the partner page. {% endcomment %}
-                {% blocktrans trimmed %}
+                {% blocktranslate trimmed %}
                   Before applying, please review the
                   <strong><a href="{{ about }}#req">minimum requirements</a></strong> for access
                   and our <strong><a href="{{ terms }}">terms of use</a></strong>.
-                {% endblocktrans %}
+                {% endblocktranslate %}
               </p>
             </div>
           {% endif %}
@@ -387,18 +387,18 @@
                 <div class="panel-body top-border">
                   {% if has_auths %}
                     {% comment %}Translators: This message is shown when a user has authorizations, linking to their respective collections page. {% endcomment %}
-                    {% blocktrans trimmed %}
+                    {% blocktranslate trimmed %}
                       View the status of your access on your <strong><a href="{{ library_url }}">My Library</a></strong> page.
-                    {% endblocktrans %}
+                    {% endblocktranslate %}
                     {% if has_open_apps %}
                       <hr />
                     {% endif %}
                   {% endif %}
                   {% if has_open_apps %}
                     {% comment %}Translators: This message is shown when a user has open applications, linking to their respective applications page. {% endcomment %}
-                    {% blocktrans trimmed %}
+                    {% blocktranslate trimmed %}
                       View the status of your application(s) on your <strong><a href="{{ applications_url }}">My Applications</a></strong> page.
-                    {% endblocktrans %}
+                    {% endblocktranslate %}
                   {% endif %}
                 </div>
               </div>
@@ -420,9 +420,9 @@
             <div class="well hidden-xs">
               {% if object.coordinator.editor.wp_username %}
                 {% comment %}Translators: When a coordinator is assigned to a partner, their details are shown on the page. This text titles that section. <strong> tags should not be translated, nor should {{ partner }}.{% endcomment %}
-                {% blocktrans trimmed with coordinator=object.coordinator.editor.wp_username partner=object.company_name %}
+                {% blocktranslate trimmed with coordinator=object.coordinator.editor.wp_username partner=object.company_name %}
                   <strong>{{ coordinator }}</strong> processes applications to {{ partner }}.
-                {% endblocktrans %}
+                {% endblocktranslate %}
 
                 <ul>
                   {% if object.coordinator.editor.wp_talk_page_url %}
@@ -444,11 +444,11 @@
                 </ul>
               {% else %}
                 {% comment %}Translators: If no account coordinator is assigned to a partner, the Wikipedia Library team will coordinate signups. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).{% endcomment %}
-                {% blocktrans trimmed %}
+                {% blocktranslate trimmed %}
                   The Wikipedia Library team will process this application. Want to
                   help? <a href="https://en.wikipedia.org/wiki/Wikipedia:The_Wikipedia_Library/Coordinators/Signup">Sign up as a
                   coordinator.</a>
-                {% endblocktrans %}
+                {% endblocktranslate %}
               {% endif %}
             </div>
             {% if object.coordinator == user or user.is_staff %}
@@ -468,11 +468,11 @@
                     {% trans "Library bundle access" %}
                     ">
                     {% comment %}Translators: Text shown to authenticated, bundle eligible users when they need to visit My Library to access collections. {% endcomment %}
-                    {% blocktrans trimmed %}
+                    {% blocktranslate trimmed %}
                       You are eligible to access Library Bundle partners.
                       Click the button above to go to your Library and browse
                       collections from this partner.
-                    {% endblocktrans %}
+                    {% endblocktranslate %}
                   {% else %}
                     {% comment %}Translators: This text labels a button authenticated, bundle eligible users can click to access the proxied resource. {% endcomment %}
                     <a class="btn btn-primary btn-lg btn-block" href="{{ partner.get_access_url }}">{% trans "Access Collection" %}</a><br />
@@ -482,10 +482,10 @@
                     {% trans "Library bundle access" %}
                     ">
                     {% comment %}Translators: Text shown to authenticated, bundle eligible users when they visit a Bundle partner page. {% endcomment %}
-                    {% blocktrans trimmed %}
+                    {% blocktranslate trimmed %}
                       You are eligible to access Library Bundle partners.
                       Click the button above to access the collection.
-                    {% endblocktrans %}
+                    {% endblocktranslate %}
                   {% endif %}
                 {% else %}
                   {% comment %}Translators: This text labels a button authenticated, bundle eligible users can click to access the proxied resource. {% endcomment %}
@@ -497,11 +497,11 @@
                   ">
                   {% url 'homepage' as homepage %}
                   {% comment %}Translators: Text shown to authenticated, bundle ineligible users when they visit a Bundle partner page. {% endcomment %}
-                  {% blocktrans trimmed %}
+                  {% blocktranslate trimmed %}
                     You are not eligible to access Library Bundle partners.
                     Visit the <a href="{{ homepage }}">homepage</a> to check the
                     eligibility criteria.
-                  {% endblocktrans %}
+                  {% endblocktranslate %}
                 {% endif %}
               {% else %}
                 {% comment %}Translators: Buttton prompting users to log in. {% endcomment %}
@@ -513,11 +513,11 @@
                 ">
                 {% url 'about' as about %}
                 {% comment %}Translators: Text shown to unauthenticated users when they visit a Bundle partner page. {% endcomment %}
-                {% blocktrans trimmed %}
+                {% blocktranslate trimmed %}
                   This resource is part of our <a href="{{ about }}">Library Bundle</a>,
                   which you can access if you meet our minimum eligibility criteria.
                   Log in to find out if you are eligible.
-                {% endblocktrans %}
+                {% endblocktranslate %}
               {% endif %}
             </div>
           {% endif %}

--- a/TWLight/resources/templates/resources/partner_tile.html
+++ b/TWLight/resources/templates/resources/partner_tile.html
@@ -28,9 +28,9 @@
       <a href="{% url 'partners:detail' partner.pk %}">
         <img src="{{ partner.partner_logo }}" class="img-responsive partner-logo" alt="
         {% comment %}Translators: Alt text for publisher logos on the browse partner page (https://wikipedialibrary.wmflabs.org/partners/). Don't translate {{ partner }}. {% endcomment %}
-          {% blocktrans trimmed %}
+          {% blocktranslate trimmed %}
             Link to {{ partner.company_name }} signup page
-          {% endblocktrans %}
+          {% endblocktranslate %}
         ">
       </a>
     </div>

--- a/TWLight/resources/templates/resources/partner_users.html
+++ b/TWLight/resources/templates/resources/partner_users.html
@@ -5,9 +5,9 @@
 
   <h1>
   {% comment %}Translators: This is the heading of a page listing editors who have applications for this partner. Don't translate {{ partner }}. {% endcomment %}
-  {% blocktrans trimmed with partner=object.company_name %}
+  {% blocktranslate trimmed with partner=object.company_name %}
   {{ partner }} approved users
-  {% endblocktrans %}
+  {% endblocktranslate %}
   </h1>
 
   <div class="alert alert-info">

--- a/TWLight/resources/templates/resources/suggestion_confirm_delete.html
+++ b/TWLight/resources/templates/resources/suggestion_confirm_delete.html
@@ -6,9 +6,9 @@
     {% csrf_token %}
     <p>
       {% comment %}Translators: This message is displayed on the page where coordinators can request the deletion of a suggestion. {% endcomment %}
-      {% blocktrans trimmed %}
+      {% blocktranslate trimmed %}
         Are you sure you want to delete <b>{{ object }}</b>?
-      {% endblocktrans %}
+      {% endblocktranslate %}
     </p>
     {% comment %}Translators: This is the button coordinators click to confirm deletion of a suggestion. {% endcomment %}
     <input type="submit" value="{% trans 'Confirm' %}" class="btn btn-danger"/>

--- a/TWLight/templates/400.html
+++ b/TWLight/templates/400.html
@@ -14,12 +14,12 @@
 
   <p>
     {% comment %}Translators: Shown on the website's 400 page, when a user sends a bad request. Don't translate {{ path }} or Phabricator. {% endcomment %}
-    {% blocktrans trimmed with request.path|urlencode as path %}
+    {% blocktranslate trimmed with request.path|urlencode as path %}
       If you think we should know what to do with that, please email us about this error at
       <a href="mailto:wikipedialibrary@wikimedia.org?Subject=Wikipedia%20Library%20{{ path }}%20Permission%20denied">wikipedialibrary@wikimedia.org</a>
       or report it to us on
       <a href="https://phabricator.wikimedia.org/maniphest/task/edit/form/1/?projectPHIDs=Library-Card-Platform&title=Wikipedia%20Library%20{{ path }}%20Bad%20Request">Phabricator</a>
-    {% endblocktrans %}
+    {% endblocktranslate %}
     (<a href="https://www.mediawiki.org/wiki/Phabricator/Help/{{ LANGUAGE_CODE }}?uselang={{ LANGUAGE_CODE }}">?</a>).
   </p>
 

--- a/TWLight/templates/403.html
+++ b/TWLight/templates/403.html
@@ -14,12 +14,12 @@
 
   <p>
     {% comment %}Translators: Shown on the website's 403 page, when a user attempts to navigate to a page they don't have permission to view. Don't translate {{ path }} or Phabricator. {% endcomment %}
-    {% blocktrans trimmed with request.path|urlencode as path %}
+    {% blocktranslate trimmed with request.path|urlencode as path %}
       If you think your account should be able to do that, please email us about this error at
       <a href="mailto:wikipedialibrary@wikimedia.org?Subject=Wikipedia%20Library%20{{ path }}%20Permission%20denied">wikipedialibrary@wikimedia.org</a>
       or report it to us on
       <a href="https://phabricator.wikimedia.org/maniphest/task/edit/form/1/?projectPHIDs=Library-Card-Platform&title=Wikipedia%20Library%20{{ path }}%20Permission%20denied">Phabricator</a>
-    {% endblocktrans %}
+    {% endblocktranslate %}
     (<a href="https://www.mediawiki.org/wiki/Phabricator/Help/{{ LANGUAGE_CODE }}?uselang={{ LANGUAGE_CODE }}">?</a>).
   </p>
 

--- a/TWLight/templates/404.html
+++ b/TWLight/templates/404.html
@@ -13,13 +13,13 @@
   </p>
   <p>
     {% comment %}Translators: Shown on the website's 404 page, when a user attempts to navigate to a page that doesn't exist. Don't translate {{ path }} or Phabricator.{% endcomment %}
-    {% blocktrans trimmed with request.path|urlencode as path %}
+    {% blocktranslate trimmed with request.path|urlencode as path %}
       If you are certain that something should be here, please email us about this error at
       <a href="mailto:wikipedialibrary@wikimedia.org?Subject=Wikipedia%20Library%20{{ path }}%20Not%20found">
       wikipedialibrary@wikimedia.org</a>
       or report it to us on
       <a href="https://phabricator.wikimedia.org/maniphest/task/edit/form/1/?projectPHIDs=Library-Card-Platform&title=Wikipedia%20Library%20{{ path }}%20Not%20found">Phabricator</a>
-    {% endblocktrans %}
+    {% endblocktranslate %}
     (<a href="https://www.mediawiki.org/wiki/Phabricator/Help/{{ LANGUAGE_CODE }}?uselang={{ LANGUAGE_CODE }}">?</a>).
   </p>
   <div class="clearfix">

--- a/TWLight/templates/about.html
+++ b/TWLight/templates/about.html
@@ -7,31 +7,31 @@
 
   <p>
     {% comment %}Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/). Wikimedia Foundation should not be translated. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library). {% endcomment %}
-    {% blocktrans trimmed %}
+    {% blocktranslate trimmed %}
       The Wikipedia Library provides free access to research materials
       to improve your ability to contribute content to Wikimedia projects.
-    {% endblocktrans %}
+    {% endblocktranslate %}
   </p>
 
   <p>
     {% comment %}Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/). Wikimedia Foundation should not be translated. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library). {% endcomment %}
-    {% blocktrans trimmed %}
+    {% blocktranslate trimmed %}
       The Wikipedia Library Card Platform is our central tool for reviewing applications and providing access to our
       collection. Here you can see which partnerships are available, search their contents, and apply for and access
       the ones you’re interested in. Volunteer coordinators, who have signed non-disclosure agreements with the
       Wikimedia Foundation, review applications and work with publishers to get you your free access.
       Some content is available without an application.
-    {% endblocktrans %}
+    {% endblocktranslate %}
   </p>
 
   <p>
     {% url 'terms' as terms_url %}
     {% comment %}Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/). Don't translate {{ terms_url }}. {% endcomment %}
-    {% blocktrans trimmed %}
+    {% blocktranslate trimmed %}
       For more information about how your information is stored and reviewed please see our <a href="{{ terms_url }}">
       terms of use and privacy policy</a>. Accounts you apply for are also subject to the Terms of Use provided by each
       partner’s platform; please review them.
-    {% endblocktrans %}
+    {% endblocktranslate %}
   </p>
 
   {% comment %}Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/). {% endcomment %}
@@ -39,20 +39,20 @@
 
   <p>
     {% comment %}Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/). Wikimedia Foundation should not be translated. {% endcomment %}
-    {% blocktrans trimmed %}
+    {% blocktranslate trimmed %}
       Any active editor in good standing can receive access. For publishers with limited numbers of accounts,
       applications are reviewed based on the editor’s needs and contributions. If you think you could use access to one
       of our partner resources and are an active editor in any project supported by the Wikimedia Foundation, please
       apply.
-    {% endblocktrans %}
+    {% endblocktranslate %}
   </p>
 
   <p>
     {% comment %}Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/). {% endcomment %}
-    {% blocktrans trimmed %}
+    {% blocktranslate trimmed %}
       Any editor can apply for access, but there are a few basic requirements. These are also the minimum technical
       requirements for access to the Library Bundle (see below):
-    {% endblocktrans %}
+    {% endblocktranslate %}
     <ul>
       <li>
         {% comment %}Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/). {% endcomment %}
@@ -78,10 +78,10 @@
 
   <p>
     {% comment %}Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/). {% endcomment %}
-    {% blocktrans trimmed %}
+    {% blocktranslate trimmed %}
       If you don't quite meet the experience requirements but think you would still be a strong candidate for access,
       feel free to apply and you may still be considered.
-    {% endblocktrans %}
+    {% endblocktranslate %}
   </p>
 
 
@@ -130,9 +130,9 @@
 
   <p>
     {% comment %}Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/). {% endcomment %}
-    {% blocktrans trimmed %}
+    {% blocktranslate trimmed %}
       Respecting these agreements allows us to continue growing the partnerships available to the community.
-    {% endblocktrans %}
+    {% endblocktranslate %}
   </p>
 
   {% comment %}Translators: This is the heading for a section on the About page (https://wikipedialibrary.wmflabs.org/about/). {% endcomment %}
@@ -140,52 +140,52 @@
 
   <p>
     {% comment %}Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).{% endcomment %}
-    {% blocktrans trimmed %}
+    {% blocktranslate trimmed %}
       EZProxy is a proxy server used to authenticate users for many Wikipedia Library partners. Users sign into EZProxy
       via the Library Card platform to verify that they are authorized users, and then the server accesses requested
       resources using its own IP address.
-    {% endblocktrans %}
+    {% endblocktranslate %}
   </p>
 
   <p>
     {% comment %}Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).{% endcomment %}
-    {% blocktrans trimmed %}
+    {% blocktranslate trimmed %}
       You may notice that when accessing resources via EZProxy that URLs are dynamically rewritten. This is why we
       recommend logging in via the Library Card platform rather than going directly to the unproxied partner website.
       When in doubt, check the URL for ‘idm.oclc’. If it’s there, then you’re connected via EZProxy.
-    {% endblocktrans %}
+    {% endblocktranslate %}
   </p>
 
   <p>
     {% comment %}Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).{% endcomment %}
-    {% blocktrans trimmed %}
+    {% blocktranslate trimmed %}
       Typically once you’ve logged in your session will remain active in your browser for up to two hours after you’ve
       finished searching. Note that use of EZProxy requires you to enable cookies. If you are having problems you
       should also try clearing your cache and restarting your browser.
-    {% endblocktrans %}
+    {% endblocktranslate %}
   </p>
 
   <h3 id="bundle-section">Library Bundle</h3>
 
   <p>
     {% comment %}Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/) {% endcomment %}
-    {% blocktrans trimmed %}
+    {% blocktranslate trimmed %}
       The Library Bundle is a collection of resources for which no application is required. If you meet the
       criteria laid out above, you will be authorized for access automatically upon logging in to the platform. Only
       some of our content is currently included in the Library Bundle, however we hope to expand the collection as
       more publishers become comfortable with participating. All Bundle content is accessed via EZProxy.
-    {% endblocktrans %}
+    {% endblocktranslate %}
   </p>
 
   <p>
     {% comment %}Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/) {% endcomment %}
-    {% blocktrans trimmed %}
+    {% blocktranslate trimmed %}
       If your account is blocked on one or more Wikimedia projects, you may still be granted access to the Library
       Bundle. You will need to contact the Wikipedia Library team, who will review your blocks. If you have been
       blocked for content issues, most notably copyright violations, or have multiple long-term blocks, we may
       decline your request. Additionally, if your block status changes after being approved, you will need to request
       another review.
-    {% endblocktrans %}
+    {% endblocktranslate %}
   </p>
 
   {% comment %}Translators: This is the heading for a section on the About page (https://wikipedialibrary.wmflabs.org/about/). {% endcomment %}
@@ -193,11 +193,11 @@
 
   <p>
     {% comment %}Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).{% endcomment %}
-    {% blocktrans trimmed %}
+    {% blocktranslate trimmed %}
       Citation practices vary by project and even by article. Generally, we support editors citing where they found
       information, in a form that allows others to check it for themselves. That often means providing both original
       source details as well as a link to the partner database in which the source was found.
-    {% endblocktrans %}
+    {% endblocktranslate %}
   </p>
 
   {% comment %}Translators: This is the heading for a section on the About page (https://wikipedialibrary.wmflabs.org/about/). {% endcomment %}
@@ -205,9 +205,9 @@
   <p>
     {% url 'contact' as contact_url %}
     {% comment %}Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).{% endcomment %}
-    {% blocktrans trimmed %}
+    {% blocktranslate trimmed %}
       If you have questions, need help, or want to volunteer to help, please see our <a href="{{ contact_url }}">contact page</a>.
-    {% endblocktrans %}
+    {% endblocktranslate %}
   </p>
 
 {% endblock content %}

--- a/TWLight/templates/base.html
+++ b/TWLight/templates/base.html
@@ -64,33 +64,33 @@
         {% url 'users:email_change' as email_url %}
         {% url 'contact' as contact_us_url %}
         {% comment %}Translators: Shown if the current user doesn't have a registered email on their account. Don't translate {{ contact_us_url }} or {{ email_url }}. {% endcomment %}
-        {% blocktrans trimmed %}
+        {% blocktranslate trimmed %}
           You don't have an email on file. We can't finalize your access to
           partner resources, and you won't be able to <a href="{{ contact_us_url }}">contact us</a> without an email. Please
           <a href="{{ email_url }}">update your email</a>.
-        {% endblocktrans %}
+        {% endblocktranslate %}
       </div>
     {% endif %}
     {% if user|restricted %}
       <div class="alert alert-warning">
         {% url 'users:restrict_data' as restrict_url %}
         {% comment %}Translators: Shown if the current user has requested the processing of their data should be restricted. {% endcomment %}
-        {% blocktrans trimmed %}
+        {% blocktranslate trimmed %}
           You have requested a restriction on the processing of your data.
           Most site functionality will not be available to you until you
           <a href="{{ restrict_url }}">lift this restriction</a>.
-        {% endblocktrans %}
+        {% endblocktranslate %}
       </div>
     {% endif %}
     {% if user.is_authenticated and not user.userprofile.terms_of_use %}
       <div class="alert alert-warning">
         {% url 'terms' as terms_url %}
         {% comment %}Translators: Shown if the current user has not agreed to the terms of use. {% endcomment %}
-        {% blocktrans trimmed %}
+        {% blocktranslate trimmed %}
           You have not agreed to the <a href="{{ terms_url }}">terms of use</a>
           of this site. Your applications will not be processed and you won't be
           able to apply or access resources you are approved for.
-        {% endblocktrans %}
+        {% endblocktranslate %}
       </div>
     {% endif %}
 

--- a/TWLight/templates/dashboard.html
+++ b/TWLight/templates/dashboard.html
@@ -202,11 +202,11 @@
         </a>
         <p>
           {% comment %}Translators: This text describes a graph on the metrics page (https://wikipedialibrary.wmflabs.org/dashboard/). {% endcomment %}
-          {% blocktrans trimmed %}
+          {% blocktranslate trimmed %}
             The x axis is the number of days to make a final decision (either
             approved or denied) on an application. The y axis is the number of
             applications that have taken exactly that many days to decide.
-          {% endblocktrans %}
+          {% endblocktranslate %}
         </p>
         <div id="app-time-histogram-graph" style="width:80%;height:300px"></div>          
 
@@ -218,10 +218,10 @@
         </a>
         <p>
           {% comment %}Translators: This text describes a graph on the metrics page (https://wikipedialibrary.wmflabs.org/dashboard/). The data is median, not mean. {% endcomment %}
-          {% blocktrans trimmed %}
+          {% blocktranslate trimmed %}
             This shows the median number of days to reach a decision on the
             applications opened in a given month.
-          {% endblocktrans %}
+          {% endblocktranslate %}
         </p>
         <div id="app-medians-graph" style="width:80%;height:300px"></div>
         {% comment %}Translators: On the dashboard page (https://wikipedialibrary.wmflabs.org/dashboard/), this text is the title of the graph showing the current distribution of applications.{% endcomment %}

--- a/TWLight/templates/home.html
+++ b/TWLight/templates/home.html
@@ -9,9 +9,9 @@
   <div class="lead">
     <p>
       {% comment %}Translators: This message is shown on the website's home page (https://wikipedialibrary.wmflabs.org/). Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).{% endcomment %}
-      {% blocktrans trimmed %}
+      {% blocktranslate trimmed %}
         The Wikipedia Library provides free access to research databases and collections.
-  		{% endblocktrans %}
+  		{% endblocktranslate %}
       {% comment %}Translators: A link users can click to read more about the project or the tool. {% endcomment %}
       <a href="{% url 'about' %}">{% trans "Learn more" %}</a>
 		</p>
@@ -45,9 +45,9 @@
           ">
         </h2>
         {% comment %}Translators: On the main page of the website (https://wikipedialibrary.wmflabs.org/), this message is displayed to all users as the description of Library Bundle eligibility panel. 'Library Bundle' is the set of resources which active users have automatic access to.{% endcomment %}
-		    {% blocktrans trimmed %}
+		    {% blocktranslate trimmed %}
 				  <p>Free and immediate access to a large selection of resources, spanning {{ bundle_partner_count }} collections, if you meet the following criteria:</p>
-		    {% endblocktrans %}
+		    {% endblocktranslate %}
 				<ul class="bundle-list">
           {% for criteria_text, meets_criteria in bundle_criteria %}
             <li>
@@ -72,18 +72,18 @@
           <p class="block-notice">
             {% url 'contact' as contact_url %}
             {% comment %}Translators: This message is shown on the homepage to users whose Wikimedia account is blocked on one or more projects. They may still be granted access to the Library Bundle, but need to contact Wikipedia Library staff to verify. {% endcomment %}
-            {% blocktrans trimmed %}
+            {% blocktranslate trimmed %}
               It looks like you have an active block on your account on at least one Wikimedia project. If you meet the other criteria you may still be permitted access to the Library Bundle - please <a href="{{ contact_url }}">contact us</a>.
-            {% endblocktrans %}
+            {% endblocktranslate %}
           </p>
         {% endif %}
         {% if user.is_authenticated and user.editor.wp_bundle_eligible %}
           <div class="alert alert-success">
             {% url 'users:my_library' as library_url %}
             {% comment %}Translators: This message is shown on the homepage to users who meet the technical eligibility criteria for the Library Bundle. {% endcomment %}
-            {% blocktrans trimmed %}
+            {% blocktranslate trimmed %}
               You meet the eligibility criteria! Check out <a href="{{ library_url }}">My Library</a> to see what you have access to.
-            {% endblocktrans %}
+            {% endblocktranslate %}
           </div>
         {% else %}
 				  {% comment %}Translators: On the main page of the website (https://wikipedialibrary.wmflabs.org/), the 'Learn more' button takes users to the 'About' page. {% endcomment %}

--- a/TWLight/templates/login_partial.html
+++ b/TWLight/templates/login_partial.html
@@ -18,7 +18,7 @@
   <div class="col-lg-6 col-md-12 col-sm-12 homepage-description">
     <p>
       {% comment %}Translators: Information about The Wikipedia Library.{% endcomment %}
-      {% blocktranslate %}
+      {% blocktranslate trimmed %}
       Over 90 of the world's top
       subscription-only databases, free
       for Wikipedians of all backgrounds
@@ -29,7 +29,7 @@
   <div class="col-lg-6 col-md-12 col-sm-12 homepage-criteria">
     <p class="criteria-info">
       {% comment %}Translators: Information about The Wikipedia Library.{% endcomment %}
-      {% blocktranslate %}
+      {% blocktranslate trimmed %}
       Meet this criteria for automatic access
       {% endblocktranslate %}
       <i class="fa fa-info-circle" aria-hidden="true" data-toggle="tooltip" data-placement="bottom" data-html="true" title="This criteria grants you access to certain collections but not all. Some collections are accessible on a per application basis only."></i>

--- a/TWLight/templates/partner_carousel.html
+++ b/TWLight/templates/partner_carousel.html
@@ -13,7 +13,7 @@
           <a class="nav-link more-item" href="{% url 'homepage' %}?tags=">
         {% endif %}
           {% comment %}Translators: This is a filter of featured collections of The Wikipedia Library.{% endcomment %}
-          {% blocktranslate %}
+          {% blocktranslate trimmed %}
             Featured
           {% endblocktranslate %}
         </a>
@@ -40,7 +40,7 @@
                   href="#" role="button" aria-haspopup="true" aria-expanded="false">
                 <strong>
                   {% comment %}Translators: A button that indicates there are more tag filter options.{% endcomment %}
-                  {% blocktranslate %}
+                  {% blocktranslate trimmed %}
                     More
                   {% endblocktranslate %}
                 </strong>
@@ -77,7 +77,7 @@
           <button id="partner-button-{{partner.pk}}" type="button" class="btn partner-glider-button"
               onclick="toggleDescription({{partner.pk}})">
             {% comment %}Translators: A button that reveals more information about a collection.{% endcomment %}
-            {% blocktranslate %}
+            {% blocktranslate trimmed %}
               More info
             {% endblocktranslate %}
           </button>

--- a/TWLight/users/templates/users/authorization_confirm_return.html
+++ b/TWLight/users/templates/users/authorization_confirm_return.html
@@ -7,10 +7,10 @@
     {% csrf_token %}
     <p>
       {% comment %}Translators: This message is displayed on the confirmation page where users can return their access to partner collections.{% endcomment %}
-    {% blocktrans trimmed with object.partners.get as partner %}
+    {% blocktranslate trimmed with object.partners.get as partner %}
       You will no longer be able to access <b>{{ partner }}'s</b> resources via the Library Card platform, but can request access again
       by clicking 'renew', if you change your mind. Are you sure you want to return your access?
-    {% endblocktrans %}
+    {% endblocktranslate %}
     </p>
     {% comment %}Translators: A button users can click to return their access to a particular resource.{% endcomment %}
     <input type="submit" value="{% trans 'Confirm' %}" class="btn btn-primary"/>

--- a/TWLight/users/templates/users/editor_detail.html
+++ b/TWLight/users/templates/users/editor_detail.html
@@ -53,11 +53,11 @@
 
   <p>
     {% comment %}Translators: This is shown on editor profiles, in their profile page or on applications.{% endcomment %}
-    {% blocktrans trimmed %}
+    {% blocktranslate trimmed %}
       Information with an * was retrieved from Wikipedia directly.
       Other information was entered directly by users or site admins,
       in their preferred language.
-    {% endblocktrans %}
+    {% endblocktranslate %}
   </p>
 
   {% if editor.user|coordinators_only %}
@@ -65,9 +65,9 @@
       <div class="col-xs-12 col-md-10 col-md-offset-1">
         <p class="well">
             {% comment %}Translators: This distinguishes users who have been flagged as account coordinators. Don't translate {{ username }}.{% endcomment %}
-            {% blocktrans trimmed with username=editor.wp_username %}
+            {% blocktranslate trimmed with username=editor.wp_username %}
               {{ username }} has coordinator privileges on this site.
-            {% endblocktrans %}
+            {% endblocktranslate %}
         </p>
       </div>
     </div>

--- a/TWLight/users/templates/users/editor_detail_data.html
+++ b/TWLight/users/templates/users/editor_detail_data.html
@@ -2,11 +2,11 @@
 
 <p>
     {% comment %}Translators: This is shown on editor profiles, under the heading for Wikipedia editor data. {% endcomment %}
-    {% blocktrans trimmed %}
+    {% blocktranslate trimmed %}
         This information is updated automatically from your Wikimedia account
         each time you log in, except for the Contributions field, where you
         can describe your Wikimedia editing history.
-    {% endblocktrans %}
+    {% endblocktranslate %}
 </p>
 
 <hr/>
@@ -54,10 +54,10 @@
         <strong>{% trans "Satisfies terms of use?" %}</strong>
         <p>
             {% comment %}Translators: when viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this question has a yes or no answer. {% endcomment %}
-            {% blocktrans trimmed %}
+            {% blocktranslate trimmed %}
                 at their last login, did this user meet the criteria set forth in the
                 terms of use?
-            {% endblocktrans %}
+            {% endblocktranslate %}
         </p>
     </div>
     <div class="col-xs-12 col-sm-9">
@@ -69,10 +69,10 @@
             <p class="bg-danger"><strong class="warning">{% trans "No" %}</strong></p>
             <p>
                 {% comment %}Translators: When viewing a user's profile in an application, this message shows if the software doesn't think that the user is eligible for access. Don't translate {{ username }}.{% endcomment %}
-                {% blocktrans trimmed with username=editor.wp_username %}
+                {% blocktranslate trimmed with username=editor.wp_username %}
                     {{ username }} may still be eligible for access grants at the
                     coordinators' discretion.
-                {% endblocktrans %}
+                {% endblocktranslate %}
             </p>
         {% endif %}
     </div>
@@ -130,9 +130,9 @@
           <p class="block-notice">
             {% url 'contact' as contact_url %}
             {% comment %}Translators: This message is shown on a user's profile if their Wikimedia account is blocked on one or more projects. They may still be granted access to the Library Bundle, but need to contact Wikipedia Library staff to verify. {% endcomment %}
-            {% blocktrans trimmed %}
+            {% blocktranslate trimmed %}
               It looks like you have an active block on your account. If you meet the other criteria you may still be permitted access to the Library Bundle - please <a href="{{ contact_url }}">contact us</a>.
-            {% endblocktrans %}
+            {% endblocktranslate %}
           </p>
       {% endif %}
   </div>
@@ -146,9 +146,9 @@
         <strong>{% trans "Eligible for Bundle?" %}</strong>
         <p>
             {% comment %}Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this question has a Yes or No answer. {% endcomment %}
-            {% blocktrans trimmed %}
+            {% blocktranslate trimmed %}
                 At their last login, did this user meet the criteria set forth in the Library Bundle? Note that satisfying terms of use is a prerequisite to bundle eligibility.
-            {% endblocktrans %}
+            {% endblocktranslate %}
         </p>
     </div>
     <div class="col-xs-12 col-sm-9">
@@ -252,20 +252,20 @@
     <p>
         <span class="glyphicon glyphicon-info-sign"></span>
         {% comment %}Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this text is in the 'Personal data' section. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).{% endcomment %}
-        {% blocktrans trimmed %}
+        {% blocktranslate trimmed %}
             The following information is visible only to you, site administrators,
             publishing partners (where required), and volunteer Wikipedia Library
             coordinators (who have signed a Non-Disclosure Agreement).
-        {% endblocktrans %}
+        {% endblocktranslate %}
     </p>
 
     <p>
         {% url 'users:pii_update' as update_url %}
         {% comment %}Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this labels a button which users can click to update or remove their personal information. Don't translate {{ update_url }}.{% endcomment %}
-        {% blocktrans trimmed %}
+        {% blocktranslate trimmed %}
             You may <a href="{{ update_url }}">update or delete</a>
             your data at any time.
-        {% endblocktrans %}
+        {% endblocktranslate %}
     </p>
 
     <hr/>

--- a/TWLight/users/templates/users/language_form.html
+++ b/TWLight/users/templates/users/language_form.html
@@ -26,8 +26,8 @@
     <input type="submit" name="submit" value="{% trans "Set language" %}" class="btn btn-default" />
   </form> <br />
   {% comment %}Translators: This text on the user page helps users naviage to the TranslateWiki Wikipedia Library Card platform translation page.{% endcomment %}
-  {% blocktrans trimmed%}
+  {% blocktranslate trimmed %}
     You can help translate the tool at <a href="https://translatewiki.net/wiki/Translating:Wikipedia_Library_Card_Platform">translatewiki.net</a>.
-  {% endblocktrans %}
+  {% endblocktranslate %}
   <br />
 </div>

--- a/TWLight/users/templates/users/my_applications.html
+++ b/TWLight/users/templates/users/my_applications.html
@@ -44,14 +44,14 @@
         {% elif app.get_version_count > 1 %} {# first version is original submission, not later review #}
           {% if app.get_latest_reviewer %}
             {% comment %}Translators: On the page listing applications, this shows next to an application which was previously reviewed. Don't translate {{ reviewer }} or {{ review_date }}.{% endcomment %}
-            {% blocktrans trimmed with reviewer=app.get_latest_reviewer review_date=app.get_latest_review_date|localize %}
+            {% blocktranslate trimmed with reviewer=app.get_latest_reviewer review_date=app.get_latest_review_date|localize %}
               Last reviewed by {{ reviewer }} on {{ review_date }}
-            {% endblocktrans %}
+            {% endblocktranslate %}
           {% else %}
             {% comment %}Translators: On the page listing applications, this shows next to an application which was previously reviewed. Don't translate {{ review_date }}.{% endcomment %}
-            {% blocktrans trimmed with review_date=app.get_latest_review_date|localize %}
+            {% blocktranslate trimmed with review_date=app.get_latest_review_date|localize %}
               Last reviewed on {{ review_date }}
-            {% endblocktrans %}
+            {% endblocktranslate %}
           {% endif %}
         {% else %}
           {% comment %}Translators: On the page listing applications, this shows next to an application which has not yet been reviewed.{% endcomment %}

--- a/TWLight/users/templates/users/resource_tile.html
+++ b/TWLight/users/templates/users/resource_tile.html
@@ -34,26 +34,26 @@
             {% if resource.valid_authorization_with_access_url %}
               {% if resource.stream %}
                 {% comment %}Translators: Title for logo in tiles that are linked to an external website. Don't translate {{ name }}.{% endcomment %}
-                {% blocktrans trimmed with name=resource.stream %}
+                {% blocktranslate trimmed with name=resource.stream %}
                    Link to {{ name }}'s external website
-                {% endblocktrans %}
+                {% endblocktranslate %}
               {% else %}
                 {% comment %}Translators: Title for logo in tiles that are linked to an external website. Don't translate {{ name }}.{% endcomment %}
-                {% blocktrans trimmed with name=resource.partner %}
+                {% blocktranslate trimmed with name=resource.partner %}
                    Link to {{ name }}'s external website
-                {% endblocktrans %}
+                {% endblocktranslate %}
               {% endif %}
             {% else %}
               {% if resource.stream %}
                 {% comment %}Translators: Title for logo in tiles that are linked to partner description  page. Don't translate {{ name }}.{% endcomment %}
-                {% blocktrans trimmed with name=resource.stream %}
+                {% blocktranslate trimmed with name=resource.stream %}
                    Link to {{ name }}'s signup page
-                {% endblocktrans %}
+                {% endblocktranslate %}
               {% else %}
                 {% comment %}Translators: Title for logo in tiles that are linked to partner description  page. Don't translate {{ name }}.{% endcomment %}
-                {% blocktrans trimmed with name=resource.partner %}
+                {% blocktranslate trimmed with name=resource.partner %}
                    Link to {{ name }}'s signup page
-                {% endblocktrans %}
+                {% endblocktranslate %}
               {% endif %}
             {% endif %}
             "
@@ -61,26 +61,26 @@
             {% if resource.valid_authorization_with_access_url %}
               {% if resource.stream %}
                 {% comment %}Translators: Alt text for publisher logos on the my library page. Don't translate {{ name }}.{% endcomment %}
-                {% blocktrans trimmed with name=resource.stream %}
+                {% blocktranslate trimmed with name=resource.stream %}
                    Link to {{ name }}'s external website
-                {% endblocktrans %}
+                {% endblocktranslate %}
               {% else %}
                 {% comment %}Translators: Alt text for publisher logos on the my library page. Don't translate {{ name }}.{% endcomment %}
-                {% blocktrans trimmed with name=resource.partner %}
+                {% blocktranslate trimmed with name=resource.partner %}
                    Link to {{ name }}'s external website
-                {% endblocktrans %}
+                {% endblocktranslate %}
               {% endif %}
             {% else %}
               {% if resource.stream %}
                 {% comment %}Translators: Alt text for publisher logos on the my library page. Don't translate {{ name }}.{% endcomment %}
-                {% blocktrans trimmed with name=resource.stream %}
+                {% blocktranslate trimmed with name=resource.stream %}
                    Link to {{ name }}'s signup page
-                {% endblocktrans %}
+                {% endblocktranslate %}
               {% else %}
                 {% comment %}Translators: Alt text for publisher logos on the my library page. Don't translate {{ name }}.{% endcomment %}
-                {% blocktrans trimmed with name=resource.partner %}
+                {% blocktranslate trimmed with name=resource.partner %}
                    Link to {{ name }}'s signup page
-                {% endblocktrans %}
+                {% endblocktranslate %}
               {% endif %}
             {% endif %}
           ">

--- a/TWLight/users/templates/users/restrict_data.html
+++ b/TWLight/users/templates/users/restrict_data.html
@@ -9,21 +9,21 @@
 
   <p>
   {% comment %}Translators: This message is displayed on the page where users can request we stop processing their data.{% endcomment %}
-  {% blocktrans trimmed %}
+  {% blocktranslate trimmed %}
       Checking this box and clicking “Restrict” will pause all processing of 
       the data you have entered into this website. You will not be able to apply 
       for access to resources, your applications will not be further processed, 
       and none of your data will be altered, until you return to this page and 
       uncheck the box. This is not the same as deleting your data.
-  {% endblocktrans %}
+  {% endblocktranslate %}
   </p>
   {% if user|coordinators_only %}
     <p>
     {% comment %}Translators: This warning message is shown to coordinators who view the data restriction page.{% endcomment %}
-    {% blocktrans trimmed %}
+    {% blocktranslate trimmed %}
       You are a coordinator on this site. If you restrict the processing of 
       your data, your coordinator flag will be removed.
-    {% endblocktrans %}
+    {% endblocktranslate %}
     </p>
   {% endif %}
   {% crispy form %}

--- a/TWLight/users/templates/users/terms.html
+++ b/TWLight/users/templates/users/terms.html
@@ -38,16 +38,16 @@ You can also view these TOU on [[Meta]], where they may be translated in other l
 <div id='terms'>
 <p>
 {% comment %}Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.{% endcomment %}
-{% blocktrans trimmed %}
+{% blocktranslate trimmed %}
 <a href="https://meta.wikimedia.org/wiki/The_Wikipedia_Library">The Wikipedia Library</a> has partnered with publishers around the world to allow users to access otherwise paywalled resources. This website allows users to apply simultaneously for access to multiple publishers’ materials, and makes the administration of and access to Wikipedia Library accounts easy and efficient.
-{% endblocktrans %}
+{% endblocktranslate %}
 </p>
 
 <p>
 {% comment %}Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Wikimedia Foundation should not be translated. WMF should not be translated. Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.{% endcomment %}
-{% blocktrans trimmed %}
+{% blocktranslate trimmed %}
 This program is administered by the Wikimedia Foundation (WMF). These terms of use and privacy notice pertain to your application for access to resources through the Wikipedia Library, your use of this website, and your access to and use of those resources. They also describe our handling of the information you provide to us in order to create and administer your Wikipedia Library account. If we make material changes to the terms, we will notify users.
-{% endblocktrans %}
+{% endblocktranslate %}
 </p>
 
 {% comment %}Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.{% endcomment %}
@@ -55,23 +55,23 @@ This program is administered by the Wikimedia Foundation (WMF). These terms of u
 
 <p>
 {% comment %}Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.{% endcomment %}
-{% blocktrans trimmed %}
+{% blocktranslate trimmed %}
 Access to resources via The Wikipedia Library is reserved for community members who have demonstrated their commitment to the Wikimedia projects, and who will use their access to these resources to improve project content. To that end, in order to be eligible for the Wikipedia Library program, we require that you be registered for a user account on the projects. We give preference to users with at least 500 edits and six (6) months of activity, but these are not strict requirements. We ask that you do not request access to any publishers whose resources you can already access for free through your local library or university, or another institution or organization, in order to provide that opportunity to others.
-{% endblocktrans %}
+{% endblocktranslate %}
 </p>
 
 <p>
 {% comment %}Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.{% endcomment %}
-{% blocktrans trimmed %}
+{% blocktranslate trimmed %}
 Additionally, if you are currently blocked or banned from a Wikimedia project, applications to resources may be rejected or restricted. If you obtain a Wikipedia Library account, but a long-term block or ban is subsequently instituted against you on one of the projects, you may lose access to your Wikipedia Library account.
-{% endblocktrans %}
+{% endblocktranslate %}
 </p>
 
 <p>
 {% comment %}Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.{% endcomment %}
-{% blocktrans trimmed %}
+{% blocktranslate trimmed %}
 Wikipedia Library Card accounts do not expire. However, access to an individual publisher’s resources will generally lapse after one year, after which you will either need to apply for renewal or your account will automatically be renewed.
-{% endblocktrans %}
+{% endblocktranslate %}
 </p>
 
 {% comment %}Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.{% endcomment %}
@@ -79,44 +79,44 @@ Wikipedia Library Card accounts do not expire. However, access to an individual 
 
 <p>
 {% comment %}Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).{% endcomment %}
-{% blocktrans trimmed %}
+{% blocktranslate trimmed %}
 In order to apply for access to a partner resource, you must provide us with certain information, which we will use to evaluate your application. If your application is approved, we may transfer the information you have given us to the publishers whose resources you wish to access. They will either contact you with the account information directly or we will send access information to you ourselves.
-{% endblocktrans %}
+{% endblocktranslate %}
 </p>
 
 <p>
 {% comment %}Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).{% endcomment %}
-{% blocktrans trimmed %}
+{% blocktranslate trimmed %}
 In addition to the basic information you provide to us, our system will retrieve some information directly from the Wikimedia projects: your username, email address, edit count, registration date, user ID number, groups to which you belong, and any special user rights.
-{% endblocktrans %}
+{% endblocktranslate %}
 </p>
 
 <p>
 {% comment %}Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.{% endcomment %}
-{% blocktrans trimmed %}
+{% blocktranslate trimmed %}
 Each time you log in to the Wikipedia Library Card Platform, this information will be automatically updated.
-{% endblocktrans %}
+{% endblocktranslate %}
 </p>
 
 <p>
 {% comment %}Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).{% endcomment %}
-{% blocktrans trimmed %}
+{% blocktranslate trimmed %}
 We will ask you to provide us with some information about your history of contributions to the Wikimedia projects. Information on contribution history is optional, but will greatly assist us in evaluating your application.
-{% endblocktrans %}
+{% endblocktranslate %}
 </p>
 
 <p>
 {% comment %}Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). WMF should not be translated. Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.{% endcomment %}
-{% blocktrans trimmed %}
+{% blocktranslate trimmed %}
 The information you provide when creating your account will be visible to you while on the site but not to others unless they are approved Wikipedia Library Coordinators, WMF Staff, or WMF Contractors who need access to this data in order to carry out their work with the Wikipedia Library, all of whom are subject to non-disclosure obligations.
-{% endblocktrans %}
+{% endblocktranslate %}
 </p>
 
 <p>
 {% comment %}Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.{% endcomment %}
-{% blocktrans trimmed %}
+{% blocktranslate trimmed %}
 The following limited information that you provide is public to all users by default: 1) when you created a Wikipedia Library Card account; 2) which publishers’ resources you have applied to access; 3) your rationale for accessing the resources of each partner to which you apply. Editors who do not wish to make points 2 and 3 public may opt out using a checkbox when filing an application.
-{% endblocktrans %}
+{% endblocktranslate %}
 </p>
 
 {% comment %}Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). {% endcomment %}
@@ -124,42 +124,42 @@ The following limited information that you provide is public to all users by def
 
 <p>
 {% comment %}Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library. {% endcomment %}
-{% blocktrans trimmed %}
+{% blocktranslate trimmed %}
 In order to access an individual publisher’s resources, you must agree to that publisher’s terms of use and privacy policy. You agree that you will not violate such terms and policies in connection with your use of the Wikipedia Library. Additionally, the following activities are prohibited while accessing publisher resources through the Wikipedia Library.
-{% endblocktrans %}
+{% endblocktranslate %}
 </p>
 
 <p>
   <ol>
     <li>
     {% comment %}Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). {% endcomment %}
-    {% blocktrans trimmed %}
+    {% blocktranslate trimmed %}
     Sharing your usernames, passwords, or any access codes for publisher resources with others;
-    {% endblocktrans %}
+    {% endblocktranslate %}
     </li>
     <li>
     {% comment %}Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). {% endcomment %}
-    {% blocktrans trimmed %}
+    {% blocktranslate trimmed %}
     Automatically scraping or downloading restricted content from publishers;
-    {% endblocktrans %}
+    {% endblocktranslate %}
     </li>
     <li>
     {% comment %}Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). {% endcomment %}
-    {% blocktrans trimmed %}
+    {% blocktranslate trimmed %}
     Systematically making printed or electronic copies of multiple extracts of restricted content available for any purpose;
-    {% endblocktrans %}
+    {% endblocktranslate %}
     </li>
     <li>
     {% comment %}Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). {% endcomment %}
-    {% blocktrans trimmed %}
+    {% blocktranslate trimmed %}
     Data mining metadata without permission—for example, in order to use metadata for auto-created stub articles;
-    {% endblocktrans %}
+    {% endblocktranslate %}
     </li>
     <li>
     {% comment %}Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library. {% endcomment %}
-    {% blocktrans trimmed %}
+    {% blocktranslate trimmed %}
     Using the access you receive through the Wikipedia Library for profit by selling access to your account or resources which you have through it.
-    {% endblocktrans %}
+    {% endblocktranslate %}
     </li>
   </ol>
 </p>
@@ -169,16 +169,16 @@ In order to access an individual publisher’s resources, you must agree to that
 
 <p>
 {% comment %}Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). {% endcomment %}
-{% blocktrans trimmed %}
+{% blocktranslate trimmed %}
 Certain resources may only be accessed using an external search service, such as the EBSCO Discovery Service, or a proxy service, such as OCLC EZProxy. If you use such external search and/or proxy services, please review the applicable terms of use and privacy policies.
-{% endblocktrans %}
+{% endblocktranslate %}
 </p>
 
 <p>
 {% comment %}Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). {% endcomment %}
-{% blocktrans trimmed %}
+{% blocktranslate trimmed %}
 In addition, if you use OCLC EZProxy, please note that you may not use it for commercial purposes.
-{% endblocktrans %}
+{% endblocktranslate %}
 </p>
 
 {% comment %}Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). {% endcomment %}
@@ -186,67 +186,67 @@ In addition, if you use OCLC EZProxy, please note that you may not use it for co
 
 <p>
 {% comment %}Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Wikimedia Foundation should not be translated. Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library. {% endcomment %}
-{% blocktrans trimmed %}
+{% blocktranslate trimmed %}
 The Wikimedia Foundation and our service providers use your information for the legitimate purpose of providing Wikipedia Library services in support of our charitable mission. When you apply for a Wikipedia Library account, or use your Wikipedia Library account, we may routinely collect the following information: your username, email address, edit count, registration date, user ID number, groups to which you belong, and any special user rights; your name, country of residence, occupation, and/or affiliation, if required by a partner to which you are applying; your narrative description of your contributions and reasons for applying for access to partner resources; and the date you agree to these terms of use.
-{% endblocktrans %}
+{% endblocktranslate %}
 </p>
 
 <p>
 {% url 'partners:filter' as all_partners_url %}
 {% comment %}Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library. {% endcomment %}
-{% blocktrans trimmed %}
+{% blocktranslate trimmed %}
 Each publisher who is a member of the Wikipedia Library program requires different specific information in the application. Some publishers may request only an email address, while others request more detailed data, such as your name, location, occupation, or institutional affiliation. When you complete your application, you will only be asked to supply information required by the publishers you have chosen, and each publisher will only receive the information they require for providing you with access. Please see our <a href="{{ all_partners_url }}">partner information</a> pages to learn what information is required by each publisher to gain access to their resources.
-{% endblocktrans %}
+{% endblocktranslate %}
 </p>
 
 <p>
 {% comment %}Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Wikimedia Foundation should not be translated. Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library. {% endcomment %}
-{% blocktrans trimmed %}
+{% blocktranslate trimmed %}
 You can browse the Wikipedia Library site without logging in, but will need to log in to apply or access proprietary partner resources. We use the data provided by you via OAuth and Wikimedia API calls to assess your application for access and to process approved requests.
-{% endblocktrans %}
+{% endblocktranslate %}
 </p>
 
 <p>
 {% url 'users:home' as profile_url %}
 {% comment %}Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). {% endcomment %}
-{% blocktrans trimmed %}
+{% blocktranslate trimmed %}
 In order to administer the Wikipedia Library program, we will retain the application data we collect from you for three years after your most recent login, unless you delete your account, as described below. You can log in and go to <a href="{{ profile_url }}">your profile page</a> in order to see the information associated with your account, and can download it in JSON format. You may access, update, restrict, or delete this information at any time, except for the information that is automatically retrieved from the projects. If you have any questions or concerns about the handling of your data, please contact <a href="mailto:wikipedialibrary@wikimedia.org?Subject=Wikipedia%20Library%20Card%20account%20deactivation">wikipedialibrary@wikimedia.org</a>.
-{% endblocktrans %}
+{% endblocktranslate %}
 </p>
 
 <p>
 {% comment %}Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library. {% endcomment %}
-{% blocktrans trimmed %}
+{% blocktranslate trimmed %}
 If you decide to disable your Wikipedia Library account, you can use the delete button on your profile to delete certain personal information associated with your account. We will delete your real name, occupation, institutional affiliation, and country of residence. Please note that the system will retain a record of your username, the publishers to which you applied or had access, and the dates of that access. Note that deletion is not reversible. Deletion of your Wikipedia Library account may also correspond with the removal of any resource access to which you were eligible or approved. If you request the deletion of account information and later wish to apply for a new account, you will need to provide the necessary information again.
-{% endblocktrans %}
+{% endblocktranslate %}
 </p>
 
 <p>
 {% comment %}Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). WMF should not be translated. Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library. {% endcomment %}
-{% blocktrans trimmed %}
+{% blocktranslate trimmed %}
 The Wikipedia Library is run by WMF Staff, Contractors, and approved volunteer Coordinators. The data associated with your account will be shared with the WMF staff, contractors, service providers, and volunteer coordinators who need to process the information in connection with their work for the Wikipedia Library, and who are subject to confidentiality obligations. We will also use your data for internal Wikipedia Library purposes such as distributing user surveys and account notifications, and in a depersonalized or aggregated fashion for statistical analysis and administration. Finally, we will share your information with the publishers whom you specifically select in order to provide you with access to resources. Otherwise, your information will not be shared with third parties, with the exception of the circumstances described below.
-{% endblocktrans %}
+{% endblocktranslate %}
 </p>
 
 <p>
 {% comment %}Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). WMF should not be translated. {% endcomment %}
-{% blocktrans trimmed %}
+{% blocktranslate trimmed %}
 We may disclose any collected information when required by law, when we have your permission, when needed to protect our rights, privacy, safety, users, or the general public, and when necessary to enforce these terms, WMF’s general <a href="https://foundation.wikimedia.org/wiki/Terms_of_Use">Terms of Use</a>, or any other WMF policy.
-{% endblocktrans %}
+{% endblocktranslate %}
 </p>
 
 <p>
 {% comment %}Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). {% endcomment %}
-{% blocktrans trimmed %}
+{% blocktranslate trimmed %}
 We take the security of your personal data seriously, and take reasonable precautions to ensure your data is protected. These precautions include access controls to limit who has access to your data and security technologies to protect data stored on the server. However, we cannot guarantee the safety of your data as it is transmitted and stored.
-{% endblocktrans %}
+{% endblocktranslate %}
 </p>
 
 <p>
 {% comment %}Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). {% endcomment %}
-{% blocktrans trimmed %}
+{% blocktranslate trimmed %}
 Please note that these terms do not control the use and handling of your data by the publishers and service providers whose resources you access or apply to access. Please read their individual privacy policies for that information.
-{% endblocktrans %}
+{% endblocktranslate %}
 </p>
 
 {% comment %}Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). {% endcomment %}
@@ -255,27 +255,27 @@ Please note that these terms do not control the use and handling of your data by
 <p>
 <strong>
 {% comment %}Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Wikimedia Foundation should not be translated. Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library. {% endcomment %}
-{% blocktrans trimmed %}
+{% blocktranslate trimmed %}
 The Wikimedia Foundation is a nonprofit organization based in San Francisco, California. The Wikipedia Library program provides access to resources held by publishers in multiple countries. If you apply for a Wikipedia Library account (whether you are inside or outside of the United States), you understand that your personal data will be collected, transferred, stored, processed, disclosed and otherwise used in the U.S. as described in this privacy policy. You also understand that your information may be transferred by us from the U.S. to other countries, which may have different or less stringent data protection laws than your country, in connection with providing services to you, including evaluating your application and securing access to your chosen publishers (locations for each publisher are outlined on their respective partner information pages).
-{% endblocktrans %}
+{% endblocktranslate %}
 </strong>
 </p>
 
 <p>
 <strong>
 {% comment %}Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). {% endcomment %}
-{% blocktrans trimmed %}
+{% blocktranslate trimmed %}
 Please note that in the event of any differences in meaning or interpretation between the original English version of these terms and a translation, the original English version takes precedence.
-{% endblocktrans %}
+{% endblocktranslate %}
 </strong>
 </p>
 
 <p>
 <strong>
 {% comment %}Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Wikimedia Foundation should not be translated. {% endcomment %}
-{% blocktrans trimmed %}
+{% blocktranslate trimmed %}
 See also the <a href="https://wikimediafoundation.org/wiki/Privacy_policy">Wikimedia Foundation Privacy Policy</a>.
-{% endblocktrans %}
+{% endblocktranslate %}
 </strong>
 </p>
 
@@ -296,9 +296,9 @@ wikipedialibrary@wikimedia.org
   {% if user.is_authenticated %}
     <p>
     {% comment %}Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library. {% endcomment %}
-    {% blocktrans trimmed %}
+    {% blocktranslate trimmed %}
        By checking this box and clicking “Submit”, you agree that you have read the above terms and that you will adhere to the terms of use in your application to and use of the The Wikipedia Library, and the publishers’ services to which you gain access through The Wikipedia Library program.
-    {% endblocktrans %}
+    {% endblocktranslate %}
     </p>
     {% crispy form %}
   {% endif %}

--- a/TWLight/users/templates/users/user_confirm_delete.html
+++ b/TWLight/users/templates/users/user_confirm_delete.html
@@ -11,13 +11,13 @@
     {% csrf_token %}
     <p>
       {% comment %}Translators: This message is displayed on the page where users can request the deletion of their data.{% endcomment %}
-      {% blocktrans trimmed %}
+      {% blocktranslate trimmed %}
           <b>Warning:</b> Performing this action will delete your Wikipedia 
           Library Card user account and all associated applications. This 
           process is not reversible. You may lose any partner accounts 
           you were granted, and will not be able to renew those 
           accounts or apply for new ones.
-      {% endblocktrans %}
+      {% endblocktranslate %}
     </p>
     <div style="text-align: center;">
       {% comment %}Translators: A button users can click to delete their account.{% endcomment %}

--- a/TWLight/users/templates/users/user_detail.html
+++ b/TWLight/users/templates/users/user_detail.html
@@ -6,20 +6,20 @@
     {% comment %}
       Translators: this should show up for people who log in with a username/password and not OAuth, so we don't know what their Wikipedia identity is.
     {% endcomment %}
-    {% blocktrans trimmed with username=user.username %}
+    {% blocktranslate trimmed with username=user.username %}
       Hi, {{ username }}! You don't have a Wikipedia editor profile attached
       to your account here, so you are probably a site administrator.
-    {% endblocktrans %}
+    {% endblocktranslate %}
   </p>
 
   <p>
     {% comment %}Translators: In the unlikely scenario that someone is able to register an account without using OAuth (thus leaving us without some of the information required for applications), users will see this message, encouraging them to re-register.{% endcomment %}
-    {% blocktrans trimmed %}
+    {% blocktranslate trimmed %}
       If you aren't a site administrator, something weird has happened. You
       won't be able to apply for access without a Wikipedia editor profile.
       You should log out and create a new account by logging in via OAuth,
       or contact a site administrator for help.
-    {% endblocktrans %}
+    {% endblocktranslate %}
   </p>
 
   {% include "users/preferences.html" %}


### PR DESCRIPTION

## Description
- trims `blocktranslate` tags
  - `find TWLight -type f -name "*.html" -print0 | xargs -0 sed -i 's/{% blocktranslate %}/{% blocktranslate trimmed %}/g'`
- replaces deprecated `blocktrans` tags with `blocktranslate` tags
  - `find TWLight -type f -name "*.html" -print0 | xargs -0 sed -i 's/{% blocktrans /{% blocktranslate /g`
  - `find TWLight -type f -name "*.html" -print0 | xargs -0 sed -i 's/endblocktrans %}/endblocktranslate %}/g'`

## Rationale
This will resolve some newline issues with translatewiki, and allow more localizations to appear in the platform.

## Phabricator Ticket
https://phabricator.wikimedia.org/T283222

## How Has This Been Tested?
I've run through the translation steps and verified that the newline errors are significantly reduced. I spot checked the non `qqq` errors and they seemed to be stray newlines in the translations from translatewiki. Marked as breaking change since this unmatches some existing translations.

## Screenshots of your changes (if appropriate):
[//]: # (It can also be a GIF to prove that your changes are working)

## Types of changes
What types of changes does your code introduce? Add an `x` in all the boxes that apply:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Minor change (fix a typo, add a translation tag, add section to README, etc.)
