### PR TITLE
Bugfix: Add twl-btn class on Go to application button

### DIFF
--- a/TWLight/users/templates/users/user_collection_tile.html
+++ b/TWLight/users/templates/users/user_collection_tile.html
@@ -87,7 +87,7 @@
         {% endif %}
         {% if user_collection.auth_open_app %}
         <div class="col-12" style="padding: 0px;">
-          <a href="{% url 'applications:evaluate' user_collection.auth_open_app.pk %}" class="btn btn-sm access-apply-button"
+          <a href="{% url 'applications:evaluate' user_collection.auth_open_app.pk %}" class="btn twl-btn btn-sm access-apply-button"
                 type="button" name="button">
             {% comment %}Translators: On the My Library page (https://wikipedialibrary.wmflabs.org/users/my_library), this labels the text on a button which takes the user to an open application. {% endcomment %}
             {% trans "Go to application" %}


### PR DESCRIPTION
[//]: # (Thank you for uploading a PR to the Wikipedia Library!)

## Description
Adds the `twl-btn` class on the `Go to application` button.

## Rationale
[//]: # (Why is this change required? What problem does it solve?)
This class styles the button.

## Phabricator Ticket
[//]: # (Link to the Phabricator ticket)
N/A

## How Has This Been Tested?
[//]: # (- Did you add tests to your changes? Did you modify tests to accommodate your changes?)
[//]: # (- Can this change be tested manually? How?)
1. Create and approve an application
2. Log out and log in (if the cache PR hasn't been merged)
3. Extend or renew the authorization
4. Log out and log in (if the cache PR hasn't been merged)
5. The button should have the same styling that the `Access collection`/`Go to site` buttons

## Screenshots of your changes (if appropriate):
[//]: # (It can also be a GIF to prove that your changes are working)

**Before**
![Screen Shot 2022-04-29 at 20 55 22](https://user-images.githubusercontent.com/7854953/166086103-b3a04d8f-05ed-41f7-a934-49439e4987c4.png)

**After**
![Screen Shot 2022-04-29 at 20 50 54](https://user-images.githubusercontent.com/7854953/166086114-113c0ae3-407d-4322-a82f-c3d335ccfa01.png)


## Types of changes
What types of changes does your code introduce? Add an `x` in all the boxes that apply:
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Minor change (fix a typo, add a translation tag, add section to README, etc.)
