### PR TITLE
Don't send renewal reminder email when a renewal has already been filed

### DIFF
--- a/TWLight/emails/tests.py
+++ b/TWLight/emails/tests.py
@@ -597,6 +597,115 @@ class UserRenewalNoticeTest(TestCase):
         call_command("user_renewal_notice")
         self.assertEqual(len(mail.outbox), 0)
 
+    def test_user_renewal_notice_user_already_filed_1_renewal(self):
+        """
+        Per T300014, a user shouldn't get an email if they have already filed
+        for a renewal. This tests when a user has three near expiration authorizations,
+        but has only filed for one renewal. Only two emails should be sent.
+        """
+        # We already have an authorization, so let's setup up
+        # an application that 'corresponds' to it.
+        application = ApplicationFactory(
+            editor=self.user.editor,
+            sent_by=self.coordinator,
+            partner=self.partner,
+            status=Application.SENT,
+            requested_access_duration=1,
+        )
+        application.save()
+
+        # File a renewal.
+        self.partner.renewals_available = True
+        self.partner.save()
+        renewed_app = application.renew()
+        renewed_app.status = application.PENDING
+        renewed_app.save()
+
+        # Create a new authorization
+        partner2 = PartnerFactory()
+        authorization2 = Authorization()
+        authorization2.user = self.user
+        authorization2.authorizer = self.coordinator
+        authorization2.date_expires = datetime.today() + timedelta(weeks=1)
+        authorization2.save()
+        authorization2.partners.add(partner2)
+
+        # Create a new authorization
+        partner3 = PartnerFactory()
+        authorization3 = Authorization()
+        authorization3.user = self.user
+        authorization3.authorizer = self.coordinator
+        authorization3.date_expires = datetime.today() + timedelta(weeks=1)
+        authorization3.save()
+        authorization3.partners.add(partner3)
+
+        # Only one mail should be sent since a renewal request has already been made
+        # for one of the authorizations
+        call_command("user_renewal_notice")
+        self.assertEqual(len(mail.outbox), 2)
+
+    def test_user_renewal_notice_user_already_filed_2_renewals(self):
+        """
+        Per T300014, a user shouldn't get an email if they have already filed
+        for a renewal. This tests when a user has three near expiration authorizations,
+        but has only filed for two renewals. Only one email should be sent.
+        """
+        # We already have an authorization, so let's setup up
+        # an application that 'corresponds' to it.
+        application = ApplicationFactory(
+            editor=self.user.editor,
+            sent_by=self.coordinator,
+            partner=self.partner,
+            status=Application.SENT,
+            requested_access_duration=1,
+        )
+        application.save()
+
+        # File a renewal.
+        self.partner.renewals_available = True
+        self.partner.save()
+        renewed_app = application.renew()
+        renewed_app.status = application.PENDING
+        renewed_app.save()
+
+        # Create a new authorization
+        partner2 = PartnerFactory()
+        authorization2 = Authorization()
+        authorization2.user = self.user
+        authorization2.authorizer = self.coordinator
+        authorization2.date_expires = datetime.today() + timedelta(weeks=1)
+        authorization2.save()
+        authorization2.partners.add(partner2)
+
+        # Create a new authorization
+        partner3 = PartnerFactory()
+        authorization3 = Authorization()
+        authorization3.user = self.user
+        authorization3.authorizer = self.coordinator
+        authorization3.date_expires = datetime.today() + timedelta(weeks=1)
+        authorization3.save()
+        authorization3.partners.add(partner3)
+
+        application2 = ApplicationFactory(
+            editor=self.user.editor,
+            sent_by=self.coordinator,
+            partner=partner3,
+            status=Application.SENT,
+            requested_access_duration=1,
+        )
+        application.save()
+
+        partner3.renewals_available = True
+        partner3.save()
+        renewed_app2 = application2.renew()
+        renewed_app2.status = application2.PENDING
+        renewed_app2.save()
+
+        # Only one mail should be sent since a renewal request has already been made
+        # for one of the authorizations
+        call_command("user_renewal_notice")
+        self.assertEqual(len(mail.outbox), 1)
+
 
 class CoordinatorReminderEmailTest(TestCase):
     @classmethod

--- a/TWLight/users/management/commands/user_renewal_notice.py
+++ b/TWLight/users/management/commands/user_renewal_notice.py
@@ -2,11 +2,13 @@ from datetime import datetime, timedelta
 
 from django.contrib.auth.models import User
 from django.core.management.base import BaseCommand
-from django.db.models import Prefetch
+from django.db.models import Prefetch, Q
 from django.urls import reverse
 
+from TWLight.applications.models import Application
+from TWLight.resources.models import Partner
 from TWLight.users.signals import Notice
-from TWLight.users.models import Authorization, get_company_name
+from TWLight.users.models import Authorization, get_company_name, Editor
 
 
 class Command(BaseCommand):
@@ -15,8 +17,21 @@ class Command(BaseCommand):
     def handle(self, *args, **options):
         # Get all authorization objects with an expiry date in the next
         # four weeks, for which we haven't yet sent a reminder email, and
-        # exclude users who disabled these emails.
-        user_qs = User.objects.prefetch_related("userprofile")
+        # exclude users who disabled these emails and who have already filed
+        # for a renewal.
+        editor_qs = Editor.objects.select_related("user")
+        users_with_applications_for_renewal = (
+            Application.objects.prefetch_related(Prefetch("editor", queryset=editor_qs))
+            .values_list("editor__user__pk")
+            .filter(
+                ~Q(partner__authorization_method=Partner.BUNDLE),
+                status__in=[Application.PENDING, Application.QUESTION],
+                parent__isnull=False,
+                editor__isnull=False,
+            )
+            .order_by("-date_created")
+        )
+        user_qs = User.objects.select_related("userprofile")
         expiring_authorizations = (
             Authorization.objects.prefetch_related(Prefetch("user", queryset=user_qs))
             .filter(
@@ -26,6 +41,7 @@ class Command(BaseCommand):
                 partners__isnull=False,
             )
             .exclude(user__userprofile__send_renewal_notices=False)
+            .exclude(user__pk__in=users_with_applications_for_renewal)
         )
 
         for authorization_object in expiring_authorizations:


### PR DESCRIPTION
[//]: # (Thank you for uploading a PR to the Wikipedia Library!)

## Description
Don't send a renewal reminder email when a renewal has already been filed.

## Rationale
[//]: # (Why is this change required? What problem does it solve?)
Two weeks before an authorization is due to expire we send users an email notifying them of this and suggesting they request a renewal if they want to continue having access. This is confusing for users who anticipated this and already filed a renewal request.

## Phabricator Ticket
[//]: # (Link to the Phabricator ticket)
[T300014](https://phabricator.wikimedia.org/T300014)

## How Has This Been Tested?
[//]: # (- Did you add tests to your changes? Did you modify tests to accommodate your changes?)
[//]: # (- Can this change be tested manually? How?)
Added a new test

## Screenshots of your changes (if appropriate):
[//]: # (It can also be a GIF to prove that your changes are working)

## Types of changes
What types of changes does your code introduce? Add an `x` in all the boxes that apply:
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Minor change (fix a typo, add a translation tag, add section to README, etc.)
