### PR TITLE
Add click version to unbreak Black formatting

### DIFF
--- a/bin/virtualenv_migrate.sh
+++ b/bin/virtualenv_migrate.sh
@@ -35,7 +35,7 @@ then
     done
 
     # Run black on all migrations.
-    find ${TWLIGHT_HOME}/TWLight -type d -name "migrations" -print0 | xargs -0 black -t py37
+    find ${TWLIGHT_HOME}/TWLight -type d -name "migrations" -print0 | xargs -0 black -t py38
 else
     exit 1
 fi

--- a/bin/virtualenv_test.sh
+++ b/bin/virtualenv_test.sh
@@ -12,8 +12,8 @@ set -euo pipefail
     if source ${TWLIGHT_HOME}/bin/virtualenv_activate.sh
     then
         # Run linter
-        echo "black --target-version py37 --check TWLight"
-        if black --target-version py37 --check TWLight
+        echo "black --target-version py38 --check TWLight"
+        if black --target-version py38 --check TWLight
         then
             echo "${TWLIGHT_HOME}/tests/shunit/twlight_i18n_lint_test.sh"
             ${TWLIGHT_HOME}/tests/shunit/twlight_i18n_lint_test.sh
@@ -30,9 +30,9 @@ set -euo pipefail
             coverage run --source TWLight manage.py test --keepdb --noinput
         else
             # If linting fails, offer some useful feedback to the user.
-            black --target-version py37 --quiet --diff TWLight
+            black --target-version py38 --quiet --diff TWLight
             echo "You can fix these issues by running the following command on your host"
-            echo "docker exec CONTAINER $(which black) -t py37 ${TWLIGHT_HOME}/TWLight"
+            echo "docker exec CONTAINER $(which black) -t py38 ${TWLIGHT_HOME}/TWLight"
             exit 1
         fi
     else

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,5 +1,6 @@
 black==21.12b0
 bleach==4.1.0
+click==8.0.4
 defusedxml==0.7.1
 django==3.2.12
 django-annoying==0.10.6

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,6 +1,6 @@
 black==21.12b0
 bleach==4.1.0
-click==8.0.4
+click==8.0.4 # This version of click has to be set because 8.1 breaks black formatting
 defusedxml==0.7.1
 django==3.2.12
 django-annoying==0.10.6


### PR DESCRIPTION
[//]: # (Thank you for uploading a PR to the Wikipedia Library!)

## Description
Add click version to unbreak Black formatting. Looks like the latest version of the `click` library is breaking Black formatting. See GitHub issue [here](https://github.com/psf/black/issues/2964).

## Rationale
[//]: # (Why is this change required? What problem does it solve?)
This is breaking CI

## Phabricator Ticket
[//]: # (Link to the Phabricator ticket)
N/A

## How Has This Been Tested?
[//]: # (- Did you add tests to your changes? Did you modify tests to accommodate your changes?)
[//]: # (- Can this change be tested manually? How?)

## Screenshots of your changes (if appropriate):
[//]: # (It can also be a GIF to prove that your changes are working)

## Types of changes
What types of changes does your code introduce? Add an `x` in all the boxes that apply:
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Minor change (fix a typo, add a translation tag, add section to README, etc.)
