### PR TITLE
Change "access collection" button width property to 100% 

### DIFF
--- a/TWLight/static/css/new-local.css
+++ b/TWLight/static/css/new-local.css
@@ -1005,7 +1005,7 @@ NEW MY LIBRARY COLLECTION TILES CSS
 }
 
 .access-apply-button{
-    width: 50%;
+    width: 100%;
     -webkit-appearance: none;
 }
 


### PR DESCRIPTION
[//]: # (Thank you for uploading a PR to the Wikipedia Library!)

## Description
Fix "Access the collection button" style on desktops

Change the width property of the element ".access-apply-button" from 50% to 100% on desktop devices

## Rationale
[//]: # (Why is this change required? What problem does it solve?)

## Phabricator Ticket
[T300072](https://phabricator.wikimedia.org/T300072)

## How Has This Been Tested?
This has been tested on the front end. By checking the design on desktops devices

## Screenshots of your changes (if appropriate):
<img width="666" alt="Screenshot" src="https://user-images.githubusercontent.com/25617064/151228273-1861ed66-6119-4d41-9b32-fd575c8505ac.png">


## Types of changes
What types of changes does your code introduce? Add an `x` in all the boxes that apply:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ]  New feature (non-breaking change which adds functionality)
- [ ]  Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ]  Minor change (fix a typo, add a translation tag, add section to README, etc.)
