### PR TITLE
Some strings in My Library aren't displaying translations

### DIFF
--- a/TWLight/resources/filters.py
+++ b/TWLight/resources/filters.py
@@ -10,7 +10,9 @@ import django_filters
 INSTANT = 0
 MULTI_STEP = 1
 ACCESS_CHOICES = (
+    # Translators: On the MyLibrary page (https://wikipedialibrary.wmflabs.org/users/my_library), this indicates that a collection collection may be accessed immediately.
     (INSTANT, _("Instant (proxy) access")),
+    # Translators: On the MyLibrary page (https://wikipedialibrary.wmflabs.org/users/my_library), this indicates that a collection collection may be accessed only after additional steps, such as submitting an application and awaiting approval.
     (MULTI_STEP, _("Multi-step access")),
 )
 

--- a/TWLight/resources/models.py
+++ b/TWLight/resources/models.py
@@ -284,8 +284,11 @@ class Partner(models.Model):
     PARTIALLY_SEARCHABLE = 2
 
     SEARCHABLE_CHOICES = (
+        # Translators: This indicates that a collection included in the centralized search tool (https://meta.wikimedia.org/wiki/Talk:Library_Card_platform/Search)
         (SEARCHABLE, _("Searchable")),
+        # Translators: This indicates that a collection is excluded from the centralized search tool (https://meta.wikimedia.org/wiki/Talk:Library_Card_platform/Search)
         (NOT_SEARCHABLE, _("Not searchable")),
+        # Translators: This indicates that a collection is partially included in the centralized search tool (https://meta.wikimedia.org/wiki/Talk:Library_Card_platform/Search)
         (PARTIALLY_SEARCHABLE, _("Partially searchable")),
     )
 

--- a/TWLight/users/templates/users/available_collection_tile.html
+++ b/TWLight/users/templates/users/available_collection_tile.html
@@ -2,10 +2,10 @@
 <div id="tile-partner-{{available_collection.pk}}" class="col-xl-3 col-lg-4 col-md-6 col-sm-12">
   <div class="card collection-tile">
     {% if available_collection.searchable == searchable %}
-      {% comment %}Translators: Hovertext for an icon which indicates whether a collection is searchable or not.. {% endcomment %}
+      {% comment %}Translators: Hovertext for an icon which indicates whether a collection is searchable or not. {% endcomment %}
       <i class="fa fa-search searchable-icon" title="{% trans 'Searchable' %}"></i>
     {% elif available_collection.searchable == partially_searchable %}
-      {% comment %}Translators: Hovertext for an icon which indicates whether a collection is searchable or not.. {% endcomment %}
+      {% comment %}Translators: Hovertext for an icon which indicates whether a collection is searchable or not. {% endcomment %}
       <i class="fa fa-search partially-searchable-icon" title="{% trans 'Partially searchable' %}"></i>
     {% endif %}
     {% if available_collection.partner_logo %}

--- a/TWLight/users/templates/users/filter_section.html
+++ b/TWLight/users/templates/users/filter_section.html
@@ -11,7 +11,7 @@
       {% comment %}Translators: On the MyLibrary page (https://wikipedialibrary.wmflabs.org/users/my_library), this label indicates the start of the key section, that explains some uses for icons. {% endcomment %}
       <p>{% trans "Key"%}</p>
       <div class="icon-section">
-        {% comment %}Translators: Hovertext for an icon which indicates whether a collection is searchable or not.. {% endcomment %}
+        {% comment %}Translators: Hovertext for an icon which indicates whether a collection is searchable or not. {% endcomment %}
         <i class="fa fa-search searchable-icon" title="{% trans 'Searchable' %}"></i>
       </div>
       <div class="key-content">
@@ -20,7 +20,7 @@
       </div>
       <br> <br>
       <div class="icon-section">
-        {% comment %}Translators: Hovertext for an icon which indicates whether a collection is searchable or not.. {% endcomment %}
+        {% comment %}Translators: Hovertext for an icon which indicates whether a collection is searchable or not. {% endcomment %}
         <i class="fa fa-search partially-searchable-icon" title="{% trans 'Partially searchable' %}"></i>
       </div>
       <div class="key-content">


### PR DESCRIPTION
## Description
Marks additional resource strings for translation. These strings are used in filters that show up in my_library and partners

## Rationale
We aim to support 100% localization

## Phabricator Ticket
https://phabricator.wikimedia.org/T293882

## How Has This Been Tested?
After making the changes, I forced the translation script locally and verified that existing localized messages came through and missing messages were now available for localization.

## Screenshots of your changes (if appropriate):
![image](https://user-images.githubusercontent.com/2986893/139315152-83a79b69-fb79-49f7-a163-7ad52650bd39.png)

## Types of changes
What types of changes does your code introduce? Add an `x` in all the boxes that apply:
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Minor change (fix a typo, add a translation tag, add section to README, etc.)
