### PR TITLE
Only send waitlist email once per application

### DIFF
--- a/TWLight/applications/models.py
+++ b/TWLight/applications/models.py
@@ -144,6 +144,10 @@ class Application(models.Model):
         default=False, help_text="Mark as True if the partner is WAITLISTED"
     )
 
+    # Has the applicant received an email about this application being
+    # waitlisted yet?
+    waitlist_email = models.BooleanField(default=False)
+
     def __str__(self):
         return "{self.editor} - {self.partner}".format(self=self)
 

--- a/TWLight/emails/tests.py
+++ b/TWLight/emails/tests.py
@@ -362,6 +362,26 @@ class ApplicationStatusTest(TestCase):
         partner.save()
         self.assertFalse(mock_email.called)
 
+    def test_waitlisting_partner_doesnt_email_users_twice(self):
+        """
+        Switching a Partner to WAITLIST status should call the email function
+        but only email users who haven't already received an email.
+        """
+        partner = PartnerFactory(status=Partner.AVAILABLE)
+        app = ApplicationFactory(status=Application.PENDING, partner=partner)
+
+        partner.status = Partner.WAITLIST
+        partner.save()
+        self.assertEqual(len(mail.outbox), 1)
+
+        partner.status = Partner.AVAILABLE
+        partner.save()
+
+        partner.status = Partner.WAITLIST
+        partner.save()
+
+        self.assertEqual(len(mail.outbox), 1)
+
 
 class ContactUsTest(TestCase):
     @classmethod


### PR DESCRIPTION
_Submitted in my capacity as a volunteer :)_

## Description
I added a new field to the application model to track whether we sent a waitlist email for that application, set it to True when the email is sent, and checked for it in the relevant email task.


## Rationale
We shouldn't send users multiple waitlist emails if a partner gets switched back and forth between waitlisted and available, as happens for busy proxy partners which have authorizations expiring on a regular basis.

## Phabricator Ticket
https://phabricator.wikimedia.org/T304512

## How Has This Been Tested?
I added a test, which was failing before I made the code changes (2 emails sent instead of the desired 1).

## Types of changes
What types of changes does your code introduce? Add an `x` in all the boxes that apply:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Minor change (fix a typo, add a translation tag, add section to README, etc.)
