### PR TITLE
Terms of Use title should move to the right-hand side for RTL languages

### DIFF
--- a/TWLight/static/css/new-local.css
+++ b/TWLight/static/css/new-local.css
@@ -122,6 +122,20 @@ COMMON CONTENT BLOCK CSS
   background-color:#333
 }
 
+.terms-content {
+    display: flex;
+    flex-direction: column;
+    margin: auto 56px;
+}
+
+.terms-header-right {
+   align-self: flex-end;
+}
+
+.terms-header-left {
+   align-self: flex-start;
+}
+
 .twl-links{
     color: #3366CC;
 }

--- a/TWLight/users/templates/users/terms.html
+++ b/TWLight/users/templates/users/terms.html
@@ -22,9 +22,6 @@
     p{
       font-size: 0.95em;
     }
-    .terms-content{
-      margin: auto 56px;
-    }
   </style>
 {% endblock extra_css %}
 
@@ -33,15 +30,15 @@
   {% include "message_partial.html" %}
   <div class="terms-content">
     {# Translators: use the date *when you are translating*, in a language-appropriate format. #}
-    <em>{% trans "Last updated 11 August 2021" %}</em>
+    <em class="terms-header-left">{% trans "Last updated 11 August 2021" %}</em>
 
-    <a class="twl-links" href="https://wikimediafoundation.org/wiki/Privacy_policy" style="float:right">
+    <a class="twl-links terms-header-right" href="https://wikimediafoundation.org/wiki/Privacy_policy">
     {% comment %}Translators: This link is on the Terms of Use page and links to the Wikimedia Foundation Privacy Policy (https://wikimediafoundation.org/wiki/Privacy_policy). Wikimedia Foundation should not be translated.{% endcomment %}
     {% trans "Wikimedia Foundation privacy policy" %}
     </a>
 
     {% comment %}Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.{% endcomment %}
-    <h2>{% trans "Wikipedia Library Card Terms of Use and Privacy Statement" %}</h2>
+    <h2 class="terms-header-left">{% trans "Wikipedia Library Card Terms of Use and Privacy Statement" %}</h2>
 
     {% comment %}
     You can also view these TOU on [[Meta]], where they may be translated in other languages. <-- awaiting link on meta


### PR DESCRIPTION


[//]: # (Thank you for uploading a PR to the Wikipedia Library!)

## Description
Describe your changes in detail following the [commit message guidelines](https://www.mediawiki.org/wiki/Gerrit/Commit_message_guidelines)

When accepting the terms of use in a right to left language, the title is in the incorrect location. 
Bug: T366046


## Rationale
[//]: # (Why is this change required? What problem does it solve?)

To fix terms title text placement for right to left languages. 

## Phabricator Ticket
[//]: # (Link to the Phabricator ticket)
[T366046](https://phabricator.wikimedia.org/T366046)

## How Has This Been Tested?
[//]: # (- Did you add tests to your changes? Did you modify tests to accommodate your changes?)
[//]: # (- Can this change be tested manually? How?)

Can be tested manually by switching your language to a right to left language when accepting the terms. 

## Screenshots of your changes (if appropriate):
[//]: # (It can also be a GIF to prove that your changes are working)

<img width="1694" alt="Screenshot_2024-05-28_at_09 55 27" src="https://github.com/WikipediaLibrary/TWLight/assets/30132257/350163eb-2ff9-4467-b00b-764e0f5474e9">

It is now respecting the right to left css transformation that situates it in the correct location. 
![Screenshot 2024-06-20 at 11 58 22 AM](https://github.com/WikipediaLibrary/TWLight/assets/30132257/010c3235-6053-4e35-b570-c311708c357b)


## Types of changes
What types of changes does your code introduce? Add an `x` in all the boxes that apply:
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Minor change (fix a typo, add a translation tag, add section to README, etc.)
