### PR TITLE
any ref with target atribute set to _blank has rel set to noopener an…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -179,3 +179,5 @@ tramp
 # cask packages
 .cask/
 
+node_modules/
+TWLight/static/css/*-rtl.css

--- a/.gitignore
+++ b/.gitignore
@@ -178,6 +178,3 @@ tramp
 
 # cask packages
 .cask/
-
-node_modules/
-TWLight/static/css/*-rtl.css

--- a/TWLight/resources/models.py
+++ b/TWLight/resources/models.py
@@ -408,7 +408,7 @@ class Partner(models.Model):
             except JSONSchemaValidationError:
                 raise ValidationError(
                     mark_safe(
-                        "Error trying to insert a tag: please choose a tag from <a rel='noopener' target='_blank' href='https://github.com/WikipediaLibrary/TWLight/blob/production/locale/en/tag_names.json'>tag_names.json</a>."
+                        "Error trying to insert a tag: please choose a tag from <a rel='noopener noreferrer' target='_blank'  href='https://github.com/WikipediaLibrary/TWLight/blob/production/locale/en/tag_names.json'>tag_names.json</a>."
                     )
                 )
 

--- a/TWLight/resources/models.py
+++ b/TWLight/resources/models.py
@@ -408,7 +408,7 @@ class Partner(models.Model):
             except JSONSchemaValidationError:
                 raise ValidationError(
                     mark_safe(
-                        "Error trying to insert a tag: please choose a tag from <a rel='noopener noreferrer' target='_blank'  href='https://github.com/WikipediaLibrary/TWLight/blob/production/locale/en/tag_names.json'>tag_names.json</a>."
+                        "Error trying to insert a tag: please choose a tag from <a rel='noopener noreferrer' target='_blank' href='https://github.com/WikipediaLibrary/TWLight/blob/production/locale/en/tag_names.json'>tag_names.json</a>."
                     )
                 )
 

--- a/TWLight/resources/templates/resources/partner_detail_apply.html
+++ b/TWLight/resources/templates/resources/partner_detail_apply.html
@@ -125,7 +125,7 @@
         {% if user.is_authenticated %}
           {% if user.editor.wp_bundle_eligible %}
             {% comment %}Translators: This text labels a button authenticated, bundle eligible users can click to access the proxied resource. {% endcomment %}
-            <a class="btn twl-btn btn-lg btn-block" href="{{ partner.get_access_url }}" target="_blank" rel="noopener">
+            <a class="btn twl-btn btn-lg btn-block" href="{{ partner.get_access_url }}" target="_blank" rel="noopener noreferrer">
               {% trans "Access Collection" %}
             </a><br />
             {% comment %}Translators: This is the name of the authorization method whereby users access resources automatically via the library bundle. {% endcomment %}

--- a/TWLight/resources/templates/resources/suggest.html
+++ b/TWLight/resources/templates/resources/suggest.html
@@ -83,7 +83,7 @@
                     {% if each_suggestion.ticket_number %}
                       <p>
                         <strong>{% trans 'Track Progress' %}:</strong>
-                        <a class="twl-links" href="https://phabricator.wikimedia.org/{{each_suggestion.ticket_number}}" target="_blank">
+                        <a class="twl-links" href="https://phabricator.wikimedia.org/{{each_suggestion.ticket_number}}" target="_blank" rel="noopener noreferrer">
                           {{ each_suggestion.ticket_number }}
                         </a>
                       </p>

--- a/TWLight/resources/tests.py
+++ b/TWLight/resources/tests.py
@@ -498,7 +498,7 @@ class PartnerModelTests(TestCase):
         """
         partner5 = PartnerFactory()
 
-        message = "Error trying to insert a tag: please choose a tag from <a rel='noopener' target='_blank' href='https://github.com/WikipediaLibrary/TWLight/blob/production/locale/en/tag_names.json'>tag_names.json</a>."
+        message = "Error trying to insert a tag: please choose a tag from <a rel='noopener noreferrer' target='_blank' href='https://github.com/WikipediaLibrary/TWLight/blob/production/locale/en/tag_names.json'>tag_names.json</a>."
 
         partner5.new_tags = {"tags": ["this_doesnt_exist_tag", "earth-sciences_tag"]}
 
@@ -515,7 +515,7 @@ class PartnerModelTests(TestCase):
         """
         partner5 = PartnerFactory()
 
-        message = "Error trying to insert a tag: please choose a tag from <a rel='noopener' target='_blank' href='https://github.com/WikipediaLibrary/TWLight/blob/production/locale/en/tag_names.json'>tag_names.json</a>."
+        message = "Error trying to insert a tag: please choose a tag from <a rel='noopener noreferrer' target='_blank' href='https://github.com/WikipediaLibrary/TWLight/blob/production/locale/en/tag_names.json'>tag_names.json</a>."
 
         partner5.new_tags = {
             "tags": ["law_tag", "earth-sciences_tag"],
@@ -537,7 +537,7 @@ class PartnerModelTests(TestCase):
         """
         partner6 = PartnerFactory()
 
-        message = "Error trying to insert a tag: please choose a tag from <a rel='noopener' target='_blank' href='https://github.com/WikipediaLibrary/TWLight/blob/production/locale/en/tag_names.json'>tag_names.json</a>."
+        message = "Error trying to insert a tag: please choose a tag from <a rel='noopener noreferrer' target='_blank' href='https://github.com/WikipediaLibrary/TWLight/blob/production/locale/en/tag_names.json'>tag_names.json</a>."
 
         partner6.new_tags = {}
 

--- a/TWLight/templates/header_partial_b4.html
+++ b/TWLight/templates/header_partial_b4.html
@@ -21,8 +21,8 @@
     <div class="col-lg-5 col-md-7 col-sm-6 col-9">
       {% if user|bundle_eligible %}
       <!-- EBSCO Search Box Begins -->
-      <form action="https://searchbox.ebsco.com/search/" target="_blank" class="ebsco-single-search">
-      <!-- <form action="https://search.ebscohost.com/login.aspx" target="_blank" class="ebsco-single-search"> -->
+      <form action="https://searchbox.ebsco.com/search/" target="_blank" rel="noopener noreferrer" class="ebsco-single-search" >
+      <!-- <form action="https://search.ebscohost.com/login.aspx" target="_blank" class="ebsco-single-search" rel="noopener noreferrer"> -->
         <input name="schemaId" value="search" type="hidden" />
         <input name="custid" value="ns253359" type="hidden" />
         <input name="groupid" value="main" type="hidden" />

--- a/TWLight/users/oauth.py
+++ b/TWLight/users/oauth.py
@@ -500,7 +500,7 @@ class OAuthCallbackView(View):
                     # fmt: off
                     # Translators: This message is shown when more information is available on another page. Do not translate {issue}
                     _("See {issue} for more information").format(
-                        issue="<a href='https://phabricator.wikimedia.org/T332650' target='_blank' rel='noopener'>T332650</a>"
+                        issue="<a href='https://phabricator.wikimedia.org/T332650' target='_blank' rel='noopener noreferrer'>T332650</a>"
                     )
                     # fmt: on
                 ),

--- a/TWLight/users/templates/users/available_collection_tile.html
+++ b/TWLight/users/templates/users/available_collection_tile.html
@@ -75,7 +75,7 @@
           <div class="collapse" id="P{{ available_collection.partner_pk }}{{ task.id }}">
             <div class="card card-body phab-task-card phab-task-{{ task.severity }}">
               {{ task.help }}
-              <a href="{{ task.url }}" target="_blank" rel="noopener">
+              <a href="{{ task.url }}" target="_blank" rel="noopener noreferrer">
                 {{ task.id }}
               </a>
             </div>

--- a/TWLight/users/templates/users/user_collection_tile.html
+++ b/TWLight/users/templates/users/user_collection_tile.html
@@ -88,7 +88,7 @@
             <div class="collapse" id="P{{ user_collection.partner_pk }}{{ task.id }}">
               <div class="card card-body phab-task-card phab-task-{{ task.severity }}">
                 {{ task.help }}
-                <a href="{{ task.url }}" target="_blank" rel="noopener">
+                <a href="{{ task.url }}" target="_blank" rel="noopener noreferrer">
                   {{ task.id }}
                 </a>
               </div>
@@ -124,7 +124,7 @@
                 <div class="col-xl-6 col-lg-12" style="padding: 0px;">
                 {% if not user_collection.partner_phabricator_disabled %}
                   <a href="{{ user_collection.partner_access_url }}" class="btn btn-sm twl-btn access-apply-button"
-                        type="button" name="button" target="_blank" rel="noopener"
+                        type="button" name="button" target="_blank" rel="noopener noreferrer"
                         style="font-size: 14px;">
                     {% if user_collection.partner_authorization_method != proxy_authorization %}
                         {% comment %}Translators: On the My Library page (https://wikipedialibrary.wmflabs.org/users/my_library), this labels the text on a button which takes the user to the partner's site. {% endcomment %}
@@ -156,7 +156,7 @@
       {% elif not user_collection.partner_phabricator_disabled %}
         <div class="col-12" style="padding: 0px;">
           <a href="{{ user_collection.partner_access_url }}" class="btn btn-sm twl-btn access-apply-button"
-                  type="button" name="button" target="_blank" rel="noopener">
+                  type="button" name="button" target="_blank" rel="noopener noreferrer">
               {% comment %}Translators: On the My Library page (https://wikipedialibrary.wmflabs.org/users/my_library), this labels the text on a button which takes the user to the partner's site. {% endcomment %}
               {% trans "Access collection" %}
           </a>


### PR DESCRIPTION
…d noreferrer

[//]: # (Thank you for uploading a PR to the Wikipedia Library!)

## Description
Describe your changes in detail following the [commit message guidelines](https://www.mediawiki.org/wiki/Gerrit/Commit_message_guidelines)

Fix refs with target attribute to include both noopener and noreferrer. 

Bug: T358131

## Rationale
[//]: # (Why is this change required? What problem does it solve?)
Ensures that links and our website remain secure.

## Phabricator Ticket
[//]: # (Link to the Phabricator ticket)
https://phabricator.wikimedia.org/T358131

## How Has This Been Tested?
[//]: # (- Did you add tests to your changes? Did you modify tests to accommodate your changes?)
No added tests, but did manually test locally. 
I also fixed tests that broke because of the additional field. 

[//]: # (- Can this change be tested manually? How?)
Yes, by clicking on the search button at the top of The Wikipedia Library. 
You can also find any other link that is opening in a new tab and test that way. 

## Screenshots of your changes (if appropriate):
[//]: # (It can also be a GIF to prove that your changes are working)

## Types of changes
What types of changes does your code introduce? Add an `x` in all the boxes that apply:
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Minor change (fix a typo, add a translation tag, add section to README, etc.)
