### PR TITLE
user language preference update

### DIFF
--- a/TWLight/forms.py
+++ b/TWLight/forms.py
@@ -1,0 +1,13 @@
+from django.conf import settings
+from django import forms
+from crispy_forms.helper import FormHelper
+from django.utils.translation import get_language
+
+
+class SetLanguageForm(forms.Form):
+    language = forms.ChoiceField(choices=settings.LANGUAGES)
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.helper = FormHelper()
+        self.fields["language"].initial = get_language()

--- a/TWLight/static/css/new-local.css
+++ b/TWLight/static/css/new-local.css
@@ -351,6 +351,11 @@ LOGIN PARTIAL CSS
 	padding:21px 0px 5px 23px;
 }
 
+.language-form{
+    float: right;
+    padding: 21px 0px 5px 23px;
+  }
+
 .homepage-title{
     font-family: Roboto;
     font-style: normal;

--- a/TWLight/static/css/new-local.rtl.css
+++ b/TWLight/static/css/new-local.rtl.css
@@ -360,8 +360,13 @@ LOGIN PARTIAL CSS
 
 .logo {
 	height:70px;
-	float:left;
+	float:right;
 	padding:21px 25px 5px 0px;
+}
+
+.language-form{
+    float: left;
+    padding: 21px 25px 5px 0px;
 }
 
 .homepage-title{

--- a/TWLight/templates/language_form.html
+++ b/TWLight/templates/language_form.html
@@ -2,7 +2,7 @@
 {% load crispy_forms_field %}
 {% load crispy_forms_utils %}
 
-<div class="float-right">
+<div class="language-form">
 <form action="/i18n/setlang/?next={% url 'homepage' %}" method="post" class="form-inline">
   {% csrf_token %}
     {% if form_show_errors %}
@@ -17,6 +17,6 @@
       </div>
     {% endfor %}
     {% comment %}Translators: Users click this button to set their interface language.{% endcomment %}
-    <input type="submit" name="submit" value="{% trans "Set language" %}" class="btn btn-light" />
+    <input type="submit" name="submit" value="{% trans "Set language" %}" class="btn btn-light mx-1" />
   </form> 
 </div>

--- a/TWLight/templates/language_form.html
+++ b/TWLight/templates/language_form.html
@@ -1,0 +1,22 @@
+{% load i18n %}
+{% load crispy_forms_field %}
+{% load crispy_forms_utils %}
+
+<div class="float-right">
+<form action="/i18n/setlang/?next={% url 'homepage' %}" method="post" class="form-inline">
+  {% csrf_token %}
+    {% if form_show_errors %}
+      {% include "bootstrap3/errors.html" %}
+    {% endif %}
+    {% for field in language_form %}
+      <div id="div_{{ field.auto_id }}" class="form-group">
+          <label for="{{ field.id_for_label }}" class="sr-only">
+            {{ field.label|safe }}
+          </label>
+          {% crispy_field field 'placeholder' field.label %}
+      </div>
+    {% endfor %}
+    {% comment %}Translators: Users click this button to set their interface language.{% endcomment %}
+    <input type="submit" name="submit" value="{% trans "Set language" %}" class="btn btn-light" />
+  </form> 
+</div>

--- a/TWLight/templates/login_partial.html
+++ b/TWLight/templates/login_partial.html
@@ -4,14 +4,20 @@
 {% load cache %}
 
 <div class="row col-12">
-  <!-- logo -->
-  <img class="logo" src="{% static 'img/Wikipedia_Library_owl.svg' %}" class="img-responsive logo" alt="
-  {% comment %}Translators: Alt text for the Wikipedia Library shown in the top left of all pages.{% endcomment %}
-  {% trans "The Wikipedia Library" %}
-  ">
-  <!-- site name -->
-  {% comment %}Translators: Name of the project/tool.{% endcomment %}
-  <p class="homepage-title">{% trans "The Wikipedia Library" %}</p>
+  <div class="col-lg-9 col-md-12">
+    <!-- logo -->
+    <img class="logo" src="{% static 'img/Wikipedia_Library_owl.svg' %}" class="img-responsive logo" alt="
+    {% comment %}Translators: Alt text for the Wikipedia Library shown in the top left of all pages.{% endcomment %}
+    {% trans "The Wikipedia Library" %}
+    ">
+    <!-- site name -->
+    {% comment %}Translators: Name of the project/tool.{% endcomment %}
+    <p class="homepage-title">{% trans "The Wikipedia Library" %}</p>
+  </div>
+  <div class="col-lg-3 col-md-12">
+    <!-- language form -->
+    {% include 'language_form.html' %}
+  </div>
 </div>
 
 <div class="row">

--- a/TWLight/users/views.py
+++ b/TWLight/users/views.py
@@ -817,6 +817,11 @@ class MyLibraryView(TemplateView):
         return context
 
     def render_to_response(self, context, **response_kwargs):
+
+        if self.request.COOKIES.get("django_language"):
+            self.request.user.userprofile.lang = get_language()
+            self.request.user.userprofile.save()
+
         user_language = self.request.user.userprofile.lang
 
         translation.activate(user_language)

--- a/TWLight/users/views.py
+++ b/TWLight/users/views.py
@@ -26,6 +26,8 @@ from django.utils.translation import gettext_lazy as _
 from django_comments.models import Comment
 from django.utils import timezone
 from django.utils.translation import get_language
+from django.utils import translation
+from django.conf import settings
 
 from TWLight.resources.filters import PartnerFilter
 from TWLight.resources.helpers import get_partner_description, get_tag_names
@@ -813,6 +815,16 @@ class MyLibraryView(TemplateView):
         }
 
         return context
+
+    def render_to_response(self, context, **response_kwargs):
+        user_language = self.request.user.userprofile.lang
+
+        translation.activate(user_language)
+        response = super(MyLibraryView, self).render_to_response(
+            context, **response_kwargs
+        )
+        response.set_cookie(settings.LANGUAGE_COOKIE_NAME, user_language)
+        return response
 
     def _build_user_collection_object(self, context, language_code, user):
         """

--- a/TWLight/views.py
+++ b/TWLight/views.py
@@ -19,6 +19,7 @@ from TWLight.resources.helpers import get_partner_description, get_tag_dict
 import logging
 
 from django.views.defaults import ERROR_400_TEMPLATE_NAME, ERROR_PAGE_TEMPLATE
+from TWLight.forms import SetLanguageForm
 
 logger = logging.getLogger(__name__)
 
@@ -108,6 +109,7 @@ class NewHomePageView(TemplateView):
                 }
             )
         context["partners"] = partners_obj
+        context["language_form"] = SetLanguageForm()
 
         return context
 


### PR DESCRIPTION
## Description
Unauthenticated users can't change the language before login, they should be able to change language without login that takes effect for the user's session.
When logged-in users select a language that differs from their browser language we should respect that and always update the interface to display in the language selected in their preferences.
When a user logs in with a different device or incognito mode the website language should be set to the user's language preference.

## Phabricator Ticket
https://phabricator.wikimedia.org/T226804
https://phabricator.wikimedia.org/T291474

## Screenshots of your changes (if appropriate):
![changelang](https://user-images.githubusercontent.com/62881091/137832190-479b07fa-5ab0-4f06-9e0e-eb815988a052.png)

## Types of changes
What types of changes does your code introduce? Add an `x` in all the boxes that apply:
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Minor change (fix a typo, add a translation tag, add section to README, etc.)




