### PR TITLE
Change django session cookie age

### DIFF
--- a/TWLight/settings/base.py
+++ b/TWLight/settings/base.py
@@ -231,6 +231,8 @@ SITE_ID = 1
 # Overwrite messages.ERROR to use danger instead, to play nice with bootstrap
 MESSAGE_TAGS = {messages.ERROR: "danger"}
 
+# Overwrite django default SESSION_COOKIE_AGE
+SESSION_COOKIE_AGE = 259200
 
 # INTERNATIONALIZATION CONFIGURATION
 # ------------------------------------------------------------------------------


### PR DESCRIPTION
## Description
We currently expire users' logins at the Django-default of two weeks. We also only update users' Wikimedia username and email address when a user logs in, because fetching this data requires a direct OAuth request. This means users' Wikimedia data can become out of date for up to 2 weeks if they, for example, change their username or email address.

So users' login session should be reduce by 3 days.

## Phabricator Ticket
https://phabricator.wikimedia.org/T255994

## Types of changes
What types of changes does your code introduce? Add an `x` in all the boxes that apply:
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Minor change (fix a typo, add a translation tag, add section to README, etc.)
