### PR TITLE
Fixed Access the collection button style

### DIFF
--- a/TWLight/static/css/new-local.css
+++ b/TWLight/static/css/new-local.css
@@ -1005,7 +1005,7 @@ NEW MY LIBRARY COLLECTION TILES CSS
 }
 
 .access-apply-button{
-    width: 50%;
+    width: 100%;
     -webkit-appearance: none;
 }
 
@@ -1014,6 +1014,7 @@ NEW MY LIBRARY COLLECTION TILES CSS
     background-color: #FFFFFF;
     width: 40%;
     -webkit-appearance: none;
+    margin-top: 10px;
 }
 
 .renew-extend-button:hover{

--- a/TWLight/static/css/new-local.css
+++ b/TWLight/static/css/new-local.css
@@ -1005,14 +1005,16 @@ NEW MY LIBRARY COLLECTION TILES CSS
 }
 
 .access-apply-button{
-    width: 50%;
+    width: 98%;
     -webkit-appearance: none;
 }
 
 .renew-extend-button{
     border: 1px solid #8E8E8E;
     background-color: #FFFFFF;
-    width: 40%;
+    width: 130%;
+    margin-top: 10%;
+    margin-left: 60%;
     -webkit-appearance: none;
 }
 

--- a/TWLight/static/css/new-local.css
+++ b/TWLight/static/css/new-local.css
@@ -1005,7 +1005,7 @@ NEW MY LIBRARY COLLECTION TILES CSS
 }
 
 .access-apply-button{
-    width: 100%;
+    width: 50%;
     -webkit-appearance: none;
 }
 
@@ -1014,7 +1014,6 @@ NEW MY LIBRARY COLLECTION TILES CSS
     background-color: #FFFFFF;
     width: 40%;
     -webkit-appearance: none;
-    margin-top: 10px;
 }
 
 .renew-extend-button:hover{

--- a/TWLight/users/templates/users/user_collection_tile.html
+++ b/TWLight/users/templates/users/user_collection_tile.html
@@ -69,7 +69,7 @@
       {% endif %}
     </p>
   </div>
-  <div class="card-footer">
+  <div class="card-footer container">
     {% if user_collection.partner_authorization_method != bundle_authorization %}
       {% if user_collection.auth_date_expires %}
         <p class="expiry-date-text">
@@ -93,7 +93,7 @@
       {% else %}
         {% if user_collection.auth_latest_sent_app %}
           {% if not user_collection.auth_has_expired %}
-            <a href="{{ user_collection.partner_access_url }}" class="btn btn-sm twl-btn access-apply-button"
+            <a href="{{ user_collection.partner_access_url }}" class="btn btn-sm twl-btn access-apply-button col"
                   type="button" name="button" target="_blank" rel="noopener">
               {% if user_collection.partner_authorization_method != proxy_authorization %}
                   {% comment %}Translators: On the My Library page (https://wikipedialibrary.wmflabs.org/users/my_library), this labels the text on a button which takes the user to the partner's site. {% endcomment %}
@@ -105,7 +105,7 @@
             </a>
           {% endif %}
           <a href="{% url 'applications:renew' user_collection.auth_latest_sent_app.pk %}"
-                class="btn btn-sm renew-extend-button pull-right" type="button" name="button">
+                class="btn btn-sm renew-extend-button pull-right col" type="button" name="button">
             {% if user_collection.auth_date_expires and user_collection.auth_has_expired %}
               {% comment %}Translators: Labels a button users can click to renew an expired account. {% endcomment %}
               {% trans "Renew" %}
@@ -117,7 +117,7 @@
         {% endif %}
       {% endif %}
     {% else %}
-        <a href="{{ user_collection.partner_access_url }}" class="btn btn-sm twl-btn access-apply-button"
+        <a href="{{ user_collection.partner_access_url }}" class="btn btn-sm twl-btn access-apply-button col"
                 type="button" name="button" target="_blank" rel="noopener">
             {% comment %}Translators: On the My Library page (https://wikipedialibrary.wmflabs.org/users/my_library), this labels the text on a button which takes the user to the partner's site. {% endcomment %}
             {% trans "Access collection" %}

--- a/TWLight/users/templates/users/user_collection_tile.html
+++ b/TWLight/users/templates/users/user_collection_tile.html
@@ -109,7 +109,7 @@
           {% endif %}
           <div class="col-xl-6 col-12">
           <a href="{% url 'applications:renew' user_collection.auth_latest_sent_app.pk %}"
-                class="btn btn-sm renew-extend-button pull-right" type="button" name="button">
+                class="btn btn-sm renew-extend-button" type="button" name="button">
             {% if user_collection.auth_date_expires and user_collection.auth_has_expired %}
               {% comment %}Translators: Labels a button users can click to renew an expired account. {% endcomment %}
               {% trans "Renew" %}

--- a/TWLight/users/templates/users/user_collection_tile.html
+++ b/TWLight/users/templates/users/user_collection_tile.html
@@ -69,7 +69,8 @@
       {% endif %}
     </p>
   </div>
-  <div class="card-footer container">
+  <div class="card-footer">
+    <div class="container">
     {% if user_collection.partner_authorization_method != bundle_authorization %}
       {% if user_collection.auth_date_expires %}
         <p class="expiry-date-text">
@@ -93,7 +94,8 @@
       {% else %}
         {% if user_collection.auth_latest_sent_app %}
           {% if not user_collection.auth_has_expired %}
-            <a href="{{ user_collection.partner_access_url }}" class="btn btn-sm twl-btn access-apply-button col"
+          <div class="col-12">
+            <a href="{{ user_collection.partner_access_url }}" class="btn btn-sm twl-btn access-apply-button"
                   type="button" name="button" target="_blank" rel="noopener">
               {% if user_collection.partner_authorization_method != proxy_authorization %}
                   {% comment %}Translators: On the My Library page (https://wikipedialibrary.wmflabs.org/users/my_library), this labels the text on a button which takes the user to the partner's site. {% endcomment %}
@@ -103,9 +105,11 @@
                   {% trans "Access collection" %}
               {% endif %}
             </a>
+          </div>
           {% endif %}
+          <div class="col-xl-6 col-12">
           <a href="{% url 'applications:renew' user_collection.auth_latest_sent_app.pk %}"
-                class="btn btn-sm renew-extend-button pull-right col" type="button" name="button">
+                class="btn btn-sm renew-extend-button pull-right" type="button" name="button">
             {% if user_collection.auth_date_expires and user_collection.auth_has_expired %}
               {% comment %}Translators: Labels a button users can click to renew an expired account. {% endcomment %}
               {% trans "Renew" %}
@@ -114,14 +118,18 @@
               {% trans "Extend" %}
             {% endif %}
           </a>
+        </div>
         {% endif %}
       {% endif %}
     {% else %}
-        <a href="{{ user_collection.partner_access_url }}" class="btn btn-sm twl-btn access-apply-button col"
+      <div class="col-12">
+        <a href="{{ user_collection.partner_access_url }}" class="btn btn-sm twl-btn access-apply-button"
                 type="button" name="button" target="_blank" rel="noopener">
             {% comment %}Translators: On the My Library page (https://wikipedialibrary.wmflabs.org/users/my_library), this labels the text on a button which takes the user to the partner's site. {% endcomment %}
             {% trans "Access collection" %}
         </a>
+      </div>
     {% endif %}
+  </div>
   </div>
 </div>


### PR DESCRIPTION
[//]: # (Thank you for uploading a PR to the Wikipedia Library!)

## Description
On the collection listing page, the style of the button to view a collection is broken. Some part of the label text is not visible because the background color doesn't cover the full button.



## Rationale
[//]: # (Why is this change required? What problem does it solve?)

## Phabricator Ticket
[//]: #[ (Link to the Phabricator ticket)](https://phabricator.wikimedia.org/T300072)

## How Has This Been Tested?
1. Apply and approve an application to a partner.
2. Add an expiration date in the admin view for that authorization
3. Check that the access collection button is shown correctly when resizing your desktop screen.


## Screenshots of your changes (if appropriate):
[//]: 
![ss10](https://user-images.githubusercontent.com/72732381/158831835-26c3279a-ed80-4b7f-a57c-b953b04f1a87.png)
![ss](https://user-images.githubusercontent.com/72732381/160045921-8c042cc0-f0e0-4dd1-9070-c08ffa2a5223.png)


## Types of changes
What types of changes does your code introduce? Add an `x` in all the boxes that apply:
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Minor change (fix a typo, add a translation tag, add section to README, etc.)
