### PR TITLE
Fix suggestion message

### DIFF
--- a/TWLight/resources/templates/resources/suggest.html
+++ b/TWLight/resources/templates/resources/suggest.html
@@ -198,6 +198,7 @@
         document.getElementById("no-suggestions-msg").style.display = "none";
       }
       else{
+        document.getElementById("no-suggestions-msg").style.display = "none";
         for(var result in searchResults){
           var suggestionId = searchResults[result].item.id;
           filteredSuggestionElems.push("suggestion-card-" + suggestionId)


### PR DESCRIPTION
## Description
Fixed the `No suggestions matching this search. ` not disappearing whenever the search term matched some suggestions.

## Rationale
This message may confuse some people who see search results alongside the message. It also looks ugly.

## Phabricator Ticket
[T339955](https://phabricator.wikimedia.org/T339955)

## How Has This Been Tested?
[//]: # (- Did you add tests to your changes? Did you modify tests to accommodate your changes?)
[//]: # (- Can this change be tested manually? How?)

   1.  Go to https://wikipedialibrary.wmflabs.org/suggest/
   2. Type in enough garbage to get the  `No suggestions matching this search. ` message
   3. Backspace until you get results
   4. Check that `No suggestions matching this search. ` does not appear.


## Screenshots of your changes (if appropriate):
[//]: # (It can also be a GIF to prove that your changes are working)

**Before**
![Screenshot 2023-07-07 at 20 16 33](https://github.com/WikipediaLibrary/TWLight/assets/7854953/471c0816-226e-472a-96cd-f20044cc6f30)

**After**
![Screenshot 2023-07-07 at 20 16 42](https://github.com/WikipediaLibrary/TWLight/assets/7854953/6afff4ea-2695-44c4-bd73-f0b36b060522)


## Types of changes
What types of changes does your code introduce? Add an `x` in all the boxes that apply:
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Minor change (fix a typo, add a translation tag, add section to README, etc.)
