### PR TITLE
users favorites: only validate favorites being added; not the entire set of favorites

### DIFF
--- a/TWLight/users/admin.py
+++ b/TWLight/users/admin.py
@@ -14,6 +14,8 @@ from TWLight.users.models import (
 )
 from TWLight.users.forms import AuthorizationAdminForm, AuthorizationInlineForm
 
+from TWLight.resources.models import Partner
+
 
 class EditorInline(admin.StackedInline):
     model = Editor
@@ -50,6 +52,7 @@ class UserProfileInline(admin.StackedInline):
                     "use_wp_email",
                     "lang",
                     "my_library_cache_key",
+                    "favorites",
                 )
             },
         ),

--- a/TWLight/users/models.py
+++ b/TWLight/users/models.py
@@ -34,6 +34,7 @@ import json
 import logging
 import urllib.request, urllib.error, urllib.parse
 from annoying.functions import get_object_or_None
+from rest_framework import serializers
 from django.conf import settings
 from django.contrib.auth.models import User
 from django.core.cache import cache
@@ -160,10 +161,13 @@ def favorites_field_changed(sender, instance, action, pk_set, **kwargs):
             if pk not in instance.user.authorizations.values_list(
                 "partners__id", flat=True
             ):
-                raise ValidationError(
-                    "We cannot add partner {partner} to your favorites because you don't have access to it".format(
-                        partner=Partner.objects.get(pk=pk)
-                    )
+                raise serializers.ValidationError(
+                    # fmt: off
+                    {
+                        # Translators: Shown if the current user tried to 'favorite' a partner they can't access. Do not translate '{partner}'
+                        "detail": _("Cannot add partner {partner} to your favorites because you don't have access to it").format(partner=Partner.objects.get(pk=pk).company_name)
+                    }
+                    # fmt: on
                 )
 
 

--- a/TWLight/users/models.py
+++ b/TWLight/users/models.py
@@ -156,14 +156,10 @@ def favorites_field_changed(sender, instance, action, pk_set, **kwargs):
     """
 
     if action == "pre_add":
-        authorized_partners = []
-        authorizations = instance.user.authorizations.all()
-        for authorization in authorizations:
-            for partner in authorization.partners.all():
-                authorized_partners.append(partner.pk)
-
         for pk in pk_set:
-            if pk not in authorized_partners:
+            if pk not in instance.user.authorizations.values_list(
+                "partners__id", flat=True
+            ):
                 raise ValidationError(
                     "We cannot add partner {partner} to your favorites because you don't have access to it".format(
                         partner=Partner.objects.get(pk=pk)

--- a/TWLight/users/serializers.py
+++ b/TWLight/users/serializers.py
@@ -14,7 +14,6 @@ class FavoriteCollectionSerializer(serializers.Serializer):
         add or remove partner from favorites
         """
         partner_pk = self.validated_data.get("partner").get("pk")
-        added = None
         user_profile = get_object_or_404(
             UserProfile, pk=self.validated_data.get("userprofile").get("pk")
         )

--- a/TWLight/users/templates/users/redesigned_my_library.html
+++ b/TWLight/users/templates/users/redesigned_my_library.html
@@ -34,6 +34,15 @@
     var search_input = document.getElementById("collection-live-search");
     search_input.oninput = searchCollections;
 
+    // present problems as django messages
+    function errorMsg(detail) {
+      var div = document.createElement('div');
+      div.classList.add('alert');
+      div.classList.add('alert-danger');
+      div.innerHTML = detail;
+      document.getElementById( 'message-container' ).appendChild(div);
+    }
+
     function searchCollections(obj) {
       var pattern = obj.target.value;
 
@@ -228,7 +237,7 @@
         error: function(response) {
             // log the error if any details are available
             if (response.responseJSON.detail) {
-              console.log(response.responseJSON.detail)
+                  errorMsg(response.responseJSON.detail + '');
             }
         }
       });

--- a/TWLight/users/tests.py
+++ b/TWLight/users/tests.py
@@ -3,6 +3,7 @@ import copy
 from datetime import datetime, date, timedelta
 import json
 import re
+import rest_framework
 from unittest.mock import patch, Mock
 from urllib.parse import urlparse
 
@@ -927,7 +928,7 @@ class UserProfileModelTestCase(TestCase):
         """
         profile = UserProfile.objects.get(user=self.editor.user)
 
-        with self.assertRaises(ValidationError):
+        with self.assertRaises(rest_framework.exceptions.ValidationError):
             profile.favorites.add(self.proxy_partner_1)
 
 


### PR DESCRIPTION
[//]: # (Thank you for uploading a PR to the Wikipedia Library!)

## Description
only validates partners being favorited upon change; If a user does somehow manage to attempt to favorite an unauthorized partner, the error is now visible to them. Also makes favorites visible in user admin for troubleshooting.

## Rationale
currently we validate the entire set of favorites, which breaks favoriting for users unnecessarily; the rest endpoint for favoriting was responding with our themed error page instead of a json response, so the error couldn't be passed back to the user via ajax.

## Phabricator Ticket
https://phabricator.wikimedia.org/T323216

## How Has This Been Tested?
I identified the issue by pulling a backup and overwriting the wiki references for an impacted user with my own wiki id. I then manually tested that the fix resolved the problem. It also passes our unit tests

## Screenshots of your changes (if appropriate):
![image](https://user-images.githubusercontent.com/2986893/214140235-341e0156-8cb0-4d61-950e-3e51cf6d3b34.png)

## Types of changes
What types of changes does your code introduce? Add an `x` in all the boxes that apply:
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Minor change (fix a typo, add a translation tag, add section to README, etc.)
