### PR TITLE
Include multidisciplinary tag in tag filters

### DIFF
--- a/TWLight/resources/filters.py
+++ b/TWLight/resources/filters.py
@@ -1,3 +1,4 @@
+from django.db.models import Q
 from django.utils.translation import gettext as _
 
 from .models import Language, Partner
@@ -42,5 +43,17 @@ class PartnerFilter(django_filters.FilterSet):
         fields = ["languages"]
 
     def tags_filter(self, queryset, name, value):
+        # Order by ascending tag order if tag name is before multidisciplinary
+        if value < "multidisciplinary_tag":
+            tag_filter = queryset.filter(
+                Q(new_tags__tags__contains=value)
+                | Q(new_tags__tags__contains="multidisciplinary_tag")
+            )
+        # Order by descending tag order if tag name is after multidisciplinary
+        else:
+            tag_filter = queryset.filter(
+                Q(new_tags__tags__contains=value)
+                | Q(new_tags__tags__contains="multidisciplinary_tag")
+            )
 
-        return queryset.filter(new_tags__tags__contains=value)
+        return tag_filter

--- a/TWLight/resources/filters.py
+++ b/TWLight/resources/filters.py
@@ -43,17 +43,8 @@ class PartnerFilter(django_filters.FilterSet):
         fields = ["languages"]
 
     def tags_filter(self, queryset, name, value):
-        # Order by ascending tag order if tag name is before multidisciplinary
-        if value < "multidisciplinary_tag":
-            tag_filter = queryset.filter(
-                Q(new_tags__tags__contains=value)
-                | Q(new_tags__tags__contains="multidisciplinary_tag")
-            )
-        # Order by descending tag order if tag name is after multidisciplinary
-        else:
-            tag_filter = queryset.filter(
-                Q(new_tags__tags__contains=value)
-                | Q(new_tags__tags__contains="multidisciplinary_tag")
-            )
-
+        tag_filter = queryset.filter(
+            Q(new_tags__tags__contains=value)
+            | Q(new_tags__tags__contains="multidisciplinary_tag")
+        )
         return tag_filter

--- a/TWLight/users/tests.py
+++ b/TWLight/users/tests.py
@@ -1659,6 +1659,10 @@ class MyLibraryViewsTest(TestCase):
         cls.proxy_partner_2.new_tags = {"tags": ["earth-sciences_tag"]}
         cls.proxy_partner_2.save()
 
+        cls.bundle_partner_4 = PartnerFactory(authorization_method=Partner.BUNDLE)
+        cls.bundle_partner_4.new_tags = {"tags": ["multidisciplinary_tag"]}
+        cls.bundle_partner_4.save()
+
         cls.user_coordinator = UserFactory(username="Jon Snow")
         cls.editor = EditorFactory()
         cls.editor.wp_bundle_eligible = True
@@ -1711,6 +1715,7 @@ class MyLibraryViewsTest(TestCase):
         self.assertIn(escape(self.bundle_partner_2.company_name), content)
         self.assertIn(escape(self.bundle_partner_3.company_name), content)
         self.assertIn(escape(self.proxy_partner_1.company_name), content)
+        self.assertIn(escape(self.bundle_partner_4.company_name), content)
         # Even though this partner is not visible, it still appears in the HTML
         # render
         self.assertIn(escape(self.proxy_partner_2.company_name), content)
@@ -1892,6 +1897,8 @@ class MyLibraryViewsTest(TestCase):
 
         self.assertIn(escape(self.bundle_partner_2.company_name), content)
         self.assertIn(escape(self.bundle_partner_3.company_name), content)
+        # Multidisciplinary partners should also appear when filtering
+        self.assertIn(escape(self.bundle_partner_4.company_name), content)
 
         self.assertNotIn(escape(self.bundle_partner_1.company_name), content)
         self.assertNotIn(escape(self.proxy_partner_1.company_name), content)
@@ -1944,6 +1951,8 @@ class MyLibraryViewsTest(TestCase):
 
         self.assertNotIn(escape(self.bundle_partner_2.company_name), content)
         self.assertNotIn(escape(self.bundle_partner_3.company_name), content)
+        # Multidisciplinary partners should also appear when filtering
+        self.assertIn(escape(self.bundle_partner_4.company_name), content)
 
         self.assertIn(escape(self.bundle_partner_1.company_name), content)
         self.assertIn(escape(self.proxy_partner_1.company_name), content)

--- a/TWLight/users/tests.py
+++ b/TWLight/users/tests.py
@@ -1651,6 +1651,10 @@ class MyLibraryViewsTest(TestCase):
         cls.bundle_partner_3.new_tags = {"tags": ["art_tag"]}
         cls.bundle_partner_3.save()
 
+        cls.bundle_partner_4 = PartnerFactory(authorization_method=Partner.BUNDLE)
+        cls.bundle_partner_4.new_tags = {"tags": ["multidisciplinary_tag"]}
+        cls.bundle_partner_4.save()
+
         cls.proxy_partner_1 = PartnerFactory(authorization_method=Partner.PROXY)
         cls.proxy_partner_1.new_tags = {"tags": ["earth-sciences_tag"]}
         cls.proxy_partner_1.save()
@@ -1659,9 +1663,9 @@ class MyLibraryViewsTest(TestCase):
         cls.proxy_partner_2.new_tags = {"tags": ["earth-sciences_tag"]}
         cls.proxy_partner_2.save()
 
-        cls.bundle_partner_4 = PartnerFactory(authorization_method=Partner.BUNDLE)
-        cls.bundle_partner_4.new_tags = {"tags": ["multidisciplinary_tag"]}
-        cls.bundle_partner_4.save()
+        cls.proxy_partner_3 = PartnerFactory(authorization_method=Partner.PROXY)
+        cls.proxy_partner_3.new_tags = {"tags": ["multidisciplinary_tag"]}
+        cls.proxy_partner_3.save()
 
         cls.user_coordinator = UserFactory(username="Jon Snow")
         cls.editor = EditorFactory()
@@ -1694,6 +1698,13 @@ class MyLibraryViewsTest(TestCase):
             sent_by=self.user_coordinator,
         )
 
+        app_bundle_partner_4 = ApplicationFactory(
+            status=Application.SENT,
+            editor=self.editor,
+            partner=self.bundle_partner_4,
+            sent_by=self.user_coordinator,
+        )
+
         app_proxy_partner_1 = ApplicationFactory(
             status=Application.SENT,
             editor=self.editor,
@@ -1719,6 +1730,7 @@ class MyLibraryViewsTest(TestCase):
         # Even though this partner is not visible, it still appears in the HTML
         # render
         self.assertIn(escape(self.proxy_partner_2.company_name), content)
+        self.assertIn(escape(self.proxy_partner_3.company_name), content)
 
     def test_user_collections_show_expiry_date_extend(self):
         """
@@ -1877,6 +1889,13 @@ class MyLibraryViewsTest(TestCase):
             sent_by=self.user_coordinator,
         )
 
+        app_bundle_partner_4 = ApplicationFactory(
+            status=Application.SENT,
+            editor=self.editor,
+            partner=self.bundle_partner_4,
+            sent_by=self.user_coordinator,
+        )
+
         app_proxy_partner_1 = ApplicationFactory(
             status=Application.SENT,
             editor=self.editor,
@@ -1899,6 +1918,7 @@ class MyLibraryViewsTest(TestCase):
         self.assertIn(escape(self.bundle_partner_3.company_name), content)
         # Multidisciplinary partners should also appear when filtering
         self.assertIn(escape(self.bundle_partner_4.company_name), content)
+        self.assertIn(escape(self.proxy_partner_3.company_name), content)
 
         self.assertNotIn(escape(self.bundle_partner_1.company_name), content)
         self.assertNotIn(escape(self.proxy_partner_1.company_name), content)
@@ -1929,6 +1949,13 @@ class MyLibraryViewsTest(TestCase):
             sent_by=self.user_coordinator,
         )
 
+        app_bundle_partner_4 = ApplicationFactory(
+            status=Application.SENT,
+            editor=self.editor,
+            partner=self.bundle_partner_4,
+            sent_by=self.user_coordinator,
+        )
+
         app_proxy_partner_1 = ApplicationFactory(
             status=Application.SENT,
             editor=self.editor,
@@ -1953,6 +1980,7 @@ class MyLibraryViewsTest(TestCase):
         self.assertNotIn(escape(self.bundle_partner_3.company_name), content)
         # Multidisciplinary partners should also appear when filtering
         self.assertIn(escape(self.bundle_partner_4.company_name), content)
+        self.assertIn(escape(self.proxy_partner_3.company_name), content)
 
         self.assertIn(escape(self.bundle_partner_1.company_name), content)
         self.assertIn(escape(self.proxy_partner_1.company_name), content)

--- a/TWLight/users/views.py
+++ b/TWLight/users/views.py
@@ -1024,7 +1024,9 @@ class MyLibraryView(TemplateView):
                 }
             )
 
-        context["available_collections"] = available_collection_obj
+        context["available_collections"] = sorted(
+            available_collection_obj, key=lambda k: k["partner_name"]
+        )
         context["number_available_collections"] = len(available_collection_obj)
 
         return context


### PR DESCRIPTION
[//]: # (Thank you for uploading a PR to the Wikipedia Library!)

## Description
Include the `multidisciplinary_tag` when filtering by other tags.

## Rationale
[//]: # (Why is this change required? What problem does it solve?)
Since multidisciplinary collections may have content by which that tag is filtered, they should be included in the filter.

## Phabricator Ticket
[//]: # (Link to the Phabricator ticket)
[T289253](https://phabricator.wikimedia.org/T289253)

## How Has This Been Tested?
[//]: # (- Did you add tests to your changes? Did you modify tests to accommodate your changes?)
[//]: # (- Can this change be tested manually? How?)
Added test cases on existing cases.

Manual testing:
1. Go to `My Library`
2. Filter the collections by a tag
3. Check that the collections are filtered by that tag and that `multidisciplinary` collections are also included

## Screenshots of your changes (if appropriate):
[//]: # (It can also be a GIF to prove that your changes are working)

**Results when filtering by `History` tag**
![Screen Shot 2021-09-13 at 16 39 45](https://user-images.githubusercontent.com/7854953/133160518-0df1b445-24ea-4e9c-8454-8f0b7cccf5aa.png)

![Screen Shot 2021-09-13 at 16 39 53](https://user-images.githubusercontent.com/7854953/133160523-e653d724-e066-4993-b052-d427436d3843.png)


## Types of changes
What types of changes does your code introduce? Add an `x` in all the boxes that apply:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Minor change (fix a typo, add a translation tag, add section to README, etc.)
