### PR TITLE
Don't create duplicate Bundle authorization when non-available resources are moved to Bundle

### DIFF
--- a/TWLight/users/signals.py
+++ b/TWLight/users/signals.py
@@ -107,12 +107,11 @@ def update_existing_bundle_authorizations(sender, instance, **kwargs):
         if previously_available and previously_bundle:
             remove_from_auths = True
 
-        # Case when partner is no more available
-        # but set to Bundle at the same time.
-        # We need to delete its existing authorizations for now
-        # whenever its status or authorization_method will change
-        # in future, situation will be handled by either add_to_auths
-        # remove_from_auths accordingly
+        # Fix T302882: Case when a partner does not have an Available status
+        # and has a Bundle authorization method set in the same operation.
+        # Then we need to delete its existing authorizations for now.
+        # If its status or authorization_method changes in future, situation will be
+        # handled by either add_to_auths or remove_from_auths accordingly.
         elif now_bundle and not previously_bundle:
             delete_defunct_authorizations = True
 

--- a/TWLight/users/signals.py
+++ b/TWLight/users/signals.py
@@ -78,6 +78,7 @@ def update_existing_bundle_authorizations(sender, instance, **kwargs):
     """
     add_to_auths = False
     remove_from_auths = False
+    delete_defunct_authorizations = False
 
     try:
         previous_data = Partner.even_not_available.get(pk=instance.pk)
@@ -106,8 +107,17 @@ def update_existing_bundle_authorizations(sender, instance, **kwargs):
         if previously_available and previously_bundle:
             remove_from_auths = True
 
+        # Case when partner is no more available
+        # but set to Bundle at the same time.
+        # We need to delete its existing authorizations for now
+        # whenever its status or authorization_method will change
+        # in future, situation will be handled by either add_to_auths
+        # remove_from_auths accordingly
+        elif now_bundle and not previously_bundle:
+            delete_defunct_authorizations = True
+
     # Let's avoid db queries if we don't need them
-    if add_to_auths or remove_from_auths:
+    if add_to_auths or remove_from_auths or delete_defunct_authorizations:
         authorizations_to_update = get_all_bundle_authorizations()
 
         if add_to_auths:
@@ -125,6 +135,13 @@ def update_existing_bundle_authorizations(sender, instance, **kwargs):
         elif remove_from_auths:
             for authorization in authorizations_to_update:
                 authorization.partners.remove(instance)
+
+        elif delete_defunct_authorizations:
+            all_partner_authorizations = Authorization.objects.filter(
+                partners__pk=instance.pk
+            )
+            for defunct_authorization in all_partner_authorizations:
+                defunct_authorization.delete()
 
 
 @receiver(post_save, sender=Partner)


### PR DESCRIPTION
[//]: # (Thank you for uploading a PR to the Wikipedia Library!)

## Description
When a partner is moved from an access method to Bundle we do some processing in [update_existing_bundle_authorizations](https://github.com/WikipediaLibrary/TWLight/blob/fe6369f1365ad8f53b630a009583ed3ba4811d7b/TWLight/users/signals.py#L72) to update authorizations accordingly.

When the partner is set to one of the non-available statuses and is moved to Bundle, it creates duplicate Bundle authorizations for users. This shouldn't happen.

## Rationale
[//]: # (Why is this change required? What problem does it solve?)
When the partner is set to one of the non-available statuses and is moved to Bundle in the same operation, 
it creates duplicate Bundle authorizations for the user. This should not happen ideally.

## Phabricator Ticket
[//]: # (Link to the Phabricator ticket)
https://phabricator.wikimedia.org/T302882

## How Has This Been Tested?
[//]: # (- Did you add tests to your changes? Did you modify tests to accommodate your changes?)
[//]: # (- Can this change be tested manually? How?)
I have tested it by moving a partner from `available` to `waitlist` and setting its `authorization_method` to `Bundle` in the same query. Later checked that it does not have duplicate Authorizations in the DB.

## Screenshots of your changes (if appropriate):
[//]: # (It can also be a GIF to prove that your changes are working)

## Types of changes
What types of changes does your code introduce? Add an `x` in all the boxes that apply:
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Minor change (fix a typo, add a translation tag, add section to README, etc.)
