### PR TITLE
requirements: update django-cron to 0.6.0

### DIFF
--- a/TWLight/crons.py
+++ b/TWLight/crons.py
@@ -29,7 +29,9 @@ class BackupCronJob(CronJobBase):
             # Using check_output here because we want to log STDOUT.
             # To avoid logging for commands with sensitive output, import and use
             # subprocess.call instead of subprocess.check_output.
-            return check_output([settings.TWLIGHT_HOME + "/bin/twlight_backup.sh"])
+            return check_output(
+                [settings.TWLIGHT_HOME + "/bin/twlight_backup.sh"], text=True
+            )
         except Exception as e:
             capture_exception(e)
 

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -8,7 +8,7 @@ django-autocomplete-light==3.9.4
 django-contrib-comments==2.2.0
 django-countries==7.5.1
 django-crispy-forms==1.14.0
-django-cron==0.5.1
+django_cron==0.6.0
 git+https://github.com/WikipediaLibrary/django-dkim.git@Jsn.sherman/py3.x
 django-durationfield==0.5.5
 django_extensions==3.2.3


### PR DESCRIPTION
## Description
Updates django-cron with a small change required for the backup cron task to work as expected.

## Rationale
I previously tried updating django-cron on this repo and it did not go well; I set dependabot to ignore this update so that we could deal with it manually. I discovered the solution while troubleshooting cron tasks for externallinks.

## Phabricator Ticket
N/A

## How Has This Been Tested?
I verified that the backup cron completes successfully, where it was erroring and rerunning with a naive upgrade. I spot check the other crons that complete in a short amount of time, and they seem fine as well.

## Screenshots of your changes (if appropriate):


## Types of changes
What types of changes does your code introduce? Add an `x` in all the boxes that apply:
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Minor change (fix a typo, add a translation tag, add section to README, etc.)
