### PR TITLE
Fix renew/extend message not showing up on My Library

### DIFF
--- a/TWLight/users/templates/users/redesigned_my_library.html
+++ b/TWLight/users/templates/users/redesigned_my_library.html
@@ -3,6 +3,7 @@
 
 {% block content %}
   {% include "header_partial_b4.html" %}
+  {% include "message_partial.html" %}
 
   {% if not editor.wp_bundle_eligible %}
     {% include "users/eligibility_modal.html" %}


### PR DESCRIPTION
[//]: # (Thank you for uploading a PR to the Wikipedia Library!)

## Description
Added the `message_partial` file to the My Library template.

## Rationale
[//]: # (Why is this change required? What problem does it solve?)
Messages should appear in order to let a user know that a coordinator is reviewing their renewal/extension.

## Phabricator Ticket
[//]: # (Link to the Phabricator ticket)
[T308197](https://phabricator.wikimedia.org/T308197)

## How Has This Been Tested?
[//]: # (- Did you add tests to your changes? Did you modify tests to accommodate your changes?)
[//]: # (- Can this change be tested manually? How?)
Tested manually
1. Create an application that requires renewal or an extension.
2. Apply for a renewal or extension.
3. You should be redirected to `My Library`, where the message will appear.

## Screenshots of your changes (if appropriate):
[//]: # (It can also be a GIF to prove that your changes are working)
![Screen Shot 2022-05-19 at 19 13 35](https://user-images.githubusercontent.com/7854953/169431780-6fd54a53-6dbd-412c-8a0e-9974a1c685a5.png)


## Types of changes
What types of changes does your code introduce? Add an `x` in all the boxes that apply:
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Minor change (fix a typo, add a translation tag, add section to README, etc.)
