### PR TITLE
Partner detail access collection button should open in a new tab

### DIFF
--- a/TWLight/resources/templates/resources/partner_detail_apply.html
+++ b/TWLight/resources/templates/resources/partner_detail_apply.html
@@ -125,7 +125,9 @@
         {% if user.is_authenticated %}
           {% if user.editor.wp_bundle_eligible %}
             {% comment %}Translators: This text labels a button authenticated, bundle eligible users can click to access the proxied resource. {% endcomment %}
-            <a class="btn twl-btn btn-lg btn-block" href="{{ partner.get_access_url }}">{% trans "Access Collection" %}</a><br />
+            <a class="btn twl-btn btn-lg btn-block" href="{{ partner.get_access_url }}" target="_blank" rel="noopener">
+              {% trans "Access Collection" %}
+            </a><br />
             {% comment %}Translators: This is the name of the authorization method whereby users access resources automatically via the library bundle. {% endcomment %}
             <img src="{% static 'img/LibraryBundle.svg' %}" class="img-fluid pull-left" style="width:45px; height:45px; padding-right: 5px;" title="{% trans 'Library Bundle' %}" alt="
             {% comment %}Translators: Alt text for the Library Bundle icon shown on the collection page. {% endcomment %}


### PR DESCRIPTION
## Description
Partner detail's `access collection` button should open in a new tab.

## Rationale
[//]: # (Why is this change required? What problem does it solve?)
This is the current behavior in `My Library` and behavior should be the same in the partner detail page for Bundle collections.

## Phabricator Ticket
[//]: # (Link to the Phabricator ticket)
N/A

## How Has This Been Tested?
[//]: # (- Did you add tests to your changes? Did you modify tests to accommodate your changes?)
[//]: # (- Can this change be tested manually? How?)

## Screenshots of your changes (if appropriate):
[//]: # (It can also be a GIF to prove that your changes are working)

## Types of changes
What types of changes does your code introduce? Add an `x` in all the boxes that apply:
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Minor change (fix a typo, add a translation tag, add section to README, etc.)
