### PR TITLE
resources/: Add Merge Partner Suggestions feature for Coordinators

### DIFF
--- a/TWLight/resources/filters.py
+++ b/TWLight/resources/filters.py
@@ -123,16 +123,16 @@ class PartnerFilter(MainPartnerFilter):
 
 
 class MergeSuggestionFilter(django_filters.FilterSet):
-    """Filter based on domain name"""
+    """Filter based on URL name"""
 
-    company_domain = django_filters.CharFilter(
-        label="Search via domain:",
+    company_url = django_filters.CharFilter(
+        label="Search via URL",
         field_name="company_url",
-        method="filter_company_domain",
+        method="filter_company_url",
     )
 
-    def filter_company_domain(self, queryset, name, value):
-        # Utility to filter suggestions based on common domain
+    def filter_company_url(self, queryset, name, value):
+        # Utility to filter suggestions based on common url
         lookup = "__".join([name, "icontains"])
 
         qs = queryset.filter(**{lookup: value})
@@ -140,10 +140,10 @@ class MergeSuggestionFilter(django_filters.FilterSet):
 
     class Meta:
         model = Suggestion
-        fields = ["company_domain"]
+        fields = ["company_url"]
 
     def __init__(self, data=None, *args, **kwargs) -> None:
         super().__init__(data, *args, **kwargs)
-        self.filters["company_domain"].field.widget.attrs.update(
+        self.filters["company_url"].field.widget.attrs.update(
             {"class": "form-control form-control-sm"}
         )

--- a/TWLight/resources/filters.py
+++ b/TWLight/resources/filters.py
@@ -10,9 +10,9 @@ import django_filters
 INSTANT = 0
 MULTI_STEP = 1
 ACCESS_CHOICES = (
-    # Translators: On the MyLibrary page (https://wikipedialibrary.wmflabs.org/users/my_library), this indicates that a  collection may be accessed immediately.
+    # Translators: On the MyLibrary page (https://wikipedialibrary.wmflabs.org/users/my_library), this indicates that a collection may be accessed immediately.
     (INSTANT, _("Instant (proxy) access")),
-    # Translators: On the MyLibrary page (https://wikipedialibrary.wmflabs.org/users/my_library), this indicates that a  collection may be accessed only after additional steps, such as submitting an application and awaiting approval.
+    # Translators: On the MyLibrary page (https://wikipedialibrary.wmflabs.org/users/my_library), this indicates that a collection may be accessed only after additional steps, such as submitting an application and awaiting approval.
     (MULTI_STEP, _("Multi-step access")),
 )
 

--- a/TWLight/resources/forms.py
+++ b/TWLight/resources/forms.py
@@ -39,18 +39,18 @@ class SuggestionForm(forms.Form):
 
 class SuggestionMergeForm(forms.Form):
 
-    suggestions_to_merge = forms.ModelMultipleChoiceField(
+    main_suggestion = forms.ModelChoiceField(queryset=Suggestion.objects.all())
+    secondary_suggestions = forms.ModelMultipleChoiceField(
         queryset=Suggestion.objects.all()
     )
-    suggestions_merged_into = forms.ModelChoiceField(queryset=Suggestion.objects.all())
 
     def __init__(self, *args, **kwargs):
         super(SuggestionMergeForm, self).__init__(*args, **kwargs)
-        self.fields["suggestions_to_merge"].label = "Merged suggestions"
-        self.fields["suggestions_merged_into"].label = "Merge suggestions into"
+        self.fields["main_suggestion"].label = "Main suggestion"
+        self.fields["secondary_suggestions"].label = "Secondary suggestions"
         self.helper = FormHelper()
         self.helper.layout = Layout(
-            "suggestions_to_merge",
-            "suggestions_merged_into",
+            "main_suggestion",
+            "secondary_suggestions",
             Submit("submit", "Submit", css_class="twl-btn"),
         )

--- a/TWLight/resources/forms.py
+++ b/TWLight/resources/forms.py
@@ -1,5 +1,6 @@
 from django import forms
 from django.utils.translation import gettext_lazy as _
+from TWLight.resources.models import Suggestion
 
 from crispy_forms.helper import FormHelper
 from crispy_forms.layout import Submit, Layout
@@ -32,5 +33,27 @@ class SuggestionForm(forms.Form):
             "company_url",
             "next",
             # Translators: This labels a button which users click to submit their suggestion.
+            Submit("submit", _("Submit"), css_class="twl-btn"),
+        )
+
+
+class SuggestionMergeForm(forms.Form):
+
+    suggestions_to_merge = forms.ModelMultipleChoiceField(
+        queryset=Suggestion.objects.all()
+    )
+    suggestions_merged_into = forms.ModelChoiceField(queryset=Suggestion.objects.all())
+
+    def __init__(self, *args, **kwargs):
+        super(SuggestionMergeForm, self).__init__(*args, **kwargs)
+        # Translators: This labels a multiple choice field to choose the suggestions to merge
+        self.fields["suggestions_to_merge"].label = _("Merged suggestions")
+        # Translators: This labels a choiceField where users can enter the suggestion to merge into
+        self.fields["suggestions_merged_into"].label = _("Merge suggestions into")
+        self.helper = FormHelper()
+        self.helper.layout = Layout(
+            "suggestions_to_merge",
+            "suggestions_merged_into",
+            # Translators: This labels a button which users click to merge suggestions.
             Submit("submit", _("Submit"), css_class="twl-btn"),
         )

--- a/TWLight/resources/forms.py
+++ b/TWLight/resources/forms.py
@@ -45,7 +45,7 @@ class SuggestionMergeForm(forms.Form):
     )
 
     def __init__(self, *args, **kwargs):
-        super(SuggestionMergeForm, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
         self.fields["main_suggestion"].label = "Main suggestion"
         self.fields["secondary_suggestions"].label = "Secondary suggestions"
         self.helper = FormHelper()

--- a/TWLight/resources/forms.py
+++ b/TWLight/resources/forms.py
@@ -46,14 +46,11 @@ class SuggestionMergeForm(forms.Form):
 
     def __init__(self, *args, **kwargs):
         super(SuggestionMergeForm, self).__init__(*args, **kwargs)
-        # Translators: This labels a multiple choice field to choose the suggestions to merge
-        self.fields["suggestions_to_merge"].label = _("Merged suggestions")
-        # Translators: This labels a choiceField where users can enter the suggestion to merge into
-        self.fields["suggestions_merged_into"].label = _("Merge suggestions into")
+        self.fields["suggestions_to_merge"].label = "Merged suggestions"
+        self.fields["suggestions_merged_into"].label = "Merge suggestions into"
         self.helper = FormHelper()
         self.helper.layout = Layout(
             "suggestions_to_merge",
             "suggestions_merged_into",
-            # Translators: This labels a button which users click to merge suggestions.
-            Submit("submit", _("Submit"), css_class="twl-btn"),
+            Submit("submit", "Submit", css_class="twl-btn"),
         )

--- a/TWLight/resources/templates/resources/merge_suggestion.html
+++ b/TWLight/resources/templates/resources/merge_suggestion.html
@@ -1,0 +1,146 @@
+{% extends "new_base.html" %}
+{% load cache %}
+{% load i18n %}
+{% load static %}
+{% load crispy_forms_tags %}
+
+{% load twlight_perms %}
+
+{% block extra_css %}
+<style>
+  .merge-card-header {
+    display: flex;
+    justify-content: space-between;
+    margin-bottom: 10px;
+  }
+</style>
+{% endblock extra_css %}
+
+
+{% block content %}
+
+{% include "header_partial_b4.html" %}
+{% include "message_partial.html" %}
+
+{% if all_suggestions %}
+<div id="main-content">
+  <form method='get' class="mb-4">
+    {{filter.form}}
+    <button class='btn twl-btn mt-1 mb-1' type='submit'>Apply</button>
+  </form>
+  {% for each_suggestion in all_suggestions %}
+  <div class="card full-width mb-4">
+    <div class="card-header merge-card-header">
+      <div class="card-title pull-left"><span class="card-title">{{ each_suggestion.suggested_company_name }}</span>
+      </div>
+
+      <div class="custom-control custom-checkbox">
+        <input type="checkbox" class="custom-control-input merge" id='merge-{{each_suggestion.id}}'
+          key={{each_suggestion.id}} display-text={{each_suggestion.suggested_company_name}}>
+        <label class="custom-control-label" for='merge-{{each_suggestion.id}}'>Merge?</label>
+      </div>
+    </div>
+    <div class="card-body ">
+      <div class="row">
+        <div class="col-lg-10">
+          <p>
+            <strong>{% trans 'Description' %}: </strong>
+            {{ each_suggestion.description | safe }}
+          </p>
+          <p>
+            <strong>{% trans 'URL' %}:</strong>
+            <a class="twl-links" href="{{ each_suggestion.company_url }}">
+              {{ each_suggestion.company_url }}
+            </a>
+          </p>
+          <p>
+            <strong>{% trans 'Proposer' %}:</strong>
+            <a class="twl-links" href="{{ each_suggestion.author.editor.wp_link_central_auth }}">
+              {{ each_suggestion.author.editor.wp_username }}
+            </a>
+          </p>
+          <div class="custom-control custom-checkbox">
+            <input type="checkbox" class="custom-control-input mergeInto" id='mergeInto-{{each_suggestion.id}}'
+              key={{each_suggestion.id}} display-text={{each_suggestion.suggested_company_name}}>
+            <label class="custom-control-label" for='mergeInto-{{each_suggestion.id}}'>Merge Into?</label>
+          </div>
+        </div>
+        {% if user.is_authenticated %}
+        <div class="col-lg-2 pull-right" style="text-align: right;">
+          <button class="btn upvote btn-success">
+            <i class="fa fa-arrow-up" aria-hidden="true"></i>
+            <span class="utext">
+              {% comment %}Translators: This is the text that shows upvotes for a suggestion {% endcomment %}
+              {% trans 'Upvotes' %}
+            </span>
+            <span class="count badge badge-light text-success">
+              {{ each_suggestion.upvoted_users.count }}
+            </span>
+          </button>
+        </div>
+        {% endif %}
+      </div>
+    </div>
+  </div>
+  {% endfor %}
+  <div class="card full-width mb-4">
+    <div class="card-header">
+      {% comment %}Translators: This is the title of the form where coordiantors can merge partner suggestions. {% endcomment %}
+      <strong><span class="card-title">{% trans 'Merge Suggestions' %}</span></strong>
+    </div>
+    <div class="card-body">
+      <form class="w-75 mx-auto" {% if user.is_authenticated %} method="post" {% elif request.GET %} method="get"
+        action="{% url 'oauth_login' %}?next={{ request.path|urlencode }}&{{ request.GET.urlencode }}" {% else %}
+        method="get" action="{% url 'oauth_login' %}?next={{ request.path|urlencode }}" {% endif %}>
+        {% crispy form %}
+      </form>
+    </div>
+  </div>
+</div>
+{% else %}
+<p> No suggestions to merge. </p>
+{% endif %}
+{% endblock content %}
+
+{% block javascript %}
+<script>
+  var merged_suggestions = []
+  var merge_into = null;
+  $('.merge').click(
+    function () {
+      merged_suggestions = [];
+
+      $('.merge:checkbox:checked').each(
+        function (ind, item) {
+          merged_suggestions.push($(item).attr("key"));
+        }
+      );
+      $('#id_suggestions_to_merge').val(merged_suggestions);
+    }
+  );
+  $('.mergeInto').click(
+    function () {
+      var this_ = $(this);
+      $('.mergeInto').not(this).prop('checked', false);
+      merge_into = this_.is(":checked") ? this_.attr("key") : "";
+      $('#id_suggestions_merged_into').val(merge_into);
+    }
+  );
+  $('#id_suggestions_to_merge').change(function () {
+    merged_suggestions = $(this).val()
+    $('#id_suggestions_to_merge option').not(':selected').each(function (ind, ele) {
+      $(`input[id=merge-${ele.value}]`).prop('checked', false);;
+    })
+    $.each(
+      merged_suggestions, function (ind, item) {
+        $(`input[id=merge-${item}]`).prop('checked', true);;
+      }
+    );
+  })
+  $('#id_suggestions_merged_into').change(function () {
+    merge_into = $(this).val()
+    $(`input[id=mergeInto-${merge_into}]`).click()
+
+  })
+</script>
+{% endblock javascript%}

--- a/TWLight/resources/templates/resources/merge_suggestion.html
+++ b/TWLight/resources/templates/resources/merge_suggestion.html
@@ -28,6 +28,19 @@
     {{filter.form}}
     <button class='btn twl-btn mt-1 mb-1' type='submit'>Apply</button>
   </form>
+  <div class="card full-width mb-4">
+    <div class="card-header">
+      {% comment %}Translators: This is the title of the form where coordiantors can merge partner suggestions. {% endcomment %}
+      <strong><span class="card-title">{% trans 'Merge Suggestions' %}</span></strong>
+    </div>
+    <div class="card-body">
+      <form class="w-75 mx-auto" {% if user.is_authenticated %} method="post" {% elif request.GET %} method="get"
+        action="{% url 'oauth_login' %}?next={{ request.path|urlencode }}&{{ request.GET.urlencode }}" {% else %}
+        method="get" action="{% url 'oauth_login' %}?next={{ request.path|urlencode }}" {% endif %}>
+        {% crispy form %}
+      </form>
+    </div>
+  </div>
   {% for each_suggestion in all_suggestions %}
   <div class="card full-width mb-4">
     <div class="card-header merge-card-header">
@@ -35,9 +48,9 @@
       </div>
 
       <div class="custom-control custom-checkbox">
-        <input type="checkbox" class="custom-control-input merge" id='merge-{{each_suggestion.id}}'
+        <input type="checkbox" class="custom-control-input mergeInto" id='mergeInto-{{each_suggestion.id}}'
           key={{each_suggestion.id}} display-text={{each_suggestion.suggested_company_name}}>
-        <label class="custom-control-label" for='merge-{{each_suggestion.id}}'>Merge?</label>
+        <label class="custom-control-label" for='mergeInto-{{each_suggestion.id}}'>Main suggestion</label>
       </div>
     </div>
     <div class="card-body ">
@@ -60,9 +73,9 @@
             </a>
           </p>
           <div class="custom-control custom-checkbox">
-            <input type="checkbox" class="custom-control-input mergeInto" id='mergeInto-{{each_suggestion.id}}'
+            <input type="checkbox" class="custom-control-input merge" id='merge-{{each_suggestion.id}}'
               key={{each_suggestion.id}} display-text={{each_suggestion.suggested_company_name}}>
-            <label class="custom-control-label" for='mergeInto-{{each_suggestion.id}}'>Merge Into?</label>
+            <label class="custom-control-label" for='merge-{{each_suggestion.id}}'>Secondary suggestion</label>
           </div>
         </div>
         {% if user.is_authenticated %}
@@ -83,19 +96,6 @@
     </div>
   </div>
   {% endfor %}
-  <div class="card full-width mb-4">
-    <div class="card-header">
-      {% comment %}Translators: This is the title of the form where coordiantors can merge partner suggestions. {% endcomment %}
-      <strong><span class="card-title">{% trans 'Merge Suggestions' %}</span></strong>
-    </div>
-    <div class="card-body">
-      <form class="w-75 mx-auto" {% if user.is_authenticated %} method="post" {% elif request.GET %} method="get"
-        action="{% url 'oauth_login' %}?next={{ request.path|urlencode }}&{{ request.GET.urlencode }}" {% else %}
-        method="get" action="{% url 'oauth_login' %}?next={{ request.path|urlencode }}" {% endif %}>
-        {% crispy form %}
-      </form>
-    </div>
-  </div>
 </div>
 {% else %}
 <p> No suggestions to merge. </p>
@@ -106,29 +106,55 @@
 <script>
   var merged_suggestions = []
   var merge_into = null;
+  // Whenever a secondary suggestion checkbox is clicked, the Secondary suggestions form will change
   $('.merge').click(
     function () {
       merged_suggestions = [];
-
       $('.merge:checkbox:checked').each(
         function (ind, item) {
-          merged_suggestions.push($(item).attr("key"));
+          var merged_suggestion_id = $(item).attr('id');
+          var suggestion_id = merged_suggestion_id.split("-")[1];
+          // Check if the main suggestion checkbox is checked
+          if($('#mergeInto-' + suggestion_id).prop('checked') && $(item).prop('checked')){
+            // Uncheck both and reset form
+            $('#mergeInto-' + suggestion_id).prop('checked', false);
+            $('.merge:checkbox:checked').prop('checked', false)
+            $('#id_secondary_suggestions').val("");
+            $('#id_main_suggestion').val("");
+          }
+          else{
+            merged_suggestions.push($(item).attr('key'));
+          }
         }
       );
-      $('#id_suggestions_to_merge').val(merged_suggestions);
+      $('#id_secondary_suggestions').val(merged_suggestions);
     }
   );
+  // Whenever a main suggestion checkbox is clicked, the Main suggestion form will change
   $('.mergeInto').click(
     function () {
       var this_ = $(this);
-      $('.mergeInto').not(this).prop('checked', false);
-      merge_into = this_.is(":checked") ? this_.attr("key") : "";
-      $('#id_suggestions_merged_into').val(merge_into);
+      var id = this_.attr('id');
+      var suggestion_id = id.split("-")[1];
+      // Check if the secondary suggestion checkbox is checked
+      if($('#merge-' + suggestion_id).prop('checked') && this_.prop('checked')){
+        // Uncheck both and reset form
+        $('.merge:checkbox:checked').prop('checked', false)
+        this_.prop('checked', false);
+        $('#id_secondary_suggestions').val("");
+        $('#id_main_suggestion').val("");
+      }
+      else{
+        $('.mergeInto').not(this_).prop('checked', false);
+        merge_into = this_.is(":checked") ? this_.attr("key") : "";
+        $('#id_main_suggestion').val(merge_into);
+      }
     }
   );
-  $('#id_suggestions_to_merge').change(function () {
+  // Whenever there is a change in secondary suggestions, the secondary checkboxes will be checked
+  $('#id_secondary_suggestions').change(function () {
     merged_suggestions = $(this).val()
-    $('#id_suggestions_to_merge option').not(':selected').each(function (ind, ele) {
+    $('#id_secondary_suggestions option').not(':selected').each(function (ind, ele) {
       $(`input[id=merge-${ele.value}]`).prop('checked', false);;
     })
     $.each(
@@ -137,7 +163,8 @@
       }
     );
   })
-  $('#id_suggestions_merged_into').change(function () {
+  // Whenever there is a change in the main suggestion, the main checkbox will be checked
+  $('#id_main_suggestion').change(function () {
     merge_into = $(this).val()
     $(`input[id=mergeInto-${merge_into}]`).click()
 

--- a/TWLight/resources/templates/resources/suggest.html
+++ b/TWLight/resources/templates/resources/suggest.html
@@ -33,6 +33,15 @@
       </div>
     </div>
     {% if all_suggestions %}
+    {% if user.is_staff %}
+      <a class="btn btn-outline-dark mb-1"
+          href="{% url 'suggest-merge' %}"s>
+        <span class="utext">
+            {% comment %}Translators: This is the text that appears in the button for staff to merge. {% endcomment %}
+            {% trans 'Merge' %}
+        </span>
+      </a>
+    {% endif %}
       <div class="card full-width">
         <div class="card-header">
           {% comment %}Translators: This is the title of the panel where user suggestions are displayed. {% endcomment %}

--- a/TWLight/resources/tests.py
+++ b/TWLight/resources/tests.py
@@ -1406,12 +1406,19 @@ class SuggestionMergeViewTests(TestCase):
             company_url="www.testingMerged1234.com"
         )
         cls.merge_suggestion_url = reverse("suggest-merge")
-        cls.editor = EditorCraftRoom(cls, Terms=True, Coordinator=True)
-        cls.restricted_editor = EditorCraftRoom(cls, Terms=True, Coordinator=False)
-        cls.upvoters_or_authors = [cls.restricted_editor, cls.editor]
-        cls.user = UserFactory(editor=cls.editor)
-        cls.suggestions_merged_into.author = cls.editor.user
-        cls.suggestions_merged_into.upvoted_users.add(cls.editor.user)
+
+        # Manually setting up with EditorFactory since we don't need a client session yet
+        cls.coordinator = EditorFactory()
+        coordinators = get_coordinators()
+        coordinators.user_set.add(cls.coordinator.user)
+        cls.staff = EditorFactory()
+        cls.staff.user.is_staff = True
+        coordinators.user_set.add(cls.staff.user)
+        cls.editor = EditorFactory()
+
+        cls.upvoters_or_authors = [cls.editor, cls.coordinator]
+        cls.suggestions_merged_into.author = cls.coordinator.user
+        cls.suggestions_merged_into.upvoted_users.add(cls.coordinator.user)
         cls.suggestions_merged_into.save()
 
         cls.suggestion_merge_count = 5
@@ -1439,62 +1446,63 @@ class SuggestionMergeViewTests(TestCase):
         super().tearDownClass()
         cls.message_patcher.stop()
 
-    def test_partner_suggestion_view_coordinators_only(self):
+    def test_partner_suggestion_view_staff_only(self):
         """
-        Tests that getting the suggested partners page for merge works only for coordinators.
+        Tests that getting the suggested partners page for merge works only for staff.
         """
 
         factory = RequestFactory()
         request = factory.get(self.merge_suggestion_url)
-        request.user = self.restricted_editor.user
-        self.assertRaises(PermissionDenied)
+        request.user = self.editor.user
+        with self.assertRaises(PermissionDenied):
+            response = SuggestionMergeView.as_view()(request)
+        request.user = self.coordinator.user
+        with self.assertRaises(PermissionDenied):
+            response = SuggestionMergeView.as_view()(request)
+        request.user = self.staff.user
+        response = SuggestionMergeView.as_view()(request)
+        self.assertEqual(response.status_code, 200)
 
     def test_merge_partner_suggestion_view_post(self):
         """
         Tests that merging a partner suggestion works properly, with upvotes too getting merged properly
         """
-        merge_suggestion_data = {
-            "suggestions_merged_into": self.suggestions_merged_into,
-            "suggestions_to_merge": self.suggestions_to_merge,
-        }
-        factory = RequestFactory()
-        request = factory.post(self.merge_suggestion_url, data=merge_suggestion_data)
-        # print(request.POST.get('suggestions_merged_into'))
-        # print(request.POST.getlist('suggestions_to_merge'))
-        coordinators = get_coordinators()
-        coordinators.user_set.add(self.user)
-        request.user = self.user
 
-        response = SuggestionMergeView.as_view()(request)
+        # setup suggestion pk form data
+        suggestions_to_merge_pks = []
+        for suggestion in self.suggestions_to_merge:
+            print(suggestion.company_url)
+            suggestions_to_merge_pks.append(suggestion.pk)
+        merge_suggestion_data = {
+            "suggestions_merged_into": self.suggestions_merged_into.pk,
+            "suggestions_to_merge": suggestions_to_merge_pks,
+        }
+
+        # Start a staff test client session
+        EditorCraftRoom(self, Terms=True, Coordinator=True, editor=self.staff)
+
+        # Submit form
+        response = self.client.post(
+            self.merge_suggestion_url, merge_suggestion_data, follow=True
+        )
         self.assertEqual(response.status_code, 200)
 
+        # Verify state after submission:
+        response = self.client.get(self.merge_suggestion_url, follow=True)
+        self.assertEqual(response.status_code, 200)
+
+        # suggestions_to_merge should be absent
+        for suggestion in self.suggestions_to_merge:
+            self.assertNotContains(response, suggestion.company_url)
+            self.assertNotContains(response, suggestion.suggested_company_name)
+
+        # merged_suggestion should be present
         merged_suggestion = Suggestion.objects.get(pk=self.suggestions_merged_into.pk)
-        print(
-            Suggestion.objects.filter(
-                pk__in=[suggestion.id for suggestion in self.suggestions_to_merge]
-            )
-        )
-        self.assertFalse(
-            Suggestion.objects.filter(
-                pk__in=[suggestion.id for suggestion in self.suggestions_to_merge]
-            ).exists()
-        )
         self.assertContains(response, merged_suggestion.suggested_company_name)
         self.assertContains(response, merged_suggestion.company_url)
+
+        # upvotes should be combined
         self.assertEqual(merged_suggestion.upvoted_users.count(), 2)
-
-    def test_merge_partner_suggestions_filter(self):
-        company_url = self.company_urls[0]
-        # Creating a temprary coordinators-only session
-        EditorCraftRoom(self, Terms=True, Coordinator=True)
-        response = self.client.get(
-            self.merge_suggestion_url, {"company_url": company_url}
-        )
-
-        self.assertEqual(response.status_code, 200)
-        for suggestion in self.suggestions_to_merge:
-            if suggestion.company_url != company_url:
-                self.assertNotContains(response, suggestion.company_url)
 
 
 class PartnerFilesTest(TestCase):

--- a/TWLight/resources/tests.py
+++ b/TWLight/resources/tests.py
@@ -1428,7 +1428,6 @@ class SuggestionMergeViewTests(TestCase):
             SuggestionFactory(company_url=random.choice(cls.company_urls))
             for _ in range(cls.suggestion_merge_count)
         ]
-        # print(cls.suggestions_to_merge)
         for suggestion in cls.suggestions_to_merge:
             upvoter_or_author = random.choice(cls.upvoters_or_authors)
             suggestion.author = upvoter_or_author.user
@@ -1471,7 +1470,6 @@ class SuggestionMergeViewTests(TestCase):
         # setup suggestion pk form data
         suggestions_to_merge_pks = []
         for suggestion in self.suggestions_to_merge:
-            print(suggestion.company_url)
             suggestions_to_merge_pks.append(suggestion.pk)
         merge_suggestion_data = {
             "suggestions_merged_into": self.suggestions_merged_into.pk,

--- a/TWLight/resources/views.py
+++ b/TWLight/resources/views.py
@@ -18,11 +18,11 @@ from TWLight.users.models import Authorization, User
 from TWLight.view_mixins import CoordinatorsOnly, PartnerCoordinatorOrSelf, EditorsOnly
 from TWLight.users.helpers.editor_data import editor_bundle_eligible
 
-from .filters import MainPartnerFilter
-from .forms import SuggestionForm
+from .filters import MainPartnerFilter, MergeSuggestionFilter
+from .forms import SuggestionForm, SuggestionMergeForm
 from .helpers import get_partner_description, get_tag_names, get_median
 from .models import Partner, Suggestion
-
+from urllib.parse import urlparse
 import bleach
 import logging
 
@@ -543,3 +543,91 @@ class SuggestionUpvoteView(EditorsOnly, RedirectView):
             else:
                 obj.upvoted_users.add(user)
         return url_
+
+
+@method_decorator(login_required, name="post")
+class SuggestionMergeView(CoordinatorsOnly, FormView):
+
+    model = Suggestion
+    template_name = "resources/merge_suggestion.html"
+    form_class = SuggestionMergeForm
+    success_url = reverse_lazy("suggest")
+
+    def get_total_upvotes(self, suggestions):
+        """
+        This function merges upvoted users for merged suggestions.
+
+        Parameters
+        ----------
+        self : view object
+
+        suggestions : Queryset<Suggestion>
+            The queryset of suggestions to merge
+
+        Returns
+        -------
+        The `queryset` of upvoted users
+
+        """
+        total_upvoted_users = User.objects.none()
+        for suggestion in suggestions.all():
+            total_upvoted_users |= suggestion.upvoted_users.all()
+
+        return total_upvoted_users.distinct()
+
+    def get_queryset(self):
+        user_qs = User.objects.select_related("editor")
+
+        return (
+            Suggestion.objects.all()
+            .prefetch_related(Prefetch("author", queryset=user_qs))
+            .prefetch_related("upvoted_users")
+        )
+
+    def get_context_data(self, **kwargs):
+        context = super(SuggestionMergeView, self).get_context_data(**kwargs)
+
+        filter_suggestion = MergeSuggestionFilter(
+            self.request.GET, queryset=self.get_queryset()
+        )
+        context["filter"] = filter_suggestion
+        all_suggestions = filter_suggestion.qs
+
+        if all_suggestions.count() > 0:
+            context["all_suggestions"] = all_suggestions
+
+        else:
+            context["all_suggestions"] = None
+
+        return context
+
+    def form_valid(self, form):
+
+        try:
+            merged_suggestion = form.cleaned_data["suggestions_merged_into"]
+            suggestions = form.cleaned_data["suggestions_to_merge"]
+            merged_suggestion.upvoted_users.add(
+                *self.get_total_upvotes(suggestions=suggestions)
+            )
+            merged_suggestion.save()
+
+            # Old suggestions shall be spliced
+            Suggestion.objects.filter(
+                id__in=suggestions.values_list("id", flat=True)
+            ).exclude(id=merged_suggestion.id).delete()
+            messages.add_message(
+                self.request,
+                messages.SUCCESS,
+                # Translators: Shown to users when they successfully merge suggestion.
+                _("Suggestions merged successfully!"),
+            )
+            return HttpResponseRedirect(self.success_url)
+
+        except (AssertionError, AttributeError) as e:
+            messages.add_message(
+                self.request,
+                messages.WARNING,
+                # Translators: This message is shown in case some error occurs during merging of suggestions.
+                _("Some Error Occured"),
+            )
+            raise PermissionDenied

--- a/TWLight/resources/views.py
+++ b/TWLight/resources/views.py
@@ -623,8 +623,7 @@ class SuggestionMergeView(CoordinatorsOnly, FormView):
             messages.add_message(
                 self.request,
                 messages.SUCCESS,
-                # Translators: Shown to users when they successfully merge suggestion.
-                _("Suggestions merged successfully!"),
+                "Suggestions merged successfully!",
             )
             return HttpResponseRedirect(self.success_url)
 
@@ -632,7 +631,6 @@ class SuggestionMergeView(CoordinatorsOnly, FormView):
             messages.add_message(
                 self.request,
                 messages.WARNING,
-                # Translators: This message is shown in case some error occurs during merging of suggestions.
-                _("Some Error Occured"),
+                "Some Error Occured",
             )
             raise PermissionDenied

--- a/TWLight/resources/views.py
+++ b/TWLight/resources/views.py
@@ -82,8 +82,7 @@ class PartnersFilterView(ListView):
 
         user = self.request.user
         if user.is_authenticated:
-            user = User.objects.select_related(
-                "editor").get(pk=self.request.user.pk)
+            user = User.objects.select_related("editor").get(pk=self.request.user.pk)
             context["user"] = user
             context["editor"] = user.editor
         partners_list = []
@@ -158,8 +157,7 @@ class PartnersDetailView(DetailView):
 
         # Obtaining translated partner description
         language_code = get_language()
-        partner_short_description_key = "{pk}_short_description".format(
-            pk=partner.pk)
+        partner_short_description_key = "{pk}_short_description".format(pk=partner.pk)
         partner_description_key = "{pk}_description".format(pk=partner.pk)
         partner_descriptions = get_partner_description(
             language_code, partner_short_description_key, partner_description_key
@@ -183,8 +181,7 @@ class PartnersDetailView(DetailView):
             partner
         )
 
-        context["total_users"] = Authorization.objects.filter(
-            partners=partner).count()
+        context["total_users"] = Authorization.objects.filter(partners=partner).count()
 
         application_end_states = [
             Application.APPROVED,
@@ -391,8 +388,7 @@ class PartnersToggleWaitlistView(CoordinatorsOnly, View):
             # Set waitlist_status to True for all the applications
             # which are Pending or Under Discussion for this partner
             applications = Application.objects.filter(
-                partner=partner, status__in=[
-                    Application.PENDING, Application.QUESTION]
+                partner=partner, status__in=[Application.PENDING, Application.QUESTION]
             )
             for app in applications:
                 app.waitlist_status = True
@@ -443,8 +439,7 @@ class PartnerSuggestionView(FormView):
         # We could probably be factored out to a common place for DRYness.
         if "suggested_company_name" in self.request.GET:
             initial.update(
-                {"suggested_company_name":
-                    self.request.GET["suggested_company_name"]}
+                {"suggested_company_name": self.request.GET["suggested_company_name"]}
             )
         if "description" in self.request.GET:
             initial.update({"description": self.request.GET["description"]})

--- a/TWLight/resources/views.py
+++ b/TWLight/resources/views.py
@@ -15,7 +15,12 @@ from TWLight.applications.helpers import count_valid_authorizations
 from TWLight.applications.models import Application
 from TWLight.users.groups import get_coordinators
 from TWLight.users.models import Authorization, User
-from TWLight.view_mixins import CoordinatorsOnly, PartnerCoordinatorOrSelf, EditorsOnly
+from TWLight.view_mixins import (
+    CoordinatorsOnly,
+    PartnerCoordinatorOrSelf,
+    EditorsOnly,
+    StaffOnly,
+)
 from TWLight.users.helpers.editor_data import editor_bundle_eligible
 
 from .filters import MainPartnerFilter, MergeSuggestionFilter
@@ -546,7 +551,7 @@ class SuggestionUpvoteView(EditorsOnly, RedirectView):
 
 
 @method_decorator(login_required, name="post")
-class SuggestionMergeView(CoordinatorsOnly, FormView):
+class SuggestionMergeView(StaffOnly, FormView):
 
     model = Suggestion
     template_name = "resources/merge_suggestion.html"
@@ -585,7 +590,7 @@ class SuggestionMergeView(CoordinatorsOnly, FormView):
         )
 
     def get_context_data(self, **kwargs):
-        context = super(SuggestionMergeView, self).get_context_data(**kwargs)
+        context = super().get_context_data(**kwargs)
 
         filter_suggestion = MergeSuggestionFilter(
             self.request.GET, queryset=self.get_queryset()

--- a/TWLight/urls.py
+++ b/TWLight/urls.py
@@ -22,6 +22,7 @@ from TWLight.resources.urls import urlpatterns as partners_urls
 from TWLight.resources.views import (
     PartnerSuggestionView,
     SuggestionDeleteView,
+    SuggestionMergeView,
     SuggestionUpvoteView,
 )
 from TWLight.users import oauth as auth
@@ -75,6 +76,7 @@ urlpatterns = [
     url(r"^terms/$", TermsView.as_view(), name="terms"),
     # For partner suggestions
     url(r"^suggest/$", PartnerSuggestionView.as_view(), name="suggest"),
+    url(r"^suggest/merge/$", SuggestionMergeView.as_view(), name="suggest-merge"),
     url(
         r"^suggest/(?P<pk>[0-9]+)/delete/$",
         login_required(SuggestionDeleteView.as_view()),

--- a/TWLight/view_mixins.py
+++ b/TWLight/view_mixins.py
@@ -65,6 +65,22 @@ class CoordinatorsOnly(object):
         return super().dispatch(request, *args, **kwargs)
 
 
+class StaffOnly(object):
+    """
+    Restricts visibility to:
+    * Staff.
+    """
+
+    def dispatch(self, request, *args, **kwargs):
+        if not request.user.is_staff:
+            messages.add_message(
+                request, messages.WARNING, "You must be staff to do that."
+            )
+            raise PermissionDenied
+
+        return super().dispatch(request, *args, **kwargs)
+
+
 def test_func_partner_coordinator(obj, user):
     obj_partner_coordinator_test = (
         user.is_superuser


### PR DESCRIPTION
With upvotes scattered across similar partner suggestions,
a feature to merge suggestions into one would result in
better administration of the same.Added filter based on
domain name would make it easy to filter for similar
suggestions and merge accordingly

Bug: [T298947](https://phabricator.wikimedia.org/T298947)

This change can be tested manually by following the below steps:
1) Jump to /suggest endpoint as an administrator or coordinator
2) Click on the **Merge** button which appears over top of all suggestions
3) Once on /suggest/merge endpoint, choose the suggestions to merge and the suggestion to merge into
4) Hit submit and scroll down to see that the upvotes are now merged into a single suggestion.


- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Minor change (fix a typo, add a translation tag, add section to README, etc.)
