### PR TITLE
Removed Apply button from the /partners collection tiles(T290884)

### DIFF
--- a/TWLight/resources/templates/resources/partner_tile.html
+++ b/TWLight/resources/templates/resources/partner_tile.html
@@ -69,6 +69,7 @@
           {% endif %}
       </div>
     </div>
+    <hr />
     {% if partner.short_description %}
       <div class="panel-partner-description">
           {{ partner.short_description | safe }}

--- a/TWLight/resources/templates/resources/partner_tile.html
+++ b/TWLight/resources/templates/resources/partner_tile.html
@@ -69,7 +69,6 @@
           {% endif %}
       </div>
     </div>
-    <hr />
     {% if partner.short_description %}
       <div class="panel-partner-description">
           {{ partner.short_description | safe }}

--- a/TWLight/resources/templates/resources/partner_tile.html
+++ b/TWLight/resources/templates/resources/partner_tile.html
@@ -73,7 +73,6 @@
       <div class="panel-partner-description">
           {{ partner.short_description | safe }}
       </div>
-      <hr />
     {% endif %}
   </div>
 </div>

--- a/TWLight/resources/templates/resources/partner_tile.html
+++ b/TWLight/resources/templates/resources/partner_tile.html
@@ -76,19 +76,5 @@
       </div>
       <hr />
     {% endif %}
-    <!-- <div class="panel-partner-info">
-      <div class="text-center">
-        <a href="{% url 'partners:detail' partner.pk %}" class="btn btn-default">
-          {% if partner.authorization_method == partner.BUNDLE %}
-            {% comment %}Translators: On the Browse page (https://wikipedialibrary.wmflabs.org/partners/), this labels the text on a button which takes the user to the bundle partner's page, where they can find more information about the partner. {% endcomment %}
-            {% trans "More info" %}
-          {% else %}
-            {% comment %}Translators: On the Browse page (https://wikipedialibrary.wmflabs.org/partners/), this labels the text on a button which takes the user to the partner's page, where they can find more information and apply for access. {% endcomment %}
-            {% trans "Apply" %}
-          {% endif %}
-        </a>
-        <br />
-      </div>
-    </div> -->
   </div>
 </div>

--- a/TWLight/resources/templates/resources/partner_tile.html
+++ b/TWLight/resources/templates/resources/partner_tile.html
@@ -76,7 +76,7 @@
       </div>
       <hr />
     {% endif %}
-    <div class="panel-partner-info">
+    <!-- <div class="panel-partner-info">
       <div class="text-center">
         <a href="{% url 'partners:detail' partner.pk %}" class="btn btn-default">
           {% if partner.authorization_method == partner.BUNDLE %}
@@ -89,6 +89,6 @@
         </a>
         <br />
       </div>
-    </div>
+    </div> -->
   </div>
 </div>


### PR DESCRIPTION
Removed Apply button from the /partners collection tiles(T290884)

[//]: # (Thank you for uploading a PR to the Wikipedia Library!)

## Description
Removed Apply button from the /partners collection tiles(T290884)

## Rationale
On https://wikipedialibrary.wmflabs.org/partners/ we still have Apply buttons next to every collection. This is confusing because a) many of these publishers don't need an application b) this page is now almost only used by people who aren't library users and c) it allows ineligible users to still apply for access.

Since this page is mostly for informational purposes at this point, and clicking both the logo and title will take you to the partner page itself, we should remove the 'Apply' button from the tiles.

That tile can be found at https://github.com/WikipediaLibrary/TWLight/blob/master/TWLight/resources/templates/resources/partner_tile.html

## Phabricator Ticket
https://phabricator.wikimedia.org/T290884

## How Has This Been Tested?
Yes, manually by adding partner.

## Screenshots of your changes (if appropriate):
![image](https://user-images.githubusercontent.com/28993689/134005063-45842a66-680c-4331-9760-eafac2564acb.png)


## Types of changes
What types of changes does your code introduce? Add an `x` in all the boxes that apply:
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Minor change (fix a typo, add a translation tag, add section to README, etc.)
