### PR TITLE
lazing load partner images in carousel and collection tiles

### DIFF
--- a/TWLight/resources/templates/resources/collection_tile.html
+++ b/TWLight/resources/templates/resources/collection_tile.html
@@ -3,12 +3,21 @@
   <div class="card collection-tile">
     {% if collection.partner_logo %}
       <a href="{% url 'partners:detail' collection.pk %}" class="tile-partner-link">
-        <img src="{{ collection.partner_logo }}" class="card-img-top library-tile-image"
-            alt="{{ collection.partner_name }} logo">
+        <img
+          src="{{ collection.partner_logo }}"
+          class="card-img-top library-tile-image"
+          alt="{{ collection.partner_name }} logo"
+          loading="lazy"
+        >
       </a>
     {% else %}
       <a href="{% url 'partners:detail' collection.pk %}" class="tile-partner-link">
-        <img src="..." class="card-img-top" alt="{{ collection.partner_name }} logo">
+        <img
+          src="..."
+          class="card-img-top"
+          alt="{{ collection.partner_name }} logo"
+          loading="lazy"
+         >
       </a>
     {% endif %}
     <div class="card-body">

--- a/TWLight/templates/partner_carousel.html
+++ b/TWLight/templates/partner_carousel.html
@@ -68,7 +68,9 @@
             <div class="partner-image-container">
               <img id="partner-image-{{partner.pk}}" src="{{ partner.partner_logo }}"
                   class="mx-auto d-block partner-glider-image fade-in-transition"
-                  alt="{{partner.partner_name}} logo"/>
+                  alt="{{partner.partner_name}} logo"
+                  loading="lazy"
+              />
             </div>
             <p id="partner-description-{{partner.pk}}" class="text-justify mx-auto d-block partner-glider-description truncate-overflow invisible">
               {{ partner.short_description|safe }}

--- a/TWLight/users/templates/users/available_collection_tile.html
+++ b/TWLight/users/templates/users/available_collection_tile.html
@@ -10,12 +10,21 @@
     {% endif %}
     {% if available_collection.partner_logo %}
       <a href="{% url 'partners:detail' available_collection.partner_pk %}" class="tile-partner-link">
-        <img src="{{ available_collection.partner_logo }}" class="card-img-top library-tile-image"
-            alt="{{ available_collection.partner_name }} logo">
+        <img
+          src="{{ available_collection.partner_logo }}"
+          class="card-img-top library-tile-image"
+          alt="{{ available_collection.partner_name }} logo"
+          loading="lazy"
+        >
       </a>
     {% else %}
       <a href="{% url 'partners:detail' available_collection.partner_pk %}" class="tile-partner-link">
-        <img src="..." class="card-img-top" alt="{{ available_collection.partner_name }} logo">
+        <img
+          src="..."
+          class="card-img-top"
+          alt="{{ available_collection.partner_name }} logo"
+          loading="lazy"
+        >
       </a>
     {% endif %}
     <div class="card-body">

--- a/TWLight/users/templates/users/user_collection_tile.html
+++ b/TWLight/users/templates/users/user_collection_tile.html
@@ -9,12 +9,21 @@
   {% endif %}
   {% if user_collection.partner_logo %}
     <a href="{% url 'partners:detail' user_collection.partner_pk %}" class="tile-partner-link">
-      <img src="{{ user_collection.partner_logo }}" class="card-img-top library-tile-image"
-        alt="{{ user_collection.partner_name }} logo">
+      <img
+        src="{{ user_collection.partner_logo }}"
+        class="card-img-top library-tile-image"
+        alt="{{ user_collection.partner_name }} logo"
+        loading="lazy"
+       >
     </a>
   {% else %}
     <a href="{% url 'partners:detail' user_collection.partner_pk %}" class="tile-partner-link">
-      <img src="..." class="card-img-top" alt="{{ user_collection.partner_name }} logo">
+      <img
+        src="..."
+        class="card-img-top"
+        alt="{{ user_collection.partner_name }} logo"
+        loading="lazy"
+      >
     </a>
   {% endif %}
   {% if user_collection.partner_pk in favorite_ids %}


### PR DESCRIPTION
[//]: # (Thank you for uploading a PR to the Wikipedia Library!)

## Description
adds the `loading="lazy"` attribute to partner images in the carousel and collection tiles

## Rationale
We're trying to reduce unnecessary image loading to keep users from hitting the cloud VPS rate limit

## Phabricator Ticket
https://phabricator.wikimedia.org/T323215

## How Has This Been Tested?
I manually tested this on the front page, the partners page, and both tabs of my library.

## Screenshots of your changes (if appropriate):
It is extremely difficult to catch the images loading in a screenshot. We're talkng milliiseconds during "unlocked" scrolling.

## Types of changes
What types of changes does your code introduce? Add an `x` in all the boxes that apply:
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Minor change (fix a typo, add a translation tag, add section to README, etc.)
