### PR TITLE
Kgraessl/t357057

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -178,3 +178,4 @@ tramp
 
 # cask packages
 .cask/
+node_modules/

--- a/Dockerfile
+++ b/Dockerfile
@@ -46,8 +46,8 @@ RUN apt update ; \
     npm \
     tar \
     wget ; \
-    rm -rf /var/lib/apt/lists/*; \
-    /usr/bin/npm install cssjanus
+    rm -rf /var/lib/apt/lists/*;
+
 
 # Utility scripts that run in the virtual environment.
 COPY bin /app/bin/
@@ -60,13 +60,15 @@ COPY locale /app/locale
 
 COPY TWLight /app/TWLight
 
+COPY twlight_cssjanus /app/twlight_cssjanus
+RUN cd /app/twlight_cssjanus
+RUN npm install
+
 WORKDIR $TWLIGHT_HOME
 
 COPY manage.py /app/manage.py
 
+EXPOSE 80
 # Configure static assets.
 RUN SECRET_KEY=twlight /app/bin/twlight_static.sh
-
-EXPOSE 80
-
 ENTRYPOINT ["/app/bin/twlight_docker_entrypoint.sh"]

--- a/TWLight/resources/templates/resources/suggest.html
+++ b/TWLight/resources/templates/resources/suggest.html
@@ -61,7 +61,7 @@
               </div>
               <div class="card-body ">
                 <div class="row">
-                  <div class="col-lg-10">
+                  <div class="col-xl-10 col-lg-12">
                     {% comment %}Translators: This is the text that appears before the description of every partner suggestion. {% endcomment %}
                     <p>
                       <strong>{% trans 'Description' %}: </strong>
@@ -83,14 +83,14 @@
                     {% if each_suggestion.ticket_number %}
                       <p>
                         <strong>{% trans 'Track Progress' %}:</strong>
-                        <a class="twl-links" href="https://phabricator.wikimedia.org/{{each_suggestion.ticket_number}}" target="_blank" rel="noopener noreferrer">
+                        <a class="twl-links" href="https://phabricator.wikimedia.org/{{each_suggestion.ticket_number}}" target="_blank">
                           {{ each_suggestion.ticket_number }}
                         </a>
                       </p>
                     {% endif %}
                   </div>
                   {% if user.is_authenticated %}
-                    <div class="col-lg-2 pull-right" style="text-align: right;">
+                    <div class="col-xl-2 col-lg-12 pull-right align-text-right">
                       <a class="btn upvote{% if user in each_suggestion.upvoted_users.all %} btn-success{% else %} btn-outline-dark{% endif %}" data-href="{{ each_suggestion.get_upvote_url }}"
                           href="">
                         <i class="fa fa-arrow-up" aria-hidden="true"></i>
@@ -185,7 +185,7 @@
       var searchResults = fuse.search(pattern);
 
       var filteredSuggestionElems = [];
-      var suggestionElems = document.getElementsByClassName("suggestion-class"); 
+      var suggestionElems = document.getElementsByClassName("suggestion-class");
 
       if (searchResults.length === 0 && pattern !== "") {
         // Hide all collections, no results to that search text found
@@ -204,7 +204,7 @@
           filteredSuggestionElems.push("suggestion-card-" + suggestionId)
         }
         displaySuggestions( suggestionElems, filteredSuggestionElems, pattern);
-      } 
+      }
 
     }
 

--- a/TWLight/resources/templates/resources/suggest.html
+++ b/TWLight/resources/templates/resources/suggest.html
@@ -83,7 +83,7 @@
                     {% if each_suggestion.ticket_number %}
                       <p>
                         <strong>{% trans 'Track Progress' %}:</strong>
-                        <a class="twl-links" href="https://phabricator.wikimedia.org/{{each_suggestion.ticket_number}}" target="_blank">
+                        <a class="twl-links" href="https://phabricator.wikimedia.org/{{each_suggestion.ticket_number}}" target="_blank" rel="noopener noreferrer">
                           {{ each_suggestion.ticket_number }}
                         </a>
                       </p>

--- a/TWLight/users/templates/users/editor_detail.html
+++ b/TWLight/users/templates/users/editor_detail.html
@@ -19,11 +19,11 @@
       <div class="row">
         <div class="col-md-5 col-lg-4">
           <a href="{% url 'users:my_library' %}" class="btn btn-default btn-lg btn-block btn-extra-large"><i class="fa fa-folder-open-o fa-4x pull-left" aria-hidden="true"></i>
-            <p class="app-list"  style="font-size:25px; float:left">
+            <p class="app-list text-float"  style="font-size:25px;">
               {% comment %}Translators: Line one of two in a button on users' profile page which when clicked takes users to their collection page.{% endcomment %}
               {% trans 'My Library' %}
-            </p><br>
-            <p class="app-list hidden-xs pull-left" style="font-size:15px; float:left">
+            </p>
+            <p class="app-list hidden-xs text-float" style="font-size:15px;">
               {% comment %}Translators: Line two of two, explaining the purpose of the page in a button on users' profile page which when clicked takes users to a page with their available collections.{% endcomment %}
               {% trans 'A collective list of collections you are authorized to access' %}
             </p>
@@ -31,11 +31,11 @@
         </div>
         <div class="col-md-5 col-lg-4">
           <a href="{% url 'users:my_applications' editor.pk %}" class="btn btn-default btn-lg btn-block btn-extra-large"><i class="fa fa-file-text-o fa-4x pull-left" aria-hidden="true"></i>
-            <p class="app-list"  style="font-size:25px; float:left">
+            <p class="app-list text-float"  style="font-size:25px;">
               {% comment %}Translators: Line one of two in a button on users' profile page which when clicked takes users to their applications page.{% endcomment %}
               {% trans 'My applications' %}
-            </p><br>
-            <p class="app-list hidden-xs" style="font-size:15px; float:left">
+            </p>
+            <p class="app-list hidden-xs text-float" style="font-size:15px;">
               {% comment %}Translators: Line two of two, explaining the purpose of the page in a button on users' profile page which when clicked takes users to a page with their collection.{% endcomment %}
               {% trans 'Both historical and current, made to various partners' %}
             </p>
@@ -51,7 +51,7 @@
       {% include 'users/editor_detail_data.html' %}
 
       {% if user == editor.user  %}
-        {% include "users/preferences.html" %}    
+        {% include "users/preferences.html" %}
       {% endif %}
 
       <p>

--- a/bin/twlight_static.sh
+++ b/bin/twlight_static.sh
@@ -3,7 +3,7 @@
 # Runs the LTR -> RTL CSS conversion script and collects static files.
 
 # Generate right to left css
-cd ${TWLIGHT_HOME} && node ${TWLIGHT_HOME}/bin/twlight_cssjanus.js || exit 1
+cd ${TWLIGHT_HOME} && node twlight_cssjanus || exit 1
 # Load virtual environment
 if source ${TWLIGHT_HOME}/bin/virtualenv_activate.sh
 then

--- a/twlight_cssjanus/index.js
+++ b/twlight_cssjanus/index.js
@@ -1,0 +1,47 @@
+// Load modules
+var fs = require('fs');
+var cssjanus = require('cssjanus');
+
+// Recursively search directory for files. Cribbed from:
+// https://stackoverflow.com/a/21459809
+var _getAllFilesFromFolder = function(dir) {
+
+    var results = [];
+
+    fs.readdirSync(dir).forEach(function(file) {
+
+        file = dir+'/'+file;
+        var stat = fs.statSync(file);
+
+        if (stat && stat.isDirectory()) {
+            results = results.concat(_getAllFilesFromFolder(file))
+        } else results.push(file);
+
+    });
+
+    return results;
+
+};
+
+// Get all the files from the css dir
+var infiles = _getAllFilesFromFolder('./TWLight/static/css');
+
+// Loop through all the files
+infiles.forEach(function(infile) {
+
+    // Check for files with .css extension
+    // but ignore files that we've already converted
+    if (!infile.endsWith('-rtl.css')) {
+        // Set up output filename to be the same as the input, but ending in -rtl.css.
+        var outfile = infile.replace(new RegExp(/^(.+)\.css$/), '$1-rtl.css');
+        if ( typeof outfile !== 'undefined' && outfile) {
+
+            // Read left to right css, create right to left css
+            var ltrcss = fs.readFileSync(infile, 'utf8');
+            var rtlcss = cssjanus.transform(ltrcss);
+
+            // Write right to left css to file
+            fs.writeFileSync(outfile, rtlcss, 'utf8');
+        };
+    };
+});

--- a/twlight_cssjanus/package-lock.json
+++ b/twlight_cssjanus/package-lock.json
@@ -1,0 +1,22 @@
+{
+  "name": "twlight_cssjanus",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "twlight_cssjanus",
+      "license": "MIT",
+      "dependencies": {
+        "cssjanus": "^2.1.0"
+      }
+    },
+    "node_modules/cssjanus": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/cssjanus/-/cssjanus-2.1.0.tgz",
+      "integrity": "sha512-kAijbny3GmdOi9k+QT6DGIXqFvL96aksNlGr4Rhk9qXDZYWUojU4bRc3IHWxdaLNOqgEZHuXoe5Wl2l7dxLW5g==",
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    }
+  }
+}

--- a/twlight_cssjanus/package.json
+++ b/twlight_cssjanus/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "twlight_cssjanus",
+  "main": "index.js",
+  "private": true,
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "author": "",
+  "license": "MIT",
+  "dependencies": {
+    "cssjanus": "^2.1.0"
+  }
+}


### PR DESCRIPTION
[//]: # (Thank you for uploading a PR to the Wikipedia Library!)

## Description
RTL user experience bugs for The Wikipedia Library

- Fixed twlight_static.sh to generate RTL css by moving the command to run it to the twlight_docker_entrypoint.sh script instead of in the Dockerfile. 
- Added generated files to the .gitignore. 
- Fixed RTL css issues with text getting cut off or overflowing parent container.

Bug: T357057

## Rationale
[//]: # (Why is this change required? What problem does it solve?)
Fixes The Wikipedia Library RTL bugs reported in https://phabricator.wikimedia.org/T357057. 

## Phabricator Ticket
[//]: # (Link to the Phabricator ticket)
https://phabricator.wikimedia.org/T357057

## How Has This Been Tested?
[//]: # (- Did you add tests to your changes? Did you modify tests to accommodate your changes?)
Since it was mostly fixing styling issues I did not add tests. 

[//]: # (- Can this change be tested manually? How?)
Yes- start the application with Docker and switch your language settings to a language that reads right to left. 
It's also probably worth manually testing non right to left settings as well. 
Steps to Reproduce: 

1. Start the app and login. 
2. Change your language in the Profile language dropdown to a RTL language (Hebrew and Arabic were the languages I used to test). 
3. Logout. 
4. View home page and ensure the text is not being cut off on the landing page.
5. Log back in to your homepage and resize the window. The two filter headers should not collide in the filter nav. 
6. Go to profile settings page and resize, ensure the two cards with the file icon and directory icon are not overflowing their containers. 
7. Go to the suggestion page, ensure the upvote button is not overflowing it's container. 

## Screenshots of your changes (if appropriate):
[//]: # (It can also be a GIF to prove that your changes are working)

## Issue 1
### Before
The RTL text was being cutoff like so: 
![image](https://github.com/WikipediaLibrary/TWLight/assets/30132257/8dc1c20f-d62b-4702-affd-0a89969f851b)

### After
Now, it looks like the following: 
![Screenshot 2024-05-10 at 11 25 13 AM](https://github.com/WikipediaLibrary/TWLight/assets/30132257/0856033c-0a48-4e59-ae74-bf4f9a0af6f2)

## Issue 2
### Before
The second issue I fixed is in the filter panel the 'Filters' and 'Reset Filters' text colliding. 
![image (1)](https://github.com/WikipediaLibrary/TWLight/assets/30132257/8f8bf7aa-8b4b-4f5e-9820-0ad7f6f14fa4)

### After 
The text wraps to a new line instead of colliding. 
![Screenshot 2024-05-10 at 11 30 04 AM](https://github.com/WikipediaLibrary/TWLight/assets/30132257/0785753c-08c1-4e7d-a2a3-ca31f0066949)

## Issue 3
### Before
The text was overflowing it's parent container 
![image (2)](https://github.com/WikipediaLibrary/TWLight/assets/30132257/dd30d781-dd1e-4914-b8c8-15b2d793b8db)

### After 
The text wraps to a new line instead of colliding. 
![Screenshot 2024-05-10 at 11 32 21 AM](https://github.com/WikipediaLibrary/TWLight/assets/30132257/c4fb0738-e8bf-42bf-b78b-61848304b44e)

## Issue 4
### Before
The button was overflowing it's parent container. 
![image (3)](https://github.com/WikipediaLibrary/TWLight/assets/30132257/1cc18925-12b3-4d17-b4ac-c5e8bb6099a8)

### After 
![Screenshot 2024-05-10 at 11 34 51 AM](https://github.com/WikipediaLibrary/TWLight/assets/30132257/4f4aec1d-3c17-43f4-9407-ae611e8a22d1)


## Types of changes
What types of changes does your code introduce? Add an `x` in all the boxes that apply:
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Minor change (fix a typo, add a translation tag, add section to README, etc.)
