### PR TITLE
Add djmail_delete_old_messages to django-cron

### DIFF
--- a/TWLight/crons.py
+++ b/TWLight/crons.py
@@ -76,3 +76,14 @@ class ClearSessions(CronJobBase):
             management.call_command("clearsessions")
         except Exception as e:
             capture_exception(e)
+
+
+class DeleteOldEmails(CronJobBase):
+    schedule = Schedule(run_every_mins=DAILY)
+    code = "djmail.djmail_delete_old_messages"
+
+    def do(self):
+        try:
+            management.call_command("djmail_delete_old_messages", days=100)
+        except Exception as e:
+            capture_exception(e)


### PR DESCRIPTION
## Description
Added the management command djmail_delete_old_messages to django-cron so we can delete messages that are more than 100 days old.

## Rationale
[//]: # (Why is this change required? What problem does it solve?)
Old emails take up a lot of space and are not needed in any way.

## Phabricator Ticket
[//]: # (Link to the Phabricator ticket)
[T350822](https://phabricator.wikimedia.org/T350822)

## How Has This Been Tested?
[//]: # (- Did you add tests to your changes? Did you modify tests to accommodate your changes?)
[//]: # (- Can this change be tested manually? How?)
Tested manually by running the cron job and seeing if the emails were deleted.

## Screenshots of your changes (if appropriate):
[//]: # (It can also be a GIF to prove that your changes are working)

## Types of changes
What types of changes does your code introduce? Add an `x` in all the boxes that apply:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Minor change (fix a typo, add a translation tag, add section to README, etc.)
