### PR TITLE
Sort `my_library` collections alphabetically

### DIFF
--- a/TWLight/users/templates/users/collections_section.html
+++ b/TWLight/users/templates/users/collections_section.html
@@ -30,9 +30,7 @@
     <!-- User Collections -->
     <div class="row">
         {% for user_collection in user_collections %}
-          {% for user_collection_partner in user_collection.partners%}
-            {% include "users/user_collection_tile.html" %}
-          {% endfor %}
+          {% include "users/user_collection_tile.html" %}
         {% endfor %}
     </div>
     <!-- Expired User Collections -->
@@ -44,9 +42,7 @@
       </h3>
       <div class="row">
         {% for user_collection in expired_user_collections %}
-          {% for user_collection_partner in user_collection.partners%}
-            {% include "users/user_collection_tile.html" %}
-          {% endfor %}
+          {% include "users/user_collection_tile.html" %}
         {% endfor %}
       </div>
     {% endif %}

--- a/TWLight/users/templates/users/user_collection_tile.html
+++ b/TWLight/users/templates/users/user_collection_tile.html
@@ -1,24 +1,24 @@
 {% load i18n %}
 <div class="col-xl-3 col-lg-4 col-md-6 col-sm-12">
   <div class="card collection-tile">
-    {% if user_collection_partner.partner_logo %}
-      <a href="{% url 'partners:detail' user_collection_partner.pk %}" class="tile-partner-link">
-        <img src="{{ user_collection_partner.partner_logo }}" class="card-img-top library-tile-image"
-          alt="{{ user_collection_partner.partner_name }} logo">
+    {% if user_collection.partner_logo %}
+      <a href="{% url 'partners:detail' user_collection.partner_pk %}" class="tile-partner-link">
+        <img src="{{ user_collection.partner_logo }}" class="card-img-top library-tile-image"
+          alt="{{ user_collection.partner_name }} logo">
       </a>
     {% else %}
-      <a href="{% url 'partners:detail' user_collection_partner.pk %}" class="tile-partner-link">
-        <img src="..." class="card-img-top" alt="{{ user_collection_partner.partner_name }} logo">
+      <a href="{% url 'partners:detail' user_collection.partner_pk %}" class="tile-partner-link">
+        <img src="..." class="card-img-top" alt="{{ user_collection.partner_name }} logo">
       </a>
     {% endif %}
     <div class="card-body">
-      <p class="card-text">{{ user_collection_partner.short_description|safe }}</p>
+      <p class="card-text">{{ user_collection.partner_short_description|safe }}</p>
       <hr>
       <p class="card-text small">
         {% comment %}Translators: On the MyLibrary page (https://wikipedialibrary.wmflabs.org/users/my_library), this text is shown to indicate how many languages a collection supports. {% endcomment %}
         <strong> {% trans "Languages" %}: </strong>
-        {% if user_collection_partner.languages %}
-          {% for language in user_collection_partner.languages%}
+        {% if user_collection.partner_languages %}
+          {% for language in user_collection.partner_languages%}
             {{ language }}{% if not forloop.last %}, {% endif %}
           {% endfor %}
         {% else %}
@@ -27,20 +27,20 @@
         {% endif %}
       </p>
       <p class="card-text">
-        {% if user_collection_partner.tags %}
-          {% for tag_key, tag_value in user_collection_partner.tags.items %}
+        {% if user_collection.partner_tags %}
+          {% for tag_key, tag_value in user_collection.partner_tags.items %}
             <a href="{% url 'users:my_library' %}?tags={{ tag_key }}" class="badge badge-pill collection-tags">
               {{ tag_value }}
             </a>
           {% endfor %}
         {% endif %}
-        {% if user_collection_partner.is_waitlisted and user_collection.has_expired %}
+        {% if user_collection.partner_is_waitlisted and user_collection.auth_has_expired %}
           <span class="badge badge-pill collection-waitlisted-badge">
             {% comment %}Translators: On the MyLibrary page (https://wikipedialibrary.wmflabs.org/users/my_library), this badge is shown when a collection is waitlisted. {% endcomment %}
             {% trans "Waitlisted" %}
           </span>
         {% endif %}
-        {% if user_collection_partner.is_not_available %}
+        {% if user_collection.partner_is_not_available %}
           <span class="badge badge-pill collection-not-available-badge">
             {% comment %}Translators: On the MyLibrary page (https://wikipedialibrary.wmflabs.org/users/my_library), this badge is shown when a collection is not available. {% endcomment %}
             {% trans "Not Available" %}
@@ -49,32 +49,32 @@
       </p>
     </div>
     <div class="card-footer">
-      {% if user_collection_partner.authorization_method != bundle_authorization %}
-        {% if user_collection.date_expires %}
+      {% if user_collection.partner_authorization_method != bundle_authorization %}
+        {% if user_collection.auth_date_expires %}
           <p class="expiry-date-text">
             {% comment %}Translators: On the My Library page (https://wikipedialibrary.wmflabs.org/users/my_library), this labels when a subscription on a collection expired. {% endcomment %}
-            {% trans "Expiry date" %}: <span {% if user_collection.has_expired %} class="text-danger" {% endif %}> {{ user_collection.date_expires|date:"M d, Y" }} </span>
-            {% if user_collection_partner.authorization_method == proxy_authorization and user_collection.is_valid %}
+            {% trans "Expiry date" %}: <span {% if user_collection.auth_has_expired %} class="text-danger" {% endif %}> {{ user_collection.auth_date_expires|date:"M d, Y" }} </span>
+            {% if user_collection.partner_authorization_method == proxy_authorization and user_collection.auth_is_valid %}
               {% comment %}Translators: A button when clicked takes users to a confirmation page to return their access for a particular resource. {% endcomment %}
-              <a href="{% url 'users:return_authorization' user_collection.pk %}"
+              <a href="{% url 'users:return_authorization' user_collection.auth_pk %}"
                   class="btn btn-sm btn-outline-danger">
                 <i class="fa fa-times" title="{% trans 'Click to return this access' %}"></i>
               </a>
             {% endif %}
           </p>
         {% endif %}
-        {% if user_collection.open_app %}
-          <a href="{% url 'applications:evaluate' user_collection.open_app.pk %}" class="btn btn-sm access-apply-button"
+        {% if user_collection.auth_open_app %}
+          <a href="{% url 'applications:evaluate' user_collection.auth_open_app.pk %}" class="btn btn-sm access-apply-button"
                 type="button" name="button">
             {% comment %}Translators: On the My Library page (https://wikipedialibrary.wmflabs.org/users/my_library), this labels the text on a button which takes the user to an open application. {% endcomment %}
             {% trans "Go to application" %}
           </a>
         {% else %}
-          {% if user_collection.latest_sent_app %}
-            {% if not user_collection.has_expired %}
-              <a href="{{ user_collection_partner.access_url }}" class="btn btn-sm access-apply-button"
+          {% if user_collection.auth_latest_sent_app %}
+            {% if not user_collection.auth_has_expired %}
+              <a href="{{ user_collection.partner_access_url }}" class="btn btn-sm access-apply-button"
                     type="button" name="button" target="_blank" rel="noopener">
-                {% if user_collection_partner.authorization_method != proxy_authorization %}
+                {% if user_collection.partner_authorization_method != proxy_authorization %}
                     {% comment %}Translators: On the My Library page (https://wikipedialibrary.wmflabs.org/users/my_library), this labels the text on a button which takes the user to the partner's site. {% endcomment %}
                     {% trans "Go to site" %}
                 {% else %}
@@ -83,9 +83,9 @@
                 {% endif %}
               </a>
             {% endif %}
-            <a href="{% url 'applications:renew' user_collection.latest_sent_app.pk %}"
+            <a href="{% url 'applications:renew' user_collection.auth_latest_sent_app.pk %}"
                   class="btn btn-sm renew-extend-button pull-right" type="button" name="button">
-              {% if user_collection.date_expires and user_collection.has_expired %}
+              {% if user_collection.auth_date_expires and user_collection.auth_has_expired %}
                 {% comment %}Translators: Labels a button users can click to renew an expired account. {% endcomment %}
                 {% trans "Renew" %}
               {% else %}
@@ -96,7 +96,7 @@
           {% endif %}
         {% endif %}
       {% else %}
-          <a href="{{ user_collection_partner.access_url }}" class="btn btn-sm access-apply-button"
+          <a href="{{ user_collection.partner_access_url }}" class="btn btn-sm access-apply-button"
                   type="button" name="button" target="_blank" rel="noopener">
               {% comment %}Translators: On the My Library page (https://wikipedialibrary.wmflabs.org/users/my_library), this labels the text on a button which takes the user to the partner's site. {% endcomment %}
               {% trans "Access collection" %}


### PR DESCRIPTION
[//]: # (Thank you for uploading a PR to the Wikipedia Library!)

## Description
This flattens out the `user_collections` and `expired_user_collections` context lists so that there is one partner per object instead of one auth per object with a nested list of partners. This makes sorting by partner name trivial.

## Rationale
We used to intentionally put bundle partners first, but now we want flat partner sorting

## Phabricator Ticket
https://phabricator.wikimedia.org/T288608

## How Has This Been Tested?
I've done manual testing of current and expired auths under two separate accounts, and of course unit tests are passing.

## Screenshots of your changes (if appropriate):
Now bundle partners and individually-authorized partners are mixed together and sorted by partner name:
![image](https://user-images.githubusercontent.com/2986893/129086837-e4811984-7742-48a4-a845-9cfb9505cd57.png)

## Types of changes
What types of changes does your code introduce? Add an `x` in all the boxes that apply:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Minor change (fix a typo, add a translation tag, add section to README, etc.)
