### PR TITLE
Don't email about blocks on exempted users first login

### DIFF
--- a/TWLight/users/helpers/editor_data.py
+++ b/TWLight/users/helpers/editor_data.py
@@ -294,5 +294,6 @@ def editor_compare_hashes(
         else:
             return previous_block_hash
     else:
-        # previous_block_hash is blank, we will make a hash of an empty dictionary
-        return make_password("{}")
+        # previous_block_hash is blank, we will make a hash of the user's
+        # block string.
+        return make_password(new_block_string)


### PR DESCRIPTION
_Submitted in my capacity as a volunteer :)_

## Description
When users login for the first time, we were always setting their block hash based on an empty dictionary. This change sets it based on their block string, which is an empty dictionary if they're not blocked, but contains their block information if they are blocked.

## Rationale
When a user is already blocked on their first login, gets exempted, and logs in a 2nd time, we currently receive a spurious email about block status changes. This should fix that.

## Phabricator Ticket
https://phabricator.wikimedia.org/T301668

## How Has This Been Tested?
I added a new test, which was failing on line 1562 before I made my change (the user's block dictionary wasn't matching what we'd saved for block hash).

## Types of changes
What types of changes does your code introduce? Add an `x` in all the boxes that apply:
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Minor change (fix a typo, add a translation tag, add section to README, etc.)
