### PR TITLE
conf: update production dkim selector

### DIFF
--- a/conf/production.twlight.env
+++ b/conf/production.twlight.env
@@ -1,7 +1,7 @@
 DJANGO_DB_HOST=tasks.production_db
 DJANGO_EMAIL_BACKEND=django_dkim.backends.smtp.EmailBackend
 DJANGO_EMAIL_ADMINS_BACKEND=django_dkim.backends.smtp.EmailBackend
-DKIM_SELECTOR=prod
+DKIM_SELECTOR=production
 DKIM_DOMAIN=twl.wmflabs.org
 DJANGO_EMAIL_HOST=mx-out03.wmcloud.org
 DJANGO_SETTINGS_MODULE=TWLight.settings.production


### PR DESCRIPTION
[//]: # (Thank you for uploading a PR to the Wikipedia Library!)

## Description
updates the `DKIM_SELECTOR` to match the environment name. I've already created a duplicate dns record, so this may be merged immediately. Given our 60 second ttl on dns records, we can very safely delete the old record the day after this is deployed.

original record:
```
prod._domainkey.twl.wmflabs.org. 60 IN	TXT	"v=DKIM1;t=s;p=MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQDMw5P5rCeHdbQeHJ4MQJjrO/uf+SLDGJUEH5HJJPFGz2gj3qhxGLXlo2nZZD18wSNsl3dgXvTRBRXBtK8Oum/KGUovIeZC3JhcidT7AzTZ8AwhJaholUH3uJr4i8rTgcC6MINx7nQECZoW3uPzCYTH56DqDyc+9ikbIP574ZQ95QIDAQAB;adkim=s"
```

new record:
```
production._domainkey.twl.wmflabs.org. 60 IN TXT "v=DKIM1;t=s;p=MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQDMw5P5rCeHdbQeHJ4MQJjrO/uf+SLDGJUEH5HJJPFGz2gj3qhxGLXlo2nZZD18wSNsl3dgXvTRBRXBtK8Oum/KGUovIeZC3JhcidT7AzTZ8AwhJaholUH3uJr4i8rTgcC6MINx7nQECZoW3uPzCYTH56DqDyc+9ikbIP574ZQ95QIDAQAB;adkim=s"
```

## Rationale
While updating the [documentation for server email config](https://github.com/WikipediaLibrary/TWLight/wiki/Debian-Server-setup#email), I realized I didn't align the dkim selector to the environment name. This makes mistakes more likely in the future.

## Phabricator Ticket
N/A

## How Has This Been Tested?
The existing record essentially serves as a test for the new record. The content is identical, just duplicated to the new selector.

## Screenshots of your changes (if appropriate):
[//]: # (It can also be a GIF to prove that your changes are working)

## Types of changes
What types of changes does your code introduce? Add an `x` in all the boxes that apply:
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Minor change (fix a typo, add a translation tag, add section to README, etc.)
