### PR TITLE
Fixed Next-to-last page is unclickable

### DIFF
--- a/TWLight/applications/templates/applications/application_list.html
+++ b/TWLight/applications/templates/applications/application_list.html
@@ -147,7 +147,7 @@
                   </a></li>
             {% endfor %}
             <li class="page-item disabled"><a class="twl-links page-link">...</a></li>
-            <li class="page-item disabled"><a class="twl-links page-link" href="?page={{ object_list.previous_page_number}}{% if filters %}{% for filter in filters %}{% if forloop.counter0 == 0 %}&Editor={{ filter.object.pk|safe }}{% elif forloop.counter0 == 1 %}&Partner={{ filter.object.pk|safe }}{% endif %}{% endfor %}{% else %}{% endif %}">
+            <li class="page-item"><a class="twl-links page-link" href="?page={{ object_list.previous_page_number}}{% if filters %}{% for filter in filters %}{% if forloop.counter0 == 0 %}&Editor={{ filter.object.pk|safe }}{% elif forloop.counter0 == 1 %}&Partner={{ filter.object.pk|safe }}{% endif %}{% endfor %}{% else %}{% endif %}">
                 {{ object_list.previous_page_number }}
                 </a></li>
             <li class="page-item active">


### PR DESCRIPTION
[//]: # (Thank you for uploading a PR to the Wikipedia Library!)

## Description
Problem : In review interface, the next-to-last page number is visible but is not clickable

## Rationale
[//]: # (Why is this change required? What problem does it solve?)

## Phabricator Ticket
[//]: # https://phabricator.wikimedia.org/T299867

## How Has This Been Tested?
[//]: # (- Did you add tests to your changes? Did you modify tests to accommodate your changes?)
[//]: # (- Can this change be tested manually? How?)

## Screenshots of your changes (if appropriate):
[//]: # 
![prevpage](https://user-images.githubusercontent.com/72732381/158162729-5662d1a5-f3a3-4777-b264-2ae2bfec3453.png)


## Types of changes
What types of changes does your code introduce? Add an `x` in all the boxes that apply:
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Minor change (fix a typo, add a translation tag, add section to README, etc.)
