### PR TITLE
nginx: remove rate limiting

### DIFF
--- a/conf/local.nginx.conf
+++ b/conf/local.nginx.conf
@@ -10,9 +10,6 @@ log_format matomo  '{"ip": "$remote_addr",'
                    '"args": {"cvar": {"1": ["Has-Session", $has_session]}},'
                    '"date": "$time_iso8601"}';
 
-# remote address is a joke here since we don't have x-forwarded-for
-limit_req_zone $binary_remote_addr zone=one:10m rate=500r/s;
-
 map $http_cookie $has_session {
   default 0;
   ~sessionid 1; # Django session cookie
@@ -46,7 +43,6 @@ server {
     }
 
     location @twlight {
-      limit_req zone=one burst=1000 nodelay;
       proxy_set_header X-Forwarded-Proto $scheme;
       proxy_set_header Host $http_host;
       # we don't want nginx trying to do something clever with

--- a/conf/production.nginx.conf
+++ b/conf/production.nginx.conf
@@ -15,11 +15,6 @@ map $http_x_forwarded_proto $web_proxy_scheme {
   https https;
 }
 
-map $http_user_agent $limit_bots {
-  default "";
-  ~*(GoogleBot|bingbot|YandexBot|mj12bot|Apache-HttpClient) $binary_remote_addr;
-}
-
 ## Testing the request method. Only GET and HEAD are caching safe.
 map $request_method $no_cache {
   default 0;
@@ -42,10 +37,6 @@ proxy_cache_path /var/lib/nginx/cache levels=1:2 keys_zone=cache:8m max_size=10g
 proxy_cache_key "$scheme$proxy_host$uri$is_args$args$http_accept_language";
 proxy_cache_lock on;
 proxy_cache_use_stale error timeout invalid_header updating http_500 http_502 http_503 http_504;
-
-# remote address is a joke here since we don't have x-forwarded-for
-limit_req_zone $limit_bots zone=bots:10m rate=1r/s;
-limit_req_zone $binary_remote_addr zone=one:10m rate=500r/s;
 
 upstream twlight {
   server twlight:80;
@@ -85,9 +76,6 @@ server {
     }
 
     location @twlight {
-      limit_req zone=bots burst=2 nodelay;
-      limit_req zone=one burst=1000 nodelay;
-      limit_req_status 429;
       proxy_set_header X-Forwarded-Proto $web_proxy_scheme;
       proxy_set_header Host $http_host;
       # we don't want nginx trying to do something clever with

--- a/conf/staging.nginx.conf
+++ b/conf/staging.nginx.conf
@@ -15,11 +15,6 @@ map $http_x_forwarded_proto $web_proxy_scheme {
   https https;
 }
 
-map $http_user_agent $limit_bots {
-  default "";
-  ~*(GoogleBot|bingbot|YandexBot|mj12bot|Apache-HttpClient) $binary_remote_addr;
-}
-
 ## Testing the request method. Only GET and HEAD are caching safe.
 map $request_method $no_cache {
   default 0;
@@ -43,10 +38,6 @@ proxy_cache_path /var/lib/nginx/cache levels=1:2 keys_zone=cache:8m max_size=10g
 proxy_cache_key "$scheme$proxy_host$uri$is_args$args$http_accept_language";
 proxy_cache_lock on;
 proxy_cache_use_stale error timeout invalid_header updating http_500 http_502 http_503 http_504;
-
-# remote address is a joke here since we don't have x-forwarded-for
-limit_req_zone $limit_bots zone=bots:10m rate=1r/s;
-limit_req_zone $binary_remote_addr zone=one:10m rate=500r/s;
 
 upstream twlight {
   server twlight:80;
@@ -86,9 +77,6 @@ server {
     }
 
     location @twlight {
-      limit_req zone=bots burst=2 nodelay;
-      limit_req zone=one burst=1000 nodelay;
-      limit_req_status 429;
       proxy_set_header X-Forwarded-Proto $web_proxy_scheme;
       proxy_set_header Host $http_host;
       # we don't want nginx trying to do something clever with


### PR DESCRIPTION
## Description
Removes rate limiting from all nginx configs.

## Rationale
Even though we can differentiate between bots and users based on user agent, we can only rate limit by IP address. We no longer have access to user IP addresses [0], so we only see the VPS proxy IP address. When we rate limit the IP associated with a bot, we're actually rate limiting the Cloud VPS web proxy. Naturally, this impacts all users, not just bots. Cloud VPS introduced its own rate limits last year [1], rendering this configuration redundant.

[0] https://lists.wikimedia.org/hyperkitty/list/cloud@lists.wikimedia.org/message/56V7H4BT6ZQA3Z4BG34YC6TWORO27MN4/
[1] https://lists.wikimedia.org/hyperkitty/list/cloud@lists.wikimedia.org/message/LH7QMFWI5PXJ5XL6T5SVT4LGZPLAVXJ3/

## Phabricator Ticket
https://phabricator.wikimedia.org/T323215

## How Has This Been Tested?
I tested this locally, and the site didn't break.

## Screenshots of your changes (if appropriate):
N/A

## Types of changes
What types of changes does your code introduce? Add an `x` in all the boxes that apply:
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Minor change (fix a typo, add a translation tag, add section to README, etc.)
