### PR TITLE
Add new guard clause in editor_compare_hashes helper function

### DIFF
--- a/TWLight/users/helpers/editor_data.py
+++ b/TWLight/users/helpers/editor_data.py
@@ -253,7 +253,10 @@ class BlockHashChangedEmail(template_mail.TemplateMail):
 
 
 def editor_compare_hashes(
-    previous_block_hash: str, new_block_string: str, wp_username: str
+    previous_block_hash: str,
+    new_block_string: str,
+    wp_username: str,
+    ignore_wp_blocks: bool,
 ):
     """
     Compares two block hashes. If they are different, it means an editor's block status
@@ -265,6 +268,8 @@ def editor_compare_hashes(
         The recently generated block dictionary without hashing.
     wp_username: str
         The Wikipedia username of the editor we are comparing block hashes from
+    ignore_wp_blocks: bool
+        Flag that indicates whether a block is overruled for access to the library
 
     Returns
     -------
@@ -274,14 +279,16 @@ def editor_compare_hashes(
     """
     if previous_block_hash != "":
         if not check_password(new_block_string, previous_block_hash):
-            # Send email to TWL team
-            email = BlockHashChangedEmail()
-            email.send(
-                os.environ.get(
-                    "TWLIGHT_ERROR_MAILTO", "wikipedialibrary@wikimedia.org"
-                ),
-                {"wp_username": wp_username},
-            )
+            # Hash does not match, checking if a user has the block override
+            if ignore_wp_blocks:
+                # Send email to TWL team
+                email = BlockHashChangedEmail()
+                email.send(
+                    os.environ.get(
+                        "TWLIGHT_ERROR_MAILTO", "wikipedialibrary@wikimedia.org"
+                    ),
+                    {"wp_username": wp_username},
+                )
 
             return make_password(new_block_string)
         else:

--- a/TWLight/users/models.py
+++ b/TWLight/users/models.py
@@ -696,7 +696,10 @@ class Editor(models.Model):
             previous_block_hash = self.wp_block_hash
             blocked_dict = editor_make_block_dict(global_userinfo["merged"])
             self.wp_block_hash = editor_compare_hashes(
-                previous_block_hash, blocked_dict, self.wp_username
+                previous_block_hash,
+                blocked_dict,
+                self.wp_username,
+                self.ignore_wp_blocks,
             )
 
         # if the account is already old enough, we shouldn't run this check everytime

--- a/TWLight/users/tests.py
+++ b/TWLight/users/tests.py
@@ -46,7 +46,6 @@ from TWLight.users.helpers.editor_data import (
     editor_reg_date,
     editor_bundle_eligible,
     editor_make_block_dict,
-    editor_compare_hashes,
 )
 
 FAKE_IDENTITY_DATA = {"query": {"userinfo": {"options": {"disablemail": 0}}}}
@@ -1382,7 +1381,68 @@ class EditorModelTestCase(TestCase):
                 new_identity, lang, new_global_userinfo
             )  # This call also saves the editor
 
-    def test_block_hash_changed(self):
+    def test_block_hash_changed_block_override(self):
+        identity = {}
+        identity["username"] = "evil_dr_porkchop"
+        # Users' unique WP IDs should not change across API calls, but are
+        # needed by update_from_wikipedia.
+        identity["sub"] = self.editor.wp_sub
+        identity["rights"] = ["deletion", "spaceflight"]
+        identity["groups"] = ["charismatic megafauna"]
+        # We should now be ignoring the oauth editcount
+        identity["editcount"] = 42
+        identity["email"] = "porkchop@example.com"
+        identity["iss"] = "zh-classical.wikipedia.org"
+        identity["registered"] = "20130205230142"
+        # validity
+        identity["blocked"] = False
+
+        global_userinfo = {}
+        global_userinfo["home"] = "zh_classicalwiki"
+        global_userinfo["id"] = identity["sub"]
+        global_userinfo["registration"] = "2013-02-05T23:01:42Z"
+        global_userinfo["name"] = identity["username"]
+        # We should now be using the global_userinfo editcount
+        global_userinfo["editcount"] = 960
+
+        global_userinfo["merged"] = copy.copy(FAKE_MERGED_ACCOUNTS)
+
+        # Don't change self.editor, or other tests will fail! Make a new one
+        # to test instead.
+        new_editor = EditorFactory(
+            wp_registered=None, wp_block_hash="", ignore_wp_blocks=True
+        )
+        new_identity = dict(identity)
+        new_global_userinfo = dict(global_userinfo)
+        new_identity["sub"] = new_editor.wp_sub
+        new_global_userinfo["id"] = new_identity["sub"]
+
+        lang = get_language()
+        new_editor.update_from_wikipedia(
+            new_identity, lang, new_global_userinfo
+        )  # This call also saves the editor
+
+        blocked_dict = editor_make_block_dict(new_global_userinfo["merged"])
+
+        self.assertTrue(check_password(blocked_dict, new_editor.wp_block_hash))
+        # No emails should be sent since the wp_block_hash was blank
+        self.assertEqual(len(mail.outbox), 0)
+
+        # Add a new block from the user
+        copied_merged_blocked_array = copy.copy(FAKE_MERGED_ACCOUNTS_BLOCKED)
+        new_global_userinfo["merged"] = copied_merged_blocked_array
+
+        new_editor.update_from_wikipedia(
+            new_identity, lang, new_global_userinfo
+        )  # This call also saves the editor
+
+        new_blocked_dict = editor_make_block_dict(new_global_userinfo["merged"])
+
+        self.assertTrue(check_password(new_blocked_dict, new_editor.wp_block_hash))
+        self.assertFalse(check_password(blocked_dict, new_editor.wp_block_hash))
+        self.assertEqual(len(mail.outbox), 1)
+
+    def test_block_hash_changed_no_block_override(self):
         identity = {}
         identity["username"] = "evil_dr_porkchop"
         # Users' unique WP IDs should not change across API calls, but are
@@ -1439,7 +1499,7 @@ class EditorModelTestCase(TestCase):
 
         self.assertTrue(check_password(new_blocked_dict, new_editor.wp_block_hash))
         self.assertFalse(check_password(blocked_dict, new_editor.wp_block_hash))
-        self.assertEqual(len(mail.outbox), 1)
+        self.assertEqual(len(mail.outbox), 0)
 
 
 class OAuthTestCase(TestCase):

--- a/TWLight/users/tests.py
+++ b/TWLight/users/tests.py
@@ -1382,6 +1382,10 @@ class EditorModelTestCase(TestCase):
             )  # This call also saves the editor
 
     def test_block_hash_changed_block_override(self):
+        """
+        Tests that an email is sent when an editor's block status changes and
+        the block override is on
+        """
         identity = {}
         identity["username"] = "evil_dr_porkchop"
         # Users' unique WP IDs should not change across API calls, but are
@@ -1443,6 +1447,10 @@ class EditorModelTestCase(TestCase):
         self.assertEqual(len(mail.outbox), 1)
 
     def test_block_hash_changed_no_block_override(self):
+        """
+        Tests that an email is not sent when an editor's block status changes and
+        the block override is off
+        """
         identity = {}
         identity["username"] = "evil_dr_porkchop"
         # Users' unique WP IDs should not change across API calls, but are


### PR DESCRIPTION
[//]: # (Thank you for uploading a PR to the Wikipedia Library!)

## Description
Added a new guard clause in the `editor_compare_hashes` helper function to check if a user has a block override before sending the email.

## Rationale
[//]: # (Why is this change required? What problem does it solve?)
Emails are being sent when any editor's block status is changed.

## Phabricator Ticket
[//]: # (Link to the Phabricator ticket)
[T295608](https://phabricator.wikimedia.org/T295608)

## How Has This Been Tested?
[//]: # (- Did you add tests to your changes? Did you modify tests to accommodate your changes?)
[//]: # (- Can this change be tested manually? How?)
Added new test

## Screenshots of your changes (if appropriate):
[//]: # (It can also be a GIF to prove that your changes are working)

## Types of changes
What types of changes does your code introduce? Add an `x` in all the boxes that apply:
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Minor change (fix a typo, add a translation tag, add section to README, etc.)
