### PR TITLE
set date_closed while withdrawing an application

### DIFF
--- a/TWLight/users/tests.py
+++ b/TWLight/users/tests.py
@@ -335,6 +335,8 @@ class ViewsTestCase(TestCase):
             request, pk=self.editor1.pk, id=app.pk
         )
         app.refresh_from_db()
+        # withdrawing application should set date closed
+        self.assertNotEqual(app.date_closed, None)
         self.assertEqual(app.status, Application.INVALID)
 
     def test_sent_application(self):

--- a/TWLight/users/views.py
+++ b/TWLight/users/views.py
@@ -769,7 +769,10 @@ class WithdrawApplication(RedirectView):
     def get_redirect_url(self, *args, **kwargs):
         withdraw_id = kwargs["id"]
         application_id = kwargs["pk"]
-        Application.objects.filter(pk=withdraw_id).update(status=Application.INVALID)
+        applications = Application.objects.filter(pk=withdraw_id)
+        for application in applications:
+            application.status = Application.INVALID
+            application.save()
         message = f"Your application has been withdrawn successfully. Head over to <a href='/users/my_applications/{application_id}'>My Applications</a> to view the status."
         messages.add_message(self.request, messages.SUCCESS, message)
         return super().get_redirect_url(*args, **kwargs)


### PR DESCRIPTION
[//]: # (Thank you for uploading a PR to the Wikipedia Library!)

## Description
When a user withdraws an application it should set the `date_closed` property on it. So that `get_num_days_open` gets calculated properly and we don't see a server error on the detail page of the application.

## Phabricator Ticket
[//]: # (Link to the Phabricator ticket)
https://phabricator.wikimedia.org/T269730

## How Has This Been Tested?
[//]: # (- Did you add tests to your changes? Did you modify tests to accommodate your changes?)
[//]: # (- Can this change be tested manually? How?)
I have added a new test case for this behavior.

## Screenshots of your changes (if appropriate):
[//]: # (It can also be a GIF to prove that your changes are working)

## Types of changes
What types of changes does your code introduce? Add an `x` in all the boxes that apply:
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Minor change (fix a typo, add a translation tag, add section to README, etc.)
