### PR TITLE
Fix ambiguous Approval Mail for Access Codes Applications

### DIFF
--- a/TWLight/emails/tasks.py
+++ b/TWLight/emails/tasks.py
@@ -303,20 +303,27 @@ def send_approval_notification_email(instance):
     path = reverse_lazy("users:my_library")
     link = "https://{base}{path}".format(base=base_url, path=path)
     email = ApprovalNotification()
-
     # If, for some reason, we're trying to send an email to a user
     # who deleted their account, stop doing that.
+
     if instance.editor:
-        email.send(
-            instance.user.email,
-            {
-                "user": instance.user.editor.wp_username,
-                "lang": instance.user.userprofile.lang,
-                "partner": instance.partner,
-                "link": link,
-                "user_instructions": instance.get_user_instructions(),
-            },
-        )
+        # Emails for approved emails in access codes method shall be sent only when finalized
+        if instance.partner.authorization_method == Partner.CODES:
+            logger.info(
+                "Email for access codes method should be sent only once,"
+                "when the status of application is finalized."
+            )
+        else:
+            email.send(
+                instance.user.email,
+                {
+                    "user": instance.user.editor.wp_username,
+                    "lang": instance.user.userprofile.lang,
+                    "partner": instance.partner,
+                    "link": link,
+                    "user_instructions": instance.get_user_instructions(),
+                },
+            )
     else:
         logger.error(
             "Tried to send an email to an editor that doesn't "

--- a/TWLight/emails/tests.py
+++ b/TWLight/emails/tests.py
@@ -14,7 +14,9 @@ from django.core.management import call_command
 from django.urls import reverse
 from django.test import TestCase, RequestFactory
 
-from TWLight.applications.factories import ApplicationFactory
+from TWLight.applications.factories import (
+    ApplicationFactory,
+)
 from TWLight.applications.models import Application
 from TWLight.resources.factories import PartnerFactory
 from TWLight.resources.models import Partner
@@ -239,6 +241,17 @@ class ApplicationStatusTest(TestCase):
         app.status = Application.APPROVED
         app.save()
         self.assertTrue(mock_email.called)
+
+    def test_approval_does_not_call_email_for_applications_with_access_codes_partner(
+        self,
+    ):
+        partner_with_access_codes = PartnerFactory(authorization_method=Partner.CODES)
+        app_with_access_codes_partner = ApplicationFactory(
+            status=Application.PENDING, partner=partner_with_access_codes
+        )
+        app_with_access_codes_partner.status = Application.APPROVED
+        app_with_access_codes_partner.save()
+        self.assertEqual(len(mail.outbox), 0)
 
     @patch("TWLight.emails.tasks.send_approval_notification_email")
     def test_reapproval_does_not_call_email_function(self, mock_email):


### PR DESCRIPTION
- Presently, two emails were sent for applications which have partners
  with access codes authorization. First on approval and then when the
  application is sent to respective partner.

- First email sounds ambiguous as mentioned in the 'first email example'
  at https://phabricator.wikimedia.org/T262521

- Fix: Suppressed approval email for respective applications

- Files Modified: emails/tests.py resources/factories.py applications/factories.py
		  for testing the change

		  emails/tasks.py logic modification for the same

Bug: T262521 on Phabricator

Phabricator [Ticket](https://phabricator.wikimedia.org/T262521)

[x]:  Did you add tests to your changes? Did you modify tests to accommodate your changes?)
       - Yes! emails/tests.py file is amended with one more test case in ApplicationStatusTest subclass
       
[x]:  Can this change be tested manually? How?
      - Go to the admin panel and create a partner with authorization as access code
      - Now either with the interface or through the same panel create an application with initial status as pending (which is also the default one)
      - As an admin or a coordinator, approve the email from /applications/list/ endpoint, notice in DjMails that no approval mail is generated
      - Now create an access code isntance with authorization set to null in the admin panel
      - Head over to the <send data to partners> link in navbar (again from /applications/list), choose an access code for the approved application, and notice that now a DjMail instance will be generated in the admin panel.

## Types of changes
What types of changes does your code introduce? Add an `x` in all the boxes that apply:
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Minor change (fix a typo, add a translation tag, add section to README, etc.)
