### PR TITLE
Change the github codeQL analysis to V2

### DIFF
--- a/.cicd/deploy.sh
+++ b/.cicd/deploy.sh
@@ -5,7 +5,7 @@ branch="${1//[\/]/-}"
 commit="${2}"
 event_name="${3}"
 gh_repo="${4}"
-wikibot_token="${5}"
+wikibot_token="${5:-}"
 quaybot_username="${6:-}"
 quaybot_password="${7:-}"
 

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -38,3 +38,8 @@ updates:
     versions:
     - 0.20.0
     - 0.20.1
+- package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      # Check for updates to GitHub Actions every month
+      interval: "monthly"

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -10,6 +10,7 @@ on:
 jobs:
   cicd:
     runs-on: ubuntu-latest
+    environment: cicd
     steps:
       - uses: actions/checkout@v3
         with:

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -34,6 +34,10 @@ jobs:
           docker compose exec --no-TTY twlight
           /app/bin/virtualenv_test.sh
       - name: deploy
+        env:
+          WIKIBOT_TOKEN: ${{secrets.WIKIBOT_TOKEN}}
+          QUAYBOT_USERNAME: ${{secrets.QUAYBOT_USERNAME}}
+          QUAYBOT_PASSWORD: ${{secrets.QUAYBOT_PASSWORD}}
         run: >
           sudo .cicd/deploy.sh
           ${GITHUB_REF_NAME}
@@ -43,10 +47,6 @@ jobs:
           ${WIKIBOT_TOKEN}
           ${QUAYBOT_USERNAME}
           ${QUAYBOT_PASSWORD}
-        env:
-          WIKIBOT_TOKEN: ${{secrets.WIKIBOT_TOKEN}}
-          QUAYBOT_USERNAME: ${{secrets.QUAYBOT_USERNAME}}
-          QUAYBOT_PASSWORD: ${{secrets.QUAYBOT_PASSWORD}}
 
       - name: cleanup
         if: always()

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -39,9 +39,14 @@ jobs:
           ${GITHUB_SHA}
           ${GITHUB_EVENT_NAME}
           ${GITHUB_REPOSITORY}
-          ${{ secrets.WIKIBOT_TOKEN }}
-          ${{ secrets.QUAYBOT_USERNAME }}
-          ${{ secrets.QUAYBOT_PASSWORD }}
+          ${WIKIBOT_TOKEN}
+          ${QUAYBOT_USERNAME}
+          ${QUAYBOT_PASSWORD}
+        env:
+          WIKIBOT_TOKEN: ${{secrets.WIKIBOT_TOKEN}}
+          QUAYBOT_USERNAME: ${{secrets.QUAYBOT_USERNAME}}
+          QUAYBOT_PASSWORD: ${{secrets.QUAYBOT_PASSWORD}}
+
       - name: cleanup
         if: always()
         run: sudo chown -R ${USER}:${USER} .

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -39,7 +39,7 @@ jobs:
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v1
+      uses: github/codeql-action/init@v2
       with:
         languages: ${{ matrix.language }}
         # If you wish to specify custom queries, you can do so here or in a config file.
@@ -50,7 +50,7 @@ jobs:
     # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
     # If this step fails, then you should remove it and run the build manually (see below)
     - name: Autobuild
-      uses: github/codeql-action/autobuild@v1
+      uses: github/codeql-action/autobuild@v2
 
     # ℹ️ Command-line programs to run using the OS shell.
     # 📚 https://git.io/JvXDl
@@ -64,4 +64,4 @@ jobs:
     #   make release
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v1
+      uses: github/codeql-action/analyze@v2


### PR DESCRIPTION
V1 seems to be deprecated now

[//]: # (Thank you for uploading a PR to the Wikipedia Library!)

## Description
I changed the GitHub codeQL analysis to V2 because V1 seems to be deprecated now.

## Rationale
[//]: # (Why is this change required? What problem does it solve?)
GitHub actions are throwing deprecation warnings and errors on our builds.

## Phabricator Ticket
[//]: # (Link to the Phabricator ticket)
[T328090](https://phabricator.wikimedia.org/T328090)

## How Has This Been Tested?
[//]: # (- Did you add tests to your changes? Did you modify tests to accommodate your changes?)
[//]: # (- Can this change be tested manually? How?)

## Screenshots of your changes (if appropriate):
[//]: # (It can also be a GIF to prove that your changes are working)

## Types of changes
What types of changes does your code introduce? Add an `x` in all the boxes that apply:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Minor change (fix a typo, add a translation tag, add section to README, etc.)
