### PR TITLE
Clarify block exemptions on user page and applications

### DIFF
--- a/TWLight/users/templates/users/editor_detail_data.html
+++ b/TWLight/users/templates/users/editor_detail_data.html
@@ -127,7 +127,11 @@
       {% else %}
           {% comment %}Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this shows if the user does not qualify the technical requirements. {% endcomment %}
           <strong class="warning">{% trans "No" %}</strong>
-          <p class="block-notice">
+          {% if editor.ignore_wp_blocks %}
+            {% comment %}Translators: If a user has received an exemption against the 'no blocks' criterion, this is shown next to "No" on their user page and applications next to this criterion. {% endcomment %}
+            {% trans "(exemption granted)" %}
+          {% else %}
+            <p>
             {% url 'contact' as contact_url %}
             {% comment %}Translators: This message is shown on a user's profile if their Wikimedia account is blocked on one or more projects. They may still be granted access to the Library Bundle, but need to contact Wikipedia Library staff to verify. {% endcomment %}
             {% blocktranslate trimmed %}
@@ -135,7 +139,8 @@
               the other criteria you may still be permitted access to the library -
               please <a class="twl-links" href="{{ contact_url }}">contact us</a>.
             {% endblocktranslate %}
-          </p>
+            </p>
+          {% endif %}
       {% endif %}
   </div>
 </div>

--- a/TWLight/users/templates/users/editor_detail_data.html
+++ b/TWLight/users/templates/users/editor_detail_data.html
@@ -128,7 +128,7 @@
           {% comment %}Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this shows if the user does not qualify the technical requirements. {% endcomment %}
           <strong class="warning">{% trans "No" %}</strong>
           {% if editor.ignore_wp_blocks %}
-            {% comment %}Translators: If a user has received an exemption against the 'no blocks' criterion, this is shown next to "No" on their user page and applications next to this criterion. {% endcomment %}
+            {% comment %}Translators: If a user has received an exemption against a criterion, this is shown next to "No" on their user page and applications next to this criterion. {% endcomment %}
             {% trans "(exemption granted)" %}
           {% else %}
             <p>


### PR DESCRIPTION
[//]: # (Thank you for uploading a PR to the Wikipedia Library!)

## Description
Added "(exemption granted)" text on user page/applications when user has been granted a block exemption.

I also removed the `block-notice` class since that didn't seem to be defined anywhere.

## Rationale
It was confusing for users and application reviewers when an exemption had been granted - "No" implied there were still block-related issues, so reviewers didn't know if the user was still eligible to receive an account or not.

## Phabricator Ticket
https://phabricator.wikimedia.org/T304650

## How Has This Been Tested?
Tested locally with a dummy account which I blocked on-wiki and granted an exemption to.

## Screenshots of your changes (if appropriate):
![image](https://github.com/WikipediaLibrary/TWLight/assets/12038840/259fa252-2788-484f-a401-1b5caa3e39e8)

## Types of changes
What types of changes does your code introduce? Add an `x` in all the boxes that apply:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Minor change (fix a typo, add a translation tag, add section to README, etc.)
