### PR TITLE
Mark filter labels in My Library for translation

### DIFF
--- a/TWLight/resources/filters.py
+++ b/TWLight/resources/filters.py
@@ -1,14 +1,25 @@
-import django_filters
+from django.utils.translation import gettext as _
 
 from .models import Language, Partner
 from .helpers import get_tag_choices
 
+import django_filters
+
 
 class PartnerFilter(django_filters.FilterSet):
+
     tags = django_filters.ChoiceFilter(
-        label="Tags", choices=get_tag_choices(), method="tags_filter"
+        # Translators: On the MyLibrary page (https://wikipedialibrary.wmflabs.org/users/my_library), this text is shown to indicate how many subject areas a collection covers.
+        label=_("Tags"),
+        choices=get_tag_choices(),
+        method="tags_filter",
     )
-    languages = django_filters.ModelChoiceFilter(queryset=Language.objects.all())
+
+    languages = django_filters.ModelChoiceFilter(
+        # Translators: On the MyLibrary page (https://wikipedialibrary.wmflabs.org/users/my_library), this text is shown to indicate how many languages a collection supports.
+        label=_("Languages"),
+        queryset=Language.objects.all(),
+    )
 
     def __init__(self, *args, **kwargs):
         # grab "language_code" from kwargs and then remove it so we can call super()


### PR DESCRIPTION
[//]: # (Thank you for uploading a PR to the Wikipedia Library!)

## Description
Wrap my library filter labels in `gettext` function and add translator comments.

## Rationale
All user-facing messages need to be localized

## Phabricator Ticket
https://phabricator.wikimedia.org/T288520

## How Has This Been Tested?

- manually verified that the English works identically to current behavior
- ran `bin/virtualenv_translate.sh force` and verified that the filter labels are now available for localization

## Screenshots of your changes (if appropriate):
[//]: # (It can also be a GIF to prove that your changes are working)

## Types of changes
What types of changes does your code introduce? Add an `x` in all the boxes that apply:
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Minor change (fix a typo, add a translation tag, add section to README, etc.)
