### PR TITLE
Corriere Della Sera Archives often goes blank when attempting to view…

### DIFF
--- a/TWLight/resources/templates/resources/partner_detail_apply.html
+++ b/TWLight/resources/templates/resources/partner_detail_apply.html
@@ -125,7 +125,7 @@
         {% if user.is_authenticated %}
           {% if user.editor.wp_bundle_eligible %}
             {% comment %}Translators: This text labels a button authenticated, bundle eligible users can click to access the proxied resource. {% endcomment %}
-            <a class="btn twl-btn btn-lg btn-block" href="{{ partner.get_access_url }}" target="_blank" rel="noopener noreferrer">
+            <a class="btn twl-btn btn-lg btn-block" href="{{ partner.get_access_url }}" target="_blank" rel="noopener">
               {% trans "Access Collection" %}
             </a><br />
             {% comment %}Translators: This is the name of the authorization method whereby users access resources automatically via the library bundle. {% endcomment %}

--- a/TWLight/users/templates/users/available_collection_tile.html
+++ b/TWLight/users/templates/users/available_collection_tile.html
@@ -75,7 +75,7 @@
           <div class="collapse" id="P{{ available_collection.partner_pk }}{{ task.id }}">
             <div class="card card-body phab-task-card phab-task-{{ task.severity }}">
               {{ task.help }}
-              <a href="{{ task.url }}" target="_blank" rel="noopener">
+              <a href="{{ task.url }}" target="_blank" rel="noopener noreferrer">
                 {{ task.id }}
               </a>
             </div>

--- a/TWLight/users/templates/users/available_collection_tile.html
+++ b/TWLight/users/templates/users/available_collection_tile.html
@@ -75,7 +75,7 @@
           <div class="collapse" id="P{{ available_collection.partner_pk }}{{ task.id }}">
             <div class="card card-body phab-task-card phab-task-{{ task.severity }}">
               {{ task.help }}
-              <a href="{{ task.url }}" target="_blank" rel="noopener noreferrer">
+              <a href="{{ task.url }}" target="_blank" rel="noopener">
                 {{ task.id }}
               </a>
             </div>

--- a/TWLight/users/templates/users/user_collection_tile.html
+++ b/TWLight/users/templates/users/user_collection_tile.html
@@ -156,7 +156,7 @@
       {% elif not user_collection.partner_phabricator_disabled %}
         <div class="col-12" style="padding: 0px;">
           <a href="{{ user_collection.partner_access_url }}" class="btn btn-sm twl-btn access-apply-button"
-                  type="button" name="button" target="_blank" rel="noopener noreferrer">
+                  type="button" name="button" target="_blank" rel="noopener">
               {% comment %}Translators: On the My Library page (https://wikipedialibrary.wmflabs.org/users/my_library), this labels the text on a button which takes the user to the partner's site. {% endcomment %}
               {% trans "Access collection" %}
           </a>

--- a/TWLight/users/templates/users/user_collection_tile.html
+++ b/TWLight/users/templates/users/user_collection_tile.html
@@ -124,7 +124,7 @@
                 <div class="col-xl-6 col-lg-12" style="padding: 0px;">
                 {% if not user_collection.partner_phabricator_disabled %}
                   <a href="{{ user_collection.partner_access_url }}" class="btn btn-sm twl-btn access-apply-button"
-                        type="button" name="button" target="_blank" rel="noopener noreferrer"
+                        type="button" name="button" target="_blank" rel="noopener"
                         style="font-size: 14px;">
                     {% if user_collection.partner_authorization_method != proxy_authorization %}
                         {% comment %}Translators: On the My Library page (https://wikipedialibrary.wmflabs.org/users/my_library), this labels the text on a button which takes the user to the partner's site. {% endcomment %}


### PR DESCRIPTION
[//]: # (Thank you for uploading a PR to the Wikipedia Library!)

## Description
Describe your changes in detail following the [commit message guidelines](https://www.mediawiki.org/wiki/Gerrit/Commit_message_guidelines)

Corriere Della Sera Archives often goes blank when attempting to view a newspaper

Bug: T345104

## Rationale
[//]: # (Why is this change required? What problem does it solve?)

Steps to reproduce:

- Access Corriere Della Sera Archives
- Search for a term
- Click the Eye next to a result to view the newspaper
- Sometimes the paper will load no problem, sometimes it will partially load, and then the screen will go blank grey.

## Phabricator Ticket
[//]: # (Link to the Phabricator ticket)

[https://phabricator.wikimedia.org/T345104](https://phabricator.wikimedia.org/T345104)

## How Has This Been Tested?
[//]: # (- Did you add tests to your changes? Did you modify tests to accommodate your changes?)
[//]: # (- Can this change be tested manually? How?)

If you go to The Wikipedia Library in production and modify the html directly in the browser for the "Access Collection" button to remove the rel="noreferrer" then the website loads as expected with the content loading as expected. 

## Screenshots of your changes (if appropriate):

![Screenshot 2024-06-21 at 8 24 13 AM](https://github.com/WikipediaLibrary/TWLight/assets/30132257/2d77b602-145e-440b-8274-b5747ceda705)

[//]: # (It can also be a GIF to prove that your changes are working)

## Types of changes
What types of changes does your code introduce? Add an `x` in all the boxes that apply:
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Minor change (fix a typo, add a translation tag, add section to README, etc.)
