### PR TITLE
Set unique=true on target_url and remove unused helper function

### DIFF
--- a/TWLight/resources/helpers.py
+++ b/TWLight/resources/helpers.py
@@ -4,48 +4,6 @@ import json
 import os
 
 
-def check_for_target_url_duplication_and_generate_error_message(self, partner=False):
-    """
-    Filter for partners (PROXY and BUNDLE) where the
-    target_url is the same as self. On filtering, if we have
-    a non-zero number of matches, we generate the appropriate
-    error message to be shown to the staff.
-
-    :param self:
-    :param partner:
-    :return:
-    """
-    from TWLight.resources.models import Partner
-
-    duplicate_target_url_partners = Partner.objects.filter(
-        authorization_method__in=[Partner.PROXY, Partner.BUNDLE],
-        target_url=self.target_url,
-    ).values_list("company_name", flat=True)
-    # Exclude self from the filtered partner list, if the operation
-    # is performed on Partners.
-    if partner:
-        duplicate_target_url_partners = duplicate_target_url_partners.exclude(
-            pk=self.pk
-        )
-
-    partner_duplicates_count = duplicate_target_url_partners.count()
-
-    if partner_duplicates_count != 0:
-        validation_error_msg = (
-            "No two or more partners can have the same target url. "
-            "The following partner(s) have the same target url: "
-        )
-        validation_error_msg_partners = "None"
-        if partner_duplicates_count > 1:
-            validation_error_msg_partners = ", ".join(duplicate_target_url_partners)
-        elif partner_duplicates_count == 1:
-            validation_error_msg_partners = duplicate_target_url_partners[0]
-
-        return validation_error_msg + " Partner(s): " + validation_error_msg_partners
-
-    return None
-
-
 def get_partner_description_json_schema():
     """
     JSON Schema for partner description translations

--- a/TWLight/resources/models.py
+++ b/TWLight/resources/models.py
@@ -17,10 +17,7 @@ from django_countries.fields import CountryField
 from django.utils.safestring import mark_safe
 from django.utils.translation import gettext_lazy as _
 
-from TWLight.resources.helpers import (
-    check_for_target_url_duplication_and_generate_error_message,
-    get_tags_json_schema,
-)
+from TWLight.resources.helpers import get_tags_json_schema
 
 # Use language autonyms from Wikimedia.
 # We periodically pull:
@@ -206,6 +203,7 @@ class Partner(models.Model):
         blank=True,
         null=True,
         help_text="Link to partner resources. Required for proxied resources; optional otherwise.",
+        unique=True,
     )
 
     terms_of_use = models.URLField(
@@ -387,16 +385,6 @@ class Partner(models.Model):
                     ]
                 }
             )
-        if self.target_url:
-            # Validate the form for the uniqueness of self.target_url across
-            # all PROXY and BUNDLE partners.
-            validation_error_msg = (
-                check_for_target_url_duplication_and_generate_error_message(
-                    self, partner=True
-                )
-            )
-            if validation_error_msg:
-                raise ValidationError({"target_url": validation_error_msg})
 
         if self.authorization_method in [self.CODES, self.LINK] and (
             not self.user_instructions

--- a/TWLight/resources/tests.py
+++ b/TWLight/resources/tests.py
@@ -25,10 +25,8 @@ from TWLight.users.helpers.authorizations import get_all_bundle_authorizations
 from TWLight.users.models import Authorization
 
 from .factories import PartnerFactory, SuggestionFactory
-from .helpers import (
-    check_for_target_url_duplication_and_generate_error_message,
-    get_partner_description_json_schema,
-)
+from .helpers import get_partner_description_json_schema
+
 from .models import (
     Language,
     RESOURCE_LANGUAGES,
@@ -430,42 +428,6 @@ class PartnerModelTests(TestCase):
                 )
             ),
         )
-
-    def test_helper_function_for_target_url_uniqueness(self):
-        partner1 = PartnerFactory(authorization_method=Partner.PROXY)
-        partner2 = PartnerFactory(authorization_method=Partner.BUNDLE)
-
-        example_url = "https://www.example.com"
-        partner1.target_url = example_url
-        partner1.requested_access_duration = (
-            True  # We don't want the ValidationError from requested_access_duration
-        )
-        partner1.save()
-        partner2.target_url = example_url
-        partner2.save()
-
-        msg = check_for_target_url_duplication_and_generate_error_message(
-            partner1, partner=True
-        )
-        self.assertIsNotNone(msg)
-        self.assertIn(partner2.company_name, msg)
-
-        self.assertRaises(ValidationError, partner1.clean)
-        try:
-            partner1.clean()
-        except ValidationError as e:
-            self.assertEqual([msg], e.messages)
-
-        msg = check_for_target_url_duplication_and_generate_error_message(
-            partner2, partner=True
-        )
-        self.assertIsNotNone(msg)
-        # We only want the duplicate partner names to be shown,
-        # not self.
-        self.assertNotIn(partner2.company_name, msg)
-        self.assertIn(partner1.company_name, msg)
-
-        self.assertIsNotNone(msg)
 
     def test_user_instructions(self):
         partner1 = PartnerFactory(authorization_method=Partner.CODES)


### PR DESCRIPTION
[//]: # (Thank you for uploading a PR to the Wikipedia Library!)

## Description
The helper function `check_for_target_url_duplication_and_generate_error_message` in the resources app was created to retain uniqueness in the `target_url` field across both `Partner` and `Stream` objects. Since we [removed streams](https://github.com/WikipediaLibrary/TWLight/commit/00151a93d36a080b2689b4c3ed515fdaac016015#diff-1ae42bccd89e0edc55fcc22a0c1cdacf0181098c9be42a283c8952899a9b7854) from TWLight, this function is superfluous and is a roundabout way of simply setting `unique=True` on the `target_url` field of the `Partner` model.

## Phabricator Ticket
https://phabricator.wikimedia.org/T346395

## How Has This Been Tested?
Tested locally by both setting a partner to have a duplicated and non-duplicated URL and everything behaved as expected. Ran tests and no issues raised.

## Screenshots of your changes (if appropriate):
<img width="688" alt="Screenshot 2023-09-14 at 21 41 11" src="https://github.com/WikipediaLibrary/TWLight/assets/12038840/6feb8e54-b221-4b5c-9cc4-aa14c5bec019">


## Types of changes
What types of changes does your code introduce? Add an `x` in all the boxes that apply:
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Minor change (fix a typo, add a translation tag, add section to README, etc.)
