### PR TITLE
Don't hide access collection button when editors extend/renew collections

### DIFF
--- a/TWLight/static/css/new-local.css
+++ b/TWLight/static/css/new-local.css
@@ -54,6 +54,7 @@ COMMON CONTENT BLOCK CSS
   color: #FFFFFF !important;
   background-color: #3366CC !important;
   border-color: #3366CC !important;
+  -webkit-appearance: none;
 }
 .twl-btn:hover {
   color: #FFFFFF !important;
@@ -81,6 +82,7 @@ COMMON CONTENT BLOCK CSS
   color: rgb(51, 51, 51);
   background-color: rgb(255, 255, 255);
   border-color: rgb(204, 204, 204);
+  -webkit-appearance: none;
 }
 .btn-default.focus, .btn-default:focus {
   color:#333;
@@ -128,6 +130,7 @@ COMMON CONTENT BLOCK CSS
     color: #000000;
     background-color: #FFFFFF;
     border-color: #CCCCCC;
+    -webkit-appearance: none;
 }
 
 .twl-secondary-btn:hover{

--- a/TWLight/users/templates/users/user_collection_tile.html
+++ b/TWLight/users/templates/users/user_collection_tile.html
@@ -85,7 +85,19 @@
         </p>
       {% endif %}
       {% if user_collection.auth_open_app %}
-        <a href="{% url 'applications:evaluate' user_collection.auth_open_app.pk %}" class="btn btn-sm access-apply-button"
+        {% if not user_collection.auth_has_expired %}
+        <a href="{{ user_collection.partner_access_url }}" class="btn btn-sm twl-btn access-apply-button"
+              type="button" name="button" target="_blank" rel="noopener">
+          {% if user_collection.partner_authorization_method != proxy_authorization %}
+              {% comment %}Translators: On the My Library page (https://wikipedialibrary.wmflabs.org/users/my_library), this labels the text on a button which takes the user to the partner's site. {% endcomment %}
+              {% trans "Go to site" %}
+          {% else %}
+              {% comment %}Translators: On the My Library page (https://wikipedialibrary.wmflabs.org/users/my_library), this labels the text on a button which takes the user to the partner's site. {% endcomment %}
+              {% trans "Access collection" %}
+          {% endif %}
+        </a>
+        {% endif %}
+        <a href="{% url 'applications:evaluate' user_collection.auth_open_app.pk %}" class="btn btn-sm twl-secondary-btn"
               type="button" name="button">
           {% comment %}Translators: On the My Library page (https://wikipedialibrary.wmflabs.org/users/my_library), this labels the text on a button which takes the user to an open application. {% endcomment %}
           {% trans "Go to application" %}


### PR DESCRIPTION
## Description
Don't hide the `Access collection/ Go to site` button when editors extend/renew collections and the current authorization is unexpired.

## Rationale
[//]: # (Why is this change required? What problem does it solve?)
Users who opt to renew an authorization in advance of its expiry become unable to access it until the renewal is processed, because the 'Access collection' button is replaced by 'Go to application'. Instead, both 'Access collection' and 'Go to application' should be visible.

## Phabricator Ticket
[//]: # (Link to the Phabricator ticket)
[T298513](https://phabricator.wikimedia.org/T298513)

## How Has This Been Tested?
[//]: # (- Did you add tests to your changes? Did you modify tests to accommodate your changes?)
[//]: # (- Can this change be tested manually? How?)
Manual testing

## Screenshots of your changes (if appropriate):
[//]: # (It can also be a GIF to prove that your changes are working)
![Screen Shot 2022-02-01 at 19 31 30](https://user-images.githubusercontent.com/7854953/152215900-3d7fb4aa-7a90-4520-beb8-81fc06c20618.png)


## Types of changes
What types of changes does your code introduce? Add an `x` in all the boxes that apply:
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Minor change (fix a typo, add a translation tag, add section to README, etc.)
