### PR TITLE
Improve workflow for suggestions from non-logged in users(T251991)

### DIFF
--- a/TWLight/resources/templates/resources/suggest.html
+++ b/TWLight/resources/templates/resources/suggest.html
@@ -115,4 +115,14 @@
   <script>
     function viewUpvoters(e,suggestion,box){}
   </script>
+  {% if not user.is_authenticated %}
+    <script>
+      {% comment %}Translators: This is to show alert to login first if unauthenticated user tries to fill suggestion form and then will be redirected to login page. {% endcomment %} 
+      var redirectURL="{% url 'oauth_login' %}?next={% url 'suggest' %}";
+      $("#id_suggested_company_name,#id_description, #id_company_url").keyup(function() {
+          alert("You are not logged in. You can't suggest partners without login. You will be redirected to login page.");
+          document.location.href = redirectURL;
+      });
+    </script>
+  {% endif %}
 {% endblock javascript %}


### PR DESCRIPTION
Improve workflow for suggestions from non-logged in users(T251991)

[//]: # (Thank you for uploading a PR to the Wikipedia Library!)

## Description
Improve workflow for suggestions from non-logged in users(T251991)

## Rationale
Users can suggest we pursue a new partnership at https://wikipedialibrary.wmflabs.org/suggest/. This works as expected when the user is logged in.

When the user is logged out, however, they can still enter data to the form. Clicking Submit will attempt to log them in, but then their previously written content is lost.

If this isn't an easy fix, we could instead not allow users to submit the form, prompting them to log in before they write anything.

## Phabricator Ticket
https://phabricator.wikimedia.org/T251991

## How Has This Been Tested?
Yes, manually.

## Screenshots of your changes (if appropriate):
![image](https://user-images.githubusercontent.com/28993689/134158829-d31fac49-ae8a-4feb-b8d4-de2a73e64de3.png)


## Types of changes
What types of changes does your code introduce? Add an `x` in all the boxes that apply:
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [] Minor change (fix a typo, add a translation tag, add section to README, etc.)
