### PR TITLE
use the oldest editor registration date available

### DIFF
--- a/TWLight/users/helpers/editor_data.py
+++ b/TWLight/users/helpers/editor_data.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timedelta
+from datetime import date, datetime, timedelta
 import json
 import logging
 import urllib.request, urllib.error, urllib.parse
@@ -71,17 +71,35 @@ def editor_reg_date(identity: dict, global_userinfo: dict):
     -------
     datetime.date
     """
-    # Try oauth registration date first.  If it's not valid, try the global_userinfo date
+
+    reg_dates = []
+    # Try oauth registration date.
     try:
-        reg_date = datetime.strptime(identity["registered"], "%Y%m%d%H%M%S").date()
+        reg_dates.append(
+            datetime.strptime(identity["registered"], "%Y%m%d%H%M%S").date()
+        )
     except (TypeError, ValueError):
-        try:
-            reg_date = datetime.strptime(
+        pass
+    # Try global_userinfo date
+    try:
+        reg_dates.append(
+            datetime.strptime(
                 global_userinfo["registration"], "%Y-%m-%dT%H:%M:%SZ"
             ).date()
-        except (TypeError, ValueError):
-            reg_date = None
-    return reg_date
+        )
+    except (TypeError, ValueError):
+        pass
+
+    # List sorting is a handy way to get the oldest date.
+    reg_dates.sort()
+    reg_date = reg_dates[0]
+
+    # If we got a date, return it.
+    if isinstance(reg_date, date):
+        return reg_date
+    # If we got something unexpected, return None.
+    else:
+        return None
 
 
 def editor_enough_edits(editcount: int):
@@ -143,7 +161,7 @@ def editor_account_old_enough(wp_registered: datetime.date):
     if wp_registered is None:
         return False
     # Check: registered >= 6 months ago
-    return datetime.today().date() - timedelta(days=182) >= wp_registered
+    return date.today() - timedelta(days=182) >= wp_registered
 
 
 def editor_valid(

--- a/TWLight/users/models.py
+++ b/TWLight/users/models.py
@@ -645,11 +645,10 @@ class Editor(models.Model):
             )
             self.wp_not_blocked = editor_not_blocked(global_userinfo["merged"])
 
-        if self.wp_registered is None:
-            self.wp_registered = editor_reg_date(identity, global_userinfo)
         # if the account is already old enough, we shouldn't run this check everytime
         # since this flag should never return back to False
-        if not self.wp_account_old_enough:
+        if self.wp_registered is None or not self.wp_account_old_enough:
+            self.wp_registered = editor_reg_date(identity, global_userinfo)
             self.wp_account_old_enough = editor_account_old_enough(self.wp_registered)
 
         self.wp_enough_edits = editor_enough_edits(self.wp_editcount)


### PR DESCRIPTION
## Description
If an editor is not eligible based on account age, check both oauth and globaluser_info registration dates when available, and use the oldest date.

## Rationale
Do to the way SUL works, some editor registration dates differ between oauth and globaluser_info. We currently prefer the oauth date, which can be newer than the globaluser_info date. This prevents editors who should be eligible from accessing resources.

## Phabricator Ticket
https://phabricator.wikimedia.org/T287240

## How Has This Been Tested?
I added some new unit tests to verify this behavior. I don't have an account with this date difference to do manual testing, but I was able to verify that this change doesn't break things for users that aren't already having a problem.

## Screenshots of your changes (if appropriate):
N/A

## Types of changes
What types of changes does your code introduce? Add an `x` in all the boxes that apply:
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Minor change (fix a typo, add a translation tag, add section to README, etc.)
