### PR TITLE
templates: search bar is for eligible users only

### DIFF
--- a/TWLight/templates/header_partial_b3.html
+++ b/TWLight/templates/header_partial_b3.html
@@ -24,6 +24,7 @@
                 </a>
               </div>
               <div class="col-lg-7 col-md-7 col-sm-6 col-xs-7">
+                {% if user.editor|bundle_eligible %}
                 <!-- EBSCO Search Box Begins -->
                 <form action="https://searchbox.ebsco.com/search/" target="_blank" class="ebsco-single-search">
                   <input name="schemaId" value="search" type="hidden" />
@@ -63,6 +64,7 @@
                   {% comment %}Translators: Link that takes a user to an external site to provide feedback on the search bar. {% endcomment %}
                   {%trans 'Feedback' %}
                 </a>
+                {% endif %}
             </div>
             <div class="col-sm-2 col-xs-3">
               <button type="button" class="navbar-toggle collapsed twl-toggle-button" data-toggle="collapse"

--- a/TWLight/templates/header_partial_b4.html
+++ b/TWLight/templates/header_partial_b4.html
@@ -19,6 +19,7 @@
       </a>
     </div>
     <div class="col-lg-5 col-md-7 col-sm-6 col-9">
+      {% if editor|bundle_eligible %}
       <!-- EBSCO Search Box Begins -->
       <form action="https://searchbox.ebsco.com/search/" target="_blank" class="ebsco-single-search">
       <!-- <form action="https://search.ebscohost.com/login.aspx" target="_blank" class="ebsco-single-search"> -->
@@ -56,6 +57,7 @@
         {% comment %}Translators: Link that takes a user to an external site to provide feedback on the search bar. {% endcomment %}
         {%trans 'Feedback' %}
       </a>
+      {% endif %}
     </div>
 
     <button class="navbar-toggler top-navbar-button" type="button" data-toggle="collapse"

--- a/TWLight/users/templatetags/twlight_perms.py
+++ b/TWLight/users/templatetags/twlight_perms.py
@@ -1,8 +1,18 @@
 from django import template
 
 from TWLight.users.groups import get_coordinators, get_restricted
+from TWLight.users.helpers.editor_data import editor_bundle_eligible
 
 register = template.Library()
+
+
+@register.filter
+def bundle_eligible(editor):
+    """Return True if editor is bundle eligible, else False"""
+    is_eligible = False
+    if editor:
+        is_eligible = editor_bundle_eligible(editor)
+    return is_eligible
 
 
 @register.filter


### PR DESCRIPTION
- Adds template tag to streamline eligibility checks in templates

[//]: # (Thank you for uploading a PR to the Wikipedia Library!)

## Description
EDS search is for bundle eligible editors only

## Rationale
EDS includes directly embedded EDS content, meaning we need to gate access

## Phabricator Ticket
https://phabricator.wikimedia.org/T294013

## How Has This Been Tested?
I did manual testing. I skipped writing unit tests in the interest of expediency.

## Screenshots of your changes (if appropriate):
![image](https://user-images.githubusercontent.com/2986893/138288939-4a087dad-69b8-4a84-95ae-6ee9bac3b130.png)

## Types of changes
What types of changes does your code introduce? Add an `x` in all the boxes that apply:
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Minor change (fix a typo, add a translation tag, add section to README, etc.)
