### PR TITLE
Removed Apply button from the /partners collection tiles (T290884) & Reword 'Tags' to 'Topics'(T290845)

### DIFF
--- a/TWLight/resources/filters.py
+++ b/TWLight/resources/filters.py
@@ -11,7 +11,7 @@ class PartnerFilter(django_filters.FilterSet):
 
     tags = django_filters.ChoiceFilter(
         # Translators: On the MyLibrary page (https://wikipedialibrary.wmflabs.org/users/my_library), this text is shown to indicate how many subject areas a collection covers.
-        label=_("Tags"),
+        label=_("Topics"),
         choices=get_tag_choices(),
         method="tags_filter",
     )

--- a/TWLight/resources/templates/resources/partner_tile.html
+++ b/TWLight/resources/templates/resources/partner_tile.html
@@ -76,7 +76,7 @@
       </div>
       <hr />
     {% endif %}
-    <div class="panel-partner-info">
+    <!-- <div class="panel-partner-info">
       <div class="text-center">
         <a href="{% url 'partners:detail' partner.pk %}" class="btn btn-default">
           {% if partner.authorization_method == partner.BUNDLE %}
@@ -89,6 +89,6 @@
         </a>
         <br />
       </div>
-    </div>
+    </div> -->
   </div>
 </div>


### PR DESCRIPTION
Removed Apply button from the /partners collection tiles(T290884)
Reword 'Tags' to 'Topics'(T290845)

[//]: # (Thank you for uploading a PR to the Wikipedia Library!)

## Description
Removed Apply button from the /partners collection tiles(T290884)
Reword 'Tags' to 'Topics'(T290845)

## Rationale


## Phabricator Ticket
https://phabricator.wikimedia.org/T290884
https://phabricator.wikimedia.org/T290845

## How Has This Been Tested?
Yes, manually by adding partner.

## Screenshots of your changes (if appropriate):
![image](https://user-images.githubusercontent.com/28993689/133994708-50ebbd35-bd4e-45bf-9dbc-eb710d21f7a9.png)


## Types of changes
What types of changes does your code introduce? Add an `x` in all the boxes that apply:
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Minor change (fix a typo, add a translation tag, add section to README, etc.)
