### PR TITLE
Add `Waitlisted` and `Not Available` badges in collection tiles

### DIFF
--- a/TWLight/static/css/new-local.css
+++ b/TWLight/static/css/new-local.css
@@ -734,6 +734,11 @@ NEW MY LIBRARY COLLECTION TILES CSS
     background-color: #AAADB0;
 }
 
+.collection-waitlisted-badge{
+    color: #000000;
+    background-color: #F0AD4E;
+}
+
 .collection-not-available-badge{
     color: #000000;
     background-color: #FF8585;

--- a/TWLight/static/css/new-local.css
+++ b/TWLight/static/css/new-local.css
@@ -734,6 +734,11 @@ NEW MY LIBRARY COLLECTION TILES CSS
     background-color: #AAADB0;
 }
 
+.collection-not-available-badge{
+    color: #000000;
+    background-color: #FF8585;
+}
+
 .expiry-date-text{
     font-size: 13px;
     text-align: right;

--- a/TWLight/static/css/new-local.rtl.css
+++ b/TWLight/static/css/new-local.rtl.css
@@ -759,6 +759,11 @@ NEW MY LIBRARY CSS
     background-color: #AAADB0;
 }
 
+.collection-waitlisted-badge{
+    color: #000000;
+    background-color: #F0AD4E;
+}
+
 .collection-not-available-badge{
     color: #000000;
     background-color: #FF8585;

--- a/TWLight/static/css/new-local.rtl.css
+++ b/TWLight/static/css/new-local.rtl.css
@@ -759,6 +759,11 @@ NEW MY LIBRARY CSS
     background-color: #AAADB0;
 }
 
+.collection-not-available-badge{
+    color: #000000;
+    background-color: #FF8585;
+}
+
 .expiry-date-text{
     font-size: 13px;
     text-align: left;

--- a/TWLight/users/templates/users/available_collection_tile.html
+++ b/TWLight/users/templates/users/available_collection_tile.html
@@ -34,11 +34,18 @@
             </a>
           {% endfor %}
         {% endif %}
+        {% if available_collection.is_not_available %}
+          <span class="badge badge-pill collection-not-available-badge">
+            {% comment %}Translators: On the MyLibrary page (https://wikipedialibrary.wmflabs.org/users/my_library), this badge is shown when a collection is not available. {% endcomment %}
+            {% trans "Not Available" %}
+          </span>
+        {% endif %}
       </p>
     </div>
     <div class="card-footer">
       <a href="{% url 'applications:apply_single' available_collection.pk %}"
-          class="btn btn-sm access-apply-button" type="button" name="button">
+          class="btn btn-sm access-apply-button {% if available_collection.is_not_available %} disabled {% endif %}"
+          type="button" name="button">
         {% comment %}Translators: On the My Library page (https://wikipedialibrary.wmflabs.org/users/my_library), this labels the text on a button which takes the user to the partner's application page, where they can apply for access. {% endcomment %}
         {% trans "Apply" %}
       </a>

--- a/TWLight/users/templates/users/available_collection_tile.html
+++ b/TWLight/users/templates/users/available_collection_tile.html
@@ -34,6 +34,12 @@
             </a>
           {% endfor %}
         {% endif %}
+        {% if available_collection.is_waitlisted %}
+          <span class="badge badge-pill collection-waitlisted-badge">
+            {% comment %}Translators: On the MyLibrary page (https://wikipedialibrary.wmflabs.org/users/my_library), this badge is shown when a collection is waitlisted. {% endcomment %}
+            {% trans "Waitlisted" %}
+          </span>
+        {% endif %}
         {% if available_collection.is_not_available %}
           <span class="badge badge-pill collection-not-available-badge">
             {% comment %}Translators: On the MyLibrary page (https://wikipedialibrary.wmflabs.org/users/my_library), this badge is shown when a collection is not available. {% endcomment %}

--- a/TWLight/users/templates/users/user_collection_tile.html
+++ b/TWLight/users/templates/users/user_collection_tile.html
@@ -25,12 +25,6 @@
           {% comment %}Translators: On the MyLibrary page (https://wikipedialibrary.wmflabs.org/users/my_library), this text is shown for a partner who has no content languages to show. {% endcomment %}
           {% trans "Language(s) not known" %}
         {% endif %}
-        {% if user_collection_partner.is_not_available %}
-          <span class="badge badge-pill collection-not-available-badge">
-            {% comment %}Translators: On the MyLibrary page (https://wikipedialibrary.wmflabs.org/users/my_library), this badge is shown when a collection is not available. {% endcomment %}
-            {% trans "Not Available" %}
-          </span>
-        {% endif %}
       </p>
       <p class="card-text">
         {% if user_collection_partner.tags %}
@@ -39,6 +33,18 @@
               {{ tag_value }}
             </a>
           {% endfor %}
+        {% endif %}
+        {% if user_collection_partner.is_waitlisted and user_collection.has_expired %}
+          <span class="badge badge-pill collection-waitlisted-badge">
+            {% comment %}Translators: On the MyLibrary page (https://wikipedialibrary.wmflabs.org/users/my_library), this badge is shown when a collection is waitlisted. {% endcomment %}
+            {% trans "Waitlisted" %}
+          </span>
+        {% endif %}
+        {% if user_collection_partner.is_not_available %}
+          <span class="badge badge-pill collection-not-available-badge">
+            {% comment %}Translators: On the MyLibrary page (https://wikipedialibrary.wmflabs.org/users/my_library), this badge is shown when a collection is not available. {% endcomment %}
+            {% trans "Not Available" %}
+          </span>
         {% endif %}
       </p>
     </div>

--- a/TWLight/users/templates/users/user_collection_tile.html
+++ b/TWLight/users/templates/users/user_collection_tile.html
@@ -25,6 +25,12 @@
           {% comment %}Translators: On the MyLibrary page (https://wikipedialibrary.wmflabs.org/users/my_library), this text is shown for a partner who has no content languages to show. {% endcomment %}
           {% trans "Language(s) not known" %}
         {% endif %}
+        {% if user_collection_partner.is_not_available %}
+          <span class="badge badge-pill collection-not-available-badge">
+            {% comment %}Translators: On the MyLibrary page (https://wikipedialibrary.wmflabs.org/users/my_library), this badge is shown when a collection is not available. {% endcomment %}
+            {% trans "Not Available" %}
+          </span>
+        {% endif %}
       </p>
       <p class="card-text">
         {% if user_collection_partner.tags %}

--- a/TWLight/users/views.py
+++ b/TWLight/users/views.py
@@ -966,6 +966,8 @@ class MyLibraryView(TemplateView):
                             "tags": translated_tags,
                             "authorization_method": user_authorization_partner.authorization_method,
                             "access_url": user_authorization_partner.get_access_url,
+                            "is_not_available": user_authorization_partner.is_not_available,
+                            "is_waitlisted": user_authorization_partner.is_waitlisted,
                         }
                     )
                     partner_id_set.add(user_authorization_partner.pk)
@@ -1067,6 +1069,8 @@ class MyLibraryView(TemplateView):
                     "description": partner_descriptions["description"],
                     "languages": available_collection.get_languages,
                     "tags": translated_tags,
+                    "is_not_available": available_collection.is_not_available,
+                    "is_waitlisted": available_collection.is_waitlisted,
                 }
             )
 


### PR DESCRIPTION
[//]: # (Thank you for uploading a PR to the Wikipedia Library!)

## Description
Add `Waitlisted` and `Not Available` badges in collection tiles for both available collections and user collections. 

## Rationale
[//]: # (Why is this change required? What problem does it solve?)
In the current iteration of the new My Library card design, we're missing indicators for when that content is Waitlisted or Not Available.


## Phabricator Ticket
[//]: # (Link to the Phabricator ticket)
[T287665](https://phabricator.wikimedia.org/T287665)

## How Has This Been Tested?
[//]: # (- Did you add tests to your changes? Did you modify tests to accommodate your changes?)
[//]: # (- Can this change be tested manually? How?)
Tested manually

## Screenshots of your changes (if appropriate):
[//]: # (It can also be a GIF to prove that your changes are working)
![Screen Shot 2021-08-03 at 16 42 22](https://user-images.githubusercontent.com/7854953/128091018-450ebcce-2181-47e5-a2b3-99cea704a515.png)


![Screen Shot 2021-08-03 at 16 42 37](https://user-images.githubusercontent.com/7854953/128091020-1aa5e6f0-746e-4b89-b50f-7999fd903a94.png)


## Types of changes
What types of changes does your code introduce? Add an `x` in all the boxes that apply:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Minor change (fix a typo, add a translation tag, add section to README, etc.)
