### PR TITLE
Display accounts available for all partner types

### DIFF
--- a/TWLight/applications/views.py
+++ b/TWLight/applications/views.py
@@ -979,12 +979,11 @@ class EvaluateApplicationView(
         context["versions"] = Version.objects.get_for_object(self.object)
 
         app = self.object
-        context["total_accounts_available_for_distribution"] = None
-        # We show accounts available for proxy partners/collections in the evaluation page
-        if app.partner.authorization_method == Partner.PROXY:
-            context[
-                "total_accounts_available_for_distribution"
-            ] = get_accounts_available(app)
+
+        # We show accounts available for partners/collections in the evaluation page
+        context["total_accounts_available_for_distribution"] = get_accounts_available(
+            app
+        )
 
         # Check if the person viewing this application is actually this
         # partner's coordinator, and not *a* coordinator who happens to


### PR DESCRIPTION
[//]: # (Thank you for uploading a PR to the Wikipedia Library!)

## Description
Accounts available for all types of partners are displayed under the partner name in each application.

## Phabricator Ticket
https://phabricator.wikimedia.org/T262164

## How Has This Been Tested?
Before changing in the code I checked for a partner whose `authorization_method` was `EMAIL`, there `Accounts Available` column was not being displayed but after changing the code  `Accounts available` is visible in the application. Similarly, I also checked for remaining partners.

![Screenshot from 2021-11-30 15-56-43](https://user-images.githubusercontent.com/79361199/144031878-63d39872-1150-47b9-b551-24b4d58326c4.png)

## Types of changes
What types of changes does your code introduce? Add an `x` in all the boxes that apply:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Minor change (fix a typo, add a translation tag, add section to README, etc.)
