### PR TITLE
Fix access collection button bug

### DIFF
--- a/TWLight/static/css/new-local.css
+++ b/TWLight/static/css/new-local.css
@@ -1008,54 +1008,27 @@ NEW MY LIBRARY COLLECTION TILES CSS
 }
 
 .access-apply-button{
-    width: 50%;
     -webkit-appearance: none;
+    width: 98%;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    -o-text-overflow: ellipsis;
+    white-space: nowrap;
 }
 
 .renew-extend-button{
     border: 1px solid #8E8E8E;
     background-color: #FFFFFF;
-    width: 40%;
     -webkit-appearance: none;
+    width: 98%;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    -o-text-overflow: ellipsis;
+    white-space: nowrap;
 }
 
 .renew-extend-button:hover{
     text-decoration: underline;
-}
-
-/* Smartphones */
-@media only screen
-and (min-device-width : 320px)
-and (max-device-width : 480px) {
-    .access-apply-button{
-        width: 100%;
-        margin-bottom: 10px;
-        -webkit-appearance: none;
-    }
-
-    .renew-extend-button{
-        border: 1px solid #8E8E8E;
-        background-color: #FFFFFF;
-        width: 100%;
-        -webkit-appearance: none;
-    }
-}
-/* Tablets */
-@media only screen
-and (min-device-width : 768px)
-and (max-device-width : 1024px) {
-    .access-apply-button{
-        width: 100%;
-        margin-bottom: 10px;
-        -webkit-appearance: none;
-    }
-
-    .renew-extend-button{
-        border: 1px solid #8E8E8E;
-        background-color: #FFFFFF;
-        width: 100%;
-        -webkit-appearance: none;
-    }
 }
 
 /* Change image width on some medium-sized screens */

--- a/TWLight/static/css/new-local.rtl.css
+++ b/TWLight/static/css/new-local.rtl.css
@@ -1029,56 +1029,31 @@ NEW MY LIBRARY COLLECTION TILES CSS
 }
 
 .access-apply-button{
-    width: 50%;
     float: right;
     -webkit-appearance: none;
+    width: 98%;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    -o-text-overflow: ellipsis;
+    white-space: nowrap;
 }
 
 .renew-extend-button{
+    color: black;
     border: 1px solid #8E8E8E;
     background-color: #FFFFFF;
-    width: 40%;
     float: left;
     -webkit-appearance: none;
+    width: 98%;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    -o-text-overflow: ellipsis;
+    white-space: nowrap;
 }
 
 .renew-extend-button:hover{
+    color: black;
     text-decoration: underline;
-}
-
-/* Smartphones */
-@media only screen
-and (min-device-width : 320px)
-and (max-device-width : 480px) {
-    .access-apply-button{
-        width: 100%;
-        margin-bottom: 10px;
-        -webkit-appearance: none;
-    }
-
-    .renew-extend-button{
-        border: 1px solid #8E8E8E;
-        background-color: #FFFFFF;
-        width: 100%;
-        -webkit-appearance: none;
-    }
-}
-/* Tablets */
-@media only screen
-and (min-device-width : 768px)
-and (max-device-width : 1024px) {
-    .access-apply-button{
-        width: 100%;
-        margin-bottom: 10px;
-        -webkit-appearance: none;
-    }
-
-    .renew-extend-button{
-        border: 1px solid #8E8E8E;
-        background-color: #FFFFFF;
-        width: 100%;
-        -webkit-appearance: none;
-    }
 }
 
 /* Change image width on some medium-sized screens */

--- a/TWLight/users/templates/users/user_collection_tile.html
+++ b/TWLight/users/templates/users/user_collection_tile.html
@@ -70,70 +70,72 @@
     </p>
   </div>
   <div class="card-footer">
-    {% if user_collection.partner_authorization_method != bundle_authorization %}
-      {% if user_collection.auth_date_expires %}
-        <p class="expiry-date-text">
-          {% comment %}Translators: On the My Library page (https://wikipedialibrary.wmflabs.org/users/my_library), this labels when a subscription on a collection expired. {% endcomment %}
-          {% trans "Expiry date" %}: <span {% if user_collection.auth_has_expired %} class="text-danger" {% endif %}> {{ user_collection.auth_date_expires|date:"M d, Y" }} </span>
-          {% if user_collection.partner_authorization_method == proxy_authorization and user_collection.auth_is_valid %}
-            {% comment %}Translators: A button when clicked takes users to a confirmation page to return their access for a particular resource. {% endcomment %}
-            <a href="{% url 'users:return_authorization' user_collection.auth_pk %}"
-                class="btn btn-sm btn-outline-danger">
-              <i class="fa fa-times" title="{% trans 'Click to return this access' %}"></i>
-            </a>
-          {% endif %}
-        </p>
-      {% endif %}
-      {% if user_collection.auth_open_app %}
-        {% if not user_collection.auth_has_expired %}
-        <a href="{{ user_collection.partner_access_url }}" class="btn btn-sm twl-btn access-apply-button"
-              type="button" name="button" target="_blank" rel="noopener">
-          {% if user_collection.partner_authorization_method != proxy_authorization %}
-              {% comment %}Translators: On the My Library page (https://wikipedialibrary.wmflabs.org/users/my_library), this labels the text on a button which takes the user to the partner's site. {% endcomment %}
-              {% trans "Go to site" %}
-          {% else %}
+    <div class="container">
+      {% if user_collection.partner_authorization_method != bundle_authorization %}
+        {% if user_collection.auth_date_expires %}
+          <p class="expiry-date-text">
+            {% comment %}Translators: On the My Library page (https://wikipedialibrary.wmflabs.org/users/my_library), this labels when a subscription on a collection expired. {% endcomment %}
+            {% trans "Expiry date" %}: <span {% if user_collection.auth_has_expired %} class="text-danger" {% endif %}> {{ user_collection.auth_date_expires|date:"M d, Y" }} </span>
+            {% if user_collection.partner_authorization_method == proxy_authorization and user_collection.auth_is_valid %}
+              {% comment %}Translators: A button when clicked takes users to a confirmation page to return their access for a particular resource. {% endcomment %}
+              <a href="{% url 'users:return_authorization' user_collection.auth_pk %}"
+                  class="btn btn-sm btn-outline-danger">
+                <i class="fa fa-times" title="{% trans 'Click to return this access' %}"></i>
+              </a>
+            {% endif %}
+          </p>
+        {% endif %}
+        {% if user_collection.auth_open_app %}
+        <div class="col-12" style="padding: 0px;">
+          <a href="{% url 'applications:evaluate' user_collection.auth_open_app.pk %}" class="btn btn-sm access-apply-button"
+                type="button" name="button">
+            {% comment %}Translators: On the My Library page (https://wikipedialibrary.wmflabs.org/users/my_library), this labels the text on a button which takes the user to an open application. {% endcomment %}
+            {% trans "Go to application" %}
+          </a>
+        </div>
+        {% else %}
+          <div class="row">
+            {% if user_collection.auth_latest_sent_app %}
+              {% if not user_collection.auth_has_expired %}
+                <div class="col-xl-6 col-lg-12" style="padding: 0px;">
+                  <a href="{{ user_collection.partner_access_url }}" class="btn btn-sm twl-btn access-apply-button"
+                        type="button" name="button" target="_blank" rel="noopener"
+                        style="font-size: 14px;">
+                    {% if user_collection.partner_authorization_method != proxy_authorization %}
+                        {% comment %}Translators: On the My Library page (https://wikipedialibrary.wmflabs.org/users/my_library), this labels the text on a button which takes the user to the partner's site. {% endcomment %}
+                        {% trans "Go to site" %}
+                    {% else %}
+                        {% comment %}Translators: On the My Library page (https://wikipedialibrary.wmflabs.org/users/my_library), this labels the text on a button which takes the user to the partner's site. {% endcomment %}
+                        {% trans "Access collection" %}
+                    {% endif %}
+                  </a>
+                </div>
+              {% endif %}
+              <div class="col-xl-6 col-lg-12" style="padding: 0px;">
+                <a href="{% url 'applications:renew' user_collection.auth_latest_sent_app.pk %}"
+                      class="btn btn-sm renew-extend-button mt-xl-0 mt-3"
+                      type="button" name="button">
+                  {% if user_collection.auth_date_expires and user_collection.auth_has_expired %}
+                    {% comment %}Translators: Labels a button users can click to renew an expired account. {% endcomment %}
+                    {% trans "Renew" %}
+                  {% else %}
+                    {% comment %}Translators: Labels a button users can click to extend the duration of their access. {% endcomment %}
+                    {% trans "Extend" %}
+                  {% endif %}
+                </a>
+              </div>
+            {% endif %}
+          </div>
+        {% endif %}
+      {% else %}
+        <div class="col-12" style="padding: 0px;">
+          <a href="{{ user_collection.partner_access_url }}" class="btn btn-sm twl-btn access-apply-button"
+                  type="button" name="button" target="_blank" rel="noopener">
               {% comment %}Translators: On the My Library page (https://wikipedialibrary.wmflabs.org/users/my_library), this labels the text on a button which takes the user to the partner's site. {% endcomment %}
               {% trans "Access collection" %}
-          {% endif %}
-        </a>
-        {% endif %}
-        <a href="{% url 'applications:evaluate' user_collection.auth_open_app.pk %}" class="btn btn-sm twl-secondary-btn"
-              type="button" name="button">
-          {% comment %}Translators: On the My Library page (https://wikipedialibrary.wmflabs.org/users/my_library), this labels the text on a button which takes the user to an open application. {% endcomment %}
-          {% trans "Go to application" %}
-        </a>
-      {% else %}
-        {% if user_collection.auth_latest_sent_app %}
-          {% if not user_collection.auth_has_expired %}
-            <a href="{{ user_collection.partner_access_url }}" class="btn btn-sm twl-btn access-apply-button"
-                  type="button" name="button" target="_blank" rel="noopener">
-              {% if user_collection.partner_authorization_method != proxy_authorization %}
-                  {% comment %}Translators: On the My Library page (https://wikipedialibrary.wmflabs.org/users/my_library), this labels the text on a button which takes the user to the partner's site. {% endcomment %}
-                  {% trans "Go to site" %}
-              {% else %}
-                  {% comment %}Translators: On the My Library page (https://wikipedialibrary.wmflabs.org/users/my_library), this labels the text on a button which takes the user to the partner's site. {% endcomment %}
-                  {% trans "Access collection" %}
-              {% endif %}
-            </a>
-          {% endif %}
-          <a href="{% url 'applications:renew' user_collection.auth_latest_sent_app.pk %}"
-                class="btn btn-sm renew-extend-button pull-right" type="button" name="button">
-            {% if user_collection.auth_date_expires and user_collection.auth_has_expired %}
-              {% comment %}Translators: Labels a button users can click to renew an expired account. {% endcomment %}
-              {% trans "Renew" %}
-            {% else %}
-              {% comment %}Translators: Labels a button users can click to extend the duration of their access. {% endcomment %}
-              {% trans "Extend" %}
-            {% endif %}
           </a>
-        {% endif %}
+        </div>
       {% endif %}
-    {% else %}
-        <a href="{{ user_collection.partner_access_url }}" class="btn btn-sm twl-btn access-apply-button"
-                type="button" name="button" target="_blank" rel="noopener">
-            {% comment %}Translators: On the My Library page (https://wikipedialibrary.wmflabs.org/users/my_library), this labels the text on a button which takes the user to the partner's site. {% endcomment %}
-            {% trans "Access collection" %}
-        </a>
-    {% endif %}
+    </div>
   </div>
 </div>


### PR DESCRIPTION
[//]: # (Thank you for uploading a PR to the Wikipedia Library!)

## Description
* Refactored the `card-footer` section of the user collection tiles.
    * Added a container and col divs so resizing is managed by Bootstrap classes
    * Removed breakpoint CSS code that wasn't working as well as Bootstrap's
* Added an ellipsis whenever the button content overflows on resizing

## Rationale
[//]: # (Why is this change required? What problem does it solve?)
This was an eye-sore of a bug

## Phabricator Ticket
[T300072](https://phabricator.wikimedia.org/T300072)

## How Has This Been Tested?
[//]: # (- Did you add tests to your changes? Did you modify tests to accommodate your changes?)
[//]: # (- Can this change be tested manually? How?)

## Screenshots of your changes (if appropriate):
[//]: # (It can also be a GIF to prove that your changes are working)
![Bugfix](https://user-images.githubusercontent.com/7854953/162260591-e75e5d8c-f260-43ae-a6c0-4fe57d12627f.gif)


## Types of changes
What types of changes does your code introduce? Add an `x` in all the boxes that apply:
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Minor change (fix a typo, add a translation tag, add section to README, etc.)
