### PR TITLE
Update Travis badge link destination

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ See the [Local setup](https://github.com/WikipediaLibrary/TWLight/wiki/Local-set
 
 Further project documentation is available in the [Wiki](https://github.com/WikipediaLibrary/TWLight/wiki). Our issue tracking takes place on the [Library-Card-Platform Phabricator](https://phabricator.wikimedia.org/project/board/2765/) board.
 
-[![Build Status](https://travis-ci.com/WikipediaLibrary/TWLight.svg?branch=master)](https://travis-ci.com/WikipediaLibrary/TWLight)
+[![Build Status](https://travis-ci.com/WikipediaLibrary/TWLight.svg?branch=master)](https://travis-ci.com/github/WikipediaLibrary/TWLight)
 
 [![Coveralls ](https://github.com/WikipediaLibrary/TWLight/actions/workflows/coveralls_check.yml/badge.svg)](https://github.com/WikipediaLibrary/TWLight/actions/workflows/coveralls_check.yml)
 [![Coverage Status](https://coveralls.io/repos/github/WikipediaLibrary/TWLight/badge.svg?branch=master)](https://coveralls.io/github/WikipediaLibrary/TWLight?branch=master)


### PR DESCRIPTION
The URL pattern changed at some point, this seems to be the correct URL now.
