### PR TITLE
Show block criteria success if user is exempted

### DIFF
--- a/TWLight/users/templates/users/eligibility_modal.html
+++ b/TWLight/users/templates/users/eligibility_modal.html
@@ -33,7 +33,7 @@
           </p>
         {% endif %}
       </div>
-      {% if not editor.wp_not_blocked %}
+      {% if not editor.wp_not_blocked and not user.editor.ignore_wp_blocks %}
         {% url 'contact' as contact_url %}
         {% comment %}Translators: This message tells users that they have an active block but they can still reach out for access.{% endcomment %}
         <p class="text-center text-danger">

--- a/TWLight/users/views.py
+++ b/TWLight/users/views.py
@@ -848,7 +848,8 @@ class MyLibraryView(TemplateView):
             # Translators: This text is shown next to a tick or cross denoting whether the current user has made more than 10 edits within the last month (30 days) from their Wikimedia account.
             _("10+ edits in the last month"): user.editor.wp_enough_recent_edits,
             # Translators: This text is shown next to a tick or cross denoting whether the current user's Wikimedia account has been blocked on any project.
-            _("No active blocks"): user.editor.wp_not_blocked,
+            _("No active blocks"): user.editor.wp_not_blocked
+            or user.editor.ignore_wp_blocks,
         }
 
         return context


### PR DESCRIPTION
[//]: # (Thank you for uploading a PR to the Wikipedia Library!)

## Description
Some users get confused when they have received a block exemption but then fall below the activity thresholds for access to the library. In doing so they still see the message about failing the block criterion, and email us asking why their exemption is no longer active. In an ideal world we could communicate something about the exemption here, but in the meantime it's less confusing to just show that they succeeded against this criterion instead of failed.

This change both shows a success and hides the extra message about contacting us.

## Phabricator Ticket
[T327489](https://phabricator.wikimedia.org/T327489)

## How Has This Been Tested?
Ran tests locally, manually tested with a blocked & exempted second account.

## Types of changes
What types of changes does your code introduce? Add an `x` in all the boxes that apply:
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Minor change (fix a typo, add a translation tag, add section to README, etc.)
