### PR TITLE
Add Editor.ignore_wp_bundle_eligible flag

### DIFF
--- a/TWLight/users/helpers/editor_data.py
+++ b/TWLight/users/helpers/editor_data.py
@@ -210,7 +210,12 @@ def editor_bundle_eligible(editor: "Editor"):
     user_staff_or_superuser = editor.user.is_staff or editor.user.is_superuser
     # Users must accept the terms of use in order to be eligible for bundle access
     user_accepted_terms = editor.user.userprofile.terms_of_use
-    if (enough_edits_and_valid or user_staff_or_superuser) and user_accepted_terms:
+    wp_bundle_eligible = (
+        enough_edits_and_valid or user_staff_or_superuser
+    ) and user_accepted_terms
+    # Except for special users that we use for load testing
+    ignore_wp_bundle_eligible = editor.ignore_wp_bundle_eligible
+    if wp_bundle_eligible or ignore_wp_bundle_eligible:
         return True
     else:
         return False

--- a/TWLight/users/models.py
+++ b/TWLight/users/models.py
@@ -205,6 +205,10 @@ class Editor(models.Model):
         default=False,
         help_text="Ignore the 'not currently blocked' criterion for access?",
     )
+    ignore_wp_bundle_eligible = models.BooleanField(
+        default=False,
+        help_text="Ignore all criteria for bundle access?",
+    )
 
     # ~~~~~~~~~~~~~~~~~~~~~~~~~~~ User-entered data ~~~~~~~~~~~~~~~~~~~~~~~~~~~
     contributions = models.TextField(


### PR DESCRIPTION
[//]: # (Thank you for uploading a PR to the Wikipedia Library!)

## Description
Add an `Editor.ignore_wp_bundle` flag to be able to bypass the bundle requirements when needed

## Rationale
[//]: # (Why is this change required? What problem does it solve?)
This will be primarily used for:
* Locust tests (performance tests)
* Testing certain functions like EDS without having to be bundle eligible

## Phabricator Ticket
[//]: # (Link to the Phabricator ticket)
Related to [T240128](https://phabricator.wikimedia.org/T240128), but first implemented by @jsnshrmn in [T279048](https://phabricator.wikimedia.org/T279048).

## How Has This Been Tested?
[//]: # (- Did you add tests to your changes? Did you modify tests to accommodate your changes?)
[//]: # (- Can this change be tested manually? How?)

## Screenshots of your changes (if appropriate):
[//]: # (It can also be a GIF to prove that your changes are working)

## Types of changes
What types of changes does your code introduce? Add an `x` in all the boxes that apply:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Minor change (fix a typo, add a translation tag, add section to README, etc.)
