### PR TITLE
Added Login button to pages without one

### DIFF
--- a/TWLight/templates/header_partial_b4.html
+++ b/TWLight/templates/header_partial_b4.html
@@ -104,6 +104,9 @@
                 {% trans "Log out" %}
               </a>
             </li>
+          {% elif not user.is_authenticated %}
+            <li role="presentation" class="mobile-menu align-middle nav-item">
+              <a class="btn twl-btn" href="{% url 'oauth_login' %}?next={{request.path}}">
           {% endif %}
         </ul>
       </div>

--- a/TWLight/templates/header_partial_b4.html
+++ b/TWLight/templates/header_partial_b4.html
@@ -104,9 +104,13 @@
                 {% trans "Log out" %}
               </a>
             </li>
-          {% elif not user.is_authenticated %}
+          {% else %}
             <li role="presentation" class="mobile-menu align-middle nav-item">
+              {% comment %}Translators: Shown in the top bar to let users log in of The Wikipedia Library. {% endcomment %}
               <a class="btn twl-btn" href="{% url 'oauth_login' %}?next={{request.path}}">
+                {% trans "Log in" %}
+              </a>
+            </li>
           {% endif %}
         </ul>
       </div>


### PR DESCRIPTION
[//]: # (Thank you for uploading a PR to the Wikipedia Library!)

## Description
Describe your changes in detail following the [commit message guidelines]Some pages on The Wikipedia Library are viewable by users who aren't logged in, but there are no obvious ways for them to initiate the login process.

When the user isn't logged in, the header should have a blue button (like the one used for linking to a logged in user's profile) at the right end which says 'Login' and will initiate the login sequence. Users should be redirected back to the page they were on.

## Rationale
[//]: # (Why is this change required? What problem does it solve?)

## Phabricator Ticket
[//]: # https://phabricator.wikimedia.org/T299638

## How Has This Been Tested?
This issue has been tested locally on by going to the page that is accessissible without logging in and observing the changes there.
Eg link - http://localhost/password/reset/

## Screenshots of your changes (if appropriate):
![45](https://user-images.githubusercontent.com/72732381/161054285-ac76aa90-8eb1-4915-a2ee-6ae56e266143.png)


## Types of changes
What types of changes does your code introduce? Add an `x` in all the boxes that apply:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Minor change (fix a typo, add a translation tag, add section to README, etc.)
