### PR TITLE
Add favorites field to UserProfile

### DIFF
--- a/TWLight/resources/models.py
+++ b/TWLight/resources/models.py
@@ -343,7 +343,7 @@ class Partner(models.Model):
     def __str__(self):
         return self.company_name
 
-    def clean(self):
+    def clean(self, *args, **kwargs):
         if self.agreement_with_terms_of_use and not self.terms_of_use:
             raise ValidationError(
                 "When agreement with terms of use is "

--- a/TWLight/users/models.py
+++ b/TWLight/users/models.py
@@ -36,7 +36,7 @@ import urllib.request, urllib.error, urllib.parse
 from annoying.functions import get_object_or_None
 from django.conf import settings
 from django.contrib.auth.models import User
-from django.core.exceptions import SuspiciousOperation
+from django.core.exceptions import SuspiciousOperation, ValidationError
 from django.urls import reverse
 from django.db import models
 from django.db.models import Q

--- a/TWLight/users/tests.py
+++ b/TWLight/users/tests.py
@@ -926,8 +926,6 @@ class UserProfileModelTestCase(TestCase):
         with self.assertRaises(ValidationError):
             profile.favorites.add(self.proxy_partner_1)
 
-        self.assertNotIn(self.proxy_partner_1, profile.favorites.all())
-
 
 class EditorModelTestCase(TestCase):
     @classmethod

--- a/TWLight/users/tests.py
+++ b/TWLight/users/tests.py
@@ -887,6 +887,10 @@ class UserProfileModelTestCase(TestCase):
         profile.favorites.add(self.bundle_partner_2)
         profile.favorites.add(self.proxy_partner_1)
 
+        self.assertIn(self.proxy_partner_1, profile.favorites.all())
+        self.assertIn(self.bundle_partner_1, profile.favorites.all())
+        self.assertIn(self.bundle_partner_2, profile.favorites.all())
+
     def test_add_favorite_expired_collection_valid(self):
         """
         Tests that a valid collection (one a user has access to, even if it has
@@ -910,6 +914,8 @@ class UserProfileModelTestCase(TestCase):
 
         profile.favorites.add(self.proxy_partner_1)
 
+        self.assertIn(self.proxy_partner_1, profile.favorites.all())
+
     def test_add_favorite_collection_invalid(self):
         """
         Tests that an invalid collection (one a user does not has access to) is not
@@ -919,6 +925,8 @@ class UserProfileModelTestCase(TestCase):
 
         with self.assertRaises(ValidationError):
             profile.favorites.add(self.proxy_partner_1)
+
+        self.assertNotIn(self.proxy_partner_1, profile.favorites.all())
 
 
 class EditorModelTestCase(TestCase):

--- a/TWLight/users/tests.py
+++ b/TWLight/users/tests.py
@@ -857,7 +857,7 @@ class UserProfileModelTestCase(TestCase):
         Tests that a valid collection (one a user has access to) is successfully
         added to the favorites
         """
-        profile = UserProfile.objects.get(user=self.user_coordinator)
+        profile = UserProfile.objects.get(user=self.editor.user)
 
         # Create an authorization object so that the partner can be added to a
         # user's favorites collection
@@ -896,7 +896,7 @@ class UserProfileModelTestCase(TestCase):
         Tests that a valid collection (one a user has access to, even if it has
         expired) is successfully added to the favorites
         """
-        profile = UserProfile.objects.get(user=self.user_coordinator)
+        profile = UserProfile.objects.get(user=self.editor.user)
 
         app_proxy_partner_1 = ApplicationFactory(
             status=Application.SENT,
@@ -921,7 +921,7 @@ class UserProfileModelTestCase(TestCase):
         Tests that an invalid collection (one a user does not has access to) is not
         added to the favorites and that a ValidationError is raised
         """
-        profile = UserProfile.objects.get(user=self.user_coordinator)
+        profile = UserProfile.objects.get(user=self.editor.user)
 
         with self.assertRaises(ValidationError):
             profile.favorites.add(self.proxy_partner_1)

--- a/TWLight/users/views.py
+++ b/TWLight/users/views.py
@@ -783,6 +783,7 @@ class MyLibraryView(TemplateView):
         context = super().get_context_data(**kwargs)
 
         editor = Editor.objects.get(pk=self.request.user.editor.pk)
+        favorites = self.request.user.userprofile.favorites.all()
         language_code = get_language()
 
         self._build_user_collection_object(context, language_code, editor)
@@ -791,6 +792,7 @@ class MyLibraryView(TemplateView):
         )
 
         context["editor"] = editor
+        context["favorites"] = favorites
         context["bundle_authorization"] = Partner.BUNDLE
         context["proxy_authorization"] = Partner.PROXY
         context["bundle_criteria"] = {


### PR DESCRIPTION
[//]: # (Thank you for uploading a PR to the Wikipedia Library!)

## Description
Add a `favorites` field to UserProfile and its respective tests

## Rationale
[//]: # (Why is this change required? What problem does it solve?)
In the new logged-in designs, users can favorite collections they want quick access to when logged in. The intention is to enable them to separate the items they're really interested in from everything that's available to them through the Library Bundle.

## Phabricator Ticket
[//]: # (Link to the Phabricator ticket)
[T284014](https://phabricator.wikimedia.org/T284014)

## How Has This Been Tested?
[//]: # (- Did you add tests to your changes? Did you modify tests to accommodate your changes?)
[//]: # (- Can this change be tested manually? How?)
Added new unit tests

## Screenshots of your changes (if appropriate):
[//]: # (It can also be a GIF to prove that your changes are working)

## Types of changes
What types of changes does your code introduce? Add an `x` in all the boxes that apply:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Minor change (fix a typo, add a translation tag, add a section to README, etc.)
