### PR TITLE
Add `searchable` filter to My Library

### DIFF
--- a/TWLight/resources/filters.py
+++ b/TWLight/resources/filters.py
@@ -1,3 +1,4 @@
+from django import forms
 from django.db.models import Q
 from django.utils.translation import gettext as _
 
@@ -22,10 +23,11 @@ class PartnerFilter(django_filters.FilterSet):
         queryset=Language.objects.all(),
     )
 
-    searchable = django_filters.ChoiceFilter(
+    searchable = django_filters.MultipleChoiceFilter(
         # Translators: On the MyLibrary page (https://wikipedialibrary.wmflabs.org/users/my_library), this text is shown to indicate if a collection is searchable.
         label=_("Searchable"),
         choices=Partner.SEARCHABLE_CHOICES,
+        widget=forms.CheckboxSelectMultiple,
     )
 
     def __init__(self, *args, **kwargs):
@@ -44,7 +46,7 @@ class PartnerFilter(django_filters.FilterSet):
             {"class": "form-control form-control-sm"}
         )
         self.filters["searchable"].field.widget.attrs.update(
-            {"class": "form-control form-control-sm"}
+            {"class": "searchable-form"}
         )
 
     class Meta:

--- a/TWLight/resources/filters.py
+++ b/TWLight/resources/filters.py
@@ -22,6 +22,12 @@ class PartnerFilter(django_filters.FilterSet):
         queryset=Language.objects.all(),
     )
 
+    searchable = django_filters.ChoiceFilter(
+        # Translators: On the MyLibrary page (https://wikipedialibrary.wmflabs.org/users/my_library), this text is shown to indicate if a collection is searchable.
+        label=_("Searchable"),
+        choices=Partner.SEARCHABLE_CHOICES,
+    )
+
     def __init__(self, *args, **kwargs):
         # grab "language_code" from kwargs and then remove it so we can call super()
         language_code = None
@@ -35,6 +41,9 @@ class PartnerFilter(django_filters.FilterSet):
             {"class": "form-control form-control-sm"}
         )
         self.filters["languages"].field.widget.attrs.update(
+            {"class": "form-control form-control-sm"}
+        )
+        self.filters["searchable"].field.widget.attrs.update(
             {"class": "form-control form-control-sm"}
         )
 

--- a/TWLight/static/css/new-local.css
+++ b/TWLight/static/css/new-local.css
@@ -738,12 +738,23 @@ NEW MY LIBRARY CSS
 
 .collection-filter-label{
     font-size: 14px;
-    text-align: left;
     font-weight: 500;
 }
 
-.collection-filter-button{
-    margin-top: 20px;
+.searchable-form{
+    font-size: 14px;
+    list-style: none;
+    padding: 0px;
+}
+
+label{
+    font-size: 14px;
+    font-weight: 500;
+}
+
+#id_searchable li label{
+    font-size: 14px;
+    font-weight: 400;
 }
 
 .v-divider{

--- a/TWLight/static/css/new-local.rtl.css
+++ b/TWLight/static/css/new-local.rtl.css
@@ -753,12 +753,23 @@ NEW MY LIBRARY CSS
 
 .collection-filter-label{
     font-size: 14px;
-    text-align: left;
     font-weight: 500;
 }
 
-.collection-filter-button{
-    margin-top: 20px;
+.searchable-form{
+    font-size: 14px;
+    list-style: none;
+    padding: 0px;
+}
+
+label{
+    font-size: 14px;
+    font-weight: 500;
+}
+
+#id_searchable li label{
+    font-size: 14px;
+    font-weight: 300;
 }
 
 .v-divider{

--- a/TWLight/users/templates/users/redesigned_my_library.html
+++ b/TWLight/users/templates/users/redesigned_my_library.html
@@ -25,11 +25,9 @@
     // Dynamically add classes to the django-filter generated labels
     labelLanguages = document.querySelector("[for=id_languages]")
     labelTags = document.querySelector("[for=id_tags]")
-    labelSearchable = document.querySelector("[for=id_searchable]")
 
     labelLanguages.classList.add("collection-filter-label");
     labelTags.classList.add("collection-filter-label");
-    labelSearchable.classList.add("collection-filter-label");
   </script>
 
 {% endblock %}

--- a/TWLight/users/templates/users/redesigned_my_library.html
+++ b/TWLight/users/templates/users/redesigned_my_library.html
@@ -25,9 +25,11 @@
     // Dynamically add classes to the django-filter generated labels
     labelLanguages = document.querySelector("[for=id_languages]")
     labelTags = document.querySelector("[for=id_tags]")
+    labelSearchable = document.querySelector("[for=id_searchable]")
 
     labelLanguages.classList.add("collection-filter-label");
     labelTags.classList.add("collection-filter-label");
+    labelSearchable.classList.add("collection-filter-label");
   </script>
 
 {% endblock %}

--- a/TWLight/users/tests.py
+++ b/TWLight/users/tests.py
@@ -1642,24 +1642,39 @@ class MyLibraryViewsTest(TestCase):
         cls.bundle_partner_1 = PartnerFactory(
             authorization_method=Partner.BUNDLE,
             new_tags={"tags": ["earth-sciences_tag"]},
+            searchable=Partner.SEARCHABLE,
         )
         cls.bundle_partner_2 = PartnerFactory(
-            authorization_method=Partner.BUNDLE, new_tags={"tags": ["art_tag"]}
+            authorization_method=Partner.BUNDLE,
+            new_tags={"tags": ["art_tag"]},
+            searchable=Partner.PARTIALLY_SEARCHABLE,
         )
 
-        cls.bundle_partner_3 = PartnerFactory(authorization_method=Partner.BUNDLE)
+        cls.bundle_partner_3 = PartnerFactory(
+            authorization_method=Partner.BUNDLE,
+            searchable=Partner.PARTIALLY_SEARCHABLE,
+        )
         cls.bundle_partner_3.new_tags = {"tags": ["art_tag"]}
         cls.bundle_partner_3.save()
 
-        cls.bundle_partner_4 = PartnerFactory(authorization_method=Partner.BUNDLE)
+        cls.bundle_partner_4 = PartnerFactory(
+            authorization_method=Partner.BUNDLE,
+            searchable=Partner.SEARCHABLE,
+        )
         cls.bundle_partner_4.new_tags = {"tags": ["multidisciplinary_tag"]}
         cls.bundle_partner_4.save()
 
-        cls.proxy_partner_1 = PartnerFactory(authorization_method=Partner.PROXY)
+        cls.proxy_partner_1 = PartnerFactory(
+            authorization_method=Partner.PROXY,
+            searchable=Partner.SEARCHABLE,
+        )
         cls.proxy_partner_1.new_tags = {"tags": ["earth-sciences_tag"]}
         cls.proxy_partner_1.save()
 
-        cls.proxy_partner_2 = PartnerFactory(authorization_method=Partner.PROXY)
+        cls.proxy_partner_2 = PartnerFactory(
+            authorization_method=Partner.PROXY,
+            searchable=Partner.SEARCHABLE,
+        )
         cls.proxy_partner_2.new_tags = {"tags": ["earth-sciences_tag"]}
         cls.proxy_partner_2.save()
 
@@ -2102,3 +2117,186 @@ class MyLibraryViewsTest(TestCase):
         eligibility_message = "Sorry, your Wikipedia account doesn’t currently qualify to access The Wikipedia Library."
 
         self.assertIn(eligibility_message, content)
+
+    def test_collection_filters_searchable(self):
+        """
+        Tests that only user collections that match the filter are shown
+        """
+        app_bundle_partner_1 = ApplicationFactory(
+            status=Application.SENT,
+            editor=self.editor,
+            partner=self.bundle_partner_1,
+            sent_by=self.user_coordinator,
+        )
+
+        app_bundle_partner_2 = ApplicationFactory(
+            status=Application.SENT,
+            editor=self.editor,
+            partner=self.bundle_partner_2,
+            sent_by=self.user_coordinator,
+        )
+
+        app_bundle_partner_3 = ApplicationFactory(
+            status=Application.SENT,
+            editor=self.editor,
+            partner=self.bundle_partner_3,
+            sent_by=self.user_coordinator,
+        )
+
+        app_bundle_partner_4 = ApplicationFactory(
+            status=Application.SENT,
+            editor=self.editor,
+            partner=self.bundle_partner_4,
+            sent_by=self.user_coordinator,
+        )
+
+        app_proxy_partner_1 = ApplicationFactory(
+            status=Application.SENT,
+            editor=self.editor,
+            partner=self.proxy_partner_1,
+            sent_by=self.user_coordinator,
+        )
+
+        factory = RequestFactory()
+        url = reverse("users:my_library")
+        url_with_searchable_param = "{url}?searchable={searchable}".format(
+            url=url, searchable=Partner.SEARCHABLE
+        )
+        request = factory.get(url_with_searchable_param)
+        request.user = self.editor.user
+        response = MyLibraryView.as_view()(request)
+
+        self.assertEqual(response.status_code, 200)
+
+        content = response.render().content.decode("utf-8")
+
+        self.assertIn(escape(self.bundle_partner_1.company_name), content)
+        self.assertIn(escape(self.bundle_partner_4.company_name), content)
+        self.assertIn(escape(self.proxy_partner_1.company_name), content)
+        self.assertIn(escape(self.proxy_partner_2.company_name), content)
+
+        self.assertNotIn(escape(self.bundle_partner_2.company_name), content)
+        self.assertNotIn(escape(self.bundle_partner_3.company_name), content)
+        self.assertNotIn(escape(self.proxy_partner_3.company_name), content)
+
+    def test_collection_filters_partially_searchable(self):
+        """
+        Tests that only user collections that match the filter are shown
+        """
+        app_bundle_partner_1 = ApplicationFactory(
+            status=Application.SENT,
+            editor=self.editor,
+            partner=self.bundle_partner_1,
+            sent_by=self.user_coordinator,
+        )
+
+        app_bundle_partner_2 = ApplicationFactory(
+            status=Application.SENT,
+            editor=self.editor,
+            partner=self.bundle_partner_2,
+            sent_by=self.user_coordinator,
+        )
+
+        app_bundle_partner_3 = ApplicationFactory(
+            status=Application.SENT,
+            editor=self.editor,
+            partner=self.bundle_partner_3,
+            sent_by=self.user_coordinator,
+        )
+
+        app_bundle_partner_4 = ApplicationFactory(
+            status=Application.SENT,
+            editor=self.editor,
+            partner=self.bundle_partner_4,
+            sent_by=self.user_coordinator,
+        )
+
+        app_proxy_partner_1 = ApplicationFactory(
+            status=Application.SENT,
+            editor=self.editor,
+            partner=self.proxy_partner_1,
+            sent_by=self.user_coordinator,
+        )
+
+        factory = RequestFactory()
+        url = reverse("users:my_library")
+        url_with_searchable_param = "{url}?searchable={searchable}".format(
+            url=url, searchable=Partner.PARTIALLY_SEARCHABLE
+        )
+        request = factory.get(url_with_searchable_param)
+        request.user = self.editor.user
+        response = MyLibraryView.as_view()(request)
+
+        self.assertEqual(response.status_code, 200)
+
+        content = response.render().content.decode("utf-8")
+
+        self.assertIn(escape(self.bundle_partner_2.company_name), content)
+        self.assertIn(escape(self.bundle_partner_3.company_name), content)
+
+        self.assertNotIn(escape(self.bundle_partner_1.company_name), content)
+        self.assertNotIn(escape(self.bundle_partner_4.company_name), content)
+        self.assertNotIn(escape(self.proxy_partner_1.company_name), content)
+        self.assertNotIn(escape(self.proxy_partner_2.company_name), content)
+        self.assertNotIn(escape(self.proxy_partner_3.company_name), content)
+
+    def test_collection_filters_not_searchable(self):
+        """
+        Tests that only user collections that match the filter are shown
+        """
+        app_bundle_partner_1 = ApplicationFactory(
+            status=Application.SENT,
+            editor=self.editor,
+            partner=self.bundle_partner_1,
+            sent_by=self.user_coordinator,
+        )
+
+        app_bundle_partner_2 = ApplicationFactory(
+            status=Application.SENT,
+            editor=self.editor,
+            partner=self.bundle_partner_2,
+            sent_by=self.user_coordinator,
+        )
+
+        app_bundle_partner_3 = ApplicationFactory(
+            status=Application.SENT,
+            editor=self.editor,
+            partner=self.bundle_partner_3,
+            sent_by=self.user_coordinator,
+        )
+
+        app_bundle_partner_4 = ApplicationFactory(
+            status=Application.SENT,
+            editor=self.editor,
+            partner=self.bundle_partner_4,
+            sent_by=self.user_coordinator,
+        )
+
+        app_proxy_partner_1 = ApplicationFactory(
+            status=Application.SENT,
+            editor=self.editor,
+            partner=self.proxy_partner_1,
+            sent_by=self.user_coordinator,
+        )
+
+        factory = RequestFactory()
+        url = reverse("users:my_library")
+        url_with_searchable_param = "{url}?searchable={searchable}".format(
+            url=url, searchable=Partner.NOT_SEARCHABLE
+        )
+        request = factory.get(url_with_searchable_param)
+        request.user = self.editor.user
+        response = MyLibraryView.as_view()(request)
+
+        self.assertEqual(response.status_code, 200)
+
+        content = response.render().content.decode("utf-8")
+
+        self.assertIn(escape(self.proxy_partner_3.company_name), content)
+
+        self.assertNotIn(escape(self.bundle_partner_1.company_name), content)
+        self.assertNotIn(escape(self.bundle_partner_2.company_name), content)
+        self.assertNotIn(escape(self.bundle_partner_3.company_name), content)
+        self.assertNotIn(escape(self.bundle_partner_4.company_name), content)
+        self.assertNotIn(escape(self.proxy_partner_1.company_name), content)
+        self.assertNotIn(escape(self.proxy_partner_2.company_name), content)


### PR DESCRIPTION
[//]: # (Thank you for uploading a PR to the Wikipedia Library!)

## Description
Added a filter that filters collections based on their EDS searchability.

## Rationale
[//]: # (Why is this change required? What problem does it solve?)
We should allow users to filter My Library on this data so that they can better understand which collections they might need to navigate to individually.

## Phabricator Ticket
[//]: # (Link to the Phabricator ticket)
[T290245](https://phabricator.wikimedia.org/T290245)

## How Has This Been Tested?
[//]: # (- Did you add tests to your changes? Did you modify tests to accommodate your changes?)
[//]: # (- Can this change be tested manually? How?)
Added tests and tested manually

## Screenshots of your changes (if appropriate):
[//]: # (It can also be a GIF to prove that your changes are working)
![Searchable_filter](https://user-images.githubusercontent.com/7854953/134263076-15be139b-0afe-48f6-9756-d1737106fc76.gif)


## Types of changes
What types of changes does your code introduce? Add an `x` in all the boxes that apply:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Minor change (fix a typo, add a translation tag, add section to README, etc.)
