### PR TITLE
Revert "Bump django-cron from 0.5.1 to 0.6.0"

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -8,7 +8,7 @@ django-autocomplete-light==3.9.4
 django-contrib-comments==2.2.0
 django-countries==7.5.1
 django-crispy-forms==1.14.0
-django-cron==0.6.0
+django-cron==0.5.1
 django-durationfield==0.5.5
 django_extensions==3.2.3
 django-filter==22.1


### PR DESCRIPTION
There was an issue in production that did not show up locally