### PR TITLE
Change server validation error to admin error.

### DIFF
--- a/TWLight/resources/models.py
+++ b/TWLight/resources/models.py
@@ -279,7 +279,12 @@ class Partner(models.Model):
     )
 
     # New tag model that uses JSONField instead of Taggit to make tags translatable
-    new_tags = models.JSONField(null=True, default=None, blank=True)
+    new_tags = models.JSONField(
+        null=True,
+        default=None,
+        blank=True,
+        help_text="Enter a valid Tag in the form &ltTagName_tag&gt.",
+    )
 
     # Non-universal form fields
     # --------------------------------------------------------------------------
@@ -406,11 +411,6 @@ class Partner(models.Model):
             if not self.target_url:
                 raise ValidationError("Proxy and Bundle partners require a target URL.")
 
-    def get_absolute_url(self):
-        return reverse_lazy("partners:detail", kwargs={"pk": self.pk})
-
-    def save(self, *args, **kwargs):
-        super(Partner, self).save(*args, **kwargs)
         # If new_tags is not empty, validate with JSONSchema
         if self.new_tags is not None:
             try:
@@ -422,6 +422,9 @@ class Partner(models.Model):
                 raise ValidationError(
                     "Error trying to insert a tag: the JSON is invalid"
                 )
+
+    def get_absolute_url(self):
+        return reverse_lazy("partners:detail", kwargs={"pk": self.pk})
 
     @property
     def get_languages(self):


### PR DESCRIPTION
    Bug: T287003

## Description
When an admin enters an invalid tag for a resource, a ValidationError is thrown, presenting the user with a server error message
Instead, it should simply present a red message next to the relevant field, denoting why the object cannot be saved.

## Phabricator Ticket
https://phabricator.wikimedia.org/T287003


## Types of changes
What types of changes does your code introduce? Add an `x` in all the boxes that apply:
- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Minor change (fix a typo, add a translation tag, add section to README, etc.)
