### PR TITLE
Update home page text to include number of languages

### DIFF
--- a/TWLight/templates/login_partial.html
+++ b/TWLight/templates/login_partial.html
@@ -27,9 +27,9 @@
     <p>
       {% comment %}Translators: Information about The Wikipedia Library.{% endcomment %}
       {% blocktranslate trimmed %}
-      Over 90 of the world's top
-      subscription-only databases, free
-      for Wikipedians of all backgrounds
+      Over 90 of the world's top subscription-only databases,
+      with content in {{ no_of_languages }} languages, 
+      free for Wikipedians of all backgrounds
       {% endblocktranslate %}
     </p>
   </div>

--- a/TWLight/views.py
+++ b/TWLight/views.py
@@ -80,17 +80,23 @@ class NewHomePageView(TemplateView):
         if tags:
             # Order by ascending tag order if tag name is before multidisciplinary
             if tags < "multidisciplinary_tag":
-                partners = Partner.objects.filter(tag_filter).order_by(
-                    "new_tags__tags", "?"
+                partners = (
+                    Partner.objects.select_related("logos")
+                    .filter(tag_filter)
+                    .order_by("new_tags__tags", "?")
                 )
             # Order by descending tag order if tag name is after multidisciplinary
             else:
-                partners = Partner.objects.filter(tag_filter).order_by(
-                    "-new_tags__tags", "?"
+                partners = (
+                    Partner.objects.select_related("logos")
+                    .filter(tag_filter)
+                    .order_by("-new_tags__tags", "?")
                 )
         # No tag filter was passed, ordering can be random
         else:
-            partners = Partner.objects.filter(tag_filter).order_by("?")
+            partners = (
+                Partner.objects.select_related("logos").filter(tag_filter).order_by("?")
+            )
 
         for partner in partners:
             # Obtaining translated partner description

--- a/TWLight/views.py
+++ b/TWLight/views.py
@@ -6,7 +6,7 @@ from django.views.generic.edit import FormView
 from django.views import View
 from django.conf import settings
 from django.contrib.messages import get_messages
-from django.db.models import Q
+from django.db.models import Q, Count
 from django.http import HttpResponse, HttpResponseBadRequest, HttpResponseRedirect
 from django.shortcuts import render, redirect
 from django.urls import reverse_lazy
@@ -115,6 +115,9 @@ class NewHomePageView(TemplateView):
                 }
             )
         context["partners"] = partners_obj
+        context["no_of_languages"] = (
+            Partner.objects.values("languages").distinct().count()
+        )
         param_next_url = self.request.GET.get("next_url", None)
         if param_next_url:
             context["next_url"] = param_next_url


### PR DESCRIPTION
[//]: # (Thank you for uploading a PR to the Wikipedia Library!)

## Description
* Change the home page text to include the number of languages collections are available in.
* Improve performance of homepage queries.

## Rationale
[//]: # (Why is this change required? What problem does it solve?)
The big sentence on the homepage could be more inviting to users if it specified that the library has content in multiple languages.

## Phabricator Ticket
[//]: # (Link to the Phabricator ticket)
[T304297](https://phabricator.wikimedia.org/T304297)

## How Has This Been Tested?
[//]: # (- Did you add tests to your changes? Did you modify tests to accommodate your changes?)
[//]: # (- Can this change be tested manually? How?)
Tested manually.

## Screenshots of your changes (if appropriate):
[//]: # (It can also be a GIF to prove that your changes are working)

### Homepage text changes

**Before**
![Screen Shot 2022-05-18 at 16 26 38](https://user-images.githubusercontent.com/7854953/169158617-4d1def7a-118d-444b-bbee-befbca4e40e3.png)


**After**
![Screen Shot 2022-05-18 at 16 26 43](https://user-images.githubusercontent.com/7854953/169158629-ccb9684f-0fb0-47a4-bff8-f0ac6af5c8ca.png)

### Query performance improvement

**Before**
![Screen Shot 2022-05-18 at 16 28 18](https://user-images.githubusercontent.com/7854953/169158890-df565b1e-a69f-4f5c-b5ea-c3a858970a3e.png)


**After**
![Screen Shot 2022-05-18 at 16 28 00](https://user-images.githubusercontent.com/7854953/169158909-da3b00e5-2d9d-4eca-bfc1-f8b8ed7d10fc.png)


## Types of changes
What types of changes does your code introduce? Add an `x` in all the boxes that apply:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Minor change (fix a typo, add a translation tag, add section to README, etc.)
