### PR TITLE
comment out syslog references and backup twice daily

### DIFF
--- a/.cicd/build.sh
+++ b/.cicd/build.sh
@@ -5,11 +5,14 @@ export COMPOSE_DOCKER_CLI_BUILD=1 # use docker cli for building
 
 branch="${1//[\/]/-}"
 commit="${2}"
-
+build_list="twlight"
+# uncomment to build syslog
+# build_list="${build_list} syslog"
 chown -R root:root .
-docker compose -f docker-compose.yml -f docker-compose.override.yml -f docker-compose.cicd.yml build twlight syslog 2>/dev/null
+docker compose -f docker-compose.yml -f docker-compose.override.yml -f docker-compose.cicd.yml build ${build_list} 2>/dev/null
 docker tag "quay.io/wikipedialibrary/twlight:local" "quay.io/wikipedialibrary/twlight:branch_${branch}"
 docker tag "quay.io/wikipedialibrary/twlight:local" "quay.io/wikipedialibrary/twlight:commit_${commit}"
-docker tag "quay.io/wikipedialibrary/twlight_syslog:local" "quay.io/wikipedialibrary/twlight_syslog:branch_${branch}"
-docker tag "quay.io/wikipedialibrary/twlight_syslog:local" "quay.io/wikipedialibrary/twlight_syslog:commit_${commit}"
+# uncomment to tag syslog
+# docker tag "quay.io/wikipedialibrary/twlight_syslog:local" "quay.io/wikipedialibrary/twlight_syslog:branch_${branch}"
+# docker tag "quay.io/wikipedialibrary/twlight_syslog:local" "quay.io/wikipedialibrary/twlight_syslog:commit_${commit}"
 docker compose up -d db twlight

--- a/.cicd/deploy.sh
+++ b/.cicd/deploy.sh
@@ -69,9 +69,13 @@ docker_push() {
     then
         branch_tag="branch_production"
         docker tag "quay.io/wikipedialibrary/twlight:local" "quay.io/wikipedialibrary/twlight:${branch_tag}"
-        docker tag "quay.io/wikipedialibrary/twlight_syslog:local" "quay.io/wikipedialibrary/twlight_syslog:${branch_tag}"
+        # uncomment to tag syslog
+        # docker tag "quay.io/wikipedialibrary/twlight_syslog:local" "quay.io/wikipedialibrary/twlight_syslog:${branch_tag}"
     fi
-    declare -a repositories=("twlight" "twlight_syslog")
+    # comment out and uncomment the second declaration to push syslog
+    declare -a repositories=("twlight")
+    # uncomment to push syslog
+    # declare -a repositories=("twlight" "twlight_syslog")
     for repo in "${repositories[@]}"
     do
       docker push quay.io/wikipedialibrary/${repo}:commit_${commit}

--- a/TWLight/crons.py
+++ b/TWLight/crons.py
@@ -6,6 +6,7 @@ from sentry_sdk import capture_exception
 
 WEEKLY = 10080
 DAILY = 1440
+SEMI_DAILY = 720
 
 
 class SendCoordinatorRemindersCronJob(CronJobBase):
@@ -20,7 +21,7 @@ class SendCoordinatorRemindersCronJob(CronJobBase):
 
 
 class BackupCronJob(CronJobBase):
-    schedule = Schedule(run_every_mins=DAILY)
+    schedule = Schedule(run_every_mins=SEMI_DAILY)
     code = "backup"
 
     def do(self):

--- a/bin/twlight_backup.sh
+++ b/bin/twlight_backup.sh
@@ -16,7 +16,7 @@ flock -n ${lockfile}
 
     PATH=/usr/local/bin:/usr/bin:/bin:/sbin:$PATH
 
-    date=$(date +'%d.%H')
+    date=$(date +'%Y%m%d%H%M')
 
     ## Dump DB
 

--- a/conf/local.nginx.conf
+++ b/conf/local.nginx.conf
@@ -33,8 +33,8 @@ server {
     client_max_body_size 4G;
     server_name localhost twlight.vagrant.localdomain;
     keepalive_timeout 5;
-    # Send matomo logs to syslog
-    access_log syslog:server=syslog,severity=info matomo;
+    # Uncomment to send matomo logs to syslog
+    # access_log syslog:server=syslog,severity=info matomo;
     # Send default logs to stdout
     access_log /dev/stdout;
 

--- a/conf/production.nginx.conf
+++ b/conf/production.nginx.conf
@@ -62,8 +62,8 @@ server {
     client_max_body_size 4G;
     server_name wikipedialibrary.wmflabs.org;
     keepalive_timeout 5;
-    # Send matomo logs to syslog
-    access_log syslog:server=syslog,severity=info matomo;
+    # Uncomment to send matomo logs to syslog
+    # access_log syslog:server=syslog,severity=info matomo;
     # Send default logs to stdout
     access_log /dev/stdout;
 

--- a/conf/staging.nginx.conf
+++ b/conf/staging.nginx.conf
@@ -63,8 +63,8 @@ server {
     client_max_body_size 4G;
     server_name twlight-staging.wmflabs.org;
     keepalive_timeout 5;
-    # Send matomo logs to syslog
-    access_log syslog:server=syslog,severity=info matomo;
+    # Uncomment to send matomo logs to syslog
+    # access_log syslog:server=syslog,severity=info matomo;
     # Send default logs to stdout
     access_log /dev/stdout;
 

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -36,5 +36,5 @@ services:
       - type: bind
         source: ./conf/local.nginx.conf
         target: /etc/nginx/conf.d/default.conf
-  syslog:
-    image: quay.io/wikipedialibrary/twlight_syslog:local
+#  syslog:
+#    image: quay.io/wikipedialibrary/twlight_syslog:local

--- a/docker-compose.production.yml
+++ b/docker-compose.production.yml
@@ -66,8 +66,8 @@ services:
       - type: bind
         source: ./conf/production.nginx.conf
         target: /etc/nginx/conf.d/default.conf
-  syslog:
-    image: quay.io/wikipedialibrary/twlight_syslog:branch_production
-    secrets:
-      - MATOMO_SITEID
-      - MATOMO_AUTH_TOKEN
+#  syslog:
+#    image: quay.io/wikipedialibrary/twlight_syslog:branch_production
+#    secrets:
+#      - MATOMO_SITEID
+#      - MATOMO_AUTH_TOKEN

--- a/docker-compose.staging.yml
+++ b/docker-compose.staging.yml
@@ -66,8 +66,8 @@ services:
       - type: bind
         source: ./conf/staging.nginx.conf
         target: /etc/nginx/conf.d/default.conf
-  syslog:
-    image: quay.io/wikipedialibrary/twlight_syslog:branch_staging
-    secrets:
-      - MATOMO_SITEID
-      - MATOMO_AUTH_TOKEN
+#  syslog:
+#    image: quay.io/wikipedialibrary/twlight_syslog:branch_staging
+#    secrets:
+#      - MATOMO_SITEID
+#      - MATOMO_AUTH_TOKEN

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -67,9 +67,9 @@ services:
         target: /app/500
     depends_on:
       - 'twlight'
-      - 'syslog'
-  syslog:
-    build:
-      context: syslog
-    environment:
-      - MATOMO_FQDN=analytics-wikipedialibrary.wmflabs.org
+      # - 'syslog'
+#  syslog:
+#    build:
+#      context: syslog
+#    environment:
+#      - MATOMO_FQDN=analytics-wikipedialibrary.wmflabs.org


### PR DESCRIPTION
[//]: # (Thank you for uploading a PR to the Wikipedia Library!)

## Description
- Comment out references to syslog, which we use for matomo.
- Backup twice daily instead of once daily.

## Rationale
- We don't need matomo right now, but we do need to free up capacity in our hosting space to create a fresh production instance
- more backups means less data loss on restore; we have the storage space for it

## Phabricator Ticket
https://phabricator.wikimedia.org/T330088

## How Has This Been Tested?
I built and ran this locally and verified that syslog was neither included nor expected in the running services

## Screenshots of your changes (if appropriate):
[//]: # (It can also be a GIF to prove that your changes are working)

## Types of changes
What types of changes does your code introduce? Add an `x` in all the boxes that apply:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Minor change (fix a typo, add a translation tag, add section to README, etc.)
