### PR TITLE
Enable users with invalid applications to delete their data

### DIFF
--- a/TWLight/emails/tasks.py
+++ b/TWLight/emails/tasks.py
@@ -420,7 +420,7 @@ def update_app_status_on_save(sender, instance, **kwargs):
 
     # Case 1: Application already existed; status has been changed.
     if instance.id:
-        orig_app = Application.objects.get(pk=instance.id)
+        orig_app = Application.include_invalid.get(pk=instance.id)
         orig_status = orig_app.status
 
         if orig_status != instance.status:

--- a/TWLight/users/tests.py
+++ b/TWLight/users/tests.py
@@ -636,6 +636,32 @@ class ViewsTestCase(TestCase):
         bundle_auth_count = Authorization.objects.filter(pk=bundle_auth_id).count()
         self.assertEqual(bundle_auth_count, 0)
 
+    def test_user_delete_with_invalid_applications(self):
+        """
+        Verify that users can delete their account even if they have an
+        invalidated application.
+        """
+        partner = PartnerFactory()
+
+        # Create an invalid application
+        application = ApplicationFactory(
+            status=Application.INVALID, editor=self.editor1, partner=partner
+        )
+
+        delete_url = reverse("users:delete_data", kwargs={"pk": self.user_editor.pk})
+
+        # Need a password so we can login
+        self.editor1.user.set_password("editor")
+        self.editor1.user.save()
+
+        self.client = Client()
+        session = self.client.session
+        self.client.login(username=self.username1, password="editor")
+
+        submit = self.client.post(delete_url)
+
+        assert not User.objects.filter(username=self.username1).exists()
+
     def test_user_data_download(self):
         """
         Verify that if users try to download their personal data they


### PR DESCRIPTION
[//]: # (Thank you for uploading a PR to the Wikipedia Library!)

## Description
Fixed bug [T338148](https://phabricator.wikimedia.org/T338148) - users who had applications with the INVALID status were unable to delete their account because we didn't use `include_invalid` when fetching application objects to check if we should send emails for status changes.

## Phabricator Ticket
https://phabricator.wikimedia.org/T338148

## How Has This Been Tested?
Added a test, which failed until I made the code change in emails/tasks.py.

## Types of changes
What types of changes does your code introduce? Add an `x` in all the boxes that apply:
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Minor change (fix a typo, add a translation tag, add section to README, etc.)
