### PR TITLE
Fix translation string error in /terms

### DIFF
--- a/TWLight/users/oauth.py
+++ b/TWLight/users/oauth.py
@@ -263,8 +263,9 @@ class OAuthBackend(object):
         # The authenticate() function of a Django auth backend must return
         # the user.
         return user
-    
-    # Implementation for https://docs.djangoproject.com/en/4.2/ref/contrib/auth/#django.contrib.auth.get_user
+
+    # Implementation for
+    # https://docs.djangoproject.com/en/4.2/ref/contrib/auth/#django.contrib.auth.get_user
     def get_user(self, user_id):
         user = User.objects.filter(pk=user_id).first()
         if user is None:

--- a/TWLight/users/oauth.py
+++ b/TWLight/users/oauth.py
@@ -180,6 +180,7 @@ class OAuthBackend(object):
             if should_update_lang:
                 user.userprofile.lang = get_language()
                 user.userprofile.save()
+
             # This login path should only be used for accounts created via
             # Wikipedia login, which all have editor objects.
             if hasattr(user, "editor"):
@@ -264,10 +265,11 @@ class OAuthBackend(object):
         return user
 
     def get_user(self, user_id):
-        try:
-            return User.objects.get(pk=user_id)
-        except User.DoesNotExist as e:
-            logger.exception(e)
+        user = User.objects.filter(pk=user_id).first()
+        if user is not None:
+            return user
+        else:
+            logger.exception("OAuthBackend.get_user: User does not exist")
             return None
 
 

--- a/TWLight/users/oauth.py
+++ b/TWLight/users/oauth.py
@@ -266,11 +266,9 @@ class OAuthBackend(object):
 
     def get_user(self, user_id):
         user = User.objects.filter(pk=user_id).first()
-        if user is not None:
-            return user
-        else:
-            logger.exception("OAuthBackend.get_user: User does not exist")
-            return None
+        if user is None:
+            logger.warning("OAuthBackend.get_user: User does not exist")
+        return user
 
 
 class OAuthInitializeView(View):

--- a/TWLight/users/oauth.py
+++ b/TWLight/users/oauth.py
@@ -263,7 +263,8 @@ class OAuthBackend(object):
         # The authenticate() function of a Django auth backend must return
         # the user.
         return user
-
+    
+    # Implementation for https://docs.djangoproject.com/en/4.2/ref/contrib/auth/#django.contrib.auth.get_user
     def get_user(self, user_id):
         user = User.objects.filter(pk=user_id).first()
         if user is None:


### PR DESCRIPTION
## Description
Fixes a translation string in Spanish which caused the `/terms` page to error out.

## Rationale
This fixes the `/terms` page, which new users who picked Spanish as their UI language must agree to before using the library.

## Phabricator Ticket
[//]: # (Link to the Phabricator ticket)
[T366620](https://phabricator.wikimedia.org/T366620)

## How Has This Been Tested?
[//]: # (- Did you add tests to your changes? Did you modify tests to accommodate your changes?)
[//]: # (- Can this change be tested manually? How?)
Tested manually that the page is loading correctly in Spanish and in other languages.

## Screenshots of your changes (if appropriate):
[//]: # (It can also be a GIF to prove that your changes are working)

## Types of changes
What types of changes does your code introduce? Add an `x` in all the boxes that apply:
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Minor change (fix a typo, add a translation tag, add section to README, etc.)
