### PR TITLE
Fix More Info bug that reverted text to English

### DIFF
--- a/TWLight/templates/homepage.html
+++ b/TWLight/templates/homepage.html
@@ -334,6 +334,8 @@
     // Getting the "More info" translation from the first button element
     var partnerButtons = document.getElementsByClassName("partner-glider-button");
     var partnerText = partnerButtons[0].innerText;
+    // Getting the Less info text from the view
+    var lessInfo = "{{ less_info }}";
 
     function toggleDescription(partnerId) {
       // Before toggling the description, search if there are any descriptions
@@ -373,7 +375,7 @@
       // If the invisible class exists in the partner image, then the button
       // needs to show "Less info"
       if (partnerImage.classList.contains("invisible")) {
-        partnerButton.innerHTML = "Less info";
+        partnerButton.innerHTML = lessInfo;
       } else {
         partnerButton.innerHTML = partnerText;
       }

--- a/TWLight/templates/homepage.html
+++ b/TWLight/templates/homepage.html
@@ -331,6 +331,10 @@
     $(function () {
       $('[data-toggle="tooltip"]').tooltip()
     });
+    // Getting the "More info" translation from the first button element
+    var partnerButtons = document.getElementsByClassName("partner-glider-button");
+    var partnerText = partnerButtons[0].innerText;
+
     function toggleDescription(partnerId) {
       // Before toggling the description, search if there are any descriptions
       // already toggled and flip them to the image
@@ -347,7 +351,6 @@
           partnerContainer.classList.toggle("partner-description-toggled");
         }
       }
-
       toggleElement("partner-image-" + partnerId);
       toggleElement("partner-description-" + partnerId);
       togglePartnerButton(partnerId);
@@ -372,7 +375,7 @@
       if (partnerImage.classList.contains("invisible")) {
         partnerButton.innerHTML = "Less info";
       } else {
-        partnerButton.innerHTML = "More info";
+        partnerButton.innerHTML = partnerText;
       }
     }
   </script>

--- a/TWLight/templates/homepage.html
+++ b/TWLight/templates/homepage.html
@@ -331,11 +331,6 @@
     $(function () {
       $('[data-toggle="tooltip"]').tooltip()
     });
-    // Getting the "More info" translation from the first button element
-    var partnerButtons = document.getElementsByClassName("partner-glider-button");
-    var partnerText = partnerButtons[0].innerText;
-    // Getting the Less info text from the view
-    var lessInfo = "{{ less_info }}";
 
     function toggleDescription(partnerId) {
       // Before toggling the description, search if there are any descriptions
@@ -375,9 +370,11 @@
       // If the invisible class exists in the partner image, then the button
       // needs to show "Less info"
       if (partnerImage.classList.contains("invisible")) {
-        partnerButton.innerHTML = lessInfo;
+        {% comment %} Translators: This text will show when a user clicks on the More Info button and the partner description shows. {% endcomment %}
+        partnerButton.innerHTML = "{% trans 'Less info' %}";
       } else {
-        partnerButton.innerHTML = partnerText;
+        {% comment %}Translators: A button that reveals more information about a collection.{% endcomment %}
+        partnerButton.innerHTML = "{% trans 'More info' %}";
       }
     }
   </script>

--- a/TWLight/views.py
+++ b/TWLight/views.py
@@ -181,9 +181,6 @@ class NewHomePageView(TemplateView):
             )
         context["partners"] = partners_obj
 
-        # Translators: This text will show when a user clicks on the More Info button and the partner description shows.
-        context["less_info"] = _("Less info")
-
         return context
 
     def get(self, request):

--- a/TWLight/views.py
+++ b/TWLight/views.py
@@ -181,6 +181,9 @@ class NewHomePageView(TemplateView):
             )
         context["partners"] = partners_obj
 
+        # Translators: This text will show when a user clicks on the More Info button and the partner description shows.
+        context["less_info"] = _("Less info")
+
         return context
 
     def get(self, request):


### PR DESCRIPTION
[//]: # (Thank you for uploading a PR to the Wikipedia Library!)

## Description
Fixed a bug where the `More Info` button would revert back to English instead of a user's chosen language when the button was clicked again.

## Rationale
[//]: # (Why is this change required? What problem does it solve?)
Fixes a bug that was created a less enjoyable experience for non-English users.

## Phabricator Ticket
[//]: # (Link to the Phabricator ticket)
[T287577](https://phabricator.wikimedia.org/T287577)

## How Has This Been Tested?
[//]: # (- Did you add tests to your changes? Did you modify tests to accommodate your changes?)
[//]: # (- Can this change be tested manually? How?)
Tested manually in the interface

## Screenshots of your changes (if appropriate):
[//]: # (It can also be a GIF to prove that your changes are working)

**Before**
![Before_fix](https://user-images.githubusercontent.com/7854953/127936256-01a6b291-ad5b-4db9-aba4-ee6643f02c00.gif)


**After**
![After_fix](https://user-images.githubusercontent.com/7854953/127936278-ea18e2e3-27f1-4716-83ef-5193ff4ceab8.gif)



## Types of changes
What types of changes does your code introduce? Add an `x` in all the boxes that apply:
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Minor change (fix a typo, add a translation tag, add section to README, etc.)
