### PR TITLE
Migrate user_detail to Bootstrap 4

### DIFF
--- a/TWLight/users/templates/users/user_detail.html
+++ b/TWLight/users/templates/users/user_detail.html
@@ -1,26 +1,30 @@
-{% extends "base.html" %}
+{% extends "new_base.html" %}
 {% load i18n %}
 
 {% block content %}
-  <p>
-    {% comment %}
-      Translators: this should show up for people who log in with a username/password and not OAuth, so we don't know what their Wikipedia identity is.
-    {% endcomment %}
-    {% blocktranslate trimmed with username=user.username %}
-      Hi, {{ username }}! You don't have a Wikipedia editor profile attached
-      to your account here, so you are probably a site administrator.
-    {% endblocktranslate %}
-  </p>
+  {% include "header_partial_b4.html" %}
+  {% include "message_partial.html" %}
+  <div id="main-content">
+    <p>
+      {% comment %}
+        Translators: this should show up for people who log in with a username/password and not OAuth, so we don't know what their Wikipedia identity is.
+      {% endcomment %}
+      {% blocktranslate trimmed with username=user.username %}
+        Hi, {{ username }}! You don't have a Wikipedia editor profile attached
+        to your account here, so you are probably a site administrator.
+      {% endblocktranslate %}
+    </p>
 
-  <p>
-    {% comment %}Translators: In the unlikely scenario that someone is able to register an account without using OAuth (thus leaving us without some of the information required for applications), users will see this message, encouraging them to re-register.{% endcomment %}
-    {% blocktranslate trimmed %}
-      If you aren't a site administrator, something weird has happened. You
-      won't be able to apply for access without a Wikipedia editor profile.
-      You should log out and create a new account by logging in via OAuth,
-      or contact a site administrator for help.
-    {% endblocktranslate %}
-  </p>
+    <p>
+      {% comment %}Translators: In the unlikely scenario that someone is able to register an account without using OAuth (thus leaving us without some of the information required for applications), users will see this message, encouraging them to re-register.{% endcomment %}
+      {% blocktranslate trimmed %}
+        If you aren't a site administrator, something weird has happened. You
+        won't be able to apply for access without a Wikipedia editor profile.
+        You should log out and create a new account by logging in via OAuth,
+        or contact a site administrator for help.
+      {% endblocktranslate %}
+    </p>
 
-  {% include "users/preferences.html" %}
+    {% include "users/preferences.html" %}
+  </div>
 {% endblock %}


### PR DESCRIPTION
[//]: # (Thank you for uploading a PR to the Wikipedia Library!)

## Description
Migrate user_detail to Bootstrap 4

## Rationale
[//]: # (Why is this change required? What problem does it solve?)
Bootstrap 3 is EOL

## Phabricator Ticket
[//]: # (Link to the Phabricator ticket)
[T296902](https://phabricator.wikimedia.org/T296902)

## How Has This Been Tested?
[//]: # (- Did you add tests to your changes? Did you modify tests to accommodate your changes?)
[//]: # (- Can this change be tested manually? How?)
1. Login with your Wikipedia account
2. Delete the editor object associated to your user account (you can do this from the django shell)
3. Navigate to `/users`
4. The alternative users view should appear

## Screenshots of your changes (if appropriate):
[//]: # (It can also be a GIF to prove that your changes are working)
![Screen Shot 2021-12-03 at 21 42 54](https://user-images.githubusercontent.com/7854953/144696659-64ac7dab-44dd-4ab7-8184-f41a198d283e.png)


## Types of changes
What types of changes does your code introduce? Add an `x` in all the boxes that apply:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Minor change (fix a typo, add a translation tag, add section to README, etc.)
