### PR TITLE
Unify CSS links and buttons classes

### DIFF
--- a/TWLight/applications/forms.py
+++ b/TWLight/applications/forms.py
@@ -119,7 +119,7 @@ class BaseApplicationForm(forms.Form):
                 "submit",
                 # Translators: Labels the button users click to apply for a partner's resources.
                 _("Apply"),
-                css_class="mx-auto twl-main-btn",
+                css_class="mx-auto twl-btn",
             )
         )
 

--- a/TWLight/applications/templates/applications/confirm_renewal.html
+++ b/TWLight/applications/templates/applications/confirm_renewal.html
@@ -26,7 +26,7 @@
         </label>
         <div class="col-lg-offset-1 col-lg-1 controls">
           {% comment %}Translators: Labels the submit button requesting confirmation of application renewal. {% endcomment %}
-          <input type="submit" value="{% trans 'Confirm' %}" class="btn twl-main-btn"/>
+          <input type="submit" value="{% trans 'Confirm' %}" class="btn twl-btn"/>
         </div>
       </div>
     </form>

--- a/TWLight/applications/templates/applications/request_for_application.html
+++ b/TWLight/applications/templates/applications/request_for_application.html
@@ -64,7 +64,7 @@
         {% comment %}Translators: On the page where users can apply for multiple partners, this text labels the button, which when clicked submits the selections.{% endcomment %}
         <button type="button" class="btn btn-primary" disabled>{% trans "Apply" %}</button>
       {% else %}
-        <input type="submit" value="{% trans "Apply" %}" class="btn twl-main-btn" />
+        <input type="submit" value="{% trans "Apply" %}" class="btn twl-btn" />
       {% endif %}
     </form>
 

--- a/TWLight/emails/forms.py
+++ b/TWLight/emails/forms.py
@@ -18,7 +18,7 @@ class ContactUsForm(forms.Form):
         self.fields["email"].label = _("Your email")
         # fmt: off
         # Translators: This is the help text for the email field in the contact us form letting users know the field is updated by value pulled from their respective user profiles.
-        self.fields["email"].help_text = _("This field is automatically updated with the email from your <a class='contact-us-links' href='{}'>user profile</a>.").format(
+        self.fields["email"].help_text = _("This field is automatically updated with the email from your <a class='twl-links' href='{}'>user profile</a>.").format(
             reverse_lazy("users:home")
         )
         # fmt: on
@@ -41,5 +41,5 @@ class ContactUsForm(forms.Form):
             "cc",
             "next",
             # Translators: This labels a button which users click to submit their email message.
-            Submit("submit", _("Submit"), css_class="contact-us-button"),
+            Submit("submit", _("Submit"), css_class="twl-btn"),
         )

--- a/TWLight/emails/templates/emails/contact.html
+++ b/TWLight/emails/templates/emails/contact.html
@@ -30,7 +30,7 @@
             <div class="pull-right">
               {% url 'suggest' as suggest %}
               {% comment %}Translators: This is the text that appears at the bottom of the contact us form directing users to the suggestions form.{% endcomment %}
-              {% blocktranslate trimmed %}(If you would like to suggest a partner, <a class="contact-us-links" href="{{ suggest }}"><strong>go here</strong></a>.){% endblocktranslate %}
+              {% blocktranslate trimmed %}(If you would like to suggest a partner, <a class="twl-links" href="{{ suggest }}"><strong>go here</strong></a>.){% endblocktranslate %}
             </div>
           </div>
         </div>
@@ -45,15 +45,15 @@
             <p>{% comment %}Translators: On the contact us page, this labels the link to the Wikipedia Library meta page.{% endcomment %}
               <strong>{% trans 'Meta page' %}: </strong>
               {% comment %}Translators: On the contact us page, this text links to the Wikipedia Library meta page.{% endcomment %}
-              <a class="contact-us-links" href="https://meta.wikimedia.org/wiki/The_Wikipedia_Library">{% trans 'The Wikipedia Library' %}</a>
+              <a class="twl-links" href="https://meta.wikimedia.org/wiki/The_Wikipedia_Library">{% trans 'The Wikipedia Library' %}</a>
             </p>
             <p>{% comment %}Translators: On the contact us page, this labels the link to the Wikipedia Library email address.{% endcomment %}
               <strong>{% trans 'Email' %}: </strong>
-              <a class="contact-us-links" href="mailto:wikipedialibrary@wikimedia.org">wikipedialibrary@wikimedia.org</a>
+              <a class="twl-links" href="mailto:wikipedialibrary@wikimedia.org">wikipedialibrary@wikimedia.org</a>
             </p>
             <p>{% comment %}Translators: On the contact us page, this labels the link to the Wikipedia Library mailing list.{% endcomment %}
               <strong>{% trans 'Mailing list' %}: </strong> <br />
-              &emsp;<a class="contact-us-links" href="https://lists.wikimedia.org/mailman/listinfo/wikipedia-library">wikipedia-library@lists.wikimedia.org</a>
+              &emsp;<a class="twl-links" href="https://lists.wikimedia.org/mailman/listinfo/wikipedia-library">wikipedia-library@lists.wikimedia.org</a>
             </p>
             <div class="clearfix"></div><hr />
             <p>

--- a/TWLight/resources/templates/resources/filter_section.html
+++ b/TWLight/resources/templates/resources/filter_section.html
@@ -18,12 +18,12 @@
         {% endif %}
       </div>
       <div class="about-links">
-        <a href="{% url 'about' %}" class="learn-more-link">
+        <a href="{% url 'about' %}" class="twl-links twl-links-underline learn-more-link">
           {% comment %}Translators: On the Browse Partners page (https://wikipedialibrary.wmflabs.org/partners/), this appears below introductory text and links to the 'About' page (https://wikipedialibrary.wmflabs.org/about/) {% endcomment %}
           {% trans "Learn more" %}
         </a>
         &ndash;
-        <a href="https://meta.wikimedia.org/wiki/Talk:The_Wikipedia_Library" class="discuss-link">
+        <a href="https://meta.wikimedia.org/wiki/Talk:The_Wikipedia_Library" class="twl-links twl-links-underline discuss-link">
           {% comment %}Translators: On the Browse Partners page (https://wikipedialibrary.wmflabs.org/partners/), this appears below introductory text and links to The Wikipedia Library Talk page on meta (https://meta.wikimedia.org/wiki/Talk:The_Wikipedia_Library) {% endcomment %}
           {% trans "Discuss" %}
         </a>
@@ -35,7 +35,7 @@
         {% comment %}Translators: On the Browse Partners page (https://wikipedialibrary.wmflabs.org/partners/), this label indicates the start of the filter section. {% endcomment %}
         {% trans "Filters" %}:
       </p>
-      <a href="?tags=&languages=" class="reset-filters-link">
+      <a href="?tags=&languages=" class="twl-links reset-filters-link">
         {% comment %}Translators: On the Browse Partners page (https://wikipedialibrary.wmflabs.org/partners/), this link will reset the filters for the collections. {% endcomment %}
         {% trans "Reset filters" %}
       </a>

--- a/TWLight/static/css/new-local.css
+++ b/TWLight/static/css/new-local.css
@@ -112,6 +112,13 @@ COMMON CONTENT BLOCK CSS
     color: #3366CC;
 }
 
+.twl-links-underline{
+    text-decoration: underline;
+}
+.twl-links-underline:hover{
+    text-decoration: none;
+}
+
 .twl-secondary-btn{
     color: #000000;
     background-color: #FFFFFF;
@@ -193,13 +200,7 @@ HEADER CSS
 .feedback-link{
     float: right;
     font-size: 12px;
-    color: #3366CC;
-    text-decoration: underline;
     margin-right: 10%;
-}
-.feedback-link:hover{
-    color: #3366CC;
-    text-decoration: none;
 }
 
 .top-navbar-button{

--- a/TWLight/static/css/new-local.css
+++ b/TWLight/static/css/new-local.css
@@ -1254,19 +1254,8 @@ CONTACT US CSS
 --------------------------------------------------------------------------
 */
 
-.contact-us-links, .evaluate-application-link{
+.evaluate-application-link{
     color: #3366CC;
-}
-
-.contact-us-button{
-    background-color: #3366CC;
-    border-color: #3366CC;
-}
-
-.contact-us-button:hover{
-    background-color: #3366CC;
-    border-color: #3366CC;
-    text-decoration: underline;
 }
 
 .contact-info-header{

--- a/TWLight/static/css/new-local.css
+++ b/TWLight/static/css/new-local.css
@@ -183,16 +183,7 @@ HEADER CSS
 }
 
 .eds-search-button{
-    font-family: Roboto;
-    color: #FFFFFF;
-    background-color: #3366CC;
     border-radius: 0 2px 2px 0;
-}
-
-.eds-search-button:hover {
-    color: #FFFFFF !important;
-    background-color: #3366CC !important;
-    text-decoration: underline !important;
 }
 
 .eds-search-icon{

--- a/TWLight/static/css/new-local.css
+++ b/TWLight/static/css/new-local.css
@@ -789,8 +789,6 @@ NEW MY LIBRARY CSS
 }
 .learn-more-link, .discuss-link, .reset-filters-link{
     font-size: 15px;
-    color: #3366CC;
-    text-decoration: underline;
 }
 .icon-section{
     display: inline-block;

--- a/TWLight/static/css/new-local.css
+++ b/TWLight/static/css/new-local.css
@@ -1254,10 +1254,6 @@ CONTACT US CSS
 --------------------------------------------------------------------------
 */
 
-.evaluate-application-link{
-    color: #3366CC;
-}
-
 .contact-info-header{
     background-color: #3366CC;
     color: #FFFFFF;

--- a/TWLight/static/css/new-local.css
+++ b/TWLight/static/css/new-local.css
@@ -1004,15 +1004,8 @@ NEW MY LIBRARY COLLECTION TILES CSS
 }
 
 .access-apply-button{
-    color: #FFFFFF;
-    background-color: #3366CC;
     width: 50%;
     -webkit-appearance: none;
-}
-
-.access-apply-button:hover{
-    color: #FFFFFF;
-    text-decoration: underline;
 }
 
 .renew-extend-button{
@@ -1031,8 +1024,6 @@ NEW MY LIBRARY COLLECTION TILES CSS
 and (min-device-width : 320px)
 and (max-device-width : 480px) {
     .access-apply-button{
-        color: #FFFFFF;
-        background-color: #3366CC;
         width: 100%;
         margin-bottom: 10px;
         -webkit-appearance: none;
@@ -1050,8 +1041,6 @@ and (max-device-width : 480px) {
 and (min-device-width : 768px)
 and (max-device-width : 1024px) {
     .access-apply-button{
-        color: #FFFFFF;
-        background-color: #3366CC;
         width: 100%;
         margin-bottom: 10px;
         -webkit-appearance: none;

--- a/TWLight/static/css/new-local.css
+++ b/TWLight/static/css/new-local.css
@@ -53,6 +53,7 @@ COMMON CONTENT BLOCK CSS
   font-size: 14px;
   color: #FFFFFF !important;
   background-color: #3366CC !important;
+  border-color: #3366CC !important;
 }
 .twl-btn:hover {
   color: #FFFFFF !important;

--- a/TWLight/static/css/new-local.css
+++ b/TWLight/static/css/new-local.css
@@ -112,6 +112,10 @@ COMMON CONTENT BLOCK CSS
     color: #3366CC;
 }
 
+.twl-links:hover{
+    color: #3366CC;
+}
+
 .twl-links-underline{
     text-decoration: underline;
 }
@@ -772,14 +776,7 @@ NEW MY LIBRARY CSS
 }
 
 .applications-link{
-    font-family: Roboto;
     font-size: 14px;
-    color: #3366CC;
-    text-decoration: underline;
-}
-.applications-link:hover{
-    color: #3366CC;
-    text-decoration: none;
 }
 .about-section, .key-section{
     font-size: 15px;

--- a/TWLight/static/css/new-local.css
+++ b/TWLight/static/css/new-local.css
@@ -41,6 +41,90 @@ body {
 
 /*
 ----------------------------------------------------------------------------
+COMMON CONTENT BLOCK CSS
+--------------------------------------------------------------------------
+*/
+#main-content {
+  padding: 0.5rem 1rem;
+}
+.twl-btn {
+  white-space: nowrap;
+  font-family: Roboto;
+  font-size: 14px;
+  color: #FFFFFF !important;
+  background-color: #3366CC !important;
+}
+.twl-btn:hover {
+  color: #FFFFFF !important;
+  background-color: #3366CC !important;
+  text-decoration: underline !important;
+}
+.btn-extra-large{
+  padding-top:30px;
+  padding-bottom:30px;
+  margin-bottom: 14px;
+  max-width: 575px;
+}
+.btn-extra-large::after {
+  content: " ";
+  display: block;
+  height: 0px;
+  clear: both;
+}
+/* uses the less-dangerous-looking pink of bootstrap 3 */
+.bg-danger-soft {
+  background-color: rgb(242, 222, 222);
+}
+/* btn-default behaviors ported from bootstrap 3 */
+.btn-default {
+  color: rgb(51, 51, 51);
+  background-color: rgb(255, 255, 255);
+  border-color: rgb(204, 204, 204);
+}
+.btn-default.focus, .btn-default:focus {
+  color:#333;
+  background-color:#e6e6e6;
+  border-color:#8c8c8c
+}
+.btn-default:hover {
+  color:#333;
+  background-color:#e6e6e6;
+  border-color:#adadad
+}
+.btn-default.active, .btn-default:active, .open>.dropdown-toggle.btn-default {
+  color:#333;
+  background-color:#e6e6e6;
+  border-color:#adadad
+}
+.btn-default.active.focus,.btn-default.active:focus, .btn-default.active:hover, .btn-default:active.focus, .btn-default:active:focus, .btn-default:active:hover, .open>.dropdown-toggle.btn-default.focus, .open>.dropdown-toggle.btn-default:focus, .open>.dropdown-toggle.btn-default:hover{color:#333;background-color:#d4d4d4;border-color:#8c8c8c}.btn-default.active, .btn-default:active, .open>.dropdown-toggle.btn-default {
+  background-image:none
+}
+.btn-default.disabled.focus, .btn-default.disabled:focus, .btn-default.disabled:hover, .btn-default[disabled].focus, .btn-default[disabled]:focus, .btn-default[disabled]:hover, fieldset[disabled] .btn-default.focus,fieldset[disabled] .btn-default:focus, fieldset[disabled] .btn-default:hover {
+  background-color:#fff;
+  border-color:#ccc
+}
+.btn-default .badge {
+  color:#fff;
+  background-color:#333
+}
+
+.twl-links{
+    color: #3366CC;
+}
+
+.twl-secondary-btn{
+    color: #000000;
+    background-color: #FFFFFF;
+    border-color: #CCCCCC;
+}
+
+.twl-secondary-btn:hover{
+    background-color: #CCCCCC;
+}
+
+
+/*
+----------------------------------------------------------------------------
 HEADER CSS
 --------------------------------------------------------------------------
 */
@@ -371,100 +455,6 @@ MESSAGE PARTIAL CSS
 #message-container {
   margin-left: 15px;
   margin-right: 15px;
-}
-
-/*
-----------------------------------------------------------------------------
-COMMON CONTENT BLOCK CSS
---------------------------------------------------------------------------
-*/
-#main-content {
-  padding: 0.5rem 1rem;
-}
-.twl-btn {
-  white-space: nowrap;
-  font-family: Roboto;
-  font-size: 14px;
-  color: #FFFFFF !important;
-  background-color: #3366CC !important;
-}
-.twl-btn:hover {
-  color: #FFFFFF !important;
-  background-color: #3366CC !important;
-  text-decoration: underline !important;
-}
-.btn-extra-large{
-  padding-top:30px;
-  padding-bottom:30px;
-  margin-bottom: 14px;
-  max-width: 575px;
-}
-.btn-extra-large::after {
-  content: " ";
-  display: block;
-  height: 0px;
-  clear: both;
-}
-/* uses the less-dangerous-looking pink of bootstrap 3 */
-.bg-danger-soft {
-  background-color: rgb(242, 222, 222);
-}
-/* btn-default behaviors ported from bootstrap 3 */
-.btn-default {
-  color: rgb(51, 51, 51);
-  background-color: rgb(255, 255, 255);
-  border-color: rgb(204, 204, 204);
-}
-.btn-default.focus, .btn-default:focus {
-  color:#333;
-  background-color:#e6e6e6;
-  border-color:#8c8c8c
-}
-.btn-default:hover {
-  color:#333;
-  background-color:#e6e6e6;
-  border-color:#adadad
-}
-.btn-default.active, .btn-default:active, .open>.dropdown-toggle.btn-default {
-  color:#333;
-  background-color:#e6e6e6;
-  border-color:#adadad
-}
-.btn-default.active.focus,.btn-default.active:focus, .btn-default.active:hover, .btn-default:active.focus, .btn-default:active:focus, .btn-default:active:hover, .open>.dropdown-toggle.btn-default.focus, .open>.dropdown-toggle.btn-default:focus, .open>.dropdown-toggle.btn-default:hover{color:#333;background-color:#d4d4d4;border-color:#8c8c8c}.btn-default.active, .btn-default:active, .open>.dropdown-toggle.btn-default {
-  background-image:none
-}
-.btn-default.disabled.focus, .btn-default.disabled:focus, .btn-default.disabled:hover, .btn-default[disabled].focus, .btn-default[disabled]:focus, .btn-default[disabled]:hover, fieldset[disabled] .btn-default.focus,fieldset[disabled] .btn-default:focus, fieldset[disabled] .btn-default:hover {
-  background-color:#fff;
-  border-color:#ccc
-}
-.btn-default .badge {
-  color:#fff;
-  background-color:#333
-}
-
-.twl-links{
-    color: #3366CC;
-}
-
-.twl-main-btn{
-    color: #FFFFFF;
-    background-color: #3366CC;
-    border-color: #3366CC;
-}
-
-.twl-main-btn:hover{
-    color: #FFFFFF;
-    text-decoration: underline;
-}
-
-.twl-secondary-btn{
-    color: #000000;
-    background-color: #FFFFFF;
-    border-color: #CCCCCC;
-}
-
-.twl-secondary-btn:hover{
-    background-color: #CCCCCC;
 }
 
 /*

--- a/TWLight/static/css/new-local.css
+++ b/TWLight/static/css/new-local.css
@@ -876,10 +876,7 @@ and (max-device-width : 1024px) {
         text-align: center;
     }
     .applications-link{
-        font-family: Roboto;
         font-size: 13px;
-        color: #3366CC;
-        text-decoration: underline;
     }
     .applications-item{
         position: absolute;
@@ -902,10 +899,7 @@ and (max-device-width : 480px) {
         text-align: center;
     }
     .applications-link{
-        font-family: Roboto;
         font-size: 13px;
-        color: #3366CC;
-        text-decoration: underline;
     }
     .applications-item{
         position: absolute;

--- a/TWLight/static/css/new-local.rtl.css
+++ b/TWLight/static/css/new-local.rtl.css
@@ -43,6 +43,90 @@ body {
 
 /*
 ----------------------------------------------------------------------------
+COMMON CONTENT BLOCK CSS
+--------------------------------------------------------------------------
+*/
+#main-content {
+  padding: 0.5rem 1rem;
+}
+
+.twl-btn {
+  white-space: nowrap;
+  font-family: Roboto;
+  font-size: 14px;
+  color: #FFFFFF !important;
+  background-color: #3366CC !important;
+}
+.twl-btn:hover {
+  color: #FFFFFF !important;
+  background-color: #3366CC !important;
+  text-decoration: underline !important;
+}
+.btn-extra-large{
+  padding-top:30px;
+  padding-bottom:30px;
+  margin-bottom: 14px;
+  max-width: 575px;
+}
+.btn-extra-large::after {
+  content: " ";
+  display: block;
+  height: 0px;
+  clear: both;
+}
+/* uses the less-dangerous-looking pink of bootstrap 3 */
+.bg-danger-soft {
+  background-color: rgb(242, 222, 222);
+}
+/* btn-default behaviors ported from bootstrap 3 */
+.btn-default {
+  color: rgb(51, 51, 51);
+  background-color: rgb(255, 255, 255);
+  border-color: rgb(204, 204, 204);
+}
+.btn-default.focus, .btn-default:focus {
+  color:#333;
+  background-color:#e6e6e6;
+  border-color:#8c8c8c
+}
+.btn-default:hover {
+  color:#333;
+  background-color:#e6e6e6;
+  border-color:#adadad
+}
+.btn-default.active, .btn-default:active, .open>.dropdown-toggle.btn-default {
+  color:#333;
+  background-color:#e6e6e6;
+  border-color:#adadad
+}
+.btn-default.active.focus,.btn-default.active:focus, .btn-default.active:hover, .btn-default:active.focus, .btn-default:active:focus, .btn-default:active:hover, .ope     n>.dropdown-toggle.btn-default.focus, .open>.dropdown-toggle.btn-default:focus, .open>.dropdown-toggle.btn-default:hover{color:#333;background-color:#d4d4d4;border-c     olor:#8c8c8c}.btn-default.active, .btn-default:active, .open>.dropdown-toggle.btn-default {
+  background-image:none
+}
+.btn-default.disabled.focus, .btn-default.disabled:focus, .btn-default.disabled:hover, .btn-default[disabled].focus, .btn-default[disabled]:focus, .btn-default[disab     led]:hover, fieldset[disabled] .btn-default.focus,fieldset[disabled] .btn-default:focus, fieldset[disabled] .btn-default:hover {
+  background-color:#fff;
+  border-color:#ccc
+}
+.btn-default .badge {
+  color:#fff;
+  background-color:#333
+}
+
+.twl-links{
+    color: #3366CC;
+}
+
+.twl-secondary-btn{
+    color: #000000;
+    background-color: #FFFFFF;
+    border-color: #CCCCCC;
+}
+
+.twl-secondary-btn:hover{
+    background-color: #CCCCCC;
+}
+
+/*
+----------------------------------------------------------------------------
 HEADER CSS
 --------------------------------------------------------------------------
 */
@@ -382,101 +466,6 @@ MESSAGE PARTIAL CSS
 #message-container {
   margin-left: 15px;
   margin-right: 15px;
-}
-
-/*
-----------------------------------------------------------------------------
-COMMON CONTENT BLOCK CSS
---------------------------------------------------------------------------
-*/
-#main-content {
-  padding: 0.5rem 1rem;
-}
-
-.twl-btn {
-  white-space: nowrap;
-  font-family: Roboto;
-  font-size: 14px;
-  color: #FFFFFF !important;
-  background-color: #3366CC !important;
-}
-.twl-btn:hover {
-  color: #FFFFFF !important;
-  background-color: #3366CC !important;
-  text-decoration: underline !important;
-}
-.btn-extra-large{
-  padding-top:30px;
-  padding-bottom:30px;
-  margin-bottom: 14px;
-  max-width: 575px;
-}
-.btn-extra-large::after {
-  content: " ";
-  display: block;
-  height: 0px;
-  clear: both;
-}
-/* uses the less-dangerous-looking pink of bootstrap 3 */
-.bg-danger-soft {
-  background-color: rgb(242, 222, 222);
-}
-/* btn-default behaviors ported from bootstrap 3 */
-.btn-default {
-  color: rgb(51, 51, 51);
-  background-color: rgb(255, 255, 255);
-  border-color: rgb(204, 204, 204);
-}
-.btn-default.focus, .btn-default:focus {
-  color:#333;
-  background-color:#e6e6e6;
-  border-color:#8c8c8c
-}
-.btn-default:hover {
-  color:#333;
-  background-color:#e6e6e6;
-  border-color:#adadad
-}
-.btn-default.active, .btn-default:active, .open>.dropdown-toggle.btn-default {
-  color:#333;
-  background-color:#e6e6e6;
-  border-color:#adadad
-}
-.btn-default.active.focus,.btn-default.active:focus, .btn-default.active:hover, .btn-default:active.focus, .btn-default:active:focus, .btn-default:active:hover, .ope     n>.dropdown-toggle.btn-default.focus, .open>.dropdown-toggle.btn-default:focus, .open>.dropdown-toggle.btn-default:hover{color:#333;background-color:#d4d4d4;border-c     olor:#8c8c8c}.btn-default.active, .btn-default:active, .open>.dropdown-toggle.btn-default {
-  background-image:none
-}
-.btn-default.disabled.focus, .btn-default.disabled:focus, .btn-default.disabled:hover, .btn-default[disabled].focus, .btn-default[disabled]:focus, .btn-default[disab     led]:hover, fieldset[disabled] .btn-default.focus,fieldset[disabled] .btn-default:focus, fieldset[disabled] .btn-default:hover {
-  background-color:#fff;
-  border-color:#ccc
-}
-.btn-default .badge {
-  color:#fff;
-  background-color:#333
-}
-
-.twl-links{
-    color: #3366CC;
-}
-
-.twl-main-btn{
-    color: #FFFFFF;
-    background-color: #3366CC;
-    border-color: #3366CC;
-}
-
-.twl-main-btn:hover{
-    color: #FFFFFF;
-    text-decoration: underline;
-}
-
-.twl-secondary-btn{
-    color: #000000;
-    background-color: #FFFFFF;
-    border-color: #CCCCCC;
-}
-
-.twl-secondary-btn:hover{
-    background-color: #CCCCCC;
 }
 
 /*

--- a/TWLight/static/css/new-local.rtl.css
+++ b/TWLight/static/css/new-local.rtl.css
@@ -1029,16 +1029,9 @@ NEW MY LIBRARY COLLECTION TILES CSS
 }
 
 .access-apply-button{
-    color: #FFFFFF;
-    background-color: #3366CC;
     width: 50%;
     float: right;
     -webkit-appearance: none;
-}
-
-.access-apply-button:hover{
-    color: #FFFFFF;
-    text-decoration: underline;
 }
 
 .renew-extend-button{
@@ -1058,8 +1051,6 @@ NEW MY LIBRARY COLLECTION TILES CSS
 and (min-device-width : 320px)
 and (max-device-width : 480px) {
     .access-apply-button{
-        color: #FFFFFF;
-        background-color: #3366CC;
         width: 100%;
         margin-bottom: 10px;
         -webkit-appearance: none;
@@ -1077,8 +1068,6 @@ and (max-device-width : 480px) {
 and (min-device-width : 768px)
 and (max-device-width : 1024px) {
     .access-apply-button{
-        color: #FFFFFF;
-        background-color: #3366CC;
         width: 100%;
         margin-bottom: 10px;
         -webkit-appearance: none;

--- a/TWLight/static/css/new-local.rtl.css
+++ b/TWLight/static/css/new-local.rtl.css
@@ -195,13 +195,7 @@ HEADER CSS
 .feedback-link{
     float: left;
     font-size: 12px;
-    color: #3366CC;
-    text-decoration: underline;
     margin-left: 12%;
-}
-.feedback-link:hover{
-    color: #3366CC;
-    text-decoration: none;
 }
 
 .top-navbar-button{

--- a/TWLight/static/css/new-local.rtl.css
+++ b/TWLight/static/css/new-local.rtl.css
@@ -1278,19 +1278,8 @@ CONTACT US CSS
 --------------------------------------------------------------------------
 */
 
-.contact-us-links, .evaluate-application-link{
+.evaluate-application-link{
     color: #3366CC;
-}
-
-.contact-us-button{
-    background-color: #3366CC;
-    border-color: #3366CC;
-}
-
-.contact-us-button:hover{
-    background-color: #3366CC;
-    border-color: #3366CC;
-    text-decoration: underline;
 }
 
 .contact-info-header{

--- a/TWLight/static/css/new-local.rtl.css
+++ b/TWLight/static/css/new-local.rtl.css
@@ -185,16 +185,7 @@ HEADER CSS
 }
 
 .eds-search-button{
-    font-family: Roboto;
-    color: #FFFFFF;
-    background-color: #3366CC;
     border-radius: 0 2px 2px 0;
-}
-
-.eds-search-button:hover {
-    color: #FFFFFF !important;
-    background-color: #3366CC !important;
-    text-decoration: underline !important;
 }
 
 .eds-search-icon{

--- a/TWLight/static/css/new-local.rtl.css
+++ b/TWLight/static/css/new-local.rtl.css
@@ -888,10 +888,7 @@ and (max-device-width : 1024px) {
         text-align: center;
     }
     .applications-link{
-        font-family: Roboto;
         font-size: 13px;
-        color: #3366CC;
-        text-decoration: underline;
     }
     .applications-item{
         position: absolute;
@@ -913,10 +910,7 @@ and (max-device-width : 480px) {
         text-align: center;
     }
     .applications-link{
-        font-family: Roboto;
         font-size: 13px;
-        color: #3366CC;
-        text-decoration: underline;
     }
     .applications-item{
         position: absolute;

--- a/TWLight/static/css/new-local.rtl.css
+++ b/TWLight/static/css/new-local.rtl.css
@@ -1278,10 +1278,6 @@ CONTACT US CSS
 --------------------------------------------------------------------------
 */
 
-.evaluate-application-link{
-    color: #3366CC;
-}
-
 .contact-info-header{
     background-color: #3366CC;
     color: #FFFFFF;

--- a/TWLight/static/css/new-local.rtl.css
+++ b/TWLight/static/css/new-local.rtl.css
@@ -795,8 +795,6 @@ NEW MY LIBRARY CSS
 }
 .learn-more-link, .discuss-link, .reset-filters-link{
     font-size: 15px;
-    color: #3366CC;
-    text-decoration: underline;
 }
 .icon-section{
     display: inline-block;

--- a/TWLight/static/css/new-local.rtl.css
+++ b/TWLight/static/css/new-local.rtl.css
@@ -115,6 +115,13 @@ COMMON CONTENT BLOCK CSS
     color: #3366CC;
 }
 
+.twl-links-underline{
+    text-decoration: underline;
+}
+.twl-links-underline:hover{
+    text-decoration: none;
+}
+
 .twl-secondary-btn{
     color: #000000;
     background-color: #FFFFFF;
@@ -778,14 +785,7 @@ NEW MY LIBRARY CSS
 }
 
 .applications-link{
-    font-family: Roboto;
     font-size: 14px;
-    color: #3366CC;
-    text-decoration: underline;
-}
-.applications-link:hover{
-    color: #3366CC;
-    text-decoration: none;
 }
 .about-section, .key-section{
     font-size: 15px;

--- a/TWLight/templates/about.html
+++ b/TWLight/templates/about.html
@@ -41,7 +41,7 @@
       {% url 'terms' as terms_url %}
       {% comment %}Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/). Don't translate {{ terms_url }}. {% endcomment %}
       {% blocktranslate trimmed %}
-        For more information about how your information is stored and reviewed please see our <a href="{{ terms_url }}">
+        For more information about how your information is stored and reviewed please see our <a class="twl-links" href="{{ terms_url }}">
         terms of use and privacy policy</a>. Accounts you apply for are also subject to the Terms of Use provided by each
         partner’s platform; please review them.
       {% endblocktranslate %}
@@ -210,7 +210,7 @@
       {% url 'contact' as contact_url %}
       {% comment %}Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).{% endcomment %}
       {% blocktranslate trimmed %}
-        If you have questions, need help, or want to volunteer to help, please see our <a href="{{ contact_url }}">contact page</a>.
+        If you have questions, need help, or want to volunteer to help, please see our <a class="twl-links" href="{{ contact_url }}">contact page</a>.
       {% endblocktranslate %}
     </p>
   </div>

--- a/TWLight/templates/header_partial_b4.html
+++ b/TWLight/templates/header_partial_b4.html
@@ -44,7 +44,7 @@
           {% comment %}Translators: Shown in the search input. {% endcomment %}
           <input id="eb-sbb-search-input" name="bquery" type="text" class="eds-search-input"
               placeholder="{% trans 'Search the library' %}" />
-          <button type="submit" class="btn eds-search-button">
+          <button type="submit" class="btn twl-btn eds-search-button">
             {% comment %}Translators: Shown in the search button. {% endcomment %}
             <span class="eds-search-text">{% trans 'Search' %}</span>
             <i class="fa fa-search eds-search-icon"></i>

--- a/TWLight/templates/header_partial_b4.html
+++ b/TWLight/templates/header_partial_b4.html
@@ -53,7 +53,7 @@
       </form>
       <!-- EBSCO Search Box Ends -->
       <a href="https://meta.wikimedia.org/wiki/Talk:Library_Card_platform/Search" target="_blank"
-          class="feedback-link">
+          class="twl-links twl-links-underline feedback-link">
         {% comment %}Translators: Link that takes a user to an external site to provide feedback on the search bar. {% endcomment %}
         {%trans 'Feedback' %}
       </a>

--- a/TWLight/users/forms.py
+++ b/TWLight/users/forms.py
@@ -188,7 +188,7 @@ class TermsForm(forms.ModelForm):
         self.helper.layout = Layout(
             "terms_of_use",
             # Translators: this 'Submit' is referenced in the terms of use and should be translated the same way both places.
-            Submit("submit", _("Submit"), css_class="btn btn-default terms-button"),
+            Submit("submit", _("Submit"), css_class="btn twl-btn"),
         )
 
 

--- a/TWLight/users/templates/users/available_collection_tile.html
+++ b/TWLight/users/templates/users/available_collection_tile.html
@@ -59,7 +59,7 @@
     </div>
     <div class="card-footer">
       <a href="{% url 'applications:apply_single' available_collection.pk %}"
-          class="btn btn-sm access-apply-button {% if available_collection.is_not_available %} disabled {% endif %}"
+          class="btn btn-sm twl-btn access-apply-button {% if available_collection.is_not_available %} disabled {% endif %}"
           type="button" name="button">
         {% comment %}Translators: On the My Library page (https://wikipedialibrary.wmflabs.org/users/my_library), this labels the text on a button which takes the user to the partner's application page, where they can apply for access. {% endcomment %}
         {% trans "Apply" %}

--- a/TWLight/users/templates/users/collections_section.html
+++ b/TWLight/users/templates/users/collections_section.html
@@ -26,7 +26,7 @@
     </li>
   </ul>
   <div class="applications-item">
-    <a href="{% url 'users:my_applications' editor.pk %}" class="nav-link applications-link">
+    <a href="{% url 'users:my_applications' editor.pk %}" class="nav-link twl-links twl-links-underline applications-link">
       {% comment %}Translators: On the MyLibrary page (https://wikipedialibrary.wmflabs.org/users/my_library), a link that will take you to the applications. {% endcomment %}
       {% trans "View my applications >" %}
     </a>

--- a/TWLight/users/templates/users/filter_section.html
+++ b/TWLight/users/templates/users/filter_section.html
@@ -15,12 +15,12 @@
         <p>{% trans "Start with the search bar at the top or browse publisher websites directly." %}</p>
       </div>
       <div class="about-links">
-        <a href="{% url 'about' %}" class="learn-more-link">
+        <a href="{% url 'about' %}" class="twl-links twl-links-underline learn-more-link">
           {% comment %}Translators: On the MyLibrary page (https://wikipedialibrary.wmflabs.org/users/my_library), this appears below introductory text and links to the 'About' page (https://wikipedialibrary.wmflabs.org/about/) {% endcomment %}
           {% trans "Learn more" %}
         </a>
         &ndash;
-        <a href="https://meta.wikimedia.org/wiki/Talk:The_Wikipedia_Library" class="discuss-link">
+        <a href="https://meta.wikimedia.org/wiki/Talk:The_Wikipedia_Library" class="twl-links twl-links-underline discuss-link">
           {% comment %}Translators: On the MyLibrary page (https://wikipedialibrary.wmflabs.org/users/my_library), this appears below introductory text and links to The Wikipedia Library Talk page on meta (https://meta.wikimedia.org/wiki/Talk:The_Wikipedia_Library) {% endcomment %}
           {% trans "Discuss" %}
         </a>
@@ -58,7 +58,7 @@
         {% comment %}Translators: On the MyLibrary page (https://wikipedialibrary.wmflabs.org/users/my_library), this label indicates the start of the filter section. {% endcomment %}
         {% trans "Filters" %}:
       </p>
-      <a href="{% url 'users:my_library' %}?tags=&languages=" class="reset-filters-link">
+      <a href="{% url 'users:my_library' %}?tags=&languages=" class="twl-links reset-filters-link">
         {% comment %}Translators: On the MyLibrary page (https://wikipedialibrary.wmflabs.org/users/my_library), this link will reset the filters for the collections. {% endcomment %}
         {% trans "Reset filters" %}
       </a>

--- a/TWLight/users/templates/users/my_applications.html
+++ b/TWLight/users/templates/users/my_applications.html
@@ -25,7 +25,7 @@
         </div>
         <div class="col-xs-8 col-sm-6">
           <h4>
-          <a class="evaluate-application-link" href="{{ app.get_absolute_url }}">
+          <a class="twl-links" href="{{ app.get_absolute_url }}">
             {{ app.partner }}
           </a>
           </h4>

--- a/TWLight/users/templates/users/terms.html
+++ b/TWLight/users/templates/users/terms.html
@@ -25,17 +25,6 @@
     .terms-content{
       margin: auto 56px;
     }
-    .terms-link{
-      color: #3366CC;
-    }
-    .terms-button{
-      background-color: #3366CC;
-      border-color: #3366CC;
-    }
-    .terms-button:hover{
-      background-color: #3366CC;
-      text-decoration: underline;
-    }
   </style>
 {% endblock extra_css %}
 
@@ -46,7 +35,7 @@
     {# Translators: use the date *when you are translating*, in a language-appropriate format. #}
     <em>{% trans "Last updated 11 August 2021" %}</em>
 
-    <a class="terms-link" href="https://wikimediafoundation.org/wiki/Privacy_policy" style="float:right">
+    <a class="twl-links" href="https://wikimediafoundation.org/wiki/Privacy_policy" style="float:right">
     {% comment %}Translators: This link is on the Terms of Use page and links to the Wikimedia Foundation Privacy Policy (https://wikimediafoundation.org/wiki/Privacy_policy). Wikimedia Foundation should not be translated.{% endcomment %}
     {% trans "Wikimedia Foundation privacy policy" %}
     </a>
@@ -62,7 +51,7 @@
       <p>
         {% comment %}Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.{% endcomment %}
         {% blocktranslate trimmed %}
-          <a class="terms-link" href="https://meta.wikimedia.org/wiki/The_Wikipedia_Library">
+          <a class="twl-links" href="https://meta.wikimedia.org/wiki/The_Wikipedia_Library">
             The Wikipedia Library
           </a>
           has partnered with publishers around the world to allow users to access otherwise
@@ -280,7 +269,7 @@
           application, you will only be asked to supply information required by the
           publishers you have chosen, and each publisher will only receive the information
           they require for providing you with access. Please see our
-          <a class="terms-link" href="{{ all_partners_url }}">partner information</a> pages to learn what
+          <a class="twl-links" href="{{ all_partners_url }}">partner information</a> pages to learn what
           information is required by each publisher to gain access to their resources.
         {% endblocktranslate %}
       </p>
@@ -302,12 +291,12 @@
           In order to administer the Wikipedia Library program, we will retain the application
           data we collect from you for three years after your most recent login, unless
           you delete your account, as described below. You can log in and go to
-          <a class="terms-link" href="{{ profile_url }}">your profile page</a> in order to see the information
+          <a class="twl-links" href="{{ profile_url }}">your profile page</a> in order to see the information
           associated with your account, and can download it in JSON format. You may access,
           update, restrict, or delete this information at any time, except for the information
           that is automatically retrieved from the projects. If you have any questions
           or concerns about the handling of your data, please contact
-          <a class="terms-link" href="mailto:wikipedialibrary@wikimedia.org?Subject=Wikipedia%20Library%20Card%20account%20deactivation">
+          <a class="twl-links" href="mailto:wikipedialibrary@wikimedia.org?Subject=Wikipedia%20Library%20Card%20account%20deactivation">
             wikipedialibrary@wikimedia.org
           </a>.
         {% endblocktranslate %}
@@ -352,7 +341,7 @@
           We may disclose any collected information when required by law, when we have
           your permission, when needed to protect our rights, privacy, safety, users,
           or the general public, and when necessary to enforce these terms, WMF’s
-          general <a class="terms-link" href="https://foundation.wikimedia.org/wiki/Terms_of_Use">Terms of Use</a>,
+          general <a class="twl-links" href="https://foundation.wikimedia.org/wiki/Terms_of_Use">Terms of Use</a>,
           or any other WMF policy.
         {% endblocktranslate %}
       </p>
@@ -414,7 +403,7 @@
         <strong>
           {% comment %}Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Wikimedia Foundation should not be translated. {% endcomment %}
           {% blocktranslate trimmed %}
-            See also the <a class="terms-link" href="https://wikimediafoundation.org/wiki/Privacy_policy">Wikimedia Foundation Privacy Policy</a>.
+            See also the <a class="twl-links" href="https://wikimediafoundation.org/wiki/Privacy_policy">Wikimedia Foundation Privacy Policy</a>.
           {% endblocktranslate %}
         </strong>
       </p>

--- a/TWLight/users/templates/users/user_collection_tile.html
+++ b/TWLight/users/templates/users/user_collection_tile.html
@@ -93,7 +93,7 @@
       {% else %}
         {% if user_collection.auth_latest_sent_app %}
           {% if not user_collection.auth_has_expired %}
-            <a href="{{ user_collection.partner_access_url }}" class="btn btn-sm access-apply-button"
+            <a href="{{ user_collection.partner_access_url }}" class="btn btn-sm twl-btn access-apply-button"
                   type="button" name="button" target="_blank" rel="noopener">
               {% if user_collection.partner_authorization_method != proxy_authorization %}
                   {% comment %}Translators: On the My Library page (https://wikipedialibrary.wmflabs.org/users/my_library), this labels the text on a button which takes the user to the partner's site. {% endcomment %}
@@ -117,7 +117,7 @@
         {% endif %}
       {% endif %}
     {% else %}
-        <a href="{{ user_collection.partner_access_url }}" class="btn btn-sm access-apply-button"
+        <a href="{{ user_collection.partner_access_url }}" class="btn btn-sm twl-btn access-apply-button"
                 type="button" name="button" target="_blank" rel="noopener">
             {% comment %}Translators: On the My Library page (https://wikipedialibrary.wmflabs.org/users/my_library), this labels the text on a button which takes the user to the partner's site. {% endcomment %}
             {% trans "Access collection" %}


### PR DESCRIPTION
[//]: # (Thank you for uploading a PR to the Wikipedia Library!)

## Description
Unified and deleted redundant CSS links and buttons classes.

## Rationale
[//]: # (Why is this change required? What problem does it solve?)
When the team started the redesign work of the library, CSS classes were created as needed. A lot of these CSS classes have repeated code that can be removed and created in a common class. This addresses the issue.

## Phabricator Ticket
[//]: # (Link to the Phabricator ticket)
[T297794](https://phabricator.wikimedia.org/T297794)

## How Has This Been Tested?
[//]: # (- Did you add tests to your changes? Did you modify tests to accommodate your changes?)
[//]: # (- Can this change be tested manually? How?)
Tested manually

## Screenshots of your changes (if appropriate):
[//]: # (It can also be a GIF to prove that your changes are working)

## Types of changes
What types of changes does your code introduce? Add an `x` in all the boxes that apply:
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Minor change (fix a typo, add a translation tag, add section to README, etc.)
