### PR TITLE
oauth: add warning message about email delivery

### DIFF
--- a/TWLight/users/oauth.py
+++ b/TWLight/users/oauth.py
@@ -589,4 +589,12 @@ class OAuthCallbackView(View):
             translation_activate(user.userprofile.lang)
             response.set_cookie(settings.LANGUAGE_COOKIE_NAME, user.userprofile.lang)
 
+        messages.warning(
+            request,
+            # fmt: off
+            # Translators: This error message is shown when there is a problem with email delivery.
+            _("We are currently experiencing a technical issue with email delivery. Emails, including application approvals and access details, may not be received as expected. Please contact us at wikipedialibrary@wikimedia.org if you have any questions. Updates will be posted on Phabricator."
+            ),
+            # fmt: on
+        )
         return response

--- a/TWLight/users/oauth.py
+++ b/TWLight/users/oauth.py
@@ -592,8 +592,8 @@ class OAuthCallbackView(View):
         messages.warning(
             request,
             # fmt: off
-            # Translators: This error message is shown when there is a problem with email delivery.
-            _("We are currently experiencing a technical issue with email delivery. Emails, including application approvals and access details, may not be received as expected. Please contact us at wikipedialibrary@wikimedia.org if you have any questions. Updates will be posted on Phabricator."
+            # Translators: This error message is shown when there is a problem with email delivery. Do not translate anything within the <a> tag.
+            _("We are currently experiencing a technical issue with email delivery. Emails, including application approvals and access details, may not be received as expected. Please contact us at wikipedialibrary@wikimedia.org if you have any questions. Updates will be posted on <a target='_blank' rel='noopener' href='https://phabricator.wikimedia.org/T352760'>Phabricator T353760</a>."
             ),
             # fmt: on
         )


### PR DESCRIPTION
## Description
Adds an email delivery warning message upon completion of oauth flow.

## Rationale
[//]: # (Why is this change required? What problem does it solve?)

## Phabricator Ticket
https://phabricator.wikimedia.org/T352760


## How Has This Been Tested?
Manual testing

## Screenshots of your changes (if appropriate):
![image](https://github.com/WikipediaLibrary/TWLight/assets/2986893/b13c7628-274e-470f-b434-730e8613ecb0)


## Types of changes
What types of changes does your code introduce? Add an `x` in all the boxes that apply:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Minor change (fix a typo, add a translation tag, add section to README, etc.)
