### PR TITLE
Fix overwriting stored email with blank string when user has no WP email

### DIFF
--- a/TWLight/users/models.py
+++ b/TWLight/users/models.py
@@ -759,12 +759,12 @@ class Editor(models.Model):
         # This will be True the first time the user logs in, since use_wp_email
         # defaults to True. Therefore we will initialize the email field if
         # they have an email at WP for us to initialize it with.
+        # We should only overwrite saved data if an email is present in the
+        # response.
         if self.user.userprofile.use_wp_email:
-            try:
+            if "email" in identity and identity["email"] != "":
                 self.user.email = identity["email"]
-            except KeyError:
-                # Email isn't guaranteed to be present in identity - don't do
-                # anything if we can't find it.
+            else:
                 logger.exception("Unable to get Editor email address from Wikipedia.")
 
         self.user.save()

--- a/TWLight/users/tests.py
+++ b/TWLight/users/tests.py
@@ -1574,6 +1574,31 @@ class EditorModelTestCase(TestCase):
         # emails
         self.assertEqual(len(mail.outbox), 0)
 
+    def test_editor_email_not_overwritten(self):
+        """
+        When a user has no Wikipedia email, but defines one in the
+        platform, we shouldn't be overwriting it with a blank string.
+        """
+        new_editor = EditorFactory(wp_registered=None)
+        new_identity = FAKE_IDENTITY
+        new_global_userinfo = FAKE_GLOBAL_USERINFO
+        new_identity["sub"] = new_editor.wp_sub
+        new_global_userinfo["id"] = new_identity["sub"]
+
+        new_identity["email"] = ""
+
+        # User sets own email
+        test_email = "test@example.com"
+        new_editor.user.email = test_email
+        new_editor.user.save()
+
+        lang = get_language()
+        new_editor.update_from_wikipedia(
+            new_identity, lang, new_global_userinfo
+        )
+
+        self.assertEqual(new_editor.user.email, test_email)
+
 
 class OAuthTestCase(TestCase):
     @classmethod

--- a/TWLight/users/tests.py
+++ b/TWLight/users/tests.py
@@ -1593,9 +1593,7 @@ class EditorModelTestCase(TestCase):
         new_editor.user.save()
 
         lang = get_language()
-        new_editor.update_from_wikipedia(
-            new_identity, lang, new_global_userinfo
-        )
+        new_editor.update_from_wikipedia(new_identity, lang, new_global_userinfo)
 
         self.assertEqual(new_editor.user.email, test_email)
 


### PR DESCRIPTION
[//]: # (Thank you for uploading a PR to the Wikipedia Library!)

## Description
Previously, if a user did not have a Wikipedia account email, but did enter an email manually into the library, every time they logged in their email would be overwritten with a blank string. After this change, Wikipedia email data is only stored if it contains content.

## Phabricator Ticket
https://phabricator.wikimedia.org/T328904

## How Has This Been Tested?
Tested locally with a few different accounts having and not having email addresses linked. Added a test, which fails with the old code and passes with the new.

## Types of changes
What types of changes does your code introduce? Add an `x` in all the boxes that apply:
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Minor change (fix a typo, add a translation tag, add section to README, etc.)
