### PR TITLE
Remove Occupation field & data

### DIFF
--- a/TWLight/applications/forms.py
+++ b/TWLight/applications/forms.py
@@ -197,7 +197,7 @@ class BaseApplicationForm(forms.Form):
 
         if all_partner_data:
             for datum in all_partner_data:
-                # This will yield fields with names like 'partner_occupation'
+                # This will yield fields with names like 'partner_country'
                 field_name = "partner_{datum}".format(datum=datum)
                 self.fields[field_name] = FIELD_TYPES[datum]
                 self.fields[field_name].label = FIELD_LABELS[datum]

--- a/TWLight/applications/helpers.py
+++ b/TWLight/applications/helpers.py
@@ -21,7 +21,6 @@ Required/nonharvestable:
 Optional/universal:
     Real name (many partners)
     Country of residence (Pelican, Numerique)
-    Occupation (Elsevier)
     Affiliation (Elsevier)
 
 Optional/unique:
@@ -33,7 +32,6 @@ Optional/unique:
 # ~~~~~ Named constants ~~~~~ #
 REAL_NAME = "real_name"
 COUNTRY_OF_RESIDENCE = "country_of_residence"
-OCCUPATION = "occupation"
 AFFILIATION = "affiliation"
 PARTNER = "partner"
 RATIONALE = "rationale"
@@ -45,7 +43,7 @@ REQUESTED_ACCESS_DURATION = "requested_access_duration"
 
 
 # ~~~~ Basic field names ~~~~ #
-USER_FORM_FIELDS = [REAL_NAME, COUNTRY_OF_RESIDENCE, OCCUPATION, AFFILIATION]
+USER_FORM_FIELDS = [REAL_NAME, COUNTRY_OF_RESIDENCE, AFFILIATION]
 
 # These fields are displayed for all partners.
 PARTNER_FORM_BASE_FIELDS = [RATIONALE, COMMENTS]
@@ -64,7 +62,6 @@ PARTNER_FORM_OPTIONAL_FIELDS = [
 FIELD_TYPES = {
     REAL_NAME: forms.CharField(max_length=128),
     COUNTRY_OF_RESIDENCE: forms.CharField(max_length=128),
-    OCCUPATION: forms.CharField(max_length=128),
     AFFILIATION: forms.CharField(max_length=128),
     PARTNER: forms.ModelChoiceField(
         queryset=Partner.objects.all(), widget=forms.HiddenInput
@@ -84,8 +81,6 @@ FIELD_LABELS = {
     REAL_NAME: _("Your real name"),
     # Translators: When filling out an application, users may need to specify the country in which they currently live
     COUNTRY_OF_RESIDENCE: _("Your country of residence"),
-    # Translators: When filling out an application, users may need to specify their current occupation
-    OCCUPATION: _("Your occupation"),
     # Translators: When filling out an application, users may need to specify if they are affiliated with an institution (e.g. a university)
     AFFILIATION: _("Your institutional affiliation"),
     # Translators: When filling out an application, this labels the name of the publisher or database the user is applying to
@@ -111,8 +106,6 @@ SEND_DATA_FIELD_LABELS = {
     REAL_NAME: _("Real name"),
     # Translators: When sending application data to partners, this is the text labelling a user's country of residence
     COUNTRY_OF_RESIDENCE: _("Country of residence"),
-    # Translators: When sending application data to partners, this is the text labelling a user's occupation
-    OCCUPATION: _("Occupation"),
     # Translators: When sending application data to partners, this is the text labelling a user's affiliation
     AFFILIATION: _("Affiliation"),
     # Translators: When sending application data to partners, this is the text labelling the specific title (e.g. a particular book) a user requested

--- a/TWLight/applications/tests.py
+++ b/TWLight/applications/tests.py
@@ -44,7 +44,6 @@ from .helpers import (
     AGREEMENT_WITH_TERMS_OF_USE,
     REAL_NAME,
     COUNTRY_OF_RESIDENCE,
-    OCCUPATION,
     AFFILIATION,
     ACCOUNT_EMAIL,
     get_output_for_application,
@@ -230,7 +229,6 @@ class SynchronizeFieldsTest(TestCase):
         editor = EditorFactory()
         setattr(editor, REAL_NAME, "Alice")
         setattr(editor, COUNTRY_OF_RESIDENCE, "Holy Roman Empire")
-        setattr(editor, OCCUPATION, "Dog surfing instructor")
         setattr(editor, AFFILIATION, "The Long Now Foundation")
         setattr(editor, "wp_username", "wp_alice")
         setattr(editor, "email", "alice@example.com")
@@ -260,7 +258,6 @@ class SynchronizeFieldsTest(TestCase):
         output = get_output_for_application(app)
         self.assertEqual(output[REAL_NAME]["data"], "Alice")
         self.assertEqual(output[COUNTRY_OF_RESIDENCE]["data"], "Holy Roman Empire")
-        self.assertEqual(output[OCCUPATION]["data"], "Dog surfing instructor")
         self.assertEqual(output[AFFILIATION]["data"], "The Long Now Foundation")
         self.assertEqual(output[SPECIFIC_TITLE]["data"], "Alice in Wonderland")
         self.assertEqual(output["Email"]["data"], "alice@example.com")
@@ -269,7 +266,7 @@ class SynchronizeFieldsTest(TestCase):
 
         # Make sure that in enumerating the keys we didn't miss any (e.g. if
         # the codebase changes).
-        self.assertEqual(8, len(list(output.keys())))
+        self.assertEqual(7, len(list(output.keys())))
 
     def test_application_output_2(self):
         """
@@ -313,7 +310,6 @@ class SynchronizeFieldsTest(TestCase):
         editor = EditorFactory()
         setattr(editor, REAL_NAME, "Alice")
         setattr(editor, COUNTRY_OF_RESIDENCE, "Holy Roman Empire")
-        setattr(editor, OCCUPATION, "Dog surfing instructor")
         setattr(editor, AFFILIATION, "The Long Now Foundation")
         setattr(editor, "wp_username", "wp_alice")
         setattr(editor, "email", "alice@example.com")
@@ -341,13 +337,12 @@ class SynchronizeFieldsTest(TestCase):
         output = get_output_for_application(app)
         self.assertEqual(output[REAL_NAME]["data"], "Alice")
         self.assertEqual(output[COUNTRY_OF_RESIDENCE]["data"], "Holy Roman Empire")
-        self.assertEqual(output[OCCUPATION]["data"], "Dog surfing instructor")
         self.assertEqual(output[AFFILIATION]["data"], "The Long Now Foundation")
         self.assertEqual(output["Email"]["data"], "alice@example.com")
 
         # Make sure that in enumerating the keys we didn't miss any (e.g. if
         # the codebase changes).
-        self.assertEqual(5, len(list(output.keys())))
+        self.assertEqual(4, len(list(output.keys())))
 
 
 class BaseApplicationViewTest(TestCase):
@@ -441,7 +436,6 @@ class SubmitApplicationTest(BaseApplicationViewTest):
             real_name=True,
             country_of_residence=False,
             specific_title=False,
-            occupation=False,
             affiliation=False,
             agreement_with_terms_of_use=False,
         )
@@ -2474,7 +2468,6 @@ class EvaluateApplicationTest(TestCase):
         self.assertContains(response, self.user.email)
         self.assertContains(response, self.editor.real_name)
         self.assertContains(response, self.editor.country_of_residence)
-        self.assertContains(response, self.editor.occupation)
         self.assertContains(response, self.editor.affiliation)
         # Users shouldn't see some things coordinators see
         self.assertNotContains(response, "Evaluate application")
@@ -2507,7 +2500,6 @@ class EvaluateApplicationTest(TestCase):
         self.assertNotContains(response, self.user.email)
         self.assertNotContains(response, self.editor.real_name)
         self.assertNotContains(response, self.editor.country_of_residence)
-        self.assertNotContains(response, self.editor.occupation)
         self.assertNotContains(response, self.editor.affiliation)
         # Coordinators can evaluate application
         self.assertContains(response, "Evaluate application")

--- a/TWLight/resources/management/commands/resources_example_data.py
+++ b/TWLight/resources/management/commands/resources_example_data.py
@@ -49,7 +49,6 @@ class Command(BaseCommand):
                 real_name=self.chance(True, False, 40),
                 country_of_residence=self.chance(True, False, 20),
                 specific_title=self.chance(True, False, 10),
-                occupation=self.chance(True, False, 10),
                 affiliation=self.chance(True, False, 10),
                 agreement_with_terms_of_use=self.chance(True, False, 10),
             )

--- a/TWLight/resources/models.py
+++ b/TWLight/resources/models.py
@@ -323,11 +323,6 @@ class Partner(models.Model):
         help_text="Mark as true if this partner requires applicants to "
         "specify the title they want to access.",
     )
-    occupation = models.BooleanField(
-        default=False,
-        help_text="Mark as true if this partner requires applicants to "
-        "specify their occupation.",
-    )
     affiliation = models.BooleanField(
         default=False,
         help_text="Mark as true if this partner requires applicants to "

--- a/TWLight/resources/templates/resources/partner_detail_timeline.html
+++ b/TWLight/resources/templates/resources/partner_detail_timeline.html
@@ -122,7 +122,7 @@
   {% endif %}
   {% endwith %}
   {% endwith %}
-  {% if object.agreement_with_terms_of_use or object.real_name or object.country_of_residence or object.occupation or object.affiliation or object.specific_title or object.account_email %}
+  {% if object.agreement_with_terms_of_use or object.real_name or object.country_of_residence or object.affiliation or object.specific_title or object.account_email %}
     <li class="timeline-inverted">
       <div class="timeline-badge"><i class="fa fa-exclamation"></i>
       </div>
@@ -158,15 +158,6 @@
                 {% comment %}Translators: If a user must provide the name of the country where they currently live to apply to a partner, they see this message, and must enter the name of the resource. Don't translate {{ publisher }}. {% endcomment %}
                 {% blocktranslate trimmed with publisher=object.company_name %}
                   {{ publisher }} requires that you provide your country of residence.
-                {% endblocktranslate %}
-              </li>
-            {% endif %}
-
-            {% if object.occupation %}
-              <li>
-                {% comment %}Translators: If a user must provide their occupation to apply to a partner, they see this message, and must enter the name of the resource. Don't translate {{ publisher }}. {% endcomment %}
-                {% blocktranslate trimmed with publisher=object.company_name %}
-                  {{ publisher }} requires that you provide your occupation.
                 {% endblocktranslate %}
               </li>
             {% endif %}

--- a/TWLight/users/factories.py
+++ b/TWLight/users/factories.py
@@ -61,7 +61,6 @@ class EditorFactory(factory.django.DjangoModelFactory):
     user = factory.SubFactory(UserFactory)
     real_name = "Alice Crypto"
     country_of_residence = "Elsewhere"
-    occupation = "Cat floofer"
     affiliation = "Institut Pasteur"
     wp_username = factory.Faker("name", locale=random.choice(settings.FAKER_LOCALES))
     wp_registered = datetime.today().date()

--- a/TWLight/users/management/commands/user_example_data.py
+++ b/TWLight/users/management/commands/user_example_data.py
@@ -49,7 +49,6 @@ class Command(BaseCommand):
                 country_of_residence=Faker(
                     random.choice(settings.FAKER_LOCALES)
                 ).country(),
-                occupation=Faker(random.choice(settings.FAKER_LOCALES)).job(),
                 affiliation=Faker(random.choice(settings.FAKER_LOCALES)).company(),
                 wp_registered=Faker(
                     random.choice(settings.FAKER_LOCALES)

--- a/TWLight/users/models.py
+++ b/TWLight/users/models.py
@@ -296,7 +296,6 @@ class Editor(models.Model):
     # **** SENSITIVE USER DATA AHOY. ****
     real_name = models.CharField(max_length=128, blank=True)
     country_of_residence = models.CharField(max_length=128, blank=True)
-    occupation = models.CharField(max_length=128, blank=True)
     affiliation = models.CharField(max_length=128, blank=True)
 
     def encode_wp_username(self, username):

--- a/TWLight/users/templates/users/editor_detail_data.html
+++ b/TWLight/users/templates/users/editor_detail_data.html
@@ -317,18 +317,6 @@
 
     <div class="row clearfix">
         <div class="col-xs-12 col-sm-3">
-            {% comment %}Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this labels the user's occupation. {% endcomment %}
-            <strong>{% trans "Occupation" %}</strong>
-        </div>
-        <div class="col-xs-12 col-sm-9">
-            {{ editor.occupation }}
-        </div>
-    </div>
-
-    <hr/>
-
-    <div class="row clearfix">
-        <div class="col-xs-12 col-sm-3">
             {% comment %}Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this labels the user's institutional affiliation (e.g. university) {% endcomment %}
             <strong>{% trans "Institutional affiliation" %}</strong>
         </div>

--- a/TWLight/users/templates/users/terms.html
+++ b/TWLight/users/templates/users/terms.html
@@ -251,7 +251,7 @@
           use your Wikipedia Library account, we may routinely collect the following
           information: your username, email address, edit count, registration date,
           user ID number, groups to which you belong, and any special user rights;
-          your name, country of residence, occupation, and/or affiliation, if required
+          your name, country of residence, and/or affiliation, if required
           by a partner to which you are applying; your narrative description of your
           contributions and reasons for applying for access to partner resources;
           and the date you agree to these terms of use.
@@ -265,7 +265,7 @@
           Each publisher who is a member of the Wikipedia Library program requires different
           specific information in the application. Some publishers may request only an
           email address, while others request more detailed data, such as your name,
-          location, occupation, or institutional affiliation. When you complete your
+          location, or institutional affiliation. When you complete your
           application, you will only be asked to supply information required by the
           publishers you have chosen, and each publisher will only receive the information
           they require for providing you with access. Please see our
@@ -307,7 +307,7 @@
         {% blocktranslate trimmed %}
           If you decide to disable your Wikipedia Library account, you can use the delete
           button on your profile to delete certain personal information associated with
-          your account. We will delete your real name, occupation, institutional affiliation,
+          your account. We will delete your real name, institutional affiliation,
           and country of residence. Please note that the system will retain a record
           of your username, the publishers to which you applied or had access, and the
           dates of that access. Note that deletion is not reversible. Deletion of your

--- a/TWLight/users/views.py
+++ b/TWLight/users/views.py
@@ -214,7 +214,6 @@ class EditorDetailView(PartnerCoordinatorOrSelf, DetailView):
                 "contributions",
                 "real_name",
                 "country_of_residence",
-                "occupation",
                 "affiliation",
             ]
             for field in user_field_list:
@@ -365,7 +364,7 @@ class PIIUpdateView(SelfOnly, UpdateView):
 
     model = Editor
     template_name = "users/editor_update.html"
-    fields = ["real_name", "country_of_residence", "occupation", "affiliation"]
+    fields = ["real_name", "country_of_residence", "affiliation"]
 
     def get_object(self):
         """

--- a/docs/admin.md
+++ b/docs/admin.md
@@ -111,7 +111,7 @@ We can *deactivate* accounts upon request. To do so:
 * from the `Action:` dropdown, select `Deactivate selected accounts` (do NOT select the delete function) and press `Go`
 
 This will perform the following steps:
-* delete the user's email and, if known, their real name, affiliation, occupation, and country of residence
+* delete the user's email and, if known, their real name, affiliation, and country of residence
 * set their account to inactive
 
 "Inactive" means the following:


### PR DESCRIPTION
[//]: # (Thank you for uploading a PR to the Wikipedia Library!)

## Description
Per https://phabricator.wikimedia.org/T363831, we have no active partners using this data and do not expect to have any in the future (we would now push back strongly on collecting this information). This PR removes occupation fields, data, and use in both user and application views.

## Phabricator Ticket
[T363831](https://phabricator.wikimedia.org/T363831)

## How Has This Been Tested?
Tests pass (after a couple of minor adjustments). Running migrations did blow up my local environment for reasons that weren't clear to me, so worth double checking the new migrations don't cause issues.

## Types of changes
What types of changes does your code introduce? Add an `x` in all the boxes that apply:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Minor change (fix a typo, add a translation tag, add section to README, etc.)
