### PR TITLE
Enable linking a suggestion to a phabricator ticket

### DIFF
--- a/TWLight/resources/models.py
+++ b/TWLight/resources/models.py
@@ -538,6 +538,12 @@ class Suggestion(models.Model):
     upvoted_users = models.ManyToManyField(
         User, blank=True, help_text="Users who have upvoted this suggestion."
     )
+    ticket_number = models.CharField(
+        max_length=10,
+        blank=True,
+        default="",
+        help_text="phabricator ticket id where we track progress of request",
+    )
 
     def __str__(self):
         return self.suggested_company_name

--- a/TWLight/resources/templates/resources/suggest.html
+++ b/TWLight/resources/templates/resources/suggest.html
@@ -70,6 +70,14 @@
                         {{ each_suggestion.author.editor.wp_username }}
                       </a>
                     </p>
+                    {% if each_suggestion.ticket_number %}
+                      <p>
+                        <strong>{% trans 'Track Progress' %}:</strong>
+                        <a class="twl-links" href="https://phabricator.wikimedia.org/{{each_suggestion.ticket_number}}" target="_blank">
+                          {{ each_suggestion.ticket_number }}
+                        </a>
+                      </p>
+                    {% endif %}
                   </div>
                   {% if user.is_authenticated %}
                     <div class="col-lg-2 pull-right" style="text-align: right;">


### PR DESCRIPTION
[//]: # (Thank you for uploading a PR to the Wikipedia Library!)

## Description
When users file suggestions for new collections, they want to be able to track the progress of that request as the maintainers go through their pipeline for trying to get a partnership with the suggested partner

## Rationale
We need a way to link the suggestions to a Phabricator ticket so that users who visit the suggestion page can click through to see what the progress on that request

## Phabricator Ticket
https://phabricator.wikimedia.org/T299883

## How Has This Been Tested?
[//]: # (- Did you add tests to your changes? Did you modify tests to accommodate your changes?)

[//]: # (- Can this change be tested manually? How?)
By going to the suggest collection page and clicking on the Phabricator ticket link.

## Screenshots of your changes (if appropriate):
[//]: # (It can also be a GIF to prove that your changes are working)
![sample](https://user-images.githubusercontent.com/31045288/159125104-7141b6fb-5932-4566-8fe1-7c2986924987.gif)

## Types of changes
What types of changes does your code introduce? Add an `x` in all the boxes that apply:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Minor change (fix a typo, add a translation tag, add section to README, etc.)
