### PR TITLE
Migrate single-argument helper functions to model methods

### DIFF
--- a/TWLight/applications/helpers.py
+++ b/TWLight/applications/helpers.py
@@ -4,7 +4,6 @@ from django.utils.translation import gettext_lazy as _
 from TWLight.resources.models import Partner
 
 from .models import Application
-from ..users.helpers.authorizations import get_valid_partner_authorizations
 
 """
 Lists and characterizes the types of information that partners can require as
@@ -156,21 +155,13 @@ def get_output_for_application(app):
     return output
 
 
-def count_valid_authorizations(partner_pk):
-    """
-    Retrieves the numbers of valid authorizations using the
-    get_valid_partner_authorizations() method above.
-    """
-    return get_valid_partner_authorizations(partner_pk).count()
-
-
 def get_accounts_available(app):
     """
     Because we allow number of accounts available on the partner level,
     we base our calculations on the partner level.
     """
     if app.partner.accounts_available is not None:
-        valid_authorizations = count_valid_authorizations(app.partner)
+        valid_authorizations = app.partner.get_valid_authorization_count
         return app.partner.accounts_available - valid_authorizations
 
 

--- a/TWLight/applications/tests.py
+++ b/TWLight/applications/tests.py
@@ -48,7 +48,6 @@ from .helpers import (
     AFFILIATION,
     ACCOUNT_EMAIL,
     get_output_for_application,
-    count_valid_authorizations,
     more_applications_than_accounts_available,
 )
 from .factories import ApplicationFactory
@@ -2133,7 +2132,7 @@ class EvaluateApplicationTest(TestCase):
         self.partner.refresh_from_db()
         self.assertEqual(self.partner.status, Partner.WAITLIST)
 
-    def test_count_valid_authorizations(self):
+    def test_get_valid_authorization_count(self):
         for _ in range(5):
             # valid
             auth1 = Authorization(
@@ -2164,17 +2163,14 @@ class EvaluateApplicationTest(TestCase):
         )
         self.assertRaises(ValidationError, auth4.save)
 
-        total_valid_authorizations = count_valid_authorizations(self.partner)
+        total_valid_authorizations = self.partner.get_valid_authorization_count
         self.assertEqual(total_valid_authorizations, 6)
 
-        # Filter logic in .helpers.get_valid_partner_authorizations and
+        # Filter logic in Partner.get_valid_authorizations and
         # TWLight.users.models.Authorization.is_valid must be in sync.
         # We test that here.
         all_authorizations_using_is_valid = Authorization.objects.filter(
             partners=self.partner
-        )
-        total_valid_authorizations_using_helper = count_valid_authorizations(
-            self.partner
         )
 
         total_valid_authorizations_using_is_valid = 0
@@ -2184,7 +2180,7 @@ class EvaluateApplicationTest(TestCase):
 
         self.assertEqual(
             total_valid_authorizations_using_is_valid,
-            total_valid_authorizations_using_helper,
+            total_valid_authorizations,
         )
 
     def test_sets_days_open(self):

--- a/TWLight/applications/views.py
+++ b/TWLight/applications/views.py
@@ -56,7 +56,6 @@ from .helpers import (
     PARTNER_FORM_OPTIONAL_FIELDS,
     PARTNER_FORM_BASE_FIELDS,
     get_output_for_application,
-    count_valid_authorizations,
     get_accounts_available,
     is_proxy_and_application_approved,
     more_applications_than_accounts_available,
@@ -982,11 +981,10 @@ class BatchEditView(CoordinatorsOnly, ToURequired, View):
         # on their valid authorizations to ensure we have enough accounts available and set the
         # boolean value for the corresponding partner_pk in the partners_distribution_flag dictionary.
         for partner_pk, app_count in applications_per_partner.items():
-            total_accounts_available = Partner.objects.filter(pk=partner_pk).values(
-                "accounts_available"
-            )[0]["accounts_available"]
+            this_partner = Partner.objects.get(pk=partner_pk)
+            total_accounts_available = this_partner.accounts_available
             if total_accounts_available is not None:
-                valid_authorizations = count_valid_authorizations(partner_pk)
+                valid_authorizations = this_partner.get_valid_authorization_count
                 total_accounts_available_for_distribution = (
                     total_accounts_available - valid_authorizations
                 )

--- a/TWLight/resources/management/commands/proxy_waitlist_disable.py
+++ b/TWLight/resources/management/commands/proxy_waitlist_disable.py
@@ -1,7 +1,6 @@
 from django.contrib.auth.models import User
 from django.core.management.base import BaseCommand, CommandError
 
-from TWLight.applications.helpers import count_valid_authorizations
 from TWLight.resources.models import Partner
 
 import logging
@@ -18,7 +17,7 @@ class Command(BaseCommand):
         ).exclude(accounts_available__isnull=True)
 
         for each_partner in all_partners:
-            valid_authorizations = count_valid_authorizations(each_partner.pk)
+            valid_authorizations = each_partner.get_valid_authorization_count
             total_accounts_available_for_distribution = (
                 each_partner.accounts_available - valid_authorizations
             )

--- a/TWLight/resources/views.py
+++ b/TWLight/resources/views.py
@@ -12,7 +12,6 @@ from django.views.generic.edit import FormView, DeleteView
 from django_filters.views import FilterView
 from django.shortcuts import get_object_or_404
 
-from TWLight.applications.helpers import count_valid_authorizations
 from TWLight.applications.models import Application
 from TWLight.users.groups import get_coordinators
 from TWLight.users.models import Authorization, User
@@ -184,9 +183,9 @@ class PartnersDetailView(DetailView):
                 "users.",
             )
 
-        context["total_accounts_distributed_partner"] = count_valid_authorizations(
-            partner
-        )
+        context[
+            "total_accounts_distributed_partner"
+        ] = partner.get_valid_authorization_count
 
         context["total_users"] = Authorization.objects.filter(partners=partner).count()
 

--- a/TWLight/users/helpers/authorizations.py
+++ b/TWLight/users/helpers/authorizations.py
@@ -17,35 +17,6 @@ def get_all_bundle_authorizations():
     ).distinct()  # distinct() required because partners__authorization_method is ManyToMany
 
 
-def get_valid_partner_authorizations(partner_pk):
-    """
-    Retrieves the valid authorizations available for a particular
-    partner. Valid authorizations are authorizations with which we can operate,
-    and is decided by certain conditions as spelled out in the is_valid property
-    of the Authorization model object (users/models.py).
-    """
-    today = datetime.date.today()
-    try:
-        # The filter below is equivalent to retrieving all authorizations for a partner
-        # and checking every authorization against the is_valid property
-        # of the authorization model, and hence *must* be kept in sync with the logic in
-        # TWLight.users.model.Authorization.is_valid property. We don't need to check for
-        # partner_id__isnull since it is functionally covered by partners=partner_pk.
-        valid_authorizations = Authorization.objects.filter(
-            Q(date_expires__isnull=False, date_expires__gte=today)
-            | Q(date_expires__isnull=True),
-            authorizer__isnull=False,
-            user__isnull=False,
-            date_authorized__isnull=False,
-            date_authorized__lte=today,
-            partners=partner_pk,
-        )
-
-        return valid_authorizations
-    except Authorization.DoesNotExist:
-        return Authorization.objects.none()
-
-
 def create_resource_dict(authorization, partner):
     resource_item = {
         "partner": partner,

--- a/TWLight/users/views.py
+++ b/TWLight/users/views.py
@@ -41,7 +41,6 @@ from TWLight.view_mixins import (
     test_func_coordinators_only,
 )
 from TWLight.users.groups import get_coordinators, get_restricted
-from TWLight.users.helpers.authorizations import get_valid_partner_authorizations
 from TWLight.users.helpers.editor_data import editor_bundle_eligible
 
 from rest_framework import status
@@ -723,7 +722,7 @@ class AuthorizedUsers(APIView):
             message = "Couldn't find a partner with this ID."
             return Response(message, status=status.HTTP_404_NOT_FOUND)
 
-        valid_partner_auths = get_valid_partner_authorizations(pk)
+        valid_partner_auths = partner.get_valid_authorizations
 
         # For Bundle partners, get auths for users who logged in within the last 2 weeks.
         if partner.authorization_method == partner.BUNDLE:


### PR DESCRIPTION
[//]: # (Thank you for uploading a PR to the Wikipedia Library!)

## Description
We had two functions floating around the users app which only took a single argument - a partner. It makes much more sense to me for these to be model methods. I wouldn't expect to need to go digging through helpers files to find this.

In the process of doing this I discovered one of the tangible downsides to the original setup which was the confusing `partner_pk` argument, which was sometimes an int (a pk) and sometimes a Partner object, depending on where the function was called. Django seemed to smooth over that inconsistency when used in filters, but it surfaced quickly once I made the functions model methods.

## Phabricator Ticket
https://phabricator.wikimedia.org/T346103

## How Has This Been Tested?
Local testing + running tests.

## Types of changes
What types of changes does your code introduce? Add an `x` in all the boxes that apply:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] Minor change (fix a typo, add a translation tag, add section to README, etc.)
