### PR TITLE
Redirect people to intended destination after login

### DIFF
--- a/TWLight/templates/login_partial.html
+++ b/TWLight/templates/login_partial.html
@@ -61,7 +61,7 @@
 <div class="row">
     <div class="col-lg-6 col-md-12 col-sm-12 homepage-login">
       {% comment %}Translators: Button that logs editors in via Wikipedia.{% endcomment %}
-      <a  class="btn btn-lg btn-light homepage-login-button" href="{% url 'oauth_login' %}?next={% url 'users:my_library' %}&from_homepage=true">
+      <a  class="btn btn-lg btn-light homepage-login-button" href="{% url 'oauth_login' %}?next={{ next_url }}}&from_homepage=true">
         {% trans "Login via Wikipedia" %}
       </a>
     </div>

--- a/TWLight/templates/login_partial.html
+++ b/TWLight/templates/login_partial.html
@@ -61,7 +61,7 @@
 <div class="row">
     <div class="col-lg-6 col-md-12 col-sm-12 homepage-login">
       {% comment %}Translators: Button that logs editors in via Wikipedia.{% endcomment %}
-      <a  class="btn btn-lg btn-light homepage-login-button" href="{% url 'oauth_login' %}?next={{ next_url }}}&from_homepage=true">
+      <a  class="btn btn-lg btn-light homepage-login-button" href="{% url 'oauth_login' %}?next={{ next_url }}&from_homepage=true">
         {% trans "Login via Wikipedia" %}
       </a>
     </div>

--- a/TWLight/users/oauth.py
+++ b/TWLight/users/oauth.py
@@ -349,8 +349,13 @@ class OAuthInitializeView(View):
                     _("To view this link you need to be an eligible library user. Please login to continue."),
                     # fmt: on
                 )
-
-                local_redirect = reverse_lazy("homepage")
+                if return_url:
+                    homepage = reverse_lazy("homepage")
+                    local_redirect = "{homepage}?next_url={return_url}".format(
+                        homepage=homepage, return_url=return_url
+                    )
+                else:
+                    local_redirect = reverse_lazy("homepage")
 
             logger.info("handshaker initiated.")
             self.request.session["request_token"] = _dehydrate_token(request_token)

--- a/TWLight/views.py
+++ b/TWLight/views.py
@@ -8,6 +8,7 @@ from django.contrib.messages import get_messages
 from django.db.models import Q
 from django.http import HttpResponse, HttpResponseBadRequest
 from django.shortcuts import render, redirect
+from django.urls import reverse_lazy
 from django.utils.translation import get_language, gettext_lazy as _
 from django.template import TemplateDoesNotExist, loader
 from django.views.decorators.csrf import requires_csrf_token
@@ -108,6 +109,11 @@ class NewHomePageView(TemplateView):
                 }
             )
         context["partners"] = partners_obj
+        param_next_url = self.request.GET.get("next_url", None)
+        if param_next_url:
+            context["next_url"] = param_next_url
+        else:
+            context["next_url"] = reverse_lazy("users:my_library")
 
         return context
 


### PR DESCRIPTION
[//]: # (Thank you for uploading a PR to the Wikipedia Library!)

## Description
Added a `next_url` parameter to preserve original link clicked before login.

## Rationale
[//]: # (Why is this change required? What problem does it solve?)
People want to be redirected to the original link they clicked, not `My Library`

## Phabricator Ticket
[//]: # (Link to the Phabricator ticket)

## How Has This Been Tested?
[//]: # (- Did you add tests to your changes? Did you modify tests to accommodate your changes?)
[//]: # (- Can this change be tested manually? How?)
Tested manually
1. Try opening a `login_required`link or a proxy link in a session where you are logged out
2. You should be redirected to the homepage with the message `To view this link you need to be an eligible library user. Please login to continue. `
3. Login
4. You should be redirected to the proxied link or the original link you navigated to

## Screenshots of your changes (if appropriate):
[//]: # (It can also be a GIF to prove that your changes are working)

## Types of changes
What types of changes does your code introduce? Add an `x` in all the boxes that apply:
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Minor change (fix a typo, add a translation tag, add section to README, etc.)
