### PR TITLE
Fix 'Access Collection' button for partners with streams

### DIFF
--- a/TWLight/users/views.py
+++ b/TWLight/users/views.py
@@ -901,6 +901,13 @@ class MyLibraryView(TemplateView):
                         language_code, user_authorization_partner.new_tags
                     )
 
+                    # Use the partner access url by default.
+                    access_url = user_authorization_partner.get_access_url
+                    # If the authorization is for a stream, and that stream has an access url, use it.
+                    stream = user_authorization.stream
+                    if stream and stream.get_access_url:
+                        access_url = stream.get_access_url
+
                     user_authorization_obj.append(
                         {
                             "auth_pk": user_authorization.pk,
@@ -920,7 +927,7 @@ class MyLibraryView(TemplateView):
                             "partner_languages": user_authorization_partner.get_languages,
                             "partner_tags": translated_tags,
                             "partner_authorization_method": user_authorization_partner.authorization_method,
-                            "partner_access_url": user_authorization_partner.get_access_url,
+                            "partner_access_url": access_url,
                             "partner_is_not_available": user_authorization_partner.is_not_available,
                             "partner_is_waitlisted": user_authorization_partner.is_waitlisted,
                         }


### PR DESCRIPTION
[//]: # (Thank you for uploading a PR to the Wikipedia Library!)

## Description
My library tiles now use `stream.access_url` if available. Otherwise maintains current behavior.

## Rationale
Stream/Collections in My Library don't currently have working access URLs; this is a problem for an online library.

## Phabricator Ticket
https://phabricator.wikimedia.org/T289124

## How Has This Been Tested?
- I manually tested by adding and removing stream access urls and checking the access urls in my library.

## Screenshots of your changes (if appropriate):
N/A

## Types of changes
What types of changes does your code introduce? Add an `x` in all the boxes that apply:
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Minor change (fix a typo, add a translation tag, add section to README, etc.)
