### PR TITLE
Migrate authorization return confirm screen to Bootstrap 4

### DIFF
--- a/TWLight/users/templates/users/authorization_confirm_return.html
+++ b/TWLight/users/templates/users/authorization_confirm_return.html
@@ -1,18 +1,22 @@
-{% extends "base.html" %}
+{% extends "new_base.html" %}
 
 {% load i18n %}
 
 {% block content %}
-  <form method="post">
-    {% csrf_token %}
-    <p>
-      {% comment %}Translators: This message is displayed on the confirmation page where users can return their access to partner collections.{% endcomment %}
-    {% blocktranslate trimmed with object.partners.get as partner %}
-      You will no longer be able to access <b>{{ partner }}'s</b> resources via the Library Card platform, but can request access again
-      by clicking 'renew', if you change your mind. Are you sure you want to return your access?
-    {% endblocktranslate %}
-    </p>
-    {% comment %}Translators: A button users can click to return their access to a particular resource.{% endcomment %}
-    <input type="submit" value="{% trans 'Confirm' %}" class="btn btn-primary"/>
-  </form>
+  {% include "header_partial_b4.html" %}
+  {% include "message_partial.html" %}
+  <div id="main-content">
+    <form method="post">
+      {% csrf_token %}
+      <p>
+        {% comment %}Translators: This message is displayed on the confirmation page where users can return their access to partner collections.{% endcomment %}
+      {% blocktranslate trimmed with object.partners.get as partner %}
+        You will no longer be able to access <b>{{ partner }}'s</b> resources via the Library Card platform, but can request access again
+        by clicking 'renew', if you change your mind. Are you sure you want to return your access?
+      {% endblocktranslate %}
+      </p>
+      {% comment %}Translators: A button users can click to return their access to a particular resource.{% endcomment %}
+      <input type="submit" value="{% trans 'Confirm' %}" class="btn twl-btn"/>
+    </form>
+  </div>
 {% endblock content %}


### PR DESCRIPTION
[//]: # (Thank you for uploading a PR to the Wikipedia Library!)

## Description
Migrated the `/users/return_authorization/[Number]/` view to Bootstrap 4.

## Rationale
[//]: # (Why is this change required? What problem does it solve?)
Bootstrap 3 is EOL.

## Phabricator Ticket
[//]: # (Link to the Phabricator ticket)
[T296904](https://phabricator.wikimedia.org/T296904)

## How Has This Been Tested?
[//]: # (- Did you add tests to your changes? Did you modify tests to accommodate your changes?)
[//]: # (- Can this change be tested manually? How?)
Tested manually

## Screenshots of your changes (if appropriate):
[//]: # (It can also be a GIF to prove that your changes are working)
![Screen Shot 2021-12-03 at 21 05 36](https://user-images.githubusercontent.com/7854953/144694968-e038b5c8-f5ed-485e-a16f-c79b1f0c5bb6.png)


## Types of changes
What types of changes does your code introduce? Add an `x` in all the boxes that apply:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Minor change (fix a typo, add a translation tag, add section to README, etc.)
