### PR TITLE
OAuth: User.DoesNotExist is not being caught in try/except

### DIFF
--- a/TWLight/resources/templates/resources/suggest.html
+++ b/TWLight/resources/templates/resources/suggest.html
@@ -157,7 +157,12 @@
       }
       var this_ = $(this);
       var upvoteURL = this_.attr("data-href");
-      $.get(upvoteURL);
+      $.ajax({
+        url: upvoteURL,
+        mode: 'same-origin', // Do not send CSRF token to another domain.
+        type: "POST",
+        headers: {'X-CSRFToken': getCookie("csrftoken")},
+      });
     });
   </script>
   <script>

--- a/TWLight/resources/views.py
+++ b/TWLight/resources/views.py
@@ -7,9 +7,10 @@ from django.db.models import Count, Prefetch
 from django.http import Http404, HttpResponseRedirect
 from django.utils.decorators import method_decorator
 from django.utils.translation import get_language, gettext as _
+from django.views.decorators.csrf import csrf_protect
 from django.views.generic import DetailView, View, RedirectView, ListView
 from django.views.generic.edit import FormView, DeleteView
-from django.shortcuts import get_object_or_404
+from django.shortcuts import get_object_or_404, redirect
 
 from TWLight.applications.models import Application
 from TWLight.users.groups import get_coordinators
@@ -573,10 +574,11 @@ class SuggestionDeleteView(CoordinatorsOnly, DeleteView):
         return super().form_valid(form)
 
 
-class SuggestionUpvoteView(EditorsOnly, RedirectView):
+@method_decorator(csrf_protect, name="dispatch")
+class SuggestionUpvoteView(EditorsOnly, View):
     """Build view which enables users to upvote suggestions."""
 
-    def get_redirect_url(self, *args, **kwargs):
+    def post(self, *args, **kwargs):
         suggestion_id = self.kwargs.get("pk")
         obj = get_object_or_404(Suggestion, id=suggestion_id)
         url_ = obj.get_absolute_url()
@@ -588,7 +590,7 @@ class SuggestionUpvoteView(EditorsOnly, RedirectView):
                 obj.upvoted_users.remove(user)
             else:
                 obj.upvoted_users.add(user)
-        return url_
+        return redirect(url_)
 
 
 @method_decorator(login_required, name="post")

--- a/TWLight/users/oauth.py
+++ b/TWLight/users/oauth.py
@@ -173,41 +173,36 @@ class OAuthBackend(object):
         call and False if we did not.
         """
         logger.info("Attempting to update editor after OAuth login.")
-        try:
-            username = self._get_username(identity)
-            user = User.objects.get(username=username)
-            should_update_lang = _check_user_preferred_language(user)
-            if should_update_lang:
-                user.userprofile.lang = get_language()
-                user.userprofile.save()
-
-            # This login path should only be used for accounts created via
-            # Wikipedia login, which all have editor objects.
-            if hasattr(user, "editor"):
-                editor = user.editor
-
-                lang = user.userprofile.lang
-                editor.update_from_wikipedia(
-                    identity, lang
-                )  # This call also saves the editor
-                logger.info("Editor updated.")
-
-                created = False
-            else:
-                try:
-                    logger.warning(
-                        "A user tried using the Wikipedia OAuth "
-                        "login path but does not have an attached editor."
-                    )
-                    editor = self._create_editor(user, identity)
-                    created = True
-                except:
-                    raise PermissionDenied
-
-        except User.DoesNotExist:
+        created = False
+        username = self._get_username(identity)
+        user = User.objects.filter(username=username).first()
+        if user is None:
             logger.info("Can't find user; creating one.")
             user, editor = self._create_user_and_editor(identity)
             created = True
+        should_update_lang = _check_user_preferred_language(user)
+        if should_update_lang:
+            user.userprofile.lang = get_language()
+            user.userprofile.save()
+        # This login path should only be used for accounts created via
+        # Wikipedia login, which all have editor objects.
+        if hasattr(user, "editor"):
+            editor = user.editor
+            lang = user.userprofile.lang
+            editor.update_from_wikipedia(
+                identity, lang
+            )  # This call also saves the editor
+            logger.info("Editor updated.")
+        else:
+            try:
+                logger.warning(
+                    "A user tried using the Wikipedia OAuth "
+                    "login path but does not have an attached editor."
+                )
+                editor = self._create_editor(user, identity)
+                created = True
+            except:
+                raise PermissionDenied
         return user, created
 
     def authenticate(self, request=None, access_token=None, handshaker=None):

--- a/TWLight/users/oauth.py
+++ b/TWLight/users/oauth.py
@@ -173,26 +173,29 @@ class OAuthBackend(object):
         call and False if we did not.
         """
         logger.info("Attempting to update editor after OAuth login.")
-        created = False
         username = self._get_username(identity)
         user = User.objects.filter(username=username).first()
         if user is None:
             logger.info("Can't find user; creating one.")
             user, editor = self._create_user_and_editor(identity)
-            created = True
+            return user, True
         should_update_lang = _check_user_preferred_language(user)
         if should_update_lang:
             user.userprofile.lang = get_language()
             user.userprofile.save()
+
         # This login path should only be used for accounts created via
         # Wikipedia login, which all have editor objects.
         if hasattr(user, "editor"):
             editor = user.editor
+
             lang = user.userprofile.lang
             editor.update_from_wikipedia(
                 identity, lang
             )  # This call also saves the editor
             logger.info("Editor updated.")
+
+            created = False
         else:
             try:
                 logger.warning(

--- a/locale/ar/LC_MESSAGES/django.po
+++ b/locale/ar/LC_MESSAGES/django.po
@@ -24,19 +24,18 @@
 # Author: محمد أحمد عبد الفتاح
 msgid ""
 msgstr ""
+""
 "Project-Id-Version: Wikipedia Library Card Platform - Website\n"
-"Report-Msgid-Bugs-To: wikipedialibrary@wikimedia.org\n"
+"Report-Msgid-Bugs-To: translatewiki.net\n"
 "POT-Creation-Date: 2024-07-11 20:54+0000\n"
-"PO-Revision-Date: 2024-07-11 12:30:12+0000\n"
+"PO-Revision-Date: 2024-07-15 12:29:12+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
 "Language: ar\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=6; plural=(n == 0) ? 0 : ( (n == 1) ? 1 : ( (n == "
-"2) ? 2 : ( (n%100 >= 3 && n%100 <= 10) ? 3 : ( (n%100 >= 11 && n%100 <= "
-"99) ? 4 : 5 ) ) ) );\n"
+"Plural-Forms: nplurals=6; plural=(n == 0) ? 0 : ( (n == 1) ? 1 : ( (n == 2) ? 2 : ( (n%100 >= 3 && n%100 <= 10) ? 3 : ( (n%100 >= 11 && n%100 <= 99) ? 4 : 5 ) ) ) );\n"
 "X-POT-Import-Date: 2024-06-25 18:44:08+0000\n"
 "X-Generator: MediaWiki 1.43.0-alpha; Translate 2024-07-16\n"
 "X-Translation-Project: translatewiki.net <https://translatewiki.net>\n"
@@ -64,12 +63,8 @@ msgstr "نبذة عنك"
 #. Translators: This note appears in a section of a form where we ask users to enter info (like country of residence) when applying for resource access.
 #: TWLight/applications/forms.py:179
 #, python-brace-format
-msgid ""
-"<p><small><i>Your personal data will be processed according to our <a "
-"class='twl-links' href='{terms_url}'> privacy policy</a>.</i></small></p>"
-msgstr ""
-"<p><small><i>سوف يجري التعامل مع بياناتك الشخصية حسب <a class='twl-links' "
-"href='{terms_url}'>سياسة الخصوصية التي نتبعها</a>.</i></small></p>"
+msgid "<p><small><i>Your personal data will be processed according to our <a class='twl-links' href='{terms_url}'> privacy policy</a>.</i></small></p>"
+msgstr "<p><small><i>سوف يجري التعامل مع بياناتك الشخصية حسب <a class='twl-links' href='{terms_url}'>سياسة الخصوصية التي نتبعها</a>.</i></small></p>"
 
 #. Translators: This is the title of the application form page, where users enter information required for the application. It lets the user know which partner application they are entering data for. {partner}
 #: TWLight/applications/forms.py:189
@@ -110,12 +105,8 @@ msgstr "البريد الإلكتروني الخاص بحسابك على موق�
 #. Translators: This labels a choice field where users will have to select the number of months they wish to have their access for as part of the application renewal confirmation.
 #. Translators: When filling out an application, users may be required to enter the length of the account (expiry) they wish to have for proxy partners.
 #: TWLight/applications/forms.py:339 TWLight/applications/helpers.py:100
-msgid ""
-"The number of months you wish to have this access for before renewal is "
-"required"
-msgstr ""
-"عدد الأشهر التي ترغب في أن تمنح فيها إمكانية الوصول قبل أن يصبح التجديد "
-"مطلوبًا"
+msgid "The number of months you wish to have this access for before renewal is required"
+msgstr "عدد الأشهر التي ترغب في أن تمنح فيها إمكانية الوصول قبل أن يصبح التجديد مطلوبًا"
 
 #. Translators: When filling out an application, users may need to specify their name
 #: TWLight/applications/helpers.py:81
@@ -203,12 +194,8 @@ msgstr "بريد إلكتروني"
 
 #. Translators: This comment is added to pending applications when our terms of use change.
 #: TWLight/applications/management/commands/notify_applicants_tou_changes.py:54
-msgid ""
-"Our terms of use have changed. Your applications will not be processed until "
-"you log in and agree to our updated terms."
-msgstr ""
-"شروط استخدامنا تغيرت. لن يمكننا التعامل مع طلباتك إلى أن تسجل الدخول وتوافق "
-"على شروطنا بعد تحديثها."
+msgid "Our terms of use have changed. Your applications will not be processed until you log in and agree to our updated terms."
+msgstr "شروط استخدامنا تغيرت. لن يمكننا التعامل مع طلباتك إلى أن تسجل الدخول وتوافق على شروطنا بعد تحديثها."
 
 #. Translators: This is the status of an application that has not yet been reviewed.
 #: TWLight/applications/models.py:54
@@ -274,42 +261,26 @@ msgstr "مسار الوصول: {access_url}"
 
 #. Translators: This text goes into account approval emails in the case that we need to send the user's details to a publisher for manual account setup.
 #: TWLight/applications/models.py:331
-msgid ""
-"You can expect to receive access details within a week or two once it has "
-"been processed."
-msgstr ""
-"توقّع تلقي تفاصيل الوصول خلال أسبوع واحد أو اثنين حال الانتهاء من التعامل مع "
-"الطلب."
+msgid "You can expect to receive access details within a week or two once it has been processed."
+msgstr "توقّع تلقي تفاصيل الوصول خلال أسبوع واحد أو اثنين حال الانتهاء من التعامل مع الطلب."
 
 #. Translators: This comment is added to open applications when a partner joins the Library Bundle, which does not require applications.
 #: TWLight/applications/signals.py:247
-msgid ""
-"This partner joined the Library Bundle, which does not require applications. "
-"This application will be marked as invalid."
-msgstr ""
-"انضم هذا الشريك إلى حزمة المكتبة، وهي حزمة لا تستلزم تقديم طلب. سوف يوسم هذا "
-"الطلب بوسم غير صالح."
+msgid "This partner joined the Library Bundle, which does not require applications. This application will be marked as invalid."
+msgstr "انضم هذا الشريك إلى حزمة المكتبة، وهي حزمة لا تستلزم تقديم طلب. سوف يوسم هذا الطلب بوسم غير صالح."
 
 #. Translators: This is shown to users if the application is to a partner for which we have run out of available accounts. The application is therefore on a 'waitlist', and will be reviewed when more accounts are available.
 #: TWLight/applications/templates/applications/application_evaluation.html:29
-msgid ""
-"This application is on the waitlist because this partner does not have any "
-"access grants available at this time."
-msgstr ""
-"هذا الطلب موجود على قائمة انتظار لأن هذا الشريك ليس لديه منح وصول متوفرة في "
-"الوقت الراهن."
+msgid "This application is on the waitlist because this partner does not have any access grants available at this time."
+msgstr "هذا الطلب موجود على قائمة انتظار لأن هذا الشريك ليس لديه منح وصول متوفرة في الوقت الراهن."
 
 #. Translators: This message is shown on pages where coordinators can see personal information about applicants.
 #: TWLight/applications/templates/applications/application_evaluation.html:36
 #: TWLight/applications/templates/applications/application_list_include.html:6
 #: TWLight/applications/templates/applications/send_partner.html:45
 #: TWLight/resources/templates/resources/partner_users.html:18
-msgid ""
-"Coordinators: This page may contain personal information such as real names "
-"and email addresses. Please remember that this information is confidential."
-msgstr ""
-"أيها المنسقين: ربما تحتوي هذه الصفحة على معلومات شخصية مثل الاسم الحقيقي "
-"وعنوان البريد الإلكتروني. يرجى تذكر أن هذه المعلومات معلومات سرية."
+msgid "Coordinators: This page may contain personal information such as real names and email addresses. Please remember that this information is confidential."
+msgstr "أيها المنسقين: ربما تحتوي هذه الصفحة على معلومات شخصية مثل الاسم الحقيقي وعنوان البريد الإلكتروني. يرجى تذكر أن هذه المعلومات معلومات سرية."
 
 #. Translators: This is the title of the application page shown to users who are a coordinator, and are able to accept or reject the application.
 #: TWLight/applications/templates/applications/application_evaluation.html:39
@@ -318,12 +289,8 @@ msgstr "تقييم الطلب"
 
 #. Translators: This text is shown to coordinators on application pages if the applicant has restricted processing of their data.
 #: TWLight/applications/templates/applications/application_evaluation.html:42
-msgid ""
-"This user has requested a restriction on the processing of their data, so "
-"you cannot change the status of their application."
-msgstr ""
-"طلب هذا المستخدم فرض قيود على التعامل مع بياناته، لذلك لا يمكنك تغيير حالة "
-"الطلب الذي قدمه."
+msgid "This user has requested a restriction on the processing of their data, so you cannot change the status of their application."
+msgstr "طلب هذا المستخدم فرض قيود على التعامل مع بياناته، لذلك لا يمكنك تغيير حالة الطلب الذي قدمه."
 
 #. Translators: This is the title of the application page shown to users who are not a coordinator.
 #: TWLight/applications/templates/applications/application_evaluation.html:48
@@ -396,11 +363,8 @@ msgstr "غير معروف"
 
 #. Translators: This is the text displayed to coordinators when an applicant has no country of residence in their profile.
 #: TWLight/applications/templates/applications/application_evaluation.html:123
-msgid ""
-"Please request the applicant add their country of residence to their profile "
-"before proceeding further."
-msgstr ""
-"أطلب رجاءً من مقدم الطلب أن يضيف دولة إقامته إلى ملفه الشخصي قبل المتابعة."
+msgid "Please request the applicant add their country of residence to their profile before proceeding further."
+msgstr "أطلب رجاءً من مقدم الطلب أن يضيف دولة إقامته إلى ملفه الشخصي قبل المتابعة."
 
 #. Translators: This labels the section of an application showing the total number of accounts available for a partner or their collection.
 #: TWLight/applications/templates/applications/application_evaluation.html:134
@@ -410,12 +374,8 @@ msgstr "عدد الحسابات المتوفرة"
 #. Translators: This labels the section of an application showing whether the user had agreed to the terms of use or not.
 #: TWLight/applications/templates/applications/application_evaluation.html:145
 #, python-format
-msgid ""
-"Has agreed to the site's <a class=\"twl-links\" href=\"%(terms_url)s\">terms "
-"of use</a>?"
-msgstr ""
-"هل وافق على <a class=\"twl-links\" href=\"%(terms_url)s\">شروط استخدام</a> "
-"الموقع الشبكي؟"
+msgid "Has agreed to the site's <a class=\"twl-links\" href=\"%(terms_url)s\">terms of use</a>?"
+msgstr "هل وافق على <a class=\"twl-links\" href=\"%(terms_url)s\">شروط استخدام</a> الموقع الشبكي؟"
 
 #. Translators: Displayed to coordinators when they've agreed to the terms of use.
 #. Translators: Displayed if the user has agreed to the terms of use.
@@ -450,12 +410,8 @@ msgstr "لا"
 
 #. Translators: This is the text displayed to coordinators when an applicant has not agreed to the terms of use.
 #: TWLight/applications/templates/applications/application_evaluation.html:159
-msgid ""
-"Please request the applicant agree to the site's terms of use before "
-"approving this application."
-msgstr ""
-"أطلب رجاءً من مقدم الطلب الموافقة على شروط استخدام الموقع الشبكي قبل الموافقة "
-"على هذا الطلب."
+msgid "Please request the applicant agree to the site's terms of use before approving this application."
+msgstr "أطلب رجاءً من مقدم الطلب الموافقة على شروط استخدام الموقع الشبكي قبل الموافقة على هذا الطلب."
 
 #. Translators: This labels the section of an application containing the user's motivation for wanting access to this resource.
 #: TWLight/applications/templates/applications/application_evaluation.html:176
@@ -475,8 +431,7 @@ msgstr "تجديد منحة الوصول الحالية؟"
 #. Translators: This message is shown next to the 'Renewal of existing access grant?' label if the application is a renewal. Don't translate HTML tags or parent_url.
 #: TWLight/applications/templates/applications/application_evaluation.html:195
 #, python-format
-msgid ""
-"Yes (<a class=\"twl-links\" href=\"%(parent_url)s\">previous application</a>)"
+msgid "Yes (<a class=\"twl-links\" href=\"%(parent_url)s\">previous application</a>)"
 msgstr "نعم (<a class=\"twl-links\" href=\"%(parent_url)s\">الطلب السابق</a>)"
 
 #. Translators: This labels the section of the application showing the length of access remaining on the user's previous authorization.
@@ -511,9 +466,7 @@ msgstr "أضف تعليق"
 
 #. Translators: On an application page, this text tells users that the comments posted on the application are visible to coordinators and the submitting user only.
 #: TWLight/applications/templates/applications/application_evaluation.html:297
-msgid ""
-"Comments are visible to all coordinators and to the editor who submitted "
-"this application."
+msgid "Comments are visible to all coordinators and to the editor who submitted this application."
 msgstr "يرى التعليقات كافة المنسقين والمحرر الذي قدم هذا الطلب."
 
 #. Translators: This is the title of the section of an application page which lists information about the user who submitted the application.
@@ -725,17 +678,8 @@ msgstr "تحديد الحالة"
 
 #: TWLight/applications/templates/applications/apply.html:20
 #, python-format
-msgid ""
-"If your application is successful we may share your email address with "
-"%(partner)s. This is required to set up your access to their resources. By "
-"submitting this form you agree to allow your email address to be shared with "
-"%(partner)s if your application is successful, for the purposes of account "
-"setup."
-msgstr ""
-"إذا كان طلبك ناجحًا، فقد نشارك عنوان بريدك الإلكتروني مع%(partner) s. هذا "
-"مطلوب لإعداد وصولك إلى مواردهم. بإرسال هذا النموذج ، فإنك توافق على السماح "
-"بمشاركة عنوان بريدك الإلكتروني مع %(partner)s إذا كان طلبك ناجحًا ، لأغراض "
-"إعداد الحساب."
+msgid "If your application is successful we may share your email address with %(partner)s. This is required to set up your access to their resources. By submitting this form you agree to allow your email address to be shared with %(partner)s if your application is successful, for the purposes of account setup."
+msgstr "إذا كان طلبك ناجحًا، فقد نشارك عنوان بريدك الإلكتروني مع%(partner) s. هذا مطلوب لإعداد وصولك إلى مواردهم. بإرسال هذا النموذج ، فإنك توافق على السماح بمشاركة عنوان بريدك الإلكتروني مع %(partner)s إذا كان طلبك ناجحًا ، لأغراض إعداد الحساب."
 
 #. Translators: This message is displayed on the page where users can confirm their renewal. Please do not translate partner.
 #: TWLight/applications/templates/applications/confirm_renewal.html:23
@@ -763,9 +707,7 @@ msgstr "ما هي الموارد التي تريد الوصول إليها؟"
 
 #. Translators: This text explains that Library Bundle partners are not shown in this list.
 #: TWLight/applications/templates/applications/request_for_application.html:26
-msgid ""
-"Library Bundle partners are not shown as eligibility is determined "
-"automatically."
+msgid "Library Bundle partners are not shown as eligibility is determined automatically."
 msgstr "شركاء حزمة المكتبة غير معروضين منذ أن الأهلية تحدد تلقائيًا."
 
 #. Translators: On the page where users can apply for multiple partners, this message shows next to the partner name, taking them to the full application page when clicked.
@@ -780,14 +722,8 @@ msgstr "لم تضف أية بيانات شريك حتى الآن."
 
 #. Translators: the HTML is so that the word 'waitlisted' will look the same as it does in the page above; please translate 'waitlisted' the same way you did elsewhere in this file.
 #: TWLight/applications/templates/applications/request_for_application.html:74
-msgid ""
-"You can apply to <span class=\"badge badge-warning\">Waitlisted</span> "
-"partners, but they don't have access grants available right now. We will "
-"process those applications when access becomes available."
-msgstr ""
-"يمكنك التقدم بطلب إلى الشركاء <span class=\"badge badge-warning\">قيد "
-"الانتظار</span>، إلا أنهم ليس لديهم منح وصول متوفرة حاليًا. سوف نتعامل مع تلك "
-"الطلبات حينما يصبح الوصول متاحًا."
+msgid "You can apply to <span class=\"badge badge-warning\">Waitlisted</span> partners, but they don't have access grants available right now. We will process those applications when access becomes available."
+msgstr "يمكنك التقدم بطلب إلى الشركاء <span class=\"badge badge-warning\">قيد الانتظار</span>، إلا أنهم ليس لديهم منح وصول متوفرة حاليًا. سوف نتعامل مع تلك الطلبات حينما يصبح الوصول متاحًا."
 
 #. Translators: On the page where coordinators can see approved applications which have not had their details sent to the partner, this message shows when there are applications ready to be processed.
 #: TWLight/applications/templates/applications/send.html:10
@@ -808,18 +744,13 @@ msgstr "بيانات الطلبات المقدمة إلى %(object)s"
 #. Translators: This message is shown when applications exceed the number of accounts available.
 #: TWLight/applications/templates/applications/send_partner.html:54
 #, python-format
-msgid ""
-"Application(s) for %(object)s, if sent, will exceed the total available "
-"accounts for the partner. Please proceed at your own discretion."
-msgstr ""
-"سوف تتخطى الطلبات المقدمة إلى %(object)s في حال إرسالها إجمالي الحسابات "
-"المتاحة للشريك. يرجى المتابعة وفقًا لتقديرك الخاص."
+msgid "Application(s) for %(object)s, if sent, will exceed the total available accounts for the partner. Please proceed at your own discretion."
+msgstr "سوف تتخطى الطلبات المقدمة إلى %(object)s في حال إرسالها إجمالي الحسابات المتاحة للشريك. يرجى المتابعة وفقًا لتقديرك الخاص."
 
 #. Translators: When viewing the list of applications ready to be sent for a particular partner, this is instructions for the coordinator to click the 'mark as sent' button after they have sent the information.
 #: TWLight/applications/templates/applications/send_partner.html:65
 msgid "When you've processed the data below, click the 'mark as sent' button."
-msgstr ""
-"عندما تنتهي من التعامل مع البيانات التالية، اضغط على زر «التعليم كمرسلة»."
+msgstr "عندما تنتهي من التعامل مع البيانات التالية، اضغط على زر «التعليم كمرسلة»."
 
 #. Translators: When viewing the list of applications ready to be sent for a particular partner, this is the title of the section containing contact information for the people applications should be sent to.
 #: TWLight/applications/templates/applications/send_partner.html:71
@@ -834,11 +765,8 @@ msgstr[5] ""
 
 #. Translators: When viewing the list of applications ready to be sent for a particular partner, this message shows if there is no information about who the applications should be sent to. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/applications/templates/applications/send_partner.html:89
-msgid ""
-"Whoops, we don't have any listed contacts. Please notify Wikipedia Library "
-"administrators."
-msgstr ""
-"عفوًا، ليس لدينا أية جهات اتصال مدرجة. يرجى إبلاغ إداري مكتبة ويكيبيديا."
+msgid "Whoops, we don't have any listed contacts. Please notify Wikipedia Library administrators."
+msgstr "عفوًا، ليس لدينا أية جهات اتصال مدرجة. يرجى إبلاغ إداري مكتبة ويكيبيديا."
 
 #. Translators: When viewing the list of applications ready to be sent for a particular partner, this is the title of the section containing the information about those applications.
 #: TWLight/applications/templates/applications/send_partner.html:94
@@ -853,12 +781,8 @@ msgstr "التعليم كمرسلة"
 
 #. Translators: This text guides coordinators in using the code sending interface for approved applications.
 #: TWLight/applications/templates/applications/send_partner.html:152
-msgid ""
-"Use the dropdown menus to denote which editor will receive each code. Access "
-"codes will be sent to users automatically."
-msgstr ""
-"استخدم القوائم المنسدلة كي تحدد من هو المحرر الذي سيتلقى كل كود. سوف ترسل "
-"أكواد الوصول إلى المستخدمين آليًا."
+msgid "Use the dropdown menus to denote which editor will receive each code. Access codes will be sent to users automatically."
+msgstr "استخدم القوائم المنسدلة كي تحدد من هو المحرر الذي سيتلقى كل كود. سوف ترسل أكواد الوصول إلى المستخدمين آليًا."
 
 #. Translators: This labels a drop-down selection where staff can assign an access code to a user.
 #: TWLight/applications/templates/applications/send_partner.html:173
@@ -873,24 +797,14 @@ msgstr "لا توجد طلبات معتمدة وغير مرسلة."
 #. Translators: When a user applies for a set of resources, they receive this message if none are currently available. They are instead placed on a 'waitlist' for later approval.
 #. Translators: When a user renews their resource, they receive this message if none are currently available. They are instead placed on a 'waitlist' for later approval.
 #: TWLight/applications/views.py:140 TWLight/applications/views.py:1282
-msgid ""
-"This partner does not have any access grants available at this time. You may "
-"still apply for access; your application will be reviewed when access grants "
-"become available."
-msgstr ""
-"هذا الشريك لا يوفر حسابات دخول مجانية إلى مصدره في الوقت الحالي. يمكنك رغم "
-"ذلك طلب حق الدخول المجاني إلى المصدر. سوف تتم مراجعة طلبك عندما يوفر الشريك "
-"الحسابات المجانية."
+msgid "This partner does not have any access grants available at this time. You may still apply for access; your application will be reviewed when access grants become available."
+msgstr "هذا الشريك لا يوفر حسابات دخول مجانية إلى مصدره في الوقت الحالي. يمكنك رغم ذلك طلب حق الدخول المجاني إلى المصدر. سوف تتم مراجعة طلبك عندما يوفر الشريك الحسابات المجانية."
 
 #. Translators: This message is shown to users once they've successfully submitted their application for review.
 #: TWLight/applications/views.py:163
 #, python-brace-format
-msgid ""
-"Your application has been submitted for review. Head over to <a "
-"href='{applications_url}'>My Applications</a> to view the status."
-msgstr ""
-"تم تقديم طلبك للمراجعة، يمكنك التحقق من حالة طلباتك على صفحة <a "
-"href='{applications_url}'>تطبيقاتي</a>"
+msgid "Your application has been submitted for review. Head over to <a href='{applications_url}'>My Applications</a> to view the status."
+msgstr "تم تقديم طلبك للمراجعة، يمكنك التحقق من حالة طلباتك على صفحة <a href='{applications_url}'>تطبيقاتي</a>"
 
 #. Translators: This text is displayed to users when the user has chosen to restrict data and is trying to apply for multiple partners
 #: TWLight/applications/views.py:276
@@ -938,21 +852,13 @@ msgstr "الطلبات المرسلة"
 
 #. Translators: After a coordinator has changed the status of an application to APPROVED, if the corresponding partner/collection is waitlisted this message appears.
 #: TWLight/applications/views.py:756
-msgid ""
-"Cannot approve application as partner with proxy authorization method is "
-"waitlisted."
-msgstr ""
-"لا يمكن الموافقة على الطلب منذ أن الشريك ذو طريقة التخويل بالنيابة موجود على "
-"قائمة الانتظار."
+msgid "Cannot approve application as partner with proxy authorization method is waitlisted."
+msgstr "لا يمكن الموافقة على الطلب منذ أن الشريك ذو طريقة التخويل بالنيابة موجود على قائمة الانتظار."
 
 #. Translators: After a coordinator has changed the status of an application to APPROVED, if the corresponding partner/collection has no accounts for distribution, this message appears.
 #: TWLight/applications/views.py:780
-msgid ""
-"Cannot approve application as partner with proxy authorization method is "
-"waitlisted and (or) has zero accounts available for distribution."
-msgstr ""
-"لا يمكن الموافقة على الطلب منذ أن الشريك ذو طريقة التخويل بالنيابة موجود على "
-"قائمة الانتظار و (أو) ليست لديه حسابات متوفرة للتوزيع."
+msgid "Cannot approve application as partner with proxy authorization method is waitlisted and (or) has zero accounts available for distribution."
+msgstr "لا يمكن الموافقة على الطلب منذ أن الشريك ذو طريقة التخويل بالنيابة موجود على قائمة الانتظار و (أو) ليست لديه حسابات متوفرة للتوزيع."
 
 #. Translators: This message appears on an "access denied" screen that stops users who attempt to authorize an editor to access a resource during a time period for which they are already authorized.
 #: TWLight/applications/views.py:803
@@ -962,16 +868,8 @@ msgstr "لقد حاولت إنشاء تخويل مكرر."
 #. Translators: This message is shown to users when they access an application page of a now Bundle partner (new applications aren't allowed for Bundle partners and the status of old applications cannot be modified)
 #: TWLight/applications/views.py:857
 #, python-brace-format
-msgid ""
-"This application cannot be modified since this partner is now part of our <a "
-"href='{bundle}'>bundle access</a>. If you are eligible, you can access this "
-"resource from <a href='{library}'>your library</a>. <a "
-"href='{contact}'>Contact us</a> if you have any questions."
-msgstr ""
-"لا يمكن تعديل هذا الطلب منذ أن الشريك الآن جزءً من <a href='{bundle}'>إمكانية "
-"الوصول للحزم</a>. لو كانت الشروط تنطبق عليك، يمكنك الوصول إلى هذا المورد من "
-"<a href='{library}'>مكتبتك</a>. <a href='{contact}'>اتصل بنا</a> لو كانت "
-"لديك أية أسئلة."
+msgid "This application cannot be modified since this partner is now part of our <a href='{bundle}'>bundle access</a>. If you are eligible, you can access this resource from <a href='{library}'>your library</a>. <a href='{contact}'>Contact us</a> if you have any questions."
+msgstr "لا يمكن تعديل هذا الطلب منذ أن الشريك الآن جزءً من <a href='{bundle}'>إمكانية الوصول للحزم</a>. لو كانت الشروط تنطبق عليك، يمكنك الوصول إلى هذا المورد من <a href='{library}'>مكتبتك</a>. <a href='{contact}'>اتصل بنا</a> لو كانت لديك أية أسئلة."
 
 #. Translators: this lets a reviewer set the status of a single application.
 #: TWLight/applications/views.py:873
@@ -980,12 +878,8 @@ msgstr "ضبط حالة الطلب"
 
 #. Translators: This warning is message is shown to applicants when the number of pending applications is greater than the number of accounts available.
 #: TWLight/applications/views.py:891
-msgid ""
-"There are more pending applications than available accounts. Your "
-"application might get waitlisted."
-msgstr ""
-"يوجد عدد طلبات قيد الانتظار يتخطى عدد الحسابات المتاحة. يجوز أن يوضع طلبك في "
-"قائمة الانتظار."
+msgid "There are more pending applications than available accounts. Your application might get waitlisted."
+msgstr "يوجد عدد طلبات قيد الانتظار يتخطى عدد الحسابات المتاحة. يجوز أن يوضع طلبك في قائمة الانتظار."
 
 #. Translators: this message is shown to coordinators who attempt to change an application's Status from INVALID to any other Status.
 #: TWLight/applications/views.py:904
@@ -1004,16 +898,8 @@ msgstr "جرى تحديث دفعة الطلبات {} بنجاح."
 
 #. Translators: After a coordinator has changed the status of a number of applications to APPROVED, if the corresponding partner(s) is/are waitlisted or has no accounts for distribution, this message appears.
 #: TWLight/applications/views.py:1051
-msgid ""
-"Cannot approve application(s) {} as partner(s) with proxy authorization "
-"method is/are waitlisted and (or) has/have not enough accounts available. If "
-"not enough accounts are available, prioritise the applications and then "
-"approve applications equal to the accounts available."
-msgstr ""
-"لا يمكن الموافقة على الطلب (الطلبات) {} منذ أن الشريك (الشركاء) ذو طريقة "
-"التخويل بالنيابة موجود على قائمة الانتظار و (أو) ليس لديه حسابات متوفرة "
-"كافية. لو لم يكن عدد الحسابات المتوفرة يكفي، حدد أولوية الطلبات ثم وافق عل "
-"عدد من الطلبات يماثل عدد الحسابات المتاحة."
+msgid "Cannot approve application(s) {} as partner(s) with proxy authorization method is/are waitlisted and (or) has/have not enough accounts available. If not enough accounts are available, prioritise the applications and then approve applications equal to the accounts available."
+msgstr "لا يمكن الموافقة على الطلب (الطلبات) {} منذ أن الشريك (الشركاء) ذو طريقة التخويل بالنيابة موجود على قائمة الانتظار و (أو) ليس لديه حسابات متوفرة كافية. لو لم يكن عدد الحسابات المتوفرة يكفي، حدد أولوية الطلبات ثم وافق عل عدد من الطلبات يماثل عدد الحسابات المتاحة."
 
 #. Translators: This message is shown to coordinators who attempt to assign the same access code to multiple users.
 #: TWLight/applications/views.py:1191
@@ -1027,12 +913,8 @@ msgstr "وسمت كافة الطلبات المحددة بوسم مرسلة."
 
 #. Translators: When a user tries to renew their resource, they receive this message if the partner is not available.
 #: TWLight/applications/views.py:1272
-msgid ""
-"Cannot renew application at this time as partner is not available. Please "
-"check back later, or contact us for more information."
-msgstr ""
-"لا يمكن تجديد الطلب حاليًا منذ أن الشريك غير متاح. يرجى مراجعة الأمر لاحقًا أو "
-"الاتصال بنا لمزيد من المعلومات."
+msgid "Cannot renew application at this time as partner is not available. Please check back later, or contact us for more information."
+msgstr "لا يمكن تجديد الطلب حاليًا منذ أن الشريك غير متاح. يرجى مراجعة الأمر لاحقًا أو الاتصال بنا لمزيد من المعلومات."
 
 #. Translators: This message is displayed when an attempt by a user to renew an application has been denied for some reason.
 #: TWLight/applications/views.py:1308
@@ -1042,16 +924,12 @@ msgstr "محاولة تجديد طلب غير حاصل على الموافقة #
 
 #. Translators: If a user requests the renewal of their account, but it wasn't renewed, this message is shown to them.
 #: TWLight/applications/views.py:1385
-msgid ""
-"This object cannot be renewed. (This probably means that you have already "
-"requested that it be renewed.)"
+msgid "This object cannot be renewed. (This probably means that you have already requested that it be renewed.)"
 msgstr "لا يمكن تجديد هذا العنصر. (قد يعني هذا أنك طلبت بالفعل تجديده.)"
 
 #. Translators: If a user requests the renewal of their account, this message is shown to them.
 #: TWLight/applications/views.py:1395
-msgid ""
-"Your renewal request has been received. A coordinator will review your "
-"request."
+msgid "Your renewal request has been received. A coordinator will review your request."
 msgstr "تلقينا طلبك للتجديد. سوف يراجع منسق طلبك."
 
 #. Translators: This labels a textfield where users can enter their email ID.
@@ -1061,12 +939,8 @@ msgstr "بريدك الإلكتروني"
 
 #. Translators: This is the help text for the email field in the contact us form letting users know the field is updated by value pulled from their respective user profiles.
 #: TWLight/emails/forms.py:21
-msgid ""
-"This field is automatically updated with the email from your <a class='twl-"
-"links' href='{}'>user profile</a>."
-msgstr ""
-"يجري تجديد هذه الخانة آليًا بعنوان البريد الإلكتروني المأخوذ من <a class='twl-"
-"links' href='{}'>ملف تعريف مستخدمك</a>."
+msgid "This field is automatically updated with the email from your <a class='twl-links' href='{}'>user profile</a>."
+msgstr "يجري تجديد هذه الخانة آليًا بعنوان البريد الإلكتروني المأخوذ من <a class='twl-links' href='{}'>ملف تعريف مستخدمك</a>."
 
 #. Translators: This labels a textfield where users can enter their email message.
 #: TWLight/emails/forms.py:26
@@ -1089,25 +963,14 @@ msgstr "إرسال"
 #. Translators: This email is sent to users with their access code. Don't translate Jinja variables in curly braces like user or partner. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/access_code_email-body-html.html:5
 #, python-format
-msgid ""
-"<p>Your approved application to %(partner)s has now been finalised. Your "
-"access code or login details can be found below:</p> <p><b>%(access_code)s</"
-"b></p> <p>%(user_instructions)s</p>"
-msgstr ""
-"<p>انتهى الآن العمل على طلبك المقبول إلى %(partner)s. ترميز الوصول أو بيانات "
-"الدخول المخصصة لك كما يلي:</p> <p><b>%(access_code)s</b></p> <p>"
-"%(user_instructions)s</p>"
+msgid "<p>Your approved application to %(partner)s has now been finalised. Your access code or login details can be found below:</p> <p><b>%(access_code)s</b></p> <p>%(user_instructions)s</p>"
+msgstr "<p>انتهى الآن العمل على طلبك المقبول إلى %(partner)s. ترميز الوصول أو بيانات الدخول المخصصة لك كما يلي:</p> <p><b>%(access_code)s</b></p> <p>%(user_instructions)s</p>"
 
 #. Translators: This email is sent to users with their access code. Don't translate Jinja variables in curly braces like user or partner. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/access_code_email-body-text.html:3
 #, python-format
-msgid ""
-"Your approved application to %(partner)s has now been finalised. Your access "
-"code or login details can be found below: %(access_code)s "
-"%(user_instructions)s"
-msgstr ""
-"انتهى الآن العمل على طلبك المقبول إلى %(partner)s. كود الوصول أو بيانات "
-"الدخول المخصصة لك كما يلي: %(access_code)s %(user_instructions)s"
+msgid "Your approved application to %(partner)s has now been finalised. Your access code or login details can be found below: %(access_code)s %(user_instructions)s"
+msgstr "انتهى الآن العمل على طلبك المقبول إلى %(partner)s. كود الوصول أو بيانات الدخول المخصصة لك كما يلي: %(access_code)s %(user_instructions)s"
 
 #. Translators: This is the subject line of an email sent to users with their access code.
 #: TWLight/emails/templates/emails/access_code_email-subject.html:3
@@ -1117,33 +980,14 @@ msgstr "رمز وصول مكتبة ويكيبيديا الخاص بك"
 #. Translators: This email is sent to users when their application is approved. Don't translate Jinja variables in curly braces like user or partner; don't translate html tags either. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/approval_notification-body-html.html:5
 #, python-format
-msgid ""
-"<p>Dear %(user)s,</p> <p>Thank you for applying for access to %(partner)s "
-"resources through The Wikipedia Library. We are happy to inform you that "
-"your application has been approved.</p> <p>%(user_instructions)s</p> <p>You "
-"can view the collections you're authorized to access at My Library: "
-"%(link)s</p> <p>Cheers!</p> <p>The Wikipedia Library</p>"
-msgstr ""
-"<p>عزيزي %(user)s،</p> <p>نشكرك على التقدم بطلب للوصول إلى موارد %(partner)s "
-"عن طريق مكتبة ويكيبيديا. يسرنا أن نبلغك أن طلبك حصل على الموافقة. </p> <p>"
-"%(user_instructions)s</p> <p>يمكنك الاطلاع على المجموعات التي حصلت على تخويل "
-"بالوصول إليها من مكتبتي: %(link)s</p> <p>مع تحياتنا،</p> <p>مكتبة ويكيبيديا</"
-"p>"
+msgid "<p>Dear %(user)s,</p> <p>Thank you for applying for access to %(partner)s resources through The Wikipedia Library. We are happy to inform you that your application has been approved.</p> <p>%(user_instructions)s</p> <p>You can view the collections you're authorized to access at My Library: %(link)s</p> <p>Cheers!</p> <p>The Wikipedia Library</p>"
+msgstr "<p>عزيزي %(user)s،</p> <p>نشكرك على التقدم بطلب للوصول إلى موارد %(partner)s عن طريق مكتبة ويكيبيديا. يسرنا أن نبلغك أن طلبك حصل على الموافقة. </p> <p>%(user_instructions)s</p> <p>يمكنك الاطلاع على المجموعات التي حصلت على تخويل بالوصول إليها من مكتبتي: %(link)s</p> <p>مع تحياتنا،</p> <p>مكتبة ويكيبيديا</p>"
 
 #. Translators: This email is sent to users when their application is approved. Don't translate Jinja variables in curly braces like user or partner. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/approval_notification-body-text.html:3
 #, python-format
-msgid ""
-"Dear %(user)s, Thank you for applying for access to %(partner)s resources "
-"through The Wikipedia Library. We are happy to inform you that your "
-"application has been approved. %(user_instructions)s You can view the "
-"collections you're authorized to access at My Library: %(link)s Cheers! The "
-"Wikipedia Library"
-msgstr ""
-"عزيزي %(user)s، نشكرك على التقدم بطلب للوصول إلى موارد %(partner)s عن طريق "
-"مكتبة ويكيبيديا. يسرنا أن نبلغك أن طلبك حصل على الموافقة. "
-"%(user_instructions)s يمكنك الاطلاع على المجموعات التي حصلت على تخويل "
-"بالوصول إليها من مكتبتي: %(link)s مع تحياتنا، مكتبة ويكيبيديا"
+msgid "Dear %(user)s, Thank you for applying for access to %(partner)s resources through The Wikipedia Library. We are happy to inform you that your application has been approved. %(user_instructions)s You can view the collections you're authorized to access at My Library: %(link)s Cheers! The Wikipedia Library"
+msgstr "عزيزي %(user)s، نشكرك على التقدم بطلب للوصول إلى موارد %(partner)s عن طريق مكتبة ويكيبيديا. يسرنا أن نبلغك أن طلبك حصل على الموافقة. %(user_instructions)s يمكنك الاطلاع على المجموعات التي حصلت على تخويل بالوصول إليها من مكتبتي: %(link)s مع تحياتنا، مكتبة ويكيبيديا"
 
 #. Translators: This is the subject of an email which is sent to users when their application has been approved. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/approval_notification-subject.html:4
@@ -1153,26 +997,14 @@ msgstr "طلبك الذي أرسلته لمكتبة ويكيبيديا تم قب
 #. Translators: This email is sent to coordinators when a comment is left on an application they are processing. Don't translate Jinja variables in curly braces like user or partner. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/comment_notification_coordinator-body-html.html:5
 #, python-format
-msgid ""
-"<p style=\"color: #500050\">%(submit_date)s - %(commenter)s</p> "
-"<blockquote><p>%(comment)s</p></blockquote> <p>Please reply to these at: <a "
-"href=\"%(app_url)s\">%(app_url)s</a></p> <p>Best,</p> <p>The Wikipedia "
-"Library</p>"
-msgstr ""
-"<p style=\"color: #500050\">%(submit_date)s - %(commenter)s</p> "
-"<blockquote><p>%(comment)s</p></blockquote> <p>يرجى الرد على هذه على: <a "
-"href=\"%(app_url)s\">%(app_url)s</a></p> <p>مع التحية،</p> <p>مكتبة "
-"ويكيبيديا</p>"
+msgid "<p style=\"color: #500050\">%(submit_date)s - %(commenter)s</p> <blockquote><p>%(comment)s</p></blockquote> <p>Please reply to these at: <a href=\"%(app_url)s\">%(app_url)s</a></p> <p>Best,</p> <p>The Wikipedia Library</p>"
+msgstr "<p style=\"color: #500050\">%(submit_date)s - %(commenter)s</p> <blockquote><p>%(comment)s</p></blockquote> <p>يرجى الرد على هذه على: <a href=\"%(app_url)s\">%(app_url)s</a></p> <p>مع التحية،</p> <p>مكتبة ويكيبيديا</p>"
 
 #. Translators: This email is sent to coordinators when a comment is left on an application they are processing. Don't translate Jinja variables in curly braces like user or partner. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/comment_notification_coordinator-body-text.html:3
 #, python-format
-msgid ""
-"%(submit_date)s - %(commenter)s %(comment)s Please reply to this at: "
-"%(app_url)s Best, The Wikipedia Library"
-msgstr ""
-"%(submit_date)s - %(commenter)s %(comment)s يرجى الرد على هذه على: "
-"%(app_url)s مع التحية، مكتبة ويكيبيديا"
+msgid "%(submit_date)s - %(commenter)s %(comment)s Please reply to this at: %(app_url)s Best, The Wikipedia Library"
+msgstr "%(submit_date)s - %(commenter)s %(comment)s يرجى الرد على هذه على: %(app_url)s مع التحية، مكتبة ويكيبيديا"
 
 #. Translators: This is the subject line of an email sent to coordinators when a comment is left on an application they processed.
 #: TWLight/emails/templates/emails/comment_notification_coordinator-subject.html:3
@@ -1182,26 +1014,14 @@ msgstr "يوجد تعليق جديد على طلب مكتبة ويكيبيديا
 #. Translators: This email is sent to users when they receive a comment on their application. Don't translate Jinja variables in curly braces like user or partner; don't translate html tags either. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/comment_notification_editors-body-html.html:5
 #, python-format
-msgid ""
-"<p style=\"color: #500050\">%(submit_date)s - %(commenter)s</p> "
-"<blockquote><p>%(comment)s</p></blockquote> <p>Please reply to these at <a "
-"href=\"%(app_url)s\">%(app_url)s</a> so we can evaluate your application.</"
-"p> <p>Best,</p> <p>The Wikipedia Library</p>"
-msgstr ""
-"<p style=\"color: #500050\">%(submit_date)s - %(commenter)s</p> "
-"<blockquote><p>%(comment)s</p></blockquote> <p>يرجى الرد على هذه على <a href="
-"\"%(app_url)s\">%(app_url)s</a> حتى يمكننا تقييم طلبك.</p> <p>مع التحية،</p> "
-"<p>مكتبة ويكيبيديا</p>"
+msgid "<p style=\"color: #500050\">%(submit_date)s - %(commenter)s</p> <blockquote><p>%(comment)s</p></blockquote> <p>Please reply to these at <a href=\"%(app_url)s\">%(app_url)s</a> so we can evaluate your application.</p> <p>Best,</p> <p>The Wikipedia Library</p>"
+msgstr "<p style=\"color: #500050\">%(submit_date)s - %(commenter)s</p> <blockquote><p>%(comment)s</p></blockquote> <p>يرجى الرد على هذه على <a href=\"%(app_url)s\">%(app_url)s</a> حتى يمكننا تقييم طلبك.</p> <p>مع التحية،</p> <p>مكتبة ويكيبيديا</p>"
 
 #. Translators: This email is sent to users when they receive a comment on their application. Don't translate Jinja variables in curly braces like user or partner. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/comment_notification_editors-body-text.html:3
 #, python-format
-msgid ""
-"%(submit_date)s - %(commenter)s %(comment)s Please reply to these at: "
-"%(app_url)s so we can evaluate your application. Best, The Wikipedia Library"
-msgstr ""
-"%(submit_date)s - %(commenter)s %(comment)s يرجى الرد على هذه على "
-"%(app_url)s حتى يمكننا تقييم طلبك. مع التحية، مكتبة ويكيبيديا"
+msgid "%(submit_date)s - %(commenter)s %(comment)s Please reply to these at: %(app_url)s so we can evaluate your application. Best, The Wikipedia Library"
+msgstr "%(submit_date)s - %(commenter)s %(comment)s يرجى الرد على هذه على %(app_url)s حتى يمكننا تقييم طلبك. مع التحية، مكتبة ويكيبيديا"
 
 #. Translators: This is the subject line of an email sent to users who have a comment added to one of their applications. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/comment_notification_editors-subject.html:3
@@ -1211,24 +1031,14 @@ msgstr "يوجد تعليق جديد على طلبك الذي قدمته إلى 
 #. Translators: This email is sent to users when an application they commented on receives another comment. Don't translate Jinja variables in curly braces like app_url; don't translate html tags either. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/comment_notification_others-body-html.html:5
 #, python-format
-msgid ""
-"<p style=\"color: #500050\">%(submit_date)s - %(commenter)s</p> "
-"<blockquote><p>%(comment)s</p></blockquote> See it at <a href=\"%(app_url)s"
-"\">%(app_url)s</a>. Thanks for helping review Wikipedia Library applications!"
-msgstr ""
-"<p style=\"color: #500050\">%(submit_date)s - %(commenter)s</p> "
-"<blockquote><p>%(comment)s</p></blockquote>طالعه على <a href=\"%(app_url)s\">"
-"%(app_url)s</a>. نشكرك على مساعدتنا في مراجعة طلبات مكتبة ويكيبيديا!"
+msgid "<p style=\"color: #500050\">%(submit_date)s - %(commenter)s</p> <blockquote><p>%(comment)s</p></blockquote> See it at <a href=\"%(app_url)s\">%(app_url)s</a>. Thanks for helping review Wikipedia Library applications!"
+msgstr "<p style=\"color: #500050\">%(submit_date)s - %(commenter)s</p> <blockquote><p>%(comment)s</p></blockquote>طالعه على <a href=\"%(app_url)s\">%(app_url)s</a>. نشكرك على مساعدتنا في مراجعة طلبات مكتبة ويكيبيديا!"
 
 #. Translators: This email is sent to users when an application they commented on receives another comment. Don't translate Jinja variables in curly braces like app_url. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/comment_notification_others-body-text.html:3
 #, python-format
-msgid ""
-"%(submit_date)s - %(commenter)s %(comment)s See it at: %(app_url)s Thanks "
-"for helping review Wikipedia Library applications!"
-msgstr ""
-"%(submit_date)s - %(commenter)s %(comment)s طالعه على %(app_url)s. نشكرك على "
-"مساعدتنا في مراجعة طلبات مكتبة ويكيبيديا!"
+msgid "%(submit_date)s - %(commenter)s %(comment)s See it at: %(app_url)s Thanks for helping review Wikipedia Library applications!"
+msgstr "%(submit_date)s - %(commenter)s %(comment)s طالعه على %(app_url)s. نشكرك على مساعدتنا في مراجعة طلبات مكتبة ويكيبيديا!"
 
 #. Translators: This is the subject line of an email sent to users who have a comment added to an application they also commented on. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/comment_notification_others-subject.html:4
@@ -1238,13 +1048,8 @@ msgstr "يوجد تعليق جديد على أحد طلبات مكتبة ويك�
 #. Translators: This text is part of a scheduled reminder email sent to coordinators who have applications requiring action. Don't translate Jinja variables in curly braces like total_apps, or user.
 #: TWLight/emails/templates/emails/coordinator_reminder_notification-body-html.html:5
 #, python-format
-msgid ""
-"<p>Dear %(user)s,</p> <p>Our records indicate that you are the designated "
-"coordinator for partners that have a total of %(total_apps)s applications.</"
-"p>"
-msgstr ""
-"<p>عزيزي %(user)s،</p> <p>تشير سجلاتنا إلى أنك المنسق المخصص للشركاء الذين "
-"يوجد لهم عدد إجمالي من الطلبات قدره %(total_apps)s طلب/طلبات.</p>"
+msgid "<p>Dear %(user)s,</p> <p>Our records indicate that you are the designated coordinator for partners that have a total of %(total_apps)s applications.</p>"
+msgstr "<p>عزيزي %(user)s،</p> <p>تشير سجلاتنا إلى أنك المنسق المخصص للشركاء الذين يوجد لهم عدد إجمالي من الطلبات قدره %(total_apps)s طلب/طلبات.</p>"
 
 #. Translators: Breakdown as in 'cost breakdown'; analysis.
 #: TWLight/emails/templates/emails/coordinator_reminder_notification-body-html.html:11
@@ -1294,43 +1099,20 @@ msgstr[5] "%(counter)s طلب حصل على موافقة."
 #. Translators: This text is part of a scheduled reminder email sent to coordinators who have applications requiring action. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library). Don't translate Jinja variables in curly braces like link; don't translate email addresses or html tags either.
 #: TWLight/emails/templates/emails/coordinator_reminder_notification-body-html.html:39
 #, python-format
-msgid ""
-"<p>This is a gentle reminder that you may review applications at <a href="
-"\"%(link)s\">%(link)s</a>.</p> <p>You can customise your reminders under "
-"'preferences' in your user profile.</p> <p>If you received this message in "
-"error, drop us a line at wikipedialibrary@wikimedia.org.</p> <p>Thanks for "
-"helping review Wikipedia Library applications!</p>"
-msgstr ""
-"<p>هذا تذكير لطيف أنه يجوز لك مراجعة الطلبات على <a href=\"%(link)s\">"
-"%(link)s</a>.</p> <p>يمكنك تخصيص تذكيراتك من قسم «التفضيلات» في ملف تعريف "
-"مستخدمك.</p> <p>لو تلقيت هذه الرسالة عن طريق الخطأ، أرسل لنا رسالة على "
-"العنوان wikipedialibrary@wikimedia.org.</p> <p>نشكرك على مساعدتنا في مراجعة "
-"طلبات مكتبة ويكيبيديا!</p>"
+msgid "<p>This is a gentle reminder that you may review applications at <a href=\"%(link)s\">%(link)s</a>.</p> <p>You can customise your reminders under 'preferences' in your user profile.</p> <p>If you received this message in error, drop us a line at wikipedialibrary@wikimedia.org.</p> <p>Thanks for helping review Wikipedia Library applications!</p>"
+msgstr "<p>هذا تذكير لطيف أنه يجوز لك مراجعة الطلبات على <a href=\"%(link)s\">%(link)s</a>.</p> <p>يمكنك تخصيص تذكيراتك من قسم «التفضيلات» في ملف تعريف مستخدمك.</p> <p>لو تلقيت هذه الرسالة عن طريق الخطأ، أرسل لنا رسالة على العنوان wikipedialibrary@wikimedia.org.</p> <p>نشكرك على مساعدتنا في مراجعة طلبات مكتبة ويكيبيديا!</p>"
 
 #. Translators: This text is part of a scheduled reminder email sent to coordinators who have applications requiring action. Don't translate Jinja variables in curly braces like total_apps, or user.
 #: TWLight/emails/templates/emails/coordinator_reminder_notification-body-text.html:3
 #, python-format
-msgid ""
-"Dear %(user)s, Our records indicate that you are the designated coordinator "
-"for partners that have a total of %(total_apps)s applications."
-msgstr ""
-"عزيزي %(user)s، تشير سجلاتنا إلى أنك المنسق المخصص للشركاء الذين يوجد لهم "
-"عدد إجمالي من الطلبات قدره %(total_apps)s طلب/طلبات."
+msgid "Dear %(user)s, Our records indicate that you are the designated coordinator for partners that have a total of %(total_apps)s applications."
+msgstr "عزيزي %(user)s، تشير سجلاتنا إلى أنك المنسق المخصص للشركاء الذين يوجد لهم عدد إجمالي من الطلبات قدره %(total_apps)s طلب/طلبات."
 
 #. Translators: This text is part of a scheduled reminder email sent to coordinators who have applications requiring action. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library). Don't translate Jinja variables in curly braces like link; don't translate the email address either.
 #: TWLight/emails/templates/emails/coordinator_reminder_notification-body-text.html:38
 #, python-format
-msgid ""
-"This is a gentle reminder that you may review applications at: %(link)s. You "
-"can customise your reminders under 'preferences' in your user profile. If "
-"you received this message in error, drop us a line at: "
-"wikipedialibrary@wikimedia.org Thanks for helping review Wikipedia Library "
-"applications!"
-msgstr ""
-"هذا تذكير لطيف أنه يجوز لك مراجعة الطلبات على %(link)s. يمكنك تخصيص تذكيراتك "
-"من قسم «التفضيلات» في ملف تعريف مستخدمك. لو تلقيت هذه الرسالة عن طريق الخطأ، "
-"أرسل لنا رسالة على العنوان wikipedialibrary@wikimedia.org. نشكرك على "
-"مساعدتنا في مراجعة طلبات مكتبة ويكيبيديا!"
+msgid "This is a gentle reminder that you may review applications at: %(link)s. You can customise your reminders under 'preferences' in your user profile. If you received this message in error, drop us a line at: wikipedialibrary@wikimedia.org Thanks for helping review Wikipedia Library applications!"
+msgstr "هذا تذكير لطيف أنه يجوز لك مراجعة الطلبات على %(link)s. يمكنك تخصيص تذكيراتك من قسم «التفضيلات» في ملف تعريف مستخدمك. لو تلقيت هذه الرسالة عن طريق الخطأ، أرسل لنا رسالة على العنوان wikipedialibrary@wikimedia.org. نشكرك على مساعدتنا في مراجعة طلبات مكتبة ويكيبيديا!"
 
 #. Translators: This is the subject line of a scheduled reminder email sent to coordinators who have applications to review. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library). Do not translate items in curly braces.
 #: TWLight/emails/templates/emails/coordinator_reminder_notification-subject.html:4
@@ -1340,30 +1122,14 @@ msgstr "طلبات مكتبة ويكيبيديا تنتظر مراجعتك"
 #. Translators: This email is sent to users when their application is rejected. Don't translate Jinja variables in curly braces like user or partner; don't translate html tags either. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/rejection_notification-body-html.html:5
 #, python-format
-msgid ""
-"<p>Dear %(user)s,</p> <p>Thank you for applying for access to %(partner)s "
-"resources through The Wikipedia Library. Unfortunately at this time your "
-"application has not been approved. You can view your application and review "
-"comments at <a href=\"%(app_url)s\">%(app_url)s</a>.</p> <p>Best,</p> <p>The "
-"Wikipedia Library</p>"
-msgstr ""
-"<p>عزيزي %(user)s،</p> <p>شكرا لك على التقدم بطلب للوصول إلى موارد "
-"%(partner)s عن طريق مكتبة ويكيبيديا. لسوء الحظ لم يحظى طلبك على الموافقة "
-"حاليًا. يمكنك مطالعة طلبك ومراجعة التعليقات على <a href=\"%(app_url)s\">"
-"%(app_url)s</a>.</p> <p>مع التحية،</p> <p>مكتبة ويكيبيديا</p>"
+msgid "<p>Dear %(user)s,</p> <p>Thank you for applying for access to %(partner)s resources through The Wikipedia Library. Unfortunately at this time your application has not been approved. You can view your application and review comments at <a href=\"%(app_url)s\">%(app_url)s</a>.</p> <p>Best,</p> <p>The Wikipedia Library</p>"
+msgstr "<p>عزيزي %(user)s،</p> <p>شكرا لك على التقدم بطلب للوصول إلى موارد %(partner)s عن طريق مكتبة ويكيبيديا. لسوء الحظ لم يحظى طلبك على الموافقة حاليًا. يمكنك مطالعة طلبك ومراجعة التعليقات على <a href=\"%(app_url)s\">%(app_url)s</a>.</p> <p>مع التحية،</p> <p>مكتبة ويكيبيديا</p>"
 
 #. Translators: This email is sent to users when their application is rejected. Don't translate Jinja variables in curly braces like user or partner. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/rejection_notification-body-text.html:3
 #, python-format
-msgid ""
-"Dear %(user)s, Thank you for applying for access to %(partner)s resources "
-"through The Wikipedia Library. Unfortunately at this time your application "
-"has not been approved. You can view your application and review comments at: "
-"%(app_url)s Best, The Wikipedia Library"
-msgstr ""
-"عزيزي %(user)s، شكرا لك على التقدم بطلب للوصول إلى موارد %(partner)s عن طريق "
-"مكتبة ويكيبيديا. لسوء الحظ لم يحظى طلبك على الموافقة حاليًا. يمكنك مطالعة "
-"طلبك ومراجعة التعليقات على %(app_url)s. مع التحية، مكتبة ويكيبيديا"
+msgid "Dear %(user)s, Thank you for applying for access to %(partner)s resources through The Wikipedia Library. Unfortunately at this time your application has not been approved. You can view your application and review comments at: %(app_url)s Best, The Wikipedia Library"
+msgstr "عزيزي %(user)s، شكرا لك على التقدم بطلب للوصول إلى موارد %(partner)s عن طريق مكتبة ويكيبيديا. لسوء الحظ لم يحظى طلبك على الموافقة حاليًا. يمكنك مطالعة طلبك ومراجعة التعليقات على %(app_url)s. مع التحية، مكتبة ويكيبيديا"
 
 #. Translators: This is the subject of an email which is sent to users when their application has been rejected. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/rejection_notification-subject.html:4
@@ -1373,37 +1139,14 @@ msgstr "الطلب الذي أرسلت إلى مكتبة ويكيبيديا"
 #. Translators: This email is sent to users when they have an account that is soon to expire. Don't translate Jinja variables in curly braces like partner_name or partner_link; don't translate html tags either. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/user_renewal_notice-body-html.html:5
 #, python-format
-msgid ""
-"<p>Dear %(user)s,</p> <p>According to our records, your access to "
-"%(partner_name)s will soon expire and you may lose access. If you want to "
-"continue making use of your free account, you can request renewal of your "
-"account by clicking the 'Renew' or 'Extend' button at %(partner_link)s.</p> "
-"<p>Best,</p> <p>The Wikipedia Library</p> <p>You can disable these emails in "
-"your user page preferences: https://wikipedialibrary.wmflabs.org/users/</p>"
-msgstr ""
-"<p>عزيزي %(user)s،</p> <p>وفقًا لسجلاتنا، ستنتهي صلاحية وصولك إلى "
-"%(partner_name)s قريبًا وقد تفقد صلاحية الوصول. إن كنت ترغب في الاستمرار في "
-"الانتفاع بحسابك المجاني، يمكنك طلب تجديد حسابك بالضغط على زر «تجديد» على "
-"%(partner_link)s.</p> <p>مع التحية،</p> <p>مكتبة ويكيبيديا</p> <p>يمكنك "
-"تعطيل رسائل البريد الإلكتروني هذه في تفضيلات صفحة المستخدم الخاصة بك: "
-"https://wikipedialibrary.wmflabs.org/users/</p>"
+msgid "<p>Dear %(user)s,</p> <p>According to our records, your access to %(partner_name)s will soon expire and you may lose access. If you want to continue making use of your free account, you can request renewal of your account by clicking the 'Renew' or 'Extend' button at %(partner_link)s.</p> <p>Best,</p> <p>The Wikipedia Library</p> <p>You can disable these emails in your user page preferences: https://wikipedialibrary.wmflabs.org/users/</p>"
+msgstr "<p>عزيزي %(user)s،</p> <p>وفقًا لسجلاتنا، ستنتهي صلاحية وصولك إلى %(partner_name)s قريبًا وقد تفقد صلاحية الوصول. إن كنت ترغب في الاستمرار في الانتفاع بحسابك المجاني، يمكنك طلب تجديد حسابك بالضغط على زر «تجديد» على %(partner_link)s.</p> <p>مع التحية،</p> <p>مكتبة ويكيبيديا</p> <p>يمكنك تعطيل رسائل البريد الإلكتروني هذه في تفضيلات صفحة المستخدم الخاصة بك: https://wikipedialibrary.wmflabs.org/users/</p>"
 
 #. Translators: This email is sent to users when they have an account that is soon to expire. Don't translate Jinja variables in curly braces like partner_name or partner_link; don't translate html tags either. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/user_renewal_notice-body-text.html:3
 #, python-format
-msgid ""
-"Dear %(user)s, According to our records, your access to %(partner_name)s "
-"will soon expire and you may lose access. If you want to continue making use "
-"of your free account, you can request renewal of your account by clicking "
-"the Renew button at %(partner_link)s. Best, The Wikipedia Library You can "
-"disable these emails in your user page preferences: https://wikipedialibrary."
-"wmflabs.org/users/"
-msgstr ""
-"عزيزي %(user)s، وفقًا لسجلاتنا، ستنتهي صلاحية وصولك إلى %(partner_name)s "
-"قريبًا وقد تفقد صلاحية الوصول. إن كنت ترغب في الاستمرار في الانتفاع بحسابك "
-"المجاني، يمكنك طلب تجديد حسابك بالضغط على زر «تجديد» على %(partner_link)s. "
-"مع التحية، مكتبة ويكيبيديا يمكنك تعطيل رسائل البريد الإلكتروني هذه في "
-"تفضيلات صفحة المستخدم الخاصة بك: https://wikipedialibrary.wmflabs.org/users/"
+msgid "Dear %(user)s, According to our records, your access to %(partner_name)s will soon expire and you may lose access. If you want to continue making use of your free account, you can request renewal of your account by clicking the Renew button at %(partner_link)s. Best, The Wikipedia Library You can disable these emails in your user page preferences: https://wikipedialibrary.wmflabs.org/users/"
+msgstr "عزيزي %(user)s، وفقًا لسجلاتنا، ستنتهي صلاحية وصولك إلى %(partner_name)s قريبًا وقد تفقد صلاحية الوصول. إن كنت ترغب في الاستمرار في الانتفاع بحسابك المجاني، يمكنك طلب تجديد حسابك بالضغط على زر «تجديد» على %(partner_link)s. مع التحية، مكتبة ويكيبيديا يمكنك تعطيل رسائل البريد الإلكتروني هذه في تفضيلات صفحة المستخدم الخاصة بك: https://wikipedialibrary.wmflabs.org/users/"
 
 #. Translators: This is the subject of an email sent to users when they have an account that is soon to expire. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/user_renewal_notice-subject.html:4
@@ -1413,34 +1156,14 @@ msgstr "قد تنتهي صلاحية وصولك لمكتبة ويكيبيديا 
 #. Translators: This email is sent to users when their application is waitlisted because there are no more accounts available. Don't translate Jinja variables in curly braces like user or partner; don't translate html tags either. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/waitlist_notification-body-html.html:5
 #, python-format
-msgid ""
-"<p>Dear %(user)s,</p> <p>Thank you for applying for access to %(partner)s "
-"resources through The Wikipedia Library. There are no accounts currently "
-"available so your application has been waitlisted. Your application will be "
-"evaluated if/when more accounts become available. You can see all available "
-"resources at <a href=\"%(link)s\">%(link)s</a>.</p> <p>Best,</p> <p>The "
-"Wikipedia Library</p>"
-msgstr ""
-"<p>عزيزي %(user)s،</p> <p>شكرا لك على التقدم للحصول على موارد %(partner)s من "
-"خلال مكتبة ويكيبيديا، لا توجد حسابات متاحة حاليا لذا تم وضع طلبك في قائمة "
-"الانتظار، سيتم تقييم طلبك إذا/عند توفر المزيد من الحسابات، يمكنك أن ترى جميع "
-"الموارد المتاحة في <a href=\"%(link)s\">%(link)s</a>.</p> <p>الأفضل،</p> "
-"<p>مكتبة ويكيبيديا</p>"
+msgid "<p>Dear %(user)s,</p> <p>Thank you for applying for access to %(partner)s resources through The Wikipedia Library. There are no accounts currently available so your application has been waitlisted. Your application will be evaluated if/when more accounts become available. You can see all available resources at <a href=\"%(link)s\">%(link)s</a>.</p> <p>Best,</p> <p>The Wikipedia Library</p>"
+msgstr "<p>عزيزي %(user)s،</p> <p>شكرا لك على التقدم للحصول على موارد %(partner)s من خلال مكتبة ويكيبيديا، لا توجد حسابات متاحة حاليا لذا تم وضع طلبك في قائمة الانتظار، سيتم تقييم طلبك إذا/عند توفر المزيد من الحسابات، يمكنك أن ترى جميع الموارد المتاحة في <a href=\"%(link)s\">%(link)s</a>.</p> <p>الأفضل،</p> <p>مكتبة ويكيبيديا</p>"
 
 #. Translators: This email is sent to users when their application is waitlisted because there are no more accounts available. Don't translate Jinja variables in curly braces like user or partner. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/waitlist_notification-body-text.html:3
 #, python-format
-msgid ""
-"Dear %(user)s, Thank you for applying for access to %(partner)s resources "
-"through The Wikipedia Library. There are no accounts currently available so "
-"your application has been waitlisted. Your application will be evaluated if/"
-"when more accounts become available. You can see all available resources at: "
-"%(link)s Best, The Wikipedia Library"
-msgstr ""
-"عزيزي %(user)s، نشكرك على التقدم بطلب للحصول على موارد %(partner)s من خلال "
-"مكتبة ويكيبيديا، لا توجد حسابات متاحة حاليا حتى يتم إدراج طلبك في القائمة، "
-"سيتم تقييم طلبك إذا/عندما تتوفر المزيد من الحسابات، يمكنك الاطلاع على جميع "
-"الموارد المتاحة على: %(link)s، الأفضل، مكتبة ويكيبيديا"
+msgid "Dear %(user)s, Thank you for applying for access to %(partner)s resources through The Wikipedia Library. There are no accounts currently available so your application has been waitlisted. Your application will be evaluated if/when more accounts become available. You can see all available resources at: %(link)s Best, The Wikipedia Library"
+msgstr "عزيزي %(user)s، نشكرك على التقدم بطلب للحصول على موارد %(partner)s من خلال مكتبة ويكيبيديا، لا توجد حسابات متاحة حاليا حتى يتم إدراج طلبك في القائمة، سيتم تقييم طلبك إذا/عندما تتوفر المزيد من الحسابات، يمكنك الاطلاع على جميع الموارد المتاحة على: %(link)s، الأفضل، مكتبة ويكيبيديا"
 
 #. Translators: This is the subject of an email sent to users when their application is waitlisted because there are no more accounts available. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/waitlist_notification-subject.html:4
@@ -1601,19 +1324,14 @@ msgstr "غير متاحة"
 #: TWLight/resources/templates/resources/filter_section.html:14
 #: TWLight/templates/about.html:12
 #: TWLight/users/templates/users/filter_section.html:13
-msgid ""
-"The Wikipedia Library allows active editors to access a wide range of "
-"collections of paywalled reliable sources for free!"
-msgstr ""
-"تسمح مكتبة ويكيبيديا للمحررين النشطين بالوصول إلى مجموعة واسعة من مجموعات "
-"المصادر الموثوقة المحمية بنظام حظر الاشتراك غير المدفوع مجانًا!"
+msgid "The Wikipedia Library allows active editors to access a wide range of collections of paywalled reliable sources for free!"
+msgstr "تسمح مكتبة ويكيبيديا للمحررين النشطين بالوصول إلى مجموعة واسعة من مجموعات المصادر الموثوقة المحمية بنظام حظر الاشتراك غير المدفوع مجانًا!"
 
 #. Translators: On the Browse Partners page (https://wikipedialibrary.wmflabs.org/partners/), this introduces users to The Wikipedia Library.
 #. Translators: On the MyLibrary page (https://wikipedialibrary.wmflabs.org/users/my_library), this introduces users to The Wikipedia Library.
 #: TWLight/resources/templates/resources/filter_section.html:17
 #: TWLight/users/templates/users/filter_section.html:15
-msgid ""
-"Start with the search bar at the top or browse publisher websites directly."
+msgid "Start with the search bar at the top or browse publisher websites directly."
 msgstr "ابدأ بشريط البحث في الأعلى أو تصفح مواقع الناشرين مباشرة."
 
 #. Translators: On the Browse Partners page (https://wikipedialibrary.wmflabs.org/partners/), this appears below introductory text and links to the 'About' page (https://wikipedialibrary.wmflabs.org/about/)
@@ -1687,67 +1405,39 @@ msgstr "العودة إلى الشركاء"
 #. Translators: If we have no available accounts for a partner, the coordinator can change the application system to a waiting list.
 #: TWLight/resources/templates/resources/partner_detail.html:36
 #: TWLight/resources/templates/resources/partner_detail_apply.html:17
-msgid ""
-"There are no access grants available for this partner at this time. You can "
-"still apply for access; applications will be processed when access is "
-"available."
-msgstr ""
-"هذا الشريك لا يوفر حسابات دخول مجانية إلى مصدره في الوقت الحالي. يمكنك رغم "
-"ذلك طلب حق الدخول المجاني إلى المصدر. سوف تتم مراجعة طلبك عندما يوفر الشريك "
-"الحسابات المجانية."
+msgid "There are no access grants available for this partner at this time. You can still apply for access; applications will be processed when access is available."
+msgstr "هذا الشريك لا يوفر حسابات دخول مجانية إلى مصدره في الوقت الحالي. يمكنك رغم ذلك طلب حق الدخول المجاني إلى المصدر. سوف تتم مراجعة طلبك عندما يوفر الشريك الحسابات المجانية."
 
 #. Translators: This text links to the minimum user requirements and terms of use on the partner page.
 #: TWLight/resources/templates/resources/partner_detail.html:48
 #: TWLight/resources/templates/resources/partner_detail_apply.html:29
 #, python-format
-msgid ""
-"Before applying, please review the <strong><a class=\"twl-links\" href="
-"\"%(about)s#req\">minimum requirements</a></strong> for access and our "
-"<strong><a class=\"twl-links\" href=\"%(terms)s\">terms of use</a></strong>."
-msgstr ""
-"قبل التقديم، تُرجًى مراجعة <a class=\"twl-links\" href=\"%(about)s#req\">الحد "
-"الأدنى من المتطلبات</a></strong> للوصول و<a class=\"twl-links\" href="
-"\"%(terms)s\">شروط استخدامنا</a></strong>."
+msgid "Before applying, please review the <strong><a class=\"twl-links\" href=\"%(about)s#req\">minimum requirements</a></strong> for access and our <strong><a class=\"twl-links\" href=\"%(terms)s\">terms of use</a></strong>."
+msgstr "قبل التقديم، تُرجًى مراجعة <a class=\"twl-links\" href=\"%(about)s#req\">الحد الأدنى من المتطلبات</a></strong> للوصول و<a class=\"twl-links\" href=\"%(terms)s\">شروط استخدامنا</a></strong>."
 
 #. Translators: This text refers to the page containing the content a user is authorized to access.
 #: TWLight/resources/templates/resources/partner_detail.html:69
 #, python-format
-msgid ""
-"View the status of your access in <strong><a class=\"twl-links\" href="
-"\"%(library_url)s\">My Library</a></strong> page."
-msgstr ""
-"اعرض حالة وصولك في صفحة <strong><a class=\"twl-links\" href=\"%(library_url)s"
-"\">مكتبتي</a></strong> ."
+msgid "View the status of your access in <strong><a class=\"twl-links\" href=\"%(library_url)s\">My Library</a></strong> page."
+msgstr "اعرض حالة وصولك في صفحة <strong><a class=\"twl-links\" href=\"%(library_url)s\">مكتبتي</a></strong> ."
 
 #. Translators: This message is shown when a user has open applications, linking to their respective applications page.
 #: TWLight/resources/templates/resources/partner_detail.html:78
 #, python-format
-msgid ""
-"View the status of your application(s) on your <strong><a class=\"twl-links"
-"\" href=\"%(applications_url)s\">My Applications</a></strong> page."
-msgstr ""
-"اعرض حالة طلبك (طلباتك) على صفحة <strong><a class=\"twl-links\" href="
-"\"%(applications_url)s\">\"تطبيقاتي\"</a></strong> الخاصة بك."
+msgid "View the status of your application(s) on your <strong><a class=\"twl-links\" href=\"%(applications_url)s\">My Applications</a></strong> page."
+msgstr "اعرض حالة طلبك (طلباتك) على صفحة <strong><a class=\"twl-links\" href=\"%(applications_url)s\">\"تطبيقاتي\"</a></strong> الخاصة بك."
 
 #. Translators: This message is shown when a user has authorizations, linking to their respective collections page.
 #: TWLight/resources/templates/resources/partner_detail_apply.html:50
 #, python-format
-msgid ""
-"View the status of your access on your <strong><a href=\"%(library_url)s\" "
-"class=\"twl-links\">My Library</a></strong> page."
-msgstr ""
-"اعرض حالة وصولك على صفحة <strong><a href=\"%(library_url)s\" class=\"twl-"
-"links\">مكتبتي</a></strong> ."
+msgid "View the status of your access on your <strong><a href=\"%(library_url)s\" class=\"twl-links\">My Library</a></strong> page."
+msgstr "اعرض حالة وصولك على صفحة <strong><a href=\"%(library_url)s\" class=\"twl-links\">مكتبتي</a></strong> ."
 
 #. Translators: This message is shown when a user has open applications, linking to their respective applications page.
 #: TWLight/resources/templates/resources/partner_detail_apply.html:60
 #, python-format
-msgid ""
-"View the status of your application(s) on your <strong><a href="
-"\"%(applications_url)s\">My Applications</a></strong> page."
-msgstr ""
-"اعرض حالة طلبك (طلباتك) على صفحة <strong><a href=\"%(applications_url)s\">"
-"\"تطبيقاتي\"</a></strong> الخاصة بك."
+msgid "View the status of your application(s) on your <strong><a href=\"%(applications_url)s\">My Applications</a></strong> page."
+msgstr "اعرض حالة طلبك (طلباتك) على صفحة <strong><a href=\"%(applications_url)s\">\"تطبيقاتي\"</a></strong> الخاصة بك."
 
 #. Translators: One the partner detail page, this text labels the button which coordinators can click to remove a partner from waitlisted status.
 #: TWLight/resources/templates/resources/partner_detail_apply.html:73
@@ -1776,14 +1466,8 @@ msgstr "صفحة خاص:مراسلة المستخدم"
 
 #. Translators: If no account coordinator is assigned to a partner, the Wikipedia Library team will coordinate signups. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/resources/templates/resources/partner_detail_apply.html:112
-msgid ""
-"The Wikipedia Library team will process this application. Want to help? <a "
-"class=\"twl-links\" href=\"https://en.wikipedia.org/wiki/Wikipedia:"
-"The_Wikipedia_Library/Coordinators/Signup\">Sign up as a coordinator.</a>"
-msgstr ""
-"سيقوم فريق مكتبة ويكيبيديا بمعالجة هذا الطلب، تريد أن تساعد؟ <a class=\"twl-"
-"links\" href=\"https://en.wikipedia.org/wiki/Wikipedia:The_Wikipedia_Library/"
-"Coordinators/Signup\">قم بالتسجيل كمنسق.</a>"
+msgid "The Wikipedia Library team will process this application. Want to help? <a class=\"twl-links\" href=\"https://en.wikipedia.org/wiki/Wikipedia:The_Wikipedia_Library/Coordinators/Signup\">Sign up as a coordinator.</a>"
+msgstr "سيقوم فريق مكتبة ويكيبيديا بمعالجة هذا الطلب، تريد أن تساعد؟ <a class=\"twl-links\" href=\"https://en.wikipedia.org/wiki/Wikipedia:The_Wikipedia_Library/Coordinators/Signup\">قم بالتسجيل كمنسق.</a>"
 
 #. Translators: This text labels a button coordinators can click to view a list of users who have applied for access for a particular partner
 #: TWLight/resources/templates/resources/partner_detail_apply.html:121
@@ -1813,23 +1497,14 @@ msgstr "حزمة المكتبة"
 
 #. Translators: Text shown to authenticated, bundle eligible users when they visit a Bundle partner page.
 #: TWLight/resources/templates/resources/partner_detail_apply.html:138
-msgid ""
-"You are eligible to access Library Bundle partners. Click the button above "
-"to access the collection."
-msgstr ""
-"أنت مؤهل للوصول إلى شركاء رزمة المكتبة. انقر فوق الزر أعلاه للوصول إلى "
-"المجموعة."
+msgid "You are eligible to access Library Bundle partners. Click the button above to access the collection."
+msgstr "أنت مؤهل للوصول إلى شركاء رزمة المكتبة. انقر فوق الزر أعلاه للوصول إلى المجموعة."
 
 #. Translators: Text shown to authenticated, bundle ineligible users when they visit a Bundle partner page.
 #: TWLight/resources/templates/resources/partner_detail_apply.html:152
 #, python-format
-msgid ""
-"You are not eligible to access Library Bundle partners. Visit the <a class="
-"\"twl-links\" href=\"%(homepage)s\">homepage</a> to check the eligibility "
-"criteria."
-msgstr ""
-"لست مؤهلاً للوصول إلى شركاء رزمة المكتبة. بإمكانك زيارة <a class=\"twl-links"
-"\" href=\"%(homepage)s\">الصفحة الرئيسة</a> للتحقق من معايير الأهلية."
+msgid "You are not eligible to access Library Bundle partners. Visit the <a class=\"twl-links\" href=\"%(homepage)s\">homepage</a> to check the eligibility criteria."
+msgstr "لست مؤهلاً للوصول إلى شركاء رزمة المكتبة. بإمكانك زيارة <a class=\"twl-links\" href=\"%(homepage)s\">الصفحة الرئيسة</a> للتحقق من معايير الأهلية."
 
 #. Translators: Buttton prompting users to log in.
 #: TWLight/resources/templates/resources/partner_detail_apply.html:160
@@ -1840,14 +1515,8 @@ msgstr "تسجيل الدخول"
 #. Translators: Text shown to unauthenticated users when they visit a Bundle partner page.
 #: TWLight/resources/templates/resources/partner_detail_apply.html:168
 #, python-format
-msgid ""
-"This resource is part of our <a class=\"twl-links\" href=\"%(about)s"
-"\">Library Bundle</a>, which you can access if you meet our minimum "
-"eligibility criteria. Log in to find out if you are eligible."
-msgstr ""
-"هذا المصدر هو جزء من <a class=\"twl-links\" href=\"%(about)s\">حزمة المكتبة</"
-"a> الخاصة بنا ، والتي يمكنك الوصول إليها إذا كنت تستوفي الحد الأدنى من "
-"معايير الأهلية لدينا. قم بتسجيل الدخول لمعرفة ما إذا كنت مؤهلاً."
+msgid "This resource is part of our <a class=\"twl-links\" href=\"%(about)s\">Library Bundle</a>, which you can access if you meet our minimum eligibility criteria. Log in to find out if you are eligible."
+msgstr "هذا المصدر هو جزء من <a class=\"twl-links\" href=\"%(about)s\">حزمة المكتبة</a> الخاصة بنا ، والتي يمكنك الوصول إليها إذا كنت تستوفي الحد الأدنى من معايير الأهلية لدينا. قم بتسجيل الدخول لمعرفة ما إذا كنت مؤهلاً."
 
 #. Translators: This is the label for a number which shows the total active accounts for one partner. (e.g. https://wikipedialibrary.wmflabs.org/partners/8/).
 #: TWLight/resources/templates/resources/partner_detail_stats.html:21
@@ -1898,34 +1567,20 @@ msgstr "حد المقتطف"
 #. Translators: If a partner has specified the excerpt limit both in words and percentage, this message will display the percentage of words and the number of words on the partner page.
 #: TWLight/resources/templates/resources/partner_detail_timeline.html:99
 #, python-format
-msgid ""
-"%(object)s allows a maximum of %(excerpt_limit)s words or "
-"%(excerpt_limit_percentage)s%% of an article be excerpted into a Wikipedia "
-"article."
-msgstr ""
-"%(object)s يسمح بحد أقصى %(excerpt_limit)s كلمات أو "
-"%(excerpt_limit_percentage)s%% من مقالة في مقالة ليتم اقتباسها في مقالة "
-"ويكيبيديا."
+msgid "%(object)s allows a maximum of %(excerpt_limit)s words or %(excerpt_limit_percentage)s%% of an article be excerpted into a Wikipedia article."
+msgstr "%(object)s يسمح بحد أقصى %(excerpt_limit)s كلمات أو %(excerpt_limit_percentage)s%% من مقالة في مقالة ليتم اقتباسها في مقالة ويكيبيديا."
 
 #. Translators: If a partner has specified the excerpt limit in words, this message will display the number of words on the partner page.
 #: TWLight/resources/templates/resources/partner_detail_timeline.html:106
 #, python-format
-msgid ""
-"%(object)s allows a maximum of %(excerpt_limit)s words be excerpted into a "
-"Wikipedia article."
-msgstr ""
-"يسمح %(object)s بحد أقصى %(excerpt_limit)s كلمات ليتم اقتباس في مقالة "
-"ويكيبيديا."
+msgid "%(object)s allows a maximum of %(excerpt_limit)s words be excerpted into a Wikipedia article."
+msgstr "يسمح %(object)s بحد أقصى %(excerpt_limit)s كلمات ليتم اقتباس في مقالة ويكيبيديا."
 
 #. Translators: If a partner has specified the excerpt limit in percentage, this message will display the percentage of words on the partner page.
 #: TWLight/resources/templates/resources/partner_detail_timeline.html:113
 #, python-format
-msgid ""
-"%(object)s allows a maximum of %(excerpt_limit_percentage)s%% of an article "
-"be excerpted into a Wikipedia article."
-msgstr ""
-"يسمح %(object)s بحد أقصى %(excerpt_limit_percentage)s%% من مقالة ليتم اقتباس "
-"في مقالة ويكيبيديا."
+msgid "%(object)s allows a maximum of %(excerpt_limit_percentage)s%% of an article be excerpted into a Wikipedia article."
+msgstr "يسمح %(object)s بحد أقصى %(excerpt_limit_percentage)s%% من مقالة ليتم اقتباس في مقالة ويكيبيديا."
 
 #. Translators: If a partner has other requirements for access, this text shows as the title for that information field. (e.g. https://wikipedialibrary.wmflabs.org/partners/10/).
 #: TWLight/resources/templates/resources/partner_detail_timeline.html:132
@@ -1935,11 +1590,8 @@ msgstr "شروط خاصة لطالبي الخدمة"
 #. Translators: If a user must agree to a Terms of Use document, they see this message, and must enter the name of the resource. Don't translate publisher or url.
 #: TWLight/resources/templates/resources/partner_detail_timeline.html:140
 #, python-format
-msgid ""
-"%(publisher)s requires that you agree with its <a href=\"%(url)s\">terms of "
-"use</a>."
-msgstr ""
-"%(publisher)s يتطلب أن توافق على <a href=\"%(url)s\">شروط استخدامه</a>."
+msgid "%(publisher)s requires that you agree with its <a href=\"%(url)s\">terms of use</a>."
+msgstr "%(publisher)s يتطلب أن توافق على <a href=\"%(url)s\">شروط استخدامه</a>."
 
 #. Translators: If a user must provide their real name to apply to a partner, they see this message, and must enter the name of the resource. Don't translate publisher.
 #: TWLight/resources/templates/resources/partner_detail_timeline.html:150
@@ -1962,19 +1614,14 @@ msgstr "%(publisher)s يتطلب منك تقديم انتسابك المؤسسي
 #. Translators: If a user must select a specific resource to apply for, they see this message, and must enter the name of the resource. Don't translate publisher.
 #: TWLight/resources/templates/resources/partner_detail_timeline.html:177
 #, python-format
-msgid ""
-"%(publisher)s requires that you specify a particular title that you want to "
-"access."
+msgid "%(publisher)s requires that you specify a particular title that you want to access."
 msgstr "%(publisher)s يتطلب منك تحديد عنوان محدد تريد الوصول إليه."
 
 #. Translators: If a user must register on the partner website before applying, they see this message. Don't translate partner.
 #: TWLight/resources/templates/resources/partner_detail_timeline.html:187
 #, python-format
-msgid ""
-"%(publisher)s requires that you sign up for an account before applying for "
-"access."
-msgstr ""
-"%(publisher)s يتطلب منك التسجيل للحصول على حساب قبل التقدم بطلب للوصول."
+msgid "%(publisher)s requires that you sign up for an account before applying for access."
+msgstr "%(publisher)s يتطلب منك التسجيل للحصول على حساب قبل التقدم بطلب للوصول."
 
 #. Translators: If a partner has their location listed, this message is a label for that location
 #: TWLight/resources/templates/resources/partner_detail_timeline.html:206
@@ -2100,12 +1747,8 @@ msgstr "هل أنت متأكد أنك تريد حذف <b>%(object)s</b>؟"
 
 #. Translators: If multiple authorizations where returned for a collection, this message is shown to a user
 #: TWLight/resources/views.py:268
-msgid ""
-"Multiple authorizations were returned – something's wrong. Please contact us "
-"and don't forget to mention this message."
-msgstr ""
-"أعيدت العديد من التفويضات، هناك خطأ ما. نرجو منك التواصل معنا ولا تنسى ذكر "
-"هذه الرسالة."
+msgid "Multiple authorizations were returned – something's wrong. Please contact us and don't forget to mention this message."
+msgstr "أعيدت العديد من التفويضات، هناك خطأ ما. نرجو منك التواصل معنا ولا تنسى ذكر هذه الرسالة."
 
 #. Translators: This message is shown when user tries to access a NOT_AVAILABLE Partner
 #: TWLight/resources/views.py:316
@@ -2145,22 +1788,8 @@ msgstr "آسفون؛ نحن لا نعرف ماذا نفعل مع ذلك."
 #. Translators: Shown on the website's 400 page, when a user sends a bad request. Don't translate path or Phabricator.
 #: TWLight/templates/400.html:20
 #, python-format
-msgid ""
-"If you think we should know what to do with that, please email us about this "
-"error at <a class=\"twl-links\" href=\"mailto:wikipedialibrary@wikimedia.org?"
-"Subject=Wikipedia%%20Library%%20%(path)s%%20Permission%%20denied"
-"\">wikipedialibrary@wikimedia.org</a> or report it to us on <a class=\"twl-"
-"links\" href=\"https://phabricator.wikimedia.org/maniphest/task/edit/form/1/?"
-"projectPHIDs=Library-Card-Platform&title=Wikipedia%%20Library%%20%(path)s"
-"%%20Bad%%20Request\">Phabricator</a>"
-msgstr ""
-"إذا كنت تعتقد أننا يجب أن نعرف ما يجب فعله بهذا الأمر، فتُرجَى مراسلتنا عبر "
-"البريد الإلكتروني حول هذا الخطأ على <a href=\"mailto:"
-"wikipedialibrary@wikimedia.org?Subject=Wikipedia%%20Library%%20%(path)s"
-"%%20Permission%%20denied\">wikipedialibrary@wikimedia.org</a> أو الإبلاغ عنه "
-"على <a href=\"https://phabricator.wikimedia.org/maniphest/task/edit/form/1/?"
-"projectPHIDs=Library-Card-Platform&title=Wikipedia%%20Library%%20%(path)s"
-"%%20Bad%%20Request\">فبريكاتور</a>"
+msgid "If you think we should know what to do with that, please email us about this error at <a class=\"twl-links\" href=\"mailto:wikipedialibrary@wikimedia.org?Subject=Wikipedia%%20Library%%20%(path)s%%20Permission%%20denied\">wikipedialibrary@wikimedia.org</a> or report it to us on <a class=\"twl-links\" href=\"https://phabricator.wikimedia.org/maniphest/task/edit/form/1/?projectPHIDs=Library-Card-Platform&title=Wikipedia%%20Library%%20%(path)s%%20Bad%%20Request\">Phabricator</a>"
+msgstr "إذا كنت تعتقد أننا يجب أن نعرف ما يجب فعله بهذا الأمر، فتُرجَى مراسلتنا عبر البريد الإلكتروني حول هذا الخطأ على <a href=\"mailto:wikipedialibrary@wikimedia.org?Subject=Wikipedia%%20Library%%20%(path)s%%20Permission%%20denied\">wikipedialibrary@wikimedia.org</a> أو الإبلاغ عنه على <a href=\"https://phabricator.wikimedia.org/maniphest/task/edit/form/1/?projectPHIDs=Library-Card-Platform&title=Wikipedia%%20Library%%20%(path)s%%20Bad%%20Request\">فبريكاتور</a>"
 
 #. Translators: Alt text for an image shown on the 400 error page.
 #. Translators: Alt text for an image shown on the 403 error page.
@@ -2181,23 +1810,8 @@ msgstr "آسفون، لم يسمح لك بالقيام بهذا الفعل."
 #. Translators: Shown on the website's 403 page, when a user attempts to navigate to a page they don't have permission to view. Don't translate path or Phabricator.
 #: TWLight/templates/403.html:20
 #, python-format
-msgid ""
-"If you think your account should be able to do that, please email us about "
-"this error at <a class=\"twl-links\" href=\"mailto:"
-"wikipedialibrary@wikimedia.org?Subject=Wikipedia%%20Library%%20%(path)s"
-"%%20Permission%%20denied\">wikipedialibrary@wikimedia.org</a> or report it "
-"to us on <a class=\"twl-links\" href=\"https://phabricator.wikimedia.org/"
-"maniphest/task/edit/form/1/?projectPHIDs=Library-Card-"
-"Platform&title=Wikipedia%%20Library%%20%(path)s%%20Permission%%20denied"
-"\">Phabricator</a>"
-msgstr ""
-"إذا كنت تعتقد أنه يجب أن يكون حسابك قادرًا على فعل ذلك،  فتُرجَى مراسلتنا عبر "
-"البريد الإلكتروني حول هذا الخطأ على <a href=\"mailto:"
-"wikipedialibrary@wikimedia.org?Subject=Wikipedia%%20Library%%20%(path)s"
-"%%20Permission%%20denied\">wikipedialibrary@wikimedia.org</a>أو الإبلاغ عنه "
-"على <a href=\"https://phabricator.wikimedia.org/maniphest/task/edit/form/1/?"
-"projectPHIDs=Library-Card-Platform&title=Wikipedia%%20Library%%20%(path)s"
-"%%20Permission%%20denied\">فبريكاتور</a>"
+msgid "If you think your account should be able to do that, please email us about this error at <a class=\"twl-links\" href=\"mailto:wikipedialibrary@wikimedia.org?Subject=Wikipedia%%20Library%%20%(path)s%%20Permission%%20denied\">wikipedialibrary@wikimedia.org</a> or report it to us on <a class=\"twl-links\" href=\"https://phabricator.wikimedia.org/maniphest/task/edit/form/1/?projectPHIDs=Library-Card-Platform&title=Wikipedia%%20Library%%20%(path)s%%20Permission%%20denied\">Phabricator</a>"
+msgstr "إذا كنت تعتقد أنه يجب أن يكون حسابك قادرًا على فعل ذلك،  فتُرجَى مراسلتنا عبر البريد الإلكتروني حول هذا الخطأ على <a href=\"mailto:wikipedialibrary@wikimedia.org?Subject=Wikipedia%%20Library%%20%(path)s%%20Permission%%20denied\">wikipedialibrary@wikimedia.org</a>أو الإبلاغ عنه على <a href=\"https://phabricator.wikimedia.org/maniphest/task/edit/form/1/?projectPHIDs=Library-Card-Platform&title=Wikipedia%%20Library%%20%(path)s%%20Permission%%20denied\">فبريكاتور</a>"
 
 #. Translators: Shown on the website's 404 page, when a user attempts to navigate to a page that doesn't exist.
 #: TWLight/templates/404.html:11
@@ -2212,22 +1826,8 @@ msgstr "آسفون، لا يمكننا العثور على ذلك."
 #. Translators: Shown on the website's 404 page, when a user attempts to navigate to a page that doesn't exist. Don't translate path or Phabricator.
 #: TWLight/templates/404.html:19
 #, python-format
-msgid ""
-"If you are certain that something should be here, please email us about this "
-"error at <a class=\"twl-links\" href=\"mailto:wikipedialibrary@wikimedia.org?"
-"Subject=Wikipedia%%20Library%%20%(path)s%%20Not%%20found\"> "
-"wikipedialibrary@wikimedia.org</a> or report it to us on <a class=\"twl-links"
-"\" href=\"https://phabricator.wikimedia.org/maniphest/task/edit/form/1/?"
-"projectPHIDs=Library-Card-Platform&title=Wikipedia%%20Library%%20%(path)s"
-"%%20Not%%20found\">Phabricator</a>"
-msgstr ""
-"إذا كنت متأكدًا من وجوب وجود شيء ما هنا،  فتُرجَى مراسلتنا عبر البريد "
-"الإلكتروني حول هذا الخطأ على <a href=\"mailto:wikipedialibrary@wikimedia.org?"
-"Subject=Wikipedia%%20Library%%20%(path)s%%20Not%%20found\"> "
-"wikipedialibrary@wikimedia.org</a> أو الإبلاغ عنه على <a href=\"https://"
-"phabricator.wikimedia.org/maniphest/task/edit/form/1/?projectPHIDs=Library-"
-"Card-Platform&title=Wikipedia%%20Library%%20%(path)s%%20Not%%20found"
-"\">فبريكاتور</a>"
+msgid "If you are certain that something should be here, please email us about this error at <a class=\"twl-links\" href=\"mailto:wikipedialibrary@wikimedia.org?Subject=Wikipedia%%20Library%%20%(path)s%%20Not%%20found\"> wikipedialibrary@wikimedia.org</a> or report it to us on <a class=\"twl-links\" href=\"https://phabricator.wikimedia.org/maniphest/task/edit/form/1/?projectPHIDs=Library-Card-Platform&title=Wikipedia%%20Library%%20%(path)s%%20Not%%20found\">Phabricator</a>"
+msgstr "إذا كنت متأكدًا من وجوب وجود شيء ما هنا،  فتُرجَى مراسلتنا عبر البريد الإلكتروني حول هذا الخطأ على <a href=\"mailto:wikipedialibrary@wikimedia.org?Subject=Wikipedia%%20Library%%20%(path)s%%20Not%%20found\"> wikipedialibrary@wikimedia.org</a> أو الإبلاغ عنه على <a href=\"https://phabricator.wikimedia.org/maniphest/task/edit/form/1/?projectPHIDs=Library-Card-Platform&title=Wikipedia%%20Library%%20%(path)s%%20Not%%20found\">فبريكاتور</a>"
 
 #. Translators: Alt text for an image shown on the 404 error page.
 #: TWLight/templates/404.html:32
@@ -2241,47 +1841,19 @@ msgstr "حول مكتبة ويكيبيديا"
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:20
-msgid ""
-"This platform is our central tool for facilitating access to our available "
-"collections. Here you can see which partnerships are available, search their "
-"contents, and apply for and access the ones you’re interested in."
-msgstr ""
-"منصة بطاقة مكتبة ويكيبيديا هي الأداة المركزية لمراجعة الطلبات وتوفير إمكانية "
-"الوصول إلى مجموعتنا، يمكنك هنا معرفة الشراكات المتاحة، والبحث في محتوياتها، "
-"والتقدم بطلب للوصول إلى تلك التي تهتم بها، منسقو المتطوعين، الذين وقعوا "
-"اتفاقيات عدم إفشاء مع مؤسسة ويكيميديا، ومراجعة الطلبات والعمل مع الناشرين "
-"لتحصل على حرية الوصول الخاصة بك، بعض المحتوى متاح بدون طلب."
+msgid "This platform is our central tool for facilitating access to our available collections. Here you can see which partnerships are available, search their contents, and apply for and access the ones you’re interested in."
+msgstr "منصة بطاقة مكتبة ويكيبيديا هي الأداة المركزية لمراجعة الطلبات وتوفير إمكانية الوصول إلى مجموعتنا، يمكنك هنا معرفة الشراكات المتاحة، والبحث في محتوياتها، والتقدم بطلب للوصول إلى تلك التي تهتم بها، منسقو المتطوعين، الذين وقعوا اتفاقيات عدم إفشاء مع مؤسسة ويكيميديا، ومراجعة الطلبات والعمل مع الناشرين لتحصل على حرية الوصول الخاصة بك، بعض المحتوى متاح بدون طلب."
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/). Wikimedia Foundation should not be translated.
 #: TWLight/templates/about.html:29
-msgid ""
-"All users receive immediate access to some collections, which can be browsed "
-"by clicking the 'Access collection' buttons or using the search bar at the "
-"top of the page. Other collections require an application before access is "
-"granted, and may be accessed directly or via an individual login or access "
-"code. Volunteer coordinators, who have signed non-disclosure agreements with "
-"the Wikimedia Foundation, review these applications and work with publishers "
-"to get you your free access."
-msgstr ""
-"منصة بطاقة مكتبة ويكيبيديا هي الأداة المركزية لمراجعة الطلبات وتوفير إمكانية "
-"الوصول إلى مجموعتنا، يمكنك هنا معرفة الشراكات المتاحة، والبحث في محتوياتها، "
-"والتقدم بطلب للوصول إلى تلك التي تهتم بها، منسقو المتطوعين، الذين وقعوا "
-"اتفاقيات عدم إفشاء مع مؤسسة ويكيميديا، ومراجعة الطلبات والعمل مع الناشرين "
-"لتحصل على حرية الوصول الخاصة بك، بعض المحتوى متاح بدون طلب."
+msgid "All users receive immediate access to some collections, which can be browsed by clicking the 'Access collection' buttons or using the search bar at the top of the page. Other collections require an application before access is granted, and may be accessed directly or via an individual login or access code. Volunteer coordinators, who have signed non-disclosure agreements with the Wikimedia Foundation, review these applications and work with publishers to get you your free access."
+msgstr "منصة بطاقة مكتبة ويكيبيديا هي الأداة المركزية لمراجعة الطلبات وتوفير إمكانية الوصول إلى مجموعتنا، يمكنك هنا معرفة الشراكات المتاحة، والبحث في محتوياتها، والتقدم بطلب للوصول إلى تلك التي تهتم بها، منسقو المتطوعين، الذين وقعوا اتفاقيات عدم إفشاء مع مؤسسة ويكيميديا، ومراجعة الطلبات والعمل مع الناشرين لتحصل على حرية الوصول الخاصة بك، بعض المحتوى متاح بدون طلب."
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/). Don't translate terms_url.
 #: TWLight/templates/about.html:43
 #, python-format
-msgid ""
-"For more information about how your information is stored and reviewed "
-"please see our <a class=\"twl-links\" href=\"%(terms_url)s\"> terms of use "
-"and privacy policy</a>. Accounts you apply for are also subject to the Terms "
-"of Use provided by each partner’s platform; please review them."
-msgstr ""
-"لمزيد من المعلومات حول كيفية تخزين معلوماتك ومراجعتها; يُرجَى الاطلاع على <a "
-"href=\"%(terms_url)s\">شروط الاستخدام وسياسة الخصوصية</a> الخاصة بنا، "
-"الحسابات التي تقدمت بطلبها تخضع أيضا لشروط الاستخدام التي يوفرها النظام "
-"الأساسي لكل شريك، تُرجَى مراجعتها."
+msgid "For more information about how your information is stored and reviewed please see our <a class=\"twl-links\" href=\"%(terms_url)s\"> terms of use and privacy policy</a>. Accounts you apply for are also subject to the Terms of Use provided by each partner’s platform; please review them."
+msgstr "لمزيد من المعلومات حول كيفية تخزين معلوماتك ومراجعتها; يُرجَى الاطلاع على <a href=\"%(terms_url)s\">شروط الاستخدام وسياسة الخصوصية</a> الخاصة بنا، الحسابات التي تقدمت بطلبها تخضع أيضا لشروط الاستخدام التي يوفرها النظام الأساسي لكل شريك، تُرجَى مراجعتها."
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:51
@@ -2290,17 +1862,8 @@ msgstr "من يمكنه الحصول على حق الدخول؟"
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/). Wikimedia Foundation should not be translated.
 #: TWLight/templates/about.html:55
-msgid ""
-"Any active editor in good standing can receive access. For publishers with "
-"limited numbers of accounts, applications are reviewed based on the editor’s "
-"needs and contributions. If you think you could use access to one of our "
-"partner resources and are an active editor in any project supported by the "
-"Wikimedia Foundation, please apply."
-msgstr ""
-"يمكن لأي محرر نشط في وضع جيد الحصول على الوصول، للناشرين الذين لديهم أعداد "
-"محدودة من الحسابات، تتم مراجعة الطلبات بناءً على احتياجات المحرر وإسهاماته، "
-"إذا كنت تعتقد أنه يمكنك استخدام الوصول إلى أحد موارد شركائنا وأن تكون محررا "
-"نشطا في أي مشروع تدعمه مؤسسة ويكيميديا، فيُرجَى تقديم طلب."
+msgid "Any active editor in good standing can receive access. For publishers with limited numbers of accounts, applications are reviewed based on the editor’s needs and contributions. If you think you could use access to one of our partner resources and are an active editor in any project supported by the Wikimedia Foundation, please apply."
+msgstr "يمكن لأي محرر نشط في وضع جيد الحصول على الوصول، للناشرين الذين لديهم أعداد محدودة من الحسابات، تتم مراجعة الطلبات بناءً على احتياجات المحرر وإسهاماته، إذا كنت تعتقد أنه يمكنك استخدام الوصول إلى أحد موارد شركائنا وأن تكون محررا نشطا في أي مشروع تدعمه مؤسسة ويكيميديا، فيُرجَى تقديم طلب."
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:65
@@ -2320,8 +1883,7 @@ msgstr "لقد أجريت 500 تعديل كحد أدنى"
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:79
 msgid "You have made at least 10 edits to Wikimedia projects in the last month"
-msgstr ""
-"لقد قمت بإجراء 10 تعديلات على الأقل على مشاريع ويكيميديا ​​في الشهر الماضي"
+msgstr "لقد قمت بإجراء 10 تعديلات على الأقل على مشاريع ويكيميديا ​​في الشهر الماضي"
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:83
@@ -2330,33 +1892,13 @@ msgstr "أنت غير ممنوع حاليا من تحرير مشروع ويكي�
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/)
 #: TWLight/templates/about.html:89
-msgid ""
-"If you are applying for an available collection, please first check that you "
-"don't already have access through another library or institution. If you do, "
-"please consider using that access rather than taking up a seat for this "
-"resource in The Wikipedia Library."
-msgstr ""
-"إذا كنت تقدم طلبًا للحصول على مجموعة متاحة، فيرجى أولاً التحقق من أنه ليس لديك "
-"حق الوصول بالفعل من خلال مكتبة أو مؤسسة أخرى. إذاكان لديك وصول. نرجو منك "
-"إعادة التفكير في استخدام هذا الوصول بدلاً من شغل مقعد لهذا المورد في مكتبة "
-"ويكيبيديا."
+msgid "If you are applying for an available collection, please first check that you don't already have access through another library or institution. If you do, please consider using that access rather than taking up a seat for this resource in The Wikipedia Library."
+msgstr "إذا كنت تقدم طلبًا للحصول على مجموعة متاحة، فيرجى أولاً التحقق من أنه ليس لديك حق الوصول بالفعل من خلال مكتبة أو مؤسسة أخرى. إذاكان لديك وصول. نرجو منك إعادة التفكير في استخدام هذا الوصول بدلاً من شغل مقعد لهذا المورد في مكتبة ويكيبيديا."
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/)
 #: TWLight/templates/about.html:99
-msgid ""
-"If your account is blocked on one or more Wikimedia projects, you may still "
-"be granted access to The Wikipedia Library. You will need to contact the "
-"Wikipedia Library team, who will review your blocks. If you have been "
-"blocked for content issues, most notably copyright violations, or have "
-"multiple long-term blocks, we may decline your request. Additionally, if "
-"your block status changes after being approved, you will need to request "
-"another review."
-msgstr ""
-"إذا حُظر حسابك في واحد أو أكثر من مشاريع ويكيميديا، فلا يزال بإمكانك الوصول "
-"إلى مكتبة ويكيبيديا. ستحتاج إلى الاتصال بفريق مكتبة ويكيبيديا، الذي سيراجع "
-"أعمالك. إذا حُظرت بسبب مشكلات المحتوى، وعلى الأخص انتهاكات حقوق النشر، أو كان "
-"لديك عدة عمليات حظر طويلة الأجل، فقد نرفض طلبك. بالإضافة إلى ذلك، إذا تغيرت "
-"حالة الحظر بعد الموافقة عليها، فستحتاج إلى طلب مراجعة أخرى."
+msgid "If your account is blocked on one or more Wikimedia projects, you may still be granted access to The Wikipedia Library. You will need to contact the Wikipedia Library team, who will review your blocks. If you have been blocked for content issues, most notably copyright violations, or have multiple long-term blocks, we may decline your request. Additionally, if your block status changes after being approved, you will need to request another review."
+msgstr "إذا حُظر حسابك في واحد أو أكثر من مشاريع ويكيميديا، فلا يزال بإمكانك الوصول إلى مكتبة ويكيبيديا. ستحتاج إلى الاتصال بفريق مكتبة ويكيبيديا، الذي سيراجع أعمالك. إذا حُظرت بسبب مشكلات المحتوى، وعلى الأخص انتهاكات حقوق النشر، أو كان لديك عدة عمليات حظر طويلة الأجل، فقد نرفض طلبك. بالإضافة إلى ذلك، إذا تغيرت حالة الحظر بعد الموافقة عليها، فستحتاج إلى طلب مراجعة أخرى."
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:110
@@ -2366,8 +1908,7 @@ msgstr "ماذا يجب أن أفعل بعد أن أتحصل على حق الد�
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:114
 msgid "Approved editors <i>may</i> use their access to:"
-msgstr ""
-"المساهمون المقبولون >i>يمكنهم>/i> إستعمال حقهم في الدخول إلى المصدر من أجل:"
+msgstr "المساهمون المقبولون >i>يمكنهم>/i> إستعمال حقهم في الدخول إلى المصدر من أجل:"
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:118
@@ -2391,12 +1932,8 @@ msgstr "<i>لا بجب</i> على المساهمين المقبولين أن:"
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:136
-msgid ""
-"Share their account logins or passwords with others, or sell their access to "
-"other parties"
-msgstr ""
-"شارك معلومات تسجيل الدخول أو كلمات المرور الخاصة بحساباتهم مع الآخرين، أو قم "
-"ببيع وصولهم إلى أطراف أخرى"
+msgid "Share their account logins or passwords with others, or sell their access to other parties"
+msgstr "شارك معلومات تسجيل الدخول أو كلمات المرور الخاصة بحساباتهم مع الآخرين، أو قم ببيع وصولهم إلى أطراف أخرى"
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:140
@@ -2405,29 +1942,18 @@ msgstr "كشط شامل أو تنزيل شامل لمحتوى الشريك"
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:144
-msgid ""
-"Systematically make printed or electronic copies of multiple extracts of "
-"restricted content available for any purpose"
-msgstr ""
-"إجراء نسخ مطبوعة أو إلكترونية بشكل منهجي لمقتطفات متعددة من المحتويات "
-"المقيدة المتاحة لأي غرض من الأغراض"
+msgid "Systematically make printed or electronic copies of multiple extracts of restricted content available for any purpose"
+msgstr "إجراء نسخ مطبوعة أو إلكترونية بشكل منهجي لمقتطفات متعددة من المحتويات المقيدة المتاحة لأي غرض من الأغراض"
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/). Stub is a technical term for a short Wikipedia article, use the appropriate Wikipedia term in your language.
 #: TWLight/templates/about.html:148
-msgid ""
-"Datamine metadata without permission, in order, for instance, to use "
-"metadata for auto-created stub articles"
-msgstr ""
-"البيانات الوصفية لمنجم البيانات بدون إذن، على سبيل المثال، من أجل استخدام "
-"بيانات التعريف لمقالات البذور المنشأة تلقائيا"
+msgid "Datamine metadata without permission, in order, for instance, to use metadata for auto-created stub articles"
+msgstr "البيانات الوصفية لمنجم البيانات بدون إذن، على سبيل المثال، من أجل استخدام بيانات التعريف لمقالات البذور المنشأة تلقائيا"
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:154
-msgid ""
-"Respecting these agreements allows us to continue growing the partnerships "
-"available to the community."
-msgstr ""
-"يسمح لنا احترام هذه الاتفاقيات بالاستمرار في تنمية الشراكات المتاحة للمجتمع."
+msgid "Respecting these agreements allows us to continue growing the partnerships available to the community."
+msgstr "يسمح لنا احترام هذه الاتفاقيات بالاستمرار في تنمية الشراكات المتاحة للمجتمع."
 
 #. Translators: This is the heading for a section on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:160
@@ -2437,58 +1963,23 @@ msgstr "الوكيل"
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:164
-msgid ""
-"EZProxy is a proxy server used to authenticate users for many Wikipedia "
-"Library partners. Users sign into EZProxy via the Library Card platform to "
-"verify that they are authorized users, and then the server accesses "
-"requested resources using its own IP address."
-msgstr ""
-"EZProxy هو خادم وكيل يُستخدَم لمصادقة المستخدمين للعديد من شركاء مكتبة "
-"ويكيبيديا، يقوم المستخدمون بتسجيل الدخول إلى EZProxy عبر النظام الأساسي "
-"لبطاقة المكتبة للتحقق من أنهم مخولون، ثم يصل الخادم إلى الموارد المطلوبة "
-"باستخدام عنوان الآيبي الخاص به."
+msgid "EZProxy is a proxy server used to authenticate users for many Wikipedia Library partners. Users sign into EZProxy via the Library Card platform to verify that they are authorized users, and then the server accesses requested resources using its own IP address."
+msgstr "EZProxy هو خادم وكيل يُستخدَم لمصادقة المستخدمين للعديد من شركاء مكتبة ويكيبيديا، يقوم المستخدمون بتسجيل الدخول إلى EZProxy عبر النظام الأساسي لبطاقة المكتبة للتحقق من أنهم مخولون، ثم يصل الخادم إلى الموارد المطلوبة باستخدام عنوان الآيبي الخاص به."
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:173
-msgid ""
-"You may notice that when accessing resources via EZProxy that URLs are "
-"dynamically rewritten. This is why we recommend logging in via the Library "
-"Card platform rather than going directly to the unproxied partner website. "
-"When in doubt, check the URL for ‘idm.oclc’. If it’s there, then you’re "
-"connected via EZProxy."
-msgstr ""
-"قد تلاحظ أنه عند الوصول إلى الموارد عبر EZProxy، تتم إعادة كتابة المسارات "
-"ديناميكيا؛ هذا هو السبب في أننا نوصي بتسجيل الدخول عبر منصة بطاقة المكتبة "
-"بدلا من الذهاب مباشرةً إلى موقع الشريك غير الموثق، عندما تكون في حالة شك، "
-"تحقق من مسار \"idm.oclc\"، إذا كان هناك، فأنت متصل عبر EZProxy."
+msgid "You may notice that when accessing resources via EZProxy that URLs are dynamically rewritten. This is why we recommend logging in via the Library Card platform rather than going directly to the unproxied partner website. When in doubt, check the URL for ‘idm.oclc’. If it’s there, then you’re connected via EZProxy."
+msgstr "قد تلاحظ أنه عند الوصول إلى الموارد عبر EZProxy، تتم إعادة كتابة المسارات ديناميكيا؛ هذا هو السبب في أننا نوصي بتسجيل الدخول عبر منصة بطاقة المكتبة بدلا من الذهاب مباشرةً إلى موقع الشريك غير الموثق، عندما تكون في حالة شك، تحقق من مسار \"idm.oclc\"، إذا كان هناك، فأنت متصل عبر EZProxy."
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:182
-msgid ""
-"Typically once you’ve logged in your session will remain active in your "
-"browser for up to two hours after you’ve finished searching. Note that use "
-"of EZProxy requires you to enable cookies. If you are having problems you "
-"should also try clearing your cache and restarting your browser."
-msgstr ""
-"عادةً ما يظل تسجيل دخولك نشطا في جلستك لمدة تصل إلى ساعتين بعد الانتهاء من "
-"البحث، لاحظ أن استخدام EZProxy يتطلب منك تمكين ملفات تعريف الارتباط، إذا كنت "
-"تواجه مشكلات، يجب عليك أيضا محو ذاكرة التخزين المؤقت وإعادة تشغيل متصفحك."
+msgid "Typically once you’ve logged in your session will remain active in your browser for up to two hours after you’ve finished searching. Note that use of EZProxy requires you to enable cookies. If you are having problems you should also try clearing your cache and restarting your browser."
+msgstr "عادةً ما يظل تسجيل دخولك نشطا في جلستك لمدة تصل إلى ساعتين بعد الانتهاء من البحث، لاحظ أن استخدام EZProxy يتطلب منك تمكين ملفات تعريف الارتباط، إذا كنت تواجه مشكلات، يجب عليك أيضا محو ذاكرة التخزين المؤقت وإعادة تشغيل متصفحك."
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/)
 #: TWLight/templates/about.html:193
-msgid ""
-"The Library Bundle is a collection of resources for which no application is "
-"required. If you meet the criteria laid out above, you will be authorized "
-"for access automatically upon logging in to the platform. Only some of our "
-"content is currently included in the Library Bundle, however we hope to "
-"expand the collection as more publishers become comfortable with "
-"participating. All Bundle content is accessed via EZProxy."
-msgstr ""
-"حزمة المكتبة عبارة عن مجموعة من الموارد التي لا يلزم تقديم أي تطبيق لها. إذا "
-"كنت تستوفي المعايير الموضحة أعلاه، فسيسمح لك بالوصول تلقائيًا عند تسجيل "
-"الدخول إلى النظام الأساسي. نضمن حالياً بعض المحتوى الخاص بنا فقط في حزمة "
-"المكتبة ، ولكننا نأمل في توسيع المجموعة حيث يصبح المزيد من الناشرين مرتاحين "
-"للمشاركة. نستخدم EZProxy للوصول إلى جميع محتويات الحزمة."
+msgid "The Library Bundle is a collection of resources for which no application is required. If you meet the criteria laid out above, you will be authorized for access automatically upon logging in to the platform. Only some of our content is currently included in the Library Bundle, however we hope to expand the collection as more publishers become comfortable with participating. All Bundle content is accessed via EZProxy."
+msgstr "حزمة المكتبة عبارة عن مجموعة من الموارد التي لا يلزم تقديم أي تطبيق لها. إذا كنت تستوفي المعايير الموضحة أعلاه، فسيسمح لك بالوصول تلقائيًا عند تسجيل الدخول إلى النظام الأساسي. نضمن حالياً بعض المحتوى الخاص بنا فقط في حزمة المكتبة ، ولكننا نأمل في توسيع المجموعة حيث يصبح المزيد من الناشرين مرتاحين للمشاركة. نستخدم EZProxy للوصول إلى جميع محتويات الحزمة."
 
 #. Translators: This is the heading for a section on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:202
@@ -2498,17 +1989,8 @@ msgstr "ممارسات الاقتباس"
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:206
 #, fuzzy
-msgid ""
-"Citation practices vary by project and even by article. Generally, we "
-"support editors citing where they found information, in a form that allows "
-"others to check it for themselves. That often means providing both original "
-"source details as well as a link to the partner database in which the source "
-"was found."
-msgstr ""
-"تختلف ممارسات الاستشهاد حسب المشروع وحتى حسب المقالة، بشكل عام، نحن ندعم "
-"المحررين في الاستشهاد بالمكان الذي وجدوا فيه المعلومات، بشكل يسمح للآخرين "
-"بالتحقق من ذلك بأنفسهم: يعني ذلك غالبا توفير تفاصيل المصدر الأصلي بالإضافة "
-"إلى رابط إلى قاعدة بيانات الشريك التي تم العثور فيها على المصدر."
+msgid "Citation practices vary by project and even by article. Generally, we support editors citing where they found information, in a form that allows others to check it for themselves. That often means providing both original source details as well as a link to the partner database in which the source was found."
+msgstr "تختلف ممارسات الاستشهاد حسب المشروع وحتى حسب المقالة، بشكل عام، نحن ندعم المحررين في الاستشهاد بالمكان الذي وجدوا فيه المعلومات، بشكل يسمح للآخرين بالتحقق من ذلك بأنفسهم: يعني ذلك غالبا توفير تفاصيل المصدر الأصلي بالإضافة إلى رابط إلى قاعدة بيانات الشريك التي تم العثور فيها على المصدر."
 
 #. Translators: This is the heading for a section on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #. Translators: This link is at the bottom of every page and can be clicked by users to contact the wikipedia library team.
@@ -2519,12 +2001,8 @@ msgstr "اتصل بنا"
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:218
 #, python-format
-msgid ""
-"If you have questions, need help, or want to volunteer to help, please see "
-"our <a class=\"twl-links\" href=\"%(contact_url)s\">contact page</a>."
-msgstr ""
-"إذا كانت لديك أسئلة أو بحاجة إلى مساعدة أو تريد التطوع للمساعدة، فيُرجَى "
-"الاطلاع على <a href=\"%(contact_url)s\">صفحة الاتصال الخاصة بنا</a>."
+msgid "If you have questions, need help, or want to volunteer to help, please see our <a class=\"twl-links\" href=\"%(contact_url)s\">contact page</a>."
+msgstr "إذا كانت لديك أسئلة أو بحاجة إلى مساعدة أو تريد التطوع للمساعدة، فيُرجَى الاطلاع على <a href=\"%(contact_url)s\">صفحة الاتصال الخاصة بنا</a>."
 
 #. Translators: This is the title of the panel box detailing the contact information for the Wikipedia Library team.
 #: TWLight/templates/contact.html:14
@@ -2563,12 +2041,8 @@ msgstr "صفحة مكتبة ويكيبيديا على تويتر"
 #. Translators: This is the text that appears at the bottom of the contact us form directing users to the suggestions form.
 #: TWLight/templates/contact.html:48
 #, python-format
-msgid ""
-"(If you would like to suggest a partner, <a class=\"twl-links\" href="
-"\"%(suggest)s\"><strong>go here</strong></a>.)"
-msgstr ""
-"(إن كنت ترغب في اقتراح شريك، <a class=\"twl-links\" href=\"%(suggest)s"
-"\"><strong>اذهب هنا</strong></a>.)"
+msgid "(If you would like to suggest a partner, <a class=\"twl-links\" href=\"%(suggest)s\"><strong>go here</strong></a>.)"
+msgstr "(إن كنت ترغب في اقتراح شريك، <a class=\"twl-links\" href=\"%(suggest)s\"><strong>اذهب هنا</strong></a>.)"
 
 #. Translators: On a special 'link to search' page, this message is shown if JavaScript is disabled.
 #: TWLight/templates/eds_search_endpoint.html:7
@@ -2625,12 +2099,8 @@ msgstr "مكتبة ويكيبيديا"
 #. Translators: Information about The Wikipedia Library.
 #: TWLight/templates/login_partial.html:53 TWLight/templates/new_base.html:21
 #, fuzzy, python-format
-msgid ""
-"More than 100 of the world's top subscription-only databases, with content "
-"in %(no_of_languages)s languages, free for Wikipedians of all backgrounds"
-msgstr ""
-"أكثر من 90 من أفضل قواعد بيانات الاشتراك فقط في العالم، مع محتوى بلغات "
-"%(no_of_languages)s، مجانًا لمستخدمي ويكيبيديا من جميع الخلفيات"
+msgid "More than 100 of the world's top subscription-only databases, with content in %(no_of_languages)s languages, free for Wikipedians of all backgrounds"
+msgstr "أكثر من 90 من أفضل قواعد بيانات الاشتراك فقط في العالم، مع محتوى بلغات %(no_of_languages)s، مجانًا لمستخدمي ويكيبيديا من جميع الخلفيات"
 
 #. Translators: Information about The Wikipedia Library.
 #: TWLight/templates/login_partial.html:64
@@ -2638,12 +2108,8 @@ msgid "Meet these criteria for automatic access"
 msgstr "تلبية هذه المعايير للوصول التلقائي"
 
 #: TWLight/templates/login_partial.html:69
-msgid ""
-"These criteria grant you access to certain collections but not all. Some "
-"collections are accessible on a per application basis only."
-msgstr ""
-"تمنحك هذه المعايير الوصول إلى مجموعات معينة ولكن ليس كلها. يمكن الوصول إلى "
-"بعض المجموعات على أساس كل تطبيق فقط."
+msgid "These criteria grant you access to certain collections but not all. Some collections are accessible on a per application basis only."
+msgstr "تمنحك هذه المعايير الوصول إلى مجموعات معينة ولكن ليس كلها. يمكن الوصول إلى بعض المجموعات على أساس كل تطبيق فقط."
 
 #: TWLight/templates/login_partial.html:89
 msgid "Login via Wikipedia"
@@ -2652,39 +2118,20 @@ msgstr "سجل دخولك بإستخدام حساب ويكيبيديا الخا�
 #. Translators: Shown if the current user doesn't have a registered email on their account. Don't translate contact_us_url or email_url.
 #: TWLight/templates/message_partial.html:15
 #, python-format
-msgid ""
-"You don't have an email on file. We can't finalize your access to partner "
-"resources, and you won't be able to <a class=\"twl-links\" href="
-"\"%(contact_us_url)s\">contact us</a> without an email. Please <a class="
-"\"twl-links\" href=\"%(email_url)s\">update your email</a>."
-msgstr ""
-"ليس لديك بريد إلكتروني في الملف؛ لا يمكننا إنهاء وصولك إلى موارد الشركاء ، "
-"ولن تتمكن من <a href=\"%(contact_us_url)s\">الاتصال بنا</a>  بدون بريد "
-"إلكتروني؛ يُرجَى <a href=\"%(email_url)s\">تحديث بريدك الإلكتروني</a>."
+msgid "You don't have an email on file. We can't finalize your access to partner resources, and you won't be able to <a class=\"twl-links\" href=\"%(contact_us_url)s\">contact us</a> without an email. Please <a class=\"twl-links\" href=\"%(email_url)s\">update your email</a>."
+msgstr "ليس لديك بريد إلكتروني في الملف؛ لا يمكننا إنهاء وصولك إلى موارد الشركاء ، ولن تتمكن من <a href=\"%(contact_us_url)s\">الاتصال بنا</a>  بدون بريد إلكتروني؛ يُرجَى <a href=\"%(email_url)s\">تحديث بريدك الإلكتروني</a>."
 
 #. Translators: Shown if the current user has requested the processing of their data should be restricted.
 #: TWLight/templates/message_partial.html:26
 #, python-format
-msgid ""
-"You have requested a restriction on the processing of your data. Most site "
-"functionality will not be available to you until you <a class=\"twl-links\" "
-"href=\"%(restrict_url)s\">lift this restriction</a>."
-msgstr ""
-"لقد طلبت تقييدا على معالجة بياناتك، لن تكون معظم وظائف الموقع متاحة لك حتى "
-"تقوم <a href=\"%(restrict_url)s\">برفع هذا التقييد</a>."
+msgid "You have requested a restriction on the processing of your data. Most site functionality will not be available to you until you <a class=\"twl-links\" href=\"%(restrict_url)s\">lift this restriction</a>."
+msgstr "لقد طلبت تقييدا على معالجة بياناتك، لن تكون معظم وظائف الموقع متاحة لك حتى تقوم <a href=\"%(restrict_url)s\">برفع هذا التقييد</a>."
 
 #. Translators: Shown if the current user has not agreed to the terms of use.
 #: TWLight/templates/message_partial.html:37
 #, python-format
-msgid ""
-"You have not agreed to the <a class=\"twl-links\" href=\"%(terms_url)s"
-"\">terms of use</a> of this site. Your applications will not be processed "
-"and you won't be able to apply or access resources you are approved for."
-msgstr ""
-"أنت لم توافق على <a class=\"twl-links\" href=\"%(terms_url)s\"><a class="
-"\"twl-links\" href=\"%(terms_url)s\"></a>شروط استخدام</a> هذا الموقع. لن تتم "
-"معالجة طلباتك ولن تتمكن من التقديم أو الوصول إلى الموارد التي تمت الموافقة "
-"عليها."
+msgid "You have not agreed to the <a class=\"twl-links\" href=\"%(terms_url)s\">terms of use</a> of this site. Your applications will not be processed and you won't be able to apply or access resources you are approved for."
+msgstr "أنت لم توافق على <a class=\"twl-links\" href=\"%(terms_url)s\"><a class=\"twl-links\" href=\"%(terms_url)s\"></a>شروط استخدام</a> هذا الموقع. لن تتم معالجة طلباتك ولن تتمكن من التقديم أو الوصول إلى الموارد التي تمت الموافقة عليها."
 
 #. Translators: This link is at the bottom of every page and links to the 'About' page (https://wikipedialibrary.wmflabs.org/about/)
 #: TWLight/templates/new_base.html:107
@@ -2730,12 +2177,8 @@ msgstr "ألغ كلمة السر"
 
 #. Translators: If a user goes to reset their password, this message asks them to enter their email to do so.
 #: TWLight/templates/registration/password_reset_form.html:13
-msgid ""
-"Forgot your password? Enter your email address below, and we'll email "
-"instructions for setting a new one."
-msgstr ""
-"نسيت كلمة مرورك؟  أدخل عنوان بريدك الإلكتروني أدناه، وسنرسل إليك تعليمات "
-"بالبريد الإلكتروني لإعداد واحدة جديدة."
+msgid "Forgot your password? Enter your email address below, and we'll email instructions for setting a new one."
+msgstr "نسيت كلمة مرورك؟  أدخل عنوان بريدك الإلكتروني أدناه، وسنرسل إليك تعليمات بالبريد الإلكتروني لإعداد واحدة جديدة."
 
 #. Translators: This is the label for a button that users click to update their public information.
 #: TWLight/users/forms.py:36
@@ -2779,21 +2222,13 @@ msgstr "أوافق على شروط الإستخدام"
 
 #. Translators: This text explains how to disagree to the site's terms of use and the restrictions that will come into effect when users disagree to the terms of use.
 #: TWLight/users/forms.py:185
-msgid ""
-"By unchecking this box and clicking “Update” you may explore the site, but "
-"you will not be able to apply for access to materials or evaluate "
-"applications unless you agree with the terms of use."
-msgstr ""
-"بريدك الالكتروني فارغ، لا يزال بإمكانك استكشاف الموقع، ولكن لن تتمكن من "
-"التقدم بطلب الوصول إلى موارد الشركاء دون بريد إلكتروني."
+msgid "By unchecking this box and clicking “Update” you may explore the site, but you will not be able to apply for access to materials or evaluate applications unless you agree with the terms of use."
+msgstr "بريدك الالكتروني فارغ، لا يزال بإمكانك استكشاف الموقع، ولكن لن تتمكن من التقدم بطلب الوصول إلى موارد الشركاء دون بريد إلكتروني."
 
 #. Translators: Users click this button to set their website email address to the one linked to their Wikipedia account.
 #: TWLight/users/forms.py:211
-msgid ""
-"Use my Wikipedia email address (will be updated the next time you login)."
-msgstr ""
-"استخدم عنوان بريدي الإلكتروني في ويكيبيديا (سيتم تحديثه في المرة التالية "
-"التي تقوم فيها بتسجيل الدخول)."
+msgid "Use my Wikipedia email address (will be updated the next time you login)."
+msgstr "استخدم عنوان بريدي الإلكتروني في ويكيبيديا (سيتم تحديثه في المرة التالية التي تقوم فيها بتسجيل الدخول)."
 
 #. Translators: This labels a button which users click to change their email.
 #: TWLight/users/forms.py:232
@@ -2803,17 +2238,8 @@ msgstr "عدل البريد الإلكتروني"
 #. Translators: Shown if the current user tried to 'favorite' a partner they can't access. Do not translate '{partner}'
 #: TWLight/users/models.py:201
 #, python-brace-format
-msgid ""
-"Cannot add partner {partner} to your favorites because you don't have access "
-"to it"
+msgid "Cannot add partner {partner} to your favorites because you don't have access to it"
 msgstr "لا يمكن إضافة الشريك {partner} إلى مفضلتك لأنه لا يمكنك الوصول إليه"
-
-#. Translators: Do not translate.
-#: TWLight/users/models.py:869
-#, fuzzy, python-brace-format
-#| msgid "Username"
-msgid "{wp_username}"
-msgstr "اسم المستخدم"
 
 #. Translators: This error message is shown when there's a problem with the authenticated login process.
 #: TWLight/users/oauth.py:243
@@ -2833,12 +2259,8 @@ msgstr "لم يتم بدء الاتصال، يرجى محاولة تسجيل ا�
 
 #. Translators: this message is displayed to users that don't have accounts and clicked on a proxied link.
 #: TWLight/users/oauth.py:388
-msgid ""
-"To view this link you need to be an eligible library user. Please login to "
-"continue."
-msgstr ""
-"لعرض هذا الرابط، يجب أن تكون مستخدم مكتبة مؤهلاً. الرجاء تسجيل الدخول "
-"للمتابعة."
+msgid "To view this link you need to be an eligible library user. Please login to continue."
+msgstr "لعرض هذا الرابط، يجب أن تكون مستخدم مكتبة مؤهلاً. الرجاء تسجيل الدخول للمتابعة."
 
 #. Translators: This warning message is shown to users when the response received from Wikimedia OAuth servers is not a valid one.
 #: TWLight/users/oauth.py:430
@@ -2874,23 +2296,13 @@ msgstr "انظر {issue} لمزيد من المعلومات."
 
 #. Translators: If the user tries to log in, but their account does not meet certain requirements, they cannot login.
 #: TWLight/users/oauth.py:528
-msgid ""
-"Your Wikipedia account does not meet the eligibility criteria in the terms "
-"of use, so your Wikipedia Library Card Platform account cannot be activated."
-msgstr ""
-"حساب ويكيبيديا الخاص بك لا يستوفي معايير الأهلية في شروط الاستخدام; لذلك لا "
-"يمكن تفعيل حساب منصة بطاقة مكتبة ويكيبيديا الخاص بك."
+msgid "Your Wikipedia account does not meet the eligibility criteria in the terms of use, so your Wikipedia Library Card Platform account cannot be activated."
+msgstr "حساب ويكيبيديا الخاص بك لا يستوفي معايير الأهلية في شروط الاستخدام; لذلك لا يمكن تفعيل حساب منصة بطاقة مكتبة ويكيبيديا الخاص بك."
 
 #. Translators: If the user tries to log in, but their account does not meet certain requirements, they cannot login.
 #: TWLight/users/oauth.py:536
-msgid ""
-"Your Wikipedia account no longer meets the eligibility criteria in the terms "
-"of use, so you cannot be logged in. If you think you should be able to log "
-"in, please email wikipedialibrary@wikimedia.org."
-msgstr ""
-"لم يعد حسابك في ويكيبيديا يستوفي معايير الأهلية في شروط الاستخدام; لذا لا "
-"يمكنك تسجيل الدخول، إذا كنت تعتقد أنه ينبغي عليك التمكن من تسجيل الدخول، "
-"فيُرجَى إرسال بريد إلكتروني إلى wikipedialibrary@wikimedia.org."
+msgid "Your Wikipedia account no longer meets the eligibility criteria in the terms of use, so you cannot be logged in. If you think you should be able to log in, please email wikipedialibrary@wikimedia.org."
+msgstr "لم يعد حسابك في ويكيبيديا يستوفي معايير الأهلية في شروط الاستخدام; لذا لا يمكنك تسجيل الدخول، إذا كنت تعتقد أنه ينبغي عليك التمكن من تسجيل الدخول، فيُرجَى إرسال بريد إلكتروني إلى wikipedialibrary@wikimedia.org."
 
 #. Translators: this message is displayed to users with brand new accounts.
 #: TWLight/users/oauth.py:549
@@ -2900,14 +2312,8 @@ msgstr "أهلا بك! تُرجَى الموافقة على شروط الاست�
 #. Translators: This message is displayed on the confirmation page where users can return their access to partner collections.
 #: TWLight/users/templates/users/authorization_confirm_return.html:13
 #, python-format
-msgid ""
-"You will no longer be able to access <b>%(partner)s's</b> resources via the "
-"Library Card platform, but can request access again by clicking 'renew', if "
-"you change your mind. Are you sure you want to return your access?"
-msgstr ""
-"لن تتمكن بعد الآن من الوصول إلى موارد <b>%(partner)s</b> عبر النظام الأساسي "
-"لبطاقة المكتبة، ولكن يمكنك طلب الوصول مرة أخرى عن طريق النقر فوق \"تجديد\"، "
-"إذا غيرت رأيك، هل تريد بالتأكيد إعادة وصولك؟"
+msgid "You will no longer be able to access <b>%(partner)s's</b> resources via the Library Card platform, but can request access again by clicking 'renew', if you change your mind. Are you sure you want to return your access?"
+msgstr "لن تتمكن بعد الآن من الوصول إلى موارد <b>%(partner)s</b> عبر النظام الأساسي لبطاقة المكتبة، ولكن يمكنك طلب الوصول مرة أخرى عن طريق النقر فوق \"تجديد\"، إذا غيرت رأيك، هل تريد بالتأكيد إعادة وصولك؟"
 
 #. Translators: On the MyLibrary page (https://wikipedialibrary.wmflabs.org/users/my_library), this tab shows all favorite collections a user has.
 #: TWLight/users/templates/users/collections_section.html:9
@@ -2976,13 +2382,8 @@ msgstr "معطيات المساهم"
 
 #. Translators: This is shown on editor profiles, in their profile page or on applications.
 #: TWLight/users/templates/users/editor_detail.html:59
-msgid ""
-"Information with an * was retrieved from Wikipedia directly. Other "
-"information was entered directly by users or site admins, in their preferred "
-"language."
-msgstr ""
-"تم استرجاع المعلومات بـ* من ويكيبيديا مباشرة، تم إدخال معلومات أخرى مباشرة "
-"من قبل المستخدمين أو إداريي الموقع، بلغتهم المفضلة."
+msgid "Information with an * was retrieved from Wikipedia directly. Other information was entered directly by users or site admins, in their preferred language."
+msgstr "تم استرجاع المعلومات بـ* من ويكيبيديا مباشرة، تم إدخال معلومات أخرى مباشرة من قبل المستخدمين أو إداريي الموقع، بلغتهم المفضلة."
 
 #. Translators: This distinguishes users who have been flagged as account coordinators. Don't translate username.
 #: TWLight/users/templates/users/editor_detail.html:71
@@ -2992,14 +2393,8 @@ msgstr "%(username)s لديه امتيازات المنسق على هذا الم
 
 #. Translators: This is shown on editor profiles, under the heading for Wikipedia editor data.
 #: TWLight/users/templates/users/editor_detail_data.html:5
-msgid ""
-"This information is updated automatically from your Wikimedia account each "
-"time you log in, except for the Contributions field, where you can describe "
-"your Wikimedia editing history."
-msgstr ""
-"يتم تحديث هذه المعلومات تلقائيا من حساب ويكيميديا الخاص بك في كل مرة تقوم "
-"فيها بتسجيل الدخول، باستثناء حقل المساهمات، حيث يمكنك وصف تاريخ تعديلاتك في "
-"ويكيميديا."
+msgid "This information is updated automatically from your Wikimedia account each time you log in, except for the Contributions field, where you can describe your Wikimedia editing history."
+msgstr "يتم تحديث هذه المعلومات تلقائيا من حساب ويكيميديا الخاص بك في كل مرة تقوم فيها بتسجيل الدخول، باستثناء حقل المساهمات، حيث يمكنك وصف تاريخ تعديلاتك في ويكيميديا."
 
 #. Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this labels the user's username.
 #: TWLight/users/templates/users/editor_detail_data.html:17
@@ -3028,19 +2423,13 @@ msgstr "يلبي شروط الاستخدام؟"
 
 #. Translators: when viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this question has a yes or no answer.
 #: TWLight/users/templates/users/editor_detail_data.html:57
-msgid ""
-"at their last login, did this user meet the criteria set forth in the terms "
-"of use?"
-msgstr ""
-"في آخر عملية تسجيل دخول، هل استوفى هذا المستخدم المعايير المنصوص عليها في "
-"شروط الاستخدام؟"
+msgid "at their last login, did this user meet the criteria set forth in the terms of use?"
+msgstr "في آخر عملية تسجيل دخول، هل استوفى هذا المستخدم المعايير المنصوص عليها في شروط الاستخدام؟"
 
 #. Translators: When viewing a user's profile in an application, this message shows if the software doesn't think that the user is eligible for access. Don't translate username.
 #: TWLight/users/templates/users/editor_detail_data.html:72
 #, python-format
-msgid ""
-"%(username)s may still be eligible for access grants at the coordinators' "
-"discretion."
+msgid "%(username)s may still be eligible for access grants at the coordinators' discretion."
 msgstr "قد لا يزال %(username)s مؤهلا للحصول على منح وفقا لتقدير المنسقين."
 
 #. Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this is the heading for a Yes/No ToU question.
@@ -3075,14 +2464,8 @@ msgstr ""
 #. Translators: This message is shown on a user's profile if their Wikimedia account is blocked on one or more projects. They may still be granted access to the Library Bundle, but need to contact Wikipedia Library staff to verify.
 #: TWLight/users/templates/users/editor_detail_data.html:137
 #, python-format
-msgid ""
-"It looks like you have an active block on your account. If you meet the "
-"other criteria you may still be permitted access to the library - please <a "
-"class=\"twl-links\" href=\"%(contact_url)s\">contact us</a>."
-msgstr ""
-"يبدو أن لديك حظرًا نشطًا في حسابك. إذا استوفيت المعايير الأخرى، فقد يظل مسموحًا "
-"لك بالوصول إلى المكتبة - يرجى <a class=\"twl-links\" href=\"%(contact_url)s"
-"\">الاتصال بنا</a>."
+msgid "It looks like you have an active block on your account. If you meet the other criteria you may still be permitted access to the library - please <a class=\"twl-links\" href=\"%(contact_url)s\">contact us</a>."
+msgstr "يبدو أن لديك حظرًا نشطًا في حسابك. إذا استوفيت المعايير الأخرى، فقد يظل مسموحًا لك بالوصول إلى المكتبة - يرجى <a class=\"twl-links\" href=\"%(contact_url)s\">الاتصال بنا</a>."
 
 #. Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this is the heading for a Yes/No program eligibility question.
 #: TWLight/users/templates/users/editor_detail_data.html:153
@@ -3091,13 +2474,8 @@ msgstr "مؤهل للحزمة؟"
 
 #. Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this question has a Yes or No answer.
 #: TWLight/users/templates/users/editor_detail_data.html:156
-msgid ""
-"At their last login, did this user meet the criteria set forth in the "
-"Library Bundle? Note that satisfying terms of use is a prerequisite to "
-"bundle eligibility."
-msgstr ""
-"في آخر عملية تسجيل دخول، هل استوفى هذا المستخدم المعايير المنصوص عليها في "
-"شروط الاستخدام؟"
+msgid "At their last login, did this user meet the criteria set forth in the Library Bundle? Note that satisfying terms of use is a prerequisite to bundle eligibility."
+msgstr "في آخر عملية تسجيل دخول، هل استوفى هذا المستخدم المعايير المنصوص عليها في شروط الاستخدام؟"
 
 #. Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this is the heading for a Yes/No program eligibility question.
 #: TWLight/users/templates/users/editor_detail_data.html:177
@@ -3141,20 +2519,13 @@ msgstr "البيانات الشخصية"
 
 #. Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this text is in the 'Personal data' section. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/users/templates/users/editor_detail_data.html:262
-msgid ""
-"The following information is visible only to you, site administrators, "
-"publishing partners (where required), and volunteer Wikipedia Library "
-"coordinators (who have signed a Non-Disclosure Agreement)."
-msgstr ""
-"المعلومات التالية مرئية لك، وإداريي الموقع، وشركاء النشر (عند الحاجة)، "
-"ومنسقي مكتبة ويكيبيديا المتطوعين (الذين وقعوا على اتفاقية عدم الإفشاء)."
+msgid "The following information is visible only to you, site administrators, publishing partners (where required), and volunteer Wikipedia Library coordinators (who have signed a Non-Disclosure Agreement)."
+msgstr "المعلومات التالية مرئية لك، وإداريي الموقع، وشركاء النشر (عند الحاجة)، ومنسقي مكتبة ويكيبيديا المتطوعين (الذين وقعوا على اتفاقية عدم الإفشاء)."
 
 #. Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this labels a button which users can click to update or remove their personal information. Don't translate update_url.
 #: TWLight/users/templates/users/editor_detail_data.html:272
 #, python-format
-msgid ""
-"You may <a class=\"twl-links\" href=\"%(update_url)s\">update or delete</a> "
-"your data at any time."
+msgid "You may <a class=\"twl-links\" href=\"%(update_url)s\">update or delete</a> your data at any time."
 msgstr "يمكنك <a href=\"%(update_url)s\">تحديث أو حذف</a> بياناتك في أي وقت."
 
 #. Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this labels the user's email. Don't remove the *.
@@ -3174,30 +2545,19 @@ msgstr "المؤسسة التي تعمل فيها"
 
 #. Translators: This message tells users that they are not eligible to access The Wikipedia Library content.
 #: TWLight/users/templates/users/eligibility_modal.html:7
-msgid ""
-"Sorry, your Wikipedia account doesn’t currently qualify to access The "
-"Wikipedia Library."
-msgstr ""
-"عذرًا، حساب ويكيبيديا الخاص بك غير مؤهل حاليًا للوصول إلى مكتبة ويكيبيديا."
+msgid "Sorry, your Wikipedia account doesn’t currently qualify to access The Wikipedia Library."
+msgstr "عذرًا، حساب ويكيبيديا الخاص بك غير مؤهل حاليًا للوصول إلى مكتبة ويكيبيديا."
 
 #. Translators: This message tells users that they have not agreed to the terms of use, therefore are ineligible to access the content in The Wikipedia Library.
 #: TWLight/users/templates/users/eligibility_modal.html:30
 #, python-format
-msgid ""
-"Agreed with <a href=\"%(terms)s\" class=\"text-danger\"> terms of use </a>"
-msgstr ""
-"تمت الموافقة <a href=\"%(terms)s\" class=\"text-danger\">على شروط الاستخدام</"
-"a>"
+msgid "Agreed with <a href=\"%(terms)s\" class=\"text-danger\"> terms of use </a>"
+msgstr "تمت الموافقة <a href=\"%(terms)s\" class=\"text-danger\">على شروط الاستخدام</a>"
 
 #: TWLight/users/templates/users/eligibility_modal.html:40
 #, python-format
-msgid ""
-"It looks like you have an active block on your account. If you meet the "
-"other criteria you may still be permitted access to the library - please <a "
-"href=\"%(contact_url)s\">contact us</a>."
-msgstr ""
-"يبدو أن لديك حظرًا نشطًا في حسابك. إذا استوفيت المعايير الأخرى، فقد يظل مسموحًا "
-"لك بالوصول إلى المكتبة - يرجى <a href=\"%(contact_url)s\">الاتصال بنا</a>."
+msgid "It looks like you have an active block on your account. If you meet the other criteria you may still be permitted access to the library - please <a href=\"%(contact_url)s\">contact us</a>."
+msgstr "يبدو أن لديك حظرًا نشطًا في حسابك. إذا استوفيت المعايير الأخرى، فقد يظل مسموحًا لك بالوصول إلى المكتبة - يرجى <a href=\"%(contact_url)s\">الاتصال بنا</a>."
 
 #. Translators: Instructions to refresh a user's data.
 #: TWLight/users/templates/users/eligibility_modal.html:50
@@ -3236,13 +2596,8 @@ msgstr "إختر اللغة"
 
 #. Translators: This text on the user page helps users naviage to the TranslateWiki Wikipedia Library Card platform translation page.
 #: TWLight/users/templates/users/language_form.html:31
-msgid ""
-"You can help translate the tool at <a class=\"twl-links\" href=\"https://"
-"translatewiki.net/wiki/Translating:Wikipedia_Library_Card_Platform"
-"\">translatewiki.net</a>."
-msgstr ""
-"يمكنك المساعدة في ترجمة الأداة على <a href=\"https://translatewiki.net/wiki/"
-"Translating:Wikipedia_Library_Card_Platform\">ترانسليت ويكي دوت نت</a>."
+msgid "You can help translate the tool at <a class=\"twl-links\" href=\"https://translatewiki.net/wiki/Translating:Wikipedia_Library_Card_Platform\">translatewiki.net</a>."
+msgstr "يمكنك المساعدة في ترجمة الأداة على <a href=\"https://translatewiki.net/wiki/Translating:Wikipedia_Library_Card_Platform\">ترانسليت ويكي دوت نت</a>."
 
 #. Translators: When the user starts a new application and submits the application, the user can view the application and withdraw if need be. This changes the label for the Withdraw button.
 #: TWLight/users/templates/users/my_applications.html:65
@@ -3261,11 +2616,8 @@ msgstr "طلب التجديد"
 
 #. Translators: On the page listing applications, this text explains a user they cannot renew their application since they've already requested a renewal or there aren't any renewals available.
 #: TWLight/users/templates/users/my_applications.html:79
-msgid ""
-"Renewals are either not required, not available right now, or you have "
-"already requested a renewal."
-msgstr ""
-"في الوقت الحالي، التجديدات إما غير مطلوبة أو غير متوفرة أو سبق لك طلب تجديد."
+msgid "Renewals are either not required, not available right now, or you have already requested a renewal."
+msgstr "في الوقت الحالي، التجديدات إما غير مطلوبة أو غير متوفرة أو سبق لك طلب تجديد."
 
 #. Translators: This text is the heading of a section in a user's profile where they can change their preferences.
 #: TWLight/users/templates/users/preferences.html:6
@@ -3328,27 +2680,13 @@ msgstr "تقييد معالجة البيانات"
 
 #. Translators: This message is displayed on the page where users can request we stop processing their data.
 #: TWLight/users/templates/users/restrict_data.html:15
-msgid ""
-"Checking this box and clicking “Restrict” will pause all processing of the "
-"data you have entered into this website. You will not be able to apply for "
-"access to resources, your applications will not be further processed, and "
-"none of your data will be altered, until you return to this page and uncheck "
-"the box. This is not the same as deleting your data."
-msgstr ""
-"سيؤدي تحديد هذا الصندوق والنقر على \"تقييد\" إلى إيقاف جميع عمليات معالجة "
-"البيانات التي أدخلتها في موقع الويب هذا مؤقتا، لن تتمكن من التقدم بطلب "
-"للحصول على الموارد، ولن تتم معالجة طلباتك مرة أخرى، ولن يتم تغيير أي من "
-"بياناتك، حتى تعود إلى هذه الصفحة وتلغي تحديد الصندوق، ليس هذا هو نفس حذف "
-"بياناتك."
+msgid "Checking this box and clicking “Restrict” will pause all processing of the data you have entered into this website. You will not be able to apply for access to resources, your applications will not be further processed, and none of your data will be altered, until you return to this page and uncheck the box. This is not the same as deleting your data."
+msgstr "سيؤدي تحديد هذا الصندوق والنقر على \"تقييد\" إلى إيقاف جميع عمليات معالجة البيانات التي أدخلتها في موقع الويب هذا مؤقتا، لن تتمكن من التقدم بطلب للحصول على الموارد، ولن تتم معالجة طلباتك مرة أخرى، ولن يتم تغيير أي من بياناتك، حتى تعود إلى هذه الصفحة وتلغي تحديد الصندوق، ليس هذا هو نفس حذف بياناتك."
 
 #. Translators: This warning message is shown to coordinators who view the data restriction page.
 #: TWLight/users/templates/users/restrict_data.html:26
-msgid ""
-"You are a coordinator on this site. If you restrict the processing of your "
-"data, your coordinator flag will be removed."
-msgstr ""
-"أنت منسق على هذا الموقع، إذا قمت بتقييد معالجة بياناتك، فستتم إزالة علم "
-"المنسق الخاص بك."
+msgid "You are a coordinator on this site. If you restrict the processing of your data, your coordinator flag will be removed."
+msgstr "أنت منسق على هذا الموقع، إذا قمت بتقييد معالجة بياناتك، فستتم إزالة علم المنسق الخاص بك."
 
 #. Translators: use the date *when you are translating*, in a language-appropriate format.
 #: TWLight/users/templates/users/terms.html:33
@@ -3367,37 +2705,14 @@ msgstr "بيان شروط استخدام بطاقة مكتبة ويكيبيدي�
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:51
-msgid ""
-"<a class=\"twl-links\" href=\"https://meta.wikimedia.org/wiki/"
-"The_Wikipedia_Library\"> The Wikipedia Library </a> has partnered with "
-"publishers around the world to allow users to access otherwise paywalled "
-"resources. This website allows Wikipedia editors to search and access these "
-"resources."
-msgstr ""
-"<a href=\"https://meta.wikimedia.org/wiki/The_Wikipedia_Library/ar\">مكتبة "
-"ويكيبيديا</a> عقدت شراكة مع الناشرين في جميع أنحاء العالم للسماح للمستخدمين "
-"بالوصول إلى الموارد المدفوعة بطريقة أخرى، يتيح موقع الويب هذا للمستخدمين "
-"إمكانية التقديم في وقت واحد للوصول إلى مواد ناشرين متعددين ط، ويجعل إدارة "
-"حسابات مكتبة ويكيبيديا والوصول إليها سهلا وفعالا."
+msgid "<a class=\"twl-links\" href=\"https://meta.wikimedia.org/wiki/The_Wikipedia_Library\"> The Wikipedia Library </a> has partnered with publishers around the world to allow users to access otherwise paywalled resources. This website allows Wikipedia editors to search and access these resources."
+msgstr "<a href=\"https://meta.wikimedia.org/wiki/The_Wikipedia_Library/ar\">مكتبة ويكيبيديا</a> عقدت شراكة مع الناشرين في جميع أنحاء العالم للسماح للمستخدمين بالوصول إلى الموارد المدفوعة بطريقة أخرى، يتيح موقع الويب هذا للمستخدمين إمكانية التقديم في وقت واحد للوصول إلى مواد ناشرين متعددين ط، ويجعل إدارة حسابات مكتبة ويكيبيديا والوصول إليها سهلا وفعالا."
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Wikimedia Foundation should not be translated. WMF should not be translated. Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:63
 #, fuzzy
-msgid ""
-"This program is administered by the Wikimedia Foundation (WMF). These terms "
-"of use and privacy notice pertain to your application for access to "
-"resources through the Wikipedia Library, your use of this website, and your "
-"access to and use of those resources. They also describe our handling of the "
-"information you provide to us in order to create and administer your "
-"Wikipedia Library account. If we make material changes to the terms, we will "
-"notify users."
-msgstr ""
-"تتعلق هذه الشروط بطلبك للوصول إلى موارد مكتبة ويكيبيديا، واستخدامك لتلك "
-"الموارد، كما أنها تصف طريقة تعاملنا مع المعلومات التي تقدمها لنا من أجل "
-"إنشاء وإدارة حسابك في مكتبة ويكيبيديا، نظام مكتبة ويكيبيديا آخذ في التطور، "
-"وبمرور الوقت قد نقوم بتحديث هذه الشروط بسبب التغيرات في التقنية، نوصيك "
-"بمراجعة البنود من وقت لآخر، إذا أجرينا تغييرات جوهرية على الشروط، فسوف نرسل "
-"إشعارا بالبريد الإلكتروني إلى مستخدمي مكتبة ويكيبيديا."
+msgid "This program is administered by the Wikimedia Foundation (WMF). These terms of use and privacy notice pertain to your application for access to resources through the Wikipedia Library, your use of this website, and your access to and use of those resources. They also describe our handling of the information you provide to us in order to create and administer your Wikipedia Library account. If we make material changes to the terms, we will notify users."
+msgstr "تتعلق هذه الشروط بطلبك للوصول إلى موارد مكتبة ويكيبيديا، واستخدامك لتلك الموارد، كما أنها تصف طريقة تعاملنا مع المعلومات التي تقدمها لنا من أجل إنشاء وإدارة حسابك في مكتبة ويكيبيديا، نظام مكتبة ويكيبيديا آخذ في التطور، وبمرور الوقت قد نقوم بتحديث هذه الشروط بسبب التغيرات في التقنية، نوصيك بمراجعة البنود من وقت لآخر، إذا أجرينا تغييرات جوهرية على الشروط، فسوف نرسل إشعارا بالبريد الإلكتروني إلى مستخدمي مكتبة ويكيبيديا."
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:74
@@ -3406,54 +2721,18 @@ msgstr "متطلبات حساب بطاقة مكتبة ويكيبيديا"
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:78
-msgid ""
-"Access to resources via The Wikipedia Library is reserved for community "
-"members who have demonstrated their commitment to the Wikimedia projects, "
-"and who will use their access to these resources to improve project content. "
-"To that end, in order to be eligible for The Wikipedia Library, we require "
-"that you be registered for a user account on the projects, with at least 500 "
-"edits, six (6) months of activity, and 10+ edits in the last month. We ask "
-"that you do not request access to any publishers with a limited number of "
-"available accounts whose resources you can already access for free through "
-"your local library or university, or another institution or organization, in "
-"order to provide that opportunity to others."
-msgstr ""
-"الوصول إلى الموارد عبر مكتبة ويكيبيديا مخصص لأفراد المجتمع الذين أظهروا "
-"التزامهم بمشاريع ويكيميديا، والذين سيستخدمون وصولهم إلى هذه الموارد لتحسين "
-"محتوى المشروع، تحقيقا لهذه الغاية؛ لكي تكون مؤهلا لبرنامج مكتبة ويكيبيديا؛ "
-"نطلب منك التسجيل لحساب مستخدم في المشاريع، نعطي الأفضلية للمستخدمين الذين "
-"لديهم ما لا يقل عن 500 تعديل وستة أشهر من النشاط، لكن هذه ليست متطلبات "
-"صارمة، نطلب منك عدم طلب الوصول إلى أي ناشرين تستطيع مواردهم بالفعل الوصول "
-"إليه مجانا من خلال مكتبتك المحلية أو جامعتك أو مؤسسة أو مؤسسة أخرى؛ لتوفير "
-"هذه الفرصة للآخرين."
+msgid "Access to resources via The Wikipedia Library is reserved for community members who have demonstrated their commitment to the Wikimedia projects, and who will use their access to these resources to improve project content. To that end, in order to be eligible for The Wikipedia Library, we require that you be registered for a user account on the projects, with at least 500 edits, six (6) months of activity, and 10+ edits in the last month. We ask that you do not request access to any publishers with a limited number of available accounts whose resources you can already access for free through your local library or university, or another institution or organization, in order to provide that opportunity to others."
+msgstr "الوصول إلى الموارد عبر مكتبة ويكيبيديا مخصص لأفراد المجتمع الذين أظهروا التزامهم بمشاريع ويكيميديا، والذين سيستخدمون وصولهم إلى هذه الموارد لتحسين محتوى المشروع، تحقيقا لهذه الغاية؛ لكي تكون مؤهلا لبرنامج مكتبة ويكيبيديا؛ نطلب منك التسجيل لحساب مستخدم في المشاريع، نعطي الأفضلية للمستخدمين الذين لديهم ما لا يقل عن 500 تعديل وستة أشهر من النشاط، لكن هذه ليست متطلبات صارمة، نطلب منك عدم طلب الوصول إلى أي ناشرين تستطيع مواردهم بالفعل الوصول إليه مجانا من خلال مكتبتك المحلية أو جامعتك أو مؤسسة أو مؤسسة أخرى؛ لتوفير هذه الفرصة للآخرين."
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:94
-msgid ""
-"Additionally, if you are currently blocked or banned from a Wikimedia "
-"project, applications to resources may be rejected or restricted. If you "
-"obtain a Wikipedia Library account, but a block or ban is subsequently "
-"instituted against you on one of the projects, you may lose access to your "
-"Wikipedia Library account."
-msgstr ""
-"بالإضافة إلى ذلك، إذا كنت ممنوعا أو مطرودا حاليا من مشروع ويكيميديا​​، فقد يتم "
-"رفض طلبات الموارد أو تقييدها، إذا حصلت على حساب مكتبة ويكيبيديا، ولكن تم فرض "
-"منع طويل الأجل أو طرد عليك فيما بعد على أحد المشاريع، فقد تفقد الوصول إلى "
-"حساب مكتبة ويكيبيديا."
+msgid "Additionally, if you are currently blocked or banned from a Wikimedia project, applications to resources may be rejected or restricted. If you obtain a Wikipedia Library account, but a block or ban is subsequently instituted against you on one of the projects, you may lose access to your Wikipedia Library account."
+msgstr "بالإضافة إلى ذلك، إذا كنت ممنوعا أو مطرودا حاليا من مشروع ويكيميديا​​، فقد يتم رفض طلبات الموارد أو تقييدها، إذا حصلت على حساب مكتبة ويكيبيديا، ولكن تم فرض منع طويل الأجل أو طرد عليك فيما بعد على أحد المشاريع، فقد تفقد الوصول إلى حساب مكتبة ويكيبيديا."
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:104
-msgid ""
-"Your eligibility to access The Wikipedia Library is assessed at each login. "
-"While more than half of the library's content is provided via this automated "
-"eligibility check, access to other publisher's content may be time limited, "
-"typically lapsing after one year, after which you will usually need to apply "
-"for renewal."
-msgstr ""
-"يتم تقييم أهليتك للوصول إلى مكتبة ويكيبيديا عند كل تسجيل دخول. بينما يتم "
-"توفير أكثر من نصف محتوى المكتبة عبر هذا التحقق الآلي من الأهلية، قد يكون "
-"الوصول إلى محتوى ناشر آخر محدودًا بزمن معين، وعادةً ما ينقضي بعد عام واحد، "
-"وبعد ذلك ستحتاج عادةً إلى تقديم طلب للتجديد."
+msgid "Your eligibility to access The Wikipedia Library is assessed at each login. While more than half of the library's content is provided via this automated eligibility check, access to other publisher's content may be time limited, typically lapsing after one year, after which you will usually need to apply for renewal."
+msgstr "يتم تقييم أهليتك للوصول إلى مكتبة ويكيبيديا عند كل تسجيل دخول. بينما يتم توفير أكثر من نصف محتوى المكتبة عبر هذا التحقق الآلي من الأهلية، قد يكون الوصول إلى محتوى ناشر آخر محدودًا بزمن معين، وعادةً ما ينقضي بعد عام واحد، وبعد ذلك ستحتاج عادةً إلى تقديم طلب للتجديد."
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:114
@@ -3463,64 +2742,28 @@ msgstr "تقديم طلب للحصول على حساب بطاقة مكتبة و�
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:118
-msgid ""
-"In order to apply for access to a partner resource, you must provide us with "
-"certain information, which we will use to evaluate your application. If your "
-"application is approved, we may transfer the information you have given us "
-"to the publishers whose resources you wish to access. They will either "
-"contact you with the account information directly or we will send access "
-"information to you ourselves."
-msgstr ""
-"من أجل التقدم للوصول إلى مورد شريك؛ يجب عليك تزويدنا بمعلومات معينة، والتي "
-"سنستخدمها لتقييم طلبك، إذا تمت الموافقة على طلبك، فيجوز لنا نقل المعلومات "
-"التي قدمتها لنا للناشرين الذين ترغب في الوصول إلى مواردهم، سيقومون إما "
-"بالاتصال بك بمعلومات الحساب مباشرة أو سوف نرسل معلومات الوصول إليك بأنفسنا."
+msgid "In order to apply for access to a partner resource, you must provide us with certain information, which we will use to evaluate your application. If your application is approved, we may transfer the information you have given us to the publishers whose resources you wish to access. They will either contact you with the account information directly or we will send access information to you ourselves."
+msgstr "من أجل التقدم للوصول إلى مورد شريك؛ يجب عليك تزويدنا بمعلومات معينة، والتي سنستخدمها لتقييم طلبك، إذا تمت الموافقة على طلبك، فيجوز لنا نقل المعلومات التي قدمتها لنا للناشرين الذين ترغب في الوصول إلى مواردهم، سيقومون إما بالاتصال بك بمعلومات الحساب مباشرة أو سوف نرسل معلومات الوصول إليك بأنفسنا."
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:130
-msgid ""
-"In addition to the basic information you provide to us, our system will "
-"retrieve some information directly from the Wikimedia projects: your "
-"username, email address, edit count, registration date, user ID number, "
-"groups to which you belong, and any special user rights."
-msgstr ""
-"بالإضافة إلى المعلومات الأساسية التي تزودنا بها، سيقوم نظامنا باسترداد بعض "
-"المعلومات مباشرة من مشاريع ويكيميديا: اسم المستخدم الخاص بك، وعنوان البريد "
-"الإلكتروني، وعد التعديلات، وتاريخ التسجيل، ورقم معرف المستخدم، والمجموعات "
-"التي تنتمي إليها، وأية صلاحيات مستخدم خاصة."
+msgid "In addition to the basic information you provide to us, our system will retrieve some information directly from the Wikimedia projects: your username, email address, edit count, registration date, user ID number, groups to which you belong, and any special user rights."
+msgstr "بالإضافة إلى المعلومات الأساسية التي تزودنا بها، سيقوم نظامنا باسترداد بعض المعلومات مباشرة من مشاريع ويكيميديا: اسم المستخدم الخاص بك، وعنوان البريد الإلكتروني، وعد التعديلات، وتاريخ التسجيل، ورقم معرف المستخدم، والمجموعات التي تنتمي إليها، وأية صلاحيات مستخدم خاصة."
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:140
-msgid ""
-"Each time you log in to the Wikipedia Library Card Platform, this "
-"information will be automatically updated."
-msgstr ""
-"في كل مرة تقوم فيها بتسجيل الدخول إلى منصة بطاقة مكتبة ويكيبيديا، سيتم تحديث "
-"هذه المعلومات تلقائيا"
+msgid "Each time you log in to the Wikipedia Library Card Platform, this information will be automatically updated."
+msgstr "في كل مرة تقوم فيها بتسجيل الدخول إلى منصة بطاقة مكتبة ويكيبيديا، سيتم تحديث هذه المعلومات تلقائيا"
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:148
-msgid ""
-"We will ask you to provide us with some information about your history of "
-"contributions to the Wikimedia projects. Information on contribution history "
-"is optional, but will greatly assist us in evaluating your application."
-msgstr ""
-"سنطلب منك تزويدنا ببعض المعلومات حول محفوظات مساهماتك في مشاريع ويكيميديا، "
-"المعلومات حول تاريخ المساهمة اختيارية، ولكنها ستساعدنا كثيرا في تقييم طلبك."
+msgid "We will ask you to provide us with some information about your history of contributions to the Wikimedia projects. Information on contribution history is optional, but will greatly assist us in evaluating your application."
+msgstr "سنطلب منك تزويدنا ببعض المعلومات حول محفوظات مساهماتك في مشاريع ويكيميديا، المعلومات حول تاريخ المساهمة اختيارية، ولكنها ستساعدنا كثيرا في تقييم طلبك."
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). WMF should not be translated. Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:157
-msgid ""
-"The information you provide when creating your account will be visible to "
-"you while on the site but not to others unless they are approved Wikipedia "
-"Library Coordinators, WMF Staff, or WMF Contractors who need access to this "
-"data in order to carry out their work with the Wikipedia Library, all of "
-"whom are subject to non-disclosure obligations."
-msgstr ""
-"ستكون المعلومات التي تقدمها عند إنشاء حسابك مرئية لك أثناء تواجدك على الموقع "
-"ولكن ليس للآخرين ما لم تتم الموافقة من منسقي مكتبة ويكيبيديا أو موظفي "
-"ويكيميديا أو مقاولي ويكيميديا الذين يحتاجون إلى الوصول إلى هذه البيانات من "
-"أجل القيام بعملهم مع  مكتبة ويكيبيديا، وكلها تخضع لالتزامات عدم الكشف."
+msgid "The information you provide when creating your account will be visible to you while on the site but not to others unless they are approved Wikipedia Library Coordinators, WMF Staff, or WMF Contractors who need access to this data in order to carry out their work with the Wikipedia Library, all of whom are subject to non-disclosure obligations."
+msgstr "ستكون المعلومات التي تقدمها عند إنشاء حسابك مرئية لك أثناء تواجدك على الموقع ولكن ليس للآخرين ما لم تتم الموافقة من منسقي مكتبة ويكيبيديا أو موظفي ويكيميديا أو مقاولي ويكيميديا الذين يحتاجون إلى الوصول إلى هذه البيانات من أجل القيام بعملهم مع  مكتبة ويكيبيديا، وكلها تخضع لالتزامات عدم الكشف."
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:167
@@ -3529,61 +2772,35 @@ msgstr "استخدامك لموارد الناشر"
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:171
-msgid ""
-"In order to access an individual publisher’s resources, you must agree to "
-"that publisher’s terms of use and privacy policy. You agree that you will "
-"not violate such terms and policies in connection with your use of the "
-"Wikipedia Library. Additionally, the following activities are prohibited "
-"while accessing publisher resources through the Wikipedia Library."
-msgstr ""
-"للوصول إلى موارد ناشر فردي؛ يجب أن توافق على شروط استخدام ذلك الناشر وسياسة "
-"الخصوصية الخاصة به، أنت توافق على أنك لن تنتهك هذه الشروط والسياسات فيما "
-"يتعلق باستخدامك لمكتبة ويكيبيديا، بالإضافة إلى ذلك، يتم حظر الأنشطة التالية "
-"أثناء الوصول إلى موارد الناشر من خلال مكتبة ويكيبيديا."
+msgid "In order to access an individual publisher’s resources, you must agree to that publisher’s terms of use and privacy policy. You agree that you will not violate such terms and policies in connection with your use of the Wikipedia Library. Additionally, the following activities are prohibited while accessing publisher resources through the Wikipedia Library."
+msgstr "للوصول إلى موارد ناشر فردي؛ يجب أن توافق على شروط استخدام ذلك الناشر وسياسة الخصوصية الخاصة به، أنت توافق على أنك لن تنتهك هذه الشروط والسياسات فيما يتعلق باستخدامك لمكتبة ويكيبيديا، بالإضافة إلى ذلك، يتم حظر الأنشطة التالية أثناء الوصول إلى موارد الناشر من خلال مكتبة ويكيبيديا."
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:184
-msgid ""
-"Sharing your Wikipedia account, usernames, passwords, or any access codes "
-"for publisher resources with others;"
-msgstr ""
-"مشاركة أسماء المستخدمين أو كلمات المرور أو أي رموز وصول لموارد الناشر مع "
-"الآخرين"
+msgid "Sharing your Wikipedia account, usernames, passwords, or any access codes for publisher resources with others;"
+msgstr "مشاركة أسماء المستخدمين أو كلمات المرور أو أي رموز وصول لموارد الناشر مع الآخرين"
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:191
-msgid ""
-"Automatically scraping or downloading restricted content from publishers;"
+msgid "Automatically scraping or downloading restricted content from publishers;"
 msgstr "إلغاء أو تنزيل المحتوى المحظور تلقائيًا من الناشرين"
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:197
 #, fuzzy
-msgid ""
-"Systematically making printed or electronic copies of multiple extracts of "
-"restricted content available for any purpose;"
-msgstr ""
-"إجراء نسخ مطبوعة أو إلكترونية بشكل منهجي لمقتطفات متعددة من المحتويات "
-"المقيدة المتاحة لأي غرض من الأغراض"
+msgid "Systematically making printed or electronic copies of multiple extracts of restricted content available for any purpose;"
+msgstr "إجراء نسخ مطبوعة أو إلكترونية بشكل منهجي لمقتطفات متعددة من المحتويات المقيدة المتاحة لأي غرض من الأغراض"
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:204
 #, fuzzy
-msgid ""
-"Data mining metadata without permission—for example, in order to use "
-"metadata for auto-created stub articles;"
-msgstr ""
-"البيانات الوصفية لمنجم البيانات بدون إذن، على سبيل المثال، من أجل استخدام "
-"بيانات التعريف لمقالات البذور المنشأة تلقائيا"
+msgid "Data mining metadata without permission—for example, in order to use metadata for auto-created stub articles;"
+msgstr "البيانات الوصفية لمنجم البيانات بدون إذن، على سبيل المثال، من أجل استخدام بيانات التعريف لمقالات البذور المنشأة تلقائيا"
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:211
-msgid ""
-"Using the access you receive through the Wikipedia Library for profit by "
-"selling access to your account or resources which you have through it."
-msgstr ""
-"استخدام الوصول الذي تتلقاه من خلال مكتبة ويكيبيديا لتحقيق الربح من خلال بيع "
-"الوصول إلى حسابك أو الموارد التي لديك من خلالها."
+msgid "Using the access you receive through the Wikipedia Library for profit by selling access to your account or resources which you have through it."
+msgstr "استخدام الوصول الذي تتلقاه من خلال مكتبة ويكيبيديا لتحقيق الربح من خلال بيع الوصول إلى حسابك أو الموارد التي لديك من خلالها."
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:220
@@ -3592,24 +2809,13 @@ msgstr "البحث الخارجي وخدمات الوكيل"
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:224
-msgid ""
-"Certain resources may only be accessed using an external search service, "
-"such as the EBSCO Discovery Service, or a proxy service, such as OCLC "
-"EZProxy. If you use such external search and/or proxy services, please "
-"review the applicable terms of use and privacy policies."
-msgstr ""
-"لا يمكن الوصول إلى بعض الموارد إلا باستخدام خدمة بحث خارجية، مثل خدمة اكتشاف "
-"EBSCO أو خدمة وكيل، مثل OCLC EZProxy، إذا كنت تستخدم خدمات البحث و/أو الوكيل "
-"الخارجية هذه، فتُرجَى مراجعة شروط الاستخدام وسياسات الخصوصية المعمول بها."
+msgid "Certain resources may only be accessed using an external search service, such as the EBSCO Discovery Service, or a proxy service, such as OCLC EZProxy. If you use such external search and/or proxy services, please review the applicable terms of use and privacy policies."
+msgstr "لا يمكن الوصول إلى بعض الموارد إلا باستخدام خدمة بحث خارجية، مثل خدمة اكتشاف EBSCO أو خدمة وكيل، مثل OCLC EZProxy، إذا كنت تستخدم خدمات البحث و/أو الوكيل الخارجية هذه، فتُرجَى مراجعة شروط الاستخدام وسياسات الخصوصية المعمول بها."
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:234
-msgid ""
-"In addition, if you use OCLC EZProxy, please note that you may not use it "
-"for commercial purposes."
-msgstr ""
-"بالإضافة إلى ذلك، إذا كنت تستخدم OCLC EZProxy، تُرجَى ملاحظة أنه لا يجوز لك "
-"استخدامه لأغراض تجارية."
+msgid "In addition, if you use OCLC EZProxy, please note that you may not use it for commercial purposes."
+msgstr "بالإضافة إلى ذلك، إذا كنت تستخدم OCLC EZProxy، تُرجَى ملاحظة أنه لا يجوز لك استخدامه لأغراض تجارية."
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:241
@@ -3619,179 +2825,51 @@ msgstr "الاحتفاظ بالبيانات والتعامل معها"
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Wikimedia Foundation should not be translated. Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:245
 #, fuzzy
-msgid ""
-"The Wikimedia Foundation and our service providers use your information for "
-"the legitimate purpose of providing Wikipedia Library services in support of "
-"our charitable mission. When you apply for a Wikipedia Library account, or "
-"use your Wikipedia Library account, we may routinely collect the following "
-"information: your username, email address, edit count, registration date, "
-"user ID number, groups to which you belong, and any special user rights; "
-"your name, country of residence, and/or affiliation, if required by a "
-"partner to which you are applying; your narrative description of your "
-"contributions and reasons for applying for access to partner resources; and "
-"the date you agree to these terms of use."
-msgstr ""
-"تستخدم مؤسسة ويكيميديا ​​ومقدمو خدماتنا معلوماتك للغرض المشروع المتمثل في "
-"توفير خدمات مكتبة ويكيبيديا لدعم مهمتنا الخيرية، عندما تتقدم بطلب للحصول على "
-"حساب مكتبة ويكيبيديا، أو تستخدم حساب مكتبة ويكيبيديا، فقد نجمع المعلومات "
-"التالية بشكل روتيني: اسم المستخدم وعنوان البريد الإلكتروني وتعديل الحساب "
-"وتاريخ التسجيل ورقم معرف المستخدم والمجموعات التي تنتمي إليها وأية صلاحيات "
-"مستخدم خاصة واسمك وبلد إقامتك و/أو وظيفتك و/أو انتمائك، إذا كان ذلك مطلوبا "
-"من قِبل شريك تقدم إليه ووصفك السردي لمساهماتك وأسباب التقدم بطلب للحصول على "
-"موارد الشريك وتاريخ موافقتك على شروط الاستخدام هذه."
+msgid "The Wikimedia Foundation and our service providers use your information for the legitimate purpose of providing Wikipedia Library services in support of our charitable mission. When you apply for a Wikipedia Library account, or use your Wikipedia Library account, we may routinely collect the following information: your username, email address, edit count, registration date, user ID number, groups to which you belong, and any special user rights; your name, country of residence, and/or affiliation, if required by a partner to which you are applying; your narrative description of your contributions and reasons for applying for access to partner resources; and the date you agree to these terms of use."
+msgstr "تستخدم مؤسسة ويكيميديا ​​ومقدمو خدماتنا معلوماتك للغرض المشروع المتمثل في توفير خدمات مكتبة ويكيبيديا لدعم مهمتنا الخيرية، عندما تتقدم بطلب للحصول على حساب مكتبة ويكيبيديا، أو تستخدم حساب مكتبة ويكيبيديا، فقد نجمع المعلومات التالية بشكل روتيني: اسم المستخدم وعنوان البريد الإلكتروني وتعديل الحساب وتاريخ التسجيل ورقم معرف المستخدم والمجموعات التي تنتمي إليها وأية صلاحيات مستخدم خاصة واسمك وبلد إقامتك و/أو وظيفتك و/أو انتمائك، إذا كان ذلك مطلوبا من قِبل شريك تقدم إليه ووصفك السردي لمساهماتك وأسباب التقدم بطلب للحصول على موارد الشريك وتاريخ موافقتك على شروط الاستخدام هذه."
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:262
 #, fuzzy, python-format
-msgid ""
-"Each publisher who is a member of the Wikipedia Library program requires "
-"different specific information in the application. Some publishers may "
-"request only an email address, while others request more detailed data, such "
-"as your name, location, or institutional affiliation. When you complete your "
-"application, you will only be asked to supply information required by the "
-"publishers you have chosen, and each publisher will only receive the "
-"information they require for providing you with access. Please see our <a "
-"class=\"twl-links\" href=\"%(all_partners_url)s\">partner information</a> "
-"pages to learn what information is required by each publisher to gain access "
-"to their resources."
-msgstr ""
-"كل ناشر يكون عضوا في برنامج مكتبة ويكيبيديا يتطلب معلومات محددة مختلفة في "
-"الطلب، قد يطلب بعض الناشرين عنوان بريد إلكتروني فقط، بينما يطلب آخرون بيانات "
-"أكثر تفصيلا، مثل اسمك أو موقعك أو مهنتك أو انتماءك المؤسسي، عند إكمال طلبك، "
-"سيُطلَب منك فقط توفير المعلومات التي يطلبها الناشرون الذين اخترتهم، وسيتلقى كل "
-"ناشر المعلومات التي يحتاجونها فقط/ يُرجَى الاطلاع على صفحات <a href="
-"\"%(all_partners_url)s\">معلومات الشريك</a> الخاصة بنا لمعرفة المعلومات "
-"المطلوبة من قبل كل ناشر للوصول إلى مواردهم."
+msgid "Each publisher who is a member of the Wikipedia Library program requires different specific information in the application. Some publishers may request only an email address, while others request more detailed data, such as your name, location, or institutional affiliation. When you complete your application, you will only be asked to supply information required by the publishers you have chosen, and each publisher will only receive the information they require for providing you with access. Please see our <a class=\"twl-links\" href=\"%(all_partners_url)s\">partner information</a> pages to learn what information is required by each publisher to gain access to their resources."
+msgstr "كل ناشر يكون عضوا في برنامج مكتبة ويكيبيديا يتطلب معلومات محددة مختلفة في الطلب، قد يطلب بعض الناشرين عنوان بريد إلكتروني فقط، بينما يطلب آخرون بيانات أكثر تفصيلا، مثل اسمك أو موقعك أو مهنتك أو انتماءك المؤسسي، عند إكمال طلبك، سيُطلَب منك فقط توفير المعلومات التي يطلبها الناشرون الذين اخترتهم، وسيتلقى كل ناشر المعلومات التي يحتاجونها فقط/ يُرجَى الاطلاع على صفحات <a href=\"%(all_partners_url)s\">معلومات الشريك</a> الخاصة بنا لمعرفة المعلومات المطلوبة من قبل كل ناشر للوصول إلى مواردهم."
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Wikimedia Foundation should not be translated. Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:277
-msgid ""
-"Some Wikipedia Library pages are visible without logging in, but you will "
-"need to log in to apply or access proprietary partner resources. We use the "
-"data provided by you via OAuth and Wikimedia API calls to assess your "
-"application for access and to process approved requests."
-msgstr ""
-"يمكنك تصفح موقع مكتبة ويكيبيديا دون تسجيل الدخول، ولكن ستحتاج إلى تسجيل "
-"الدخول للتطبيق أو الوصول إلى موارد شريك الملكية، نحن نستخدم البيانات التي "
-"تقدمها عن طريق استدعاءات أوث وAPI ويكيبيديا لتقييم طلبك للوصول ومعالجة "
-"الطلبات المعتمدة."
+msgid "Some Wikipedia Library pages are visible without logging in, but you will need to log in to apply or access proprietary partner resources. We use the data provided by you via OAuth and Wikimedia API calls to assess your application for access and to process approved requests."
+msgstr "يمكنك تصفح موقع مكتبة ويكيبيديا دون تسجيل الدخول، ولكن ستحتاج إلى تسجيل الدخول للتطبيق أو الوصول إلى موارد شريك الملكية، نحن نستخدم البيانات التي تقدمها عن طريق استدعاءات أوث وAPI ويكيبيديا لتقييم طلبك للوصول ومعالجة الطلبات المعتمدة."
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:288
 #, python-format
-msgid ""
-"In order to administer the Wikipedia Library program, we will retain the "
-"application data we collect from you for three years after your most recent "
-"login, unless you delete your account, as described below. You can log in "
-"and go to <a class=\"twl-links\" href=\"%(profile_url)s\">your profile page</"
-"a> in order to see the information associated with your account, and can "
-"download it in JSON format. You may access, update, restrict, or delete this "
-"information at any time, except for the information that is automatically "
-"retrieved from the projects. If you have any questions or concerns about the "
-"handling of your data, please contact <a class=\"twl-links\" href=\"mailto:"
-"wikipedialibrary@wikimedia.org?Subject=Wikipedia%%20Library%%20Card"
-"%%20account%%20deactivation\"> wikipedialibrary@wikimedia.org </a>."
-msgstr ""
-"لإدارة برنامج مكتبة ويكيبيديا؛ سنحتفظ ببيانات الطلب التي نجمعها منك لمدة "
-"ثلاث سنوات بعد تسجيل الدخول الأخير، ما لم تحذف حسابك، كما هو موضح أدناه، "
-"يمكنك تسجيل الدخول والانتقال إلى <a href=\"%(profile_url)s\">صفحة ملفك "
-"الشخصي</a> لمشاهدة المعلومات المرتبطة بحسابك، ويمكنك تنزيلها بتنسيق JSON، "
-"يمكنك الوصول إلى هذه المعلومات أو تحديثها أو تقييدها أو حذفها في أي وقت، "
-"باستثناء المعلومات التي يتم استردادها تلقائيا من المشاريع، إذا كانت لديك أية "
-"أسئلة أو استفسارات حول معالجة بياناتك، فيُرجَى الاتصال بـ<a href=\"mailto:"
-"wikipedialibrary@wikimedia.org?Subject=Wikipedia%%20Library%%20Card"
-"%%20account%%20deactivation\">wikipedialibrary@wikimedia.org</a>."
+msgid "In order to administer the Wikipedia Library program, we will retain the application data we collect from you for three years after your most recent login, unless you delete your account, as described below. You can log in and go to <a class=\"twl-links\" href=\"%(profile_url)s\">your profile page</a> in order to see the information associated with your account, and can download it in JSON format. You may access, update, restrict, or delete this information at any time, except for the information that is automatically retrieved from the projects. If you have any questions or concerns about the handling of your data, please contact <a class=\"twl-links\" href=\"mailto:wikipedialibrary@wikimedia.org?Subject=Wikipedia%%20Library%%20Card%%20account%%20deactivation\"> wikipedialibrary@wikimedia.org </a>."
+msgstr "لإدارة برنامج مكتبة ويكيبيديا؛ سنحتفظ ببيانات الطلب التي نجمعها منك لمدة ثلاث سنوات بعد تسجيل الدخول الأخير، ما لم تحذف حسابك، كما هو موضح أدناه، يمكنك تسجيل الدخول والانتقال إلى <a href=\"%(profile_url)s\">صفحة ملفك الشخصي</a> لمشاهدة المعلومات المرتبطة بحسابك، ويمكنك تنزيلها بتنسيق JSON، يمكنك الوصول إلى هذه المعلومات أو تحديثها أو تقييدها أو حذفها في أي وقت، باستثناء المعلومات التي يتم استردادها تلقائيا من المشاريع، إذا كانت لديك أية أسئلة أو استفسارات حول معالجة بياناتك، فيُرجَى الاتصال بـ<a href=\"mailto:wikipedialibrary@wikimedia.org?Subject=Wikipedia%%20Library%%20Card%%20account%%20deactivation\">wikipedialibrary@wikimedia.org</a>."
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:305
 #, fuzzy
-msgid ""
-"If you decide to disable your Wikipedia Library account, you can use the "
-"delete button on your profile to delete certain personal information "
-"associated with your account. We will delete your real name, institutional "
-"affiliation, and country of residence. Please note that the system will "
-"retain a record of your username, the publishers to which you applied or had "
-"access, and the dates of that access. Note that deletion is not reversible. "
-"Deletion of your Wikipedia Library account may also correspond with the "
-"removal of any resource access to which you were eligible or approved. If "
-"you request the deletion of account information and later wish to apply for "
-"a new account, you will need to provide the necessary information again."
-msgstr ""
-"إذا قررت تعطيل حساب مكتبة ويكيبيديا الخاص بك، يمكنك مراسلتنا على <a href="
-"\"mailto:wikipedialibrary@wikimedia.org?Subject=Wikipedia%%20Library%%20Card%"
-"%20account%%20deactivation\">wikipedialibrary@wikimedia.org</a> لطلب حذف بعض "
-"المعلومات الشخصية المرتبطة بحسابك، سنحذف اسمك الحقيقي، ومهنتك، وانتسابك "
-"المؤسسي، وبلد إقامتك تُرجَى ملاحظة أن النظام سيحتفظ بسجل عن اسم المستخدم الخاص "
-"بك، والناشرين الذين قمت بطلبهم أو كان لهم حق الوصول إليهه، وتواريخ الوصول، "
-"إذا طلبت حذف معلومات الحساب وترغب لاحقا في التقدم بطلب للحصول على حساب جديد، "
-"فستحتاج إلى تقديم المعلومات الضرورية مرة أخرى."
+msgid "If you decide to disable your Wikipedia Library account, you can use the delete button on your profile to delete certain personal information associated with your account. We will delete your real name, institutional affiliation, and country of residence. Please note that the system will retain a record of your username, the publishers to which you applied or had access, and the dates of that access. Note that deletion is not reversible. Deletion of your Wikipedia Library account may also correspond with the removal of any resource access to which you were eligible or approved. If you request the deletion of account information and later wish to apply for a new account, you will need to provide the necessary information again."
+msgstr "إذا قررت تعطيل حساب مكتبة ويكيبيديا الخاص بك، يمكنك مراسلتنا على <a href=\"mailto:wikipedialibrary@wikimedia.org?Subject=Wikipedia%%20Library%%20Card%%20account%%20deactivation\">wikipedialibrary@wikimedia.org</a> لطلب حذف بعض المعلومات الشخصية المرتبطة بحسابك، سنحذف اسمك الحقيقي، ومهنتك، وانتسابك المؤسسي، وبلد إقامتك تُرجَى ملاحظة أن النظام سيحتفظ بسجل عن اسم المستخدم الخاص بك، والناشرين الذين قمت بطلبهم أو كان لهم حق الوصول إليهه، وتواريخ الوصول، إذا طلبت حذف معلومات الحساب وترغب لاحقا في التقدم بطلب للحصول على حساب جديد، فستحتاج إلى تقديم المعلومات الضرورية مرة أخرى."
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). WMF should not be translated. Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:321
-msgid ""
-"The Wikipedia Library is run by WMF Staff, Contractors, and approved "
-"volunteer Coordinators. The data associated with your account will be shared "
-"with the WMF staff, contractors, service providers, and volunteer "
-"coordinators who need to process the information in connection with their "
-"work for the Wikipedia Library, and who are subject to confidentiality "
-"obligations. We will also use your data for internal Wikipedia Library "
-"purposes such as distributing user surveys and account notifications, and in "
-"a depersonalized or aggregated fashion for statistical analysis and "
-"administration. Finally, we will share your information with the publishers "
-"whom you specifically select in order to provide you with access to "
-"resources. Otherwise, your information will not be shared with third "
-"parties, with the exception of the circumstances described below."
-msgstr ""
-"يتم تشغيل مكتبة ويكيبيديا من قبل موظفي مؤسسة ويكيميديا والمقاولين والمنسقين "
-"المتطوعين المعتمدين، ستتم مشاركة البيانات المرتبطة بحسابك مع موظفي مؤسسة "
-"ويكيميديا والمقاولين ومقدمي الخدمات ومنسقي المتطوعين الذين يحتاجون إلى "
-"معالجة المعلومات المتعلقة بعملهم في مكتبة ويكيبيديا، والذين يخضعون لالتزامات "
-"السرية، سنستخدم أيضا بياناتك لأغراض مكتبة ويكيبيديا الداخلية مثل توزيع "
-"استطلاعات المستخدم وإشعارات الحساب، وبطريقة غير شخصية أو مجمعة للتحليل "
-"الإحصائي والإدارة، أخيرا، سنشارك معلوماتك مع الناشرين الذين حددتهم على وجه "
-"التحديد من أجل تزويدك بالوصول إلى الموارد، وإلا، فلن تتم مشاركة معلوماتك مع "
-"أطراف ثالثة، باستثناء الحالات الموضحة أدناه."
+msgid "The Wikipedia Library is run by WMF Staff, Contractors, and approved volunteer Coordinators. The data associated with your account will be shared with the WMF staff, contractors, service providers, and volunteer coordinators who need to process the information in connection with their work for the Wikipedia Library, and who are subject to confidentiality obligations. We will also use your data for internal Wikipedia Library purposes such as distributing user surveys and account notifications, and in a depersonalized or aggregated fashion for statistical analysis and administration. Finally, we will share your information with the publishers whom you specifically select in order to provide you with access to resources. Otherwise, your information will not be shared with third parties, with the exception of the circumstances described below."
+msgstr "يتم تشغيل مكتبة ويكيبيديا من قبل موظفي مؤسسة ويكيميديا والمقاولين والمنسقين المتطوعين المعتمدين، ستتم مشاركة البيانات المرتبطة بحسابك مع موظفي مؤسسة ويكيميديا والمقاولين ومقدمي الخدمات ومنسقي المتطوعين الذين يحتاجون إلى معالجة المعلومات المتعلقة بعملهم في مكتبة ويكيبيديا، والذين يخضعون لالتزامات السرية، سنستخدم أيضا بياناتك لأغراض مكتبة ويكيبيديا الداخلية مثل توزيع استطلاعات المستخدم وإشعارات الحساب، وبطريقة غير شخصية أو مجمعة للتحليل الإحصائي والإدارة، أخيرا، سنشارك معلوماتك مع الناشرين الذين حددتهم على وجه التحديد من أجل تزويدك بالوصول إلى الموارد، وإلا، فلن تتم مشاركة معلوماتك مع أطراف ثالثة، باستثناء الحالات الموضحة أدناه."
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). WMF should not be translated.
 #: TWLight/users/templates/users/terms.html:338
-msgid ""
-"We may disclose any collected information when required by law, when we have "
-"your permission, when needed to protect our rights, privacy, safety, users, "
-"or the general public, and when necessary to enforce these terms, WMF’s "
-"general <a class=\"twl-links\" href=\"https://foundation.wikimedia.org/wiki/"
-"Terms_of_Use\">Terms of Use</a>, or any other WMF policy."
-msgstr ""
-"قد نكشف عن أية معلومات تم جمعها عندما يتطلب القانون ذلك، عندما يكون لدينا "
-"إذن منك، أو عند الحاجة لحماية حقوقنا أو خصوصيتنا أو سلامتنا أو مستخدمينا أو "
-"عامة الناس، أو عند الضرورة لفرض هذه الشروط أو <a href=\"https://foundation."
-"wikimedia.org/wiki/Terms_of_Use\">شروط استخدام</a> مؤسسة ويكيميديا، أو أية "
-"سياسة مؤسسة ويكيميديا أخرى."
+msgid "We may disclose any collected information when required by law, when we have your permission, when needed to protect our rights, privacy, safety, users, or the general public, and when necessary to enforce these terms, WMF’s general <a class=\"twl-links\" href=\"https://foundation.wikimedia.org/wiki/Terms_of_Use\">Terms of Use</a>, or any other WMF policy."
+msgstr "قد نكشف عن أية معلومات تم جمعها عندما يتطلب القانون ذلك، عندما يكون لدينا إذن منك، أو عند الحاجة لحماية حقوقنا أو خصوصيتنا أو سلامتنا أو مستخدمينا أو عامة الناس، أو عند الضرورة لفرض هذه الشروط أو <a href=\"https://foundation.wikimedia.org/wiki/Terms_of_Use\">شروط استخدام</a> مؤسسة ويكيميديا، أو أية سياسة مؤسسة ويكيميديا أخرى."
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:349
-msgid ""
-"We take the security of your personal data seriously, and take reasonable "
-"precautions to ensure your data is protected. These precautions include "
-"access controls to limit who has access to your data and security "
-"technologies to protect data stored on the server. However, we cannot "
-"guarantee the safety of your data as it is transmitted and stored."
-msgstr ""
-"نحن نأخذ أمان بياناتك الشخصية على محمل الجد، ونتخذ الاحتياطات المعقولة لضمان "
-"حماية بياناتك، تتضمن هذه الاحتياطات عناصر تحكم في الوصول لتحديد من لديه حق "
-"الوصول إلى بياناتك وتقنيات الأمان لحماية البيانات المخزنة على الخادم، ومع "
-"ذلك، لا يمكننا ضمان سلامة بياناتك عند إرسالها وتخزينها."
+msgid "We take the security of your personal data seriously, and take reasonable precautions to ensure your data is protected. These precautions include access controls to limit who has access to your data and security technologies to protect data stored on the server. However, we cannot guarantee the safety of your data as it is transmitted and stored."
+msgstr "نحن نأخذ أمان بياناتك الشخصية على محمل الجد، ونتخذ الاحتياطات المعقولة لضمان حماية بياناتك، تتضمن هذه الاحتياطات عناصر تحكم في الوصول لتحديد من لديه حق الوصول إلى بياناتك وتقنيات الأمان لحماية البيانات المخزنة على الخادم، ومع ذلك، لا يمكننا ضمان سلامة بياناتك عند إرسالها وتخزينها."
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:360
-msgid ""
-"Please note that these terms do not control the use and handling of your "
-"data by the publishers and service providers whose resources you access or "
-"apply to access. Please read their individual privacy policies for that "
-"information."
-msgstr ""
-"تُرجَى ملاحظة أن هذه الشروط لا تتحكم في استخدام بياناتك ومعالجتها من قبل "
-"الناشرين ومقدمي الخدمات الذين تصل مواردهم أو تنطبق عليها للوصول، تُرجَى قراءة "
-"سياسات الخصوصية الفردية لهذه المعلومات."
+msgid "Please note that these terms do not control the use and handling of your data by the publishers and service providers whose resources you access or apply to access. Please read their individual privacy policies for that information."
+msgstr "تُرجَى ملاحظة أن هذه الشروط لا تتحكم في استخدام بياناتك ومعالجتها من قبل الناشرين ومقدمي الخدمات الذين تصل مواردهم أو تنطبق عليها للوصول، تُرجَى قراءة سياسات الخصوصية الفردية لهذه المعلومات."
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:368
@@ -3801,50 +2879,18 @@ msgstr "مستورد"
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Wikimedia Foundation should not be translated. Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:373
-msgid ""
-"The Wikimedia Foundation is a nonprofit organization based in San Francisco, "
-"California. The Wikipedia Library program provides access to resources held "
-"by publishers in multiple countries. If you apply for a Wikipedia Library "
-"account (whether you are inside or outside of the United States), you "
-"understand that your personal data will be collected, transferred, stored, "
-"processed, disclosed and otherwise used in the U.S. as described in this "
-"privacy policy. You also understand that your information may be transferred "
-"by us from the U.S. to other countries, which may have different or less "
-"stringent data protection laws than your country, in connection with "
-"providing services to you, including evaluating your application and "
-"securing access to your chosen publishers (locations for each publisher are "
-"outlined on their respective partner information pages)."
-msgstr ""
-"مؤسسة ويكيميديا ​​هي منظمة غير ربحية مقرها في سان فرانسيسكو، كاليفورنيا، يوفر "
-"برنامج مكتبة ويكيبيديا الوصول إلى الموارد التي يحتفظ بها الناشرون في بلدان "
-"متعددة، إذا تقدمت بطلب للحصول على حساب مكتبة ويكيبيديا (سواء كنت داخل "
-"الولايات المتحدة أو خارجها)، فأنت تدرك أن بياناتك الشخصية سيتم جمعها ونقلها "
-"وتخزينها ومعالجتها والكشف عنها واستخدامها بطريقة أخرى في الولايات المتحدة "
-"كما هو موضح في سياسة الخصوصية هذه، أنت تدرك أيضا أن معلوماتك قد يتم نقلها من "
-"الولايات المتحدة إلى بلدان أخرى، والتي قد تكون لديها قوانين مختلفة أو أقل "
-"صرامة لحماية البيانات من بلدك، فيما يتعلق بتقديم الخدمات لك، بما في ذلك "
-"تقييم طلبك وتأمين الوصول إلى اختيارك  الناشرين (يتم تحديد مواقع كل ناشر على "
-"صفحات معلومات الشركاء المعنيين)."
+msgid "The Wikimedia Foundation is a nonprofit organization based in San Francisco, California. The Wikipedia Library program provides access to resources held by publishers in multiple countries. If you apply for a Wikipedia Library account (whether you are inside or outside of the United States), you understand that your personal data will be collected, transferred, stored, processed, disclosed and otherwise used in the U.S. as described in this privacy policy. You also understand that your information may be transferred by us from the U.S. to other countries, which may have different or less stringent data protection laws than your country, in connection with providing services to you, including evaluating your application and securing access to your chosen publishers (locations for each publisher are outlined on their respective partner information pages)."
+msgstr "مؤسسة ويكيميديا ​​هي منظمة غير ربحية مقرها في سان فرانسيسكو، كاليفورنيا، يوفر برنامج مكتبة ويكيبيديا الوصول إلى الموارد التي يحتفظ بها الناشرون في بلدان متعددة، إذا تقدمت بطلب للحصول على حساب مكتبة ويكيبيديا (سواء كنت داخل الولايات المتحدة أو خارجها)، فأنت تدرك أن بياناتك الشخصية سيتم جمعها ونقلها وتخزينها ومعالجتها والكشف عنها واستخدامها بطريقة أخرى في الولايات المتحدة كما هو موضح في سياسة الخصوصية هذه، أنت تدرك أيضا أن معلوماتك قد يتم نقلها من الولايات المتحدة إلى بلدان أخرى، والتي قد تكون لديها قوانين مختلفة أو أقل صرامة لحماية البيانات من بلدك، فيما يتعلق بتقديم الخدمات لك، بما في ذلك تقييم طلبك وتأمين الوصول إلى اختيارك  الناشرين (يتم تحديد مواقع كل ناشر على صفحات معلومات الشركاء المعنيين)."
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:392
-msgid ""
-"Please note that in the event of any differences in meaning or "
-"interpretation between the original English version of these terms and a "
-"translation, the original English version takes precedence."
-msgstr ""
-"تُرجَى ملاحظة أنه في حالة وجود أية اختلافات في المعنى أو التفسير بين النسخة "
-"الإنجليزية الأصلية من هذه المصطلحات والترجمة، فإن النسخة الإنجليزية الأصلية "
-"تكون لها الأسبقية."
+msgid "Please note that in the event of any differences in meaning or interpretation between the original English version of these terms and a translation, the original English version takes precedence."
+msgstr "تُرجَى ملاحظة أنه في حالة وجود أية اختلافات في المعنى أو التفسير بين النسخة الإنجليزية الأصلية من هذه المصطلحات والترجمة، فإن النسخة الإنجليزية الأصلية تكون لها الأسبقية."
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Wikimedia Foundation should not be translated.
 #: TWLight/users/templates/users/terms.html:403
-msgid ""
-"See also the <a class=\"twl-links\" href=\"https://wikimediafoundation.org/"
-"wiki/Privacy_policy\">Wikimedia Foundation Privacy Policy</a>."
-msgstr ""
-"انظر أيضا <a href=\"https://wikimediafoundation.org/wiki/Privacy_policy"
-"\">سياسة خصوصية مؤسسة ويكيميديا</a>."
+msgid "See also the <a class=\"twl-links\" href=\"https://wikimediafoundation.org/wiki/Privacy_policy\">Wikimedia Foundation Privacy Policy</a>."
+msgstr "انظر أيضا <a href=\"https://wikimediafoundation.org/wiki/Privacy_policy\">سياسة خصوصية مؤسسة ويكيميديا</a>."
 
 #. Translators: This is the second to last line of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:412
@@ -3864,16 +2910,8 @@ msgstr "سياسة خصوصية مؤسسة ويكيميديا"
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:426
-msgid ""
-"By checking this box and clicking “Submit”, you agree that you have read the "
-"above terms and that you will adhere to the terms of use in your application "
-"to and use of the The Wikipedia Library, and the publishers’ services to "
-"which you gain access through The Wikipedia Library program."
-msgstr ""
-"من خلال تحديد هذا الصندوق والنقر فوق \"أوافق\"، فإنك توافق على أنك قد قرأت "
-"الشروط المذكورة أعلاه وأنك ستلتزم بشروط الاستخدام في تطبيقك واستخدام مكتبة "
-"ويكيبيديا وخدمات الناشرين التي يمكنك الوصول إليها من خلال برنامج مكتبة "
-"ويكيبيديا."
+msgid "By checking this box and clicking “Submit”, you agree that you have read the above terms and that you will adhere to the terms of use in your application to and use of the The Wikipedia Library, and the publishers’ services to which you gain access through The Wikipedia Library program."
+msgstr "من خلال تحديد هذا الصندوق والنقر فوق \"أوافق\"، فإنك توافق على أنك قد قرأت الشروط المذكورة أعلاه وأنك ستلتزم بشروط الاستخدام في تطبيقك واستخدام مكتبة ويكيبيديا وخدمات الناشرين التي يمكنك الوصول إليها من خلال برنامج مكتبة ويكيبيديا."
 
 #: TWLight/users/templates/users/user_collection_tile.html:32
 msgid "Remove this collection from favorites"
@@ -3925,39 +2963,19 @@ msgstr "احذف جميع البيانات"
 
 #. Translators: This message is displayed on the page where users can request the deletion of their data.
 #: TWLight/users/templates/users/user_confirm_delete.html:17
-msgid ""
-"<b>Warning:</b> Performing this action will delete your Wikipedia Library "
-"Card user account and all associated applications. This process is not "
-"reversible. You may lose any partner accounts you were granted, and will not "
-"be able to renew those accounts or apply for new ones."
-msgstr ""
-"<b>تحذير:</b> يؤدي تنفيذ هذا الإجراء إلى حذف حساب مستخدم بطاقة مكتبة "
-"ويكيبيديا الخاص بك وكل الطلبات المرتبطة به، هذه العملية لا يمكن عكسها، قد "
-"تفقد أي من حسابات الشركاء التي حصلت عليها، ولن تتمكن من تجديد هذه الحسابات "
-"أو التقدم بطلب للحصول على حسابات جديدة."
+msgid "<b>Warning:</b> Performing this action will delete your Wikipedia Library Card user account and all associated applications. This process is not reversible. You may lose any partner accounts you were granted, and will not be able to renew those accounts or apply for new ones."
+msgstr "<b>تحذير:</b> يؤدي تنفيذ هذا الإجراء إلى حذف حساب مستخدم بطاقة مكتبة ويكيبيديا الخاص بك وكل الطلبات المرتبطة به، هذه العملية لا يمكن عكسها، قد تفقد أي من حسابات الشركاء التي حصلت عليها، ولن تتمكن من تجديد هذه الحسابات أو التقدم بطلب للحصول على حسابات جديدة."
 
 #. Translators: this should show up for people who log in with a username/password and not OAuth, so we don't know what their Wikipedia identity is.
-#.
 #: TWLight/users/templates/users/user_detail.html:12
 #, python-format
-msgid ""
-"Hi, %(username)s! You don't have a Wikipedia editor profile attached to your "
-"account here, so you are probably a site administrator."
-msgstr ""
-"مرحبا، %(username)s! ليس لديك ملف تعريف محرر ويكيبيديا مرفق بحسابك هنا ، لذا "
-"فأنت على الأرجح إداري موقع."
+msgid "Hi, %(username)s! You don't have a Wikipedia editor profile attached to your account here, so you are probably a site administrator."
+msgstr "مرحبا، %(username)s! ليس لديك ملف تعريف محرر ويكيبيديا مرفق بحسابك هنا ، لذا فأنت على الأرجح إداري موقع."
 
 #. Translators: In the unlikely scenario that someone is able to register an account without using OAuth (thus leaving us without some of the information required for applications), users will see this message, encouraging them to re-register.
 #: TWLight/users/templates/users/user_detail.html:20
-msgid ""
-"If you aren't a site administrator, something weird has happened. You won't "
-"be able to apply for access without a Wikipedia editor profile. You should "
-"log out and create a new account by logging in via OAuth, or contact a site "
-"administrator for help."
-msgstr ""
-"إذا لم تكن إداري موقع، فقد حدث شيء غريب، لن تتمكن من التقدم بطلب الوصول بدون "
-"ملف تعريف محرر ويكيبيديا، يجب تسجيل الخروج وإنشاء حساب جديد عن طريق تسجيل "
-"الدخول عبر OAuth، أو الاتصال بإداري موقع للحصول على المساعدة."
+msgid "If you aren't a site administrator, something weird has happened. You won't be able to apply for access without a Wikipedia editor profile. You should log out and create a new account by logging in via OAuth, or contact a site administrator for help."
+msgstr "إذا لم تكن إداري موقع، فقد حدث شيء غريب، لن تتمكن من التقدم بطلب الوصول بدون ملف تعريف محرر ويكيبيديا، يجب تسجيل الخروج وإنشاء حساب جديد عن طريق تسجيل الدخول عبر OAuth، أو الاتصال بإداري موقع للحصول على المساعدة."
 
 #. Translators: Labels a sections where coordinators can select their email preferences.
 #: TWLight/users/templates/users/user_email_preferences.html:15
@@ -3967,23 +2985,13 @@ msgstr "المنسقين فقط"
 #. Translators: This message is shown on user's own profile page, encouraging them to make sure their information is up to date, so that account coordinators can use the information to judge applications.
 #: TWLight/users/views.py:176
 #, python-brace-format
-msgid ""
-"Please <a class='twl-links' href='{url}'>update your contributions</a> to "
-"Wikipedia to help coordinators evaluate your applications."
-msgstr ""
-"الرجاء <a href=\"{url}\">uتحديث مساهماتك</a> في ويكيبيديا لمساعدة المنسقين "
-"على تقييم طلباتك."
+msgid "Please <a class='twl-links' href='{url}'>update your contributions</a> to Wikipedia to help coordinators evaluate your applications."
+msgstr "الرجاء <a href=\"{url}\">uتحديث مساهماتك</a> في ويكيبيديا لمساعدة المنسقين على تقييم طلباتك."
 
 #. Translators: Coordinators are shown this message when they unselect all three types of reminder email options under preferences.
 #: TWLight/users/views.py:288
-msgid ""
-"You have chosen not to receive reminder emails. As a coordinator, you should "
-"receive at least one type of reminder emails, so consider changing your "
-"preferences."
-msgstr ""
-"لقد اخترت عدم تلقي رسائل بريد إلكتروني للتذكير. بصفتك منسقًا، يجب أن تتلقى "
-"نوعًا واحدًا على الأقل من رسائل التذكير عبر البريد الإلكتروني، لذا انظر في "
-"تغيير تفضيلاتك."
+msgid "You have chosen not to receive reminder emails. As a coordinator, you should receive at least one type of reminder emails, so consider changing your preferences."
+msgstr "لقد اخترت عدم تلقي رسائل بريد إلكتروني للتذكير. بصفتك منسقًا، يجب أن تتلقى نوعًا واحدًا على الأقل من رسائل التذكير عبر البريد الإلكتروني، لذا انظر في تغيير تفضيلاتك."
 
 #. Translators: Coordinators are shown this message when they make changes to their reminder email options under preferences.
 #: TWLight/users/views.py:296
@@ -4006,9 +3014,7 @@ msgstr "معطياتك تم تعديلها."
 #. Translators: If a user tries to save the 'email change form' without entering one and checking the 'use my Wikipedia email address' checkbox, this message is presented.
 #: TWLight/users/views.py:448
 msgid "Both the values cannot be blank. Either enter a email or check the box."
-msgstr ""
-"لا يمكن أن تكون كلتا القيمتان فارغتين؛ إما أن تقوم بإدخال بريد إلكتروني أو "
-"تحديد الصندوق."
+msgstr "لا يمكن أن تكون كلتا القيمتان فارغتين؛ إما أن تقوم بإدخال بريد إلكتروني أو تحديد الصندوق."
 
 #. Translators: Shown to users when they successfully modify their email. Don't translate {email}.
 #: TWLight/users/views.py:476
@@ -4018,12 +3024,8 @@ msgstr "بريدك الإلكتروني تم تعديله ليصبح {email}"
 
 #. Translators: If the user has not filled out their email, they can browse the website but cannot apply for access to resources.
 #: TWLight/users/views.py:487
-msgid ""
-"Your email is blank. You can still explore the site, but you won't be able "
-"to apply for access to partner resources without an email."
-msgstr ""
-"بريدك الالكتروني فارغ، لا يزال بإمكانك استكشاف الموقع، ولكن لن تتمكن من "
-"التقدم بطلب الوصول إلى موارد الشركاء دون بريد إلكتروني."
+msgid "Your email is blank. You can still explore the site, but you won't be able to apply for access to partner resources without an email."
+msgstr "بريدك الالكتروني فارغ، لا يزال بإمكانك استكشاف الموقع، ولكن لن تتمكن من التقدم بطلب الوصول إلى موارد الشركاء دون بريد إلكتروني."
 
 #. Translators: This message is shown once the access to a partner has successfully been returned.
 #: TWLight/users/views.py:801
@@ -4057,31 +3059,3 @@ msgstr "لا منع حالي"
 msgid "10+ edits in the last 30 days"
 msgstr "أكثر من 10 تعديلات في الشهر الماضي"
 
-#: tests/shunit/data/bad_i18n_comment_1.py:3
-#: tests/shunit/data/bad_i18n_newline_1.py:5
-msgid "1"
-msgstr ""
-
-#. Translators: Lorem ipsum dolor sit amet, consectetur adipiscing elit. Mauris vitae ipsum ut purus faucibus pretium. Proin tempus neque et aliquet consectetur. Ut egestas sapien in consectetur sagittis. Mauris neque lacus, dapibus non viverra vitae, interdum ut aenean ipsum.
-#. Translators: Lorem ipsum dolor sit amet, consectetur adipiscing elit. Mauris vitae ipsum ut purus faucibus pretium. Proin tempus neque et aliquet consectetur. Ut egestas sapien in consectetur sagittis. Mauris neque lacus, dapibus non.
-#: tests/shunit/data/bad_i18n_comment_2.py:4
-#: tests/shunit/data/bad_i18n_newline_2.py:5 tests/shunit/data/good_i18n_1.py:2
-#: tests/shunit/data/good_i18n_2.py:2
-msgid "2"
-msgstr ""
-
-#: tests/shunit/data/bad_i18n_newline_3.py:5
-msgid "3"
-msgstr ""
-
-#: tests/shunit/data/bad_i18n_newline_4.py:5
-msgid "4"
-msgstr ""
-
-#: tests/shunit/data/bad_i18n_newline_5.py:5
-msgid "5"
-msgstr ""
-
-#: tests/shunit/data/bad_i18n_newline_6.py:5
-msgid "6"
-msgstr ""

--- a/locale/bcl/LC_MESSAGES/django.po
+++ b/locale/bcl/LC_MESSAGES/django.po
@@ -10,10 +10,11 @@
 # Author: ShimunUfesoj
 msgid ""
 msgstr ""
+""
 "Project-Id-Version: Wikipedia Library Card Platform - Website\n"
-"Report-Msgid-Bugs-To: wikipedialibrary@wikimedia.org\n"
+"Report-Msgid-Bugs-To: translatewiki.net\n"
 "POT-Creation-Date: 2024-07-11 20:54+0000\n"
-"PO-Revision-Date: 2024-07-11 12:30:12+0000\n"
+"PO-Revision-Date: 2024-07-15 12:29:12+0000\n"
 "Language: bcl\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
@@ -45,13 +46,8 @@ msgstr "Manongod saimo"
 #. Translators: This note appears in a section of a form where we ask users to enter info (like country of residence) when applying for resource access.
 #: TWLight/applications/forms.py:179
 #, python-brace-format
-msgid ""
-"<p><small><i>Your personal data will be processed according to our <a "
-"class='twl-links' href='{terms_url}'> privacy policy</a>.</i></small></p>"
-msgstr ""
-"<p><small><i>An saimong personal na data ipoproseso base sa samuyang <a "
-"class=\"twl-links\" href='{terms_url}'>polisiyang pangpribasidad</a>.</i></"
-"small></p>"
+msgid "<p><small><i>Your personal data will be processed according to our <a class='twl-links' href='{terms_url}'> privacy policy</a>.</i></small></p>"
+msgstr "<p><small><i>An saimong personal na data ipoproseso base sa samuyang <a class=\"twl-links\" href='{terms_url}'>polisiyang pangpribasidad</a>.</i></small></p>"
 
 #. Translators: This is the title of the application form page, where users enter information required for the application. It lets the user know which partner application they are entering data for. {partner}
 #: TWLight/applications/forms.py:189
@@ -92,9 +88,7 @@ msgstr "An e-surat sa saimong panlaog sa websityo kan kapareha"
 #. Translators: This labels a choice field where users will have to select the number of months they wish to have their access for as part of the application renewal confirmation.
 #. Translators: When filling out an application, users may be required to enter the length of the account (expiry) they wish to have for proxy partners.
 #: TWLight/applications/forms.py:339 TWLight/applications/helpers.py:100
-msgid ""
-"The number of months you wish to have this access for before renewal is "
-"required"
+msgid "The number of months you wish to have this access for before renewal is required"
 msgstr ""
 
 #. Translators: When filling out an application, users may need to specify their name
@@ -130,8 +124,7 @@ msgstr "Iba pang muya mong sabihon"
 #. Translators: When filling out an application, users may be required to check a box to say they agree with the website's Terms of Use document, which is linked
 #: TWLight/applications/helpers.py:95
 msgid "You must agree with the partner's terms of use"
-msgstr ""
-"Kaipuhan mong mag-sang-ayon sa mga termino kan paggamit kan saimong kapareha"
+msgstr "Kaipuhan mong mag-sang-ayon sa mga termino kan paggamit kan saimong kapareha"
 
 #. Translators: When sending application data to partners, this is the text labelling a user's real name
 #. Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this labels the user's real name.
@@ -184,9 +177,7 @@ msgstr "E-surat"
 
 #. Translators: This comment is added to pending applications when our terms of use change.
 #: TWLight/applications/management/commands/notify_applicants_tou_changes.py:54
-msgid ""
-"Our terms of use have changed. Your applications will not be processed until "
-"you log in and agree to our updated terms."
+msgid "Our terms of use have changed. Your applications will not be processed until you log in and agree to our updated terms."
 msgstr ""
 
 #. Translators: This is the status of an application that has not yet been reviewed.
@@ -253,23 +244,17 @@ msgstr ""
 
 #. Translators: This text goes into account approval emails in the case that we need to send the user's details to a publisher for manual account setup.
 #: TWLight/applications/models.py:331
-msgid ""
-"You can expect to receive access details within a week or two once it has "
-"been processed."
+msgid "You can expect to receive access details within a week or two once it has been processed."
 msgstr ""
 
 #. Translators: This comment is added to open applications when a partner joins the Library Bundle, which does not require applications.
 #: TWLight/applications/signals.py:247
-msgid ""
-"This partner joined the Library Bundle, which does not require applications. "
-"This application will be marked as invalid."
+msgid "This partner joined the Library Bundle, which does not require applications. This application will be marked as invalid."
 msgstr ""
 
 #. Translators: This is shown to users if the application is to a partner for which we have run out of available accounts. The application is therefore on a 'waitlist', and will be reviewed when more accounts are available.
 #: TWLight/applications/templates/applications/application_evaluation.html:29
-msgid ""
-"This application is on the waitlist because this partner does not have any "
-"access grants available at this time."
+msgid "This application is on the waitlist because this partner does not have any access grants available at this time."
 msgstr ""
 
 #. Translators: This message is shown on pages where coordinators can see personal information about applicants.
@@ -277,9 +262,7 @@ msgstr ""
 #: TWLight/applications/templates/applications/application_list_include.html:6
 #: TWLight/applications/templates/applications/send_partner.html:45
 #: TWLight/resources/templates/resources/partner_users.html:18
-msgid ""
-"Coordinators: This page may contain personal information such as real names "
-"and email addresses. Please remember that this information is confidential."
+msgid "Coordinators: This page may contain personal information such as real names and email addresses. Please remember that this information is confidential."
 msgstr ""
 
 #. Translators: This is the title of the application page shown to users who are a coordinator, and are able to accept or reject the application.
@@ -289,9 +272,7 @@ msgstr "Surion an aplikasyon"
 
 #. Translators: This text is shown to coordinators on application pages if the applicant has restricted processing of their data.
 #: TWLight/applications/templates/applications/application_evaluation.html:42
-msgid ""
-"This user has requested a restriction on the processing of their data, so "
-"you cannot change the status of their application."
+msgid "This user has requested a restriction on the processing of their data, so you cannot change the status of their application."
 msgstr ""
 
 #. Translators: This is the title of the application page shown to users who are not a coordinator.
@@ -365,9 +346,7 @@ msgstr ""
 
 #. Translators: This is the text displayed to coordinators when an applicant has no country of residence in their profile.
 #: TWLight/applications/templates/applications/application_evaluation.html:123
-msgid ""
-"Please request the applicant add their country of residence to their profile "
-"before proceeding further."
+msgid "Please request the applicant add their country of residence to their profile before proceeding further."
 msgstr ""
 
 #. Translators: This labels the section of an application showing the total number of accounts available for a partner or their collection.
@@ -378,12 +357,8 @@ msgstr ""
 #. Translators: This labels the section of an application showing whether the user had agreed to the terms of use or not.
 #: TWLight/applications/templates/applications/application_evaluation.html:145
 #, fuzzy, python-format
-msgid ""
-"Has agreed to the site's <a class=\"twl-links\" href=\"%(terms_url)s\">terms "
-"of use</a>?"
-msgstr ""
-"%(publisher)s nagoobliga na magtugot sa mga <a href=\"%(url)s\">termino kan "
-"paggamit</a>."
+msgid "Has agreed to the site's <a class=\"twl-links\" href=\"%(terms_url)s\">terms of use</a>?"
+msgstr "%(publisher)s nagoobliga na magtugot sa mga <a href=\"%(url)s\">termino kan paggamit</a>."
 
 #. Translators: Displayed to coordinators when they've agreed to the terms of use.
 #. Translators: Displayed if the user has agreed to the terms of use.
@@ -418,9 +393,7 @@ msgstr "Dai"
 
 #. Translators: This is the text displayed to coordinators when an applicant has not agreed to the terms of use.
 #: TWLight/applications/templates/applications/application_evaluation.html:159
-msgid ""
-"Please request the applicant agree to the site's terms of use before "
-"approving this application."
+msgid "Please request the applicant agree to the site's terms of use before approving this application."
 msgstr ""
 
 #. Translators: This labels the section of an application containing the user's motivation for wanting access to this resource.
@@ -441,10 +414,8 @@ msgstr "Pagpapanibago kan eksistidong pagtugot sa pag-access?"
 #. Translators: This message is shown next to the 'Renewal of existing access grant?' label if the application is a renewal. Don't translate HTML tags or parent_url.
 #: TWLight/applications/templates/applications/application_evaluation.html:195
 #, python-format
-msgid ""
-"Yes (<a class=\"twl-links\" href=\"%(parent_url)s\">previous application</a>)"
-msgstr ""
-"Iyo (<a class=\"twl-links\" href=\"%(parent_url)s\">dating aplikasyon</a>)"
+msgid "Yes (<a class=\"twl-links\" href=\"%(parent_url)s\">previous application</a>)"
+msgstr "Iyo (<a class=\"twl-links\" href=\"%(parent_url)s\">dating aplikasyon</a>)"
 
 #. Translators: This labels the section of the application showing the length of access remaining on the user's previous authorization.
 #: TWLight/applications/templates/applications/application_evaluation.html:208
@@ -478,9 +449,7 @@ msgstr "Magdagdag nin Komento"
 
 #. Translators: On an application page, this text tells users that the comments posted on the application are visible to coordinators and the submitting user only.
 #: TWLight/applications/templates/applications/application_evaluation.html:297
-msgid ""
-"Comments are visible to all coordinators and to the editor who submitted "
-"this application."
+msgid "Comments are visible to all coordinators and to the editor who submitted this application."
 msgstr ""
 
 #. Translators: This is the title of the section of an application page which lists information about the user who submitted the application.
@@ -693,12 +662,7 @@ msgstr "Ikaag an kamugtakan"
 
 #: TWLight/applications/templates/applications/apply.html:20
 #, python-format
-msgid ""
-"If your application is successful we may share your email address with "
-"%(partner)s. This is required to set up your access to their resources. By "
-"submitting this form you agree to allow your email address to be shared with "
-"%(partner)s if your application is successful, for the purposes of account "
-"setup."
+msgid "If your application is successful we may share your email address with %(partner)s. This is required to set up your access to their resources. By submitting this form you agree to allow your email address to be shared with %(partner)s if your application is successful, for the purposes of account setup."
 msgstr ""
 
 #. Translators: This message is displayed on the page where users can confirm their renewal. Please do not translate partner.
@@ -727,9 +691,7 @@ msgstr "Anong mga tabang sa pag-adal an gusto mong i-access?"
 
 #. Translators: This text explains that Library Bundle partners are not shown in this list.
 #: TWLight/applications/templates/applications/request_for_application.html:26
-msgid ""
-"Library Bundle partners are not shown as eligibility is determined "
-"automatically."
+msgid "Library Bundle partners are not shown as eligibility is determined automatically."
 msgstr ""
 
 #. Translators: On the page where users can apply for multiple partners, this message shows next to the partner name, taking them to the full application page when clicked.
@@ -744,10 +706,7 @@ msgstr "Mayo pang impormasyon kan kapareha na naikaag."
 
 #. Translators: the HTML is so that the word 'waitlisted' will look the same as it does in the page above; please translate 'waitlisted' the same way you did elsewhere in this file.
 #: TWLight/applications/templates/applications/request_for_application.html:74
-msgid ""
-"You can apply to <span class=\"badge badge-warning\">Waitlisted</span> "
-"partners, but they don't have access grants available right now. We will "
-"process those applications when access becomes available."
+msgid "You can apply to <span class=\"badge badge-warning\">Waitlisted</span> partners, but they don't have access grants available right now. We will process those applications when access becomes available."
 msgstr ""
 
 #. Translators: On the page where coordinators can see approved applications which have not had their details sent to the partner, this message shows when there are applications ready to be processed.
@@ -769,17 +728,13 @@ msgstr "Data kan aplikasyon para sa %(object)s"
 #. Translators: This message is shown when applications exceed the number of accounts available.
 #: TWLight/applications/templates/applications/send_partner.html:54
 #, python-format
-msgid ""
-"Application(s) for %(object)s, if sent, will exceed the total available "
-"accounts for the partner. Please proceed at your own discretion."
+msgid "Application(s) for %(object)s, if sent, will exceed the total available accounts for the partner. Please proceed at your own discretion."
 msgstr ""
 
 #. Translators: When viewing the list of applications ready to be sent for a particular partner, this is instructions for the coordinator to click the 'mark as sent' button after they have sent the information.
 #: TWLight/applications/templates/applications/send_partner.html:65
 msgid "When you've processed the data below, click the 'mark as sent' button."
-msgstr ""
-"Kun nai-proseso mo na an data sa ibaba, i=klik an 'markahan bilang naipadara "
-"na.'"
+msgstr "Kun nai-proseso mo na an data sa ibaba, i=klik an 'markahan bilang naipadara na.'"
 
 #. Translators: When viewing the list of applications ready to be sent for a particular partner, this is the title of the section containing contact information for the people applications should be sent to.
 #: TWLight/applications/templates/applications/send_partner.html:71
@@ -790,12 +745,8 @@ msgstr[1] "Mga Kontak"
 
 #. Translators: When viewing the list of applications ready to be sent for a particular partner, this message shows if there is no information about who the applications should be sent to. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/applications/templates/applications/send_partner.html:89
-msgid ""
-"Whoops, we don't have any listed contacts. Please notify Wikipedia Library "
-"administrators."
-msgstr ""
-"Oops, mayong nakalistang kontak. Pakisabihan an mga administrador kan "
-"Wikipedyang Libraryo."
+msgid "Whoops, we don't have any listed contacts. Please notify Wikipedia Library administrators."
+msgstr "Oops, mayong nakalistang kontak. Pakisabihan an mga administrador kan Wikipedyang Libraryo."
 
 #. Translators: When viewing the list of applications ready to be sent for a particular partner, this is the title of the section containing the information about those applications.
 #: TWLight/applications/templates/applications/send_partner.html:94
@@ -810,9 +761,7 @@ msgstr "Markahan bilang naipadara"
 
 #. Translators: This text guides coordinators in using the code sending interface for approved applications.
 #: TWLight/applications/templates/applications/send_partner.html:152
-msgid ""
-"Use the dropdown menus to denote which editor will receive each code. Access "
-"codes will be sent to users automatically."
+msgid "Use the dropdown menus to denote which editor will receive each code. Access codes will be sent to users automatically."
 msgstr ""
 
 #. Translators: This labels a drop-down selection where staff can assign an access code to a user.
@@ -828,18 +777,13 @@ msgstr "Mayo nin aprub, dai naipadarang mga aplikasyon."
 #. Translators: When a user applies for a set of resources, they receive this message if none are currently available. They are instead placed on a 'waitlist' for later approval.
 #. Translators: When a user renews their resource, they receive this message if none are currently available. They are instead placed on a 'waitlist' for later approval.
 #: TWLight/applications/views.py:140 TWLight/applications/views.py:1282
-msgid ""
-"This partner does not have any access grants available at this time. You may "
-"still apply for access; your application will be reviewed when access grants "
-"become available."
+msgid "This partner does not have any access grants available at this time. You may still apply for access; your application will be reviewed when access grants become available."
 msgstr ""
 
 #. Translators: This message is shown to users once they've successfully submitted their application for review.
 #: TWLight/applications/views.py:163
 #, python-brace-format
-msgid ""
-"Your application has been submitted for review. Head over to <a "
-"href='{applications_url}'>My Applications</a> to view the status."
+msgid "Your application has been submitted for review. Head over to <a href='{applications_url}'>My Applications</a> to view the status."
 msgstr ""
 
 #. Translators: This text is displayed to users when the user has chosen to restrict data and is trying to apply for multiple partners
@@ -888,16 +832,12 @@ msgstr "Mga naipadarang aplikasyon"
 
 #. Translators: After a coordinator has changed the status of an application to APPROVED, if the corresponding partner/collection is waitlisted this message appears.
 #: TWLight/applications/views.py:756
-msgid ""
-"Cannot approve application as partner with proxy authorization method is "
-"waitlisted."
+msgid "Cannot approve application as partner with proxy authorization method is waitlisted."
 msgstr ""
 
 #. Translators: After a coordinator has changed the status of an application to APPROVED, if the corresponding partner/collection has no accounts for distribution, this message appears.
 #: TWLight/applications/views.py:780
-msgid ""
-"Cannot approve application as partner with proxy authorization method is "
-"waitlisted and (or) has zero accounts available for distribution."
+msgid "Cannot approve application as partner with proxy authorization method is waitlisted and (or) has zero accounts available for distribution."
 msgstr ""
 
 #. Translators: This message appears on an "access denied" screen that stops users who attempt to authorize an editor to access a resource during a time period for which they are already authorized.
@@ -908,11 +848,7 @@ msgstr "Ika nagporbar maggibo nin dobleng awtorisasyon."
 #. Translators: This message is shown to users when they access an application page of a now Bundle partner (new applications aren't allowed for Bundle partners and the status of old applications cannot be modified)
 #: TWLight/applications/views.py:857
 #, python-brace-format
-msgid ""
-"This application cannot be modified since this partner is now part of our <a "
-"href='{bundle}'>bundle access</a>. If you are eligible, you can access this "
-"resource from <a href='{library}'>your library</a>. <a "
-"href='{contact}'>Contact us</a> if you have any questions."
+msgid "This application cannot be modified since this partner is now part of our <a href='{bundle}'>bundle access</a>. If you are eligible, you can access this resource from <a href='{library}'>your library</a>. <a href='{contact}'>Contact us</a> if you have any questions."
 msgstr ""
 
 #. Translators: this lets a reviewer set the status of a single application.
@@ -922,9 +858,7 @@ msgstr "Itakda an estado kan aplikasyon"
 
 #. Translators: This warning is message is shown to applicants when the number of pending applications is greater than the number of accounts available.
 #: TWLight/applications/views.py:891
-msgid ""
-"There are more pending applications than available accounts. Your "
-"application might get waitlisted."
+msgid "There are more pending applications than available accounts. Your application might get waitlisted."
 msgstr ""
 
 #. Translators: this message is shown to coordinators who attempt to change an application's Status from INVALID to any other Status.
@@ -945,11 +879,7 @@ msgstr "Matrayumpo an grupong pagbago."
 
 #. Translators: After a coordinator has changed the status of a number of applications to APPROVED, if the corresponding partner(s) is/are waitlisted or has no accounts for distribution, this message appears.
 #: TWLight/applications/views.py:1051
-msgid ""
-"Cannot approve application(s) {} as partner(s) with proxy authorization "
-"method is/are waitlisted and (or) has/have not enough accounts available. If "
-"not enough accounts are available, prioritise the applications and then "
-"approve applications equal to the accounts available."
+msgid "Cannot approve application(s) {} as partner(s) with proxy authorization method is/are waitlisted and (or) has/have not enough accounts available. If not enough accounts are available, prioritise the applications and then approve applications equal to the accounts available."
 msgstr ""
 
 #. Translators: This message is shown to coordinators who attempt to assign the same access code to multiple users.
@@ -964,9 +894,7 @@ msgstr "Gabos na napiling aplikasyon namarkahan ng naipadara."
 
 #. Translators: When a user tries to renew their resource, they receive this message if the partner is not available.
 #: TWLight/applications/views.py:1272
-msgid ""
-"Cannot renew application at this time as partner is not available. Please "
-"check back later, or contact us for more information."
+msgid "Cannot renew application at this time as partner is not available. Please check back later, or contact us for more information."
 msgstr ""
 
 #. Translators: This message is displayed when an attempt by a user to renew an application has been denied for some reason.
@@ -977,19 +905,13 @@ msgstr ""
 
 #. Translators: If a user requests the renewal of their account, but it wasn't renewed, this message is shown to them.
 #: TWLight/applications/views.py:1385
-msgid ""
-"This object cannot be renewed. (This probably means that you have already "
-"requested that it be renewed.)"
+msgid "This object cannot be renewed. (This probably means that you have already requested that it be renewed.)"
 msgstr ""
 
 #. Translators: If a user requests the renewal of their account, this message is shown to them.
 #: TWLight/applications/views.py:1395
-msgid ""
-"Your renewal request has been received. A coordinator will review your "
-"request."
-msgstr ""
-"An saimong hinagad na pagpanibago naresibe na. Sarong koordinator an masuri "
-"kan saimong hinahagad."
+msgid "Your renewal request has been received. A coordinator will review your request."
+msgstr "An saimong hinagad na pagpanibago naresibe na. Sarong koordinator an masuri kan saimong hinahagad."
 
 #. Translators: This labels a textfield where users can enter their email ID.
 #: TWLight/emails/forms.py:18
@@ -998,9 +920,7 @@ msgstr "An saimong e-surat"
 
 #. Translators: This is the help text for the email field in the contact us form letting users know the field is updated by value pulled from their respective user profiles.
 #: TWLight/emails/forms.py:21
-msgid ""
-"This field is automatically updated with the email from your <a class='twl-"
-"links' href='{}'>user profile</a>."
+msgid "This field is automatically updated with the email from your <a class='twl-links' href='{}'>user profile</a>."
 msgstr ""
 
 #. Translators: This labels a textfield where users can enter their email message.
@@ -1024,19 +944,13 @@ msgstr "Isumite"
 #. Translators: This email is sent to users with their access code. Don't translate Jinja variables in curly braces like user or partner. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/access_code_email-body-html.html:5
 #, python-format
-msgid ""
-"<p>Your approved application to %(partner)s has now been finalised. Your "
-"access code or login details can be found below:</p> <p><b>%(access_code)s</"
-"b></p> <p>%(user_instructions)s</p>"
+msgid "<p>Your approved application to %(partner)s has now been finalised. Your access code or login details can be found below:</p> <p><b>%(access_code)s</b></p> <p>%(user_instructions)s</p>"
 msgstr ""
 
 #. Translators: This email is sent to users with their access code. Don't translate Jinja variables in curly braces like user or partner. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/access_code_email-body-text.html:3
 #, python-format
-msgid ""
-"Your approved application to %(partner)s has now been finalised. Your access "
-"code or login details can be found below: %(access_code)s "
-"%(user_instructions)s"
+msgid "Your approved application to %(partner)s has now been finalised. Your access code or login details can be found below: %(access_code)s %(user_instructions)s"
 msgstr ""
 
 #. Translators: This is the subject line of an email sent to users with their access code.
@@ -1047,23 +961,13 @@ msgstr "An saimong Wikipedia Library access code"
 #. Translators: This email is sent to users when their application is approved. Don't translate Jinja variables in curly braces like user or partner; don't translate html tags either. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/approval_notification-body-html.html:5
 #, python-format
-msgid ""
-"<p>Dear %(user)s,</p> <p>Thank you for applying for access to %(partner)s "
-"resources through The Wikipedia Library. We are happy to inform you that "
-"your application has been approved.</p> <p>%(user_instructions)s</p> <p>You "
-"can view the collections you're authorized to access at My Library: "
-"%(link)s</p> <p>Cheers!</p> <p>The Wikipedia Library</p>"
+msgid "<p>Dear %(user)s,</p> <p>Thank you for applying for access to %(partner)s resources through The Wikipedia Library. We are happy to inform you that your application has been approved.</p> <p>%(user_instructions)s</p> <p>You can view the collections you're authorized to access at My Library: %(link)s</p> <p>Cheers!</p> <p>The Wikipedia Library</p>"
 msgstr ""
 
 #. Translators: This email is sent to users when their application is approved. Don't translate Jinja variables in curly braces like user or partner. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/approval_notification-body-text.html:3
 #, python-format
-msgid ""
-"Dear %(user)s, Thank you for applying for access to %(partner)s resources "
-"through The Wikipedia Library. We are happy to inform you that your "
-"application has been approved. %(user_instructions)s You can view the "
-"collections you're authorized to access at My Library: %(link)s Cheers! The "
-"Wikipedia Library"
+msgid "Dear %(user)s, Thank you for applying for access to %(partner)s resources through The Wikipedia Library. We are happy to inform you that your application has been approved. %(user_instructions)s You can view the collections you're authorized to access at My Library: %(link)s Cheers! The Wikipedia Library"
 msgstr ""
 
 #. Translators: This is the subject of an email which is sent to users when their application has been approved. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
@@ -1074,43 +978,30 @@ msgstr "An saimong aplikasyon sa Wikipedia Library naaprubahan na!"
 #. Translators: This email is sent to coordinators when a comment is left on an application they are processing. Don't translate Jinja variables in curly braces like user or partner. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/comment_notification_coordinator-body-html.html:5
 #, python-format
-msgid ""
-"<p style=\"color: #500050\">%(submit_date)s - %(commenter)s</p> "
-"<blockquote><p>%(comment)s</p></blockquote> <p>Please reply to these at: <a "
-"href=\"%(app_url)s\">%(app_url)s</a></p> <p>Best,</p> <p>The Wikipedia "
-"Library</p>"
+msgid "<p style=\"color: #500050\">%(submit_date)s - %(commenter)s</p> <blockquote><p>%(comment)s</p></blockquote> <p>Please reply to these at: <a href=\"%(app_url)s\">%(app_url)s</a></p> <p>Best,</p> <p>The Wikipedia Library</p>"
 msgstr ""
 
 #. Translators: This email is sent to coordinators when a comment is left on an application they are processing. Don't translate Jinja variables in curly braces like user or partner. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/comment_notification_coordinator-body-text.html:3
 #, python-format
-msgid ""
-"%(submit_date)s - %(commenter)s %(comment)s Please reply to this at: "
-"%(app_url)s Best, The Wikipedia Library"
+msgid "%(submit_date)s - %(commenter)s %(comment)s Please reply to this at: %(app_url)s Best, The Wikipedia Library"
 msgstr ""
 
 #. Translators: This is the subject line of an email sent to coordinators when a comment is left on an application they processed.
 #: TWLight/emails/templates/emails/comment_notification_coordinator-subject.html:3
 msgid "New comment on a Wikipedia Library application you processed"
-msgstr ""
-"Bagong komento sa aplikasyon sa Wikipedyang Libraryo saimong pigproseso"
+msgstr "Bagong komento sa aplikasyon sa Wikipedyang Libraryo saimong pigproseso"
 
 #. Translators: This email is sent to users when they receive a comment on their application. Don't translate Jinja variables in curly braces like user or partner; don't translate html tags either. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/comment_notification_editors-body-html.html:5
 #, python-format
-msgid ""
-"<p style=\"color: #500050\">%(submit_date)s - %(commenter)s</p> "
-"<blockquote><p>%(comment)s</p></blockquote> <p>Please reply to these at <a "
-"href=\"%(app_url)s\">%(app_url)s</a> so we can evaluate your application.</"
-"p> <p>Best,</p> <p>The Wikipedia Library</p>"
+msgid "<p style=\"color: #500050\">%(submit_date)s - %(commenter)s</p> <blockquote><p>%(comment)s</p></blockquote> <p>Please reply to these at <a href=\"%(app_url)s\">%(app_url)s</a> so we can evaluate your application.</p> <p>Best,</p> <p>The Wikipedia Library</p>"
 msgstr ""
 
 #. Translators: This email is sent to users when they receive a comment on their application. Don't translate Jinja variables in curly braces like user or partner. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/comment_notification_editors-body-text.html:3
 #, python-format
-msgid ""
-"%(submit_date)s - %(commenter)s %(comment)s Please reply to these at: "
-"%(app_url)s so we can evaluate your application. Best, The Wikipedia Library"
+msgid "%(submit_date)s - %(commenter)s %(comment)s Please reply to these at: %(app_url)s so we can evaluate your application. Best, The Wikipedia Library"
 msgstr ""
 
 #. Translators: This is the subject line of an email sent to users who have a comment added to one of their applications. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
@@ -1121,33 +1012,24 @@ msgstr "Bagong komento sa saimong aplikasyon sa Wikipedyang Libraryo"
 #. Translators: This email is sent to users when an application they commented on receives another comment. Don't translate Jinja variables in curly braces like app_url; don't translate html tags either. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/comment_notification_others-body-html.html:5
 #, python-format
-msgid ""
-"<p style=\"color: #500050\">%(submit_date)s - %(commenter)s</p> "
-"<blockquote><p>%(comment)s</p></blockquote> See it at <a href=\"%(app_url)s"
-"\">%(app_url)s</a>. Thanks for helping review Wikipedia Library applications!"
+msgid "<p style=\"color: #500050\">%(submit_date)s - %(commenter)s</p> <blockquote><p>%(comment)s</p></blockquote> See it at <a href=\"%(app_url)s\">%(app_url)s</a>. Thanks for helping review Wikipedia Library applications!"
 msgstr ""
 
 #. Translators: This email is sent to users when an application they commented on receives another comment. Don't translate Jinja variables in curly braces like app_url. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/comment_notification_others-body-text.html:3
 #, python-format
-msgid ""
-"%(submit_date)s - %(commenter)s %(comment)s See it at: %(app_url)s Thanks "
-"for helping review Wikipedia Library applications!"
+msgid "%(submit_date)s - %(commenter)s %(comment)s See it at: %(app_url)s Thanks for helping review Wikipedia Library applications!"
 msgstr ""
 
 #. Translators: This is the subject line of an email sent to users who have a comment added to an application they also commented on. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/comment_notification_others-subject.html:4
 msgid "New comment on a Wikipedia Library application you commented on"
-msgstr ""
-"Bagong komento sa aplikasyon sa Wikipedyang Libraryong saimong pigkomentohan"
+msgstr "Bagong komento sa aplikasyon sa Wikipedyang Libraryong saimong pigkomentohan"
 
 #. Translators: This text is part of a scheduled reminder email sent to coordinators who have applications requiring action. Don't translate Jinja variables in curly braces like total_apps, or user.
 #: TWLight/emails/templates/emails/coordinator_reminder_notification-body-html.html:5
 #, python-format
-msgid ""
-"<p>Dear %(user)s,</p> <p>Our records indicate that you are the designated "
-"coordinator for partners that have a total of %(total_apps)s applications.</"
-"p>"
+msgid "<p>Dear %(user)s,</p> <p>Our records indicate that you are the designated coordinator for partners that have a total of %(total_apps)s applications.</p>"
 msgstr ""
 
 #. Translators: Breakdown as in 'cost breakdown'; analysis.
@@ -1186,31 +1068,19 @@ msgstr[1] "Bilang kan mga aprubadong aplikasyon"
 #. Translators: This text is part of a scheduled reminder email sent to coordinators who have applications requiring action. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library). Don't translate Jinja variables in curly braces like link; don't translate email addresses or html tags either.
 #: TWLight/emails/templates/emails/coordinator_reminder_notification-body-html.html:39
 #, python-format
-msgid ""
-"<p>This is a gentle reminder that you may review applications at <a href="
-"\"%(link)s\">%(link)s</a>.</p> <p>You can customise your reminders under "
-"'preferences' in your user profile.</p> <p>If you received this message in "
-"error, drop us a line at wikipedialibrary@wikimedia.org.</p> <p>Thanks for "
-"helping review Wikipedia Library applications!</p>"
+msgid "<p>This is a gentle reminder that you may review applications at <a href=\"%(link)s\">%(link)s</a>.</p> <p>You can customise your reminders under 'preferences' in your user profile.</p> <p>If you received this message in error, drop us a line at wikipedialibrary@wikimedia.org.</p> <p>Thanks for helping review Wikipedia Library applications!</p>"
 msgstr ""
 
 #. Translators: This text is part of a scheduled reminder email sent to coordinators who have applications requiring action. Don't translate Jinja variables in curly braces like total_apps, or user.
 #: TWLight/emails/templates/emails/coordinator_reminder_notification-body-text.html:3
 #, python-format
-msgid ""
-"Dear %(user)s, Our records indicate that you are the designated coordinator "
-"for partners that have a total of %(total_apps)s applications."
+msgid "Dear %(user)s, Our records indicate that you are the designated coordinator for partners that have a total of %(total_apps)s applications."
 msgstr ""
 
 #. Translators: This text is part of a scheduled reminder email sent to coordinators who have applications requiring action. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library). Don't translate Jinja variables in curly braces like link; don't translate the email address either.
 #: TWLight/emails/templates/emails/coordinator_reminder_notification-body-text.html:38
 #, python-format
-msgid ""
-"This is a gentle reminder that you may review applications at: %(link)s. You "
-"can customise your reminders under 'preferences' in your user profile. If "
-"you received this message in error, drop us a line at: "
-"wikipedialibrary@wikimedia.org Thanks for helping review Wikipedia Library "
-"applications!"
+msgid "This is a gentle reminder that you may review applications at: %(link)s. You can customise your reminders under 'preferences' in your user profile. If you received this message in error, drop us a line at: wikipedialibrary@wikimedia.org Thanks for helping review Wikipedia Library applications!"
 msgstr ""
 
 #. Translators: This is the subject line of a scheduled reminder email sent to coordinators who have applications to review. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library). Do not translate items in curly braces.
@@ -1221,22 +1091,13 @@ msgstr ""
 #. Translators: This email is sent to users when their application is rejected. Don't translate Jinja variables in curly braces like user or partner; don't translate html tags either. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/rejection_notification-body-html.html:5
 #, python-format
-msgid ""
-"<p>Dear %(user)s,</p> <p>Thank you for applying for access to %(partner)s "
-"resources through The Wikipedia Library. Unfortunately at this time your "
-"application has not been approved. You can view your application and review "
-"comments at <a href=\"%(app_url)s\">%(app_url)s</a>.</p> <p>Best,</p> <p>The "
-"Wikipedia Library</p>"
+msgid "<p>Dear %(user)s,</p> <p>Thank you for applying for access to %(partner)s resources through The Wikipedia Library. Unfortunately at this time your application has not been approved. You can view your application and review comments at <a href=\"%(app_url)s\">%(app_url)s</a>.</p> <p>Best,</p> <p>The Wikipedia Library</p>"
 msgstr ""
 
 #. Translators: This email is sent to users when their application is rejected. Don't translate Jinja variables in curly braces like user or partner. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/rejection_notification-body-text.html:3
 #, python-format
-msgid ""
-"Dear %(user)s, Thank you for applying for access to %(partner)s resources "
-"through The Wikipedia Library. Unfortunately at this time your application "
-"has not been approved. You can view your application and review comments at: "
-"%(app_url)s Best, The Wikipedia Library"
+msgid "Dear %(user)s, Thank you for applying for access to %(partner)s resources through The Wikipedia Library. Unfortunately at this time your application has not been approved. You can view your application and review comments at: %(app_url)s Best, The Wikipedia Library"
 msgstr ""
 
 #. Translators: This is the subject of an email which is sent to users when their application has been rejected. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
@@ -1247,25 +1108,13 @@ msgstr ""
 #. Translators: This email is sent to users when they have an account that is soon to expire. Don't translate Jinja variables in curly braces like partner_name or partner_link; don't translate html tags either. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/user_renewal_notice-body-html.html:5
 #, python-format
-msgid ""
-"<p>Dear %(user)s,</p> <p>According to our records, your access to "
-"%(partner_name)s will soon expire and you may lose access. If you want to "
-"continue making use of your free account, you can request renewal of your "
-"account by clicking the 'Renew' or 'Extend' button at %(partner_link)s.</p> "
-"<p>Best,</p> <p>The Wikipedia Library</p> <p>You can disable these emails in "
-"your user page preferences: https://wikipedialibrary.wmflabs.org/users/</p>"
+msgid "<p>Dear %(user)s,</p> <p>According to our records, your access to %(partner_name)s will soon expire and you may lose access. If you want to continue making use of your free account, you can request renewal of your account by clicking the 'Renew' or 'Extend' button at %(partner_link)s.</p> <p>Best,</p> <p>The Wikipedia Library</p> <p>You can disable these emails in your user page preferences: https://wikipedialibrary.wmflabs.org/users/</p>"
 msgstr ""
 
 #. Translators: This email is sent to users when they have an account that is soon to expire. Don't translate Jinja variables in curly braces like partner_name or partner_link; don't translate html tags either. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/user_renewal_notice-body-text.html:3
 #, python-format
-msgid ""
-"Dear %(user)s, According to our records, your access to %(partner_name)s "
-"will soon expire and you may lose access. If you want to continue making use "
-"of your free account, you can request renewal of your account by clicking "
-"the Renew button at %(partner_link)s. Best, The Wikipedia Library You can "
-"disable these emails in your user page preferences: https://wikipedialibrary."
-"wmflabs.org/users/"
+msgid "Dear %(user)s, According to our records, your access to %(partner_name)s will soon expire and you may lose access. If you want to continue making use of your free account, you can request renewal of your account by clicking the Renew button at %(partner_link)s. Best, The Wikipedia Library You can disable these emails in your user page preferences: https://wikipedialibrary.wmflabs.org/users/"
 msgstr ""
 
 #. Translators: This is the subject of an email sent to users when they have an account that is soon to expire. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
@@ -1276,38 +1125,24 @@ msgstr "An saimong access sa Wikipedyang Libraryo madali nang mapalso"
 #. Translators: This email is sent to users when their application is waitlisted because there are no more accounts available. Don't translate Jinja variables in curly braces like user or partner; don't translate html tags either. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/waitlist_notification-body-html.html:5
 #, python-format
-msgid ""
-"<p>Dear %(user)s,</p> <p>Thank you for applying for access to %(partner)s "
-"resources through The Wikipedia Library. There are no accounts currently "
-"available so your application has been waitlisted. Your application will be "
-"evaluated if/when more accounts become available. You can see all available "
-"resources at <a href=\"%(link)s\">%(link)s</a>.</p> <p>Best,</p> <p>The "
-"Wikipedia Library</p>"
+msgid "<p>Dear %(user)s,</p> <p>Thank you for applying for access to %(partner)s resources through The Wikipedia Library. There are no accounts currently available so your application has been waitlisted. Your application will be evaluated if/when more accounts become available. You can see all available resources at <a href=\"%(link)s\">%(link)s</a>.</p> <p>Best,</p> <p>The Wikipedia Library</p>"
 msgstr ""
 
 #. Translators: This email is sent to users when their application is waitlisted because there are no more accounts available. Don't translate Jinja variables in curly braces like user or partner. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/waitlist_notification-body-text.html:3
 #, python-format
-msgid ""
-"Dear %(user)s, Thank you for applying for access to %(partner)s resources "
-"through The Wikipedia Library. There are no accounts currently available so "
-"your application has been waitlisted. Your application will be evaluated if/"
-"when more accounts become available. You can see all available resources at: "
-"%(link)s Best, The Wikipedia Library"
+msgid "Dear %(user)s, Thank you for applying for access to %(partner)s resources through The Wikipedia Library. There are no accounts currently available so your application has been waitlisted. Your application will be evaluated if/when more accounts become available. You can see all available resources at: %(link)s Best, The Wikipedia Library"
 msgstr ""
 
 #. Translators: This is the subject of an email sent to users when their application is waitlisted because there are no more accounts available. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/waitlist_notification-subject.html:4
 msgid "Your Wikipedia Library application has been waitlisted"
-msgstr ""
-"An saimong aplikasyon sa Wikipedyang Libraryo ikinaag sa listahan kan "
-"paghalat"
+msgstr "An saimong aplikasyon sa Wikipedyang Libraryo ikinaag sa listahan kan paghalat"
 
 #. Translators: Shown to users when they successfully submit a new message using the contact us form.
 #: TWLight/emails/views.py:51
 msgid "Your message has been sent. We'll get back to you soon!"
-msgstr ""
-"An saimong mensahe naipadara na! Mabalik kami saimo sa madaling panahon."
+msgstr "An saimong mensahe naipadara na! Mabalik kami saimo sa madaling panahon."
 
 #. Translators: This message is shown to non-wikipedia editors who attempt to post data to the contact us form.
 #. Translators: This message is shown to non-wikipedia editors who attempt to post data to suggestion form.
@@ -1464,17 +1299,14 @@ msgstr "Mayo"
 #: TWLight/resources/templates/resources/filter_section.html:14
 #: TWLight/templates/about.html:12
 #: TWLight/users/templates/users/filter_section.html:13
-msgid ""
-"The Wikipedia Library allows active editors to access a wide range of "
-"collections of paywalled reliable sources for free!"
+msgid "The Wikipedia Library allows active editors to access a wide range of collections of paywalled reliable sources for free!"
 msgstr ""
 
 #. Translators: On the Browse Partners page (https://wikipedialibrary.wmflabs.org/partners/), this introduces users to The Wikipedia Library.
 #. Translators: On the MyLibrary page (https://wikipedialibrary.wmflabs.org/users/my_library), this introduces users to The Wikipedia Library.
 #: TWLight/resources/templates/resources/filter_section.html:17
 #: TWLight/users/templates/users/filter_section.html:15
-msgid ""
-"Start with the search bar at the top or browse publisher websites directly."
+msgid "Start with the search bar at the top or browse publisher websites directly."
 msgstr ""
 
 #. Translators: On the Browse Partners page (https://wikipedialibrary.wmflabs.org/partners/), this appears below introductory text and links to the 'About' page (https://wikipedialibrary.wmflabs.org/about/)
@@ -1555,52 +1387,38 @@ msgstr ""
 #. Translators: If we have no available accounts for a partner, the coordinator can change the application system to a waiting list.
 #: TWLight/resources/templates/resources/partner_detail.html:36
 #: TWLight/resources/templates/resources/partner_detail_apply.html:17
-msgid ""
-"There are no access grants available for this partner at this time. You can "
-"still apply for access; applications will be processed when access is "
-"available."
+msgid "There are no access grants available for this partner at this time. You can still apply for access; applications will be processed when access is available."
 msgstr ""
 
 #. Translators: This text links to the minimum user requirements and terms of use on the partner page.
 #: TWLight/resources/templates/resources/partner_detail.html:48
 #: TWLight/resources/templates/resources/partner_detail_apply.html:29
 #, python-format
-msgid ""
-"Before applying, please review the <strong><a class=\"twl-links\" href="
-"\"%(about)s#req\">minimum requirements</a></strong> for access and our "
-"<strong><a class=\"twl-links\" href=\"%(terms)s\">terms of use</a></strong>."
+msgid "Before applying, please review the <strong><a class=\"twl-links\" href=\"%(about)s#req\">minimum requirements</a></strong> for access and our <strong><a class=\"twl-links\" href=\"%(terms)s\">terms of use</a></strong>."
 msgstr ""
 
 #. Translators: This text refers to the page containing the content a user is authorized to access.
 #: TWLight/resources/templates/resources/partner_detail.html:69
 #, python-format
-msgid ""
-"View the status of your access in <strong><a class=\"twl-links\" href="
-"\"%(library_url)s\">My Library</a></strong> page."
+msgid "View the status of your access in <strong><a class=\"twl-links\" href=\"%(library_url)s\">My Library</a></strong> page."
 msgstr ""
 
 #. Translators: This message is shown when a user has open applications, linking to their respective applications page.
 #: TWLight/resources/templates/resources/partner_detail.html:78
 #, python-format
-msgid ""
-"View the status of your application(s) on your <strong><a class=\"twl-links"
-"\" href=\"%(applications_url)s\">My Applications</a></strong> page."
+msgid "View the status of your application(s) on your <strong><a class=\"twl-links\" href=\"%(applications_url)s\">My Applications</a></strong> page."
 msgstr ""
 
 #. Translators: This message is shown when a user has authorizations, linking to their respective collections page.
 #: TWLight/resources/templates/resources/partner_detail_apply.html:50
 #, python-format
-msgid ""
-"View the status of your access on your <strong><a href=\"%(library_url)s\" "
-"class=\"twl-links\">My Library</a></strong> page."
+msgid "View the status of your access on your <strong><a href=\"%(library_url)s\" class=\"twl-links\">My Library</a></strong> page."
 msgstr ""
 
 #. Translators: This message is shown when a user has open applications, linking to their respective applications page.
 #: TWLight/resources/templates/resources/partner_detail_apply.html:60
 #, python-format
-msgid ""
-"View the status of your application(s) on your <strong><a href="
-"\"%(applications_url)s\">My Applications</a></strong> page."
+msgid "View the status of your application(s) on your <strong><a href=\"%(applications_url)s\">My Applications</a></strong> page."
 msgstr ""
 
 #. Translators: One the partner detail page, this text labels the button which coordinators can click to remove a partner from waitlisted status.
@@ -1616,9 +1434,7 @@ msgstr "Naitakda sa listahan kan paghalat"
 #: TWLight/resources/templates/resources/partner_detail_apply.html:86
 #, python-format
 msgid "<strong>%(coordinator)s</strong> processes applications to %(partner)s."
-msgstr ""
-"<strong>%(coordinator)s</strong> mga proseso kan mga aplikasyon sa "
-"%(partner)s."
+msgstr "<strong>%(coordinator)s</strong> mga proseso kan mga aplikasyon sa %(partner)s."
 
 #. Translators: When a coordinator is assigned to a partner, their details are shown on the page. This text labels a link to their Talk page on Wikipedia, and should be translated to the text used for Talk pages in the language you are translating to.
 #: TWLight/resources/templates/resources/partner_detail_apply.html:95
@@ -1632,15 +1448,8 @@ msgstr "Espesyal: Esurat/Paragamit na pahina"
 
 #. Translators: If no account coordinator is assigned to a partner, the Wikipedia Library team will coordinate signups. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/resources/templates/resources/partner_detail_apply.html:112
-msgid ""
-"The Wikipedia Library team will process this application. Want to help? <a "
-"class=\"twl-links\" href=\"https://en.wikipedia.org/wiki/Wikipedia:"
-"The_Wikipedia_Library/Coordinators/Signup\">Sign up as a coordinator.</a>"
-msgstr ""
-"An grupo kan Wikipedyang Libraryo ipo-proseso an aplikasyon na ini. Gusto "
-"magtabang? <a class=\"twl-links\" href=\"https://en.wikipedia.org/wiki/"
-"Wikipedia:The_Wikipedia_Library/Coordinators/Signup\">Magsali bilang sarong "
-"koordinator.</a>"
+msgid "The Wikipedia Library team will process this application. Want to help? <a class=\"twl-links\" href=\"https://en.wikipedia.org/wiki/Wikipedia:The_Wikipedia_Library/Coordinators/Signup\">Sign up as a coordinator.</a>"
+msgstr "An grupo kan Wikipedyang Libraryo ipo-proseso an aplikasyon na ini. Gusto magtabang? <a class=\"twl-links\" href=\"https://en.wikipedia.org/wiki/Wikipedia:The_Wikipedia_Library/Coordinators/Signup\">Magsali bilang sarong koordinator.</a>"
 
 #. Translators: This text labels a button coordinators can click to view a list of users who have applied for access for a particular partner
 #: TWLight/resources/templates/resources/partner_detail_apply.html:121
@@ -1669,18 +1478,13 @@ msgstr ""
 
 #. Translators: Text shown to authenticated, bundle eligible users when they visit a Bundle partner page.
 #: TWLight/resources/templates/resources/partner_detail_apply.html:138
-msgid ""
-"You are eligible to access Library Bundle partners. Click the button above "
-"to access the collection."
+msgid "You are eligible to access Library Bundle partners. Click the button above to access the collection."
 msgstr ""
 
 #. Translators: Text shown to authenticated, bundle ineligible users when they visit a Bundle partner page.
 #: TWLight/resources/templates/resources/partner_detail_apply.html:152
 #, python-format
-msgid ""
-"You are not eligible to access Library Bundle partners. Visit the <a class="
-"\"twl-links\" href=\"%(homepage)s\">homepage</a> to check the eligibility "
-"criteria."
+msgid "You are not eligible to access Library Bundle partners. Visit the <a class=\"twl-links\" href=\"%(homepage)s\">homepage</a> to check the eligibility criteria."
 msgstr ""
 
 #. Translators: Buttton prompting users to log in.
@@ -1692,10 +1496,7 @@ msgstr "Maglaog"
 #. Translators: Text shown to unauthenticated users when they visit a Bundle partner page.
 #: TWLight/resources/templates/resources/partner_detail_apply.html:168
 #, python-format
-msgid ""
-"This resource is part of our <a class=\"twl-links\" href=\"%(about)s"
-"\">Library Bundle</a>, which you can access if you meet our minimum "
-"eligibility criteria. Log in to find out if you are eligible."
+msgid "This resource is part of our <a class=\"twl-links\" href=\"%(about)s\">Library Bundle</a>, which you can access if you meet our minimum eligibility criteria. Log in to find out if you are eligible."
 msgstr ""
 
 #. Translators: This is the label for a number which shows the total active accounts for one partner. (e.g. https://wikipedialibrary.wmflabs.org/partners/8/).
@@ -1746,34 +1547,20 @@ msgstr "Limit kan excerpt"
 #. Translators: If a partner has specified the excerpt limit both in words and percentage, this message will display the percentage of words and the number of words on the partner page.
 #: TWLight/resources/templates/resources/partner_detail_timeline.html:99
 #, python-format
-msgid ""
-"%(object)s allows a maximum of %(excerpt_limit)s words or "
-"%(excerpt_limit_percentage)s%% of an article be excerpted into a Wikipedia "
-"article."
-msgstr ""
-"%(object)s nagtutugot hanggang sa %(excerpt_limit)s tataramon o "
-"%(excerpt_limit_percentage)s%% kan artikulo na pwedeng isipi sa artikulo kan "
-"Wikipedia."
+msgid "%(object)s allows a maximum of %(excerpt_limit)s words or %(excerpt_limit_percentage)s%% of an article be excerpted into a Wikipedia article."
+msgstr "%(object)s nagtutugot hanggang sa %(excerpt_limit)s tataramon o %(excerpt_limit_percentage)s%% kan artikulo na pwedeng isipi sa artikulo kan Wikipedia."
 
 #. Translators: If a partner has specified the excerpt limit in words, this message will display the number of words on the partner page.
 #: TWLight/resources/templates/resources/partner_detail_timeline.html:106
 #, python-format
-msgid ""
-"%(object)s allows a maximum of %(excerpt_limit)s words be excerpted into a "
-"Wikipedia article."
-msgstr ""
-"%(object)s nagtutugot hanggang sa %(excerpt_limit)s kan tataramon na isisipi "
-"sa artikulo kan Wikipedya."
+msgid "%(object)s allows a maximum of %(excerpt_limit)s words be excerpted into a Wikipedia article."
+msgstr "%(object)s nagtutugot hanggang sa %(excerpt_limit)s kan tataramon na isisipi sa artikulo kan Wikipedya."
 
 #. Translators: If a partner has specified the excerpt limit in percentage, this message will display the percentage of words on the partner page.
 #: TWLight/resources/templates/resources/partner_detail_timeline.html:113
 #, python-format
-msgid ""
-"%(object)s allows a maximum of %(excerpt_limit_percentage)s%% of an article "
-"be excerpted into a Wikipedia article."
-msgstr ""
-"%(object)s nagtutugot hanggang sa %(excerpt_limit_percentage)s%% kan "
-"artikulo na pwedeng isipi sa artikulo kan Wikipedya."
+msgid "%(object)s allows a maximum of %(excerpt_limit_percentage)s%% of an article be excerpted into a Wikipedia article."
+msgstr "%(object)s nagtutugot hanggang sa %(excerpt_limit_percentage)s%% kan artikulo na pwedeng isipi sa artikulo kan Wikipedya."
 
 #. Translators: If a partner has other requirements for access, this text shows as the title for that information field. (e.g. https://wikipedialibrary.wmflabs.org/partners/10/).
 #: TWLight/resources/templates/resources/partner_detail_timeline.html:132
@@ -1783,12 +1570,8 @@ msgstr "Espesyal na kaipuhan para sa mga aplikante"
 #. Translators: If a user must agree to a Terms of Use document, they see this message, and must enter the name of the resource. Don't translate publisher or url.
 #: TWLight/resources/templates/resources/partner_detail_timeline.html:140
 #, python-format
-msgid ""
-"%(publisher)s requires that you agree with its <a href=\"%(url)s\">terms of "
-"use</a>."
-msgstr ""
-"%(publisher)s nagoobliga na magtugot sa mga <a href=\"%(url)s\">termino kan "
-"paggamit</a>."
+msgid "%(publisher)s requires that you agree with its <a href=\"%(url)s\">terms of use</a>."
+msgstr "%(publisher)s nagoobliga na magtugot sa mga <a href=\"%(url)s\">termino kan paggamit</a>."
 
 #. Translators: If a user must provide their real name to apply to a partner, they see this message, and must enter the name of the resource. Don't translate publisher.
 #: TWLight/resources/templates/resources/partner_detail_timeline.html:150
@@ -1806,25 +1589,18 @@ msgstr "%(publisher)s nag-oobliga na magtao kan bansang iniistaran."
 #: TWLight/resources/templates/resources/partner_detail_timeline.html:168
 #, python-format
 msgid "%(publisher)s requires that you provide your institutional affiliation."
-msgstr ""
-"%(publisher)s nag-oobliga na magtao kan saimong institusyonal na afilyasyon."
+msgstr "%(publisher)s nag-oobliga na magtao kan saimong institusyonal na afilyasyon."
 
 #. Translators: If a user must select a specific resource to apply for, they see this message, and must enter the name of the resource. Don't translate publisher.
 #: TWLight/resources/templates/resources/partner_detail_timeline.html:177
 #, python-format
-msgid ""
-"%(publisher)s requires that you specify a particular title that you want to "
-"access."
-msgstr ""
-"%(publisher)s nangangaipuhan na isambit an partikular na titulo na gusto "
-"mong i-access."
+msgid "%(publisher)s requires that you specify a particular title that you want to access."
+msgstr "%(publisher)s nangangaipuhan na isambit an partikular na titulo na gusto mong i-access."
 
 #. Translators: If a user must register on the partner website before applying, they see this message. Don't translate partner.
 #: TWLight/resources/templates/resources/partner_detail_timeline.html:187
 #, python-format
-msgid ""
-"%(publisher)s requires that you sign up for an account before applying for "
-"access."
+msgid "%(publisher)s requires that you sign up for an account before applying for access."
 msgstr ""
 
 #. Translators: If a partner has their location listed, this message is a label for that location
@@ -1952,9 +1728,7 @@ msgstr "Sigurado ka nang gusto mong puraon an %(object)s?"
 
 #. Translators: If multiple authorizations where returned for a collection, this message is shown to a user
 #: TWLight/resources/views.py:268
-msgid ""
-"Multiple authorizations were returned – something's wrong. Please contact us "
-"and don't forget to mention this message."
+msgid "Multiple authorizations were returned – something's wrong. Please contact us and don't forget to mention this message."
 msgstr ""
 
 #. Translators: This message is shown when user tries to access a NOT_AVAILABLE Partner
@@ -1995,14 +1769,7 @@ msgstr ""
 #. Translators: Shown on the website's 400 page, when a user sends a bad request. Don't translate path or Phabricator.
 #: TWLight/templates/400.html:20
 #, python-format
-msgid ""
-"If you think we should know what to do with that, please email us about this "
-"error at <a class=\"twl-links\" href=\"mailto:wikipedialibrary@wikimedia.org?"
-"Subject=Wikipedia%%20Library%%20%(path)s%%20Permission%%20denied"
-"\">wikipedialibrary@wikimedia.org</a> or report it to us on <a class=\"twl-"
-"links\" href=\"https://phabricator.wikimedia.org/maniphest/task/edit/form/1/?"
-"projectPHIDs=Library-Card-Platform&title=Wikipedia%%20Library%%20%(path)s"
-"%%20Bad%%20Request\">Phabricator</a>"
+msgid "If you think we should know what to do with that, please email us about this error at <a class=\"twl-links\" href=\"mailto:wikipedialibrary@wikimedia.org?Subject=Wikipedia%%20Library%%20%(path)s%%20Permission%%20denied\">wikipedialibrary@wikimedia.org</a> or report it to us on <a class=\"twl-links\" href=\"https://phabricator.wikimedia.org/maniphest/task/edit/form/1/?projectPHIDs=Library-Card-Platform&title=Wikipedia%%20Library%%20%(path)s%%20Bad%%20Request\">Phabricator</a>"
 msgstr ""
 
 #. Translators: Alt text for an image shown on the 400 error page.
@@ -2024,15 +1791,7 @@ msgstr "Pasensya: ika pinagbabawalan na gibuhon yan"
 #. Translators: Shown on the website's 403 page, when a user attempts to navigate to a page they don't have permission to view. Don't translate path or Phabricator.
 #: TWLight/templates/403.html:20
 #, python-format
-msgid ""
-"If you think your account should be able to do that, please email us about "
-"this error at <a class=\"twl-links\" href=\"mailto:"
-"wikipedialibrary@wikimedia.org?Subject=Wikipedia%%20Library%%20%(path)s"
-"%%20Permission%%20denied\">wikipedialibrary@wikimedia.org</a> or report it "
-"to us on <a class=\"twl-links\" href=\"https://phabricator.wikimedia.org/"
-"maniphest/task/edit/form/1/?projectPHIDs=Library-Card-"
-"Platform&title=Wikipedia%%20Library%%20%(path)s%%20Permission%%20denied"
-"\">Phabricator</a>"
+msgid "If you think your account should be able to do that, please email us about this error at <a class=\"twl-links\" href=\"mailto:wikipedialibrary@wikimedia.org?Subject=Wikipedia%%20Library%%20%(path)s%%20Permission%%20denied\">wikipedialibrary@wikimedia.org</a> or report it to us on <a class=\"twl-links\" href=\"https://phabricator.wikimedia.org/maniphest/task/edit/form/1/?projectPHIDs=Library-Card-Platform&title=Wikipedia%%20Library%%20%(path)s%%20Permission%%20denied\">Phabricator</a>"
 msgstr ""
 
 #. Translators: Shown on the website's 404 page, when a user attempts to navigate to a page that doesn't exist.
@@ -2048,14 +1807,7 @@ msgstr "Pasensiya; dai makahanap nin arog kaiyan."
 #. Translators: Shown on the website's 404 page, when a user attempts to navigate to a page that doesn't exist. Don't translate path or Phabricator.
 #: TWLight/templates/404.html:19
 #, python-format
-msgid ""
-"If you are certain that something should be here, please email us about this "
-"error at <a class=\"twl-links\" href=\"mailto:wikipedialibrary@wikimedia.org?"
-"Subject=Wikipedia%%20Library%%20%(path)s%%20Not%%20found\"> "
-"wikipedialibrary@wikimedia.org</a> or report it to us on <a class=\"twl-links"
-"\" href=\"https://phabricator.wikimedia.org/maniphest/task/edit/form/1/?"
-"projectPHIDs=Library-Card-Platform&title=Wikipedia%%20Library%%20%(path)s"
-"%%20Not%%20found\">Phabricator</a>"
+msgid "If you are certain that something should be here, please email us about this error at <a class=\"twl-links\" href=\"mailto:wikipedialibrary@wikimedia.org?Subject=Wikipedia%%20Library%%20%(path)s%%20Not%%20found\"> wikipedialibrary@wikimedia.org</a> or report it to us on <a class=\"twl-links\" href=\"https://phabricator.wikimedia.org/maniphest/task/edit/form/1/?projectPHIDs=Library-Card-Platform&title=Wikipedia%%20Library%%20%(path)s%%20Not%%20found\">Phabricator</a>"
 msgstr ""
 
 #. Translators: Alt text for an image shown on the 404 error page.
@@ -2070,32 +1822,18 @@ msgstr "Manongod sa Wikipedyang Libraryo"
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:20
-msgid ""
-"This platform is our central tool for facilitating access to our available "
-"collections. Here you can see which partnerships are available, search their "
-"contents, and apply for and access the ones you’re interested in."
+msgid "This platform is our central tool for facilitating access to our available collections. Here you can see which partnerships are available, search their contents, and apply for and access the ones you’re interested in."
 msgstr ""
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/). Wikimedia Foundation should not be translated.
 #: TWLight/templates/about.html:29
-msgid ""
-"All users receive immediate access to some collections, which can be browsed "
-"by clicking the 'Access collection' buttons or using the search bar at the "
-"top of the page. Other collections require an application before access is "
-"granted, and may be accessed directly or via an individual login or access "
-"code. Volunteer coordinators, who have signed non-disclosure agreements with "
-"the Wikimedia Foundation, review these applications and work with publishers "
-"to get you your free access."
+msgid "All users receive immediate access to some collections, which can be browsed by clicking the 'Access collection' buttons or using the search bar at the top of the page. Other collections require an application before access is granted, and may be accessed directly or via an individual login or access code. Volunteer coordinators, who have signed non-disclosure agreements with the Wikimedia Foundation, review these applications and work with publishers to get you your free access."
 msgstr ""
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/). Don't translate terms_url.
 #: TWLight/templates/about.html:43
 #, python-format
-msgid ""
-"For more information about how your information is stored and reviewed "
-"please see our <a class=\"twl-links\" href=\"%(terms_url)s\"> terms of use "
-"and privacy policy</a>. Accounts you apply for are also subject to the Terms "
-"of Use provided by each partner’s platform; please review them."
+msgid "For more information about how your information is stored and reviewed please see our <a class=\"twl-links\" href=\"%(terms_url)s\"> terms of use and privacy policy</a>. Accounts you apply for are also subject to the Terms of Use provided by each partner’s platform; please review them."
 msgstr ""
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
@@ -2105,12 +1843,7 @@ msgstr ""
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/). Wikimedia Foundation should not be translated.
 #: TWLight/templates/about.html:55
-msgid ""
-"Any active editor in good standing can receive access. For publishers with "
-"limited numbers of accounts, applications are reviewed based on the editor’s "
-"needs and contributions. If you think you could use access to one of our "
-"partner resources and are an active editor in any project supported by the "
-"Wikimedia Foundation, please apply."
+msgid "Any active editor in good standing can receive access. For publishers with limited numbers of accounts, applications are reviewed based on the editor’s needs and contributions. If you think you could use access to one of our partner resources and are an active editor in any project supported by the Wikimedia Foundation, please apply."
 msgstr ""
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
@@ -2131,9 +1864,7 @@ msgstr ""
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:79
 msgid "You have made at least 10 edits to Wikimedia projects in the last month"
-msgstr ""
-"Ika nakagibo ni dai mababa sa 10 pagliwat sa mga proyekto kan Wikimedia kan "
-"nakaaging bulan"
+msgstr "Ika nakagibo ni dai mababa sa 10 pagliwat sa mga proyekto kan Wikimedia kan nakaaging bulan"
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:83
@@ -2142,23 +1873,12 @@ msgstr "Ika dai man nabagat sa pagliwat sa Wikipedya"
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/)
 #: TWLight/templates/about.html:89
-msgid ""
-"If you are applying for an available collection, please first check that you "
-"don't already have access through another library or institution. If you do, "
-"please consider using that access rather than taking up a seat for this "
-"resource in The Wikipedia Library."
+msgid "If you are applying for an available collection, please first check that you don't already have access through another library or institution. If you do, please consider using that access rather than taking up a seat for this resource in The Wikipedia Library."
 msgstr ""
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/)
 #: TWLight/templates/about.html:99
-msgid ""
-"If your account is blocked on one or more Wikimedia projects, you may still "
-"be granted access to The Wikipedia Library. You will need to contact the "
-"Wikipedia Library team, who will review your blocks. If you have been "
-"blocked for content issues, most notably copyright violations, or have "
-"multiple long-term blocks, we may decline your request. Additionally, if "
-"your block status changes after being approved, you will need to request "
-"another review."
+msgid "If your account is blocked on one or more Wikimedia projects, you may still be granted access to The Wikipedia Library. You will need to contact the Wikipedia Library team, who will review your blocks. If you have been blocked for content issues, most notably copyright violations, or have multiple long-term blocks, we may decline your request. Additionally, if your block status changes after being approved, you will need to request another review."
 msgstr ""
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
@@ -2193,9 +1913,7 @@ msgstr "An mga aprubadong paraliwat <i>dai dapat</i>:"
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:136
-msgid ""
-"Share their account logins or passwords with others, or sell their access to "
-"other parties"
+msgid "Share their account logins or passwords with others, or sell their access to other parties"
 msgstr ""
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
@@ -2205,23 +1923,17 @@ msgstr ""
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:144
-msgid ""
-"Systematically make printed or electronic copies of multiple extracts of "
-"restricted content available for any purpose"
+msgid "Systematically make printed or electronic copies of multiple extracts of restricted content available for any purpose"
 msgstr ""
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/). Stub is a technical term for a short Wikipedia article, use the appropriate Wikipedia term in your language.
 #: TWLight/templates/about.html:148
-msgid ""
-"Datamine metadata without permission, in order, for instance, to use "
-"metadata for auto-created stub articles"
+msgid "Datamine metadata without permission, in order, for instance, to use metadata for auto-created stub articles"
 msgstr ""
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:154
-msgid ""
-"Respecting these agreements allows us to continue growing the partnerships "
-"available to the community."
+msgid "Respecting these agreements allows us to continue growing the partnerships available to the community."
 msgstr ""
 
 #. Translators: This is the heading for a section on the About page (https://wikipedialibrary.wmflabs.org/about/).
@@ -2231,41 +1943,22 @@ msgstr ""
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:164
-msgid ""
-"EZProxy is a proxy server used to authenticate users for many Wikipedia "
-"Library partners. Users sign into EZProxy via the Library Card platform to "
-"verify that they are authorized users, and then the server accesses "
-"requested resources using its own IP address."
+msgid "EZProxy is a proxy server used to authenticate users for many Wikipedia Library partners. Users sign into EZProxy via the Library Card platform to verify that they are authorized users, and then the server accesses requested resources using its own IP address."
 msgstr ""
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:173
-msgid ""
-"You may notice that when accessing resources via EZProxy that URLs are "
-"dynamically rewritten. This is why we recommend logging in via the Library "
-"Card platform rather than going directly to the unproxied partner website. "
-"When in doubt, check the URL for ‘idm.oclc’. If it’s there, then you’re "
-"connected via EZProxy."
+msgid "You may notice that when accessing resources via EZProxy that URLs are dynamically rewritten. This is why we recommend logging in via the Library Card platform rather than going directly to the unproxied partner website. When in doubt, check the URL for ‘idm.oclc’. If it’s there, then you’re connected via EZProxy."
 msgstr ""
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:182
-msgid ""
-"Typically once you’ve logged in your session will remain active in your "
-"browser for up to two hours after you’ve finished searching. Note that use "
-"of EZProxy requires you to enable cookies. If you are having problems you "
-"should also try clearing your cache and restarting your browser."
+msgid "Typically once you’ve logged in your session will remain active in your browser for up to two hours after you’ve finished searching. Note that use of EZProxy requires you to enable cookies. If you are having problems you should also try clearing your cache and restarting your browser."
 msgstr ""
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/)
 #: TWLight/templates/about.html:193
-msgid ""
-"The Library Bundle is a collection of resources for which no application is "
-"required. If you meet the criteria laid out above, you will be authorized "
-"for access automatically upon logging in to the platform. Only some of our "
-"content is currently included in the Library Bundle, however we hope to "
-"expand the collection as more publishers become comfortable with "
-"participating. All Bundle content is accessed via EZProxy."
+msgid "The Library Bundle is a collection of resources for which no application is required. If you meet the criteria laid out above, you will be authorized for access automatically upon logging in to the platform. Only some of our content is currently included in the Library Bundle, however we hope to expand the collection as more publishers become comfortable with participating. All Bundle content is accessed via EZProxy."
 msgstr ""
 
 #. Translators: This is the heading for a section on the About page (https://wikipedialibrary.wmflabs.org/about/).
@@ -2275,12 +1968,7 @@ msgstr ""
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:206
-msgid ""
-"Citation practices vary by project and even by article. Generally, we "
-"support editors citing where they found information, in a form that allows "
-"others to check it for themselves. That often means providing both original "
-"source details as well as a link to the partner database in which the source "
-"was found."
+msgid "Citation practices vary by project and even by article. Generally, we support editors citing where they found information, in a form that allows others to check it for themselves. That often means providing both original source details as well as a link to the partner database in which the source was found."
 msgstr ""
 
 #. Translators: This is the heading for a section on the About page (https://wikipedialibrary.wmflabs.org/about/).
@@ -2292,9 +1980,7 @@ msgstr "Hadoyon kami"
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:218
 #, python-format
-msgid ""
-"If you have questions, need help, or want to volunteer to help, please see "
-"our <a class=\"twl-links\" href=\"%(contact_url)s\">contact page</a>."
+msgid "If you have questions, need help, or want to volunteer to help, please see our <a class=\"twl-links\" href=\"%(contact_url)s\">contact page</a>."
 msgstr ""
 
 #. Translators: This is the title of the panel box detailing the contact information for the Wikipedia Library team.
@@ -2334,12 +2020,8 @@ msgstr "An pahina sa Twitter kan Wikipedyang Libraryo"
 #. Translators: This is the text that appears at the bottom of the contact us form directing users to the suggestions form.
 #: TWLight/templates/contact.html:48
 #, python-format
-msgid ""
-"(If you would like to suggest a partner, <a class=\"twl-links\" href="
-"\"%(suggest)s\"><strong>go here</strong></a>.)"
-msgstr ""
-"(Kun gusto mo magmungkahi nin kapareha, <a class=\"twl-links\" href="
-"\"%(suggest)s\"><strong>go here</strong></a>.)"
+msgid "(If you would like to suggest a partner, <a class=\"twl-links\" href=\"%(suggest)s\"><strong>go here</strong></a>.)"
+msgstr "(Kun gusto mo magmungkahi nin kapareha, <a class=\"twl-links\" href=\"%(suggest)s\"><strong>go here</strong></a>.)"
 
 #. Translators: On a special 'link to search' page, this message is shown if JavaScript is disabled.
 #: TWLight/templates/eds_search_endpoint.html:7
@@ -2399,9 +2081,7 @@ msgstr "An Wikipedyang Libraryo"
 #. Translators: Information about The Wikipedia Library.
 #: TWLight/templates/login_partial.html:53 TWLight/templates/new_base.html:21
 #, python-format
-msgid ""
-"More than 100 of the world's top subscription-only databases, with content "
-"in %(no_of_languages)s languages, free for Wikipedians of all backgrounds"
+msgid "More than 100 of the world's top subscription-only databases, with content in %(no_of_languages)s languages, free for Wikipedians of all backgrounds"
 msgstr ""
 
 #. Translators: Information about The Wikipedia Library.
@@ -2410,9 +2090,7 @@ msgid "Meet these criteria for automatic access"
 msgstr ""
 
 #: TWLight/templates/login_partial.html:69
-msgid ""
-"These criteria grant you access to certain collections but not all. Some "
-"collections are accessible on a per application basis only."
+msgid "These criteria grant you access to certain collections but not all. Some collections are accessible on a per application basis only."
 msgstr ""
 
 #: TWLight/templates/login_partial.html:89
@@ -2422,29 +2100,19 @@ msgstr ""
 #. Translators: Shown if the current user doesn't have a registered email on their account. Don't translate contact_us_url or email_url.
 #: TWLight/templates/message_partial.html:15
 #, python-format
-msgid ""
-"You don't have an email on file. We can't finalize your access to partner "
-"resources, and you won't be able to <a class=\"twl-links\" href="
-"\"%(contact_us_url)s\">contact us</a> without an email. Please <a class="
-"\"twl-links\" href=\"%(email_url)s\">update your email</a>."
+msgid "You don't have an email on file. We can't finalize your access to partner resources, and you won't be able to <a class=\"twl-links\" href=\"%(contact_us_url)s\">contact us</a> without an email. Please <a class=\"twl-links\" href=\"%(email_url)s\">update your email</a>."
 msgstr ""
 
 #. Translators: Shown if the current user has requested the processing of their data should be restricted.
 #: TWLight/templates/message_partial.html:26
 #, python-format
-msgid ""
-"You have requested a restriction on the processing of your data. Most site "
-"functionality will not be available to you until you <a class=\"twl-links\" "
-"href=\"%(restrict_url)s\">lift this restriction</a>."
+msgid "You have requested a restriction on the processing of your data. Most site functionality will not be available to you until you <a class=\"twl-links\" href=\"%(restrict_url)s\">lift this restriction</a>."
 msgstr ""
 
 #. Translators: Shown if the current user has not agreed to the terms of use.
 #: TWLight/templates/message_partial.html:37
 #, python-format
-msgid ""
-"You have not agreed to the <a class=\"twl-links\" href=\"%(terms_url)s"
-"\">terms of use</a> of this site. Your applications will not be processed "
-"and you won't be able to apply or access resources you are approved for."
+msgid "You have not agreed to the <a class=\"twl-links\" href=\"%(terms_url)s\">terms of use</a> of this site. Your applications will not be processed and you won't be able to apply or access resources you are approved for."
 msgstr ""
 
 #. Translators: This link is at the bottom of every page and links to the 'About' page (https://wikipedialibrary.wmflabs.org/about/)
@@ -2491,9 +2159,7 @@ msgstr "Pakibago kan sekretong panlaog"
 
 #. Translators: If a user goes to reset their password, this message asks them to enter their email to do so.
 #: TWLight/templates/registration/password_reset_form.html:13
-msgid ""
-"Forgot your password? Enter your email address below, and we'll email "
-"instructions for setting a new one."
+msgid "Forgot your password? Enter your email address below, and we'll email instructions for setting a new one."
 msgstr ""
 
 #. Translators: This is the label for a button that users click to update their public information.
@@ -2504,9 +2170,7 @@ msgstr "Sumpayan an profile"
 #. Translators: This labels a field where users can describe their activity on Wikipedia in a small biography.
 #: TWLight/users/forms.py:45
 msgid "Describe your contributions to Wikipedia: topics edited, et cetera."
-msgstr ""
-"Iladawan an saimong mga kaambagan sa Wikipedya: mga paksang niliwat, et "
-"cetera."
+msgstr "Iladawan an saimong mga kaambagan sa Wikipedya: mga paksang niliwat, et cetera."
 
 #. Translators: In the preferences section (Emails) of a user profile, this text labels the checkbox users can (un)click to change if they wish to receive account renewal notices or not.
 #: TWLight/users/forms.py:98
@@ -2540,16 +2204,12 @@ msgstr "Nagtutugot ako sa termino kan paggamit"
 
 #. Translators: This text explains how to disagree to the site's terms of use and the restrictions that will come into effect when users disagree to the terms of use.
 #: TWLight/users/forms.py:185
-msgid ""
-"By unchecking this box and clicking “Update” you may explore the site, but "
-"you will not be able to apply for access to materials or evaluate "
-"applications unless you agree with the terms of use."
+msgid "By unchecking this box and clicking “Update” you may explore the site, but you will not be able to apply for access to materials or evaluate applications unless you agree with the terms of use."
 msgstr ""
 
 #. Translators: Users click this button to set their website email address to the one linked to their Wikipedia account.
 #: TWLight/users/forms.py:211
-msgid ""
-"Use my Wikipedia email address (will be updated the next time you login)."
+msgid "Use my Wikipedia email address (will be updated the next time you login)."
 msgstr ""
 
 #. Translators: This labels a button which users click to change their email.
@@ -2560,17 +2220,8 @@ msgstr "Baguhon an e-surat"
 #. Translators: Shown if the current user tried to 'favorite' a partner they can't access. Do not translate '{partner}'
 #: TWLight/users/models.py:201
 #, python-brace-format
-msgid ""
-"Cannot add partner {partner} to your favorites because you don't have access "
-"to it"
+msgid "Cannot add partner {partner} to your favorites because you don't have access to it"
 msgstr ""
-
-#. Translators: Do not translate.
-#: TWLight/users/models.py:869
-#, fuzzy, python-brace-format
-#| msgid "Username"
-msgid "{wp_username}"
-msgstr "Ngaran nin Paragamit:"
 
 #. Translators: This error message is shown when there's a problem with the authenticated login process.
 #: TWLight/users/oauth.py:243
@@ -2590,9 +2241,7 @@ msgstr ""
 
 #. Translators: this message is displayed to users that don't have accounts and clicked on a proxied link.
 #: TWLight/users/oauth.py:388
-msgid ""
-"To view this link you need to be an eligible library user. Please login to "
-"continue."
+msgid "To view this link you need to be an eligible library user. Please login to continue."
 msgstr ""
 
 #. Translators: This warning message is shown to users when the response received from Wikimedia OAuth servers is not a valid one.
@@ -2628,17 +2277,12 @@ msgstr "Impormasyon nin paragamit"
 
 #. Translators: If the user tries to log in, but their account does not meet certain requirements, they cannot login.
 #: TWLight/users/oauth.py:528
-msgid ""
-"Your Wikipedia account does not meet the eligibility criteria in the terms "
-"of use, so your Wikipedia Library Card Platform account cannot be activated."
+msgid "Your Wikipedia account does not meet the eligibility criteria in the terms of use, so your Wikipedia Library Card Platform account cannot be activated."
 msgstr ""
 
 #. Translators: If the user tries to log in, but their account does not meet certain requirements, they cannot login.
 #: TWLight/users/oauth.py:536
-msgid ""
-"Your Wikipedia account no longer meets the eligibility criteria in the terms "
-"of use, so you cannot be logged in. If you think you should be able to log "
-"in, please email wikipedialibrary@wikimedia.org."
+msgid "Your Wikipedia account no longer meets the eligibility criteria in the terms of use, so you cannot be logged in. If you think you should be able to log in, please email wikipedialibrary@wikimedia.org."
 msgstr ""
 
 #. Translators: this message is displayed to users with brand new accounts.
@@ -2649,10 +2293,7 @@ msgstr "Dagos! Magtugot tabi sa termino kan paggamit."
 #. Translators: This message is displayed on the confirmation page where users can return their access to partner collections.
 #: TWLight/users/templates/users/authorization_confirm_return.html:13
 #, python-format
-msgid ""
-"You will no longer be able to access <b>%(partner)s's</b> resources via the "
-"Library Card platform, but can request access again by clicking 'renew', if "
-"you change your mind. Are you sure you want to return your access?"
+msgid "You will no longer be able to access <b>%(partner)s's</b> resources via the Library Card platform, but can request access again by clicking 'renew', if you change your mind. Are you sure you want to return your access?"
 msgstr ""
 
 #. Translators: On the MyLibrary page (https://wikipedialibrary.wmflabs.org/users/my_library), this tab shows all favorite collections a user has.
@@ -2724,10 +2365,7 @@ msgstr "Data kan paraliwat"
 
 #. Translators: This is shown on editor profiles, in their profile page or on applications.
 #: TWLight/users/templates/users/editor_detail.html:59
-msgid ""
-"Information with an * was retrieved from Wikipedia directly. Other "
-"information was entered directly by users or site admins, in their preferred "
-"language."
+msgid "Information with an * was retrieved from Wikipedia directly. Other information was entered directly by users or site admins, in their preferred language."
 msgstr ""
 
 #. Translators: This distinguishes users who have been flagged as account coordinators. Don't translate username.
@@ -2738,10 +2376,7 @@ msgstr ""
 
 #. Translators: This is shown on editor profiles, under the heading for Wikipedia editor data.
 #: TWLight/users/templates/users/editor_detail_data.html:5
-msgid ""
-"This information is updated automatically from your Wikimedia account each "
-"time you log in, except for the Contributions field, where you can describe "
-"your Wikimedia editing history."
+msgid "This information is updated automatically from your Wikimedia account each time you log in, except for the Contributions field, where you can describe your Wikimedia editing history."
 msgstr ""
 
 #. Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this labels the user's username.
@@ -2771,17 +2406,13 @@ msgstr ""
 
 #. Translators: when viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this question has a yes or no answer.
 #: TWLight/users/templates/users/editor_detail_data.html:57
-msgid ""
-"at their last login, did this user meet the criteria set forth in the terms "
-"of use?"
+msgid "at their last login, did this user meet the criteria set forth in the terms of use?"
 msgstr ""
 
 #. Translators: When viewing a user's profile in an application, this message shows if the software doesn't think that the user is eligible for access. Don't translate username.
 #: TWLight/users/templates/users/editor_detail_data.html:72
 #, python-format
-msgid ""
-"%(username)s may still be eligible for access grants at the coordinators' "
-"discretion."
+msgid "%(username)s may still be eligible for access grants at the coordinators' discretion."
 msgstr ""
 
 #. Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this is the heading for a Yes/No ToU question.
@@ -2816,10 +2447,7 @@ msgstr ""
 #. Translators: This message is shown on a user's profile if their Wikimedia account is blocked on one or more projects. They may still be granted access to the Library Bundle, but need to contact Wikipedia Library staff to verify.
 #: TWLight/users/templates/users/editor_detail_data.html:137
 #, python-format
-msgid ""
-"It looks like you have an active block on your account. If you meet the "
-"other criteria you may still be permitted access to the library - please <a "
-"class=\"twl-links\" href=\"%(contact_url)s\">contact us</a>."
+msgid "It looks like you have an active block on your account. If you meet the other criteria you may still be permitted access to the library - please <a class=\"twl-links\" href=\"%(contact_url)s\">contact us</a>."
 msgstr ""
 
 #. Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this is the heading for a Yes/No program eligibility question.
@@ -2829,10 +2457,7 @@ msgstr ""
 
 #. Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this question has a Yes or No answer.
 #: TWLight/users/templates/users/editor_detail_data.html:156
-msgid ""
-"At their last login, did this user meet the criteria set forth in the "
-"Library Bundle? Note that satisfying terms of use is a prerequisite to "
-"bundle eligibility."
+msgid "At their last login, did this user meet the criteria set forth in the Library Bundle? Note that satisfying terms of use is a prerequisite to bundle eligibility."
 msgstr ""
 
 #. Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this is the heading for a Yes/No program eligibility question.
@@ -2877,18 +2502,13 @@ msgstr ""
 
 #. Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this text is in the 'Personal data' section. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/users/templates/users/editor_detail_data.html:262
-msgid ""
-"The following information is visible only to you, site administrators, "
-"publishing partners (where required), and volunteer Wikipedia Library "
-"coordinators (who have signed a Non-Disclosure Agreement)."
+msgid "The following information is visible only to you, site administrators, publishing partners (where required), and volunteer Wikipedia Library coordinators (who have signed a Non-Disclosure Agreement)."
 msgstr ""
 
 #. Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this labels a button which users can click to update or remove their personal information. Don't translate update_url.
 #: TWLight/users/templates/users/editor_detail_data.html:272
 #, python-format
-msgid ""
-"You may <a class=\"twl-links\" href=\"%(update_url)s\">update or delete</a> "
-"your data at any time."
+msgid "You may <a class=\"twl-links\" href=\"%(update_url)s\">update or delete</a> your data at any time."
 msgstr ""
 
 #. Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this labels the user's email. Don't remove the *.
@@ -2908,24 +2528,18 @@ msgstr ""
 
 #. Translators: This message tells users that they are not eligible to access The Wikipedia Library content.
 #: TWLight/users/templates/users/eligibility_modal.html:7
-msgid ""
-"Sorry, your Wikipedia account doesn’t currently qualify to access The "
-"Wikipedia Library."
+msgid "Sorry, your Wikipedia account doesn’t currently qualify to access The Wikipedia Library."
 msgstr ""
 
 #. Translators: This message tells users that they have not agreed to the terms of use, therefore are ineligible to access the content in The Wikipedia Library.
 #: TWLight/users/templates/users/eligibility_modal.html:30
 #, python-format
-msgid ""
-"Agreed with <a href=\"%(terms)s\" class=\"text-danger\"> terms of use </a>"
+msgid "Agreed with <a href=\"%(terms)s\" class=\"text-danger\"> terms of use </a>"
 msgstr ""
 
 #: TWLight/users/templates/users/eligibility_modal.html:40
 #, python-format
-msgid ""
-"It looks like you have an active block on your account. If you meet the "
-"other criteria you may still be permitted access to the library - please <a "
-"href=\"%(contact_url)s\">contact us</a>."
+msgid "It looks like you have an active block on your account. If you meet the other criteria you may still be permitted access to the library - please <a href=\"%(contact_url)s\">contact us</a>."
 msgstr ""
 
 #. Translators: Instructions to refresh a user's data.
@@ -2965,10 +2579,7 @@ msgstr "I-set an lengguwahe:"
 
 #. Translators: This text on the user page helps users naviage to the TranslateWiki Wikipedia Library Card platform translation page.
 #: TWLight/users/templates/users/language_form.html:31
-msgid ""
-"You can help translate the tool at <a class=\"twl-links\" href=\"https://"
-"translatewiki.net/wiki/Translating:Wikipedia_Library_Card_Platform"
-"\">translatewiki.net</a>."
+msgid "You can help translate the tool at <a class=\"twl-links\" href=\"https://translatewiki.net/wiki/Translating:Wikipedia_Library_Card_Platform\">translatewiki.net</a>."
 msgstr ""
 
 #. Translators: When the user starts a new application and submits the application, the user can view the application and withdraw if need be. This changes the label for the Withdraw button.
@@ -2988,12 +2599,8 @@ msgstr "Maghagad nin pampanibago"
 
 #. Translators: On the page listing applications, this text explains a user they cannot renew their application since they've already requested a renewal or there aren't any renewals available.
 #: TWLight/users/templates/users/my_applications.html:79
-msgid ""
-"Renewals are either not required, not available right now, or you have "
-"already requested a renewal."
-msgstr ""
-"An pagpanibago dai kaipuhan, dai pwede sa ngunyan o nakapaghagad ka na nin "
-"pagpanibago."
+msgid "Renewals are either not required, not available right now, or you have already requested a renewal."
+msgstr "An pagpanibago dai kaipuhan, dai pwede sa ngunyan o nakapaghagad ka na nin pagpanibago."
 
 #. Translators: This text is the heading of a section in a user's profile where they can change their preferences.
 #: TWLight/users/templates/users/preferences.html:6
@@ -3056,19 +2663,12 @@ msgstr ""
 
 #. Translators: This message is displayed on the page where users can request we stop processing their data.
 #: TWLight/users/templates/users/restrict_data.html:15
-msgid ""
-"Checking this box and clicking “Restrict” will pause all processing of the "
-"data you have entered into this website. You will not be able to apply for "
-"access to resources, your applications will not be further processed, and "
-"none of your data will be altered, until you return to this page and uncheck "
-"the box. This is not the same as deleting your data."
+msgid "Checking this box and clicking “Restrict” will pause all processing of the data you have entered into this website. You will not be able to apply for access to resources, your applications will not be further processed, and none of your data will be altered, until you return to this page and uncheck the box. This is not the same as deleting your data."
 msgstr ""
 
 #. Translators: This warning message is shown to coordinators who view the data restriction page.
 #: TWLight/users/templates/users/restrict_data.html:26
-msgid ""
-"You are a coordinator on this site. If you restrict the processing of your "
-"data, your coordinator flag will be removed."
+msgid "You are a coordinator on this site. If you restrict the processing of your data, your coordinator flag will be removed."
 msgstr ""
 
 #. Translators: use the date *when you are translating*, in a language-appropriate format.
@@ -3085,29 +2685,16 @@ msgstr "Kalakawan kan pribasidad kan Wikimedia Foundation"
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:41
 msgid "Wikipedia Library Card Terms of Use and Privacy Statement"
-msgstr ""
-"Termino kan paggamit asin kalakawan kan pribasidad kan Wikipedia Library Card"
+msgstr "Termino kan paggamit asin kalakawan kan pribasidad kan Wikipedia Library Card"
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:51
-msgid ""
-"<a class=\"twl-links\" href=\"https://meta.wikimedia.org/wiki/"
-"The_Wikipedia_Library\"> The Wikipedia Library </a> has partnered with "
-"publishers around the world to allow users to access otherwise paywalled "
-"resources. This website allows Wikipedia editors to search and access these "
-"resources."
+msgid "<a class=\"twl-links\" href=\"https://meta.wikimedia.org/wiki/The_Wikipedia_Library\"> The Wikipedia Library </a> has partnered with publishers around the world to allow users to access otherwise paywalled resources. This website allows Wikipedia editors to search and access these resources."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Wikimedia Foundation should not be translated. WMF should not be translated. Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:63
-msgid ""
-"This program is administered by the Wikimedia Foundation (WMF). These terms "
-"of use and privacy notice pertain to your application for access to "
-"resources through the Wikipedia Library, your use of this website, and your "
-"access to and use of those resources. They also describe our handling of the "
-"information you provide to us in order to create and administer your "
-"Wikipedia Library account. If we make material changes to the terms, we will "
-"notify users."
+msgid "This program is administered by the Wikimedia Foundation (WMF). These terms of use and privacy notice pertain to your application for access to resources through the Wikipedia Library, your use of this website, and your access to and use of those resources. They also describe our handling of the information you provide to us in order to create and administer your Wikipedia Library account. If we make material changes to the terms, we will notify users."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
@@ -3117,37 +2704,17 @@ msgstr "Mga kaipuhan para sa panindog sa Wikipedia Library Card"
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:78
-msgid ""
-"Access to resources via The Wikipedia Library is reserved for community "
-"members who have demonstrated their commitment to the Wikimedia projects, "
-"and who will use their access to these resources to improve project content. "
-"To that end, in order to be eligible for The Wikipedia Library, we require "
-"that you be registered for a user account on the projects, with at least 500 "
-"edits, six (6) months of activity, and 10+ edits in the last month. We ask "
-"that you do not request access to any publishers with a limited number of "
-"available accounts whose resources you can already access for free through "
-"your local library or university, or another institution or organization, in "
-"order to provide that opportunity to others."
+msgid "Access to resources via The Wikipedia Library is reserved for community members who have demonstrated their commitment to the Wikimedia projects, and who will use their access to these resources to improve project content. To that end, in order to be eligible for The Wikipedia Library, we require that you be registered for a user account on the projects, with at least 500 edits, six (6) months of activity, and 10+ edits in the last month. We ask that you do not request access to any publishers with a limited number of available accounts whose resources you can already access for free through your local library or university, or another institution or organization, in order to provide that opportunity to others."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:94
-msgid ""
-"Additionally, if you are currently blocked or banned from a Wikimedia "
-"project, applications to resources may be rejected or restricted. If you "
-"obtain a Wikipedia Library account, but a block or ban is subsequently "
-"instituted against you on one of the projects, you may lose access to your "
-"Wikipedia Library account."
+msgid "Additionally, if you are currently blocked or banned from a Wikimedia project, applications to resources may be rejected or restricted. If you obtain a Wikipedia Library account, but a block or ban is subsequently instituted against you on one of the projects, you may lose access to your Wikipedia Library account."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:104
-msgid ""
-"Your eligibility to access The Wikipedia Library is assessed at each login. "
-"While more than half of the library's content is provided via this automated "
-"eligibility check, access to other publisher's content may be time limited, "
-"typically lapsing after one year, after which you will usually need to apply "
-"for renewal."
+msgid "Your eligibility to access The Wikipedia Library is assessed at each login. While more than half of the library's content is provided via this automated eligibility check, access to other publisher's content may be time limited, typically lapsing after one year, after which you will usually need to apply for renewal."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
@@ -3157,47 +2724,27 @@ msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:118
-msgid ""
-"In order to apply for access to a partner resource, you must provide us with "
-"certain information, which we will use to evaluate your application. If your "
-"application is approved, we may transfer the information you have given us "
-"to the publishers whose resources you wish to access. They will either "
-"contact you with the account information directly or we will send access "
-"information to you ourselves."
+msgid "In order to apply for access to a partner resource, you must provide us with certain information, which we will use to evaluate your application. If your application is approved, we may transfer the information you have given us to the publishers whose resources you wish to access. They will either contact you with the account information directly or we will send access information to you ourselves."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:130
-msgid ""
-"In addition to the basic information you provide to us, our system will "
-"retrieve some information directly from the Wikimedia projects: your "
-"username, email address, edit count, registration date, user ID number, "
-"groups to which you belong, and any special user rights."
+msgid "In addition to the basic information you provide to us, our system will retrieve some information directly from the Wikimedia projects: your username, email address, edit count, registration date, user ID number, groups to which you belong, and any special user rights."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:140
-msgid ""
-"Each time you log in to the Wikipedia Library Card Platform, this "
-"information will be automatically updated."
+msgid "Each time you log in to the Wikipedia Library Card Platform, this information will be automatically updated."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:148
-msgid ""
-"We will ask you to provide us with some information about your history of "
-"contributions to the Wikimedia projects. Information on contribution history "
-"is optional, but will greatly assist us in evaluating your application."
+msgid "We will ask you to provide us with some information about your history of contributions to the Wikimedia projects. Information on contribution history is optional, but will greatly assist us in evaluating your application."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). WMF should not be translated. Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:157
-msgid ""
-"The information you provide when creating your account will be visible to "
-"you while on the site but not to others unless they are approved Wikipedia "
-"Library Coordinators, WMF Staff, or WMF Contractors who need access to this "
-"data in order to carry out their work with the Wikipedia Library, all of "
-"whom are subject to non-disclosure obligations."
+msgid "The information you provide when creating your account will be visible to you while on the site but not to others unless they are approved Wikipedia Library Coordinators, WMF Staff, or WMF Contractors who need access to this data in order to carry out their work with the Wikipedia Library, all of whom are subject to non-disclosure obligations."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
@@ -3207,46 +2754,32 @@ msgstr "An saimong paggamit kan mga resources kan taga-publikar"
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:171
-msgid ""
-"In order to access an individual publisher’s resources, you must agree to "
-"that publisher’s terms of use and privacy policy. You agree that you will "
-"not violate such terms and policies in connection with your use of the "
-"Wikipedia Library. Additionally, the following activities are prohibited "
-"while accessing publisher resources through the Wikipedia Library."
+msgid "In order to access an individual publisher’s resources, you must agree to that publisher’s terms of use and privacy policy. You agree that you will not violate such terms and policies in connection with your use of the Wikipedia Library. Additionally, the following activities are prohibited while accessing publisher resources through the Wikipedia Library."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:184
-msgid ""
-"Sharing your Wikipedia account, usernames, passwords, or any access codes "
-"for publisher resources with others;"
+msgid "Sharing your Wikipedia account, usernames, passwords, or any access codes for publisher resources with others;"
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:191
-msgid ""
-"Automatically scraping or downloading restricted content from publishers;"
+msgid "Automatically scraping or downloading restricted content from publishers;"
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:197
-msgid ""
-"Systematically making printed or electronic copies of multiple extracts of "
-"restricted content available for any purpose;"
+msgid "Systematically making printed or electronic copies of multiple extracts of restricted content available for any purpose;"
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:204
-msgid ""
-"Data mining metadata without permission—for example, in order to use "
-"metadata for auto-created stub articles;"
+msgid "Data mining metadata without permission—for example, in order to use metadata for auto-created stub articles;"
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:211
-msgid ""
-"Using the access you receive through the Wikipedia Library for profit by "
-"selling access to your account or resources which you have through it."
+msgid "Using the access you receive through the Wikipedia Library for profit by selling access to your account or resources which you have through it."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
@@ -3256,18 +2789,12 @@ msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:224
-msgid ""
-"Certain resources may only be accessed using an external search service, "
-"such as the EBSCO Discovery Service, or a proxy service, such as OCLC "
-"EZProxy. If you use such external search and/or proxy services, please "
-"review the applicable terms of use and privacy policies."
+msgid "Certain resources may only be accessed using an external search service, such as the EBSCO Discovery Service, or a proxy service, such as OCLC EZProxy. If you use such external search and/or proxy services, please review the applicable terms of use and privacy policies."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:234
-msgid ""
-"In addition, if you use OCLC EZProxy, please note that you may not use it "
-"for commercial purposes."
+msgid "In addition, if you use OCLC EZProxy, please note that you may not use it for commercial purposes."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
@@ -3277,120 +2804,49 @@ msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Wikimedia Foundation should not be translated. Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:245
-msgid ""
-"The Wikimedia Foundation and our service providers use your information for "
-"the legitimate purpose of providing Wikipedia Library services in support of "
-"our charitable mission. When you apply for a Wikipedia Library account, or "
-"use your Wikipedia Library account, we may routinely collect the following "
-"information: your username, email address, edit count, registration date, "
-"user ID number, groups to which you belong, and any special user rights; "
-"your name, country of residence, and/or affiliation, if required by a "
-"partner to which you are applying; your narrative description of your "
-"contributions and reasons for applying for access to partner resources; and "
-"the date you agree to these terms of use."
+msgid "The Wikimedia Foundation and our service providers use your information for the legitimate purpose of providing Wikipedia Library services in support of our charitable mission. When you apply for a Wikipedia Library account, or use your Wikipedia Library account, we may routinely collect the following information: your username, email address, edit count, registration date, user ID number, groups to which you belong, and any special user rights; your name, country of residence, and/or affiliation, if required by a partner to which you are applying; your narrative description of your contributions and reasons for applying for access to partner resources; and the date you agree to these terms of use."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:262
 #, python-format
-msgid ""
-"Each publisher who is a member of the Wikipedia Library program requires "
-"different specific information in the application. Some publishers may "
-"request only an email address, while others request more detailed data, such "
-"as your name, location, or institutional affiliation. When you complete your "
-"application, you will only be asked to supply information required by the "
-"publishers you have chosen, and each publisher will only receive the "
-"information they require for providing you with access. Please see our <a "
-"class=\"twl-links\" href=\"%(all_partners_url)s\">partner information</a> "
-"pages to learn what information is required by each publisher to gain access "
-"to their resources."
+msgid "Each publisher who is a member of the Wikipedia Library program requires different specific information in the application. Some publishers may request only an email address, while others request more detailed data, such as your name, location, or institutional affiliation. When you complete your application, you will only be asked to supply information required by the publishers you have chosen, and each publisher will only receive the information they require for providing you with access. Please see our <a class=\"twl-links\" href=\"%(all_partners_url)s\">partner information</a> pages to learn what information is required by each publisher to gain access to their resources."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Wikimedia Foundation should not be translated. Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:277
-msgid ""
-"Some Wikipedia Library pages are visible without logging in, but you will "
-"need to log in to apply or access proprietary partner resources. We use the "
-"data provided by you via OAuth and Wikimedia API calls to assess your "
-"application for access and to process approved requests."
+msgid "Some Wikipedia Library pages are visible without logging in, but you will need to log in to apply or access proprietary partner resources. We use the data provided by you via OAuth and Wikimedia API calls to assess your application for access and to process approved requests."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:288
 #, python-format
-msgid ""
-"In order to administer the Wikipedia Library program, we will retain the "
-"application data we collect from you for three years after your most recent "
-"login, unless you delete your account, as described below. You can log in "
-"and go to <a class=\"twl-links\" href=\"%(profile_url)s\">your profile page</"
-"a> in order to see the information associated with your account, and can "
-"download it in JSON format. You may access, update, restrict, or delete this "
-"information at any time, except for the information that is automatically "
-"retrieved from the projects. If you have any questions or concerns about the "
-"handling of your data, please contact <a class=\"twl-links\" href=\"mailto:"
-"wikipedialibrary@wikimedia.org?Subject=Wikipedia%%20Library%%20Card"
-"%%20account%%20deactivation\"> wikipedialibrary@wikimedia.org </a>."
+msgid "In order to administer the Wikipedia Library program, we will retain the application data we collect from you for three years after your most recent login, unless you delete your account, as described below. You can log in and go to <a class=\"twl-links\" href=\"%(profile_url)s\">your profile page</a> in order to see the information associated with your account, and can download it in JSON format. You may access, update, restrict, or delete this information at any time, except for the information that is automatically retrieved from the projects. If you have any questions or concerns about the handling of your data, please contact <a class=\"twl-links\" href=\"mailto:wikipedialibrary@wikimedia.org?Subject=Wikipedia%%20Library%%20Card%%20account%%20deactivation\"> wikipedialibrary@wikimedia.org </a>."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:305
-msgid ""
-"If you decide to disable your Wikipedia Library account, you can use the "
-"delete button on your profile to delete certain personal information "
-"associated with your account. We will delete your real name, institutional "
-"affiliation, and country of residence. Please note that the system will "
-"retain a record of your username, the publishers to which you applied or had "
-"access, and the dates of that access. Note that deletion is not reversible. "
-"Deletion of your Wikipedia Library account may also correspond with the "
-"removal of any resource access to which you were eligible or approved. If "
-"you request the deletion of account information and later wish to apply for "
-"a new account, you will need to provide the necessary information again."
+msgid "If you decide to disable your Wikipedia Library account, you can use the delete button on your profile to delete certain personal information associated with your account. We will delete your real name, institutional affiliation, and country of residence. Please note that the system will retain a record of your username, the publishers to which you applied or had access, and the dates of that access. Note that deletion is not reversible. Deletion of your Wikipedia Library account may also correspond with the removal of any resource access to which you were eligible or approved. If you request the deletion of account information and later wish to apply for a new account, you will need to provide the necessary information again."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). WMF should not be translated. Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:321
-msgid ""
-"The Wikipedia Library is run by WMF Staff, Contractors, and approved "
-"volunteer Coordinators. The data associated with your account will be shared "
-"with the WMF staff, contractors, service providers, and volunteer "
-"coordinators who need to process the information in connection with their "
-"work for the Wikipedia Library, and who are subject to confidentiality "
-"obligations. We will also use your data for internal Wikipedia Library "
-"purposes such as distributing user surveys and account notifications, and in "
-"a depersonalized or aggregated fashion for statistical analysis and "
-"administration. Finally, we will share your information with the publishers "
-"whom you specifically select in order to provide you with access to "
-"resources. Otherwise, your information will not be shared with third "
-"parties, with the exception of the circumstances described below."
+msgid "The Wikipedia Library is run by WMF Staff, Contractors, and approved volunteer Coordinators. The data associated with your account will be shared with the WMF staff, contractors, service providers, and volunteer coordinators who need to process the information in connection with their work for the Wikipedia Library, and who are subject to confidentiality obligations. We will also use your data for internal Wikipedia Library purposes such as distributing user surveys and account notifications, and in a depersonalized or aggregated fashion for statistical analysis and administration. Finally, we will share your information with the publishers whom you specifically select in order to provide you with access to resources. Otherwise, your information will not be shared with third parties, with the exception of the circumstances described below."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). WMF should not be translated.
 #: TWLight/users/templates/users/terms.html:338
-msgid ""
-"We may disclose any collected information when required by law, when we have "
-"your permission, when needed to protect our rights, privacy, safety, users, "
-"or the general public, and when necessary to enforce these terms, WMF’s "
-"general <a class=\"twl-links\" href=\"https://foundation.wikimedia.org/wiki/"
-"Terms_of_Use\">Terms of Use</a>, or any other WMF policy."
+msgid "We may disclose any collected information when required by law, when we have your permission, when needed to protect our rights, privacy, safety, users, or the general public, and when necessary to enforce these terms, WMF’s general <a class=\"twl-links\" href=\"https://foundation.wikimedia.org/wiki/Terms_of_Use\">Terms of Use</a>, or any other WMF policy."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:349
-msgid ""
-"We take the security of your personal data seriously, and take reasonable "
-"precautions to ensure your data is protected. These precautions include "
-"access controls to limit who has access to your data and security "
-"technologies to protect data stored on the server. However, we cannot "
-"guarantee the safety of your data as it is transmitted and stored."
+msgid "We take the security of your personal data seriously, and take reasonable precautions to ensure your data is protected. These precautions include access controls to limit who has access to your data and security technologies to protect data stored on the server. However, we cannot guarantee the safety of your data as it is transmitted and stored."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:360
-msgid ""
-"Please note that these terms do not control the use and handling of your "
-"data by the publishers and service providers whose resources you access or "
-"apply to access. Please read their individual privacy policies for that "
-"information."
+msgid "Please note that these terms do not control the use and handling of your data by the publishers and service providers whose resources you access or apply to access. Please read their individual privacy policies for that information."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
@@ -3400,34 +2856,17 @@ msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Wikimedia Foundation should not be translated. Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:373
-msgid ""
-"The Wikimedia Foundation is a nonprofit organization based in San Francisco, "
-"California. The Wikipedia Library program provides access to resources held "
-"by publishers in multiple countries. If you apply for a Wikipedia Library "
-"account (whether you are inside or outside of the United States), you "
-"understand that your personal data will be collected, transferred, stored, "
-"processed, disclosed and otherwise used in the U.S. as described in this "
-"privacy policy. You also understand that your information may be transferred "
-"by us from the U.S. to other countries, which may have different or less "
-"stringent data protection laws than your country, in connection with "
-"providing services to you, including evaluating your application and "
-"securing access to your chosen publishers (locations for each publisher are "
-"outlined on their respective partner information pages)."
+msgid "The Wikimedia Foundation is a nonprofit organization based in San Francisco, California. The Wikipedia Library program provides access to resources held by publishers in multiple countries. If you apply for a Wikipedia Library account (whether you are inside or outside of the United States), you understand that your personal data will be collected, transferred, stored, processed, disclosed and otherwise used in the U.S. as described in this privacy policy. You also understand that your information may be transferred by us from the U.S. to other countries, which may have different or less stringent data protection laws than your country, in connection with providing services to you, including evaluating your application and securing access to your chosen publishers (locations for each publisher are outlined on their respective partner information pages)."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:392
-msgid ""
-"Please note that in the event of any differences in meaning or "
-"interpretation between the original English version of these terms and a "
-"translation, the original English version takes precedence."
+msgid "Please note that in the event of any differences in meaning or interpretation between the original English version of these terms and a translation, the original English version takes precedence."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Wikimedia Foundation should not be translated.
 #: TWLight/users/templates/users/terms.html:403
-msgid ""
-"See also the <a class=\"twl-links\" href=\"https://wikimediafoundation.org/"
-"wiki/Privacy_policy\">Wikimedia Foundation Privacy Policy</a>."
+msgid "See also the <a class=\"twl-links\" href=\"https://wikimediafoundation.org/wiki/Privacy_policy\">Wikimedia Foundation Privacy Policy</a>."
 msgstr ""
 
 #. Translators: This is the second to last line of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
@@ -3447,11 +2886,7 @@ msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:426
-msgid ""
-"By checking this box and clicking “Submit”, you agree that you have read the "
-"above terms and that you will adhere to the terms of use in your application "
-"to and use of the The Wikipedia Library, and the publishers’ services to "
-"which you gain access through The Wikipedia Library program."
+msgid "By checking this box and clicking “Submit”, you agree that you have read the above terms and that you will adhere to the terms of use in your application to and use of the The Wikipedia Library, and the publishers’ services to which you gain access through The Wikipedia Library program."
 msgstr ""
 
 #: TWLight/users/templates/users/user_collection_tile.html:32
@@ -3506,29 +2941,18 @@ msgstr "Puraon gabos na data"
 
 #. Translators: This message is displayed on the page where users can request the deletion of their data.
 #: TWLight/users/templates/users/user_confirm_delete.html:17
-msgid ""
-"<b>Warning:</b> Performing this action will delete your Wikipedia Library "
-"Card user account and all associated applications. This process is not "
-"reversible. You may lose any partner accounts you were granted, and will not "
-"be able to renew those accounts or apply for new ones."
+msgid "<b>Warning:</b> Performing this action will delete your Wikipedia Library Card user account and all associated applications. This process is not reversible. You may lose any partner accounts you were granted, and will not be able to renew those accounts or apply for new ones."
 msgstr ""
 
 #. Translators: this should show up for people who log in with a username/password and not OAuth, so we don't know what their Wikipedia identity is.
-#.
 #: TWLight/users/templates/users/user_detail.html:12
 #, python-format
-msgid ""
-"Hi, %(username)s! You don't have a Wikipedia editor profile attached to your "
-"account here, so you are probably a site administrator."
+msgid "Hi, %(username)s! You don't have a Wikipedia editor profile attached to your account here, so you are probably a site administrator."
 msgstr ""
 
 #. Translators: In the unlikely scenario that someone is able to register an account without using OAuth (thus leaving us without some of the information required for applications), users will see this message, encouraging them to re-register.
 #: TWLight/users/templates/users/user_detail.html:20
-msgid ""
-"If you aren't a site administrator, something weird has happened. You won't "
-"be able to apply for access without a Wikipedia editor profile. You should "
-"log out and create a new account by logging in via OAuth, or contact a site "
-"administrator for help."
+msgid "If you aren't a site administrator, something weird has happened. You won't be able to apply for access without a Wikipedia editor profile. You should log out and create a new account by logging in via OAuth, or contact a site administrator for help."
 msgstr ""
 
 #. Translators: Labels a sections where coordinators can select their email preferences.
@@ -3539,17 +2963,12 @@ msgstr ""
 #. Translators: This message is shown on user's own profile page, encouraging them to make sure their information is up to date, so that account coordinators can use the information to judge applications.
 #: TWLight/users/views.py:176
 #, python-brace-format
-msgid ""
-"Please <a class='twl-links' href='{url}'>update your contributions</a> to "
-"Wikipedia to help coordinators evaluate your applications."
+msgid "Please <a class='twl-links' href='{url}'>update your contributions</a> to Wikipedia to help coordinators evaluate your applications."
 msgstr ""
 
 #. Translators: Coordinators are shown this message when they unselect all three types of reminder email options under preferences.
 #: TWLight/users/views.py:288
-msgid ""
-"You have chosen not to receive reminder emails. As a coordinator, you should "
-"receive at least one type of reminder emails, so consider changing your "
-"preferences."
+msgid "You have chosen not to receive reminder emails. As a coordinator, you should receive at least one type of reminder emails, so consider changing your preferences."
 msgstr ""
 
 #. Translators: Coordinators are shown this message when they make changes to their reminder email options under preferences.
@@ -3583,9 +3002,7 @@ msgstr "An saimong e-surat binago sa {email}."
 
 #. Translators: If the user has not filled out their email, they can browse the website but cannot apply for access to resources.
 #: TWLight/users/views.py:487
-msgid ""
-"Your email is blank. You can still explore the site, but you won't be able "
-"to apply for access to partner resources without an email."
+msgid "Your email is blank. You can still explore the site, but you won't be able to apply for access to partner resources without an email."
 msgstr ""
 
 #. Translators: This message is shown once the access to a partner has successfully been returned.
@@ -3618,31 +3035,3 @@ msgstr ""
 msgid "10+ edits in the last 30 days"
 msgstr ""
 
-#: tests/shunit/data/bad_i18n_comment_1.py:3
-#: tests/shunit/data/bad_i18n_newline_1.py:5
-msgid "1"
-msgstr ""
-
-#. Translators: Lorem ipsum dolor sit amet, consectetur adipiscing elit. Mauris vitae ipsum ut purus faucibus pretium. Proin tempus neque et aliquet consectetur. Ut egestas sapien in consectetur sagittis. Mauris neque lacus, dapibus non viverra vitae, interdum ut aenean ipsum.
-#. Translators: Lorem ipsum dolor sit amet, consectetur adipiscing elit. Mauris vitae ipsum ut purus faucibus pretium. Proin tempus neque et aliquet consectetur. Ut egestas sapien in consectetur sagittis. Mauris neque lacus, dapibus non.
-#: tests/shunit/data/bad_i18n_comment_2.py:4
-#: tests/shunit/data/bad_i18n_newline_2.py:5 tests/shunit/data/good_i18n_1.py:2
-#: tests/shunit/data/good_i18n_2.py:2
-msgid "2"
-msgstr ""
-
-#: tests/shunit/data/bad_i18n_newline_3.py:5
-msgid "3"
-msgstr ""
-
-#: tests/shunit/data/bad_i18n_newline_4.py:5
-msgid "4"
-msgstr ""
-
-#: tests/shunit/data/bad_i18n_newline_5.py:5
-msgid "5"
-msgstr ""
-
-#: tests/shunit/data/bad_i18n_newline_6.py:5
-msgid "6"
-msgstr ""

--- a/locale/br/LC_MESSAGES/django.po
+++ b/locale/br/LC_MESSAGES/django.po
@@ -11,10 +11,11 @@
 # Author: MuratTheTurkish
 msgid ""
 msgstr ""
+""
 "Project-Id-Version: Wikipedia Library Card Platform - Website\n"
-"Report-Msgid-Bugs-To: wikipedialibrary@wikimedia.org\n"
+"Report-Msgid-Bugs-To: translatewiki.net\n"
 "POT-Creation-Date: 2024-07-11 20:55+0000\n"
-"PO-Revision-Date: 2024-07-11 12:30:12+0000\n"
+"PO-Revision-Date: 2024-07-15 12:29:12+0000\n"
 "Language: br\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
@@ -46,12 +47,8 @@ msgstr "Diwar-benn"
 #. Translators: This note appears in a section of a form where we ask users to enter info (like country of residence) when applying for resource access.
 #: TWLight/applications/forms.py:179
 #, python-brace-format
-msgid ""
-"<p><small><i>Your personal data will be processed according to our <a "
-"class='twl-links' href='{terms_url}'> privacy policy</a>.</i></small></p>"
-msgstr ""
-"<p><small>Graet e vo war-dro ho roadennoù personel hervez hor <a class='twl-"
-"links' href='{terms_url}'>politikerezh prevezded</a>.</i></small></p>"
+msgid "<p><small><i>Your personal data will be processed according to our <a class='twl-links' href='{terms_url}'> privacy policy</a>.</i></small></p>"
+msgstr "<p><small>Graet e vo war-dro ho roadennoù personel hervez hor <a class='twl-links' href='{terms_url}'>politikerezh prevezded</a>.</i></small></p>"
 
 #. Translators: This is the title of the application form page, where users enter information required for the application. It lets the user know which partner application they are entering data for. {partner}
 #: TWLight/applications/forms.py:189
@@ -63,9 +60,7 @@ msgstr "Ho koulenn ouzh {partner}"
 #: TWLight/applications/forms.py:220
 #, fuzzy, python-brace-format
 msgid "You must register at {url} before applying."
-msgstr ""
-"Rankout a reot enrollañ ac'hanoc'h war <a href=\"{url}\">{url}</a> a-raok "
-"ober ar goulenn."
+msgstr "Rankout a reot enrollañ ac'hanoc'h war <a href=\"{url}\">{url}</a> a-raok ober ar goulenn."
 
 #. Translators: Label of the field where coordinators can enter the username of a user
 #. Translators: This labels the column description that lists the name of the applicants.
@@ -95,9 +90,7 @@ msgstr "Postel ho kont e lec'hienn web ar c'heveler"
 #. Translators: This labels a choice field where users will have to select the number of months they wish to have their access for as part of the application renewal confirmation.
 #. Translators: When filling out an application, users may be required to enter the length of the account (expiry) they wish to have for proxy partners.
 #: TWLight/applications/forms.py:339 TWLight/applications/helpers.py:100
-msgid ""
-"The number of months you wish to have this access for before renewal is "
-"required"
+msgid "The number of months you wish to have this access for before renewal is required"
 msgstr ""
 
 #. Translators: When filling out an application, users may need to specify their name
@@ -186,9 +179,7 @@ msgstr "Postel"
 
 #. Translators: This comment is added to pending applications when our terms of use change.
 #: TWLight/applications/management/commands/notify_applicants_tou_changes.py:54
-msgid ""
-"Our terms of use have changed. Your applications will not be processed until "
-"you log in and agree to our updated terms."
+msgid "Our terms of use have changed. Your applications will not be processed until you log in and agree to our updated terms."
 msgstr ""
 
 #. Translators: This is the status of an application that has not yet been reviewed.
@@ -255,23 +246,17 @@ msgstr "URL da haeziñ: {access_url}"
 
 #. Translators: This text goes into account approval emails in the case that we need to send the user's details to a publisher for manual account setup.
 #: TWLight/applications/models.py:331
-msgid ""
-"You can expect to receive access details within a week or two once it has "
-"been processed."
+msgid "You can expect to receive access details within a week or two once it has been processed."
 msgstr ""
 
 #. Translators: This comment is added to open applications when a partner joins the Library Bundle, which does not require applications.
 #: TWLight/applications/signals.py:247
-msgid ""
-"This partner joined the Library Bundle, which does not require applications. "
-"This application will be marked as invalid."
+msgid "This partner joined the Library Bundle, which does not require applications. This application will be marked as invalid."
 msgstr ""
 
 #. Translators: This is shown to users if the application is to a partner for which we have run out of available accounts. The application is therefore on a 'waitlist', and will be reviewed when more accounts are available.
 #: TWLight/applications/templates/applications/application_evaluation.html:29
-msgid ""
-"This application is on the waitlist because this partner does not have any "
-"access grants available at this time."
+msgid "This application is on the waitlist because this partner does not have any access grants available at this time."
 msgstr ""
 
 #. Translators: This message is shown on pages where coordinators can see personal information about applicants.
@@ -279,12 +264,8 @@ msgstr ""
 #: TWLight/applications/templates/applications/application_list_include.html:6
 #: TWLight/applications/templates/applications/send_partner.html:45
 #: TWLight/resources/templates/resources/partner_users.html:18
-msgid ""
-"Coordinators: This page may contain personal information such as real names "
-"and email addresses. Please remember that this information is confidential."
-msgstr ""
-"Kenurzhierien : er bajenn-mañ e c'hall bezañ titouroù personel evel ar gwir "
-"anvioù pe ar chomlec'hioù postel."
+msgid "Coordinators: This page may contain personal information such as real names and email addresses. Please remember that this information is confidential."
+msgstr "Kenurzhierien : er bajenn-mañ e c'hall bezañ titouroù personel evel ar gwir anvioù pe ar chomlec'hioù postel."
 
 #. Translators: This is the title of the application page shown to users who are a coordinator, and are able to accept or reject the application.
 #: TWLight/applications/templates/applications/application_evaluation.html:39
@@ -293,9 +274,7 @@ msgstr "Priziañ ar goulenn"
 
 #. Translators: This text is shown to coordinators on application pages if the applicant has restricted processing of their data.
 #: TWLight/applications/templates/applications/application_evaluation.html:42
-msgid ""
-"This user has requested a restriction on the processing of their data, so "
-"you cannot change the status of their application."
+msgid "This user has requested a restriction on the processing of their data, so you cannot change the status of their application."
 msgstr ""
 
 #. Translators: This is the title of the application page shown to users who are not a coordinator.
@@ -371,9 +350,7 @@ msgstr "Dianav"
 
 #. Translators: This is the text displayed to coordinators when an applicant has no country of residence in their profile.
 #: TWLight/applications/templates/applications/application_evaluation.html:123
-msgid ""
-"Please request the applicant add their country of residence to their profile "
-"before proceeding further."
+msgid "Please request the applicant add their country of residence to their profile before proceeding further."
 msgstr ""
 
 #. Translators: This labels the section of an application showing the total number of accounts available for a partner or their collection.
@@ -385,9 +362,7 @@ msgstr "N'eo ket hegerz"
 #. Translators: This labels the section of an application showing whether the user had agreed to the terms of use or not.
 #: TWLight/applications/templates/applications/application_evaluation.html:145
 #, python-format
-msgid ""
-"Has agreed to the site's <a class=\"twl-links\" href=\"%(terms_url)s\">terms "
-"of use</a>?"
+msgid "Has agreed to the site's <a class=\"twl-links\" href=\"%(terms_url)s\">terms of use</a>?"
 msgstr ""
 
 #. Translators: Displayed to coordinators when they've agreed to the terms of use.
@@ -423,9 +398,7 @@ msgstr "Ket"
 
 #. Translators: This is the text displayed to coordinators when an applicant has not agreed to the terms of use.
 #: TWLight/applications/templates/applications/application_evaluation.html:159
-msgid ""
-"Please request the applicant agree to the site's terms of use before "
-"approving this application."
+msgid "Please request the applicant agree to the site's terms of use before approving this application."
 msgstr ""
 
 #. Translators: This labels the section of an application containing the user's motivation for wanting access to this resource.
@@ -446,8 +419,7 @@ msgstr "Adneveziñ ar gwirioù monet zo anezho ?"
 #. Translators: This message is shown next to the 'Renewal of existing access grant?' label if the application is a renewal. Don't translate HTML tags or parent_url.
 #: TWLight/applications/templates/applications/application_evaluation.html:195
 #, python-format
-msgid ""
-"Yes (<a class=\"twl-links\" href=\"%(parent_url)s\">previous application</a>)"
+msgid "Yes (<a class=\"twl-links\" href=\"%(parent_url)s\">previous application</a>)"
 msgstr "Ya (<a class=\"twl-links\" href=\"%(parent_url)s\">goulenn kent</a>)"
 
 #. Translators: This labels the section of the application showing the length of access remaining on the user's previous authorization.
@@ -484,12 +456,8 @@ msgstr "Ouzhpennañ un evezhiadenn"
 
 #. Translators: On an application page, this text tells users that the comments posted on the application are visible to coordinators and the submitting user only.
 #: TWLight/applications/templates/applications/application_evaluation.html:297
-msgid ""
-"Comments are visible to all coordinators and to the editor who submitted "
-"this application."
-msgstr ""
-"Gallout a ra an evezhiadennoù bezañ gwelet gant an holl genurzhierien ha "
-"gant an den en deus kaset ar goulenn-mañ."
+msgid "Comments are visible to all coordinators and to the editor who submitted this application."
+msgstr "Gallout a ra an evezhiadennoù bezañ gwelet gant an holl genurzhierien ha gant an den en deus kaset ar goulenn-mañ."
 
 #. Translators: This is the title of the section of an application page which lists information about the user who submitted the application.
 #. Translators: On the page where coordinators can view data on applications to a partner they coordinate, this is a table column heading for the username.
@@ -704,12 +672,7 @@ msgstr "Diuzañ ar statud"
 
 #: TWLight/applications/templates/applications/apply.html:20
 #, python-format
-msgid ""
-"If your application is successful we may share your email address with "
-"%(partner)s. This is required to set up your access to their resources. By "
-"submitting this form you agree to allow your email address to be shared with "
-"%(partner)s if your application is successful, for the purposes of account "
-"setup."
+msgid "If your application is successful we may share your email address with %(partner)s. This is required to set up your access to their resources. By submitting this form you agree to allow your email address to be shared with %(partner)s if your application is successful, for the purposes of account setup."
 msgstr ""
 
 #. Translators: This message is displayed on the page where users can confirm their renewal. Please do not translate partner.
@@ -738,9 +701,7 @@ msgstr ""
 
 #. Translators: This text explains that Library Bundle partners are not shown in this list.
 #: TWLight/applications/templates/applications/request_for_application.html:26
-msgid ""
-"Library Bundle partners are not shown as eligibility is determined "
-"automatically."
+msgid "Library Bundle partners are not shown as eligibility is determined automatically."
 msgstr ""
 
 #. Translators: On the page where users can apply for multiple partners, this message shows next to the partner name, taking them to the full application page when clicked.
@@ -755,17 +716,13 @@ msgstr "N'eus bet ouzhpennet roadenn keveler ebet c'hoazh."
 
 #. Translators: the HTML is so that the word 'waitlisted' will look the same as it does in the page above; please translate 'waitlisted' the same way you did elsewhere in this file.
 #: TWLight/applications/templates/applications/request_for_application.html:74
-msgid ""
-"You can apply to <span class=\"badge badge-warning\">Waitlisted</span> "
-"partners, but they don't have access grants available right now. We will "
-"process those applications when access becomes available."
+msgid "You can apply to <span class=\"badge badge-warning\">Waitlisted</span> partners, but they don't have access grants available right now. We will process those applications when access becomes available."
 msgstr ""
 
 #. Translators: On the page where coordinators can see approved applications which have not had their details sent to the partner, this message shows when there are applications ready to be processed.
 #: TWLight/applications/templates/applications/send.html:10
 msgid "Partners with approved, unsent applications"
-msgstr ""
-"Kevelerien gant goulennoù hag a zo aprouet met n'int ket bet kaset c'hoazh."
+msgstr "Kevelerien gant goulennoù hag a zo aprouet met n'int ket bet kaset c'hoazh."
 
 #. Translators: On the page where coordinators can see approved applications which have not had their details sent to the partner, this message shows when no such applications exist or all have already been sent.
 #: TWLight/applications/templates/applications/send.html:23
@@ -781,17 +738,13 @@ msgstr "Roadennoù arloañ evit %(object)s"
 #. Translators: This message is shown when applications exceed the number of accounts available.
 #: TWLight/applications/templates/applications/send_partner.html:54
 #, python-format
-msgid ""
-"Application(s) for %(object)s, if sent, will exceed the total available "
-"accounts for the partner. Please proceed at your own discretion."
+msgid "Application(s) for %(object)s, if sent, will exceed the total available accounts for the partner. Please proceed at your own discretion."
 msgstr ""
 
 #. Translators: When viewing the list of applications ready to be sent for a particular partner, this is instructions for the coordinator to click the 'mark as sent' button after they have sent the information.
 #: TWLight/applications/templates/applications/send_partner.html:65
 msgid "When you've processed the data below, click the 'mark as sent' button."
-msgstr ""
-"P'ho peus graet war-dro ar roadennoù amañ dindan, klikit war ar bouton « "
-"Merkañ evel kaset »"
+msgstr "P'ho peus graet war-dro ar roadennoù amañ dindan, klikit war ar bouton « Merkañ evel kaset »"
 
 #. Translators: When viewing the list of applications ready to be sent for a particular partner, this is the title of the section containing contact information for the people applications should be sent to.
 #: TWLight/applications/templates/applications/send_partner.html:71
@@ -802,12 +755,8 @@ msgstr[1] "Darempredoù"
 
 #. Translators: When viewing the list of applications ready to be sent for a particular partner, this message shows if there is no information about who the applications should be sent to. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/applications/templates/applications/send_partner.html:89
-msgid ""
-"Whoops, we don't have any listed contacts. Please notify Wikipedia Library "
-"administrators."
-msgstr ""
-"Siwazh, n'hon eus renablet darempred ebet. En roit da c'houzout da verourien "
-"Levraoueg Wikipedia mar plij."
+msgid "Whoops, we don't have any listed contacts. Please notify Wikipedia Library administrators."
+msgstr "Siwazh, n'hon eus renablet darempred ebet. En roit da c'houzout da verourien Levraoueg Wikipedia mar plij."
 
 #. Translators: When viewing the list of applications ready to be sent for a particular partner, this is the title of the section containing the information about those applications.
 #: TWLight/applications/templates/applications/send_partner.html:94
@@ -822,9 +771,7 @@ msgstr "Merkañ evel kaset"
 
 #. Translators: This text guides coordinators in using the code sending interface for approved applications.
 #: TWLight/applications/templates/applications/send_partner.html:152
-msgid ""
-"Use the dropdown menus to denote which editor will receive each code. Access "
-"codes will be sent to users automatically."
+msgid "Use the dropdown menus to denote which editor will receive each code. Access codes will be sent to users automatically."
 msgstr ""
 
 #. Translators: This labels a drop-down selection where staff can assign an access code to a user.
@@ -840,21 +787,14 @@ msgstr "Goulenn aprouet ebet n'eo bet kaset c'hoazh."
 #. Translators: When a user applies for a set of resources, they receive this message if none are currently available. They are instead placed on a 'waitlist' for later approval.
 #. Translators: When a user renews their resource, they receive this message if none are currently available. They are instead placed on a 'waitlist' for later approval.
 #: TWLight/applications/views.py:140 TWLight/applications/views.py:1282
-msgid ""
-"This partner does not have any access grants available at this time. You may "
-"still apply for access; your application will be reviewed when access grants "
-"become available."
+msgid "This partner does not have any access grants available at this time. You may still apply for access; your application will be reviewed when access grants become available."
 msgstr ""
 
 #. Translators: This message is shown to users once they've successfully submitted their application for review.
 #: TWLight/applications/views.py:163
 #, fuzzy, python-brace-format
-msgid ""
-"Your application has been submitted for review. Head over to <a "
-"href='{applications_url}'>My Applications</a> to view the status."
-msgstr ""
-"Kaset eo bet ho koulenn  evit bezañ kemeret e kont. Gallout a reot gwiriañ "
-"statud ho koulenn war ar bajenn-mañ."
+msgid "Your application has been submitted for review. Head over to <a href='{applications_url}'>My Applications</a> to view the status."
+msgstr "Kaset eo bet ho koulenn  evit bezañ kemeret e kont. Gallout a reot gwiriañ statud ho koulenn war ar bajenn-mañ."
 
 #. Translators: This text is displayed to users when the user has chosen to restrict data and is trying to apply for multiple partners
 #: TWLight/applications/views.py:276
@@ -903,16 +843,12 @@ msgstr "Goulennoù kaset"
 
 #. Translators: After a coordinator has changed the status of an application to APPROVED, if the corresponding partner/collection is waitlisted this message appears.
 #: TWLight/applications/views.py:756
-msgid ""
-"Cannot approve application as partner with proxy authorization method is "
-"waitlisted."
+msgid "Cannot approve application as partner with proxy authorization method is waitlisted."
 msgstr ""
 
 #. Translators: After a coordinator has changed the status of an application to APPROVED, if the corresponding partner/collection has no accounts for distribution, this message appears.
 #: TWLight/applications/views.py:780
-msgid ""
-"Cannot approve application as partner with proxy authorization method is "
-"waitlisted and (or) has zero accounts available for distribution."
+msgid "Cannot approve application as partner with proxy authorization method is waitlisted and (or) has zero accounts available for distribution."
 msgstr ""
 
 #. Translators: This message appears on an "access denied" screen that stops users who attempt to authorize an editor to access a resource during a time period for which they are already authorized.
@@ -923,11 +859,7 @@ msgstr "Klasket ho peus krouiñ un aotre eildet"
 #. Translators: This message is shown to users when they access an application page of a now Bundle partner (new applications aren't allowed for Bundle partners and the status of old applications cannot be modified)
 #: TWLight/applications/views.py:857
 #, python-brace-format
-msgid ""
-"This application cannot be modified since this partner is now part of our <a "
-"href='{bundle}'>bundle access</a>. If you are eligible, you can access this "
-"resource from <a href='{library}'>your library</a>. <a "
-"href='{contact}'>Contact us</a> if you have any questions."
+msgid "This application cannot be modified since this partner is now part of our <a href='{bundle}'>bundle access</a>. If you are eligible, you can access this resource from <a href='{library}'>your library</a>. <a href='{contact}'>Contact us</a> if you have any questions."
 msgstr ""
 
 #. Translators: this lets a reviewer set the status of a single application.
@@ -937,9 +869,7 @@ msgstr ""
 
 #. Translators: This warning is message is shown to applicants when the number of pending applications is greater than the number of accounts available.
 #: TWLight/applications/views.py:891
-msgid ""
-"There are more pending applications than available accounts. Your "
-"application might get waitlisted."
+msgid "There are more pending applications than available accounts. Your application might get waitlisted."
 msgstr ""
 
 #. Translators: this message is shown to coordinators who attempt to change an application's Status from INVALID to any other Status.
@@ -959,11 +889,7 @@ msgstr ""
 
 #. Translators: After a coordinator has changed the status of a number of applications to APPROVED, if the corresponding partner(s) is/are waitlisted or has no accounts for distribution, this message appears.
 #: TWLight/applications/views.py:1051
-msgid ""
-"Cannot approve application(s) {} as partner(s) with proxy authorization "
-"method is/are waitlisted and (or) has/have not enough accounts available. If "
-"not enough accounts are available, prioritise the applications and then "
-"approve applications equal to the accounts available."
+msgid "Cannot approve application(s) {} as partner(s) with proxy authorization method is/are waitlisted and (or) has/have not enough accounts available. If not enough accounts are available, prioritise the applications and then approve applications equal to the accounts available."
 msgstr ""
 
 #. Translators: This message is shown to coordinators who attempt to assign the same access code to multiple users.
@@ -978,9 +904,7 @@ msgstr "Merket eo bet an holl c'houlennoù diuzet evel kaset."
 
 #. Translators: When a user tries to renew their resource, they receive this message if the partner is not available.
 #: TWLight/applications/views.py:1272
-msgid ""
-"Cannot renew application at this time as partner is not available. Please "
-"check back later, or contact us for more information."
+msgid "Cannot renew application at this time as partner is not available. Please check back later, or contact us for more information."
 msgstr ""
 
 #. Translators: This message is displayed when an attempt by a user to renew an application has been denied for some reason.
@@ -991,16 +915,12 @@ msgstr ""
 
 #. Translators: If a user requests the renewal of their account, but it wasn't renewed, this message is shown to them.
 #: TWLight/applications/views.py:1385
-msgid ""
-"This object cannot be renewed. (This probably means that you have already "
-"requested that it be renewed.)"
+msgid "This object cannot be renewed. (This probably means that you have already requested that it be renewed.)"
 msgstr ""
 
 #. Translators: If a user requests the renewal of their account, this message is shown to them.
 #: TWLight/applications/views.py:1395
-msgid ""
-"Your renewal request has been received. A coordinator will review your "
-"request."
+msgid "Your renewal request has been received. A coordinator will review your request."
 msgstr ""
 
 #. Translators: This labels a textfield where users can enter their email ID.
@@ -1010,12 +930,8 @@ msgstr "Ho chomlec'h postel"
 
 #. Translators: This is the help text for the email field in the contact us form letting users know the field is updated by value pulled from their respective user profiles.
 #: TWLight/emails/forms.py:21
-msgid ""
-"This field is automatically updated with the email from your <a class='twl-"
-"links' href='{}'>user profile</a>."
-msgstr ""
-"Hizivaet eo ar vaezienn-mañ en un doare emgefreek gant postel ho <a "
-"class='twl-links' href='{}'>profil utilisateur</a>."
+msgid "This field is automatically updated with the email from your <a class='twl-links' href='{}'>user profile</a>."
+msgstr "Hizivaet eo ar vaezienn-mañ en un doare emgefreek gant postel ho <a class='twl-links' href='{}'>profil utilisateur</a>."
 
 #. Translators: This labels a textfield where users can enter their email message.
 #: TWLight/emails/forms.py:26
@@ -1038,19 +954,13 @@ msgstr "Kas"
 #. Translators: This email is sent to users with their access code. Don't translate Jinja variables in curly braces like user or partner. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/access_code_email-body-html.html:5
 #, python-format
-msgid ""
-"<p>Your approved application to %(partner)s has now been finalised. Your "
-"access code or login details can be found below:</p> <p><b>%(access_code)s</"
-"b></p> <p>%(user_instructions)s</p>"
+msgid "<p>Your approved application to %(partner)s has now been finalised. Your access code or login details can be found below:</p> <p><b>%(access_code)s</b></p> <p>%(user_instructions)s</p>"
 msgstr ""
 
 #. Translators: This email is sent to users with their access code. Don't translate Jinja variables in curly braces like user or partner. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/access_code_email-body-text.html:3
 #, python-format
-msgid ""
-"Your approved application to %(partner)s has now been finalised. Your access "
-"code or login details can be found below: %(access_code)s "
-"%(user_instructions)s"
+msgid "Your approved application to %(partner)s has now been finalised. Your access code or login details can be found below: %(access_code)s %(user_instructions)s"
 msgstr ""
 
 #. Translators: This is the subject line of an email sent to users with their access code.
@@ -1061,34 +971,14 @@ msgstr "Ho kod moned Levraoueg Wikipedia"
 #. Translators: This email is sent to users when their application is approved. Don't translate Jinja variables in curly braces like user or partner; don't translate html tags either. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/approval_notification-body-html.html:5
 #, python-format
-msgid ""
-"<p>Dear %(user)s,</p> <p>Thank you for applying for access to %(partner)s "
-"resources through The Wikipedia Library. We are happy to inform you that "
-"your application has been approved.</p> <p>%(user_instructions)s</p> <p>You "
-"can view the collections you're authorized to access at My Library: "
-"%(link)s</p> <p>Cheers!</p> <p>The Wikipedia Library</p>"
-msgstr ""
-"<p>%(user)s ker</p> <p> Trugarez da vezañ goulennet ar gwir da dizhout "
-"pourvezioù %(partner)s dre al levraoueg Wikipedia. Laouen omp o kelaouiñ "
-"ac'hanoc'h eo bet aprouet ho koulenn.</p> <p>%(user_instructions)s</p> "
-"<p>Gallout a rit gwelet an dastumadoù oc'h aotreet da gaout e Ma Levraoueg: "
-"%(link)s</p> <p>Trugarez deoc'h!</p> <p>Al Levraoueg Wikipedia</p>"
+msgid "<p>Dear %(user)s,</p> <p>Thank you for applying for access to %(partner)s resources through The Wikipedia Library. We are happy to inform you that your application has been approved.</p> <p>%(user_instructions)s</p> <p>You can view the collections you're authorized to access at My Library: %(link)s</p> <p>Cheers!</p> <p>The Wikipedia Library</p>"
+msgstr "<p>%(user)s ker</p> <p> Trugarez da vezañ goulennet ar gwir da dizhout pourvezioù %(partner)s dre al levraoueg Wikipedia. Laouen omp o kelaouiñ ac'hanoc'h eo bet aprouet ho koulenn.</p> <p>%(user_instructions)s</p> <p>Gallout a rit gwelet an dastumadoù oc'h aotreet da gaout e Ma Levraoueg: %(link)s</p> <p>Trugarez deoc'h!</p> <p>Al Levraoueg Wikipedia</p>"
 
 #. Translators: This email is sent to users when their application is approved. Don't translate Jinja variables in curly braces like user or partner. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/approval_notification-body-text.html:3
 #, python-format
-msgid ""
-"Dear %(user)s, Thank you for applying for access to %(partner)s resources "
-"through The Wikipedia Library. We are happy to inform you that your "
-"application has been approved. %(user_instructions)s You can view the "
-"collections you're authorized to access at My Library: %(link)s Cheers! The "
-"Wikipedia Library"
-msgstr ""
-"%(user)s ker, Trugarez da vezañ goulennet ar gwir da dizhout pourvezioù "
-"%(partner)s dre al levraoueg Wikipedia. Laouen omp o kelaouiñ ac'hanoc'h eo "
-"bet aprouet ho koulenn. %(user_instructions)s Gallout a rit gwelet an "
-"dastumadoù oc'h aotreet da gaout e Ma Levraoueg: %(link)s Trugarez deoc'h! "
-"Al Levraoueg Wikipedia"
+msgid "Dear %(user)s, Thank you for applying for access to %(partner)s resources through The Wikipedia Library. We are happy to inform you that your application has been approved. %(user_instructions)s You can view the collections you're authorized to access at My Library: %(link)s Cheers! The Wikipedia Library"
+msgstr "%(user)s ker, Trugarez da vezañ goulennet ar gwir da dizhout pourvezioù %(partner)s dre al levraoueg Wikipedia. Laouen omp o kelaouiñ ac'hanoc'h eo bet aprouet ho koulenn. %(user_instructions)s Gallout a rit gwelet an dastumadoù oc'h aotreet da gaout e Ma Levraoueg: %(link)s Trugarez deoc'h! Al Levraoueg Wikipedia"
 
 #. Translators: This is the subject of an email which is sent to users when their application has been approved. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/approval_notification-subject.html:4
@@ -1098,44 +988,30 @@ msgstr "Aprouet eo bet ho koulenn ouzh al Levraoueg Wikipedia"
 #. Translators: This email is sent to coordinators when a comment is left on an application they are processing. Don't translate Jinja variables in curly braces like user or partner. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/comment_notification_coordinator-body-html.html:5
 #, python-format
-msgid ""
-"<p style=\"color: #500050\">%(submit_date)s - %(commenter)s</p> "
-"<blockquote><p>%(comment)s</p></blockquote> <p>Please reply to these at: <a "
-"href=\"%(app_url)s\">%(app_url)s</a></p> <p>Best,</p> <p>The Wikipedia "
-"Library</p>"
+msgid "<p style=\"color: #500050\">%(submit_date)s - %(commenter)s</p> <blockquote><p>%(comment)s</p></blockquote> <p>Please reply to these at: <a href=\"%(app_url)s\">%(app_url)s</a></p> <p>Best,</p> <p>The Wikipedia Library</p>"
 msgstr ""
 
 #. Translators: This email is sent to coordinators when a comment is left on an application they are processing. Don't translate Jinja variables in curly braces like user or partner. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/comment_notification_coordinator-body-text.html:3
 #, python-format
-msgid ""
-"%(submit_date)s - %(commenter)s %(comment)s Please reply to this at: "
-"%(app_url)s Best, The Wikipedia Library"
+msgid "%(submit_date)s - %(commenter)s %(comment)s Please reply to this at: %(app_url)s Best, The Wikipedia Library"
 msgstr ""
 
 #. Translators: This is the subject line of an email sent to coordinators when a comment is left on an application they processed.
 #: TWLight/emails/templates/emails/comment_notification_coordinator-subject.html:3
 msgid "New comment on a Wikipedia Library application you processed"
-msgstr ""
-"Displegadenn nevez war ur goulenn ho peus graet war e dro evit a sell ouzh "
-"al levraoueg Wikipedia"
+msgstr "Displegadenn nevez war ur goulenn ho peus graet war e dro evit a sell ouzh al levraoueg Wikipedia"
 
 #. Translators: This email is sent to users when they receive a comment on their application. Don't translate Jinja variables in curly braces like user or partner; don't translate html tags either. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/comment_notification_editors-body-html.html:5
 #, python-format
-msgid ""
-"<p style=\"color: #500050\">%(submit_date)s - %(commenter)s</p> "
-"<blockquote><p>%(comment)s</p></blockquote> <p>Please reply to these at <a "
-"href=\"%(app_url)s\">%(app_url)s</a> so we can evaluate your application.</"
-"p> <p>Best,</p> <p>The Wikipedia Library</p>"
+msgid "<p style=\"color: #500050\">%(submit_date)s - %(commenter)s</p> <blockquote><p>%(comment)s</p></blockquote> <p>Please reply to these at <a href=\"%(app_url)s\">%(app_url)s</a> so we can evaluate your application.</p> <p>Best,</p> <p>The Wikipedia Library</p>"
 msgstr ""
 
 #. Translators: This email is sent to users when they receive a comment on their application. Don't translate Jinja variables in curly braces like user or partner. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/comment_notification_editors-body-text.html:3
 #, python-format
-msgid ""
-"%(submit_date)s - %(commenter)s %(comment)s Please reply to these at: "
-"%(app_url)s so we can evaluate your application. Best, The Wikipedia Library"
+msgid "%(submit_date)s - %(commenter)s %(comment)s Please reply to these at: %(app_url)s so we can evaluate your application. Best, The Wikipedia Library"
 msgstr ""
 
 #. Translators: This is the subject line of an email sent to users who have a comment added to one of their applications. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
@@ -1146,18 +1022,13 @@ msgstr "Displegadenn nevez war ho koulenn eus al levraoueg Wikipedia."
 #. Translators: This email is sent to users when an application they commented on receives another comment. Don't translate Jinja variables in curly braces like app_url; don't translate html tags either. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/comment_notification_others-body-html.html:5
 #, python-format
-msgid ""
-"<p style=\"color: #500050\">%(submit_date)s - %(commenter)s</p> "
-"<blockquote><p>%(comment)s</p></blockquote> See it at <a href=\"%(app_url)s"
-"\">%(app_url)s</a>. Thanks for helping review Wikipedia Library applications!"
+msgid "<p style=\"color: #500050\">%(submit_date)s - %(commenter)s</p> <blockquote><p>%(comment)s</p></blockquote> See it at <a href=\"%(app_url)s\">%(app_url)s</a>. Thanks for helping review Wikipedia Library applications!"
 msgstr ""
 
 #. Translators: This email is sent to users when an application they commented on receives another comment. Don't translate Jinja variables in curly braces like app_url. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/comment_notification_others-body-text.html:3
 #, python-format
-msgid ""
-"%(submit_date)s - %(commenter)s %(comment)s See it at: %(app_url)s Thanks "
-"for helping review Wikipedia Library applications!"
+msgid "%(submit_date)s - %(commenter)s %(comment)s See it at: %(app_url)s Thanks for helping review Wikipedia Library applications!"
 msgstr ""
 
 #. Translators: This is the subject line of an email sent to users who have a comment added to an application they also commented on. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
@@ -1168,10 +1039,7 @@ msgstr ""
 #. Translators: This text is part of a scheduled reminder email sent to coordinators who have applications requiring action. Don't translate Jinja variables in curly braces like total_apps, or user.
 #: TWLight/emails/templates/emails/coordinator_reminder_notification-body-html.html:5
 #, python-format
-msgid ""
-"<p>Dear %(user)s,</p> <p>Our records indicate that you are the designated "
-"coordinator for partners that have a total of %(total_apps)s applications.</"
-"p>"
+msgid "<p>Dear %(user)s,</p> <p>Our records indicate that you are the designated coordinator for partners that have a total of %(total_apps)s applications.</p>"
 msgstr ""
 
 #. Translators: Breakdown as in 'cost breakdown'; analysis.
@@ -1210,31 +1078,19 @@ msgstr[1] "Niver a c'houlennoù aprouet"
 #. Translators: This text is part of a scheduled reminder email sent to coordinators who have applications requiring action. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library). Don't translate Jinja variables in curly braces like link; don't translate email addresses or html tags either.
 #: TWLight/emails/templates/emails/coordinator_reminder_notification-body-html.html:39
 #, python-format
-msgid ""
-"<p>This is a gentle reminder that you may review applications at <a href="
-"\"%(link)s\">%(link)s</a>.</p> <p>You can customise your reminders under "
-"'preferences' in your user profile.</p> <p>If you received this message in "
-"error, drop us a line at wikipedialibrary@wikimedia.org.</p> <p>Thanks for "
-"helping review Wikipedia Library applications!</p>"
+msgid "<p>This is a gentle reminder that you may review applications at <a href=\"%(link)s\">%(link)s</a>.</p> <p>You can customise your reminders under 'preferences' in your user profile.</p> <p>If you received this message in error, drop us a line at wikipedialibrary@wikimedia.org.</p> <p>Thanks for helping review Wikipedia Library applications!</p>"
 msgstr ""
 
 #. Translators: This text is part of a scheduled reminder email sent to coordinators who have applications requiring action. Don't translate Jinja variables in curly braces like total_apps, or user.
 #: TWLight/emails/templates/emails/coordinator_reminder_notification-body-text.html:3
 #, python-format
-msgid ""
-"Dear %(user)s, Our records indicate that you are the designated coordinator "
-"for partners that have a total of %(total_apps)s applications."
+msgid "Dear %(user)s, Our records indicate that you are the designated coordinator for partners that have a total of %(total_apps)s applications."
 msgstr ""
 
 #. Translators: This text is part of a scheduled reminder email sent to coordinators who have applications requiring action. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library). Don't translate Jinja variables in curly braces like link; don't translate the email address either.
 #: TWLight/emails/templates/emails/coordinator_reminder_notification-body-text.html:38
 #, python-format
-msgid ""
-"This is a gentle reminder that you may review applications at: %(link)s. You "
-"can customise your reminders under 'preferences' in your user profile. If "
-"you received this message in error, drop us a line at: "
-"wikipedialibrary@wikimedia.org Thanks for helping review Wikipedia Library "
-"applications!"
+msgid "This is a gentle reminder that you may review applications at: %(link)s. You can customise your reminders under 'preferences' in your user profile. If you received this message in error, drop us a line at: wikipedialibrary@wikimedia.org Thanks for helping review Wikipedia Library applications!"
 msgstr ""
 
 #. Translators: This is the subject line of a scheduled reminder email sent to coordinators who have applications to review. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library). Do not translate items in curly braces.
@@ -1245,22 +1101,13 @@ msgstr ""
 #. Translators: This email is sent to users when their application is rejected. Don't translate Jinja variables in curly braces like user or partner; don't translate html tags either. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/rejection_notification-body-html.html:5
 #, python-format
-msgid ""
-"<p>Dear %(user)s,</p> <p>Thank you for applying for access to %(partner)s "
-"resources through The Wikipedia Library. Unfortunately at this time your "
-"application has not been approved. You can view your application and review "
-"comments at <a href=\"%(app_url)s\">%(app_url)s</a>.</p> <p>Best,</p> <p>The "
-"Wikipedia Library</p>"
+msgid "<p>Dear %(user)s,</p> <p>Thank you for applying for access to %(partner)s resources through The Wikipedia Library. Unfortunately at this time your application has not been approved. You can view your application and review comments at <a href=\"%(app_url)s\">%(app_url)s</a>.</p> <p>Best,</p> <p>The Wikipedia Library</p>"
 msgstr ""
 
 #. Translators: This email is sent to users when their application is rejected. Don't translate Jinja variables in curly braces like user or partner. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/rejection_notification-body-text.html:3
 #, python-format
-msgid ""
-"Dear %(user)s, Thank you for applying for access to %(partner)s resources "
-"through The Wikipedia Library. Unfortunately at this time your application "
-"has not been approved. You can view your application and review comments at: "
-"%(app_url)s Best, The Wikipedia Library"
+msgid "Dear %(user)s, Thank you for applying for access to %(partner)s resources through The Wikipedia Library. Unfortunately at this time your application has not been approved. You can view your application and review comments at: %(app_url)s Best, The Wikipedia Library"
 msgstr ""
 
 #. Translators: This is the subject of an email which is sent to users when their application has been rejected. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
@@ -1272,25 +1119,13 @@ msgstr "Displegadenn nevez war ho koulenn eus al levraoueg Wikipedia."
 #. Translators: This email is sent to users when they have an account that is soon to expire. Don't translate Jinja variables in curly braces like partner_name or partner_link; don't translate html tags either. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/user_renewal_notice-body-html.html:5
 #, python-format
-msgid ""
-"<p>Dear %(user)s,</p> <p>According to our records, your access to "
-"%(partner_name)s will soon expire and you may lose access. If you want to "
-"continue making use of your free account, you can request renewal of your "
-"account by clicking the 'Renew' or 'Extend' button at %(partner_link)s.</p> "
-"<p>Best,</p> <p>The Wikipedia Library</p> <p>You can disable these emails in "
-"your user page preferences: https://wikipedialibrary.wmflabs.org/users/</p>"
+msgid "<p>Dear %(user)s,</p> <p>According to our records, your access to %(partner_name)s will soon expire and you may lose access. If you want to continue making use of your free account, you can request renewal of your account by clicking the 'Renew' or 'Extend' button at %(partner_link)s.</p> <p>Best,</p> <p>The Wikipedia Library</p> <p>You can disable these emails in your user page preferences: https://wikipedialibrary.wmflabs.org/users/</p>"
 msgstr ""
 
 #. Translators: This email is sent to users when they have an account that is soon to expire. Don't translate Jinja variables in curly braces like partner_name or partner_link; don't translate html tags either. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/user_renewal_notice-body-text.html:3
 #, python-format
-msgid ""
-"Dear %(user)s, According to our records, your access to %(partner_name)s "
-"will soon expire and you may lose access. If you want to continue making use "
-"of your free account, you can request renewal of your account by clicking "
-"the Renew button at %(partner_link)s. Best, The Wikipedia Library You can "
-"disable these emails in your user page preferences: https://wikipedialibrary."
-"wmflabs.org/users/"
+msgid "Dear %(user)s, According to our records, your access to %(partner_name)s will soon expire and you may lose access. If you want to continue making use of your free account, you can request renewal of your account by clicking the Renew button at %(partner_link)s. Best, The Wikipedia Library You can disable these emails in your user page preferences: https://wikipedialibrary.wmflabs.org/users/"
 msgstr ""
 
 #. Translators: This is the subject of an email sent to users when they have an account that is soon to expire. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
@@ -1302,24 +1137,13 @@ msgstr "Kartenn eus Levraoueg Wikipedia"
 #. Translators: This email is sent to users when their application is waitlisted because there are no more accounts available. Don't translate Jinja variables in curly braces like user or partner; don't translate html tags either. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/waitlist_notification-body-html.html:5
 #, python-format
-msgid ""
-"<p>Dear %(user)s,</p> <p>Thank you for applying for access to %(partner)s "
-"resources through The Wikipedia Library. There are no accounts currently "
-"available so your application has been waitlisted. Your application will be "
-"evaluated if/when more accounts become available. You can see all available "
-"resources at <a href=\"%(link)s\">%(link)s</a>.</p> <p>Best,</p> <p>The "
-"Wikipedia Library</p>"
+msgid "<p>Dear %(user)s,</p> <p>Thank you for applying for access to %(partner)s resources through The Wikipedia Library. There are no accounts currently available so your application has been waitlisted. Your application will be evaluated if/when more accounts become available. You can see all available resources at <a href=\"%(link)s\">%(link)s</a>.</p> <p>Best,</p> <p>The Wikipedia Library</p>"
 msgstr ""
 
 #. Translators: This email is sent to users when their application is waitlisted because there are no more accounts available. Don't translate Jinja variables in curly braces like user or partner. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/waitlist_notification-body-text.html:3
 #, python-format
-msgid ""
-"Dear %(user)s, Thank you for applying for access to %(partner)s resources "
-"through The Wikipedia Library. There are no accounts currently available so "
-"your application has been waitlisted. Your application will be evaluated if/"
-"when more accounts become available. You can see all available resources at: "
-"%(link)s Best, The Wikipedia Library"
+msgid "Dear %(user)s, Thank you for applying for access to %(partner)s resources through The Wikipedia Library. There are no accounts currently available so your application has been waitlisted. Your application will be evaluated if/when more accounts become available. You can see all available resources at: %(link)s Best, The Wikipedia Library"
 msgstr ""
 
 #. Translators: This is the subject of an email sent to users when their application is waitlisted because there are no more accounts available. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
@@ -1482,17 +1306,14 @@ msgstr "N'eo ket hegerz"
 #: TWLight/resources/templates/resources/filter_section.html:14
 #: TWLight/templates/about.html:12
 #: TWLight/users/templates/users/filter_section.html:13
-msgid ""
-"The Wikipedia Library allows active editors to access a wide range of "
-"collections of paywalled reliable sources for free!"
+msgid "The Wikipedia Library allows active editors to access a wide range of collections of paywalled reliable sources for free!"
 msgstr ""
 
 #. Translators: On the Browse Partners page (https://wikipedialibrary.wmflabs.org/partners/), this introduces users to The Wikipedia Library.
 #. Translators: On the MyLibrary page (https://wikipedialibrary.wmflabs.org/users/my_library), this introduces users to The Wikipedia Library.
 #: TWLight/resources/templates/resources/filter_section.html:17
 #: TWLight/users/templates/users/filter_section.html:15
-msgid ""
-"Start with the search bar at the top or browse publisher websites directly."
+msgid "Start with the search bar at the top or browse publisher websites directly."
 msgstr ""
 
 #. Translators: On the Browse Partners page (https://wikipedialibrary.wmflabs.org/partners/), this appears below introductory text and links to the 'About' page (https://wikipedialibrary.wmflabs.org/about/)
@@ -1567,52 +1388,38 @@ msgstr "Kas d'ar c'heveler"
 #. Translators: If we have no available accounts for a partner, the coordinator can change the application system to a waiting list.
 #: TWLight/resources/templates/resources/partner_detail.html:36
 #: TWLight/resources/templates/resources/partner_detail_apply.html:17
-msgid ""
-"There are no access grants available for this partner at this time. You can "
-"still apply for access; applications will be processed when access is "
-"available."
+msgid "There are no access grants available for this partner at this time. You can still apply for access; applications will be processed when access is available."
 msgstr ""
 
 #. Translators: This text links to the minimum user requirements and terms of use on the partner page.
 #: TWLight/resources/templates/resources/partner_detail.html:48
 #: TWLight/resources/templates/resources/partner_detail_apply.html:29
 #, python-format
-msgid ""
-"Before applying, please review the <strong><a class=\"twl-links\" href="
-"\"%(about)s#req\">minimum requirements</a></strong> for access and our "
-"<strong><a class=\"twl-links\" href=\"%(terms)s\">terms of use</a></strong>."
+msgid "Before applying, please review the <strong><a class=\"twl-links\" href=\"%(about)s#req\">minimum requirements</a></strong> for access and our <strong><a class=\"twl-links\" href=\"%(terms)s\">terms of use</a></strong>."
 msgstr ""
 
 #. Translators: This text refers to the page containing the content a user is authorized to access.
 #: TWLight/resources/templates/resources/partner_detail.html:69
 #, python-format
-msgid ""
-"View the status of your access in <strong><a class=\"twl-links\" href="
-"\"%(library_url)s\">My Library</a></strong> page."
+msgid "View the status of your access in <strong><a class=\"twl-links\" href=\"%(library_url)s\">My Library</a></strong> page."
 msgstr ""
 
 #. Translators: This message is shown when a user has open applications, linking to their respective applications page.
 #: TWLight/resources/templates/resources/partner_detail.html:78
 #, python-format
-msgid ""
-"View the status of your application(s) on your <strong><a class=\"twl-links"
-"\" href=\"%(applications_url)s\">My Applications</a></strong> page."
+msgid "View the status of your application(s) on your <strong><a class=\"twl-links\" href=\"%(applications_url)s\">My Applications</a></strong> page."
 msgstr ""
 
 #. Translators: This message is shown when a user has authorizations, linking to their respective collections page.
 #: TWLight/resources/templates/resources/partner_detail_apply.html:50
 #, python-format
-msgid ""
-"View the status of your access on your <strong><a href=\"%(library_url)s\" "
-"class=\"twl-links\">My Library</a></strong> page."
+msgid "View the status of your access on your <strong><a href=\"%(library_url)s\" class=\"twl-links\">My Library</a></strong> page."
 msgstr ""
 
 #. Translators: This message is shown when a user has open applications, linking to their respective applications page.
 #: TWLight/resources/templates/resources/partner_detail_apply.html:60
 #, python-format
-msgid ""
-"View the status of your application(s) on your <strong><a href="
-"\"%(applications_url)s\">My Applications</a></strong> page."
+msgid "View the status of your application(s) on your <strong><a href=\"%(applications_url)s\">My Applications</a></strong> page."
 msgstr ""
 
 #. Translators: One the partner detail page, this text labels the button which coordinators can click to remove a partner from waitlisted status.
@@ -1642,10 +1449,7 @@ msgstr "Pajenn a-ratozh : EmailUser"
 
 #. Translators: If no account coordinator is assigned to a partner, the Wikipedia Library team will coordinate signups. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/resources/templates/resources/partner_detail_apply.html:112
-msgid ""
-"The Wikipedia Library team will process this application. Want to help? <a "
-"class=\"twl-links\" href=\"https://en.wikipedia.org/wiki/Wikipedia:"
-"The_Wikipedia_Library/Coordinators/Signup\">Sign up as a coordinator.</a>"
+msgid "The Wikipedia Library team will process this application. Want to help? <a class=\"twl-links\" href=\"https://en.wikipedia.org/wiki/Wikipedia:The_Wikipedia_Library/Coordinators/Signup\">Sign up as a coordinator.</a>"
 msgstr ""
 
 #. Translators: This text labels a button coordinators can click to view a list of users who have applied for access for a particular partner
@@ -1675,18 +1479,13 @@ msgstr ""
 
 #. Translators: Text shown to authenticated, bundle eligible users when they visit a Bundle partner page.
 #: TWLight/resources/templates/resources/partner_detail_apply.html:138
-msgid ""
-"You are eligible to access Library Bundle partners. Click the button above "
-"to access the collection."
+msgid "You are eligible to access Library Bundle partners. Click the button above to access the collection."
 msgstr ""
 
 #. Translators: Text shown to authenticated, bundle ineligible users when they visit a Bundle partner page.
 #: TWLight/resources/templates/resources/partner_detail_apply.html:152
 #, python-format
-msgid ""
-"You are not eligible to access Library Bundle partners. Visit the <a class="
-"\"twl-links\" href=\"%(homepage)s\">homepage</a> to check the eligibility "
-"criteria."
+msgid "You are not eligible to access Library Bundle partners. Visit the <a class=\"twl-links\" href=\"%(homepage)s\">homepage</a> to check the eligibility criteria."
 msgstr ""
 
 #. Translators: Buttton prompting users to log in.
@@ -1698,10 +1497,7 @@ msgstr "Kevreañ"
 #. Translators: Text shown to unauthenticated users when they visit a Bundle partner page.
 #: TWLight/resources/templates/resources/partner_detail_apply.html:168
 #, python-format
-msgid ""
-"This resource is part of our <a class=\"twl-links\" href=\"%(about)s"
-"\">Library Bundle</a>, which you can access if you meet our minimum "
-"eligibility criteria. Log in to find out if you are eligible."
+msgid "This resource is part of our <a class=\"twl-links\" href=\"%(about)s\">Library Bundle</a>, which you can access if you meet our minimum eligibility criteria. Log in to find out if you are eligible."
 msgstr ""
 
 #. Translators: This is the label for a number which shows the total active accounts for one partner. (e.g. https://wikipedialibrary.wmflabs.org/partners/8/).
@@ -1752,26 +1548,19 @@ msgstr ""
 #. Translators: If a partner has specified the excerpt limit both in words and percentage, this message will display the percentage of words and the number of words on the partner page.
 #: TWLight/resources/templates/resources/partner_detail_timeline.html:99
 #, python-format
-msgid ""
-"%(object)s allows a maximum of %(excerpt_limit)s words or "
-"%(excerpt_limit_percentage)s%% of an article be excerpted into a Wikipedia "
-"article."
+msgid "%(object)s allows a maximum of %(excerpt_limit)s words or %(excerpt_limit_percentage)s%% of an article be excerpted into a Wikipedia article."
 msgstr ""
 
 #. Translators: If a partner has specified the excerpt limit in words, this message will display the number of words on the partner page.
 #: TWLight/resources/templates/resources/partner_detail_timeline.html:106
 #, python-format
-msgid ""
-"%(object)s allows a maximum of %(excerpt_limit)s words be excerpted into a "
-"Wikipedia article."
+msgid "%(object)s allows a maximum of %(excerpt_limit)s words be excerpted into a Wikipedia article."
 msgstr ""
 
 #. Translators: If a partner has specified the excerpt limit in percentage, this message will display the percentage of words on the partner page.
 #: TWLight/resources/templates/resources/partner_detail_timeline.html:113
 #, python-format
-msgid ""
-"%(object)s allows a maximum of %(excerpt_limit_percentage)s%% of an article "
-"be excerpted into a Wikipedia article."
+msgid "%(object)s allows a maximum of %(excerpt_limit_percentage)s%% of an article be excerpted into a Wikipedia article."
 msgstr ""
 
 #. Translators: If a partner has other requirements for access, this text shows as the title for that information field. (e.g. https://wikipedialibrary.wmflabs.org/partners/10/).
@@ -1782,9 +1571,7 @@ msgstr ""
 #. Translators: If a user must agree to a Terms of Use document, they see this message, and must enter the name of the resource. Don't translate publisher or url.
 #: TWLight/resources/templates/resources/partner_detail_timeline.html:140
 #, python-format
-msgid ""
-"%(publisher)s requires that you agree with its <a href=\"%(url)s\">terms of "
-"use</a>."
+msgid "%(publisher)s requires that you agree with its <a href=\"%(url)s\">terms of use</a>."
 msgstr ""
 
 #. Translators: If a user must provide their real name to apply to a partner, they see this message, and must enter the name of the resource. Don't translate publisher.
@@ -1808,17 +1595,13 @@ msgstr ""
 #. Translators: If a user must select a specific resource to apply for, they see this message, and must enter the name of the resource. Don't translate publisher.
 #: TWLight/resources/templates/resources/partner_detail_timeline.html:177
 #, python-format
-msgid ""
-"%(publisher)s requires that you specify a particular title that you want to "
-"access."
+msgid "%(publisher)s requires that you specify a particular title that you want to access."
 msgstr ""
 
 #. Translators: If a user must register on the partner website before applying, they see this message. Don't translate partner.
 #: TWLight/resources/templates/resources/partner_detail_timeline.html:187
 #, python-format
-msgid ""
-"%(publisher)s requires that you sign up for an account before applying for "
-"access."
+msgid "%(publisher)s requires that you sign up for an account before applying for access."
 msgstr ""
 
 #. Translators: If a partner has their location listed, this message is a label for that location
@@ -1945,9 +1728,7 @@ msgstr "Ha sur eo ho peus c'hoant da lemel <b>%(object)s</b) ?"
 
 #. Translators: If multiple authorizations where returned for a collection, this message is shown to a user
 #: TWLight/resources/views.py:268
-msgid ""
-"Multiple authorizations were returned – something's wrong. Please contact us "
-"and don't forget to mention this message."
+msgid "Multiple authorizations were returned – something's wrong. Please contact us and don't forget to mention this message."
 msgstr ""
 
 #. Translators: This message is shown when user tries to access a NOT_AVAILABLE Partner
@@ -1988,14 +1769,7 @@ msgstr "Siwazh, n'ouzomp ket petra ober gant an dra-se."
 #. Translators: Shown on the website's 400 page, when a user sends a bad request. Don't translate path or Phabricator.
 #: TWLight/templates/400.html:20
 #, python-format
-msgid ""
-"If you think we should know what to do with that, please email us about this "
-"error at <a class=\"twl-links\" href=\"mailto:wikipedialibrary@wikimedia.org?"
-"Subject=Wikipedia%%20Library%%20%(path)s%%20Permission%%20denied"
-"\">wikipedialibrary@wikimedia.org</a> or report it to us on <a class=\"twl-"
-"links\" href=\"https://phabricator.wikimedia.org/maniphest/task/edit/form/1/?"
-"projectPHIDs=Library-Card-Platform&title=Wikipedia%%20Library%%20%(path)s"
-"%%20Bad%%20Request\">Phabricator</a>"
+msgid "If you think we should know what to do with that, please email us about this error at <a class=\"twl-links\" href=\"mailto:wikipedialibrary@wikimedia.org?Subject=Wikipedia%%20Library%%20%(path)s%%20Permission%%20denied\">wikipedialibrary@wikimedia.org</a> or report it to us on <a class=\"twl-links\" href=\"https://phabricator.wikimedia.org/maniphest/task/edit/form/1/?projectPHIDs=Library-Card-Platform&title=Wikipedia%%20Library%%20%(path)s%%20Bad%%20Request\">Phabricator</a>"
 msgstr ""
 
 #. Translators: Alt text for an image shown on the 400 error page.
@@ -2017,15 +1791,7 @@ msgstr "Siwazh, n'oc'h ket aotreet d'ober an dra-se."
 #. Translators: Shown on the website's 403 page, when a user attempts to navigate to a page they don't have permission to view. Don't translate path or Phabricator.
 #: TWLight/templates/403.html:20
 #, python-format
-msgid ""
-"If you think your account should be able to do that, please email us about "
-"this error at <a class=\"twl-links\" href=\"mailto:"
-"wikipedialibrary@wikimedia.org?Subject=Wikipedia%%20Library%%20%(path)s"
-"%%20Permission%%20denied\">wikipedialibrary@wikimedia.org</a> or report it "
-"to us on <a class=\"twl-links\" href=\"https://phabricator.wikimedia.org/"
-"maniphest/task/edit/form/1/?projectPHIDs=Library-Card-"
-"Platform&title=Wikipedia%%20Library%%20%(path)s%%20Permission%%20denied"
-"\">Phabricator</a>"
+msgid "If you think your account should be able to do that, please email us about this error at <a class=\"twl-links\" href=\"mailto:wikipedialibrary@wikimedia.org?Subject=Wikipedia%%20Library%%20%(path)s%%20Permission%%20denied\">wikipedialibrary@wikimedia.org</a> or report it to us on <a class=\"twl-links\" href=\"https://phabricator.wikimedia.org/maniphest/task/edit/form/1/?projectPHIDs=Library-Card-Platform&title=Wikipedia%%20Library%%20%(path)s%%20Permission%%20denied\">Phabricator</a>"
 msgstr ""
 
 #. Translators: Shown on the website's 404 page, when a user attempts to navigate to a page that doesn't exist.
@@ -2041,14 +1807,7 @@ msgstr "Siwazh, ne c'hallomp kavout anezhi."
 #. Translators: Shown on the website's 404 page, when a user attempts to navigate to a page that doesn't exist. Don't translate path or Phabricator.
 #: TWLight/templates/404.html:19
 #, python-format
-msgid ""
-"If you are certain that something should be here, please email us about this "
-"error at <a class=\"twl-links\" href=\"mailto:wikipedialibrary@wikimedia.org?"
-"Subject=Wikipedia%%20Library%%20%(path)s%%20Not%%20found\"> "
-"wikipedialibrary@wikimedia.org</a> or report it to us on <a class=\"twl-links"
-"\" href=\"https://phabricator.wikimedia.org/maniphest/task/edit/form/1/?"
-"projectPHIDs=Library-Card-Platform&title=Wikipedia%%20Library%%20%(path)s"
-"%%20Not%%20found\">Phabricator</a>"
+msgid "If you are certain that something should be here, please email us about this error at <a class=\"twl-links\" href=\"mailto:wikipedialibrary@wikimedia.org?Subject=Wikipedia%%20Library%%20%(path)s%%20Not%%20found\"> wikipedialibrary@wikimedia.org</a> or report it to us on <a class=\"twl-links\" href=\"https://phabricator.wikimedia.org/maniphest/task/edit/form/1/?projectPHIDs=Library-Card-Platform&title=Wikipedia%%20Library%%20%(path)s%%20Not%%20found\">Phabricator</a>"
 msgstr ""
 
 #. Translators: Alt text for an image shown on the 404 error page.
@@ -2063,32 +1822,18 @@ msgstr "Diwar-benn Levraoueg Wikipedia"
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:20
-msgid ""
-"This platform is our central tool for facilitating access to our available "
-"collections. Here you can see which partnerships are available, search their "
-"contents, and apply for and access the ones you’re interested in."
+msgid "This platform is our central tool for facilitating access to our available collections. Here you can see which partnerships are available, search their contents, and apply for and access the ones you’re interested in."
 msgstr ""
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/). Wikimedia Foundation should not be translated.
 #: TWLight/templates/about.html:29
-msgid ""
-"All users receive immediate access to some collections, which can be browsed "
-"by clicking the 'Access collection' buttons or using the search bar at the "
-"top of the page. Other collections require an application before access is "
-"granted, and may be accessed directly or via an individual login or access "
-"code. Volunteer coordinators, who have signed non-disclosure agreements with "
-"the Wikimedia Foundation, review these applications and work with publishers "
-"to get you your free access."
+msgid "All users receive immediate access to some collections, which can be browsed by clicking the 'Access collection' buttons or using the search bar at the top of the page. Other collections require an application before access is granted, and may be accessed directly or via an individual login or access code. Volunteer coordinators, who have signed non-disclosure agreements with the Wikimedia Foundation, review these applications and work with publishers to get you your free access."
 msgstr ""
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/). Don't translate terms_url.
 #: TWLight/templates/about.html:43
 #, python-format
-msgid ""
-"For more information about how your information is stored and reviewed "
-"please see our <a class=\"twl-links\" href=\"%(terms_url)s\"> terms of use "
-"and privacy policy</a>. Accounts you apply for are also subject to the Terms "
-"of Use provided by each partner’s platform; please review them."
+msgid "For more information about how your information is stored and reviewed please see our <a class=\"twl-links\" href=\"%(terms_url)s\"> terms of use and privacy policy</a>. Accounts you apply for are also subject to the Terms of Use provided by each partner’s platform; please review them."
 msgstr ""
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
@@ -2098,12 +1843,7 @@ msgstr ""
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/). Wikimedia Foundation should not be translated.
 #: TWLight/templates/about.html:55
-msgid ""
-"Any active editor in good standing can receive access. For publishers with "
-"limited numbers of accounts, applications are reviewed based on the editor’s "
-"needs and contributions. If you think you could use access to one of our "
-"partner resources and are an active editor in any project supported by the "
-"Wikimedia Foundation, please apply."
+msgid "Any active editor in good standing can receive access. For publishers with limited numbers of accounts, applications are reviewed based on the editor’s needs and contributions. If you think you could use access to one of our partner resources and are an active editor in any project supported by the Wikimedia Foundation, please apply."
 msgstr ""
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
@@ -2133,23 +1873,12 @@ msgstr ""
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/)
 #: TWLight/templates/about.html:89
-msgid ""
-"If you are applying for an available collection, please first check that you "
-"don't already have access through another library or institution. If you do, "
-"please consider using that access rather than taking up a seat for this "
-"resource in The Wikipedia Library."
+msgid "If you are applying for an available collection, please first check that you don't already have access through another library or institution. If you do, please consider using that access rather than taking up a seat for this resource in The Wikipedia Library."
 msgstr ""
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/)
 #: TWLight/templates/about.html:99
-msgid ""
-"If your account is blocked on one or more Wikimedia projects, you may still "
-"be granted access to The Wikipedia Library. You will need to contact the "
-"Wikipedia Library team, who will review your blocks. If you have been "
-"blocked for content issues, most notably copyright violations, or have "
-"multiple long-term blocks, we may decline your request. Additionally, if "
-"your block status changes after being approved, you will need to request "
-"another review."
+msgid "If your account is blocked on one or more Wikimedia projects, you may still be granted access to The Wikipedia Library. You will need to contact the Wikipedia Library team, who will review your blocks. If you have been blocked for content issues, most notably copyright violations, or have multiple long-term blocks, we may decline your request. Additionally, if your block status changes after being approved, you will need to request another review."
 msgstr ""
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
@@ -2184,9 +1913,7 @@ msgstr ""
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:136
-msgid ""
-"Share their account logins or passwords with others, or sell their access to "
-"other parties"
+msgid "Share their account logins or passwords with others, or sell their access to other parties"
 msgstr ""
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
@@ -2196,23 +1923,17 @@ msgstr ""
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:144
-msgid ""
-"Systematically make printed or electronic copies of multiple extracts of "
-"restricted content available for any purpose"
+msgid "Systematically make printed or electronic copies of multiple extracts of restricted content available for any purpose"
 msgstr ""
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/). Stub is a technical term for a short Wikipedia article, use the appropriate Wikipedia term in your language.
 #: TWLight/templates/about.html:148
-msgid ""
-"Datamine metadata without permission, in order, for instance, to use "
-"metadata for auto-created stub articles"
+msgid "Datamine metadata without permission, in order, for instance, to use metadata for auto-created stub articles"
 msgstr ""
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:154
-msgid ""
-"Respecting these agreements allows us to continue growing the partnerships "
-"available to the community."
+msgid "Respecting these agreements allows us to continue growing the partnerships available to the community."
 msgstr ""
 
 #. Translators: This is the heading for a section on the About page (https://wikipedialibrary.wmflabs.org/about/).
@@ -2223,41 +1944,22 @@ msgstr "Proksi"
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:164
-msgid ""
-"EZProxy is a proxy server used to authenticate users for many Wikipedia "
-"Library partners. Users sign into EZProxy via the Library Card platform to "
-"verify that they are authorized users, and then the server accesses "
-"requested resources using its own IP address."
+msgid "EZProxy is a proxy server used to authenticate users for many Wikipedia Library partners. Users sign into EZProxy via the Library Card platform to verify that they are authorized users, and then the server accesses requested resources using its own IP address."
 msgstr ""
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:173
-msgid ""
-"You may notice that when accessing resources via EZProxy that URLs are "
-"dynamically rewritten. This is why we recommend logging in via the Library "
-"Card platform rather than going directly to the unproxied partner website. "
-"When in doubt, check the URL for ‘idm.oclc’. If it’s there, then you’re "
-"connected via EZProxy."
+msgid "You may notice that when accessing resources via EZProxy that URLs are dynamically rewritten. This is why we recommend logging in via the Library Card platform rather than going directly to the unproxied partner website. When in doubt, check the URL for ‘idm.oclc’. If it’s there, then you’re connected via EZProxy."
 msgstr ""
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:182
-msgid ""
-"Typically once you’ve logged in your session will remain active in your "
-"browser for up to two hours after you’ve finished searching. Note that use "
-"of EZProxy requires you to enable cookies. If you are having problems you "
-"should also try clearing your cache and restarting your browser."
+msgid "Typically once you’ve logged in your session will remain active in your browser for up to two hours after you’ve finished searching. Note that use of EZProxy requires you to enable cookies. If you are having problems you should also try clearing your cache and restarting your browser."
 msgstr ""
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/)
 #: TWLight/templates/about.html:193
-msgid ""
-"The Library Bundle is a collection of resources for which no application is "
-"required. If you meet the criteria laid out above, you will be authorized "
-"for access automatically upon logging in to the platform. Only some of our "
-"content is currently included in the Library Bundle, however we hope to "
-"expand the collection as more publishers become comfortable with "
-"participating. All Bundle content is accessed via EZProxy."
+msgid "The Library Bundle is a collection of resources for which no application is required. If you meet the criteria laid out above, you will be authorized for access automatically upon logging in to the platform. Only some of our content is currently included in the Library Bundle, however we hope to expand the collection as more publishers become comfortable with participating. All Bundle content is accessed via EZProxy."
 msgstr ""
 
 #. Translators: This is the heading for a section on the About page (https://wikipedialibrary.wmflabs.org/about/).
@@ -2267,12 +1969,7 @@ msgstr ""
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:206
-msgid ""
-"Citation practices vary by project and even by article. Generally, we "
-"support editors citing where they found information, in a form that allows "
-"others to check it for themselves. That often means providing both original "
-"source details as well as a link to the partner database in which the source "
-"was found."
+msgid "Citation practices vary by project and even by article. Generally, we support editors citing where they found information, in a form that allows others to check it for themselves. That often means providing both original source details as well as a link to the partner database in which the source was found."
 msgstr ""
 
 #. Translators: This is the heading for a section on the About page (https://wikipedialibrary.wmflabs.org/about/).
@@ -2284,9 +1981,7 @@ msgstr "Mont e darempred ganeomp"
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:218
 #, python-format
-msgid ""
-"If you have questions, need help, or want to volunteer to help, please see "
-"our <a class=\"twl-links\" href=\"%(contact_url)s\">contact page</a>."
+msgid "If you have questions, need help, or want to volunteer to help, please see our <a class=\"twl-links\" href=\"%(contact_url)s\">contact page</a>."
 msgstr ""
 
 #. Translators: This is the title of the panel box detailing the contact information for the Wikipedia Library team.
@@ -2326,9 +2021,7 @@ msgstr "Pajenn dTwitter Levraoueg Wikipedia"
 #. Translators: This is the text that appears at the bottom of the contact us form directing users to the suggestions form.
 #: TWLight/templates/contact.html:48
 #, python-format
-msgid ""
-"(If you would like to suggest a partner, <a class=\"twl-links\" href="
-"\"%(suggest)s\"><strong>go here</strong></a>.)"
+msgid "(If you would like to suggest a partner, <a class=\"twl-links\" href=\"%(suggest)s\"><strong>go here</strong></a>.)"
 msgstr ""
 
 #. Translators: On a special 'link to search' page, this message is shown if JavaScript is disabled.
@@ -2386,9 +2079,7 @@ msgstr "Levraoueg Wikipedia"
 #. Translators: Information about The Wikipedia Library.
 #: TWLight/templates/login_partial.html:53 TWLight/templates/new_base.html:21
 #, python-format
-msgid ""
-"More than 100 of the world's top subscription-only databases, with content "
-"in %(no_of_languages)s languages, free for Wikipedians of all backgrounds"
+msgid "More than 100 of the world's top subscription-only databases, with content in %(no_of_languages)s languages, free for Wikipedians of all backgrounds"
 msgstr ""
 
 #. Translators: Information about The Wikipedia Library.
@@ -2397,9 +2088,7 @@ msgid "Meet these criteria for automatic access"
 msgstr ""
 
 #: TWLight/templates/login_partial.html:69
-msgid ""
-"These criteria grant you access to certain collections but not all. Some "
-"collections are accessible on a per application basis only."
+msgid "These criteria grant you access to certain collections but not all. Some collections are accessible on a per application basis only."
 msgstr ""
 
 #: TWLight/templates/login_partial.html:89
@@ -2409,29 +2098,19 @@ msgstr "Kevreañ gant ho kont Wikipedia"
 #. Translators: Shown if the current user doesn't have a registered email on their account. Don't translate contact_us_url or email_url.
 #: TWLight/templates/message_partial.html:15
 #, python-format
-msgid ""
-"You don't have an email on file. We can't finalize your access to partner "
-"resources, and you won't be able to <a class=\"twl-links\" href="
-"\"%(contact_us_url)s\">contact us</a> without an email. Please <a class="
-"\"twl-links\" href=\"%(email_url)s\">update your email</a>."
+msgid "You don't have an email on file. We can't finalize your access to partner resources, and you won't be able to <a class=\"twl-links\" href=\"%(contact_us_url)s\">contact us</a> without an email. Please <a class=\"twl-links\" href=\"%(email_url)s\">update your email</a>."
 msgstr ""
 
 #. Translators: Shown if the current user has requested the processing of their data should be restricted.
 #: TWLight/templates/message_partial.html:26
 #, python-format
-msgid ""
-"You have requested a restriction on the processing of your data. Most site "
-"functionality will not be available to you until you <a class=\"twl-links\" "
-"href=\"%(restrict_url)s\">lift this restriction</a>."
+msgid "You have requested a restriction on the processing of your data. Most site functionality will not be available to you until you <a class=\"twl-links\" href=\"%(restrict_url)s\">lift this restriction</a>."
 msgstr ""
 
 #. Translators: Shown if the current user has not agreed to the terms of use.
 #: TWLight/templates/message_partial.html:37
 #, python-format
-msgid ""
-"You have not agreed to the <a class=\"twl-links\" href=\"%(terms_url)s"
-"\">terms of use</a> of this site. Your applications will not be processed "
-"and you won't be able to apply or access resources you are approved for."
+msgid "You have not agreed to the <a class=\"twl-links\" href=\"%(terms_url)s\">terms of use</a> of this site. Your applications will not be processed and you won't be able to apply or access resources you are approved for."
 msgstr ""
 
 #. Translators: This link is at the bottom of every page and links to the 'About' page (https://wikipedialibrary.wmflabs.org/about/)
@@ -2478,12 +2157,8 @@ msgstr "Adderaouekaat ar ger-tremen"
 
 #. Translators: If a user goes to reset their password, this message asks them to enter their email to do so.
 #: TWLight/templates/registration/password_reset_form.html:13
-msgid ""
-"Forgot your password? Enter your email address below, and we'll email "
-"instructions for setting a new one."
-msgstr ""
-"Ger tremen ankounac'haet? Bizskrivit ho chomlec'h postel amañ dindan ha kas "
-"a raimp ar c'hemennadoù deoc'h evit krouiñ unan nevez."
+msgid "Forgot your password? Enter your email address below, and we'll email instructions for setting a new one."
+msgstr "Ger tremen ankounac'haet? Bizskrivit ho chomlec'h postel amañ dindan ha kas a raimp ar c'hemennadoù deoc'h evit krouiñ unan nevez."
 
 #. Translators: This is the label for a button that users click to update their public information.
 #: TWLight/users/forms.py:36
@@ -2493,8 +2168,7 @@ msgstr "Hizivaat ar profil"
 #. Translators: This labels a field where users can describe their activity on Wikipedia in a small biography.
 #: TWLight/users/forms.py:45
 msgid "Describe your contributions to Wikipedia: topics edited, et cetera."
-msgstr ""
-"Deskrivit ho tegasadennoù da Wikipedia : danvezioù embannet ha kement zo..."
+msgstr "Deskrivit ho tegasadennoù da Wikipedia : danvezioù embannet ha kement zo..."
 
 #. Translators: In the preferences section (Emails) of a user profile, this text labels the checkbox users can (un)click to change if they wish to receive account renewal notices or not.
 #: TWLight/users/forms.py:98
@@ -2531,16 +2205,12 @@ msgstr "A-du emaon gant an divizoù implijout"
 
 #. Translators: This text explains how to disagree to the site's terms of use and the restrictions that will come into effect when users disagree to the terms of use.
 #: TWLight/users/forms.py:185
-msgid ""
-"By unchecking this box and clicking “Update” you may explore the site, but "
-"you will not be able to apply for access to materials or evaluate "
-"applications unless you agree with the terms of use."
+msgid "By unchecking this box and clicking “Update” you may explore the site, but you will not be able to apply for access to materials or evaluate applications unless you agree with the terms of use."
 msgstr ""
 
 #. Translators: Users click this button to set their website email address to the one linked to their Wikipedia account.
 #: TWLight/users/forms.py:211
-msgid ""
-"Use my Wikipedia email address (will be updated the next time you login)."
+msgid "Use my Wikipedia email address (will be updated the next time you login)."
 msgstr ""
 
 #. Translators: This labels a button which users click to change their email.
@@ -2551,23 +2221,13 @@ msgstr "Hizivaat ho postel"
 #. Translators: Shown if the current user tried to 'favorite' a partner they can't access. Do not translate '{partner}'
 #: TWLight/users/models.py:201
 #, python-brace-format
-msgid ""
-"Cannot add partner {partner} to your favorites because you don't have access "
-"to it"
+msgid "Cannot add partner {partner} to your favorites because you don't have access to it"
 msgstr ""
-
-#. Translators: Do not translate.
-#: TWLight/users/models.py:869
-#, fuzzy, python-brace-format
-#| msgid "Username"
-msgid "{wp_username}"
-msgstr "Anv implijer"
 
 #. Translators: This error message is shown when there's a problem with the authenticated login process.
 #: TWLight/users/oauth.py:243
 msgid "You tried to log in but presented an invalid access token."
-msgstr ""
-"Klasket ho peus kevreañ met kinniget ho peus ur jedouer monet n'eo ket mat."
+msgstr "Klasket ho peus kevreañ met kinniget ho peus ur jedouer monet n'eo ket mat."
 
 #. Translators: This message is shown when the OAuth login process fails because the request came from the wrong website. Don't translate {domain}.
 #: TWLight/users/oauth.py:298 TWLight/users/oauth.py:444
@@ -2582,9 +2242,7 @@ msgstr ""
 
 #. Translators: this message is displayed to users that don't have accounts and clicked on a proxied link.
 #: TWLight/users/oauth.py:388
-msgid ""
-"To view this link you need to be an eligible library user. Please login to "
-"continue."
+msgid "To view this link you need to be an eligible library user. Please login to continue."
 msgstr ""
 
 #. Translators: This warning message is shown to users when the response received from Wikimedia OAuth servers is not a valid one.
@@ -2621,17 +2279,12 @@ msgstr "Titouroù diwar-benn un implijer"
 
 #. Translators: If the user tries to log in, but their account does not meet certain requirements, they cannot login.
 #: TWLight/users/oauth.py:528
-msgid ""
-"Your Wikipedia account does not meet the eligibility criteria in the terms "
-"of use, so your Wikipedia Library Card Platform account cannot be activated."
+msgid "Your Wikipedia account does not meet the eligibility criteria in the terms of use, so your Wikipedia Library Card Platform account cannot be activated."
 msgstr ""
 
 #. Translators: If the user tries to log in, but their account does not meet certain requirements, they cannot login.
 #: TWLight/users/oauth.py:536
-msgid ""
-"Your Wikipedia account no longer meets the eligibility criteria in the terms "
-"of use, so you cannot be logged in. If you think you should be able to log "
-"in, please email wikipedialibrary@wikimedia.org."
+msgid "Your Wikipedia account no longer meets the eligibility criteria in the terms of use, so you cannot be logged in. If you think you should be able to log in, please email wikipedialibrary@wikimedia.org."
 msgstr ""
 
 #. Translators: this message is displayed to users with brand new accounts.
@@ -2642,10 +2295,7 @@ msgstr ""
 #. Translators: This message is displayed on the confirmation page where users can return their access to partner collections.
 #: TWLight/users/templates/users/authorization_confirm_return.html:13
 #, python-format
-msgid ""
-"You will no longer be able to access <b>%(partner)s's</b> resources via the "
-"Library Card platform, but can request access again by clicking 'renew', if "
-"you change your mind. Are you sure you want to return your access?"
+msgid "You will no longer be able to access <b>%(partner)s's</b> resources via the Library Card platform, but can request access again by clicking 'renew', if you change your mind. Are you sure you want to return your access?"
 msgstr ""
 
 #. Translators: On the MyLibrary page (https://wikipedialibrary.wmflabs.org/users/my_library), this tab shows all favorite collections a user has.
@@ -2715,10 +2365,7 @@ msgstr "Roadennoù implijer"
 
 #. Translators: This is shown on editor profiles, in their profile page or on applications.
 #: TWLight/users/templates/users/editor_detail.html:59
-msgid ""
-"Information with an * was retrieved from Wikipedia directly. Other "
-"information was entered directly by users or site admins, in their preferred "
-"language."
+msgid "Information with an * was retrieved from Wikipedia directly. Other information was entered directly by users or site admins, in their preferred language."
 msgstr ""
 
 #. Translators: This distinguishes users who have been flagged as account coordinators. Don't translate username.
@@ -2729,10 +2376,7 @@ msgstr ""
 
 #. Translators: This is shown on editor profiles, under the heading for Wikipedia editor data.
 #: TWLight/users/templates/users/editor_detail_data.html:5
-msgid ""
-"This information is updated automatically from your Wikimedia account each "
-"time you log in, except for the Contributions field, where you can describe "
-"your Wikimedia editing history."
+msgid "This information is updated automatically from your Wikimedia account each time you log in, except for the Contributions field, where you can describe your Wikimedia editing history."
 msgstr ""
 
 #. Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this labels the user's username.
@@ -2762,17 +2406,13 @@ msgstr "A respont d'an divizoù implijout ?"
 
 #. Translators: when viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this question has a yes or no answer.
 #: TWLight/users/templates/users/editor_detail_data.html:57
-msgid ""
-"at their last login, did this user meet the criteria set forth in the terms "
-"of use?"
+msgid "at their last login, did this user meet the criteria set forth in the terms of use?"
 msgstr ""
 
 #. Translators: When viewing a user's profile in an application, this message shows if the software doesn't think that the user is eligible for access. Don't translate username.
 #: TWLight/users/templates/users/editor_detail_data.html:72
 #, python-format
-msgid ""
-"%(username)s may still be eligible for access grants at the coordinators' "
-"discretion."
+msgid "%(username)s may still be eligible for access grants at the coordinators' discretion."
 msgstr ""
 
 #. Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this is the heading for a Yes/No ToU question.
@@ -2807,10 +2447,7 @@ msgstr ""
 #. Translators: This message is shown on a user's profile if their Wikimedia account is blocked on one or more projects. They may still be granted access to the Library Bundle, but need to contact Wikipedia Library staff to verify.
 #: TWLight/users/templates/users/editor_detail_data.html:137
 #, python-format
-msgid ""
-"It looks like you have an active block on your account. If you meet the "
-"other criteria you may still be permitted access to the library - please <a "
-"class=\"twl-links\" href=\"%(contact_url)s\">contact us</a>."
+msgid "It looks like you have an active block on your account. If you meet the other criteria you may still be permitted access to the library - please <a class=\"twl-links\" href=\"%(contact_url)s\">contact us</a>."
 msgstr ""
 
 #. Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this is the heading for a Yes/No program eligibility question.
@@ -2820,10 +2457,7 @@ msgstr ""
 
 #. Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this question has a Yes or No answer.
 #: TWLight/users/templates/users/editor_detail_data.html:156
-msgid ""
-"At their last login, did this user meet the criteria set forth in the "
-"Library Bundle? Note that satisfying terms of use is a prerequisite to "
-"bundle eligibility."
+msgid "At their last login, did this user meet the criteria set forth in the Library Bundle? Note that satisfying terms of use is a prerequisite to bundle eligibility."
 msgstr ""
 
 #. Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this is the heading for a Yes/No program eligibility question.
@@ -2868,21 +2502,14 @@ msgstr "Titouroù personel"
 
 #. Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this text is in the 'Personal data' section. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/users/templates/users/editor_detail_data.html:262
-msgid ""
-"The following information is visible only to you, site administrators, "
-"publishing partners (where required), and volunteer Wikipedia Library "
-"coordinators (who have signed a Non-Disclosure Agreement)."
+msgid "The following information is visible only to you, site administrators, publishing partners (where required), and volunteer Wikipedia Library coordinators (who have signed a Non-Disclosure Agreement)."
 msgstr ""
 
 #. Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this labels a button which users can click to update or remove their personal information. Don't translate update_url.
 #: TWLight/users/templates/users/editor_detail_data.html:272
 #, python-format
-msgid ""
-"You may <a class=\"twl-links\" href=\"%(update_url)s\">update or delete</a> "
-"your data at any time."
-msgstr ""
-"Gallout a reot <a class=\"twl-links\" href=\"%(update_url)s\">hizivaat pe "
-"lemel</a> ho roadennoù forzh pegoulz."
+msgid "You may <a class=\"twl-links\" href=\"%(update_url)s\">update or delete</a> your data at any time."
+msgstr "Gallout a reot <a class=\"twl-links\" href=\"%(update_url)s\">hizivaat pe lemel</a> ho roadennoù forzh pegoulz."
 
 #. Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this labels the user's email. Don't remove the *.
 #: TWLight/users/templates/users/editor_detail_data.html:283
@@ -2901,24 +2528,18 @@ msgstr "Emezeladur ensavadurel"
 
 #. Translators: This message tells users that they are not eligible to access The Wikipedia Library content.
 #: TWLight/users/templates/users/eligibility_modal.html:7
-msgid ""
-"Sorry, your Wikipedia account doesn’t currently qualify to access The "
-"Wikipedia Library."
+msgid "Sorry, your Wikipedia account doesn’t currently qualify to access The Wikipedia Library."
 msgstr ""
 
 #. Translators: This message tells users that they have not agreed to the terms of use, therefore are ineligible to access the content in The Wikipedia Library.
 #: TWLight/users/templates/users/eligibility_modal.html:30
 #, python-format
-msgid ""
-"Agreed with <a href=\"%(terms)s\" class=\"text-danger\"> terms of use </a>"
+msgid "Agreed with <a href=\"%(terms)s\" class=\"text-danger\"> terms of use </a>"
 msgstr ""
 
 #: TWLight/users/templates/users/eligibility_modal.html:40
 #, python-format
-msgid ""
-"It looks like you have an active block on your account. If you meet the "
-"other criteria you may still be permitted access to the library - please <a "
-"href=\"%(contact_url)s\">contact us</a>."
+msgid "It looks like you have an active block on your account. If you meet the other criteria you may still be permitted access to the library - please <a href=\"%(contact_url)s\">contact us</a>."
 msgstr ""
 
 #. Translators: Instructions to refresh a user's data.
@@ -2958,14 +2579,8 @@ msgstr "Termenañ ar yezh"
 
 #. Translators: This text on the user page helps users naviage to the TranslateWiki Wikipedia Library Card platform translation page.
 #: TWLight/users/templates/users/language_form.html:31
-msgid ""
-"You can help translate the tool at <a class=\"twl-links\" href=\"https://"
-"translatewiki.net/wiki/Translating:Wikipedia_Library_Card_Platform"
-"\">translatewiki.net</a>."
-msgstr ""
-"Gallout a rit sikour da dreiñ an ostilh war <a class=\"twl-links\" href="
-"\"https://translatewiki.net/wiki/Translating:Wikipedia_Library_Card_Platform"
-"\">translatewiki.net</a>."
+msgid "You can help translate the tool at <a class=\"twl-links\" href=\"https://translatewiki.net/wiki/Translating:Wikipedia_Library_Card_Platform\">translatewiki.net</a>."
+msgstr "Gallout a rit sikour da dreiñ an ostilh war <a class=\"twl-links\" href=\"https://translatewiki.net/wiki/Translating:Wikipedia_Library_Card_Platform\">translatewiki.net</a>."
 
 #. Translators: When the user starts a new application and submits the application, the user can view the application and withdraw if need be. This changes the label for the Withdraw button.
 #: TWLight/users/templates/users/my_applications.html:65
@@ -2984,9 +2599,7 @@ msgstr "Goulenn adneveziñ"
 
 #. Translators: On the page listing applications, this text explains a user they cannot renew their application since they've already requested a renewal or there aren't any renewals available.
 #: TWLight/users/templates/users/my_applications.html:79
-msgid ""
-"Renewals are either not required, not available right now, or you have "
-"already requested a renewal."
+msgid "Renewals are either not required, not available right now, or you have already requested a renewal."
 msgstr ""
 
 #. Translators: This text is the heading of a section in a user's profile where they can change their preferences.
@@ -3050,19 +2663,12 @@ msgstr ""
 
 #. Translators: This message is displayed on the page where users can request we stop processing their data.
 #: TWLight/users/templates/users/restrict_data.html:15
-msgid ""
-"Checking this box and clicking “Restrict” will pause all processing of the "
-"data you have entered into this website. You will not be able to apply for "
-"access to resources, your applications will not be further processed, and "
-"none of your data will be altered, until you return to this page and uncheck "
-"the box. This is not the same as deleting your data."
+msgid "Checking this box and clicking “Restrict” will pause all processing of the data you have entered into this website. You will not be able to apply for access to resources, your applications will not be further processed, and none of your data will be altered, until you return to this page and uncheck the box. This is not the same as deleting your data."
 msgstr ""
 
 #. Translators: This warning message is shown to coordinators who view the data restriction page.
 #: TWLight/users/templates/users/restrict_data.html:26
-msgid ""
-"You are a coordinator on this site. If you restrict the processing of your "
-"data, your coordinator flag will be removed."
+msgid "You are a coordinator on this site. If you restrict the processing of your data, your coordinator flag will be removed."
 msgstr ""
 
 #. Translators: use the date *when you are translating*, in a language-appropriate format.
@@ -3082,24 +2688,12 @@ msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:51
-msgid ""
-"<a class=\"twl-links\" href=\"https://meta.wikimedia.org/wiki/"
-"The_Wikipedia_Library\"> The Wikipedia Library </a> has partnered with "
-"publishers around the world to allow users to access otherwise paywalled "
-"resources. This website allows Wikipedia editors to search and access these "
-"resources."
+msgid "<a class=\"twl-links\" href=\"https://meta.wikimedia.org/wiki/The_Wikipedia_Library\"> The Wikipedia Library </a> has partnered with publishers around the world to allow users to access otherwise paywalled resources. This website allows Wikipedia editors to search and access these resources."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Wikimedia Foundation should not be translated. WMF should not be translated. Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:63
-msgid ""
-"This program is administered by the Wikimedia Foundation (WMF). These terms "
-"of use and privacy notice pertain to your application for access to "
-"resources through the Wikipedia Library, your use of this website, and your "
-"access to and use of those resources. They also describe our handling of the "
-"information you provide to us in order to create and administer your "
-"Wikipedia Library account. If we make material changes to the terms, we will "
-"notify users."
+msgid "This program is administered by the Wikimedia Foundation (WMF). These terms of use and privacy notice pertain to your application for access to resources through the Wikipedia Library, your use of this website, and your access to and use of those resources. They also describe our handling of the information you provide to us in order to create and administer your Wikipedia Library account. If we make material changes to the terms, we will notify users."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
@@ -3109,37 +2703,17 @@ msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:78
-msgid ""
-"Access to resources via The Wikipedia Library is reserved for community "
-"members who have demonstrated their commitment to the Wikimedia projects, "
-"and who will use their access to these resources to improve project content. "
-"To that end, in order to be eligible for The Wikipedia Library, we require "
-"that you be registered for a user account on the projects, with at least 500 "
-"edits, six (6) months of activity, and 10+ edits in the last month. We ask "
-"that you do not request access to any publishers with a limited number of "
-"available accounts whose resources you can already access for free through "
-"your local library or university, or another institution or organization, in "
-"order to provide that opportunity to others."
+msgid "Access to resources via The Wikipedia Library is reserved for community members who have demonstrated their commitment to the Wikimedia projects, and who will use their access to these resources to improve project content. To that end, in order to be eligible for The Wikipedia Library, we require that you be registered for a user account on the projects, with at least 500 edits, six (6) months of activity, and 10+ edits in the last month. We ask that you do not request access to any publishers with a limited number of available accounts whose resources you can already access for free through your local library or university, or another institution or organization, in order to provide that opportunity to others."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:94
-msgid ""
-"Additionally, if you are currently blocked or banned from a Wikimedia "
-"project, applications to resources may be rejected or restricted. If you "
-"obtain a Wikipedia Library account, but a block or ban is subsequently "
-"instituted against you on one of the projects, you may lose access to your "
-"Wikipedia Library account."
+msgid "Additionally, if you are currently blocked or banned from a Wikimedia project, applications to resources may be rejected or restricted. If you obtain a Wikipedia Library account, but a block or ban is subsequently instituted against you on one of the projects, you may lose access to your Wikipedia Library account."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:104
-msgid ""
-"Your eligibility to access The Wikipedia Library is assessed at each login. "
-"While more than half of the library's content is provided via this automated "
-"eligibility check, access to other publisher's content may be time limited, "
-"typically lapsing after one year, after which you will usually need to apply "
-"for renewal."
+msgid "Your eligibility to access The Wikipedia Library is assessed at each login. While more than half of the library's content is provided via this automated eligibility check, access to other publisher's content may be time limited, typically lapsing after one year, after which you will usually need to apply for renewal."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
@@ -3150,47 +2724,27 @@ msgstr "Kartenn eus Levraoueg Wikipedia"
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:118
-msgid ""
-"In order to apply for access to a partner resource, you must provide us with "
-"certain information, which we will use to evaluate your application. If your "
-"application is approved, we may transfer the information you have given us "
-"to the publishers whose resources you wish to access. They will either "
-"contact you with the account information directly or we will send access "
-"information to you ourselves."
+msgid "In order to apply for access to a partner resource, you must provide us with certain information, which we will use to evaluate your application. If your application is approved, we may transfer the information you have given us to the publishers whose resources you wish to access. They will either contact you with the account information directly or we will send access information to you ourselves."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:130
-msgid ""
-"In addition to the basic information you provide to us, our system will "
-"retrieve some information directly from the Wikimedia projects: your "
-"username, email address, edit count, registration date, user ID number, "
-"groups to which you belong, and any special user rights."
+msgid "In addition to the basic information you provide to us, our system will retrieve some information directly from the Wikimedia projects: your username, email address, edit count, registration date, user ID number, groups to which you belong, and any special user rights."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:140
-msgid ""
-"Each time you log in to the Wikipedia Library Card Platform, this "
-"information will be automatically updated."
+msgid "Each time you log in to the Wikipedia Library Card Platform, this information will be automatically updated."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:148
-msgid ""
-"We will ask you to provide us with some information about your history of "
-"contributions to the Wikimedia projects. Information on contribution history "
-"is optional, but will greatly assist us in evaluating your application."
+msgid "We will ask you to provide us with some information about your history of contributions to the Wikimedia projects. Information on contribution history is optional, but will greatly assist us in evaluating your application."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). WMF should not be translated. Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:157
-msgid ""
-"The information you provide when creating your account will be visible to "
-"you while on the site but not to others unless they are approved Wikipedia "
-"Library Coordinators, WMF Staff, or WMF Contractors who need access to this "
-"data in order to carry out their work with the Wikipedia Library, all of "
-"whom are subject to non-disclosure obligations."
+msgid "The information you provide when creating your account will be visible to you while on the site but not to others unless they are approved Wikipedia Library Coordinators, WMF Staff, or WMF Contractors who need access to this data in order to carry out their work with the Wikipedia Library, all of whom are subject to non-disclosure obligations."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
@@ -3200,46 +2754,32 @@ msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:171
-msgid ""
-"In order to access an individual publisher’s resources, you must agree to "
-"that publisher’s terms of use and privacy policy. You agree that you will "
-"not violate such terms and policies in connection with your use of the "
-"Wikipedia Library. Additionally, the following activities are prohibited "
-"while accessing publisher resources through the Wikipedia Library."
+msgid "In order to access an individual publisher’s resources, you must agree to that publisher’s terms of use and privacy policy. You agree that you will not violate such terms and policies in connection with your use of the Wikipedia Library. Additionally, the following activities are prohibited while accessing publisher resources through the Wikipedia Library."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:184
-msgid ""
-"Sharing your Wikipedia account, usernames, passwords, or any access codes "
-"for publisher resources with others;"
+msgid "Sharing your Wikipedia account, usernames, passwords, or any access codes for publisher resources with others;"
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:191
-msgid ""
-"Automatically scraping or downloading restricted content from publishers;"
+msgid "Automatically scraping or downloading restricted content from publishers;"
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:197
-msgid ""
-"Systematically making printed or electronic copies of multiple extracts of "
-"restricted content available for any purpose;"
+msgid "Systematically making printed or electronic copies of multiple extracts of restricted content available for any purpose;"
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:204
-msgid ""
-"Data mining metadata without permission—for example, in order to use "
-"metadata for auto-created stub articles;"
+msgid "Data mining metadata without permission—for example, in order to use metadata for auto-created stub articles;"
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:211
-msgid ""
-"Using the access you receive through the Wikipedia Library for profit by "
-"selling access to your account or resources which you have through it."
+msgid "Using the access you receive through the Wikipedia Library for profit by selling access to your account or resources which you have through it."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
@@ -3249,18 +2789,12 @@ msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:224
-msgid ""
-"Certain resources may only be accessed using an external search service, "
-"such as the EBSCO Discovery Service, or a proxy service, such as OCLC "
-"EZProxy. If you use such external search and/or proxy services, please "
-"review the applicable terms of use and privacy policies."
+msgid "Certain resources may only be accessed using an external search service, such as the EBSCO Discovery Service, or a proxy service, such as OCLC EZProxy. If you use such external search and/or proxy services, please review the applicable terms of use and privacy policies."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:234
-msgid ""
-"In addition, if you use OCLC EZProxy, please note that you may not use it "
-"for commercial purposes."
+msgid "In addition, if you use OCLC EZProxy, please note that you may not use it for commercial purposes."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
@@ -3270,120 +2804,49 @@ msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Wikimedia Foundation should not be translated. Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:245
-msgid ""
-"The Wikimedia Foundation and our service providers use your information for "
-"the legitimate purpose of providing Wikipedia Library services in support of "
-"our charitable mission. When you apply for a Wikipedia Library account, or "
-"use your Wikipedia Library account, we may routinely collect the following "
-"information: your username, email address, edit count, registration date, "
-"user ID number, groups to which you belong, and any special user rights; "
-"your name, country of residence, and/or affiliation, if required by a "
-"partner to which you are applying; your narrative description of your "
-"contributions and reasons for applying for access to partner resources; and "
-"the date you agree to these terms of use."
+msgid "The Wikimedia Foundation and our service providers use your information for the legitimate purpose of providing Wikipedia Library services in support of our charitable mission. When you apply for a Wikipedia Library account, or use your Wikipedia Library account, we may routinely collect the following information: your username, email address, edit count, registration date, user ID number, groups to which you belong, and any special user rights; your name, country of residence, and/or affiliation, if required by a partner to which you are applying; your narrative description of your contributions and reasons for applying for access to partner resources; and the date you agree to these terms of use."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:262
 #, python-format
-msgid ""
-"Each publisher who is a member of the Wikipedia Library program requires "
-"different specific information in the application. Some publishers may "
-"request only an email address, while others request more detailed data, such "
-"as your name, location, or institutional affiliation. When you complete your "
-"application, you will only be asked to supply information required by the "
-"publishers you have chosen, and each publisher will only receive the "
-"information they require for providing you with access. Please see our <a "
-"class=\"twl-links\" href=\"%(all_partners_url)s\">partner information</a> "
-"pages to learn what information is required by each publisher to gain access "
-"to their resources."
+msgid "Each publisher who is a member of the Wikipedia Library program requires different specific information in the application. Some publishers may request only an email address, while others request more detailed data, such as your name, location, or institutional affiliation. When you complete your application, you will only be asked to supply information required by the publishers you have chosen, and each publisher will only receive the information they require for providing you with access. Please see our <a class=\"twl-links\" href=\"%(all_partners_url)s\">partner information</a> pages to learn what information is required by each publisher to gain access to their resources."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Wikimedia Foundation should not be translated. Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:277
-msgid ""
-"Some Wikipedia Library pages are visible without logging in, but you will "
-"need to log in to apply or access proprietary partner resources. We use the "
-"data provided by you via OAuth and Wikimedia API calls to assess your "
-"application for access and to process approved requests."
+msgid "Some Wikipedia Library pages are visible without logging in, but you will need to log in to apply or access proprietary partner resources. We use the data provided by you via OAuth and Wikimedia API calls to assess your application for access and to process approved requests."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:288
 #, python-format
-msgid ""
-"In order to administer the Wikipedia Library program, we will retain the "
-"application data we collect from you for three years after your most recent "
-"login, unless you delete your account, as described below. You can log in "
-"and go to <a class=\"twl-links\" href=\"%(profile_url)s\">your profile page</"
-"a> in order to see the information associated with your account, and can "
-"download it in JSON format. You may access, update, restrict, or delete this "
-"information at any time, except for the information that is automatically "
-"retrieved from the projects. If you have any questions or concerns about the "
-"handling of your data, please contact <a class=\"twl-links\" href=\"mailto:"
-"wikipedialibrary@wikimedia.org?Subject=Wikipedia%%20Library%%20Card"
-"%%20account%%20deactivation\"> wikipedialibrary@wikimedia.org </a>."
+msgid "In order to administer the Wikipedia Library program, we will retain the application data we collect from you for three years after your most recent login, unless you delete your account, as described below. You can log in and go to <a class=\"twl-links\" href=\"%(profile_url)s\">your profile page</a> in order to see the information associated with your account, and can download it in JSON format. You may access, update, restrict, or delete this information at any time, except for the information that is automatically retrieved from the projects. If you have any questions or concerns about the handling of your data, please contact <a class=\"twl-links\" href=\"mailto:wikipedialibrary@wikimedia.org?Subject=Wikipedia%%20Library%%20Card%%20account%%20deactivation\"> wikipedialibrary@wikimedia.org </a>."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:305
-msgid ""
-"If you decide to disable your Wikipedia Library account, you can use the "
-"delete button on your profile to delete certain personal information "
-"associated with your account. We will delete your real name, institutional "
-"affiliation, and country of residence. Please note that the system will "
-"retain a record of your username, the publishers to which you applied or had "
-"access, and the dates of that access. Note that deletion is not reversible. "
-"Deletion of your Wikipedia Library account may also correspond with the "
-"removal of any resource access to which you were eligible or approved. If "
-"you request the deletion of account information and later wish to apply for "
-"a new account, you will need to provide the necessary information again."
+msgid "If you decide to disable your Wikipedia Library account, you can use the delete button on your profile to delete certain personal information associated with your account. We will delete your real name, institutional affiliation, and country of residence. Please note that the system will retain a record of your username, the publishers to which you applied or had access, and the dates of that access. Note that deletion is not reversible. Deletion of your Wikipedia Library account may also correspond with the removal of any resource access to which you were eligible or approved. If you request the deletion of account information and later wish to apply for a new account, you will need to provide the necessary information again."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). WMF should not be translated. Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:321
-msgid ""
-"The Wikipedia Library is run by WMF Staff, Contractors, and approved "
-"volunteer Coordinators. The data associated with your account will be shared "
-"with the WMF staff, contractors, service providers, and volunteer "
-"coordinators who need to process the information in connection with their "
-"work for the Wikipedia Library, and who are subject to confidentiality "
-"obligations. We will also use your data for internal Wikipedia Library "
-"purposes such as distributing user surveys and account notifications, and in "
-"a depersonalized or aggregated fashion for statistical analysis and "
-"administration. Finally, we will share your information with the publishers "
-"whom you specifically select in order to provide you with access to "
-"resources. Otherwise, your information will not be shared with third "
-"parties, with the exception of the circumstances described below."
+msgid "The Wikipedia Library is run by WMF Staff, Contractors, and approved volunteer Coordinators. The data associated with your account will be shared with the WMF staff, contractors, service providers, and volunteer coordinators who need to process the information in connection with their work for the Wikipedia Library, and who are subject to confidentiality obligations. We will also use your data for internal Wikipedia Library purposes such as distributing user surveys and account notifications, and in a depersonalized or aggregated fashion for statistical analysis and administration. Finally, we will share your information with the publishers whom you specifically select in order to provide you with access to resources. Otherwise, your information will not be shared with third parties, with the exception of the circumstances described below."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). WMF should not be translated.
 #: TWLight/users/templates/users/terms.html:338
-msgid ""
-"We may disclose any collected information when required by law, when we have "
-"your permission, when needed to protect our rights, privacy, safety, users, "
-"or the general public, and when necessary to enforce these terms, WMF’s "
-"general <a class=\"twl-links\" href=\"https://foundation.wikimedia.org/wiki/"
-"Terms_of_Use\">Terms of Use</a>, or any other WMF policy."
+msgid "We may disclose any collected information when required by law, when we have your permission, when needed to protect our rights, privacy, safety, users, or the general public, and when necessary to enforce these terms, WMF’s general <a class=\"twl-links\" href=\"https://foundation.wikimedia.org/wiki/Terms_of_Use\">Terms of Use</a>, or any other WMF policy."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:349
-msgid ""
-"We take the security of your personal data seriously, and take reasonable "
-"precautions to ensure your data is protected. These precautions include "
-"access controls to limit who has access to your data and security "
-"technologies to protect data stored on the server. However, we cannot "
-"guarantee the safety of your data as it is transmitted and stored."
+msgid "We take the security of your personal data seriously, and take reasonable precautions to ensure your data is protected. These precautions include access controls to limit who has access to your data and security technologies to protect data stored on the server. However, we cannot guarantee the safety of your data as it is transmitted and stored."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:360
-msgid ""
-"Please note that these terms do not control the use and handling of your "
-"data by the publishers and service providers whose resources you access or "
-"apply to access. Please read their individual privacy policies for that "
-"information."
+msgid "Please note that these terms do not control the use and handling of your data by the publishers and service providers whose resources you access or apply to access. Please read their individual privacy policies for that information."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
@@ -3393,34 +2856,17 @@ msgstr "Notenn a-bouez"
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Wikimedia Foundation should not be translated. Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:373
-msgid ""
-"The Wikimedia Foundation is a nonprofit organization based in San Francisco, "
-"California. The Wikipedia Library program provides access to resources held "
-"by publishers in multiple countries. If you apply for a Wikipedia Library "
-"account (whether you are inside or outside of the United States), you "
-"understand that your personal data will be collected, transferred, stored, "
-"processed, disclosed and otherwise used in the U.S. as described in this "
-"privacy policy. You also understand that your information may be transferred "
-"by us from the U.S. to other countries, which may have different or less "
-"stringent data protection laws than your country, in connection with "
-"providing services to you, including evaluating your application and "
-"securing access to your chosen publishers (locations for each publisher are "
-"outlined on their respective partner information pages)."
+msgid "The Wikimedia Foundation is a nonprofit organization based in San Francisco, California. The Wikipedia Library program provides access to resources held by publishers in multiple countries. If you apply for a Wikipedia Library account (whether you are inside or outside of the United States), you understand that your personal data will be collected, transferred, stored, processed, disclosed and otherwise used in the U.S. as described in this privacy policy. You also understand that your information may be transferred by us from the U.S. to other countries, which may have different or less stringent data protection laws than your country, in connection with providing services to you, including evaluating your application and securing access to your chosen publishers (locations for each publisher are outlined on their respective partner information pages)."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:392
-msgid ""
-"Please note that in the event of any differences in meaning or "
-"interpretation between the original English version of these terms and a "
-"translation, the original English version takes precedence."
+msgid "Please note that in the event of any differences in meaning or interpretation between the original English version of these terms and a translation, the original English version takes precedence."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Wikimedia Foundation should not be translated.
 #: TWLight/users/templates/users/terms.html:403
-msgid ""
-"See also the <a class=\"twl-links\" href=\"https://wikimediafoundation.org/"
-"wiki/Privacy_policy\">Wikimedia Foundation Privacy Policy</a>."
+msgid "See also the <a class=\"twl-links\" href=\"https://wikimediafoundation.org/wiki/Privacy_policy\">Wikimedia Foundation Privacy Policy</a>."
 msgstr ""
 
 #. Translators: This is the second to last line of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
@@ -3441,11 +2887,7 @@ msgstr "Niver a gemmoù war Wikipedia"
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:426
-msgid ""
-"By checking this box and clicking “Submit”, you agree that you have read the "
-"above terms and that you will adhere to the terms of use in your application "
-"to and use of the The Wikipedia Library, and the publishers’ services to "
-"which you gain access through The Wikipedia Library program."
+msgid "By checking this box and clicking “Submit”, you agree that you have read the above terms and that you will adhere to the terms of use in your application to and use of the The Wikipedia Library, and the publishers’ services to which you gain access through The Wikipedia Library program."
 msgstr ""
 
 #: TWLight/users/templates/users/user_collection_tile.html:32
@@ -3498,29 +2940,18 @@ msgstr "Dilemel an holl roadennoù"
 
 #. Translators: This message is displayed on the page where users can request the deletion of their data.
 #: TWLight/users/templates/users/user_confirm_delete.html:17
-msgid ""
-"<b>Warning:</b> Performing this action will delete your Wikipedia Library "
-"Card user account and all associated applications. This process is not "
-"reversible. You may lose any partner accounts you were granted, and will not "
-"be able to renew those accounts or apply for new ones."
+msgid "<b>Warning:</b> Performing this action will delete your Wikipedia Library Card user account and all associated applications. This process is not reversible. You may lose any partner accounts you were granted, and will not be able to renew those accounts or apply for new ones."
 msgstr ""
 
 #. Translators: this should show up for people who log in with a username/password and not OAuth, so we don't know what their Wikipedia identity is.
-#.
 #: TWLight/users/templates/users/user_detail.html:12
 #, python-format
-msgid ""
-"Hi, %(username)s! You don't have a Wikipedia editor profile attached to your "
-"account here, so you are probably a site administrator."
+msgid "Hi, %(username)s! You don't have a Wikipedia editor profile attached to your account here, so you are probably a site administrator."
 msgstr ""
 
 #. Translators: In the unlikely scenario that someone is able to register an account without using OAuth (thus leaving us without some of the information required for applications), users will see this message, encouraging them to re-register.
 #: TWLight/users/templates/users/user_detail.html:20
-msgid ""
-"If you aren't a site administrator, something weird has happened. You won't "
-"be able to apply for access without a Wikipedia editor profile. You should "
-"log out and create a new account by logging in via OAuth, or contact a site "
-"administrator for help."
+msgid "If you aren't a site administrator, something weird has happened. You won't be able to apply for access without a Wikipedia editor profile. You should log out and create a new account by logging in via OAuth, or contact a site administrator for help."
 msgstr ""
 
 #. Translators: Labels a sections where coordinators can select their email preferences.
@@ -3531,17 +2962,12 @@ msgstr ""
 #. Translators: This message is shown on user's own profile page, encouraging them to make sure their information is up to date, so that account coordinators can use the information to judge applications.
 #: TWLight/users/views.py:176
 #, python-brace-format
-msgid ""
-"Please <a class='twl-links' href='{url}'>update your contributions</a> to "
-"Wikipedia to help coordinators evaluate your applications."
+msgid "Please <a class='twl-links' href='{url}'>update your contributions</a> to Wikipedia to help coordinators evaluate your applications."
 msgstr ""
 
 #. Translators: Coordinators are shown this message when they unselect all three types of reminder email options under preferences.
 #: TWLight/users/views.py:288
-msgid ""
-"You have chosen not to receive reminder emails. As a coordinator, you should "
-"receive at least one type of reminder emails, so consider changing your "
-"preferences."
+msgid "You have chosen not to receive reminder emails. As a coordinator, you should receive at least one type of reminder emails, so consider changing your preferences."
 msgstr ""
 
 #. Translators: Coordinators are shown this message when they make changes to their reminder email options under preferences.
@@ -3575,9 +3001,7 @@ msgstr ""
 
 #. Translators: If the user has not filled out their email, they can browse the website but cannot apply for access to resources.
 #: TWLight/users/views.py:487
-msgid ""
-"Your email is blank. You can still explore the site, but you won't be able "
-"to apply for access to partner resources without an email."
+msgid "Your email is blank. You can still explore the site, but you won't be able to apply for access to partner resources without an email."
 msgstr ""
 
 #. Translators: This message is shown once the access to a partner has successfully been returned.
@@ -3610,31 +3034,3 @@ msgstr "Stankadennoù oberiant ebet"
 msgid "10+ edits in the last 30 days"
 msgstr "10+ kemmoù e-kerzh an 30 devezh diwezhañ"
 
-#: tests/shunit/data/bad_i18n_comment_1.py:3
-#: tests/shunit/data/bad_i18n_newline_1.py:5
-msgid "1"
-msgstr ""
-
-#. Translators: Lorem ipsum dolor sit amet, consectetur adipiscing elit. Mauris vitae ipsum ut purus faucibus pretium. Proin tempus neque et aliquet consectetur. Ut egestas sapien in consectetur sagittis. Mauris neque lacus, dapibus non viverra vitae, interdum ut aenean ipsum.
-#. Translators: Lorem ipsum dolor sit amet, consectetur adipiscing elit. Mauris vitae ipsum ut purus faucibus pretium. Proin tempus neque et aliquet consectetur. Ut egestas sapien in consectetur sagittis. Mauris neque lacus, dapibus non.
-#: tests/shunit/data/bad_i18n_comment_2.py:4
-#: tests/shunit/data/bad_i18n_newline_2.py:5 tests/shunit/data/good_i18n_1.py:2
-#: tests/shunit/data/good_i18n_2.py:2
-msgid "2"
-msgstr ""
-
-#: tests/shunit/data/bad_i18n_newline_3.py:5
-msgid "3"
-msgstr ""
-
-#: tests/shunit/data/bad_i18n_newline_4.py:5
-msgid "4"
-msgstr ""
-
-#: tests/shunit/data/bad_i18n_newline_5.py:5
-msgid "5"
-msgstr ""
-
-#: tests/shunit/data/bad_i18n_newline_6.py:5
-msgid "6"
-msgstr ""

--- a/locale/ca/LC_MESSAGES/django.po
+++ b/locale/ca/LC_MESSAGES/django.po
@@ -15,10 +15,11 @@
 # Author: Xavier Dengra
 msgid ""
 msgstr ""
+""
 "Project-Id-Version: Wikipedia Library Card Platform - Website\n"
-"Report-Msgid-Bugs-To: wikipedialibrary@wikimedia.org\n"
+"Report-Msgid-Bugs-To: translatewiki.net\n"
 "POT-Creation-Date: 2024-07-11 20:54+0000\n"
-"PO-Revision-Date: 2024-07-11 12:30:13+0000\n"
+"PO-Revision-Date: 2024-07-15 12:29:13+0000\n"
 "Language: ca\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
@@ -50,13 +51,8 @@ msgstr "Quant a vós"
 #. Translators: This note appears in a section of a form where we ask users to enter info (like country of residence) when applying for resource access.
 #: TWLight/applications/forms.py:179
 #, python-brace-format
-msgid ""
-"<p><small><i>Your personal data will be processed according to our <a "
-"class='twl-links' href='{terms_url}'> privacy policy</a>.</i></small></p>"
-msgstr ""
-"<p><small><i>Les vostres dades personals seran processades d'acord amb la "
-"nostra <a class='twl-links' href='{terms_url}'>política de privadesa</a>.</"
-"i></small></p>"
+msgid "<p><small><i>Your personal data will be processed according to our <a class='twl-links' href='{terms_url}'> privacy policy</a>.</i></small></p>"
+msgstr "<p><small><i>Les vostres dades personals seran processades d'acord amb la nostra <a class='twl-links' href='{terms_url}'>política de privadesa</a>.</i></small></p>"
 
 #. Translators: This is the title of the application form page, where users enter information required for the application. It lets the user know which partner application they are entering data for. {partner}
 #: TWLight/applications/forms.py:189
@@ -92,18 +88,13 @@ msgstr "Confirmació de renovació"
 #. Translators: When filling out an application, users may be required to enter an email they have used to register on the partner's website.
 #: TWLight/applications/forms.py:329 TWLight/applications/helpers.py:97
 msgid "The email for your account on the partner's website"
-msgstr ""
-"El correu electrònic del vostre compte al lloc web del nostre col·laborador"
+msgstr "El correu electrònic del vostre compte al lloc web del nostre col·laborador"
 
 #. Translators: This labels a choice field where users will have to select the number of months they wish to have their access for as part of the application renewal confirmation.
 #. Translators: When filling out an application, users may be required to enter the length of the account (expiry) they wish to have for proxy partners.
 #: TWLight/applications/forms.py:339 TWLight/applications/helpers.py:100
-msgid ""
-"The number of months you wish to have this access for before renewal is "
-"required"
-msgstr ""
-"El nombre de mesos que desitgeu mantenir actiu el vostre accés institucional "
-"abans que la seva renovació sigui obligatòria"
+msgid "The number of months you wish to have this access for before renewal is required"
+msgstr "El nombre de mesos que desitgeu mantenir actiu el vostre accés institucional abans que la seva renovació sigui obligatòria"
 
 #. Translators: When filling out an application, users may need to specify their name
 #: TWLight/applications/helpers.py:81
@@ -138,8 +129,7 @@ msgstr "Quelcom més que desitgeu afegir"
 #. Translators: When filling out an application, users may be required to check a box to say they agree with the website's Terms of Use document, which is linked
 #: TWLight/applications/helpers.py:95
 msgid "You must agree with the partner's terms of use"
-msgstr ""
-"Heu d'acceptar obligatòriament les condicions d'ús del nostre col·laborador"
+msgstr "Heu d'acceptar obligatòriament les condicions d'ús del nostre col·laborador"
 
 #. Translators: When sending application data to partners, this is the text labelling a user's real name
 #. Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this labels the user's real name.
@@ -192,13 +182,8 @@ msgstr "Adreça electrònica"
 
 #. Translators: This comment is added to pending applications when our terms of use change.
 #: TWLight/applications/management/commands/notify_applicants_tou_changes.py:54
-msgid ""
-"Our terms of use have changed. Your applications will not be processed until "
-"you log in and agree to our updated terms."
-msgstr ""
-"Les nostres condicions d'ús han canviat. La vostra sol·licitud no serà "
-"processada fins que no inicieu la vostra sessió i n'accepteu les "
-"actualitzacions."
+msgid "Our terms of use have changed. Your applications will not be processed until you log in and agree to our updated terms."
+msgstr "Les nostres condicions d'ús han canviat. La vostra sol·licitud no serà processada fins que no inicieu la vostra sessió i n'accepteu les actualitzacions."
 
 #. Translators: This is the status of an application that has not yet been reviewed.
 #: TWLight/applications/models.py:54
@@ -264,43 +249,26 @@ msgstr "URL d'accés: {access_url}"
 
 #. Translators: This text goes into account approval emails in the case that we need to send the user's details to a publisher for manual account setup.
 #: TWLight/applications/models.py:331
-msgid ""
-"You can expect to receive access details within a week or two once it has "
-"been processed."
-msgstr ""
-"Normalment rebràs els detalls d'accés una o dues setmanes després de que es "
-"processin"
+msgid "You can expect to receive access details within a week or two once it has been processed."
+msgstr "Normalment rebràs els detalls d'accés una o dues setmanes després de que es processin"
 
 #. Translators: This comment is added to open applications when a partner joins the Library Bundle, which does not require applications.
 #: TWLight/applications/signals.py:247
-msgid ""
-"This partner joined the Library Bundle, which does not require applications. "
-"This application will be marked as invalid."
-msgstr ""
-"Aquest col·laborador s'ha unit al nostre Paquet Institucional, que no "
-"necessita cap sol·licitud. La sol·licitud serà marcada com a invàlida."
+msgid "This partner joined the Library Bundle, which does not require applications. This application will be marked as invalid."
+msgstr "Aquest col·laborador s'ha unit al nostre Paquet Institucional, que no necessita cap sol·licitud. La sol·licitud serà marcada com a invàlida."
 
 #. Translators: This is shown to users if the application is to a partner for which we have run out of available accounts. The application is therefore on a 'waitlist', and will be reviewed when more accounts are available.
 #: TWLight/applications/templates/applications/application_evaluation.html:29
-msgid ""
-"This application is on the waitlist because this partner does not have any "
-"access grants available at this time."
-msgstr ""
-"Aquesta sol·licitud roman a la llista d'espera perquè aquest col·laborador "
-"no té cap mitjà d'accés disponible ara mateix."
+msgid "This application is on the waitlist because this partner does not have any access grants available at this time."
+msgstr "Aquesta sol·licitud roman a la llista d'espera perquè aquest col·laborador no té cap mitjà d'accés disponible ara mateix."
 
 #. Translators: This message is shown on pages where coordinators can see personal information about applicants.
 #: TWLight/applications/templates/applications/application_evaluation.html:36
 #: TWLight/applications/templates/applications/application_list_include.html:6
 #: TWLight/applications/templates/applications/send_partner.html:45
 #: TWLight/resources/templates/resources/partner_users.html:18
-msgid ""
-"Coordinators: This page may contain personal information such as real names "
-"and email addresses. Please remember that this information is confidential."
-msgstr ""
-"Coordinadors: Aquesta pàgina pot contenir dades personals com ara noms reals "
-"i adreces de correu electrònic. Si us plau, recordeu que tota aquesta "
-"informació és estrictament confidencial."
+msgid "Coordinators: This page may contain personal information such as real names and email addresses. Please remember that this information is confidential."
+msgstr "Coordinadors: Aquesta pàgina pot contenir dades personals com ara noms reals i adreces de correu electrònic. Si us plau, recordeu que tota aquesta informació és estrictament confidencial."
 
 #. Translators: This is the title of the application page shown to users who are a coordinator, and are able to accept or reject the application.
 #: TWLight/applications/templates/applications/application_evaluation.html:39
@@ -309,13 +277,8 @@ msgstr "Avalueu la sol·licitud"
 
 #. Translators: This text is shown to coordinators on application pages if the applicant has restricted processing of their data.
 #: TWLight/applications/templates/applications/application_evaluation.html:42
-msgid ""
-"This user has requested a restriction on the processing of their data, so "
-"you cannot change the status of their application."
-msgstr ""
-"Aquest usuari ha sol·licitat una restricció en el procés de la seva "
-"informació personal, per la qual cosa no podeu canviar l'estatus de la seva "
-"petició."
+msgid "This user has requested a restriction on the processing of their data, so you cannot change the status of their application."
+msgstr "Aquest usuari ha sol·licitat una restricció en el procés de la seva informació personal, per la qual cosa no podeu canviar l'estatus de la seva petició."
 
 #. Translators: This is the title of the application page shown to users who are not a coordinator.
 #: TWLight/applications/templates/applications/application_evaluation.html:48
@@ -388,12 +351,8 @@ msgstr "Desconegut"
 
 #. Translators: This is the text displayed to coordinators when an applicant has no country of residence in their profile.
 #: TWLight/applications/templates/applications/application_evaluation.html:123
-msgid ""
-"Please request the applicant add their country of residence to their profile "
-"before proceeding further."
-msgstr ""
-"Si us plau, demaneu al sol·licitant que afegeixi el seu país de residència "
-"al perfil abans de continuar més enllà."
+msgid "Please request the applicant add their country of residence to their profile before proceeding further."
+msgstr "Si us plau, demaneu al sol·licitant que afegeixi el seu país de residència al perfil abans de continuar més enllà."
 
 #. Translators: This labels the section of an application showing the total number of accounts available for a partner or their collection.
 #: TWLight/applications/templates/applications/application_evaluation.html:134
@@ -403,12 +362,8 @@ msgstr "Comptes disponibles"
 #. Translators: This labels the section of an application showing whether the user had agreed to the terms of use or not.
 #: TWLight/applications/templates/applications/application_evaluation.html:145
 #, python-format
-msgid ""
-"Has agreed to the site's <a class=\"twl-links\" href=\"%(terms_url)s\">terms "
-"of use</a>?"
-msgstr ""
-"Ha acceptat les <a class=\"twl-links\" href=\"%(terms_url)s\">condicions "
-"d'ús</a> del lloc?"
+msgid "Has agreed to the site's <a class=\"twl-links\" href=\"%(terms_url)s\">terms of use</a>?"
+msgstr "Ha acceptat les <a class=\"twl-links\" href=\"%(terms_url)s\">condicions d'ús</a> del lloc?"
 
 #. Translators: Displayed to coordinators when they've agreed to the terms of use.
 #. Translators: Displayed if the user has agreed to the terms of use.
@@ -443,12 +398,8 @@ msgstr "No"
 
 #. Translators: This is the text displayed to coordinators when an applicant has not agreed to the terms of use.
 #: TWLight/applications/templates/applications/application_evaluation.html:159
-msgid ""
-"Please request the applicant agree to the site's terms of use before "
-"approving this application."
-msgstr ""
-"Si us plau, demaneu al sol·licitant que accepti les condicions d'ús del lloc "
-"web abans d'aprovar la seua petició."
+msgid "Please request the applicant agree to the site's terms of use before approving this application."
+msgstr "Si us plau, demaneu al sol·licitant que accepti les condicions d'ús del lloc web abans d'aprovar la seua petició."
 
 #. Translators: This labels the section of an application containing the user's motivation for wanting access to this resource.
 #: TWLight/applications/templates/applications/application_evaluation.html:176
@@ -468,10 +419,8 @@ msgstr "Renovació de l'accés institucional existent?"
 #. Translators: This message is shown next to the 'Renewal of existing access grant?' label if the application is a renewal. Don't translate HTML tags or parent_url.
 #: TWLight/applications/templates/applications/application_evaluation.html:195
 #, python-format
-msgid ""
-"Yes (<a class=\"twl-links\" href=\"%(parent_url)s\">previous application</a>)"
-msgstr ""
-"Sí (<a class=\"twl-links\" href=\"%(parent_url)s\">sol·licitud anterior</a>)"
+msgid "Yes (<a class=\"twl-links\" href=\"%(parent_url)s\">previous application</a>)"
+msgstr "Sí (<a class=\"twl-links\" href=\"%(parent_url)s\">sol·licitud anterior</a>)"
 
 #. Translators: This labels the section of the application showing the length of access remaining on the user's previous authorization.
 #: TWLight/applications/templates/applications/application_evaluation.html:208
@@ -491,8 +440,7 @@ msgstr "Peticions recents (últims 90 dies)"
 #. Translators: This text is shown to Coordinators when applicant has not made any application in the last 90 days.
 #: TWLight/applications/templates/applications/application_evaluation.html:264
 msgid "No applications were made in last 90 days by the applicant"
-msgstr ""
-"El sol·licitant no ha realitzat cap sol·licitud durant els darrers 90 dies"
+msgstr "El sol·licitant no ha realitzat cap sol·licitud durant els darrers 90 dies"
 
 #. Translators: This is the title of the section of an application page which contains the comment thread between the user and account coordinator.
 #: TWLight/applications/templates/applications/application_evaluation.html:268
@@ -506,12 +454,8 @@ msgstr "Afegeix un comentari"
 
 #. Translators: On an application page, this text tells users that the comments posted on the application are visible to coordinators and the submitting user only.
 #: TWLight/applications/templates/applications/application_evaluation.html:297
-msgid ""
-"Comments are visible to all coordinators and to the editor who submitted "
-"this application."
-msgstr ""
-"Els comentaris són visibles per a tot l'equip de coordinació i per al "
-"viquipedista que ha presentat la sol·licitud."
+msgid "Comments are visible to all coordinators and to the editor who submitted this application."
+msgstr "Els comentaris són visibles per a tot l'equip de coordinació i per al viquipedista que ha presentat la sol·licitud."
 
 #. Translators: This is the title of the section of an application page which lists information about the user who submitted the application.
 #. Translators: On the page where coordinators can view data on applications to a partner they coordinate, this is a table column heading for the username.
@@ -722,27 +666,14 @@ msgstr "Fixa l'estat"
 
 #: TWLight/applications/templates/applications/apply.html:20
 #, python-format
-msgid ""
-"If your application is successful we may share your email address with "
-"%(partner)s. This is required to set up your access to their resources. By "
-"submitting this form you agree to allow your email address to be shared with "
-"%(partner)s if your application is successful, for the purposes of account "
-"setup."
-msgstr ""
-"Si la vostra sol·licitud té èxit, probablement haguem de compartir la vostra "
-"adreça de correu electrònic amb els nostres %(partner)s. Això és necessari a "
-"fi i efecte de programar l'accés als seus continguts. Quan empleneu aquest "
-"formulari, accepteu que el vostre correu electrònic es comparteixi amb els "
-"%(partner)s en cas que la vostra sol·licitud sigui acceptada i per a "
-"propòsits d'activació de la subscripció."
+msgid "If your application is successful we may share your email address with %(partner)s. This is required to set up your access to their resources. By submitting this form you agree to allow your email address to be shared with %(partner)s if your application is successful, for the purposes of account setup."
+msgstr "Si la vostra sol·licitud té èxit, probablement haguem de compartir la vostra adreça de correu electrònic amb els nostres %(partner)s. Això és necessari a fi i efecte de programar l'accés als seus continguts. Quan empleneu aquest formulari, accepteu que el vostre correu electrònic es comparteixi amb els %(partner)s en cas que la vostra sol·licitud sigui acceptada i per a propòsits d'activació de la subscripció."
 
 #. Translators: This message is displayed on the page where users can confirm their renewal. Please do not translate partner.
 #: TWLight/applications/templates/applications/confirm_renewal.html:23
 #, python-format
 msgid "Click 'confirm' to renew your application for %(partner)s"
-msgstr ""
-"Seleccioneu «Confirma» per tal de renovar la teva petició d'accés per a "
-"%(partner)s"
+msgstr "Seleccioneu «Confirma» per tal de renovar la teva petició d'accés per a %(partner)s"
 
 #. Translators: Labels the submit button requesting confirmation of application renewal.
 #. Translators: This is the button coordinators click to confirm deletion of a suggestion.
@@ -764,12 +695,8 @@ msgstr "A quins recursos bibliogràfics voleu tenir accés?"
 
 #. Translators: This text explains that Library Bundle partners are not shown in this list.
 #: TWLight/applications/templates/applications/request_for_application.html:26
-msgid ""
-"Library Bundle partners are not shown as eligibility is determined "
-"automatically."
-msgstr ""
-"Els col·laboradors del Paquet Institucional no us apareixen atès que la "
-"vostra elegibilitat per a accedir-hi és valorada automàticament."
+msgid "Library Bundle partners are not shown as eligibility is determined automatically."
+msgstr "Els col·laboradors del Paquet Institucional no us apareixen atès que la vostra elegibilitat per a accedir-hi és valorada automàticament."
 
 #. Translators: On the page where users can apply for multiple partners, this message shows next to the partner name, taking them to the full application page when clicked.
 #: TWLight/applications/templates/applications/request_for_application.html:48
@@ -783,15 +710,8 @@ msgstr "No s'ha afegit encara cap dada dels col·laboradors."
 
 #. Translators: the HTML is so that the word 'waitlisted' will look the same as it does in the page above; please translate 'waitlisted' the same way you did elsewhere in this file.
 #: TWLight/applications/templates/applications/request_for_application.html:74
-msgid ""
-"You can apply to <span class=\"badge badge-warning\">Waitlisted</span> "
-"partners, but they don't have access grants available right now. We will "
-"process those applications when access becomes available."
-msgstr ""
-"Podeu sol·licitar l'opció del contingut de col·laboradors <span class="
-"\"badge badge-warning\"> en llista d'espera</span>, malgrat que no tenen més "
-"accessos disponibles a hores d'ara. Processarem totes aquestes sol·licituds "
-"tan bon punt els puguem assegurar disponibilitat d'accés."
+msgid "You can apply to <span class=\"badge badge-warning\">Waitlisted</span> partners, but they don't have access grants available right now. We will process those applications when access becomes available."
+msgstr "Podeu sol·licitar l'opció del contingut de col·laboradors <span class=\"badge badge-warning\"> en llista d'espera</span>, malgrat que no tenen més accessos disponibles a hores d'ara. Processarem totes aquestes sol·licituds tan bon punt els puguem assegurar disponibilitat d'accés."
 
 #. Translators: On the page where coordinators can see approved applications which have not had their details sent to the partner, this message shows when there are applications ready to be processed.
 #: TWLight/applications/templates/applications/send.html:10
@@ -801,8 +721,7 @@ msgstr "Col·laboradors amb sol·licituds aprovades i no trameses"
 #. Translators: On the page where coordinators can see approved applications which have not had their details sent to the partner, this message shows when no such applications exist or all have already been sent.
 #: TWLight/applications/templates/applications/send.html:23
 msgid "There are no partners with applications ready to send."
-msgstr ""
-"No hi ha col·laboradors amb sol·licituds enllestides per a ser trameses."
+msgstr "No hi ha col·laboradors amb sol·licituds enllestides per a ser trameses."
 
 #. Translators: When viewing the list of applications ready to be sent for a particular partner, this is the title of the page, where object will be the name of the partner. Don't translate object.
 #: TWLight/applications/templates/applications/send_partner.html:40
@@ -813,20 +732,13 @@ msgstr "Dades de la sol·licitud per a %(object)s"
 #. Translators: This message is shown when applications exceed the number of accounts available.
 #: TWLight/applications/templates/applications/send_partner.html:54
 #, python-format
-msgid ""
-"Application(s) for %(object)s, if sent, will exceed the total available "
-"accounts for the partner. Please proceed at your own discretion."
-msgstr ""
-"Les sol·licituds per a %(object)s, en cas d'ésser trameses, superaran el "
-"total d'accessos disponibles proporcionats per aquest col·laborador. Si us "
-"plau, gestioneu-ho com millor us sembli."
+msgid "Application(s) for %(object)s, if sent, will exceed the total available accounts for the partner. Please proceed at your own discretion."
+msgstr "Les sol·licituds per a %(object)s, en cas d'ésser trameses, superaran el total d'accessos disponibles proporcionats per aquest col·laborador. Si us plau, gestioneu-ho com millor us sembli."
 
 #. Translators: When viewing the list of applications ready to be sent for a particular partner, this is instructions for the coordinator to click the 'mark as sent' button after they have sent the information.
 #: TWLight/applications/templates/applications/send_partner.html:65
 msgid "When you've processed the data below, click the 'mark as sent' button."
-msgstr ""
-"Quan hagueu processat les dades següents, feu clic al botó «Marca com a "
-"tramès»."
+msgstr "Quan hagueu processat les dades següents, feu clic al botó «Marca com a tramès»."
 
 #. Translators: When viewing the list of applications ready to be sent for a particular partner, this is the title of the section containing contact information for the people applications should be sent to.
 #: TWLight/applications/templates/applications/send_partner.html:71
@@ -837,12 +749,8 @@ msgstr[1] "Contactes"
 
 #. Translators: When viewing the list of applications ready to be sent for a particular partner, this message shows if there is no information about who the applications should be sent to. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/applications/templates/applications/send_partner.html:89
-msgid ""
-"Whoops, we don't have any listed contacts. Please notify Wikipedia Library "
-"administrators."
-msgstr ""
-"Vaja, no tenim cap llista de contactes. Si us plau, notifiqueu-ho a un "
-"coordinador de la Biblioteca de la Viquipèdia."
+msgid "Whoops, we don't have any listed contacts. Please notify Wikipedia Library administrators."
+msgstr "Vaja, no tenim cap llista de contactes. Si us plau, notifiqueu-ho a un coordinador de la Biblioteca de la Viquipèdia."
 
 #. Translators: When viewing the list of applications ready to be sent for a particular partner, this is the title of the section containing the information about those applications.
 #: TWLight/applications/templates/applications/send_partner.html:94
@@ -857,13 +765,8 @@ msgstr "Marca com a llegit"
 
 #. Translators: This text guides coordinators in using the code sending interface for approved applications.
 #: TWLight/applications/templates/applications/send_partner.html:152
-msgid ""
-"Use the dropdown menus to denote which editor will receive each code. Access "
-"codes will be sent to users automatically."
-msgstr ""
-"Utilitzeu els menús desplegables per a concretar quin viquipedista tindrà "
-"accés a quin codi d'accés concret. Aquests codis s'enviaran automàticament "
-"als viquipedistes."
+msgid "Use the dropdown menus to denote which editor will receive each code. Access codes will be sent to users automatically."
+msgstr "Utilitzeu els menús desplegables per a concretar quin viquipedista tindrà accés a quin codi d'accés concret. Aquests codis s'enviaran automàticament als viquipedistes."
 
 #. Translators: This labels a drop-down selection where staff can assign an access code to a user.
 #: TWLight/applications/templates/applications/send_partner.html:173
@@ -878,25 +781,14 @@ msgstr "No hi ha cap sol·licitud aprovada pendent de tramitar."
 #. Translators: When a user applies for a set of resources, they receive this message if none are currently available. They are instead placed on a 'waitlist' for later approval.
 #. Translators: When a user renews their resource, they receive this message if none are currently available. They are instead placed on a 'waitlist' for later approval.
 #: TWLight/applications/views.py:140 TWLight/applications/views.py:1282
-msgid ""
-"This partner does not have any access grants available at this time. You may "
-"still apply for access; your application will be reviewed when access grants "
-"become available."
-msgstr ""
-"Aquest col·laborador no té cap més accés institucional disponible a hores "
-"d'ara. Podeu sol·licitar-lo igualment, per bé que no es revisarà fins que el "
-"col·laborador n'hagi proporcionat més a disposició dels viquipedistes."
+msgid "This partner does not have any access grants available at this time. You may still apply for access; your application will be reviewed when access grants become available."
+msgstr "Aquest col·laborador no té cap més accés institucional disponible a hores d'ara. Podeu sol·licitar-lo igualment, per bé que no es revisarà fins que el col·laborador n'hagi proporcionat més a disposició dels viquipedistes."
 
 #. Translators: This message is shown to users once they've successfully submitted their application for review.
 #: TWLight/applications/views.py:163
 #, python-brace-format
-msgid ""
-"Your application has been submitted for review. Head over to <a "
-"href='{applications_url}'>My Applications</a> to view the status."
-msgstr ""
-"La vostra sol·licitud ha estat tramesa correctament a l'espera d'ésser "
-"revisada. Feu clic a <a href='{applications_url}'>Les meves sol·licituds</a> "
-"per a veure'n l'estat."
+msgid "Your application has been submitted for review. Head over to <a href='{applications_url}'>My Applications</a> to view the status."
+msgstr "La vostra sol·licitud ha estat tramesa correctament a l'espera d'ésser revisada. Feu clic a <a href='{applications_url}'>Les meves sol·licituds</a> per a veure'n l'estat."
 
 #. Translators: This text is displayed to users when the user has chosen to restrict data and is trying to apply for multiple partners
 #: TWLight/applications/views.py:276
@@ -944,23 +836,13 @@ msgstr "Sol·licituds enviades"
 
 #. Translators: After a coordinator has changed the status of an application to APPROVED, if the corresponding partner/collection is waitlisted this message appears.
 #: TWLight/applications/views.py:756
-msgid ""
-"Cannot approve application as partner with proxy authorization method is "
-"waitlisted."
-msgstr ""
-"No es pot aprovar la sol·licitud atès que aquest col·laborador (que empra "
-"autoritzacions per mitjà de servidors intermediaris) roman en llista "
-"d'espera."
+msgid "Cannot approve application as partner with proxy authorization method is waitlisted."
+msgstr "No es pot aprovar la sol·licitud atès que aquest col·laborador (que empra autoritzacions per mitjà de servidors intermediaris) roman en llista d'espera."
 
 #. Translators: After a coordinator has changed the status of an application to APPROVED, if the corresponding partner/collection has no accounts for distribution, this message appears.
 #: TWLight/applications/views.py:780
-msgid ""
-"Cannot approve application as partner with proxy authorization method is "
-"waitlisted and (or) has zero accounts available for distribution."
-msgstr ""
-"No es pot aprovar la sol·licitud atès que aquest col·laborador (que empra "
-"autoritzacions per mitjà de servidors intermediaris) roman en llista "
-"d'espera o no té cap més accés disponible per oferir."
+msgid "Cannot approve application as partner with proxy authorization method is waitlisted and (or) has zero accounts available for distribution."
+msgstr "No es pot aprovar la sol·licitud atès que aquest col·laborador (que empra autoritzacions per mitjà de servidors intermediaris) roman en llista d'espera o no té cap més accés disponible per oferir."
 
 #. Translators: This message appears on an "access denied" screen that stops users who attempt to authorize an editor to access a resource during a time period for which they are already authorized.
 #: TWLight/applications/views.py:803
@@ -970,18 +852,8 @@ msgstr "Heu intentat crear una autorització duplicada."
 #. Translators: This message is shown to users when they access an application page of a now Bundle partner (new applications aren't allowed for Bundle partners and the status of old applications cannot be modified)
 #: TWLight/applications/views.py:857
 #, python-brace-format
-msgid ""
-"This application cannot be modified since this partner is now part of our <a "
-"href='{bundle}'>bundle access</a>. If you are eligible, you can access this "
-"resource from <a href='{library}'>your library</a>. <a "
-"href='{contact}'>Contact us</a> if you have any questions."
-msgstr ""
-"Aquesta sol·licitud no pot ésser modificada puix que el nostre col·laborador "
-"ara ha passat a formar part del nostre <a href='{bundle}'>Paquet "
-"Institucional</a>. Si sou elegible per a accedir a aquest recurs "
-"bibliogràfic, podeu consultar-lo a través de <a href='{library}'>la vostra "
-"biblioteca</a>. <a href='{contact}'>Envieu-nos un missatge</a> si teniu cap "
-"dubte."
+msgid "This application cannot be modified since this partner is now part of our <a href='{bundle}'>bundle access</a>. If you are eligible, you can access this resource from <a href='{library}'>your library</a>. <a href='{contact}'>Contact us</a> if you have any questions."
+msgstr "Aquesta sol·licitud no pot ésser modificada puix que el nostre col·laborador ara ha passat a formar part del nostre <a href='{bundle}'>Paquet Institucional</a>. Si sou elegible per a accedir a aquest recurs bibliogràfic, podeu consultar-lo a través de <a href='{library}'>la vostra biblioteca</a>. <a href='{contact}'>Envieu-nos un missatge</a> si teniu cap dubte."
 
 #. Translators: this lets a reviewer set the status of a single application.
 #: TWLight/applications/views.py:873
@@ -990,12 +862,8 @@ msgstr "Marca un estat de la sol·licitud"
 
 #. Translators: This warning is message is shown to applicants when the number of pending applications is greater than the number of accounts available.
 #: TWLight/applications/views.py:891
-msgid ""
-"There are more pending applications than available accounts. Your "
-"application might get waitlisted."
-msgstr ""
-"Hi ha més sol·licituds pendents que accessos disponibles. La vostra petició "
-"romandrà en llista d'espera."
+msgid "There are more pending applications than available accounts. Your application might get waitlisted."
+msgstr "Hi ha més sol·licituds pendents que accessos disponibles. La vostra petició romandrà en llista d'espera."
 
 #. Translators: this message is shown to coordinators who attempt to change an application's Status from INVALID to any other Status.
 #: TWLight/applications/views.py:904
@@ -1014,17 +882,8 @@ msgstr "El lot de sol·licituds {} s'ha actualitzat amb èxit."
 
 #. Translators: After a coordinator has changed the status of a number of applications to APPROVED, if the corresponding partner(s) is/are waitlisted or has no accounts for distribution, this message appears.
 #: TWLight/applications/views.py:1051
-msgid ""
-"Cannot approve application(s) {} as partner(s) with proxy authorization "
-"method is/are waitlisted and (or) has/have not enough accounts available. If "
-"not enough accounts are available, prioritise the applications and then "
-"approve applications equal to the accounts available."
-msgstr ""
-"No es pot aprovar la sol·licitud {} atès que el sistema d'autorització per "
-"servidor intermediari del(s) nostre(s) col·laborador(s) es troba en llista "
-"d'espera o no té prous codis d'accés disponibles per als viquipedistes. Si "
-"és per aquest segon motiu, si us plau prioritzeu les sol·licituds com creieu "
-"més adient i aproveu-ne només tantes com n'hi hagi de disponibles."
+msgid "Cannot approve application(s) {} as partner(s) with proxy authorization method is/are waitlisted and (or) has/have not enough accounts available. If not enough accounts are available, prioritise the applications and then approve applications equal to the accounts available."
+msgstr "No es pot aprovar la sol·licitud {} atès que el sistema d'autorització per servidor intermediari del(s) nostre(s) col·laborador(s) es troba en llista d'espera o no té prous codis d'accés disponibles per als viquipedistes. Si és per aquest segon motiu, si us plau prioritzeu les sol·licituds com creieu més adient i aproveu-ne només tantes com n'hi hagi de disponibles."
 
 #. Translators: This message is shown to coordinators who attempt to assign the same access code to multiple users.
 #: TWLight/applications/views.py:1191
@@ -1034,18 +893,12 @@ msgstr "Error: Codi utilitzat moltes vegades."
 #. Translators: After a coordinator has marked a number of applications as 'sent', this message appears.
 #: TWLight/applications/views.py:1241
 msgid "All selected applications have been marked as sent."
-msgstr ""
-"Totes les sol·licituds seleccionades han estat marcades com a trameses."
+msgstr "Totes les sol·licituds seleccionades han estat marcades com a trameses."
 
 #. Translators: When a user tries to renew their resource, they receive this message if the partner is not available.
 #: TWLight/applications/views.py:1272
-msgid ""
-"Cannot renew application at this time as partner is not available. Please "
-"check back later, or contact us for more information."
-msgstr ""
-"No es pot renovar la sol·licitud perquè aquest col·laborador no està "
-"disponible. Si us plau proveu-ho més tard o contacteu-nos per a més "
-"informació."
+msgid "Cannot renew application at this time as partner is not available. Please check back later, or contact us for more information."
+msgstr "No es pot renovar la sol·licitud perquè aquest col·laborador no està disponible. Si us plau proveu-ho més tard o contacteu-nos per a més informació."
 
 #. Translators: This message is displayed when an attempt by a user to renew an application has been denied for some reason.
 #: TWLight/applications/views.py:1308
@@ -1055,21 +908,13 @@ msgstr "L'intent de renovar la sol·licitud no aprovada #{pk} ha estat denegada"
 
 #. Translators: If a user requests the renewal of their account, but it wasn't renewed, this message is shown to them.
 #: TWLight/applications/views.py:1385
-msgid ""
-"This object cannot be renewed. (This probably means that you have already "
-"requested that it be renewed.)"
-msgstr ""
-"Aquest element no pot ser renovat (probablement perquè ja heu demanat que "
-"sigui renovat)."
+msgid "This object cannot be renewed. (This probably means that you have already requested that it be renewed.)"
+msgstr "Aquest element no pot ser renovat (probablement perquè ja heu demanat que sigui renovat)."
 
 #. Translators: If a user requests the renewal of their account, this message is shown to them.
 #: TWLight/applications/views.py:1395
-msgid ""
-"Your renewal request has been received. A coordinator will review your "
-"request."
-msgstr ""
-"La vostra petició de renovació ha estat rebuda correctament. Un coordinador "
-"revisarà la vostra sol·licitud."
+msgid "Your renewal request has been received. A coordinator will review your request."
+msgstr "La vostra petició de renovació ha estat rebuda correctament. Un coordinador revisarà la vostra sol·licitud."
 
 #. Translators: This labels a textfield where users can enter their email ID.
 #: TWLight/emails/forms.py:18
@@ -1078,13 +923,8 @@ msgstr "El teu correu electrònic"
 
 #. Translators: This is the help text for the email field in the contact us form letting users know the field is updated by value pulled from their respective user profiles.
 #: TWLight/emails/forms.py:21
-msgid ""
-"This field is automatically updated with the email from your <a class='twl-"
-"links' href='{}'>user profile</a>."
-msgstr ""
-"Aquest camp s'actualitza automàticament amb el correu electrònic "
-"proporcionat al <a class='twl-links' href='{}'>vostre perfil de "
-"viquipedista</a>."
+msgid "This field is automatically updated with the email from your <a class='twl-links' href='{}'>user profile</a>."
+msgstr "Aquest camp s'actualitza automàticament amb el correu electrònic proporcionat al <a class='twl-links' href='{}'>vostre perfil de viquipedista</a>."
 
 #. Translators: This labels a textfield where users can enter their email message.
 #: TWLight/emails/forms.py:26
@@ -1107,26 +947,14 @@ msgstr "Envia"
 #. Translators: This email is sent to users with their access code. Don't translate Jinja variables in curly braces like user or partner. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/access_code_email-body-html.html:5
 #, python-format
-msgid ""
-"<p>Your approved application to %(partner)s has now been finalised. Your "
-"access code or login details can be found below:</p> <p><b>%(access_code)s</"
-"b></p> <p>%(user_instructions)s</p>"
-msgstr ""
-"<p>La sol·licitud aprovada per accedir a %(partner)s ha finalitzat. El "
-"vostre codi d'accés o detalls d'inici de sessió són els següents:</p> <p><b>"
-"%(access_code)s</b></p> <p>%(user_instructions)s</p>"
+msgid "<p>Your approved application to %(partner)s has now been finalised. Your access code or login details can be found below:</p> <p><b>%(access_code)s</b></p> <p>%(user_instructions)s</p>"
+msgstr "<p>La sol·licitud aprovada per accedir a %(partner)s ha finalitzat. El vostre codi d'accés o detalls d'inici de sessió són els següents:</p> <p><b>%(access_code)s</b></p> <p>%(user_instructions)s</p>"
 
 #. Translators: This email is sent to users with their access code. Don't translate Jinja variables in curly braces like user or partner. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/access_code_email-body-text.html:3
 #, python-format
-msgid ""
-"Your approved application to %(partner)s has now been finalised. Your access "
-"code or login details can be found below: %(access_code)s "
-"%(user_instructions)s"
-msgstr ""
-"La vostra sol·licitud aprovada per accedir a %(partner)s ha finalitzat. El "
-"vostre codi d'accés o detalls d'inici de sessió són els següents: "
-"%(access_code)s %(user_instructions)s"
+msgid "Your approved application to %(partner)s has now been finalised. Your access code or login details can be found below: %(access_code)s %(user_instructions)s"
+msgstr "La vostra sol·licitud aprovada per accedir a %(partner)s ha finalitzat. El vostre codi d'accés o detalls d'inici de sessió són els següents: %(access_code)s %(user_instructions)s"
 
 #. Translators: This is the subject line of an email sent to users with their access code.
 #: TWLight/emails/templates/emails/access_code_email-subject.html:3
@@ -1136,148 +964,76 @@ msgstr "El teu codi d'accés de la Biblioteca de la Viquipèdia"
 #. Translators: This email is sent to users when their application is approved. Don't translate Jinja variables in curly braces like user or partner; don't translate html tags either. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/approval_notification-body-html.html:5
 #, python-format
-msgid ""
-"<p>Dear %(user)s,</p> <p>Thank you for applying for access to %(partner)s "
-"resources through The Wikipedia Library. We are happy to inform you that "
-"your application has been approved.</p> <p>%(user_instructions)s</p> <p>You "
-"can view the collections you're authorized to access at My Library: "
-"%(link)s</p> <p>Cheers!</p> <p>The Wikipedia Library</p>"
-msgstr ""
-"<p>Viquipedista %(user)s,</p> <p>Us agraïm la vostra sol·licitud per accedir "
-"als recursos bibliogràfics de %(partner)s a través de la Biblioteca de la "
-"Viquipèdia. Ens satisfà immensament d'informar-vos que la vostra petició ha "
-"estat aprovada.</p> <p>%(user_instructions)s</p> <p>Ja podeu navegar i "
-"consultar les col·leccions per a les quals heu rebut l'autorització a La "
-"meva biblioteca: %(link)s</p> <p>Salut i Viquipèdia!</p> <p>La Biblioteca de "
-"la Viquipèdia</p>"
+msgid "<p>Dear %(user)s,</p> <p>Thank you for applying for access to %(partner)s resources through The Wikipedia Library. We are happy to inform you that your application has been approved.</p> <p>%(user_instructions)s</p> <p>You can view the collections you're authorized to access at My Library: %(link)s</p> <p>Cheers!</p> <p>The Wikipedia Library</p>"
+msgstr "<p>Viquipedista %(user)s,</p> <p>Us agraïm la vostra sol·licitud per accedir als recursos bibliogràfics de %(partner)s a través de la Biblioteca de la Viquipèdia. Ens satisfà immensament d'informar-vos que la vostra petició ha estat aprovada.</p> <p>%(user_instructions)s</p> <p>Ja podeu navegar i consultar les col·leccions per a les quals heu rebut l'autorització a La meva biblioteca: %(link)s</p> <p>Salut i Viquipèdia!</p> <p>La Biblioteca de la Viquipèdia</p>"
 
 #. Translators: This email is sent to users when their application is approved. Don't translate Jinja variables in curly braces like user or partner. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/approval_notification-body-text.html:3
 #, python-format
-msgid ""
-"Dear %(user)s, Thank you for applying for access to %(partner)s resources "
-"through The Wikipedia Library. We are happy to inform you that your "
-"application has been approved. %(user_instructions)s You can view the "
-"collections you're authorized to access at My Library: %(link)s Cheers! The "
-"Wikipedia Library"
-msgstr ""
-"Viquipedista %(user)s, Us agraïm la vostra sol·licitud per accedir als "
-"recursos bibliogràfics de %(partner)s a través de la Biblioteca de la "
-"Viquipèdia. Ens satisfà immensament d'informar-vos que la vostra petició ha "
-"estat aprovada. %(user_instructions)s Ja podeu navegar i consultar les "
-"col·leccions per a les quals heu rebut l'autorització a La meva biblioteca: "
-"%(link)s Salut i Viquipèdia! La Biblioteca de la Viquipèdia"
+msgid "Dear %(user)s, Thank you for applying for access to %(partner)s resources through The Wikipedia Library. We are happy to inform you that your application has been approved. %(user_instructions)s You can view the collections you're authorized to access at My Library: %(link)s Cheers! The Wikipedia Library"
+msgstr "Viquipedista %(user)s, Us agraïm la vostra sol·licitud per accedir als recursos bibliogràfics de %(partner)s a través de la Biblioteca de la Viquipèdia. Ens satisfà immensament d'informar-vos que la vostra petició ha estat aprovada. %(user_instructions)s Ja podeu navegar i consultar les col·leccions per a les quals heu rebut l'autorització a La meva biblioteca: %(link)s Salut i Viquipèdia! La Biblioteca de la Viquipèdia"
 
 #. Translators: This is the subject of an email which is sent to users when their application has been approved. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/approval_notification-subject.html:4
 msgid "Your Wikipedia Library application has been approved"
-msgstr ""
-"La vostra sol·licitud a la Biblioteca de la Viquipèdia ha estat aprovada"
+msgstr "La vostra sol·licitud a la Biblioteca de la Viquipèdia ha estat aprovada"
 
 #. Translators: This email is sent to coordinators when a comment is left on an application they are processing. Don't translate Jinja variables in curly braces like user or partner. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/comment_notification_coordinator-body-html.html:5
 #, python-format
-msgid ""
-"<p style=\"color: #500050\">%(submit_date)s - %(commenter)s</p> "
-"<blockquote><p>%(comment)s</p></blockquote> <p>Please reply to these at: <a "
-"href=\"%(app_url)s\">%(app_url)s</a></p> <p>Best,</p> <p>The Wikipedia "
-"Library</p>"
-msgstr ""
-"<p style=\"color: #500050\">%(submit_date)s - %(commenter)s</p> "
-"<blockquote><p>%(comment)s</p></blockquote> <p>Si us plau, respongueu a això "
-"a: <a href=\"%(app_url)s\">%(app_url)s</a></p> <p>Best,</p> <p>La Biblioteca "
-"de la Viquipèdia</p>"
+msgid "<p style=\"color: #500050\">%(submit_date)s - %(commenter)s</p> <blockquote><p>%(comment)s</p></blockquote> <p>Please reply to these at: <a href=\"%(app_url)s\">%(app_url)s</a></p> <p>Best,</p> <p>The Wikipedia Library</p>"
+msgstr "<p style=\"color: #500050\">%(submit_date)s - %(commenter)s</p> <blockquote><p>%(comment)s</p></blockquote> <p>Si us plau, respongueu a això a: <a href=\"%(app_url)s\">%(app_url)s</a></p> <p>Best,</p> <p>La Biblioteca de la Viquipèdia</p>"
 
 #. Translators: This email is sent to coordinators when a comment is left on an application they are processing. Don't translate Jinja variables in curly braces like user or partner. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/comment_notification_coordinator-body-text.html:3
 #, python-format
-msgid ""
-"%(submit_date)s - %(commenter)s %(comment)s Please reply to this at: "
-"%(app_url)s Best, The Wikipedia Library"
-msgstr ""
-"%(submit_date)s - %(commenter)s %(comment)s Si us plau, respongueu a això a: "
-"%(app_url)s Salutacions, la Biblioteca de la Viquipèdia"
+msgid "%(submit_date)s - %(commenter)s %(comment)s Please reply to this at: %(app_url)s Best, The Wikipedia Library"
+msgstr "%(submit_date)s - %(commenter)s %(comment)s Si us plau, respongueu a això a: %(app_url)s Salutacions, la Biblioteca de la Viquipèdia"
 
 #. Translators: This is the subject line of an email sent to coordinators when a comment is left on an application they processed.
 #: TWLight/emails/templates/emails/comment_notification_coordinator-subject.html:3
 msgid "New comment on a Wikipedia Library application you processed"
-msgstr ""
-"Nou comentari en la sol·licitud a la Biblioteca de la Viquipèdia que vau "
-"tramitar"
+msgstr "Nou comentari en la sol·licitud a la Biblioteca de la Viquipèdia que vau tramitar"
 
 #. Translators: This email is sent to users when they receive a comment on their application. Don't translate Jinja variables in curly braces like user or partner; don't translate html tags either. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/comment_notification_editors-body-html.html:5
 #, python-format
-msgid ""
-"<p style=\"color: #500050\">%(submit_date)s - %(commenter)s</p> "
-"<blockquote><p>%(comment)s</p></blockquote> <p>Please reply to these at <a "
-"href=\"%(app_url)s\">%(app_url)s</a> so we can evaluate your application.</"
-"p> <p>Best,</p> <p>The Wikipedia Library</p>"
-msgstr ""
-"<p style=\"color: #500050\">%(submit_date)s - %(commenter)s</p> "
-"<blockquote><p>%(comment)s</p></blockquote> <p>Si us plau, respongueu a això "
-"a<a href=\"%(app_url)s\">%(app_url)s</a> de manera que puguem avaluar la "
-"vostra sol·licitud.</p> <p>Best,</p> <p>The Wikipedia Library</p>"
+msgid "<p style=\"color: #500050\">%(submit_date)s - %(commenter)s</p> <blockquote><p>%(comment)s</p></blockquote> <p>Please reply to these at <a href=\"%(app_url)s\">%(app_url)s</a> so we can evaluate your application.</p> <p>Best,</p> <p>The Wikipedia Library</p>"
+msgstr "<p style=\"color: #500050\">%(submit_date)s - %(commenter)s</p> <blockquote><p>%(comment)s</p></blockquote> <p>Si us plau, respongueu a això a<a href=\"%(app_url)s\">%(app_url)s</a> de manera que puguem avaluar la vostra sol·licitud.</p> <p>Best,</p> <p>The Wikipedia Library</p>"
 
 #. Translators: This email is sent to users when they receive a comment on their application. Don't translate Jinja variables in curly braces like user or partner. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/comment_notification_editors-body-text.html:3
 #, python-format
-msgid ""
-"%(submit_date)s - %(commenter)s %(comment)s Please reply to these at: "
-"%(app_url)s so we can evaluate your application. Best, The Wikipedia Library"
-msgstr ""
-"%(submit_date)s - %(commenter)s %(comment)s Si us plau, respongueu a: "
-"%(app_url)s per tal que puguem avaluar la vostra sol·licitud.\n"
-"\n"
-"La Biblioteca de la Viquipèdia"
+msgid "%(submit_date)s - %(commenter)s %(comment)s Please reply to these at: %(app_url)s so we can evaluate your application. Best, The Wikipedia Library"
+msgstr "%(submit_date)s - %(commenter)s %(comment)s Si us plau, respongueu a: %(app_url)s per tal que puguem avaluar la vostra sol·licitud.\n\nLa Biblioteca de la Viquipèdia"
 
 #. Translators: This is the subject line of an email sent to users who have a comment added to one of their applications. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/comment_notification_editors-subject.html:3
 msgid "New comment on your Wikipedia Library application"
-msgstr ""
-"Nou comentari en la vostra sol·licitud a la Biblioteca de la Viquipèdia"
+msgstr "Nou comentari en la vostra sol·licitud a la Biblioteca de la Viquipèdia"
 
 #. Translators: This email is sent to users when an application they commented on receives another comment. Don't translate Jinja variables in curly braces like app_url; don't translate html tags either. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/comment_notification_others-body-html.html:5
 #, python-format
-msgid ""
-"<p style=\"color: #500050\">%(submit_date)s - %(commenter)s</p> "
-"<blockquote><p>%(comment)s</p></blockquote> See it at <a href=\"%(app_url)s"
-"\">%(app_url)s</a>. Thanks for helping review Wikipedia Library applications!"
-msgstr ""
-"<p style=\"color: #500050\">%(submit_date)s - %(commenter)s</p> "
-"<blockquote><p>%(comment)s</p></blockquote> Vegeu <a href=\"%(app_url)s\">"
-"%(app_url)s</a>. Us agraïm que ens ajudeu a revisar les sol·licituds que rep "
-"la Biblioteca de la Viquipèdia!"
+msgid "<p style=\"color: #500050\">%(submit_date)s - %(commenter)s</p> <blockquote><p>%(comment)s</p></blockquote> See it at <a href=\"%(app_url)s\">%(app_url)s</a>. Thanks for helping review Wikipedia Library applications!"
+msgstr "<p style=\"color: #500050\">%(submit_date)s - %(commenter)s</p> <blockquote><p>%(comment)s</p></blockquote> Vegeu <a href=\"%(app_url)s\">%(app_url)s</a>. Us agraïm que ens ajudeu a revisar les sol·licituds que rep la Biblioteca de la Viquipèdia!"
 
 #. Translators: This email is sent to users when an application they commented on receives another comment. Don't translate Jinja variables in curly braces like app_url. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/comment_notification_others-body-text.html:3
 #, python-format
-msgid ""
-"%(submit_date)s - %(commenter)s %(comment)s See it at: %(app_url)s Thanks "
-"for helping review Wikipedia Library applications!"
-msgstr ""
-"%(submit_date)s - %(commenter)s %(comment)s Vegeu: %(app_url)s Gràcies per "
-"ajudar-nos a revisar les sol·licituds que rep la Biblioteca de la Viquipèdia!"
+msgid "%(submit_date)s - %(commenter)s %(comment)s See it at: %(app_url)s Thanks for helping review Wikipedia Library applications!"
+msgstr "%(submit_date)s - %(commenter)s %(comment)s Vegeu: %(app_url)s Gràcies per ajudar-nos a revisar les sol·licituds que rep la Biblioteca de la Viquipèdia!"
 
 #. Translators: This is the subject line of an email sent to users who have a comment added to an application they also commented on. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/comment_notification_others-subject.html:4
 msgid "New comment on a Wikipedia Library application you commented on"
-msgstr ""
-"Un comentari nou en la sol·licitud de la Biblioteca de la Viquipèdia en què "
-"havíeu participat prèviament"
+msgstr "Un comentari nou en la sol·licitud de la Biblioteca de la Viquipèdia en què havíeu participat prèviament"
 
 #. Translators: This text is part of a scheduled reminder email sent to coordinators who have applications requiring action. Don't translate Jinja variables in curly braces like total_apps, or user.
 #: TWLight/emails/templates/emails/coordinator_reminder_notification-body-html.html:5
 #, python-format
-msgid ""
-"<p>Dear %(user)s,</p> <p>Our records indicate that you are the designated "
-"coordinator for partners that have a total of %(total_apps)s applications.</"
-"p>"
-msgstr ""
-"<p>%(user)s,</p> <p>Els nostres arxius indiquen esteu al càrrec de coordinar "
-"editorials col·laboradores que tenen acumulades un total de %(total_apps)s "
-"sol·licituds d'accés.</p>"
+msgid "<p>Dear %(user)s,</p> <p>Our records indicate that you are the designated coordinator for partners that have a total of %(total_apps)s applications.</p>"
+msgstr "<p>%(user)s,</p> <p>Els nostres arxius indiquen esteu al càrrec de coordinar editorials col·laboradores que tenen acumulades un total de %(total_apps)s sol·licituds d'accés.</p>"
 
 #. Translators: Breakdown as in 'cost breakdown'; analysis.
 #: TWLight/emails/templates/emails/coordinator_reminder_notification-body-html.html:11
@@ -1315,75 +1071,36 @@ msgstr[1] "%(counter)s sol·licituds aprovades."
 #. Translators: This text is part of a scheduled reminder email sent to coordinators who have applications requiring action. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library). Don't translate Jinja variables in curly braces like link; don't translate email addresses or html tags either.
 #: TWLight/emails/templates/emails/coordinator_reminder_notification-body-html.html:39
 #, python-format
-msgid ""
-"<p>This is a gentle reminder that you may review applications at <a href="
-"\"%(link)s\">%(link)s</a>.</p> <p>You can customise your reminders under "
-"'preferences' in your user profile.</p> <p>If you received this message in "
-"error, drop us a line at wikipedialibrary@wikimedia.org.</p> <p>Thanks for "
-"helping review Wikipedia Library applications!</p>"
-msgstr ""
-"<p>Us enviem aquest recordatori perquè reviseu les sol·licituds <a href="
-"\"%(link)s\">%(link)s</a>.</p> <p>Podeu personalitzar aquests recordatoris a "
-"la secció «Preferències» del vostre compte d'usuari.</p> <p>Si per ventura "
-"heu rebut aquest missatge i es tracta d'un error, envieu-nos un correu "
-"electrònic a wikipedialibrary@wikimedia.org.</p> <p>Gràcies per ajudar-nos a "
-"revisar les sol·licituds que ens arriben a la Biblioteca de la Viquipèdia!</"
-"p>"
+msgid "<p>This is a gentle reminder that you may review applications at <a href=\"%(link)s\">%(link)s</a>.</p> <p>You can customise your reminders under 'preferences' in your user profile.</p> <p>If you received this message in error, drop us a line at wikipedialibrary@wikimedia.org.</p> <p>Thanks for helping review Wikipedia Library applications!</p>"
+msgstr "<p>Us enviem aquest recordatori perquè reviseu les sol·licituds <a href=\"%(link)s\">%(link)s</a>.</p> <p>Podeu personalitzar aquests recordatoris a la secció «Preferències» del vostre compte d'usuari.</p> <p>Si per ventura heu rebut aquest missatge i es tracta d'un error, envieu-nos un correu electrònic a wikipedialibrary@wikimedia.org.</p> <p>Gràcies per ajudar-nos a revisar les sol·licituds que ens arriben a la Biblioteca de la Viquipèdia!</p>"
 
 #. Translators: This text is part of a scheduled reminder email sent to coordinators who have applications requiring action. Don't translate Jinja variables in curly braces like total_apps, or user.
 #: TWLight/emails/templates/emails/coordinator_reminder_notification-body-text.html:3
 #, python-format
-msgid ""
-"Dear %(user)s, Our records indicate that you are the designated coordinator "
-"for partners that have a total of %(total_apps)s applications."
-msgstr ""
-"<p>%(user)s,</p> <p>Els nostres arxius indiquen esteu al càrrec de coordinar "
-"editorials col·laboradores que tenen acumulades un total de %(total_apps)s "
-"sol·licituds d'accés.</p>"
+msgid "Dear %(user)s, Our records indicate that you are the designated coordinator for partners that have a total of %(total_apps)s applications."
+msgstr "<p>%(user)s,</p> <p>Els nostres arxius indiquen esteu al càrrec de coordinar editorials col·laboradores que tenen acumulades un total de %(total_apps)s sol·licituds d'accés.</p>"
 
 #. Translators: This text is part of a scheduled reminder email sent to coordinators who have applications requiring action. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library). Don't translate Jinja variables in curly braces like link; don't translate the email address either.
 #: TWLight/emails/templates/emails/coordinator_reminder_notification-body-text.html:38
 #, python-format
-msgid ""
-"This is a gentle reminder that you may review applications at: %(link)s. You "
-"can customise your reminders under 'preferences' in your user profile. If "
-"you received this message in error, drop us a line at: "
-"wikipedialibrary@wikimedia.org Thanks for helping review Wikipedia Library "
-"applications!"
-msgstr ""
-"Us enviem aquest recordatori perquè reviseu les sol·licituds <a href="
-"\"%(link)s\">%(link)s</a>.</p> Podeu personalitzar aquests recordatoris a la "
-"secció «Preferències» del vostre compte d'usuari.</p> <p>Si per ventura heu "
-"rebut aquest missatge i es tracta d'un error, envieu-nos un correu "
-"electrònic a wikipedialibrary@wikimedia.org. Gràcies per ajudar-nos a "
-"revisar les sol·licituds que ens arriben a la Biblioteca de la Viquipèdia!"
+msgid "This is a gentle reminder that you may review applications at: %(link)s. You can customise your reminders under 'preferences' in your user profile. If you received this message in error, drop us a line at: wikipedialibrary@wikimedia.org Thanks for helping review Wikipedia Library applications!"
+msgstr "Us enviem aquest recordatori perquè reviseu les sol·licituds <a href=\"%(link)s\">%(link)s</a>.</p> Podeu personalitzar aquests recordatoris a la secció «Preferències» del vostre compte d'usuari.</p> <p>Si per ventura heu rebut aquest missatge i es tracta d'un error, envieu-nos un correu electrònic a wikipedialibrary@wikimedia.org. Gràcies per ajudar-nos a revisar les sol·licituds que ens arriben a la Biblioteca de la Viquipèdia!"
 
 #. Translators: This is the subject line of a scheduled reminder email sent to coordinators who have applications to review. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library). Do not translate items in curly braces.
 #: TWLight/emails/templates/emails/coordinator_reminder_notification-subject.html:4
 msgid "Wikipedia Library applications await your review"
-msgstr ""
-"Hi ha sol·licituds de la Biblioteca de la Viquipèdia pendents de la vostra "
-"revisió"
+msgstr "Hi ha sol·licituds de la Biblioteca de la Viquipèdia pendents de la vostra revisió"
 
 #. Translators: This email is sent to users when their application is rejected. Don't translate Jinja variables in curly braces like user or partner; don't translate html tags either. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/rejection_notification-body-html.html:5
 #, python-format
-msgid ""
-"<p>Dear %(user)s,</p> <p>Thank you for applying for access to %(partner)s "
-"resources through The Wikipedia Library. Unfortunately at this time your "
-"application has not been approved. You can view your application and review "
-"comments at <a href=\"%(app_url)s\">%(app_url)s</a>.</p> <p>Best,</p> <p>The "
-"Wikipedia Library</p>"
+msgid "<p>Dear %(user)s,</p> <p>Thank you for applying for access to %(partner)s resources through The Wikipedia Library. Unfortunately at this time your application has not been approved. You can view your application and review comments at <a href=\"%(app_url)s\">%(app_url)s</a>.</p> <p>Best,</p> <p>The Wikipedia Library</p>"
 msgstr ""
 
 #. Translators: This email is sent to users when their application is rejected. Don't translate Jinja variables in curly braces like user or partner. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/rejection_notification-body-text.html:3
 #, python-format
-msgid ""
-"Dear %(user)s, Thank you for applying for access to %(partner)s resources "
-"through The Wikipedia Library. Unfortunately at this time your application "
-"has not been approved. You can view your application and review comments at: "
-"%(app_url)s Best, The Wikipedia Library"
+msgid "Dear %(user)s, Thank you for applying for access to %(partner)s resources through The Wikipedia Library. Unfortunately at this time your application has not been approved. You can view your application and review comments at: %(app_url)s Best, The Wikipedia Library"
 msgstr ""
 
 #. Translators: This is the subject of an email which is sent to users when their application has been rejected. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
@@ -1394,25 +1111,13 @@ msgstr "La vostra sol·licitud a la Biblioteca de la Viquipèdia"
 #. Translators: This email is sent to users when they have an account that is soon to expire. Don't translate Jinja variables in curly braces like partner_name or partner_link; don't translate html tags either. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/user_renewal_notice-body-html.html:5
 #, python-format
-msgid ""
-"<p>Dear %(user)s,</p> <p>According to our records, your access to "
-"%(partner_name)s will soon expire and you may lose access. If you want to "
-"continue making use of your free account, you can request renewal of your "
-"account by clicking the 'Renew' or 'Extend' button at %(partner_link)s.</p> "
-"<p>Best,</p> <p>The Wikipedia Library</p> <p>You can disable these emails in "
-"your user page preferences: https://wikipedialibrary.wmflabs.org/users/</p>"
+msgid "<p>Dear %(user)s,</p> <p>According to our records, your access to %(partner_name)s will soon expire and you may lose access. If you want to continue making use of your free account, you can request renewal of your account by clicking the 'Renew' or 'Extend' button at %(partner_link)s.</p> <p>Best,</p> <p>The Wikipedia Library</p> <p>You can disable these emails in your user page preferences: https://wikipedialibrary.wmflabs.org/users/</p>"
 msgstr ""
 
 #. Translators: This email is sent to users when they have an account that is soon to expire. Don't translate Jinja variables in curly braces like partner_name or partner_link; don't translate html tags either. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/user_renewal_notice-body-text.html:3
 #, python-format
-msgid ""
-"Dear %(user)s, According to our records, your access to %(partner_name)s "
-"will soon expire and you may lose access. If you want to continue making use "
-"of your free account, you can request renewal of your account by clicking "
-"the Renew button at %(partner_link)s. Best, The Wikipedia Library You can "
-"disable these emails in your user page preferences: https://wikipedialibrary."
-"wmflabs.org/users/"
+msgid "Dear %(user)s, According to our records, your access to %(partner_name)s will soon expire and you may lose access. If you want to continue making use of your free account, you can request renewal of your account by clicking the Renew button at %(partner_link)s. Best, The Wikipedia Library You can disable these emails in your user page preferences: https://wikipedialibrary.wmflabs.org/users/"
 msgstr ""
 
 #. Translators: This is the subject of an email sent to users when they have an account that is soon to expire. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
@@ -1423,38 +1128,24 @@ msgstr "El teu accés a la Biblioteca de la Viquipèdia pot caducar aviat"
 #. Translators: This email is sent to users when their application is waitlisted because there are no more accounts available. Don't translate Jinja variables in curly braces like user or partner; don't translate html tags either. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/waitlist_notification-body-html.html:5
 #, python-format
-msgid ""
-"<p>Dear %(user)s,</p> <p>Thank you for applying for access to %(partner)s "
-"resources through The Wikipedia Library. There are no accounts currently "
-"available so your application has been waitlisted. Your application will be "
-"evaluated if/when more accounts become available. You can see all available "
-"resources at <a href=\"%(link)s\">%(link)s</a>.</p> <p>Best,</p> <p>The "
-"Wikipedia Library</p>"
+msgid "<p>Dear %(user)s,</p> <p>Thank you for applying for access to %(partner)s resources through The Wikipedia Library. There are no accounts currently available so your application has been waitlisted. Your application will be evaluated if/when more accounts become available. You can see all available resources at <a href=\"%(link)s\">%(link)s</a>.</p> <p>Best,</p> <p>The Wikipedia Library</p>"
 msgstr ""
 
 #. Translators: This email is sent to users when their application is waitlisted because there are no more accounts available. Don't translate Jinja variables in curly braces like user or partner. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/waitlist_notification-body-text.html:3
 #, python-format
-msgid ""
-"Dear %(user)s, Thank you for applying for access to %(partner)s resources "
-"through The Wikipedia Library. There are no accounts currently available so "
-"your application has been waitlisted. Your application will be evaluated if/"
-"when more accounts become available. You can see all available resources at: "
-"%(link)s Best, The Wikipedia Library"
+msgid "Dear %(user)s, Thank you for applying for access to %(partner)s resources through The Wikipedia Library. There are no accounts currently available so your application has been waitlisted. Your application will be evaluated if/when more accounts become available. You can see all available resources at: %(link)s Best, The Wikipedia Library"
 msgstr ""
 
 #. Translators: This is the subject of an email sent to users when their application is waitlisted because there are no more accounts available. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/waitlist_notification-subject.html:4
 msgid "Your Wikipedia Library application has been waitlisted"
-msgstr ""
-"La vostra sol·licitud a la Biblioteca de la Viquipèdia ha entrat a la llista "
-"d'espera"
+msgstr "La vostra sol·licitud a la Biblioteca de la Viquipèdia ha entrat a la llista d'espera"
 
 #. Translators: Shown to users when they successfully submit a new message using the contact us form.
 #: TWLight/emails/views.py:51
 msgid "Your message has been sent. We'll get back to you soon!"
-msgstr ""
-"El vostre missatge s'ha enviat. Ens posarem en contacte amb tu de seguida!"
+msgstr "El vostre missatge s'ha enviat. Ens posarem en contacte amb tu de seguida!"
 
 #. Translators: This message is shown to non-wikipedia editors who attempt to post data to the contact us form.
 #. Translators: This message is shown to non-wikipedia editors who attempt to post data to suggestion form.
@@ -1605,23 +1296,15 @@ msgstr "No disponible"
 #: TWLight/resources/templates/resources/filter_section.html:14
 #: TWLight/templates/about.html:12
 #: TWLight/users/templates/users/filter_section.html:13
-msgid ""
-"The Wikipedia Library allows active editors to access a wide range of "
-"collections of paywalled reliable sources for free!"
-msgstr ""
-"La Biblioteca de la Viquipèdia permet a qualsevol viquipedista actiu "
-"d'accedir de franc a un ampli ventall de col·leccions bibliogràfiques de "
-"pagament!"
+msgid "The Wikipedia Library allows active editors to access a wide range of collections of paywalled reliable sources for free!"
+msgstr "La Biblioteca de la Viquipèdia permet a qualsevol viquipedista actiu d'accedir de franc a un ampli ventall de col·leccions bibliogràfiques de pagament!"
 
 #. Translators: On the Browse Partners page (https://wikipedialibrary.wmflabs.org/partners/), this introduces users to The Wikipedia Library.
 #. Translators: On the MyLibrary page (https://wikipedialibrary.wmflabs.org/users/my_library), this introduces users to The Wikipedia Library.
 #: TWLight/resources/templates/resources/filter_section.html:17
 #: TWLight/users/templates/users/filter_section.html:15
-msgid ""
-"Start with the search bar at the top or browse publisher websites directly."
-msgstr ""
-"Comenceu amb la barra de cerca de l'inici de pàgina o cerqueu directament al "
-"lloc web de l'editorial."
+msgid "Start with the search bar at the top or browse publisher websites directly."
+msgstr "Comenceu amb la barra de cerca de l'inici de pàgina o cerqueu directament al lloc web de l'editorial."
 
 #. Translators: On the Browse Partners page (https://wikipedialibrary.wmflabs.org/partners/), this appears below introductory text and links to the 'About' page (https://wikipedialibrary.wmflabs.org/about/)
 #. Translators: On the MyLibrary page (https://wikipedialibrary.wmflabs.org/users/my_library), this appears below introductory text and links to the 'About' page (https://wikipedialibrary.wmflabs.org/about/)
@@ -1694,68 +1377,39 @@ msgstr "Torna als col·laboradors"
 #. Translators: If we have no available accounts for a partner, the coordinator can change the application system to a waiting list.
 #: TWLight/resources/templates/resources/partner_detail.html:36
 #: TWLight/resources/templates/resources/partner_detail_apply.html:17
-msgid ""
-"There are no access grants available for this partner at this time. You can "
-"still apply for access; applications will be processed when access is "
-"available."
-msgstr ""
-"Ara mateix no hi ha mitjans d'accés disponible per a aquest col·laborador. "
-"Tanmateix, podeu sol·licitar-ne l'accés; les peticions seran processades "
-"quan l'accés esdevingui actiu."
+msgid "There are no access grants available for this partner at this time. You can still apply for access; applications will be processed when access is available."
+msgstr "Ara mateix no hi ha mitjans d'accés disponible per a aquest col·laborador. Tanmateix, podeu sol·licitar-ne l'accés; les peticions seran processades quan l'accés esdevingui actiu."
 
 #. Translators: This text links to the minimum user requirements and terms of use on the partner page.
 #: TWLight/resources/templates/resources/partner_detail.html:48
 #: TWLight/resources/templates/resources/partner_detail_apply.html:29
 #, python-format
-msgid ""
-"Before applying, please review the <strong><a class=\"twl-links\" href="
-"\"%(about)s#req\">minimum requirements</a></strong> for access and our "
-"<strong><a class=\"twl-links\" href=\"%(terms)s\">terms of use</a></strong>."
-msgstr ""
-"Abans de tramitar la vostra sol·licitud, si us plau pareu atenció als "
-"<strong><a class=\"twl-links\" href=\"%(about)s#req\">requisits mínims "
-"d'accés</a></strong> i també a les nostres <strong><a class=\"twl-links\" "
-"href=\"%(terms)s\">condicions d'ús</a></strong>."
+msgid "Before applying, please review the <strong><a class=\"twl-links\" href=\"%(about)s#req\">minimum requirements</a></strong> for access and our <strong><a class=\"twl-links\" href=\"%(terms)s\">terms of use</a></strong>."
+msgstr "Abans de tramitar la vostra sol·licitud, si us plau pareu atenció als <strong><a class=\"twl-links\" href=\"%(about)s#req\">requisits mínims d'accés</a></strong> i també a les nostres <strong><a class=\"twl-links\" href=\"%(terms)s\">condicions d'ús</a></strong>."
 
 #. Translators: This text refers to the page containing the content a user is authorized to access.
 #: TWLight/resources/templates/resources/partner_detail.html:69
 #, python-format
-msgid ""
-"View the status of your access in <strong><a class=\"twl-links\" href="
-"\"%(library_url)s\">My Library</a></strong> page."
-msgstr ""
-"Vegeu l'estatus del vostre accés institucional a <strong><a class=\"twl-links"
-"\" href=\"%(library_url)s\">La meva Biblioteca</a></strong>."
+msgid "View the status of your access in <strong><a class=\"twl-links\" href=\"%(library_url)s\">My Library</a></strong> page."
+msgstr "Vegeu l'estatus del vostre accés institucional a <strong><a class=\"twl-links\" href=\"%(library_url)s\">La meva Biblioteca</a></strong>."
 
 #. Translators: This message is shown when a user has open applications, linking to their respective applications page.
 #: TWLight/resources/templates/resources/partner_detail.html:78
 #, python-format
-msgid ""
-"View the status of your application(s) on your <strong><a class=\"twl-links"
-"\" href=\"%(applications_url)s\">My Applications</a></strong> page."
-msgstr ""
-"Vegeu l'estatus de la vostra sol·licitud a <strong><a class=\"twl-links\" "
-"href=\"%(applications_url)s\">Les meves peticions</a></strong>."
+msgid "View the status of your application(s) on your <strong><a class=\"twl-links\" href=\"%(applications_url)s\">My Applications</a></strong> page."
+msgstr "Vegeu l'estatus de la vostra sol·licitud a <strong><a class=\"twl-links\" href=\"%(applications_url)s\">Les meves peticions</a></strong>."
 
 #. Translators: This message is shown when a user has authorizations, linking to their respective collections page.
 #: TWLight/resources/templates/resources/partner_detail_apply.html:50
 #, python-format
-msgid ""
-"View the status of your access on your <strong><a href=\"%(library_url)s\" "
-"class=\"twl-links\">My Library</a></strong> page."
-msgstr ""
-"Vegeu l'estatus del vostre accés institucional a <strong><a href="
-"\"%(library_url)s\" class=\"twl-links\">La meva Biblioteca</a></strong>."
+msgid "View the status of your access on your <strong><a href=\"%(library_url)s\" class=\"twl-links\">My Library</a></strong> page."
+msgstr "Vegeu l'estatus del vostre accés institucional a <strong><a href=\"%(library_url)s\" class=\"twl-links\">La meva Biblioteca</a></strong>."
 
 #. Translators: This message is shown when a user has open applications, linking to their respective applications page.
 #: TWLight/resources/templates/resources/partner_detail_apply.html:60
 #, python-format
-msgid ""
-"View the status of your application(s) on your <strong><a href="
-"\"%(applications_url)s\">My Applications</a></strong> page."
-msgstr ""
-"Vegeu l'estatus de la vostra sol·licitud a <strong><a href="
-"\"%(applications_url)s\">Les meves peticions</a></strong>."
+msgid "View the status of your application(s) on your <strong><a href=\"%(applications_url)s\">My Applications</a></strong> page."
+msgstr "Vegeu l'estatus de la vostra sol·licitud a <strong><a href=\"%(applications_url)s\">Les meves peticions</a></strong>."
 
 #. Translators: One the partner detail page, this text labels the button which coordinators can click to remove a partner from waitlisted status.
 #: TWLight/resources/templates/resources/partner_detail_apply.html:73
@@ -1770,8 +1424,7 @@ msgstr "Afegit a la llista d'espera"
 #: TWLight/resources/templates/resources/partner_detail_apply.html:86
 #, python-format
 msgid "<strong>%(coordinator)s</strong> processes applications to %(partner)s."
-msgstr ""
-"<strong>%(coordinator)s</strong> trameten les sol·licituds als %(partner)s."
+msgstr "<strong>%(coordinator)s</strong> trameten les sol·licituds als %(partner)s."
 
 #. Translators: When a coordinator is assigned to a partner, their details are shown on the page. This text labels a link to their Talk page on Wikipedia, and should be translated to the text used for Talk pages in the language you are translating to.
 #: TWLight/resources/templates/resources/partner_detail_apply.html:95
@@ -1785,15 +1438,8 @@ msgstr "Special:EmailUser page"
 
 #. Translators: If no account coordinator is assigned to a partner, the Wikipedia Library team will coordinate signups. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/resources/templates/resources/partner_detail_apply.html:112
-msgid ""
-"The Wikipedia Library team will process this application. Want to help? <a "
-"class=\"twl-links\" href=\"https://en.wikipedia.org/wiki/Wikipedia:"
-"The_Wikipedia_Library/Coordinators/Signup\">Sign up as a coordinator.</a>"
-msgstr ""
-"L'equip de la Biblioteca de la Viquipèdia processarà la vostra sol·licitud. "
-"Ens voleu ajudar? <a class=\"twl-links\" href=\"https://en.wikipedia.org/"
-"wiki/Wikipedia:The_Wikipedia_Library/Coordinators/Signup\">Registreu-vos-hi "
-"com a coordinador.</a>"
+msgid "The Wikipedia Library team will process this application. Want to help? <a class=\"twl-links\" href=\"https://en.wikipedia.org/wiki/Wikipedia:The_Wikipedia_Library/Coordinators/Signup\">Sign up as a coordinator.</a>"
+msgstr "L'equip de la Biblioteca de la Viquipèdia processarà la vostra sol·licitud. Ens voleu ajudar? <a class=\"twl-links\" href=\"https://en.wikipedia.org/wiki/Wikipedia:The_Wikipedia_Library/Coordinators/Signup\">Registreu-vos-hi com a coordinador.</a>"
 
 #. Translators: This text labels a button coordinators can click to view a list of users who have applied for access for a particular partner
 #: TWLight/resources/templates/resources/partner_detail_apply.html:121
@@ -1822,24 +1468,14 @@ msgstr "Accés al Paquet Institucional"
 
 #. Translators: Text shown to authenticated, bundle eligible users when they visit a Bundle partner page.
 #: TWLight/resources/templates/resources/partner_detail_apply.html:138
-msgid ""
-"You are eligible to access Library Bundle partners. Click the button above "
-"to access the collection."
-msgstr ""
-"Reuniu els requisits per accedir al Paquet Institucional dels nostres "
-"col·laboradors. Feu clic al botó de més amunt i accediu a la col·lecció."
+msgid "You are eligible to access Library Bundle partners. Click the button above to access the collection."
+msgstr "Reuniu els requisits per accedir al Paquet Institucional dels nostres col·laboradors. Feu clic al botó de més amunt i accediu a la col·lecció."
 
 #. Translators: Text shown to authenticated, bundle ineligible users when they visit a Bundle partner page.
 #: TWLight/resources/templates/resources/partner_detail_apply.html:152
 #, python-format
-msgid ""
-"You are not eligible to access Library Bundle partners. Visit the <a class="
-"\"twl-links\" href=\"%(homepage)s\">homepage</a> to check the eligibility "
-"criteria."
-msgstr ""
-"No reuniu els requisits per accedir al Paquet Institucional dels nostres "
-"col·laboradors. Pareu atenció a la <a class=\"twl-links\" href=\"%(homepage)s"
-"\">pàgina principal</a> per a llegir-hi els criteris mínims d'accés."
+msgid "You are not eligible to access Library Bundle partners. Visit the <a class=\"twl-links\" href=\"%(homepage)s\">homepage</a> to check the eligibility criteria."
+msgstr "No reuniu els requisits per accedir al Paquet Institucional dels nostres col·laboradors. Pareu atenció a la <a class=\"twl-links\" href=\"%(homepage)s\">pàgina principal</a> per a llegir-hi els criteris mínims d'accés."
 
 #. Translators: Buttton prompting users to log in.
 #: TWLight/resources/templates/resources/partner_detail_apply.html:160
@@ -1850,15 +1486,8 @@ msgstr "Inicia la sessió"
 #. Translators: Text shown to unauthenticated users when they visit a Bundle partner page.
 #: TWLight/resources/templates/resources/partner_detail_apply.html:168
 #, python-format
-msgid ""
-"This resource is part of our <a class=\"twl-links\" href=\"%(about)s"
-"\">Library Bundle</a>, which you can access if you meet our minimum "
-"eligibility criteria. Log in to find out if you are eligible."
-msgstr ""
-"Aquest arxiu forma part del nostre <a class=\"twl-links\" href=\"%(about)s"
-"\">Paquet Institucional</a>, al qual podeu accedir si compliu els nostres "
-"requisits mínims d'accés. Inicieu la sessió per a comprovar si, en efecte, "
-"els compliu."
+msgid "This resource is part of our <a class=\"twl-links\" href=\"%(about)s\">Library Bundle</a>, which you can access if you meet our minimum eligibility criteria. Log in to find out if you are eligible."
+msgstr "Aquest arxiu forma part del nostre <a class=\"twl-links\" href=\"%(about)s\">Paquet Institucional</a>, al qual podeu accedir si compliu els nostres requisits mínims d'accés. Inicieu la sessió per a comprovar si, en efecte, els compliu."
 
 #. Translators: This is the label for a number which shows the total active accounts for one partner. (e.g. https://wikipedialibrary.wmflabs.org/partners/8/).
 #: TWLight/resources/templates/resources/partner_detail_stats.html:21
@@ -1908,36 +1537,20 @@ msgstr "Límit del fragment"
 #. Translators: If a partner has specified the excerpt limit both in words and percentage, this message will display the percentage of words and the number of words on the partner page.
 #: TWLight/resources/templates/resources/partner_detail_timeline.html:99
 #, python-format
-msgid ""
-"%(object)s allows a maximum of %(excerpt_limit)s words or "
-"%(excerpt_limit_percentage)s%% of an article be excerpted into a Wikipedia "
-"article."
-msgstr ""
-"%(object)s permet que feu servir un màxim de %(excerpt_limit)s mots o un "
-"%(excerpt_limit_percentage)s%% d'aquesta obra en articles de la Viquipèdia o "
-"en textos d'altres projectes Wikimedia."
+msgid "%(object)s allows a maximum of %(excerpt_limit)s words or %(excerpt_limit_percentage)s%% of an article be excerpted into a Wikipedia article."
+msgstr "%(object)s permet que feu servir un màxim de %(excerpt_limit)s mots o un %(excerpt_limit_percentage)s%% d'aquesta obra en articles de la Viquipèdia o en textos d'altres projectes Wikimedia."
 
 #. Translators: If a partner has specified the excerpt limit in words, this message will display the number of words on the partner page.
 #: TWLight/resources/templates/resources/partner_detail_timeline.html:106
 #, python-format
-msgid ""
-"%(object)s allows a maximum of %(excerpt_limit)s words be excerpted into a "
-"Wikipedia article."
-msgstr ""
-"%(object)s permet que feu servir un màxim de %(excerpt_limit)s mots "
-"d'aquesta obra en articles de la Viquipèdia o en textos d'altres projectes "
-"Wikimedia."
+msgid "%(object)s allows a maximum of %(excerpt_limit)s words be excerpted into a Wikipedia article."
+msgstr "%(object)s permet que feu servir un màxim de %(excerpt_limit)s mots d'aquesta obra en articles de la Viquipèdia o en textos d'altres projectes Wikimedia."
 
 #. Translators: If a partner has specified the excerpt limit in percentage, this message will display the percentage of words on the partner page.
 #: TWLight/resources/templates/resources/partner_detail_timeline.html:113
 #, python-format
-msgid ""
-"%(object)s allows a maximum of %(excerpt_limit_percentage)s%% of an article "
-"be excerpted into a Wikipedia article."
-msgstr ""
-"%(object)s permet que feu servir un màxim del %(excerpt_limit_percentage)s%% "
-"d'aquesta obra en articles de la Viquipèdia o en textos d'altres projectes "
-"Wikimedia."
+msgid "%(object)s allows a maximum of %(excerpt_limit_percentage)s%% of an article be excerpted into a Wikipedia article."
+msgstr "%(object)s permet que feu servir un màxim del %(excerpt_limit_percentage)s%% d'aquesta obra en articles de la Viquipèdia o en textos d'altres projectes Wikimedia."
 
 #. Translators: If a partner has other requirements for access, this text shows as the title for that information field. (e.g. https://wikipedialibrary.wmflabs.org/partners/10/).
 #: TWLight/resources/templates/resources/partner_detail_timeline.html:132
@@ -1947,12 +1560,8 @@ msgstr "Requisits especials per a sol·licitants"
 #. Translators: If a user must agree to a Terms of Use document, they see this message, and must enter the name of the resource. Don't translate publisher or url.
 #: TWLight/resources/templates/resources/partner_detail_timeline.html:140
 #, python-format
-msgid ""
-"%(publisher)s requires that you agree with its <a href=\"%(url)s\">terms of "
-"use</a>."
-msgstr ""
-"%(publisher)s exigeix que accepteu les seves <a href=\"%(url)s\">condicions "
-"d'ús</a>."
+msgid "%(publisher)s requires that you agree with its <a href=\"%(url)s\">terms of use</a>."
+msgstr "%(publisher)s exigeix que accepteu les seves <a href=\"%(url)s\">condicions d'ús</a>."
 
 #. Translators: If a user must provide their real name to apply to a partner, they see this message, and must enter the name of the resource. Don't translate publisher.
 #: TWLight/resources/templates/resources/partner_detail_timeline.html:150
@@ -1964,35 +1573,25 @@ msgstr "%(publisher)s exigeix que li proporcioneu el vostre nom real."
 #: TWLight/resources/templates/resources/partner_detail_timeline.html:159
 #, python-format
 msgid "%(publisher)s requires that you provide your country of residence."
-msgstr ""
-"%(publisher)s exigeix que li proporcioneu el vostre estat de residència."
+msgstr "%(publisher)s exigeix que li proporcioneu el vostre estat de residència."
 
 #. Translators: If a user must provide their institutional affiliation (e.g. university) to apply to a partner, they see this message, and must enter the name of the resource. Don't translate publisher.
 #: TWLight/resources/templates/resources/partner_detail_timeline.html:168
 #, python-format
 msgid "%(publisher)s requires that you provide your institutional affiliation."
-msgstr ""
-"%(publisher)s exigeix que li proporcioneu la vostra afiliació institucional."
+msgstr "%(publisher)s exigeix que li proporcioneu la vostra afiliació institucional."
 
 #. Translators: If a user must select a specific resource to apply for, they see this message, and must enter the name of the resource. Don't translate publisher.
 #: TWLight/resources/templates/resources/partner_detail_timeline.html:177
 #, python-format
-msgid ""
-"%(publisher)s requires that you specify a particular title that you want to "
-"access."
-msgstr ""
-"%(publisher)s exigeix que li detalleu un títol específic al qual voleu tenir "
-"accés."
+msgid "%(publisher)s requires that you specify a particular title that you want to access."
+msgstr "%(publisher)s exigeix que li detalleu un títol específic al qual voleu tenir accés."
 
 #. Translators: If a user must register on the partner website before applying, they see this message. Don't translate partner.
 #: TWLight/resources/templates/resources/partner_detail_timeline.html:187
 #, python-format
-msgid ""
-"%(publisher)s requires that you sign up for an account before applying for "
-"access."
-msgstr ""
-"%(publisher)s exigeix que creeu un compte abans de tramitar la vostra "
-"petició d'accés."
+msgid "%(publisher)s requires that you sign up for an account before applying for access."
+msgstr "%(publisher)s exigeix que creeu un compte abans de tramitar la vostra petició d'accés."
 
 #. Translators: If a partner has their location listed, this message is a label for that location
 #: TWLight/resources/templates/resources/partner_detail_timeline.html:206
@@ -2118,18 +1717,13 @@ msgstr "N'esteu segurs, que voleu suprimir <b>%(object)s</b>?"
 
 #. Translators: If multiple authorizations where returned for a collection, this message is shown to a user
 #: TWLight/resources/views.py:268
-msgid ""
-"Multiple authorizations were returned – something's wrong. Please contact us "
-"and don't forget to mention this message."
-msgstr ""
-"Múltiples autoritzacions han estat retornades; quelcom ha anat malament. Si "
-"us plau, contacteu-nos i no us oblideu d'esmentar aquest missatge d'error."
+msgid "Multiple authorizations were returned – something's wrong. Please contact us and don't forget to mention this message."
+msgstr "Múltiples autoritzacions han estat retornades; quelcom ha anat malament. Si us plau, contacteu-nos i no us oblideu d'esmentar aquest missatge d'error."
 
 #. Translators: This message is shown when user tries to access a NOT_AVAILABLE Partner
 #: TWLight/resources/views.py:316
 msgid "This partner is currently not open for applications"
-msgstr ""
-"Aquest col·laborador no està disponible ara mateix per a rebre sol·licituds"
+msgstr "Aquest col·laborador no està disponible ara mateix per a rebre sol·licituds"
 
 #. Translators: When an account coordinator changes a partner from being open to applications to having a 'waitlist', they are shown this message.
 #: TWLight/resources/views.py:408
@@ -2164,23 +1758,8 @@ msgstr "Disculpeu... No sabem què fer amb això."
 #. Translators: Shown on the website's 400 page, when a user sends a bad request. Don't translate path or Phabricator.
 #: TWLight/templates/400.html:20
 #, python-format
-msgid ""
-"If you think we should know what to do with that, please email us about this "
-"error at <a class=\"twl-links\" href=\"mailto:wikipedialibrary@wikimedia.org?"
-"Subject=Wikipedia%%20Library%%20%(path)s%%20Permission%%20denied"
-"\">wikipedialibrary@wikimedia.org</a> or report it to us on <a class=\"twl-"
-"links\" href=\"https://phabricator.wikimedia.org/maniphest/task/edit/form/1/?"
-"projectPHIDs=Library-Card-Platform&title=Wikipedia%%20Library%%20%(path)s"
-"%%20Bad%%20Request\">Phabricator</a>"
-msgstr ""
-"Si us plau, si sabeu què fer amb això, envieu-nos un correu electrònic amb "
-"aquest error a <a class=\"twl-links\" href=\"mailto:"
-"wikipedialibrary@wikimedia.org?Subject=Wikipedia%%20Library%%20%(path)s"
-"%%20Permission%%20denied\">wikipedialibrary@wikimedia.org</a> o feu-nos-el "
-"arribar amb un tiquet d'error a <a class=\"twl-links\" href=\"https://"
-"phabricator.wikimedia.org/maniphest/task/edit/form/1/?projectPHIDs=Library-"
-"Card-Platform&title=Wikipedia%%20Library%%20%(path)s%%20Bad%%20Request"
-"\">Phabricator</a>"
+msgid "If you think we should know what to do with that, please email us about this error at <a class=\"twl-links\" href=\"mailto:wikipedialibrary@wikimedia.org?Subject=Wikipedia%%20Library%%20%(path)s%%20Permission%%20denied\">wikipedialibrary@wikimedia.org</a> or report it to us on <a class=\"twl-links\" href=\"https://phabricator.wikimedia.org/maniphest/task/edit/form/1/?projectPHIDs=Library-Card-Platform&title=Wikipedia%%20Library%%20%(path)s%%20Bad%%20Request\">Phabricator</a>"
+msgstr "Si us plau, si sabeu què fer amb això, envieu-nos un correu electrònic amb aquest error a <a class=\"twl-links\" href=\"mailto:wikipedialibrary@wikimedia.org?Subject=Wikipedia%%20Library%%20%(path)s%%20Permission%%20denied\">wikipedialibrary@wikimedia.org</a> o feu-nos-el arribar amb un tiquet d'error a <a class=\"twl-links\" href=\"https://phabricator.wikimedia.org/maniphest/task/edit/form/1/?projectPHIDs=Library-Card-Platform&title=Wikipedia%%20Library%%20%(path)s%%20Bad%%20Request\">Phabricator</a>"
 
 #. Translators: Alt text for an image shown on the 400 error page.
 #. Translators: Alt text for an image shown on the 403 error page.
@@ -2201,24 +1780,8 @@ msgstr "Ho sentim; no teniu permís per a això."
 #. Translators: Shown on the website's 403 page, when a user attempts to navigate to a page they don't have permission to view. Don't translate path or Phabricator.
 #: TWLight/templates/403.html:20
 #, python-format
-msgid ""
-"If you think your account should be able to do that, please email us about "
-"this error at <a class=\"twl-links\" href=\"mailto:"
-"wikipedialibrary@wikimedia.org?Subject=Wikipedia%%20Library%%20%(path)s"
-"%%20Permission%%20denied\">wikipedialibrary@wikimedia.org</a> or report it "
-"to us on <a class=\"twl-links\" href=\"https://phabricator.wikimedia.org/"
-"maniphest/task/edit/form/1/?projectPHIDs=Library-Card-"
-"Platform&title=Wikipedia%%20Library%%20%(path)s%%20Permission%%20denied"
-"\">Phabricator</a>"
-msgstr ""
-"Si creieu que el vostre compte hauria de poder fer això, si us plau envieu-"
-"nos un correu electrònic sobre aquest error a <a class=\"twl-links\" href="
-"\"mailto:wikipedialibrary@wikimedia.org?Subject=Wikipedia%%20Library"
-"%%20%(path)s%%20Permission%%20denied\">wikipedialibrary@wikimedia.org</a> o "
-"obriu un tiquet d'error <a class=\"twl-links\" href=\"https://phabricator."
-"wikimedia.org/maniphest/task/edit/form/1/?projectPHIDs=Library-Card-"
-"Platform&title=Wikipedia%%20Library%%20%(path)s%%20Permission%%20denied"
-"\">Phabricator</a>"
+msgid "If you think your account should be able to do that, please email us about this error at <a class=\"twl-links\" href=\"mailto:wikipedialibrary@wikimedia.org?Subject=Wikipedia%%20Library%%20%(path)s%%20Permission%%20denied\">wikipedialibrary@wikimedia.org</a> or report it to us on <a class=\"twl-links\" href=\"https://phabricator.wikimedia.org/maniphest/task/edit/form/1/?projectPHIDs=Library-Card-Platform&title=Wikipedia%%20Library%%20%(path)s%%20Permission%%20denied\">Phabricator</a>"
+msgstr "Si creieu que el vostre compte hauria de poder fer això, si us plau envieu-nos un correu electrònic sobre aquest error a <a class=\"twl-links\" href=\"mailto:wikipedialibrary@wikimedia.org?Subject=Wikipedia%%20Library%%20%(path)s%%20Permission%%20denied\">wikipedialibrary@wikimedia.org</a> o obriu un tiquet d'error <a class=\"twl-links\" href=\"https://phabricator.wikimedia.org/maniphest/task/edit/form/1/?projectPHIDs=Library-Card-Platform&title=Wikipedia%%20Library%%20%(path)s%%20Permission%%20denied\">Phabricator</a>"
 
 #. Translators: Shown on the website's 404 page, when a user attempts to navigate to a page that doesn't exist.
 #: TWLight/templates/404.html:11
@@ -2233,23 +1796,8 @@ msgstr "Ho sentim, no podem trobar-ho."
 #. Translators: Shown on the website's 404 page, when a user attempts to navigate to a page that doesn't exist. Don't translate path or Phabricator.
 #: TWLight/templates/404.html:19
 #, python-format
-msgid ""
-"If you are certain that something should be here, please email us about this "
-"error at <a class=\"twl-links\" href=\"mailto:wikipedialibrary@wikimedia.org?"
-"Subject=Wikipedia%%20Library%%20%(path)s%%20Not%%20found\"> "
-"wikipedialibrary@wikimedia.org</a> or report it to us on <a class=\"twl-links"
-"\" href=\"https://phabricator.wikimedia.org/maniphest/task/edit/form/1/?"
-"projectPHIDs=Library-Card-Platform&title=Wikipedia%%20Library%%20%(path)s"
-"%%20Not%%20found\">Phabricator</a>"
-msgstr ""
-"Si teniu el convenciment que hi hauria d'haver quelcom aquí, si us plau "
-"envieu-nos un correu electrònic sobre aquest error a <a class=\"twl-links\" "
-"href=\"mailto:wikipedialibrary@wikimedia.org?Subject=Wikipedia%%20Library"
-"%%20%(path)s%%20Not%%20found\"> wikipedialibrary@wikimedia.org</a> o obriu "
-"un tiquet d'error a <a class=\"twl-links\" href=\"https://phabricator."
-"wikimedia.org/maniphest/task/edit/form/1/?projectPHIDs=Library-Card-"
-"Platform&title=Wikipedia%%20Library%%20%(path)s%%20Not%%20found"
-"\">Phabricator</a>"
+msgid "If you are certain that something should be here, please email us about this error at <a class=\"twl-links\" href=\"mailto:wikipedialibrary@wikimedia.org?Subject=Wikipedia%%20Library%%20%(path)s%%20Not%%20found\"> wikipedialibrary@wikimedia.org</a> or report it to us on <a class=\"twl-links\" href=\"https://phabricator.wikimedia.org/maniphest/task/edit/form/1/?projectPHIDs=Library-Card-Platform&title=Wikipedia%%20Library%%20%(path)s%%20Not%%20found\">Phabricator</a>"
+msgstr "Si teniu el convenciment que hi hauria d'haver quelcom aquí, si us plau envieu-nos un correu electrònic sobre aquest error a <a class=\"twl-links\" href=\"mailto:wikipedialibrary@wikimedia.org?Subject=Wikipedia%%20Library%%20%(path)s%%20Not%%20found\"> wikipedialibrary@wikimedia.org</a> o obriu un tiquet d'error a <a class=\"twl-links\" href=\"https://phabricator.wikimedia.org/maniphest/task/edit/form/1/?projectPHIDs=Library-Card-Platform&title=Wikipedia%%20Library%%20%(path)s%%20Not%%20found\">Phabricator</a>"
 
 #. Translators: Alt text for an image shown on the 404 error page.
 #: TWLight/templates/404.html:32
@@ -2263,52 +1811,19 @@ msgstr "Sobre la Biblioteca de la Viquipèdia"
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:20
-msgid ""
-"This platform is our central tool for facilitating access to our available "
-"collections. Here you can see which partnerships are available, search their "
-"contents, and apply for and access the ones you’re interested in."
-msgstr ""
-"Aquesta plataforma és la nostra eina principal per a facilitar l'accés a les "
-"nostres col·leccions disponibles. Aquí podreu trobar quines col·laboracions "
-"institucionals tenim disponibles, explorar llurs continguts i sol·licitar-hi "
-"accés si hi esteu interessats."
+msgid "This platform is our central tool for facilitating access to our available collections. Here you can see which partnerships are available, search their contents, and apply for and access the ones you’re interested in."
+msgstr "Aquesta plataforma és la nostra eina principal per a facilitar l'accés a les nostres col·leccions disponibles. Aquí podreu trobar quines col·laboracions institucionals tenim disponibles, explorar llurs continguts i sol·licitar-hi accés si hi esteu interessats."
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/). Wikimedia Foundation should not be translated.
 #: TWLight/templates/about.html:29
-msgid ""
-"All users receive immediate access to some collections, which can be browsed "
-"by clicking the 'Access collection' buttons or using the search bar at the "
-"top of the page. Other collections require an application before access is "
-"granted, and may be accessed directly or via an individual login or access "
-"code. Volunteer coordinators, who have signed non-disclosure agreements with "
-"the Wikimedia Foundation, review these applications and work with publishers "
-"to get you your free access."
-msgstr ""
-"Qualsevol viquipedista rebrà accés immediat a diverses col·leccions, que "
-"podeu navegar si feu clic al botó «Accediu a la col·lecció» o a través de la "
-"barra de cerca de l'inici de la pàgina. Altres col·leccions exigeixen un "
-"procés de sol·licitud abans de poder atorgar-vos-hi cap accés i pot ser que "
-"permetin o bé un accés directe, l'inici de sessió o bé un codi d'accés. "
-"L'equip de coordinació, fet per voluntaris i que ha signat un acord de "
-"confidencialitat amb la Fundació Wikimedia, és el que revisa les vostres "
-"sol·licituds i treballa amb les editorials per tal de proporcionar-vos els "
-"accessos institucionals de franc."
+msgid "All users receive immediate access to some collections, which can be browsed by clicking the 'Access collection' buttons or using the search bar at the top of the page. Other collections require an application before access is granted, and may be accessed directly or via an individual login or access code. Volunteer coordinators, who have signed non-disclosure agreements with the Wikimedia Foundation, review these applications and work with publishers to get you your free access."
+msgstr "Qualsevol viquipedista rebrà accés immediat a diverses col·leccions, que podeu navegar si feu clic al botó «Accediu a la col·lecció» o a través de la barra de cerca de l'inici de la pàgina. Altres col·leccions exigeixen un procés de sol·licitud abans de poder atorgar-vos-hi cap accés i pot ser que permetin o bé un accés directe, l'inici de sessió o bé un codi d'accés. L'equip de coordinació, fet per voluntaris i que ha signat un acord de confidencialitat amb la Fundació Wikimedia, és el que revisa les vostres sol·licituds i treballa amb les editorials per tal de proporcionar-vos els accessos institucionals de franc."
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/). Don't translate terms_url.
 #: TWLight/templates/about.html:43
 #, python-format
-msgid ""
-"For more information about how your information is stored and reviewed "
-"please see our <a class=\"twl-links\" href=\"%(terms_url)s\"> terms of use "
-"and privacy policy</a>. Accounts you apply for are also subject to the Terms "
-"of Use provided by each partner’s platform; please review them."
-msgstr ""
-"Per a més informació sobre com la vostra informació és emmagatzemada i "
-"processada, si us plau llegiu <a class=\"twl-links\" href=\"%(terms_url)s"
-"\">condicions d'ús i la política de privadesa</a>. Els accessos a les "
-"col·leccions que sol·liciteu també estan subjectes a les condicions d'ús "
-"proporcionades per cadascuna de les plataformes externes; us encoratgem a "
-"consultar-les."
+msgid "For more information about how your information is stored and reviewed please see our <a class=\"twl-links\" href=\"%(terms_url)s\"> terms of use and privacy policy</a>. Accounts you apply for are also subject to the Terms of Use provided by each partner’s platform; please review them."
+msgstr "Per a més informació sobre com la vostra informació és emmagatzemada i processada, si us plau llegiu <a class=\"twl-links\" href=\"%(terms_url)s\">condicions d'ús i la política de privadesa</a>. Els accessos a les col·leccions que sol·liciteu també estan subjectes a les condicions d'ús proporcionades per cadascuna de les plataformes externes; us encoratgem a consultar-les."
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:51
@@ -2317,26 +1832,13 @@ msgstr "Qui pot rebre-hi accés?"
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/). Wikimedia Foundation should not be translated.
 #: TWLight/templates/about.html:55
-msgid ""
-"Any active editor in good standing can receive access. For publishers with "
-"limited numbers of accounts, applications are reviewed based on the editor’s "
-"needs and contributions. If you think you could use access to one of our "
-"partner resources and are an active editor in any project supported by the "
-"Wikimedia Foundation, please apply."
-msgstr ""
-"Qualsevol viquipedista actiu pot rebre-hi accés. Pel que fa a les editorials "
-"que ens hi permeten l'accés amb un nombre limitat de comptes, les peticions "
-"són revisades a partir de les contribucions i les necessitats de cada "
-"viquipedista. Si creieu que us servirà accedir als arxius bibliogràfics dels "
-"nostres col·laboradors i sou viquipedistes actius en qualsevol dels "
-"projectes Wikimedia, si us plau envieu-nos una sol·licitud."
+msgid "Any active editor in good standing can receive access. For publishers with limited numbers of accounts, applications are reviewed based on the editor’s needs and contributions. If you think you could use access to one of our partner resources and are an active editor in any project supported by the Wikimedia Foundation, please apply."
+msgstr "Qualsevol viquipedista actiu pot rebre-hi accés. Pel que fa a les editorials que ens hi permeten l'accés amb un nombre limitat de comptes, les peticions són revisades a partir de les contribucions i les necessitats de cada viquipedista. Si creieu que us servirà accedir als arxius bibliogràfics dels nostres col·laboradors i sou viquipedistes actius en qualsevol dels projectes Wikimedia, si us plau envieu-nos una sol·licitud."
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:65
 msgid "Any editor can use the library if they meet a few basic requirements:"
-msgstr ""
-"Qualsevol viquipedista pot emprar la Biblioteca si compleix els següents "
-"requisits fonamentals:"
+msgstr "Qualsevol viquipedista pot emprar la Biblioteca si compleix els següents requisits fonamentals:"
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:71
@@ -2360,38 +1862,13 @@ msgstr "Ara mateix no esteu blocat en cap dels projectes Wikimedia"
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/)
 #: TWLight/templates/about.html:89
-msgid ""
-"If you are applying for an available collection, please first check that you "
-"don't already have access through another library or institution. If you do, "
-"please consider using that access rather than taking up a seat for this "
-"resource in The Wikipedia Library."
-msgstr ""
-"Si sol·liciteu una col·lecció disponible, comproveu primer si hi teniu accés "
-"amb credencials de la vostra biblioteca municipal, institucional o "
-"universitària. Si és així, prioritzeu aquest altre accés, de manera que "
-"aquesta credencial cedida i acordada amb la Biblioteca de la Viquipèdia "
-"quedi disponible per a algú altre que de debò la necessiti i que no tingui "
-"cap altra alternativa d'accés."
+msgid "If you are applying for an available collection, please first check that you don't already have access through another library or institution. If you do, please consider using that access rather than taking up a seat for this resource in The Wikipedia Library."
+msgstr "Si sol·liciteu una col·lecció disponible, comproveu primer si hi teniu accés amb credencials de la vostra biblioteca municipal, institucional o universitària. Si és així, prioritzeu aquest altre accés, de manera que aquesta credencial cedida i acordada amb la Biblioteca de la Viquipèdia quedi disponible per a algú altre que de debò la necessiti i que no tingui cap altra alternativa d'accés."
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/)
 #: TWLight/templates/about.html:99
-msgid ""
-"If your account is blocked on one or more Wikimedia projects, you may still "
-"be granted access to The Wikipedia Library. You will need to contact the "
-"Wikipedia Library team, who will review your blocks. If you have been "
-"blocked for content issues, most notably copyright violations, or have "
-"multiple long-term blocks, we may decline your request. Additionally, if "
-"your block status changes after being approved, you will need to request "
-"another review."
-msgstr ""
-"Si el vostre compte està blocat en qualsevol projecte Wikimedia, no està tot "
-"perdut: encara és possible d'accedir a la Biblioteca de la Viquipèdia. "
-"Nogensmenys, haureu de contactar l'equip de coordinació de la Biblioteca de "
-"la Viquipèdia, que revisarà el vostre cas. Si heu estat blocat per temes de "
-"contingut —especialment vulneracions dels drets d'autor— o heu rebut "
-"bloquejos reiterats i de llarg termini, és evident que segurament rebutjarem "
-"la vostra petició. A més a més, si el vostre estatus de blocatge canvia un "
-"cop haguem aprovat la vostra petició, n'haureu de sol·licitar una nova."
+msgid "If your account is blocked on one or more Wikimedia projects, you may still be granted access to The Wikipedia Library. You will need to contact the Wikipedia Library team, who will review your blocks. If you have been blocked for content issues, most notably copyright violations, or have multiple long-term blocks, we may decline your request. Additionally, if your block status changes after being approved, you will need to request another review."
+msgstr "Si el vostre compte està blocat en qualsevol projecte Wikimedia, no està tot perdut: encara és possible d'accedir a la Biblioteca de la Viquipèdia. Nogensmenys, haureu de contactar l'equip de coordinació de la Biblioteca de la Viquipèdia, que revisarà el vostre cas. Si heu estat blocat per temes de contingut —especialment vulneracions dels drets d'autor— o heu rebut bloquejos reiterats i de llarg termini, és evident que segurament rebutjarem la vostra petició. A més a més, si el vostre estatus de blocatge canvia un cop haguem aprovat la vostra petició, n'haureu de sol·licitar una nova."
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:110
@@ -2401,9 +1878,7 @@ msgstr "Què puc fer un cop hi tingui accés?"
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:114
 msgid "Approved editors <i>may</i> use their access to:"
-msgstr ""
-"Els viquipedistes que rebin l'aprovació de la plataforma <i>poden</i> emprar-"
-"la per a:"
+msgstr "Els viquipedistes que rebin l'aprovació de la plataforma <i>poden</i> emprar-la per a:"
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:118
@@ -2427,47 +1902,28 @@ msgstr "Els viquipedistes acceptats <i>no haurien de</i>:"
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:136
-msgid ""
-"Share their account logins or passwords with others, or sell their access to "
-"other parties"
-msgstr ""
-"Compartir els seus accessos institucionals o contrasenyes amb d'altres, i "
-"molt menys vendre el seu accés a d'altres parts"
+msgid "Share their account logins or passwords with others, or sell their access to other parties"
+msgstr "Compartir els seus accessos institucionals o contrasenyes amb d'altres, i molt menys vendre el seu accés a d'altres parts"
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:140
 msgid "Mass scrape or mass download partner content"
-msgstr ""
-"Usos ilegítims i descàrregues massives del contingut dels nostres "
-"col·laboradors"
+msgstr "Usos ilegítims i descàrregues massives del contingut dels nostres col·laboradors"
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:144
-msgid ""
-"Systematically make printed or electronic copies of multiple extracts of "
-"restricted content available for any purpose"
-msgstr ""
-"Abusar de les descàrregues digitals o de les còpies impreses per mitjà de "
-"múltiples extractes del contingut limitat, sigui quina sigui la seva "
-"finalitat"
+msgid "Systematically make printed or electronic copies of multiple extracts of restricted content available for any purpose"
+msgstr "Abusar de les descàrregues digitals o de les còpies impreses per mitjà de múltiples extractes del contingut limitat, sigui quina sigui la seva finalitat"
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/). Stub is a technical term for a short Wikipedia article, use the appropriate Wikipedia term in your language.
 #: TWLight/templates/about.html:148
-msgid ""
-"Datamine metadata without permission, in order, for instance, to use "
-"metadata for auto-created stub articles"
-msgstr ""
-"Processar metadades sense permís per tal de crear esborranys automàtics "
-"d'articles a la Viquipèdia (no utilitzeu bots)"
+msgid "Datamine metadata without permission, in order, for instance, to use metadata for auto-created stub articles"
+msgstr "Processar metadades sense permís per tal de crear esborranys automàtics d'articles a la Viquipèdia (no utilitzeu bots)"
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:154
-msgid ""
-"Respecting these agreements allows us to continue growing the partnerships "
-"available to the community."
-msgstr ""
-"Només si respecteu totes aquestes condicions podrem seguir creixent per tal "
-"de facilitar aquest servei a tota la comunitat viquipedista."
+msgid "Respecting these agreements allows us to continue growing the partnerships available to the community."
+msgstr "Només si respecteu totes aquestes condicions podrem seguir creixent per tal de facilitar aquest servei a tota la comunitat viquipedista."
 
 #. Translators: This is the heading for a section on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:160
@@ -2476,62 +1932,23 @@ msgstr "EZProxy"
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:164
-msgid ""
-"EZProxy is a proxy server used to authenticate users for many Wikipedia "
-"Library partners. Users sign into EZProxy via the Library Card platform to "
-"verify that they are authorized users, and then the server accesses "
-"requested resources using its own IP address."
-msgstr ""
-"EZproxy és un servidor intermediari que permet autentificar viquipedistes "
-"per a molts dels col·laboradors de la Biblioteca de la Viquipèdia. Els "
-"usuaris signeu a EZProxy a través de la plataforma de la Targeta "
-"Bibliotecària per tal de verificar que en sou usuaris autoritzats. Llavors "
-"el servidor accedeix als recursos sol·licitats emprant la seva pròpia adreça "
-"IP."
+msgid "EZProxy is a proxy server used to authenticate users for many Wikipedia Library partners. Users sign into EZProxy via the Library Card platform to verify that they are authorized users, and then the server accesses requested resources using its own IP address."
+msgstr "EZproxy és un servidor intermediari que permet autentificar viquipedistes per a molts dels col·laboradors de la Biblioteca de la Viquipèdia. Els usuaris signeu a EZProxy a través de la plataforma de la Targeta Bibliotecària per tal de verificar que en sou usuaris autoritzats. Llavors el servidor accedeix als recursos sol·licitats emprant la seva pròpia adreça IP."
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:173
-msgid ""
-"You may notice that when accessing resources via EZProxy that URLs are "
-"dynamically rewritten. This is why we recommend logging in via the Library "
-"Card platform rather than going directly to the unproxied partner website. "
-"When in doubt, check the URL for ‘idm.oclc’. If it’s there, then you’re "
-"connected via EZProxy."
-msgstr ""
-"És possible que us adoneu que, quan accediu a les col·leccions per mitjà "
-"d'EZProxy, les adreces URL es reescriuen dinàmicament. És per això que us "
-"recomanem que inicieu sessió a través de la plataforma de la Targeta "
-"Bibliotecària en comptes d'accedir directament al lloc web extern sense "
-"intermediaris. En cas de dubte, comproveu l'adreça URL «idm.oclc». Si hi és, "
-"vol dir que la vostra connexió s'executa via EZProxy."
+msgid "You may notice that when accessing resources via EZProxy that URLs are dynamically rewritten. This is why we recommend logging in via the Library Card platform rather than going directly to the unproxied partner website. When in doubt, check the URL for ‘idm.oclc’. If it’s there, then you’re connected via EZProxy."
+msgstr "És possible que us adoneu que, quan accediu a les col·leccions per mitjà d'EZProxy, les adreces URL es reescriuen dinàmicament. És per això que us recomanem que inicieu sessió a través de la plataforma de la Targeta Bibliotecària en comptes d'accedir directament al lloc web extern sense intermediaris. En cas de dubte, comproveu l'adreça URL «idm.oclc». Si hi és, vol dir que la vostra connexió s'executa via EZProxy."
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:182
-msgid ""
-"Typically once you’ve logged in your session will remain active in your "
-"browser for up to two hours after you’ve finished searching. Note that use "
-"of EZProxy requires you to enable cookies. If you are having problems you "
-"should also try clearing your cache and restarting your browser."
+msgid "Typically once you’ve logged in your session will remain active in your browser for up to two hours after you’ve finished searching. Note that use of EZProxy requires you to enable cookies. If you are having problems you should also try clearing your cache and restarting your browser."
 msgstr ""
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/)
 #: TWLight/templates/about.html:193
-msgid ""
-"The Library Bundle is a collection of resources for which no application is "
-"required. If you meet the criteria laid out above, you will be authorized "
-"for access automatically upon logging in to the platform. Only some of our "
-"content is currently included in the Library Bundle, however we hope to "
-"expand the collection as more publishers become comfortable with "
-"participating. All Bundle content is accessed via EZProxy."
-msgstr ""
-"El Paquet Institucional és una col·lecció de recursos per la qual no és "
-"necessària cap sol·licitud. Si reuniu els criteris especificats més amunt, "
-"rebreu l'autorització d'accés immediat un cop inicieu la sessió a la "
-"plataforma. Només alguns dels nostres continguts formen part del Paquet "
-"Institucional. Tanmateix, desitgem ampliar aquesta col·lecció amb moltes "
-"altres editorials un cop aquestes se n'adonin del benefici que això suposa i "
-"s'hi sentin còmodes. Tots els arxius del Paquet Institucional són "
-"accessibles via EZProxy."
+msgid "The Library Bundle is a collection of resources for which no application is required. If you meet the criteria laid out above, you will be authorized for access automatically upon logging in to the platform. Only some of our content is currently included in the Library Bundle, however we hope to expand the collection as more publishers become comfortable with participating. All Bundle content is accessed via EZProxy."
+msgstr "El Paquet Institucional és una col·lecció de recursos per la qual no és necessària cap sol·licitud. Si reuniu els criteris especificats més amunt, rebreu l'autorització d'accés immediat un cop inicieu la sessió a la plataforma. Només alguns dels nostres continguts formen part del Paquet Institucional. Tanmateix, desitgem ampliar aquesta col·lecció amb moltes altres editorials un cop aquestes se n'adonin del benefici que això suposa i s'hi sentin còmodes. Tots els arxius del Paquet Institucional són accessibles via EZProxy."
 
 #. Translators: This is the heading for a section on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:202
@@ -2540,20 +1957,8 @@ msgstr "Pràctiques de citació"
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:206
-msgid ""
-"Citation practices vary by project and even by article. Generally, we "
-"support editors citing where they found information, in a form that allows "
-"others to check it for themselves. That often means providing both original "
-"source details as well as a link to the partner database in which the source "
-"was found."
-msgstr ""
-"Les pràctiques de citació varien segons cada projecte Wikimedia i àdhuc "
-"segons cada article o pàgina wiki. El nostre esperit és el de recolzar els "
-"viquipedistes que citen les seves fonts d'informació de tal manera que "
-"qualsevol altra persona pugui comprovar i verificar cada referència pel seu "
-"compte. Sovint, això significa proporcionar amb rigorositat els detalls de "
-"la font original i el seu corresponent enllaç en cas que sigui digital (és a "
-"dir, cap a la base de dades o repositori on la va trobar)."
+msgid "Citation practices vary by project and even by article. Generally, we support editors citing where they found information, in a form that allows others to check it for themselves. That often means providing both original source details as well as a link to the partner database in which the source was found."
+msgstr "Les pràctiques de citació varien segons cada projecte Wikimedia i àdhuc segons cada article o pàgina wiki. El nostre esperit és el de recolzar els viquipedistes que citen les seves fonts d'informació de tal manera que qualsevol altra persona pugui comprovar i verificar cada referència pel seu compte. Sovint, això significa proporcionar amb rigorositat els detalls de la font original i el seu corresponent enllaç en cas que sigui digital (és a dir, cap a la base de dades o repositori on la va trobar)."
 
 #. Translators: This is the heading for a section on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #. Translators: This link is at the bottom of every page and can be clicked by users to contact the wikipedia library team.
@@ -2564,13 +1969,8 @@ msgstr "Contacteu-nos"
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:218
 #, python-format
-msgid ""
-"If you have questions, need help, or want to volunteer to help, please see "
-"our <a class=\"twl-links\" href=\"%(contact_url)s\">contact page</a>."
-msgstr ""
-"Si teniu cap dubte, necessiteu ajuda o voleu voluntariejar per ser els qui "
-"oferiu aquesta ajuda, si us plau consulteu la nostra <a class=\"twl-links\" "
-"href=\"%(contact_url)s\">pàgina de contacte</a>."
+msgid "If you have questions, need help, or want to volunteer to help, please see our <a class=\"twl-links\" href=\"%(contact_url)s\">contact page</a>."
+msgstr "Si teniu cap dubte, necessiteu ajuda o voleu voluntariejar per ser els qui oferiu aquesta ajuda, si us plau consulteu la nostra <a class=\"twl-links\" href=\"%(contact_url)s\">pàgina de contacte</a>."
 
 #. Translators: This is the title of the panel box detailing the contact information for the Wikipedia Library team.
 #: TWLight/templates/contact.html:14
@@ -2609,12 +2009,8 @@ msgstr "El perfil de Twitter de la Biblioteca de la Viquipèdia (en anglès)"
 #. Translators: This is the text that appears at the bottom of the contact us form directing users to the suggestions form.
 #: TWLight/templates/contact.html:48
 #, python-format
-msgid ""
-"(If you would like to suggest a partner, <a class=\"twl-links\" href="
-"\"%(suggest)s\"><strong>go here</strong></a>.)"
-msgstr ""
-"(Si voleu suggerir una editorial col·laboradora, <a class=\"twl-links\" href="
-"\"%(suggest)s\"><strong>feu-ho ací</strong></a>.)"
+msgid "(If you would like to suggest a partner, <a class=\"twl-links\" href=\"%(suggest)s\"><strong>go here</strong></a>.)"
+msgstr "(Si voleu suggerir una editorial col·laboradora, <a class=\"twl-links\" href=\"%(suggest)s\"><strong>feu-ho ací</strong></a>.)"
 
 #. Translators: On a special 'link to search' page, this message is shown if JavaScript is disabled.
 #: TWLight/templates/eds_search_endpoint.html:7
@@ -2671,13 +2067,8 @@ msgstr "La Biblioteca de la Viquipèdia"
 #. Translators: Information about The Wikipedia Library.
 #: TWLight/templates/login_partial.html:53 TWLight/templates/new_base.html:21
 #, python-format
-msgid ""
-"More than 100 of the world's top subscription-only databases, with content "
-"in %(no_of_languages)s languages, free for Wikipedians of all backgrounds"
-msgstr ""
-"Més de 100 dels repositoris bibliogràfics de pagament més prestigiosos del "
-"món, amb contingut en %(no_of_languages)s llengües, de franc per a "
-"viquipedistes de qualsevol especialitat"
+msgid "More than 100 of the world's top subscription-only databases, with content in %(no_of_languages)s languages, free for Wikipedians of all backgrounds"
+msgstr "Més de 100 dels repositoris bibliogràfics de pagament més prestigiosos del món, amb contingut en %(no_of_languages)s llengües, de franc per a viquipedistes de qualsevol especialitat"
 
 #. Translators: Information about The Wikipedia Library.
 #: TWLight/templates/login_partial.html:64
@@ -2685,13 +2076,8 @@ msgid "Meet these criteria for automatic access"
 msgstr "Reuniu aquests requisits i hi rebreu accés immediat"
 
 #: TWLight/templates/login_partial.html:69
-msgid ""
-"These criteria grant you access to certain collections but not all. Some "
-"collections are accessible on a per application basis only."
-msgstr ""
-"Aquests requisits us garanteixen l'accés institucional a diversos "
-"col·leccions específiques, però no a totes. Algunes són accessibles només "
-"per mitjà d'una sol·licitud prèvia."
+msgid "These criteria grant you access to certain collections but not all. Some collections are accessible on a per application basis only."
+msgstr "Aquests requisits us garanteixen l'accés institucional a diversos col·leccions específiques, però no a totes. Algunes són accessibles només per mitjà d'una sol·licitud prèvia."
 
 #: TWLight/templates/login_partial.html:89
 msgid "Login via Wikipedia"
@@ -2700,34 +2086,19 @@ msgstr "Accediu-hi amb el vostre compte de Wikimedia"
 #. Translators: Shown if the current user doesn't have a registered email on their account. Don't translate contact_us_url or email_url.
 #: TWLight/templates/message_partial.html:15
 #, python-format
-msgid ""
-"You don't have an email on file. We can't finalize your access to partner "
-"resources, and you won't be able to <a class=\"twl-links\" href="
-"\"%(contact_us_url)s\">contact us</a> without an email. Please <a class="
-"\"twl-links\" href=\"%(email_url)s\">update your email</a>."
-msgstr ""
-"No teniu un correu electrònic associat al vostre compte d'usuari. No podem "
-"enllestir el vostre accés als recursos dels nostres col·laboradors i no "
-"podreu <a class=\"twl-links\" href=\"%(contact_us_url)s\">contactar-nos</a> "
-"sense una adreça establerta. Si us plau, <a class=\"twl-links\" href="
-"\"%(email_url)s\">afegiu un correu electrònic al vostre compte</a>."
+msgid "You don't have an email on file. We can't finalize your access to partner resources, and you won't be able to <a class=\"twl-links\" href=\"%(contact_us_url)s\">contact us</a> without an email. Please <a class=\"twl-links\" href=\"%(email_url)s\">update your email</a>."
+msgstr "No teniu un correu electrònic associat al vostre compte d'usuari. No podem enllestir el vostre accés als recursos dels nostres col·laboradors i no podreu <a class=\"twl-links\" href=\"%(contact_us_url)s\">contactar-nos</a> sense una adreça establerta. Si us plau, <a class=\"twl-links\" href=\"%(email_url)s\">afegiu un correu electrònic al vostre compte</a>."
 
 #. Translators: Shown if the current user has requested the processing of their data should be restricted.
 #: TWLight/templates/message_partial.html:26
 #, python-format
-msgid ""
-"You have requested a restriction on the processing of your data. Most site "
-"functionality will not be available to you until you <a class=\"twl-links\" "
-"href=\"%(restrict_url)s\">lift this restriction</a>."
+msgid "You have requested a restriction on the processing of your data. Most site functionality will not be available to you until you <a class=\"twl-links\" href=\"%(restrict_url)s\">lift this restriction</a>."
 msgstr ""
 
 #. Translators: Shown if the current user has not agreed to the terms of use.
 #: TWLight/templates/message_partial.html:37
 #, python-format
-msgid ""
-"You have not agreed to the <a class=\"twl-links\" href=\"%(terms_url)s"
-"\">terms of use</a> of this site. Your applications will not be processed "
-"and you won't be able to apply or access resources you are approved for."
+msgid "You have not agreed to the <a class=\"twl-links\" href=\"%(terms_url)s\">terms of use</a> of this site. Your applications will not be processed and you won't be able to apply or access resources you are approved for."
 msgstr ""
 
 #. Translators: This link is at the bottom of every page and links to the 'About' page (https://wikipedialibrary.wmflabs.org/about/)
@@ -2774,13 +2145,8 @@ msgstr "Restableix la contrasenya"
 
 #. Translators: If a user goes to reset their password, this message asks them to enter their email to do so.
 #: TWLight/templates/registration/password_reset_form.html:13
-msgid ""
-"Forgot your password? Enter your email address below, and we'll email "
-"instructions for setting a new one."
-msgstr ""
-"Heu oblidat la vostra contrasenya? Introduïu la vostra adreça de correu "
-"electrònic a continuació i us hi enviarem un missatge amb els passos per a "
-"que en pugueu establir una de nova."
+msgid "Forgot your password? Enter your email address below, and we'll email instructions for setting a new one."
+msgstr "Heu oblidat la vostra contrasenya? Introduïu la vostra adreça de correu electrònic a continuació i us hi enviarem un missatge amb els passos per a que en pugueu establir una de nova."
 
 #. Translators: This is the label for a button that users click to update their public information.
 #: TWLight/users/forms.py:36
@@ -2790,9 +2156,7 @@ msgstr "Actualitza el perfil"
 #. Translators: This labels a field where users can describe their activity on Wikipedia in a small biography.
 #: TWLight/users/forms.py:45
 msgid "Describe your contributions to Wikipedia: topics edited, et cetera."
-msgstr ""
-"Descriviu les vostres contribucions a la Viquipèdia o en d'altres projectes "
-"Wikimedia: els temes que editeu, com hi participeu, etcètera."
+msgstr "Descriviu les vostres contribucions a la Viquipèdia o en d'altres projectes Wikimedia: els temes que editeu, com hi participeu, etcètera."
 
 #. Translators: In the preferences section (Emails) of a user profile, this text labels the checkbox users can (un)click to change if they wish to receive account renewal notices or not.
 #: TWLight/users/forms.py:98
@@ -2826,22 +2190,13 @@ msgstr "Acccepto els termes d'ús"
 
 #. Translators: This text explains how to disagree to the site's terms of use and the restrictions that will come into effect when users disagree to the terms of use.
 #: TWLight/users/forms.py:185
-msgid ""
-"By unchecking this box and clicking “Update” you may explore the site, but "
-"you will not be able to apply for access to materials or evaluate "
-"applications unless you agree with the terms of use."
-msgstr ""
-"Si desactiveu aquesta casella i premeu «Actualitza», podreu explorar aquest "
-"lloc web. Tanmateix, ja no tindreu accés als materials de consulta ni podreu "
-"avaluar sol·licituds si no accepteu les condicions d'ús."
+msgid "By unchecking this box and clicking “Update” you may explore the site, but you will not be able to apply for access to materials or evaluate applications unless you agree with the terms of use."
+msgstr "Si desactiveu aquesta casella i premeu «Actualitza», podreu explorar aquest lloc web. Tanmateix, ja no tindreu accés als materials de consulta ni podreu avaluar sol·licituds si no accepteu les condicions d'ús."
 
 #. Translators: Users click this button to set their website email address to the one linked to their Wikipedia account.
 #: TWLight/users/forms.py:211
-msgid ""
-"Use my Wikipedia email address (will be updated the next time you login)."
-msgstr ""
-"Utilitza el mateix correu electrònic que al meu compte de Wikimedia "
-"(s'actualitzarà el proper cop que inicieu la sessió)."
+msgid "Use my Wikipedia email address (will be updated the next time you login)."
+msgstr "Utilitza el mateix correu electrònic que al meu compte de Wikimedia (s'actualitzarà el proper cop que inicieu la sessió)."
 
 #. Translators: This labels a button which users click to change their email.
 #: TWLight/users/forms.py:232
@@ -2851,25 +2206,13 @@ msgstr "Actualitza el correu electrònic"
 #. Translators: Shown if the current user tried to 'favorite' a partner they can't access. Do not translate '{partner}'
 #: TWLight/users/models.py:201
 #, python-brace-format
-msgid ""
-"Cannot add partner {partner} to your favorites because you don't have access "
-"to it"
-msgstr ""
-"No hem pogut afegir el col·laborador editorial {partner} als vostres "
-"preferits perquè no hi teniu accés"
-
-#. Translators: Do not translate.
-#: TWLight/users/models.py:869
-#, fuzzy, python-brace-format
-#| msgid "Username"
-msgid "{wp_username}"
-msgstr "Nom d’usuari"
+msgid "Cannot add partner {partner} to your favorites because you don't have access to it"
+msgstr "No hem pogut afegir el col·laborador editorial {partner} als vostres preferits perquè no hi teniu accés"
 
 #. Translators: This error message is shown when there's a problem with the authenticated login process.
 #: TWLight/users/oauth.py:243
 msgid "You tried to log in but presented an invalid access token."
-msgstr ""
-"Heu provat d'iniciar sessió, però heu presentat un testimoni d'accés invàlid."
+msgstr "Heu provat d'iniciar sessió, però heu presentat un testimoni d'accés invàlid."
 
 #. Translators: This message is shown when the OAuth login process fails because the request came from the wrong website. Don't translate {domain}.
 #: TWLight/users/oauth.py:298 TWLight/users/oauth.py:444
@@ -2880,18 +2223,12 @@ msgstr "{domain} no és un amfitrió permès."
 #. Translators: This warning message is shown to users when OAuth handshaker can't be initiated.
 #: TWLight/users/oauth.py:364
 msgid "Handshaker not initiated, please try logging in again."
-msgstr ""
-"Conformitat de connexió no iniciada. Si us plau, inicieu la sessió una altra "
-"vegada."
+msgstr "Conformitat de connexió no iniciada. Si us plau, inicieu la sessió una altra vegada."
 
 #. Translators: this message is displayed to users that don't have accounts and clicked on a proxied link.
 #: TWLight/users/oauth.py:388
-msgid ""
-"To view this link you need to be an eligible library user. Please login to "
-"continue."
-msgstr ""
-"Per accedir a l'enllaç, heu de ser un usuari apte per a la Biblioteca de la "
-"Viquipèdia. Si us plau, inicieu la sessió per a continuar."
+msgid "To view this link you need to be an eligible library user. Please login to continue."
+msgstr "Per accedir a l'enllaç, heu de ser un usuari apte per a la Biblioteca de la Viquipèdia. Si us plau, inicieu la sessió per a continuar."
 
 #. Translators: This warning message is shown to users when the response received from Wikimedia OAuth servers is not a valid one.
 #: TWLight/users/oauth.py:430
@@ -2916,9 +2253,7 @@ msgstr "Cap fitxa de sol·licitud."
 #. Translators: This message is shown when the OAuth login process fails.
 #: TWLight/users/oauth.py:498
 msgid "Access token generation failed, please try logging in again."
-msgstr ""
-"La creació d'una fitxa de sol·licitud ha fallat. Si us plau, proveu "
-"d'iniciar la sessió un altre cop."
+msgstr "La creació d'una fitxa de sol·licitud ha fallat. Si us plau, proveu d'iniciar la sessió un altre cop."
 
 #. Translators: This message is shown when more information is available on another page. Do not translate {issue}
 #: TWLight/users/oauth.py:507
@@ -2928,25 +2263,13 @@ msgstr "Vegeu {issue} per a més informació"
 
 #. Translators: If the user tries to log in, but their account does not meet certain requirements, they cannot login.
 #: TWLight/users/oauth.py:528
-msgid ""
-"Your Wikipedia account does not meet the eligibility criteria in the terms "
-"of use, so your Wikipedia Library Card Platform account cannot be activated."
-msgstr ""
-"El vostre compte de Wikimedia no reuneix els criteris d'elegibilitat "
-"establerts per les condicions d'ús, per la qual cosa el vostre accés a "
-"l'Espai v-Carnet de la Biblioteca de la Viquipèdia no podrà ser activat."
+msgid "Your Wikipedia account does not meet the eligibility criteria in the terms of use, so your Wikipedia Library Card Platform account cannot be activated."
+msgstr "El vostre compte de Wikimedia no reuneix els criteris d'elegibilitat establerts per les condicions d'ús, per la qual cosa el vostre accés a l'Espai v-Carnet de la Biblioteca de la Viquipèdia no podrà ser activat."
 
 #. Translators: If the user tries to log in, but their account does not meet certain requirements, they cannot login.
 #: TWLight/users/oauth.py:536
-msgid ""
-"Your Wikipedia account no longer meets the eligibility criteria in the terms "
-"of use, so you cannot be logged in. If you think you should be able to log "
-"in, please email wikipedialibrary@wikimedia.org."
-msgstr ""
-"El vostre compte de Wikimedia ja no reuneix els requisits d'elecció "
-"establerts a les condicions d'ús. Consegüentment, no podreu iniciar la "
-"sessió. Si creieu que hi hauríeu de poder, si us plau contacteu-nos a "
-"l'adreça wikipedialibrary@wikimedia.org."
+msgid "Your Wikipedia account no longer meets the eligibility criteria in the terms of use, so you cannot be logged in. If you think you should be able to log in, please email wikipedialibrary@wikimedia.org."
+msgstr "El vostre compte de Wikimedia ja no reuneix els requisits d'elecció establerts a les condicions d'ús. Consegüentment, no podreu iniciar la sessió. Si creieu que hi hauríeu de poder, si us plau contacteu-nos a l'adreça wikipedialibrary@wikimedia.org."
 
 #. Translators: this message is displayed to users with brand new accounts.
 #: TWLight/users/oauth.py:549
@@ -2956,14 +2279,8 @@ msgstr "Us donem la benvinguda! Si us plau, accepteu les condicions d'ús."
 #. Translators: This message is displayed on the confirmation page where users can return their access to partner collections.
 #: TWLight/users/templates/users/authorization_confirm_return.html:13
 #, python-format
-msgid ""
-"You will no longer be able to access <b>%(partner)s's</b> resources via the "
-"Library Card platform, but can request access again by clicking 'renew', if "
-"you change your mind. Are you sure you want to return your access?"
-msgstr ""
-"Ja no pots accedir als recursos de %(partner)s a través de l'Espai v-Carnet, "
-"però pots tornar a demanar accés clicant \"renova\" si canvies d'idea. Estàs "
-"segur que vols tornar el teu accés?"
+msgid "You will no longer be able to access <b>%(partner)s's</b> resources via the Library Card platform, but can request access again by clicking 'renew', if you change your mind. Are you sure you want to return your access?"
+msgstr "Ja no pots accedir als recursos de %(partner)s a través de l'Espai v-Carnet, però pots tornar a demanar accés clicant \"renova\" si canvies d'idea. Estàs segur que vols tornar el teu accés?"
 
 #. Translators: On the MyLibrary page (https://wikipedialibrary.wmflabs.org/users/my_library), this tab shows all favorite collections a user has.
 #: TWLight/users/templates/users/collections_section.html:9
@@ -3032,14 +2349,8 @@ msgstr "Dades del viquipedista"
 
 #. Translators: This is shown on editor profiles, in their profile page or on applications.
 #: TWLight/users/templates/users/editor_detail.html:59
-msgid ""
-"Information with an * was retrieved from Wikipedia directly. Other "
-"information was entered directly by users or site admins, in their preferred "
-"language."
-msgstr ""
-"La informació amb un * ha estat obtinguda automàticament dels projectes "
-"Wikimedia. La resta de dades han estat introduïdes directament pels "
-"viquipedistes o administradors de cada wiki en la seva pròpia llengua."
+msgid "Information with an * was retrieved from Wikipedia directly. Other information was entered directly by users or site admins, in their preferred language."
+msgstr "La informació amb un * ha estat obtinguda automàticament dels projectes Wikimedia. La resta de dades han estat introduïdes directament pels viquipedistes o administradors de cada wiki en la seva pròpia llengua."
 
 #. Translators: This distinguishes users who have been flagged as account coordinators. Don't translate username.
 #: TWLight/users/templates/users/editor_detail.html:71
@@ -3049,10 +2360,7 @@ msgstr ""
 
 #. Translators: This is shown on editor profiles, under the heading for Wikipedia editor data.
 #: TWLight/users/templates/users/editor_detail_data.html:5
-msgid ""
-"This information is updated automatically from your Wikimedia account each "
-"time you log in, except for the Contributions field, where you can describe "
-"your Wikimedia editing history."
+msgid "This information is updated automatically from your Wikimedia account each time you log in, except for the Contributions field, where you can describe your Wikimedia editing history."
 msgstr ""
 
 #. Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this labels the user's username.
@@ -3082,19 +2390,13 @@ msgstr "Reuneix les condicions d'ús establertes?"
 
 #. Translators: when viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this question has a yes or no answer.
 #: TWLight/users/templates/users/editor_detail_data.html:57
-msgid ""
-"at their last login, did this user meet the criteria set forth in the terms "
-"of use?"
-msgstr ""
-"Durant el seu darrer inici de sessió, aquest viquipedista va reunir els "
-"criteris establerts a les condicions d'ús?"
+msgid "at their last login, did this user meet the criteria set forth in the terms of use?"
+msgstr "Durant el seu darrer inici de sessió, aquest viquipedista va reunir els criteris establerts a les condicions d'ús?"
 
 #. Translators: When viewing a user's profile in an application, this message shows if the software doesn't think that the user is eligible for access. Don't translate username.
 #: TWLight/users/templates/users/editor_detail_data.html:72
 #, python-format
-msgid ""
-"%(username)s may still be eligible for access grants at the coordinators' "
-"discretion."
+msgid "%(username)s may still be eligible for access grants at the coordinators' discretion."
 msgstr ""
 
 #. Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this is the heading for a Yes/No ToU question.
@@ -3129,15 +2431,8 @@ msgstr "(exempció concedida)"
 #. Translators: This message is shown on a user's profile if their Wikimedia account is blocked on one or more projects. They may still be granted access to the Library Bundle, but need to contact Wikipedia Library staff to verify.
 #: TWLight/users/templates/users/editor_detail_data.html:137
 #, python-format
-msgid ""
-"It looks like you have an active block on your account. If you meet the "
-"other criteria you may still be permitted access to the library - please <a "
-"class=\"twl-links\" href=\"%(contact_url)s\">contact us</a>."
-msgstr ""
-"Sembla que el vostre compte està actualment bloquejat... Si compliu la resta "
-"de criteris d'elegibilitat, potser encara us podem permetre l'accés a la "
-"Biblioteca de la Viquipèdia. Si us plau, <a class=\"twl-links\" href="
-"\"%(contact_url)s\">poseu-vos en contacte</a> amb nosaltres."
+msgid "It looks like you have an active block on your account. If you meet the other criteria you may still be permitted access to the library - please <a class=\"twl-links\" href=\"%(contact_url)s\">contact us</a>."
+msgstr "Sembla que el vostre compte està actualment bloquejat... Si compliu la resta de criteris d'elegibilitat, potser encara us podem permetre l'accés a la Biblioteca de la Viquipèdia. Si us plau, <a class=\"twl-links\" href=\"%(contact_url)s\">poseu-vos en contacte</a> amb nosaltres."
 
 #. Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this is the heading for a Yes/No program eligibility question.
 #: TWLight/users/templates/users/editor_detail_data.html:153
@@ -3146,14 +2441,8 @@ msgstr "Elegible per al Paquet Institucional?"
 
 #. Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this question has a Yes or No answer.
 #: TWLight/users/templates/users/editor_detail_data.html:156
-msgid ""
-"At their last login, did this user meet the criteria set forth in the "
-"Library Bundle? Note that satisfying terms of use is a prerequisite to "
-"bundle eligibility."
-msgstr ""
-"En el darrer inici de sessió, aquest usuari complia el criteri establert per "
-"accedir al Paquet Institucional? Tingueu en compte que acceptar les "
-"condicions d'ús és un prerequisit indispensable per a optar-hi."
+msgid "At their last login, did this user meet the criteria set forth in the Library Bundle? Note that satisfying terms of use is a prerequisite to bundle eligibility."
+msgstr "En el darrer inici de sessió, aquest usuari complia el criteri establert per accedir al Paquet Institucional? Tingueu en compte que acceptar les condicions d'ús és un prerequisit indispensable per a optar-hi."
 
 #. Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this is the heading for a Yes/No program eligibility question.
 #: TWLight/users/templates/users/editor_detail_data.html:177
@@ -3197,25 +2486,14 @@ msgstr "Dades personals"
 
 #. Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this text is in the 'Personal data' section. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/users/templates/users/editor_detail_data.html:262
-msgid ""
-"The following information is visible only to you, site administrators, "
-"publishing partners (where required), and volunteer Wikipedia Library "
-"coordinators (who have signed a Non-Disclosure Agreement)."
-msgstr ""
-"La informació següent és només visible per vós, pels administradors d'aquest "
-"lloc, pels col·laboradors editorials (fins allà on sigui imprescindible) i "
-"pels voluntaris de coordinació de la Biblioteca de la Viquipèdia —només "
-"aquells que han signat un contracte de confidencialitat de dades."
+msgid "The following information is visible only to you, site administrators, publishing partners (where required), and volunteer Wikipedia Library coordinators (who have signed a Non-Disclosure Agreement)."
+msgstr "La informació següent és només visible per vós, pels administradors d'aquest lloc, pels col·laboradors editorials (fins allà on sigui imprescindible) i pels voluntaris de coordinació de la Biblioteca de la Viquipèdia —només aquells que han signat un contracte de confidencialitat de dades."
 
 #. Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this labels a button which users can click to update or remove their personal information. Don't translate update_url.
 #: TWLight/users/templates/users/editor_detail_data.html:272
 #, python-format
-msgid ""
-"You may <a class=\"twl-links\" href=\"%(update_url)s\">update or delete</a> "
-"your data at any time."
-msgstr ""
-"Podeu <a class=\"twl-links\" href=\"%(update_url)s\">actualitzar o suprimir</"
-"a> totes les vostres dades quan ho desitgeu."
+msgid "You may <a class=\"twl-links\" href=\"%(update_url)s\">update or delete</a> your data at any time."
+msgstr "Podeu <a class=\"twl-links\" href=\"%(update_url)s\">actualitzar o suprimir</a> totes les vostres dades quan ho desitgeu."
 
 #. Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this labels the user's email. Don't remove the *.
 #: TWLight/users/templates/users/editor_detail_data.html:283
@@ -3234,32 +2512,19 @@ msgstr "Afiliació institucional"
 
 #. Translators: This message tells users that they are not eligible to access The Wikipedia Library content.
 #: TWLight/users/templates/users/eligibility_modal.html:7
-msgid ""
-"Sorry, your Wikipedia account doesn’t currently qualify to access The "
-"Wikipedia Library."
-msgstr ""
-"Ho sentim, el vostre compte de Wikimedia no reuneix les condicions per "
-"accedir a la Biblioteca de la Viquipèdia."
+msgid "Sorry, your Wikipedia account doesn’t currently qualify to access The Wikipedia Library."
+msgstr "Ho sentim, el vostre compte de Wikimedia no reuneix les condicions per accedir a la Biblioteca de la Viquipèdia."
 
 #. Translators: This message tells users that they have not agreed to the terms of use, therefore are ineligible to access the content in The Wikipedia Library.
 #: TWLight/users/templates/users/eligibility_modal.html:30
 #, python-format
-msgid ""
-"Agreed with <a href=\"%(terms)s\" class=\"text-danger\"> terms of use </a>"
-msgstr ""
-"D'acord amb les <a href=\"%(terms)s\" class=\"text-danger\">condicions d'ús</"
-"a>"
+msgid "Agreed with <a href=\"%(terms)s\" class=\"text-danger\"> terms of use </a>"
+msgstr "D'acord amb les <a href=\"%(terms)s\" class=\"text-danger\">condicions d'ús</a>"
 
 #: TWLight/users/templates/users/eligibility_modal.html:40
 #, python-format
-msgid ""
-"It looks like you have an active block on your account. If you meet the "
-"other criteria you may still be permitted access to the library - please <a "
-"href=\"%(contact_url)s\">contact us</a>."
-msgstr ""
-"Sembla que teniu un blocatge actiu al teu compte d'usuari. Si compliu amb "
-"les altres condicions, potser encara podríem donar-vos accés a la "
-"Biblioteca, però si us plau <a href=\"%(contact_url)s\">contacteu-nos</a>."
+msgid "It looks like you have an active block on your account. If you meet the other criteria you may still be permitted access to the library - please <a href=\"%(contact_url)s\">contact us</a>."
+msgstr "Sembla que teniu un blocatge actiu al teu compte d'usuari. Si compliu amb les altres condicions, potser encara podríem donar-vos accés a la Biblioteca, però si us plau <a href=\"%(contact_url)s\">contacteu-nos</a>."
 
 #. Translators: Instructions to refresh a user's data.
 #: TWLight/users/templates/users/eligibility_modal.html:50
@@ -3284,8 +2549,7 @@ msgstr "La col·lecció és plenament navegable a través de la barra de cerca"
 #. Translators: Text that describes a search icon.
 #: TWLight/users/templates/users/filter_section.html:54
 msgid "Collection is only partially searchable via the search bar"
-msgstr ""
-"La col·lecció és només parcialment navegable a través de la barra de cerca"
+msgstr "La col·lecció és només parcialment navegable a través de la barra de cerca"
 
 #. Translators: Text that explains when there is no search icon.
 #: TWLight/users/templates/users/filter_section.html:58
@@ -3299,14 +2563,8 @@ msgstr "Estableix l'idioma"
 
 #. Translators: This text on the user page helps users naviage to the TranslateWiki Wikipedia Library Card platform translation page.
 #: TWLight/users/templates/users/language_form.html:31
-msgid ""
-"You can help translate the tool at <a class=\"twl-links\" href=\"https://"
-"translatewiki.net/wiki/Translating:Wikipedia_Library_Card_Platform"
-"\">translatewiki.net</a>."
-msgstr ""
-"Podeu ajudar-nos a traduir l'interfície d'aquesta plataforma a <a class="
-"\"twl-links\" href=\"https://translatewiki.net/wiki/Translating:"
-"Wikipedia_Library_Card_Platform\">translatewiki.net</a>."
+msgid "You can help translate the tool at <a class=\"twl-links\" href=\"https://translatewiki.net/wiki/Translating:Wikipedia_Library_Card_Platform\">translatewiki.net</a>."
+msgstr "Podeu ajudar-nos a traduir l'interfície d'aquesta plataforma a <a class=\"twl-links\" href=\"https://translatewiki.net/wiki/Translating:Wikipedia_Library_Card_Platform\">translatewiki.net</a>."
 
 #. Translators: When the user starts a new application and submits the application, the user can view the application and withdraw if need be. This changes the label for the Withdraw button.
 #: TWLight/users/templates/users/my_applications.html:65
@@ -3325,12 +2583,8 @@ msgstr "Sol·licita'n la renovació"
 
 #. Translators: On the page listing applications, this text explains a user they cannot renew their application since they've already requested a renewal or there aren't any renewals available.
 #: TWLight/users/templates/users/my_applications.html:79
-msgid ""
-"Renewals are either not required, not available right now, or you have "
-"already requested a renewal."
-msgstr ""
-"Les renovacions o bé no són necessàries, o bé no estan disponibles a hores "
-"d'ara, o bé ja les heu demanades."
+msgid "Renewals are either not required, not available right now, or you have already requested a renewal."
+msgstr "Les renovacions o bé no són necessàries, o bé no estan disponibles a hores d'ara, o bé ja les heu demanades."
 
 #. Translators: This text is the heading of a section in a user's profile where they can change their preferences.
 #: TWLight/users/templates/users/preferences.html:6
@@ -3393,22 +2647,13 @@ msgstr "Restringeix el processament de dades"
 
 #. Translators: This message is displayed on the page where users can request we stop processing their data.
 #: TWLight/users/templates/users/restrict_data.html:15
-msgid ""
-"Checking this box and clicking “Restrict” will pause all processing of the "
-"data you have entered into this website. You will not be able to apply for "
-"access to resources, your applications will not be further processed, and "
-"none of your data will be altered, until you return to this page and uncheck "
-"the box. This is not the same as deleting your data."
+msgid "Checking this box and clicking “Restrict” will pause all processing of the data you have entered into this website. You will not be able to apply for access to resources, your applications will not be further processed, and none of your data will be altered, until you return to this page and uncheck the box. This is not the same as deleting your data."
 msgstr ""
 
 #. Translators: This warning message is shown to coordinators who view the data restriction page.
 #: TWLight/users/templates/users/restrict_data.html:26
-msgid ""
-"You are a coordinator on this site. If you restrict the processing of your "
-"data, your coordinator flag will be removed."
-msgstr ""
-"Ets un coordinador d'aquest lloc. Si es restringeix la tramitació de les "
-"teves dades, els privilegis de coordinador es perdran."
+msgid "You are a coordinator on this site. If you restrict the processing of your data, your coordinator flag will be removed."
+msgstr "Ets un coordinador d'aquest lloc. Si es restringeix la tramitació de les teves dades, els privilegis de coordinador es perdran."
 
 #. Translators: use the date *when you are translating*, in a language-appropriate format.
 #: TWLight/users/templates/users/terms.html:33
@@ -3423,135 +2668,66 @@ msgstr "Política de privadesa de la Fundació Wikimedia"
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:41
 msgid "Wikipedia Library Card Terms of Use and Privacy Statement"
-msgstr ""
-"Condicions d'ús i política de privadesa del v-Carnet de la Biblioteca de la "
-"Viquipèdia"
+msgstr "Condicions d'ús i política de privadesa del v-Carnet de la Biblioteca de la Viquipèdia"
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:51
-msgid ""
-"<a class=\"twl-links\" href=\"https://meta.wikimedia.org/wiki/"
-"The_Wikipedia_Library\"> The Wikipedia Library </a> has partnered with "
-"publishers around the world to allow users to access otherwise paywalled "
-"resources. This website allows Wikipedia editors to search and access these "
-"resources."
-msgstr ""
-"<a class=\"twl-links\" href=\"https://meta.wikimedia.org/wiki/"
-"The_Wikipedia_Library\"> La Biblioteca de la Viquipèdia </a> ha establert "
-"acords arreu del món per tal de permetre que la comunitat viquipedista pugui "
-"accedir a fonts de pagament. Aquesta plataforma permet als viquipedistes "
-"d'accedir i navegar aquests recursos bibliogràfics."
+msgid "<a class=\"twl-links\" href=\"https://meta.wikimedia.org/wiki/The_Wikipedia_Library\"> The Wikipedia Library </a> has partnered with publishers around the world to allow users to access otherwise paywalled resources. This website allows Wikipedia editors to search and access these resources."
+msgstr "<a class=\"twl-links\" href=\"https://meta.wikimedia.org/wiki/The_Wikipedia_Library\"> La Biblioteca de la Viquipèdia </a> ha establert acords arreu del món per tal de permetre que la comunitat viquipedista pugui accedir a fonts de pagament. Aquesta plataforma permet als viquipedistes d'accedir i navegar aquests recursos bibliogràfics."
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Wikimedia Foundation should not be translated. WMF should not be translated. Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:63
-msgid ""
-"This program is administered by the Wikimedia Foundation (WMF). These terms "
-"of use and privacy notice pertain to your application for access to "
-"resources through the Wikipedia Library, your use of this website, and your "
-"access to and use of those resources. They also describe our handling of the "
-"information you provide to us in order to create and administer your "
-"Wikipedia Library account. If we make material changes to the terms, we will "
-"notify users."
+msgid "This program is administered by the Wikimedia Foundation (WMF). These terms of use and privacy notice pertain to your application for access to resources through the Wikipedia Library, your use of this website, and your access to and use of those resources. They also describe our handling of the information you provide to us in order to create and administer your Wikipedia Library account. If we make material changes to the terms, we will notify users."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:74
 msgid "Requirements for a Wikipedia Library Card Account"
-msgstr ""
-"Condicions dels comptes d'accés al v-Carnet de la Biblioteca de la Viquipèdia"
+msgstr "Condicions dels comptes d'accés al v-Carnet de la Biblioteca de la Viquipèdia"
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:78
-msgid ""
-"Access to resources via The Wikipedia Library is reserved for community "
-"members who have demonstrated their commitment to the Wikimedia projects, "
-"and who will use their access to these resources to improve project content. "
-"To that end, in order to be eligible for The Wikipedia Library, we require "
-"that you be registered for a user account on the projects, with at least 500 "
-"edits, six (6) months of activity, and 10+ edits in the last month. We ask "
-"that you do not request access to any publishers with a limited number of "
-"available accounts whose resources you can already access for free through "
-"your local library or university, or another institution or organization, in "
-"order to provide that opportunity to others."
+msgid "Access to resources via The Wikipedia Library is reserved for community members who have demonstrated their commitment to the Wikimedia projects, and who will use their access to these resources to improve project content. To that end, in order to be eligible for The Wikipedia Library, we require that you be registered for a user account on the projects, with at least 500 edits, six (6) months of activity, and 10+ edits in the last month. We ask that you do not request access to any publishers with a limited number of available accounts whose resources you can already access for free through your local library or university, or another institution or organization, in order to provide that opportunity to others."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:94
-msgid ""
-"Additionally, if you are currently blocked or banned from a Wikimedia "
-"project, applications to resources may be rejected or restricted. If you "
-"obtain a Wikipedia Library account, but a block or ban is subsequently "
-"instituted against you on one of the projects, you may lose access to your "
-"Wikipedia Library account."
+msgid "Additionally, if you are currently blocked or banned from a Wikimedia project, applications to resources may be rejected or restricted. If you obtain a Wikipedia Library account, but a block or ban is subsequently instituted against you on one of the projects, you may lose access to your Wikipedia Library account."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:104
-msgid ""
-"Your eligibility to access The Wikipedia Library is assessed at each login. "
-"While more than half of the library's content is provided via this automated "
-"eligibility check, access to other publisher's content may be time limited, "
-"typically lapsing after one year, after which you will usually need to apply "
-"for renewal."
-msgstr ""
-"L'elegibilitat d'accés a la Biblioteca de la Viquipèdia s'avalua "
-"automàticament cada cop que hi inicieu sessió. Mentre que més de la meitat "
-"dels nostres recursos són facilitats per mitjà d'aquest pas, l'accés a "
-"contingut editorial d'altres col·laboradors podria ésser limitat i sovint "
-"amb un permís anual i renovable amb una petició."
+msgid "Your eligibility to access The Wikipedia Library is assessed at each login. While more than half of the library's content is provided via this automated eligibility check, access to other publisher's content may be time limited, typically lapsing after one year, after which you will usually need to apply for renewal."
+msgstr "L'elegibilitat d'accés a la Biblioteca de la Viquipèdia s'avalua automàticament cada cop que hi inicieu sessió. Mentre que més de la meitat dels nostres recursos són facilitats per mitjà d'aquest pas, l'accés a contingut editorial d'altres col·laboradors podria ésser limitat i sovint amb un permís anual i renovable amb una petició."
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:114
 msgid "Applying via Your Wikipedia Library Card Account"
-msgstr ""
-"Sol·licitar accés a través del compte vinculat al v-Carnet de la Biblioteca "
-"de la Viquipèdia"
+msgstr "Sol·licitar accés a través del compte vinculat al v-Carnet de la Biblioteca de la Viquipèdia"
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:118
-msgid ""
-"In order to apply for access to a partner resource, you must provide us with "
-"certain information, which we will use to evaluate your application. If your "
-"application is approved, we may transfer the information you have given us "
-"to the publishers whose resources you wish to access. They will either "
-"contact you with the account information directly or we will send access "
-"information to you ourselves."
+msgid "In order to apply for access to a partner resource, you must provide us with certain information, which we will use to evaluate your application. If your application is approved, we may transfer the information you have given us to the publishers whose resources you wish to access. They will either contact you with the account information directly or we will send access information to you ourselves."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:130
-msgid ""
-"In addition to the basic information you provide to us, our system will "
-"retrieve some information directly from the Wikimedia projects: your "
-"username, email address, edit count, registration date, user ID number, "
-"groups to which you belong, and any special user rights."
+msgid "In addition to the basic information you provide to us, our system will retrieve some information directly from the Wikimedia projects: your username, email address, edit count, registration date, user ID number, groups to which you belong, and any special user rights."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:140
-msgid ""
-"Each time you log in to the Wikipedia Library Card Platform, this "
-"information will be automatically updated."
-msgstr ""
-"Cada cop que inicieu la vostra sessió a l'Espai v-Carnet de la Biblioteca de "
-"la Viquipèdia, aquesta informació s'actualitzarà automàticament."
+msgid "Each time you log in to the Wikipedia Library Card Platform, this information will be automatically updated."
+msgstr "Cada cop que inicieu la vostra sessió a l'Espai v-Carnet de la Biblioteca de la Viquipèdia, aquesta informació s'actualitzarà automàticament."
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:148
-msgid ""
-"We will ask you to provide us with some information about your history of "
-"contributions to the Wikimedia projects. Information on contribution history "
-"is optional, but will greatly assist us in evaluating your application."
+msgid "We will ask you to provide us with some information about your history of contributions to the Wikimedia projects. Information on contribution history is optional, but will greatly assist us in evaluating your application."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). WMF should not be translated. Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:157
-msgid ""
-"The information you provide when creating your account will be visible to "
-"you while on the site but not to others unless they are approved Wikipedia "
-"Library Coordinators, WMF Staff, or WMF Contractors who need access to this "
-"data in order to carry out their work with the Wikipedia Library, all of "
-"whom are subject to non-disclosure obligations."
+msgid "The information you provide when creating your account will be visible to you while on the site but not to others unless they are approved Wikipedia Library Coordinators, WMF Staff, or WMF Contractors who need access to this data in order to carry out their work with the Wikipedia Library, all of whom are subject to non-disclosure obligations."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
@@ -3561,48 +2737,32 @@ msgstr "El vostre ús dels nostres recursos editorials"
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:171
-msgid ""
-"In order to access an individual publisher’s resources, you must agree to "
-"that publisher’s terms of use and privacy policy. You agree that you will "
-"not violate such terms and policies in connection with your use of the "
-"Wikipedia Library. Additionally, the following activities are prohibited "
-"while accessing publisher resources through the Wikipedia Library."
+msgid "In order to access an individual publisher’s resources, you must agree to that publisher’s terms of use and privacy policy. You agree that you will not violate such terms and policies in connection with your use of the Wikipedia Library. Additionally, the following activities are prohibited while accessing publisher resources through the Wikipedia Library."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:184
-msgid ""
-"Sharing your Wikipedia account, usernames, passwords, or any access codes "
-"for publisher resources with others;"
-msgstr ""
-"Compartir el vostre compte de la Viquipèdia, noms d'usuari, contrasenyes, o "
-"qualsevol codi d'accés per publicar recursos amb altres;"
+msgid "Sharing your Wikipedia account, usernames, passwords, or any access codes for publisher resources with others;"
+msgstr "Compartir el vostre compte de la Viquipèdia, noms d'usuari, contrasenyes, o qualsevol codi d'accés per publicar recursos amb altres;"
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:191
-msgid ""
-"Automatically scraping or downloading restricted content from publishers;"
+msgid "Automatically scraping or downloading restricted content from publishers;"
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:197
-msgid ""
-"Systematically making printed or electronic copies of multiple extracts of "
-"restricted content available for any purpose;"
+msgid "Systematically making printed or electronic copies of multiple extracts of restricted content available for any purpose;"
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:204
-msgid ""
-"Data mining metadata without permission—for example, in order to use "
-"metadata for auto-created stub articles;"
+msgid "Data mining metadata without permission—for example, in order to use metadata for auto-created stub articles;"
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:211
-msgid ""
-"Using the access you receive through the Wikipedia Library for profit by "
-"selling access to your account or resources which you have through it."
+msgid "Using the access you receive through the Wikipedia Library for profit by selling access to your account or resources which you have through it."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
@@ -3612,18 +2772,12 @@ msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:224
-msgid ""
-"Certain resources may only be accessed using an external search service, "
-"such as the EBSCO Discovery Service, or a proxy service, such as OCLC "
-"EZProxy. If you use such external search and/or proxy services, please "
-"review the applicable terms of use and privacy policies."
+msgid "Certain resources may only be accessed using an external search service, such as the EBSCO Discovery Service, or a proxy service, such as OCLC EZProxy. If you use such external search and/or proxy services, please review the applicable terms of use and privacy policies."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:234
-msgid ""
-"In addition, if you use OCLC EZProxy, please note that you may not use it "
-"for commercial purposes."
+msgid "In addition, if you use OCLC EZProxy, please note that you may not use it for commercial purposes."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
@@ -3634,152 +2788,49 @@ msgstr ""
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Wikimedia Foundation should not be translated. Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:245
 #, fuzzy
-msgid ""
-"The Wikimedia Foundation and our service providers use your information for "
-"the legitimate purpose of providing Wikipedia Library services in support of "
-"our charitable mission. When you apply for a Wikipedia Library account, or "
-"use your Wikipedia Library account, we may routinely collect the following "
-"information: your username, email address, edit count, registration date, "
-"user ID number, groups to which you belong, and any special user rights; "
-"your name, country of residence, and/or affiliation, if required by a "
-"partner to which you are applying; your narrative description of your "
-"contributions and reasons for applying for access to partner resources; and "
-"the date you agree to these terms of use."
-msgstr ""
-"La Fundació Wikimedia i els nostres proveïdors de serveis utilitzen la "
-"vostra informació amb el propòsit legítim de proporcionar serveis de la "
-"Biblioteca de Viquipèdia com a suport a la nostra missió social. Quan "
-"sol·liciteu accés a la Biblioteca de Viquipèdia o en feu servir el compte, "
-"recollim rutinàriament la informació següent: el vostre nom d'usuari, "
-"l'adreça de correu electrònic, el recompte d'edicions, la data de registre, "
-"el número d'identificació d'usuari, els grups als quals pertanyeu i també "
-"qualsevol dret especial d'usuari; el vostre nom, país de residència, "
-"ocupació i/o afiliació si ho demana un col·laborador editorial del qual en "
-"feu servir credencials; així com la descripció narrativa de les vostres "
-"contribucions i les raons per sol·licitar accés als seus recursos i, en "
-"darrer lloc, la data en què accepteu aquestes condicions d'ús."
+msgid "The Wikimedia Foundation and our service providers use your information for the legitimate purpose of providing Wikipedia Library services in support of our charitable mission. When you apply for a Wikipedia Library account, or use your Wikipedia Library account, we may routinely collect the following information: your username, email address, edit count, registration date, user ID number, groups to which you belong, and any special user rights; your name, country of residence, and/or affiliation, if required by a partner to which you are applying; your narrative description of your contributions and reasons for applying for access to partner resources; and the date you agree to these terms of use."
+msgstr "La Fundació Wikimedia i els nostres proveïdors de serveis utilitzen la vostra informació amb el propòsit legítim de proporcionar serveis de la Biblioteca de Viquipèdia com a suport a la nostra missió social. Quan sol·liciteu accés a la Biblioteca de Viquipèdia o en feu servir el compte, recollim rutinàriament la informació següent: el vostre nom d'usuari, l'adreça de correu electrònic, el recompte d'edicions, la data de registre, el número d'identificació d'usuari, els grups als quals pertanyeu i també qualsevol dret especial d'usuari; el vostre nom, país de residència, ocupació i/o afiliació si ho demana un col·laborador editorial del qual en feu servir credencials; així com la descripció narrativa de les vostres contribucions i les raons per sol·licitar accés als seus recursos i, en darrer lloc, la data en què accepteu aquestes condicions d'ús."
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:262
 #, python-format
-msgid ""
-"Each publisher who is a member of the Wikipedia Library program requires "
-"different specific information in the application. Some publishers may "
-"request only an email address, while others request more detailed data, such "
-"as your name, location, or institutional affiliation. When you complete your "
-"application, you will only be asked to supply information required by the "
-"publishers you have chosen, and each publisher will only receive the "
-"information they require for providing you with access. Please see our <a "
-"class=\"twl-links\" href=\"%(all_partners_url)s\">partner information</a> "
-"pages to learn what information is required by each publisher to gain access "
-"to their resources."
+msgid "Each publisher who is a member of the Wikipedia Library program requires different specific information in the application. Some publishers may request only an email address, while others request more detailed data, such as your name, location, or institutional affiliation. When you complete your application, you will only be asked to supply information required by the publishers you have chosen, and each publisher will only receive the information they require for providing you with access. Please see our <a class=\"twl-links\" href=\"%(all_partners_url)s\">partner information</a> pages to learn what information is required by each publisher to gain access to their resources."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Wikimedia Foundation should not be translated. Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:277
-msgid ""
-"Some Wikipedia Library pages are visible without logging in, but you will "
-"need to log in to apply or access proprietary partner resources. We use the "
-"data provided by you via OAuth and Wikimedia API calls to assess your "
-"application for access and to process approved requests."
+msgid "Some Wikipedia Library pages are visible without logging in, but you will need to log in to apply or access proprietary partner resources. We use the data provided by you via OAuth and Wikimedia API calls to assess your application for access and to process approved requests."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:288
 #, python-format
-msgid ""
-"In order to administer the Wikipedia Library program, we will retain the "
-"application data we collect from you for three years after your most recent "
-"login, unless you delete your account, as described below. You can log in "
-"and go to <a class=\"twl-links\" href=\"%(profile_url)s\">your profile page</"
-"a> in order to see the information associated with your account, and can "
-"download it in JSON format. You may access, update, restrict, or delete this "
-"information at any time, except for the information that is automatically "
-"retrieved from the projects. If you have any questions or concerns about the "
-"handling of your data, please contact <a class=\"twl-links\" href=\"mailto:"
-"wikipedialibrary@wikimedia.org?Subject=Wikipedia%%20Library%%20Card"
-"%%20account%%20deactivation\"> wikipedialibrary@wikimedia.org </a>."
+msgid "In order to administer the Wikipedia Library program, we will retain the application data we collect from you for three years after your most recent login, unless you delete your account, as described below. You can log in and go to <a class=\"twl-links\" href=\"%(profile_url)s\">your profile page</a> in order to see the information associated with your account, and can download it in JSON format. You may access, update, restrict, or delete this information at any time, except for the information that is automatically retrieved from the projects. If you have any questions or concerns about the handling of your data, please contact <a class=\"twl-links\" href=\"mailto:wikipedialibrary@wikimedia.org?Subject=Wikipedia%%20Library%%20Card%%20account%%20deactivation\"> wikipedialibrary@wikimedia.org </a>."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:305
-msgid ""
-"If you decide to disable your Wikipedia Library account, you can use the "
-"delete button on your profile to delete certain personal information "
-"associated with your account. We will delete your real name, institutional "
-"affiliation, and country of residence. Please note that the system will "
-"retain a record of your username, the publishers to which you applied or had "
-"access, and the dates of that access. Note that deletion is not reversible. "
-"Deletion of your Wikipedia Library account may also correspond with the "
-"removal of any resource access to which you were eligible or approved. If "
-"you request the deletion of account information and later wish to apply for "
-"a new account, you will need to provide the necessary information again."
+msgid "If you decide to disable your Wikipedia Library account, you can use the delete button on your profile to delete certain personal information associated with your account. We will delete your real name, institutional affiliation, and country of residence. Please note that the system will retain a record of your username, the publishers to which you applied or had access, and the dates of that access. Note that deletion is not reversible. Deletion of your Wikipedia Library account may also correspond with the removal of any resource access to which you were eligible or approved. If you request the deletion of account information and later wish to apply for a new account, you will need to provide the necessary information again."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). WMF should not be translated. Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:321
-msgid ""
-"The Wikipedia Library is run by WMF Staff, Contractors, and approved "
-"volunteer Coordinators. The data associated with your account will be shared "
-"with the WMF staff, contractors, service providers, and volunteer "
-"coordinators who need to process the information in connection with their "
-"work for the Wikipedia Library, and who are subject to confidentiality "
-"obligations. We will also use your data for internal Wikipedia Library "
-"purposes such as distributing user surveys and account notifications, and in "
-"a depersonalized or aggregated fashion for statistical analysis and "
-"administration. Finally, we will share your information with the publishers "
-"whom you specifically select in order to provide you with access to "
-"resources. Otherwise, your information will not be shared with third "
-"parties, with the exception of the circumstances described below."
-msgstr ""
-"La Biblioteca de la Viquipèdia funciona gràcies a personal assalariat de la "
-"Fundació Wikimedia, autònoms i voluntaris aprovats com a coordinadors. Les "
-"dades associades al vostre compte són compartides amb totes aquestes "
-"persones que necessiten processar la informació en relació amb la seua "
-"funció a la Biblioteca de la Viquipèdia. Consegüentment, estan sotmeses a "
-"obligacions de confidencialitat i tractament de dades personals. També farem "
-"servir les vostres dades per a finalitats internes de la Biblioteca de la "
-"Viquipèdia com ara distribuir enquestes d'usuari i notificacions als vostres "
-"comptes, o per a finalitats estadístiques i administratives amb agregació de "
-"dades (sense personalitzar-les). En darrer lloc, us enviarem informació per "
-"a facilitar-vos l'accés als recursos bibliogràfics que sol·liciteu. Us fem "
-"explícit que la vostra informació no serà compartida amb tercers, excepte en "
-"els casos descrits a continuació."
+msgid "The Wikipedia Library is run by WMF Staff, Contractors, and approved volunteer Coordinators. The data associated with your account will be shared with the WMF staff, contractors, service providers, and volunteer coordinators who need to process the information in connection with their work for the Wikipedia Library, and who are subject to confidentiality obligations. We will also use your data for internal Wikipedia Library purposes such as distributing user surveys and account notifications, and in a depersonalized or aggregated fashion for statistical analysis and administration. Finally, we will share your information with the publishers whom you specifically select in order to provide you with access to resources. Otherwise, your information will not be shared with third parties, with the exception of the circumstances described below."
+msgstr "La Biblioteca de la Viquipèdia funciona gràcies a personal assalariat de la Fundació Wikimedia, autònoms i voluntaris aprovats com a coordinadors. Les dades associades al vostre compte són compartides amb totes aquestes persones que necessiten processar la informació en relació amb la seua funció a la Biblioteca de la Viquipèdia. Consegüentment, estan sotmeses a obligacions de confidencialitat i tractament de dades personals. També farem servir les vostres dades per a finalitats internes de la Biblioteca de la Viquipèdia com ara distribuir enquestes d'usuari i notificacions als vostres comptes, o per a finalitats estadístiques i administratives amb agregació de dades (sense personalitzar-les). En darrer lloc, us enviarem informació per a facilitar-vos l'accés als recursos bibliogràfics que sol·liciteu. Us fem explícit que la vostra informació no serà compartida amb tercers, excepte en els casos descrits a continuació."
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). WMF should not be translated.
 #: TWLight/users/templates/users/terms.html:338
-msgid ""
-"We may disclose any collected information when required by law, when we have "
-"your permission, when needed to protect our rights, privacy, safety, users, "
-"or the general public, and when necessary to enforce these terms, WMF’s "
-"general <a class=\"twl-links\" href=\"https://foundation.wikimedia.org/wiki/"
-"Terms_of_Use\">Terms of Use</a>, or any other WMF policy."
-msgstr ""
-"Podem revelar qualsevol informació de què disposem quan sigui obligat per la "
-"llei, quan tinguem el vostre permís, quan sigui imprescindible per a emparar "
-"els nostres drets, intimitat, seguretat, usuaris de la plataforma o el "
-"públic general i també quan sigui necessari per a complir aquests les <a "
-"class=\"twl-links\" href=\"https://foundation.wikimedia.org/wiki/Terms_of_Use"
-"\">Condicions generals d'ús</a> de la Fundació Wikimedia i les seves "
-"polítiques."
+msgid "We may disclose any collected information when required by law, when we have your permission, when needed to protect our rights, privacy, safety, users, or the general public, and when necessary to enforce these terms, WMF’s general <a class=\"twl-links\" href=\"https://foundation.wikimedia.org/wiki/Terms_of_Use\">Terms of Use</a>, or any other WMF policy."
+msgstr "Podem revelar qualsevol informació de què disposem quan sigui obligat per la llei, quan tinguem el vostre permís, quan sigui imprescindible per a emparar els nostres drets, intimitat, seguretat, usuaris de la plataforma o el públic general i també quan sigui necessari per a complir aquests les <a class=\"twl-links\" href=\"https://foundation.wikimedia.org/wiki/Terms_of_Use\">Condicions generals d'ús</a> de la Fundació Wikimedia i les seves polítiques."
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:349
-msgid ""
-"We take the security of your personal data seriously, and take reasonable "
-"precautions to ensure your data is protected. These precautions include "
-"access controls to limit who has access to your data and security "
-"technologies to protect data stored on the server. However, we cannot "
-"guarantee the safety of your data as it is transmitted and stored."
+msgid "We take the security of your personal data seriously, and take reasonable precautions to ensure your data is protected. These precautions include access controls to limit who has access to your data and security technologies to protect data stored on the server. However, we cannot guarantee the safety of your data as it is transmitted and stored."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:360
-msgid ""
-"Please note that these terms do not control the use and handling of your "
-"data by the publishers and service providers whose resources you access or "
-"apply to access. Please read their individual privacy policies for that "
-"information."
+msgid "Please note that these terms do not control the use and handling of your data by the publishers and service providers whose resources you access or apply to access. Please read their individual privacy policies for that information."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
@@ -3789,34 +2840,17 @@ msgstr "Nota important"
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Wikimedia Foundation should not be translated. Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:373
-msgid ""
-"The Wikimedia Foundation is a nonprofit organization based in San Francisco, "
-"California. The Wikipedia Library program provides access to resources held "
-"by publishers in multiple countries. If you apply for a Wikipedia Library "
-"account (whether you are inside or outside of the United States), you "
-"understand that your personal data will be collected, transferred, stored, "
-"processed, disclosed and otherwise used in the U.S. as described in this "
-"privacy policy. You also understand that your information may be transferred "
-"by us from the U.S. to other countries, which may have different or less "
-"stringent data protection laws than your country, in connection with "
-"providing services to you, including evaluating your application and "
-"securing access to your chosen publishers (locations for each publisher are "
-"outlined on their respective partner information pages)."
+msgid "The Wikimedia Foundation is a nonprofit organization based in San Francisco, California. The Wikipedia Library program provides access to resources held by publishers in multiple countries. If you apply for a Wikipedia Library account (whether you are inside or outside of the United States), you understand that your personal data will be collected, transferred, stored, processed, disclosed and otherwise used in the U.S. as described in this privacy policy. You also understand that your information may be transferred by us from the U.S. to other countries, which may have different or less stringent data protection laws than your country, in connection with providing services to you, including evaluating your application and securing access to your chosen publishers (locations for each publisher are outlined on their respective partner information pages)."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:392
-msgid ""
-"Please note that in the event of any differences in meaning or "
-"interpretation between the original English version of these terms and a "
-"translation, the original English version takes precedence."
+msgid "Please note that in the event of any differences in meaning or interpretation between the original English version of these terms and a translation, the original English version takes precedence."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Wikimedia Foundation should not be translated.
 #: TWLight/users/templates/users/terms.html:403
-msgid ""
-"See also the <a class=\"twl-links\" href=\"https://wikimediafoundation.org/"
-"wiki/Privacy_policy\">Wikimedia Foundation Privacy Policy</a>."
+msgid "See also the <a class=\"twl-links\" href=\"https://wikimediafoundation.org/wiki/Privacy_policy\">Wikimedia Foundation Privacy Policy</a>."
 msgstr ""
 
 #. Translators: This is the second to last line of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
@@ -3836,17 +2870,8 @@ msgstr "Fundació Wikimedia"
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:426
-msgid ""
-"By checking this box and clicking “Submit”, you agree that you have read the "
-"above terms and that you will adhere to the terms of use in your application "
-"to and use of the The Wikipedia Library, and the publishers’ services to "
-"which you gain access through The Wikipedia Library program."
-msgstr ""
-"En marcar aquesta casella i fer clic a «Envia», accepteu que heu llegit les "
-"condicions anteriors i que us adheriu a les condicions d'ús de la vostra "
-"sol·licitud i a les funcions de la Biblioteca de la Viquipèdia, així com als "
-"serveis dels col·laboradors editorials dels quals rebreu credencials d'accés "
-"per mitjà de la Biblioteca de la Viquipèdia."
+msgid "By checking this box and clicking “Submit”, you agree that you have read the above terms and that you will adhere to the terms of use in your application to and use of the The Wikipedia Library, and the publishers’ services to which you gain access through The Wikipedia Library program."
+msgstr "En marcar aquesta casella i fer clic a «Envia», accepteu que heu llegit les condicions anteriors i que us adheriu a les condicions d'ús de la vostra sol·licitud i a les funcions de la Biblioteca de la Viquipèdia, així com als serveis dels col·laboradors editorials dels quals rebreu credencials d'accés per mitjà de la Biblioteca de la Viquipèdia."
 
 #: TWLight/users/templates/users/user_collection_tile.html:32
 msgid "Remove this collection from favorites"
@@ -3898,42 +2923,19 @@ msgstr "Eliminar totes les dades"
 
 #. Translators: This message is displayed on the page where users can request the deletion of their data.
 #: TWLight/users/templates/users/user_confirm_delete.html:17
-msgid ""
-"<b>Warning:</b> Performing this action will delete your Wikipedia Library "
-"Card user account and all associated applications. This process is not "
-"reversible. You may lose any partner accounts you were granted, and will not "
-"be able to renew those accounts or apply for new ones."
-msgstr ""
-"<b>Atenció:</b> Aquesta acció eliminarà el compte de la vostre v-Carnet "
-"pertanyent a la Biblioteca de la Viquipèdia i totes les sol·licituds "
-"associades. És un procés irreversible. Perdreu l'accés de totes les "
-"credencials que ja us havíem proporcionat anteriorment, no podreu renovar-"
-"les i tampoc podreu sol·licitar-ne de noves."
+msgid "<b>Warning:</b> Performing this action will delete your Wikipedia Library Card user account and all associated applications. This process is not reversible. You may lose any partner accounts you were granted, and will not be able to renew those accounts or apply for new ones."
+msgstr "<b>Atenció:</b> Aquesta acció eliminarà el compte de la vostre v-Carnet pertanyent a la Biblioteca de la Viquipèdia i totes les sol·licituds associades. És un procés irreversible. Perdreu l'accés de totes les credencials que ja us havíem proporcionat anteriorment, no podreu renovar-les i tampoc podreu sol·licitar-ne de noves."
 
 #. Translators: this should show up for people who log in with a username/password and not OAuth, so we don't know what their Wikipedia identity is.
-#.
 #: TWLight/users/templates/users/user_detail.html:12
 #, python-format
-msgid ""
-"Hi, %(username)s! You don't have a Wikipedia editor profile attached to your "
-"account here, so you are probably a site administrator."
-msgstr ""
-"Com anem, %(username)s! No tens un compte d'usuari de Viquipèdia vinculat al "
-"teu compte d'aquí, per tant assumim que ets un administrador del web."
+msgid "Hi, %(username)s! You don't have a Wikipedia editor profile attached to your account here, so you are probably a site administrator."
+msgstr "Com anem, %(username)s! No tens un compte d'usuari de Viquipèdia vinculat al teu compte d'aquí, per tant assumim que ets un administrador del web."
 
 #. Translators: In the unlikely scenario that someone is able to register an account without using OAuth (thus leaving us without some of the information required for applications), users will see this message, encouraging them to re-register.
 #: TWLight/users/templates/users/user_detail.html:20
-msgid ""
-"If you aren't a site administrator, something weird has happened. You won't "
-"be able to apply for access without a Wikipedia editor profile. You should "
-"log out and create a new account by logging in via OAuth, or contact a site "
-"administrator for help."
-msgstr ""
-"Si no ets un administrador d'aquest web, vatua... Això és quelcom ben "
-"estrany. No podràs sol·licitar credencials d'accés sense un compte d'usuari "
-"de la Viquipèdia. O bé hauries de tancar la sessió i crear un nou compte via "
-"l'inici de sessió OAuth, o bé contactar els administradors de la Biblioteca "
-"de la Viquipèdia per a demanar-los ajuda."
+msgid "If you aren't a site administrator, something weird has happened. You won't be able to apply for access without a Wikipedia editor profile. You should log out and create a new account by logging in via OAuth, or contact a site administrator for help."
+msgstr "Si no ets un administrador d'aquest web, vatua... Això és quelcom ben estrany. No podràs sol·licitar credencials d'accés sense un compte d'usuari de la Viquipèdia. O bé hauries de tancar la sessió i crear un nou compte via l'inici de sessió OAuth, o bé contactar els administradors de la Biblioteca de la Viquipèdia per a demanar-los ajuda."
 
 #. Translators: Labels a sections where coordinators can select their email preferences.
 #: TWLight/users/templates/users/user_email_preferences.html:15
@@ -3943,28 +2945,18 @@ msgstr "Només coordinadors"
 #. Translators: This message is shown on user's own profile page, encouraging them to make sure their information is up to date, so that account coordinators can use the information to judge applications.
 #: TWLight/users/views.py:176
 #, python-brace-format
-msgid ""
-"Please <a class='twl-links' href='{url}'>update your contributions</a> to "
-"Wikipedia to help coordinators evaluate your applications."
+msgid "Please <a class='twl-links' href='{url}'>update your contributions</a> to Wikipedia to help coordinators evaluate your applications."
 msgstr ""
 
 #. Translators: Coordinators are shown this message when they unselect all three types of reminder email options under preferences.
 #: TWLight/users/views.py:288
-msgid ""
-"You have chosen not to receive reminder emails. As a coordinator, you should "
-"receive at least one type of reminder emails, so consider changing your "
-"preferences."
-msgstr ""
-"Heu escollit no rebre recordatoris per correu electrònic. Com a membre de "
-"coordinació, hauríeu de rebre, pel cap baix, alguna mena de recordatori. Per "
-"tant, si us plau, plantegeu-vos l'opció de canviar les vostres preferències."
+msgid "You have chosen not to receive reminder emails. As a coordinator, you should receive at least one type of reminder emails, so consider changing your preferences."
+msgstr "Heu escollit no rebre recordatoris per correu electrònic. Com a membre de coordinació, hauríeu de rebre, pel cap baix, alguna mena de recordatori. Per tant, si us plau, plantegeu-vos l'opció de canviar les vostres preferències."
 
 #. Translators: Coordinators are shown this message when they make changes to their reminder email options under preferences.
 #: TWLight/users/views.py:296
 msgid "Your reminder email preferences are updated."
-msgstr ""
-"Les vostres preferències de recordatoris via correu electrònic s'han "
-"actualitzat."
+msgstr "Les vostres preferències de recordatoris via correu electrònic s'han actualitzat."
 
 #. Translators: This message is shown to users who attempt to update their personal information without being logged in.
 #. Translators: If a user tries to do something (such as updating their email) when not logged in, this message is presented.
@@ -3982,9 +2974,7 @@ msgstr "La teva informació s'ha actualitzat."
 #. Translators: If a user tries to save the 'email change form' without entering one and checking the 'use my Wikipedia email address' checkbox, this message is presented.
 #: TWLight/users/views.py:448
 msgid "Both the values cannot be blank. Either enter a email or check the box."
-msgstr ""
-"No podeu deixar en blanc les dues opcions. Introduïu un correu electrònic o "
-"feu clic a la caixa."
+msgstr "No podeu deixar en blanc les dues opcions. Introduïu un correu electrònic o feu clic a la caixa."
 
 #. Translators: Shown to users when they successfully modify their email. Don't translate {email}.
 #: TWLight/users/views.py:476
@@ -3994,13 +2984,8 @@ msgstr "El vostre e-mail s'ha canviat a {email}."
 
 #. Translators: If the user has not filled out their email, they can browse the website but cannot apply for access to resources.
 #: TWLight/users/views.py:487
-msgid ""
-"Your email is blank. You can still explore the site, but you won't be able "
-"to apply for access to partner resources without an email."
-msgstr ""
-"La vostra adreça de correu electrònic està buida. Podeu navegar per la "
-"plataforma, però no podreu demanar accés a cap recurs bibliogràfic dels "
-"col·laboradors sense un correu vàlid."
+msgid "Your email is blank. You can still explore the site, but you won't be able to apply for access to partner resources without an email."
+msgstr "La vostra adreça de correu electrònic està buida. Podeu navegar per la plataforma, però no podreu demanar accés a cap recurs bibliogràfic dels col·laboradors sense un correu vàlid."
 
 #. Translators: This message is shown once the access to a partner has successfully been returned.
 #: TWLight/users/views.py:801
@@ -4032,31 +3017,3 @@ msgstr "No hi ha blocatges actius"
 msgid "10+ edits in the last 30 days"
 msgstr "Més de 10 edicions durant el darrer mes"
 
-#: tests/shunit/data/bad_i18n_comment_1.py:3
-#: tests/shunit/data/bad_i18n_newline_1.py:5
-msgid "1"
-msgstr ""
-
-#. Translators: Lorem ipsum dolor sit amet, consectetur adipiscing elit. Mauris vitae ipsum ut purus faucibus pretium. Proin tempus neque et aliquet consectetur. Ut egestas sapien in consectetur sagittis. Mauris neque lacus, dapibus non viverra vitae, interdum ut aenean ipsum.
-#. Translators: Lorem ipsum dolor sit amet, consectetur adipiscing elit. Mauris vitae ipsum ut purus faucibus pretium. Proin tempus neque et aliquet consectetur. Ut egestas sapien in consectetur sagittis. Mauris neque lacus, dapibus non.
-#: tests/shunit/data/bad_i18n_comment_2.py:4
-#: tests/shunit/data/bad_i18n_newline_2.py:5 tests/shunit/data/good_i18n_1.py:2
-#: tests/shunit/data/good_i18n_2.py:2
-msgid "2"
-msgstr ""
-
-#: tests/shunit/data/bad_i18n_newline_3.py:5
-msgid "3"
-msgstr ""
-
-#: tests/shunit/data/bad_i18n_newline_4.py:5
-msgid "4"
-msgstr ""
-
-#: tests/shunit/data/bad_i18n_newline_5.py:5
-msgid "5"
-msgstr ""
-
-#: tests/shunit/data/bad_i18n_newline_6.py:5
-msgid "6"
-msgstr ""

--- a/locale/ce/LC_MESSAGES/django.po
+++ b/locale/ce/LC_MESSAGES/django.po
@@ -4,10 +4,11 @@
 # Author: Умар
 msgid ""
 msgstr ""
+""
 "Project-Id-Version: Wikipedia Library Card Platform - Website\n"
-"Report-Msgid-Bugs-To: wikipedialibrary@wikimedia.org\n"
+"Report-Msgid-Bugs-To: translatewiki.net\n"
 "POT-Creation-Date: 2024-07-11 20:54+0000\n"
-"PO-Revision-Date: 2024-07-11 12:30:13+0000\n"
+"PO-Revision-Date: 2024-07-15 12:29:13+0000\n"
 "Language: ce\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
@@ -39,9 +40,7 @@ msgstr "Хьоьх лаьцна"
 #. Translators: This note appears in a section of a form where we ask users to enter info (like country of residence) when applying for resource access.
 #: TWLight/applications/forms.py:179
 #, python-brace-format
-msgid ""
-"<p><small><i>Your personal data will be processed according to our <a "
-"class='twl-links' href='{terms_url}'> privacy policy</a>.</i></small></p>"
+msgid "<p><small><i>Your personal data will be processed according to our <a class='twl-links' href='{terms_url}'> privacy policy</a>.</i></small></p>"
 msgstr ""
 
 #. Translators: This is the title of the application form page, where users enter information required for the application. It lets the user know which partner application they are entering data for. {partner}
@@ -83,9 +82,7 @@ msgstr ""
 #. Translators: This labels a choice field where users will have to select the number of months they wish to have their access for as part of the application renewal confirmation.
 #. Translators: When filling out an application, users may be required to enter the length of the account (expiry) they wish to have for proxy partners.
 #: TWLight/applications/forms.py:339 TWLight/applications/helpers.py:100
-msgid ""
-"The number of months you wish to have this access for before renewal is "
-"required"
+msgid "The number of months you wish to have this access for before renewal is required"
 msgstr ""
 
 #. Translators: When filling out an application, users may need to specify their name
@@ -174,9 +171,7 @@ msgstr "Эл. пошта"
 
 #. Translators: This comment is added to pending applications when our terms of use change.
 #: TWLight/applications/management/commands/notify_applicants_tou_changes.py:54
-msgid ""
-"Our terms of use have changed. Your applications will not be processed until "
-"you log in and agree to our updated terms."
+msgid "Our terms of use have changed. Your applications will not be processed until you log in and agree to our updated terms."
 msgstr ""
 
 #. Translators: This is the status of an application that has not yet been reviewed.
@@ -243,23 +238,17 @@ msgstr "ТӀекхача хьажорг: {access_url}"
 
 #. Translators: This text goes into account approval emails in the case that we need to send the user's details to a publisher for manual account setup.
 #: TWLight/applications/models.py:331
-msgid ""
-"You can expect to receive access details within a week or two once it has "
-"been processed."
+msgid "You can expect to receive access details within a week or two once it has been processed."
 msgstr ""
 
 #. Translators: This comment is added to open applications when a partner joins the Library Bundle, which does not require applications.
 #: TWLight/applications/signals.py:247
-msgid ""
-"This partner joined the Library Bundle, which does not require applications. "
-"This application will be marked as invalid."
+msgid "This partner joined the Library Bundle, which does not require applications. This application will be marked as invalid."
 msgstr ""
 
 #. Translators: This is shown to users if the application is to a partner for which we have run out of available accounts. The application is therefore on a 'waitlist', and will be reviewed when more accounts are available.
 #: TWLight/applications/templates/applications/application_evaluation.html:29
-msgid ""
-"This application is on the waitlist because this partner does not have any "
-"access grants available at this time."
+msgid "This application is on the waitlist because this partner does not have any access grants available at this time."
 msgstr ""
 
 #. Translators: This message is shown on pages where coordinators can see personal information about applicants.
@@ -267,9 +256,7 @@ msgstr ""
 #: TWLight/applications/templates/applications/application_list_include.html:6
 #: TWLight/applications/templates/applications/send_partner.html:45
 #: TWLight/resources/templates/resources/partner_users.html:18
-msgid ""
-"Coordinators: This page may contain personal information such as real names "
-"and email addresses. Please remember that this information is confidential."
+msgid "Coordinators: This page may contain personal information such as real names and email addresses. Please remember that this information is confidential."
 msgstr ""
 
 #. Translators: This is the title of the application page shown to users who are a coordinator, and are able to accept or reject the application.
@@ -279,9 +266,7 @@ msgstr ""
 
 #. Translators: This text is shown to coordinators on application pages if the applicant has restricted processing of their data.
 #: TWLight/applications/templates/applications/application_evaluation.html:42
-msgid ""
-"This user has requested a restriction on the processing of their data, so "
-"you cannot change the status of their application."
+msgid "This user has requested a restriction on the processing of their data, so you cannot change the status of their application."
 msgstr ""
 
 #. Translators: This is the title of the application page shown to users who are not a coordinator.
@@ -355,9 +340,7 @@ msgstr "Хууш дац"
 
 #. Translators: This is the text displayed to coordinators when an applicant has no country of residence in their profile.
 #: TWLight/applications/templates/applications/application_evaluation.html:123
-msgid ""
-"Please request the applicant add their country of residence to their profile "
-"before proceeding further."
+msgid "Please request the applicant add their country of residence to their profile before proceeding further."
 msgstr ""
 
 #. Translators: This labels the section of an application showing the total number of accounts available for a partner or their collection.
@@ -368,9 +351,7 @@ msgstr "ТӀекхочу аккаунташ:"
 #. Translators: This labels the section of an application showing whether the user had agreed to the terms of use or not.
 #: TWLight/applications/templates/applications/application_evaluation.html:145
 #, python-format
-msgid ""
-"Has agreed to the site's <a class=\"twl-links\" href=\"%(terms_url)s\">terms "
-"of use</a>?"
+msgid "Has agreed to the site's <a class=\"twl-links\" href=\"%(terms_url)s\">terms of use</a>?"
 msgstr ""
 
 #. Translators: Displayed to coordinators when they've agreed to the terms of use.
@@ -406,9 +387,7 @@ msgstr "ХӀан-хӀа"
 
 #. Translators: This is the text displayed to coordinators when an applicant has not agreed to the terms of use.
 #: TWLight/applications/templates/applications/application_evaluation.html:159
-msgid ""
-"Please request the applicant agree to the site's terms of use before "
-"approving this application."
+msgid "Please request the applicant agree to the site's terms of use before approving this application."
 msgstr ""
 
 #. Translators: This labels the section of an application containing the user's motivation for wanting access to this resource.
@@ -429,8 +408,7 @@ msgstr ""
 #. Translators: This message is shown next to the 'Renewal of existing access grant?' label if the application is a renewal. Don't translate HTML tags or parent_url.
 #: TWLight/applications/templates/applications/application_evaluation.html:195
 #, python-format
-msgid ""
-"Yes (<a class=\"twl-links\" href=\"%(parent_url)s\">previous application</a>)"
+msgid "Yes (<a class=\"twl-links\" href=\"%(parent_url)s\">previous application</a>)"
 msgstr ""
 
 #. Translators: This labels the section of the application showing the length of access remaining on the user's previous authorization.
@@ -465,9 +443,7 @@ msgstr "ТӀетоха коммент"
 
 #. Translators: On an application page, this text tells users that the comments posted on the application are visible to coordinators and the submitting user only.
 #: TWLight/applications/templates/applications/application_evaluation.html:297
-msgid ""
-"Comments are visible to all coordinators and to the editor who submitted "
-"this application."
+msgid "Comments are visible to all coordinators and to the editor who submitted this application."
 msgstr ""
 
 #. Translators: This is the title of the section of an application page which lists information about the user who submitted the application.
@@ -679,12 +655,7 @@ msgstr "ДӀахӀоттайе статус"
 
 #: TWLight/applications/templates/applications/apply.html:20
 #, python-format
-msgid ""
-"If your application is successful we may share your email address with "
-"%(partner)s. This is required to set up your access to their resources. By "
-"submitting this form you agree to allow your email address to be shared with "
-"%(partner)s if your application is successful, for the purposes of account "
-"setup."
+msgid "If your application is successful we may share your email address with %(partner)s. This is required to set up your access to their resources. By submitting this form you agree to allow your email address to be shared with %(partner)s if your application is successful, for the purposes of account setup."
 msgstr ""
 
 #. Translators: This message is displayed on the page where users can confirm their renewal. Please do not translate partner.
@@ -713,9 +684,7 @@ msgstr ""
 
 #. Translators: This text explains that Library Bundle partners are not shown in this list.
 #: TWLight/applications/templates/applications/request_for_application.html:26
-msgid ""
-"Library Bundle partners are not shown as eligibility is determined "
-"automatically."
+msgid "Library Bundle partners are not shown as eligibility is determined automatically."
 msgstr ""
 
 #. Translators: On the page where users can apply for multiple partners, this message shows next to the partner name, taking them to the full application page when clicked.
@@ -730,10 +699,7 @@ msgstr ""
 
 #. Translators: the HTML is so that the word 'waitlisted' will look the same as it does in the page above; please translate 'waitlisted' the same way you did elsewhere in this file.
 #: TWLight/applications/templates/applications/request_for_application.html:74
-msgid ""
-"You can apply to <span class=\"badge badge-warning\">Waitlisted</span> "
-"partners, but they don't have access grants available right now. We will "
-"process those applications when access becomes available."
+msgid "You can apply to <span class=\"badge badge-warning\">Waitlisted</span> partners, but they don't have access grants available right now. We will process those applications when access becomes available."
 msgstr ""
 
 #. Translators: On the page where coordinators can see approved applications which have not had their details sent to the partner, this message shows when there are applications ready to be processed.
@@ -755,9 +721,7 @@ msgstr ""
 #. Translators: This message is shown when applications exceed the number of accounts available.
 #: TWLight/applications/templates/applications/send_partner.html:54
 #, python-format
-msgid ""
-"Application(s) for %(object)s, if sent, will exceed the total available "
-"accounts for the partner. Please proceed at your own discretion."
+msgid "Application(s) for %(object)s, if sent, will exceed the total available accounts for the partner. Please proceed at your own discretion."
 msgstr ""
 
 #. Translators: When viewing the list of applications ready to be sent for a particular partner, this is instructions for the coordinator to click the 'mark as sent' button after they have sent the information.
@@ -774,9 +738,7 @@ msgstr[1] ""
 
 #. Translators: When viewing the list of applications ready to be sent for a particular partner, this message shows if there is no information about who the applications should be sent to. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/applications/templates/applications/send_partner.html:89
-msgid ""
-"Whoops, we don't have any listed contacts. Please notify Wikipedia Library "
-"administrators."
+msgid "Whoops, we don't have any listed contacts. Please notify Wikipedia Library administrators."
 msgstr ""
 
 #. Translators: When viewing the list of applications ready to be sent for a particular partner, this is the title of the section containing the information about those applications.
@@ -792,9 +754,7 @@ msgstr "Билгалйе дӀайахьийтина санна"
 
 #. Translators: This text guides coordinators in using the code sending interface for approved applications.
 #: TWLight/applications/templates/applications/send_partner.html:152
-msgid ""
-"Use the dropdown menus to denote which editor will receive each code. Access "
-"codes will be sent to users automatically."
+msgid "Use the dropdown menus to denote which editor will receive each code. Access codes will be sent to users automatically."
 msgstr ""
 
 #. Translators: This labels a drop-down selection where staff can assign an access code to a user.
@@ -810,18 +770,13 @@ msgstr ""
 #. Translators: When a user applies for a set of resources, they receive this message if none are currently available. They are instead placed on a 'waitlist' for later approval.
 #. Translators: When a user renews their resource, they receive this message if none are currently available. They are instead placed on a 'waitlist' for later approval.
 #: TWLight/applications/views.py:140 TWLight/applications/views.py:1282
-msgid ""
-"This partner does not have any access grants available at this time. You may "
-"still apply for access; your application will be reviewed when access grants "
-"become available."
+msgid "This partner does not have any access grants available at this time. You may still apply for access; your application will be reviewed when access grants become available."
 msgstr ""
 
 #. Translators: This message is shown to users once they've successfully submitted their application for review.
 #: TWLight/applications/views.py:163
 #, python-brace-format
-msgid ""
-"Your application has been submitted for review. Head over to <a "
-"href='{applications_url}'>My Applications</a> to view the status."
+msgid "Your application has been submitted for review. Head over to <a href='{applications_url}'>My Applications</a> to view the status."
 msgstr ""
 
 #. Translators: This text is displayed to users when the user has chosen to restrict data and is trying to apply for multiple partners
@@ -870,16 +825,12 @@ msgstr "ДӀадахийтина дехарш"
 
 #. Translators: After a coordinator has changed the status of an application to APPROVED, if the corresponding partner/collection is waitlisted this message appears.
 #: TWLight/applications/views.py:756
-msgid ""
-"Cannot approve application as partner with proxy authorization method is "
-"waitlisted."
+msgid "Cannot approve application as partner with proxy authorization method is waitlisted."
 msgstr ""
 
 #. Translators: After a coordinator has changed the status of an application to APPROVED, if the corresponding partner/collection has no accounts for distribution, this message appears.
 #: TWLight/applications/views.py:780
-msgid ""
-"Cannot approve application as partner with proxy authorization method is "
-"waitlisted and (or) has zero accounts available for distribution."
+msgid "Cannot approve application as partner with proxy authorization method is waitlisted and (or) has zero accounts available for distribution."
 msgstr ""
 
 #. Translators: This message appears on an "access denied" screen that stops users who attempt to authorize an editor to access a resource during a time period for which they are already authorized.
@@ -890,11 +841,7 @@ msgstr ""
 #. Translators: This message is shown to users when they access an application page of a now Bundle partner (new applications aren't allowed for Bundle partners and the status of old applications cannot be modified)
 #: TWLight/applications/views.py:857
 #, python-brace-format
-msgid ""
-"This application cannot be modified since this partner is now part of our <a "
-"href='{bundle}'>bundle access</a>. If you are eligible, you can access this "
-"resource from <a href='{library}'>your library</a>. <a "
-"href='{contact}'>Contact us</a> if you have any questions."
+msgid "This application cannot be modified since this partner is now part of our <a href='{bundle}'>bundle access</a>. If you are eligible, you can access this resource from <a href='{library}'>your library</a>. <a href='{contact}'>Contact us</a> if you have any questions."
 msgstr ""
 
 #. Translators: this lets a reviewer set the status of a single application.
@@ -904,9 +851,7 @@ msgstr "Дехаран статус дӀахӀоттайе"
 
 #. Translators: This warning is message is shown to applicants when the number of pending applications is greater than the number of accounts available.
 #: TWLight/applications/views.py:891
-msgid ""
-"There are more pending applications than available accounts. Your "
-"application might get waitlisted."
+msgid "There are more pending applications than available accounts. Your application might get waitlisted."
 msgstr ""
 
 #. Translators: this message is shown to coordinators who attempt to change an application's Status from INVALID to any other Status.
@@ -926,11 +871,7 @@ msgstr ""
 
 #. Translators: After a coordinator has changed the status of a number of applications to APPROVED, if the corresponding partner(s) is/are waitlisted or has no accounts for distribution, this message appears.
 #: TWLight/applications/views.py:1051
-msgid ""
-"Cannot approve application(s) {} as partner(s) with proxy authorization "
-"method is/are waitlisted and (or) has/have not enough accounts available. If "
-"not enough accounts are available, prioritise the applications and then "
-"approve applications equal to the accounts available."
+msgid "Cannot approve application(s) {} as partner(s) with proxy authorization method is/are waitlisted and (or) has/have not enough accounts available. If not enough accounts are available, prioritise the applications and then approve applications equal to the accounts available."
 msgstr ""
 
 #. Translators: This message is shown to coordinators who attempt to assign the same access code to multiple users.
@@ -945,9 +886,7 @@ msgstr ""
 
 #. Translators: When a user tries to renew their resource, they receive this message if the partner is not available.
 #: TWLight/applications/views.py:1272
-msgid ""
-"Cannot renew application at this time as partner is not available. Please "
-"check back later, or contact us for more information."
+msgid "Cannot renew application at this time as partner is not available. Please check back later, or contact us for more information."
 msgstr ""
 
 #. Translators: This message is displayed when an attempt by a user to renew an application has been denied for some reason.
@@ -958,16 +897,12 @@ msgstr ""
 
 #. Translators: If a user requests the renewal of their account, but it wasn't renewed, this message is shown to them.
 #: TWLight/applications/views.py:1385
-msgid ""
-"This object cannot be renewed. (This probably means that you have already "
-"requested that it be renewed.)"
+msgid "This object cannot be renewed. (This probably means that you have already requested that it be renewed.)"
 msgstr ""
 
 #. Translators: If a user requests the renewal of their account, this message is shown to them.
 #: TWLight/applications/views.py:1395
-msgid ""
-"Your renewal request has been received. A coordinator will review your "
-"request."
+msgid "Your renewal request has been received. A coordinator will review your request."
 msgstr ""
 
 #. Translators: This labels a textfield where users can enter their email ID.
@@ -977,9 +912,7 @@ msgstr "Хьан эл. поштан адрес"
 
 #. Translators: This is the help text for the email field in the contact us form letting users know the field is updated by value pulled from their respective user profiles.
 #: TWLight/emails/forms.py:21
-msgid ""
-"This field is automatically updated with the email from your <a class='twl-"
-"links' href='{}'>user profile</a>."
+msgid "This field is automatically updated with the email from your <a class='twl-links' href='{}'>user profile</a>."
 msgstr ""
 
 #. Translators: This labels a textfield where users can enter their email message.
@@ -1003,19 +936,13 @@ msgstr "ДӀадахьийта"
 #. Translators: This email is sent to users with their access code. Don't translate Jinja variables in curly braces like user or partner. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/access_code_email-body-html.html:5
 #, python-format
-msgid ""
-"<p>Your approved application to %(partner)s has now been finalised. Your "
-"access code or login details can be found below:</p> <p><b>%(access_code)s</"
-"b></p> <p>%(user_instructions)s</p>"
+msgid "<p>Your approved application to %(partner)s has now been finalised. Your access code or login details can be found below:</p> <p><b>%(access_code)s</b></p> <p>%(user_instructions)s</p>"
 msgstr ""
 
 #. Translators: This email is sent to users with their access code. Don't translate Jinja variables in curly braces like user or partner. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/access_code_email-body-text.html:3
 #, python-format
-msgid ""
-"Your approved application to %(partner)s has now been finalised. Your access "
-"code or login details can be found below: %(access_code)s "
-"%(user_instructions)s"
+msgid "Your approved application to %(partner)s has now been finalised. Your access code or login details can be found below: %(access_code)s %(user_instructions)s"
 msgstr ""
 
 #. Translators: This is the subject line of an email sent to users with their access code.
@@ -1026,23 +953,13 @@ msgstr ""
 #. Translators: This email is sent to users when their application is approved. Don't translate Jinja variables in curly braces like user or partner; don't translate html tags either. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/approval_notification-body-html.html:5
 #, python-format
-msgid ""
-"<p>Dear %(user)s,</p> <p>Thank you for applying for access to %(partner)s "
-"resources through The Wikipedia Library. We are happy to inform you that "
-"your application has been approved.</p> <p>%(user_instructions)s</p> <p>You "
-"can view the collections you're authorized to access at My Library: "
-"%(link)s</p> <p>Cheers!</p> <p>The Wikipedia Library</p>"
+msgid "<p>Dear %(user)s,</p> <p>Thank you for applying for access to %(partner)s resources through The Wikipedia Library. We are happy to inform you that your application has been approved.</p> <p>%(user_instructions)s</p> <p>You can view the collections you're authorized to access at My Library: %(link)s</p> <p>Cheers!</p> <p>The Wikipedia Library</p>"
 msgstr ""
 
 #. Translators: This email is sent to users when their application is approved. Don't translate Jinja variables in curly braces like user or partner. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/approval_notification-body-text.html:3
 #, python-format
-msgid ""
-"Dear %(user)s, Thank you for applying for access to %(partner)s resources "
-"through The Wikipedia Library. We are happy to inform you that your "
-"application has been approved. %(user_instructions)s You can view the "
-"collections you're authorized to access at My Library: %(link)s Cheers! The "
-"Wikipedia Library"
+msgid "Dear %(user)s, Thank you for applying for access to %(partner)s resources through The Wikipedia Library. We are happy to inform you that your application has been approved. %(user_instructions)s You can view the collections you're authorized to access at My Library: %(link)s Cheers! The Wikipedia Library"
 msgstr ""
 
 #. Translators: This is the subject of an email which is sent to users when their application has been approved. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
@@ -1053,19 +970,13 @@ msgstr ""
 #. Translators: This email is sent to coordinators when a comment is left on an application they are processing. Don't translate Jinja variables in curly braces like user or partner. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/comment_notification_coordinator-body-html.html:5
 #, python-format
-msgid ""
-"<p style=\"color: #500050\">%(submit_date)s - %(commenter)s</p> "
-"<blockquote><p>%(comment)s</p></blockquote> <p>Please reply to these at: <a "
-"href=\"%(app_url)s\">%(app_url)s</a></p> <p>Best,</p> <p>The Wikipedia "
-"Library</p>"
+msgid "<p style=\"color: #500050\">%(submit_date)s - %(commenter)s</p> <blockquote><p>%(comment)s</p></blockquote> <p>Please reply to these at: <a href=\"%(app_url)s\">%(app_url)s</a></p> <p>Best,</p> <p>The Wikipedia Library</p>"
 msgstr ""
 
 #. Translators: This email is sent to coordinators when a comment is left on an application they are processing. Don't translate Jinja variables in curly braces like user or partner. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/comment_notification_coordinator-body-text.html:3
 #, python-format
-msgid ""
-"%(submit_date)s - %(commenter)s %(comment)s Please reply to this at: "
-"%(app_url)s Best, The Wikipedia Library"
+msgid "%(submit_date)s - %(commenter)s %(comment)s Please reply to this at: %(app_url)s Best, The Wikipedia Library"
 msgstr ""
 
 #. Translators: This is the subject line of an email sent to coordinators when a comment is left on an application they processed.
@@ -1076,19 +987,13 @@ msgstr ""
 #. Translators: This email is sent to users when they receive a comment on their application. Don't translate Jinja variables in curly braces like user or partner; don't translate html tags either. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/comment_notification_editors-body-html.html:5
 #, python-format
-msgid ""
-"<p style=\"color: #500050\">%(submit_date)s - %(commenter)s</p> "
-"<blockquote><p>%(comment)s</p></blockquote> <p>Please reply to these at <a "
-"href=\"%(app_url)s\">%(app_url)s</a> so we can evaluate your application.</"
-"p> <p>Best,</p> <p>The Wikipedia Library</p>"
+msgid "<p style=\"color: #500050\">%(submit_date)s - %(commenter)s</p> <blockquote><p>%(comment)s</p></blockquote> <p>Please reply to these at <a href=\"%(app_url)s\">%(app_url)s</a> so we can evaluate your application.</p> <p>Best,</p> <p>The Wikipedia Library</p>"
 msgstr ""
 
 #. Translators: This email is sent to users when they receive a comment on their application. Don't translate Jinja variables in curly braces like user or partner. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/comment_notification_editors-body-text.html:3
 #, python-format
-msgid ""
-"%(submit_date)s - %(commenter)s %(comment)s Please reply to these at: "
-"%(app_url)s so we can evaluate your application. Best, The Wikipedia Library"
+msgid "%(submit_date)s - %(commenter)s %(comment)s Please reply to these at: %(app_url)s so we can evaluate your application. Best, The Wikipedia Library"
 msgstr ""
 
 #. Translators: This is the subject line of an email sent to users who have a comment added to one of their applications. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
@@ -1099,18 +1004,13 @@ msgstr ""
 #. Translators: This email is sent to users when an application they commented on receives another comment. Don't translate Jinja variables in curly braces like app_url; don't translate html tags either. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/comment_notification_others-body-html.html:5
 #, python-format
-msgid ""
-"<p style=\"color: #500050\">%(submit_date)s - %(commenter)s</p> "
-"<blockquote><p>%(comment)s</p></blockquote> See it at <a href=\"%(app_url)s"
-"\">%(app_url)s</a>. Thanks for helping review Wikipedia Library applications!"
+msgid "<p style=\"color: #500050\">%(submit_date)s - %(commenter)s</p> <blockquote><p>%(comment)s</p></blockquote> See it at <a href=\"%(app_url)s\">%(app_url)s</a>. Thanks for helping review Wikipedia Library applications!"
 msgstr ""
 
 #. Translators: This email is sent to users when an application they commented on receives another comment. Don't translate Jinja variables in curly braces like app_url. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/comment_notification_others-body-text.html:3
 #, python-format
-msgid ""
-"%(submit_date)s - %(commenter)s %(comment)s See it at: %(app_url)s Thanks "
-"for helping review Wikipedia Library applications!"
+msgid "%(submit_date)s - %(commenter)s %(comment)s See it at: %(app_url)s Thanks for helping review Wikipedia Library applications!"
 msgstr ""
 
 #. Translators: This is the subject line of an email sent to users who have a comment added to an application they also commented on. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
@@ -1121,10 +1021,7 @@ msgstr ""
 #. Translators: This text is part of a scheduled reminder email sent to coordinators who have applications requiring action. Don't translate Jinja variables in curly braces like total_apps, or user.
 #: TWLight/emails/templates/emails/coordinator_reminder_notification-body-html.html:5
 #, python-format
-msgid ""
-"<p>Dear %(user)s,</p> <p>Our records indicate that you are the designated "
-"coordinator for partners that have a total of %(total_apps)s applications.</"
-"p>"
+msgid "<p>Dear %(user)s,</p> <p>Our records indicate that you are the designated coordinator for partners that have a total of %(total_apps)s applications.</p>"
 msgstr ""
 
 #. Translators: Breakdown as in 'cost breakdown'; analysis.
@@ -1163,31 +1060,19 @@ msgstr[1] ""
 #. Translators: This text is part of a scheduled reminder email sent to coordinators who have applications requiring action. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library). Don't translate Jinja variables in curly braces like link; don't translate email addresses or html tags either.
 #: TWLight/emails/templates/emails/coordinator_reminder_notification-body-html.html:39
 #, python-format
-msgid ""
-"<p>This is a gentle reminder that you may review applications at <a href="
-"\"%(link)s\">%(link)s</a>.</p> <p>You can customise your reminders under "
-"'preferences' in your user profile.</p> <p>If you received this message in "
-"error, drop us a line at wikipedialibrary@wikimedia.org.</p> <p>Thanks for "
-"helping review Wikipedia Library applications!</p>"
+msgid "<p>This is a gentle reminder that you may review applications at <a href=\"%(link)s\">%(link)s</a>.</p> <p>You can customise your reminders under 'preferences' in your user profile.</p> <p>If you received this message in error, drop us a line at wikipedialibrary@wikimedia.org.</p> <p>Thanks for helping review Wikipedia Library applications!</p>"
 msgstr ""
 
 #. Translators: This text is part of a scheduled reminder email sent to coordinators who have applications requiring action. Don't translate Jinja variables in curly braces like total_apps, or user.
 #: TWLight/emails/templates/emails/coordinator_reminder_notification-body-text.html:3
 #, python-format
-msgid ""
-"Dear %(user)s, Our records indicate that you are the designated coordinator "
-"for partners that have a total of %(total_apps)s applications."
+msgid "Dear %(user)s, Our records indicate that you are the designated coordinator for partners that have a total of %(total_apps)s applications."
 msgstr ""
 
 #. Translators: This text is part of a scheduled reminder email sent to coordinators who have applications requiring action. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library). Don't translate Jinja variables in curly braces like link; don't translate the email address either.
 #: TWLight/emails/templates/emails/coordinator_reminder_notification-body-text.html:38
 #, python-format
-msgid ""
-"This is a gentle reminder that you may review applications at: %(link)s. You "
-"can customise your reminders under 'preferences' in your user profile. If "
-"you received this message in error, drop us a line at: "
-"wikipedialibrary@wikimedia.org Thanks for helping review Wikipedia Library "
-"applications!"
+msgid "This is a gentle reminder that you may review applications at: %(link)s. You can customise your reminders under 'preferences' in your user profile. If you received this message in error, drop us a line at: wikipedialibrary@wikimedia.org Thanks for helping review Wikipedia Library applications!"
 msgstr ""
 
 #. Translators: This is the subject line of a scheduled reminder email sent to coordinators who have applications to review. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library). Do not translate items in curly braces.
@@ -1198,22 +1083,13 @@ msgstr ""
 #. Translators: This email is sent to users when their application is rejected. Don't translate Jinja variables in curly braces like user or partner; don't translate html tags either. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/rejection_notification-body-html.html:5
 #, python-format
-msgid ""
-"<p>Dear %(user)s,</p> <p>Thank you for applying for access to %(partner)s "
-"resources through The Wikipedia Library. Unfortunately at this time your "
-"application has not been approved. You can view your application and review "
-"comments at <a href=\"%(app_url)s\">%(app_url)s</a>.</p> <p>Best,</p> <p>The "
-"Wikipedia Library</p>"
+msgid "<p>Dear %(user)s,</p> <p>Thank you for applying for access to %(partner)s resources through The Wikipedia Library. Unfortunately at this time your application has not been approved. You can view your application and review comments at <a href=\"%(app_url)s\">%(app_url)s</a>.</p> <p>Best,</p> <p>The Wikipedia Library</p>"
 msgstr ""
 
 #. Translators: This email is sent to users when their application is rejected. Don't translate Jinja variables in curly braces like user or partner. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/rejection_notification-body-text.html:3
 #, python-format
-msgid ""
-"Dear %(user)s, Thank you for applying for access to %(partner)s resources "
-"through The Wikipedia Library. Unfortunately at this time your application "
-"has not been approved. You can view your application and review comments at: "
-"%(app_url)s Best, The Wikipedia Library"
+msgid "Dear %(user)s, Thank you for applying for access to %(partner)s resources through The Wikipedia Library. Unfortunately at this time your application has not been approved. You can view your application and review comments at: %(app_url)s Best, The Wikipedia Library"
 msgstr ""
 
 #. Translators: This is the subject of an email which is sent to users when their application has been rejected. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
@@ -1224,25 +1100,13 @@ msgstr ""
 #. Translators: This email is sent to users when they have an account that is soon to expire. Don't translate Jinja variables in curly braces like partner_name or partner_link; don't translate html tags either. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/user_renewal_notice-body-html.html:5
 #, python-format
-msgid ""
-"<p>Dear %(user)s,</p> <p>According to our records, your access to "
-"%(partner_name)s will soon expire and you may lose access. If you want to "
-"continue making use of your free account, you can request renewal of your "
-"account by clicking the 'Renew' or 'Extend' button at %(partner_link)s.</p> "
-"<p>Best,</p> <p>The Wikipedia Library</p> <p>You can disable these emails in "
-"your user page preferences: https://wikipedialibrary.wmflabs.org/users/</p>"
+msgid "<p>Dear %(user)s,</p> <p>According to our records, your access to %(partner_name)s will soon expire and you may lose access. If you want to continue making use of your free account, you can request renewal of your account by clicking the 'Renew' or 'Extend' button at %(partner_link)s.</p> <p>Best,</p> <p>The Wikipedia Library</p> <p>You can disable these emails in your user page preferences: https://wikipedialibrary.wmflabs.org/users/</p>"
 msgstr ""
 
 #. Translators: This email is sent to users when they have an account that is soon to expire. Don't translate Jinja variables in curly braces like partner_name or partner_link; don't translate html tags either. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/user_renewal_notice-body-text.html:3
 #, python-format
-msgid ""
-"Dear %(user)s, According to our records, your access to %(partner_name)s "
-"will soon expire and you may lose access. If you want to continue making use "
-"of your free account, you can request renewal of your account by clicking "
-"the Renew button at %(partner_link)s. Best, The Wikipedia Library You can "
-"disable these emails in your user page preferences: https://wikipedialibrary."
-"wmflabs.org/users/"
+msgid "Dear %(user)s, According to our records, your access to %(partner_name)s will soon expire and you may lose access. If you want to continue making use of your free account, you can request renewal of your account by clicking the Renew button at %(partner_link)s. Best, The Wikipedia Library You can disable these emails in your user page preferences: https://wikipedialibrary.wmflabs.org/users/"
 msgstr ""
 
 #. Translators: This is the subject of an email sent to users when they have an account that is soon to expire. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
@@ -1253,24 +1117,13 @@ msgstr ""
 #. Translators: This email is sent to users when their application is waitlisted because there are no more accounts available. Don't translate Jinja variables in curly braces like user or partner; don't translate html tags either. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/waitlist_notification-body-html.html:5
 #, python-format
-msgid ""
-"<p>Dear %(user)s,</p> <p>Thank you for applying for access to %(partner)s "
-"resources through The Wikipedia Library. There are no accounts currently "
-"available so your application has been waitlisted. Your application will be "
-"evaluated if/when more accounts become available. You can see all available "
-"resources at <a href=\"%(link)s\">%(link)s</a>.</p> <p>Best,</p> <p>The "
-"Wikipedia Library</p>"
+msgid "<p>Dear %(user)s,</p> <p>Thank you for applying for access to %(partner)s resources through The Wikipedia Library. There are no accounts currently available so your application has been waitlisted. Your application will be evaluated if/when more accounts become available. You can see all available resources at <a href=\"%(link)s\">%(link)s</a>.</p> <p>Best,</p> <p>The Wikipedia Library</p>"
 msgstr ""
 
 #. Translators: This email is sent to users when their application is waitlisted because there are no more accounts available. Don't translate Jinja variables in curly braces like user or partner. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/waitlist_notification-body-text.html:3
 #, python-format
-msgid ""
-"Dear %(user)s, Thank you for applying for access to %(partner)s resources "
-"through The Wikipedia Library. There are no accounts currently available so "
-"your application has been waitlisted. Your application will be evaluated if/"
-"when more accounts become available. You can see all available resources at: "
-"%(link)s Best, The Wikipedia Library"
+msgid "Dear %(user)s, Thank you for applying for access to %(partner)s resources through The Wikipedia Library. There are no accounts currently available so your application has been waitlisted. Your application will be evaluated if/when more accounts become available. You can see all available resources at: %(link)s Best, The Wikipedia Library"
 msgstr ""
 
 #. Translators: This is the subject of an email sent to users when their application is waitlisted because there are no more accounts available. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
@@ -1432,17 +1285,14 @@ msgstr "ТӀецакхочу"
 #: TWLight/resources/templates/resources/filter_section.html:14
 #: TWLight/templates/about.html:12
 #: TWLight/users/templates/users/filter_section.html:13
-msgid ""
-"The Wikipedia Library allows active editors to access a wide range of "
-"collections of paywalled reliable sources for free!"
+msgid "The Wikipedia Library allows active editors to access a wide range of collections of paywalled reliable sources for free!"
 msgstr ""
 
 #. Translators: On the Browse Partners page (https://wikipedialibrary.wmflabs.org/partners/), this introduces users to The Wikipedia Library.
 #. Translators: On the MyLibrary page (https://wikipedialibrary.wmflabs.org/users/my_library), this introduces users to The Wikipedia Library.
 #: TWLight/resources/templates/resources/filter_section.html:17
 #: TWLight/users/templates/users/filter_section.html:15
-msgid ""
-"Start with the search bar at the top or browse publisher websites directly."
+msgid "Start with the search bar at the top or browse publisher websites directly."
 msgstr ""
 
 #. Translators: On the Browse Partners page (https://wikipedialibrary.wmflabs.org/partners/), this appears below introductory text and links to the 'About' page (https://wikipedialibrary.wmflabs.org/about/)
@@ -1516,52 +1366,38 @@ msgstr ""
 #. Translators: If we have no available accounts for a partner, the coordinator can change the application system to a waiting list.
 #: TWLight/resources/templates/resources/partner_detail.html:36
 #: TWLight/resources/templates/resources/partner_detail_apply.html:17
-msgid ""
-"There are no access grants available for this partner at this time. You can "
-"still apply for access; applications will be processed when access is "
-"available."
+msgid "There are no access grants available for this partner at this time. You can still apply for access; applications will be processed when access is available."
 msgstr ""
 
 #. Translators: This text links to the minimum user requirements and terms of use on the partner page.
 #: TWLight/resources/templates/resources/partner_detail.html:48
 #: TWLight/resources/templates/resources/partner_detail_apply.html:29
 #, python-format
-msgid ""
-"Before applying, please review the <strong><a class=\"twl-links\" href="
-"\"%(about)s#req\">minimum requirements</a></strong> for access and our "
-"<strong><a class=\"twl-links\" href=\"%(terms)s\">terms of use</a></strong>."
+msgid "Before applying, please review the <strong><a class=\"twl-links\" href=\"%(about)s#req\">minimum requirements</a></strong> for access and our <strong><a class=\"twl-links\" href=\"%(terms)s\">terms of use</a></strong>."
 msgstr ""
 
 #. Translators: This text refers to the page containing the content a user is authorized to access.
 #: TWLight/resources/templates/resources/partner_detail.html:69
 #, python-format
-msgid ""
-"View the status of your access in <strong><a class=\"twl-links\" href="
-"\"%(library_url)s\">My Library</a></strong> page."
+msgid "View the status of your access in <strong><a class=\"twl-links\" href=\"%(library_url)s\">My Library</a></strong> page."
 msgstr ""
 
 #. Translators: This message is shown when a user has open applications, linking to their respective applications page.
 #: TWLight/resources/templates/resources/partner_detail.html:78
 #, python-format
-msgid ""
-"View the status of your application(s) on your <strong><a class=\"twl-links"
-"\" href=\"%(applications_url)s\">My Applications</a></strong> page."
+msgid "View the status of your application(s) on your <strong><a class=\"twl-links\" href=\"%(applications_url)s\">My Applications</a></strong> page."
 msgstr ""
 
 #. Translators: This message is shown when a user has authorizations, linking to their respective collections page.
 #: TWLight/resources/templates/resources/partner_detail_apply.html:50
 #, python-format
-msgid ""
-"View the status of your access on your <strong><a href=\"%(library_url)s\" "
-"class=\"twl-links\">My Library</a></strong> page."
+msgid "View the status of your access on your <strong><a href=\"%(library_url)s\" class=\"twl-links\">My Library</a></strong> page."
 msgstr ""
 
 #. Translators: This message is shown when a user has open applications, linking to their respective applications page.
 #: TWLight/resources/templates/resources/partner_detail_apply.html:60
 #, python-format
-msgid ""
-"View the status of your application(s) on your <strong><a href="
-"\"%(applications_url)s\">My Applications</a></strong> page."
+msgid "View the status of your application(s) on your <strong><a href=\"%(applications_url)s\">My Applications</a></strong> page."
 msgstr ""
 
 #. Translators: One the partner detail page, this text labels the button which coordinators can click to remove a partner from waitlisted status.
@@ -1591,14 +1427,8 @@ msgstr "Декъашхочуьнга электронан кехат йазде"
 
 #. Translators: If no account coordinator is assigned to a partner, the Wikipedia Library team will coordinate signups. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/resources/templates/resources/partner_detail_apply.html:112
-msgid ""
-"The Wikipedia Library team will process this application. Want to help? <a "
-"class=\"twl-links\" href=\"https://en.wikipedia.org/wiki/Wikipedia:"
-"The_Wikipedia_Library/Coordinators/Signup\">Sign up as a coordinator.</a>"
-msgstr ""
-"Википедин библиотекин командас хӀара дехар кечдира ду. Лаьий гӀодан? <a "
-"class=\"twl-links\" href=\"https://en.wikipedia.org/wiki/Wikipedia:"
-"The_Wikipedia_Library/Coordinators/Signup\">ДӀайазло координатор хилла.</a>"
+msgid "The Wikipedia Library team will process this application. Want to help? <a class=\"twl-links\" href=\"https://en.wikipedia.org/wiki/Wikipedia:The_Wikipedia_Library/Coordinators/Signup\">Sign up as a coordinator.</a>"
+msgstr "Википедин библиотекин командас хӀара дехар кечдира ду. Лаьий гӀодан? <a class=\"twl-links\" href=\"https://en.wikipedia.org/wiki/Wikipedia:The_Wikipedia_Library/Coordinators/Signup\">ДӀайазло координатор хилла.</a>"
 
 #. Translators: This text labels a button coordinators can click to view a list of users who have applied for access for a particular partner
 #: TWLight/resources/templates/resources/partner_detail_apply.html:121
@@ -1627,18 +1457,13 @@ msgstr ""
 
 #. Translators: Text shown to authenticated, bundle eligible users when they visit a Bundle partner page.
 #: TWLight/resources/templates/resources/partner_detail_apply.html:138
-msgid ""
-"You are eligible to access Library Bundle partners. Click the button above "
-"to access the collection."
+msgid "You are eligible to access Library Bundle partners. Click the button above to access the collection."
 msgstr ""
 
 #. Translators: Text shown to authenticated, bundle ineligible users when they visit a Bundle partner page.
 #: TWLight/resources/templates/resources/partner_detail_apply.html:152
 #, python-format
-msgid ""
-"You are not eligible to access Library Bundle partners. Visit the <a class="
-"\"twl-links\" href=\"%(homepage)s\">homepage</a> to check the eligibility "
-"criteria."
+msgid "You are not eligible to access Library Bundle partners. Visit the <a class=\"twl-links\" href=\"%(homepage)s\">homepage</a> to check the eligibility criteria."
 msgstr ""
 
 #. Translators: Buttton prompting users to log in.
@@ -1650,10 +1475,7 @@ msgstr "ЧугӀо"
 #. Translators: Text shown to unauthenticated users when they visit a Bundle partner page.
 #: TWLight/resources/templates/resources/partner_detail_apply.html:168
 #, python-format
-msgid ""
-"This resource is part of our <a class=\"twl-links\" href=\"%(about)s"
-"\">Library Bundle</a>, which you can access if you meet our minimum "
-"eligibility criteria. Log in to find out if you are eligible."
+msgid "This resource is part of our <a class=\"twl-links\" href=\"%(about)s\">Library Bundle</a>, which you can access if you meet our minimum eligibility criteria. Log in to find out if you are eligible."
 msgstr ""
 
 #. Translators: This is the label for a number which shows the total active accounts for one partner. (e.g. https://wikipedialibrary.wmflabs.org/partners/8/).
@@ -1704,26 +1526,19 @@ msgstr "Арадалийтаран лимиташ"
 #. Translators: If a partner has specified the excerpt limit both in words and percentage, this message will display the percentage of words and the number of words on the partner page.
 #: TWLight/resources/templates/resources/partner_detail_timeline.html:99
 #, python-format
-msgid ""
-"%(object)s allows a maximum of %(excerpt_limit)s words or "
-"%(excerpt_limit_percentage)s%% of an article be excerpted into a Wikipedia "
-"article."
+msgid "%(object)s allows a maximum of %(excerpt_limit)s words or %(excerpt_limit_percentage)s%% of an article be excerpted into a Wikipedia article."
 msgstr ""
 
 #. Translators: If a partner has specified the excerpt limit in words, this message will display the number of words on the partner page.
 #: TWLight/resources/templates/resources/partner_detail_timeline.html:106
 #, python-format
-msgid ""
-"%(object)s allows a maximum of %(excerpt_limit)s words be excerpted into a "
-"Wikipedia article."
+msgid "%(object)s allows a maximum of %(excerpt_limit)s words be excerpted into a Wikipedia article."
 msgstr ""
 
 #. Translators: If a partner has specified the excerpt limit in percentage, this message will display the percentage of words on the partner page.
 #: TWLight/resources/templates/resources/partner_detail_timeline.html:113
 #, python-format
-msgid ""
-"%(object)s allows a maximum of %(excerpt_limit_percentage)s%% of an article "
-"be excerpted into a Wikipedia article."
+msgid "%(object)s allows a maximum of %(excerpt_limit_percentage)s%% of an article be excerpted into a Wikipedia article."
 msgstr ""
 
 #. Translators: If a partner has other requirements for access, this text shows as the title for that information field. (e.g. https://wikipedialibrary.wmflabs.org/partners/10/).
@@ -1734,9 +1549,7 @@ msgstr ""
 #. Translators: If a user must agree to a Terms of Use document, they see this message, and must enter the name of the resource. Don't translate publisher or url.
 #: TWLight/resources/templates/resources/partner_detail_timeline.html:140
 #, python-format
-msgid ""
-"%(publisher)s requires that you agree with its <a href=\"%(url)s\">terms of "
-"use</a>."
+msgid "%(publisher)s requires that you agree with its <a href=\"%(url)s\">terms of use</a>."
 msgstr ""
 
 #. Translators: If a user must provide their real name to apply to a partner, they see this message, and must enter the name of the resource. Don't translate publisher.
@@ -1760,17 +1573,13 @@ msgstr ""
 #. Translators: If a user must select a specific resource to apply for, they see this message, and must enter the name of the resource. Don't translate publisher.
 #: TWLight/resources/templates/resources/partner_detail_timeline.html:177
 #, python-format
-msgid ""
-"%(publisher)s requires that you specify a particular title that you want to "
-"access."
+msgid "%(publisher)s requires that you specify a particular title that you want to access."
 msgstr ""
 
 #. Translators: If a user must register on the partner website before applying, they see this message. Don't translate partner.
 #: TWLight/resources/templates/resources/partner_detail_timeline.html:187
 #, python-format
-msgid ""
-"%(publisher)s requires that you sign up for an account before applying for "
-"access."
+msgid "%(publisher)s requires that you sign up for an account before applying for access."
 msgstr ""
 
 #. Translators: If a partner has their location listed, this message is a label for that location
@@ -1897,9 +1706,7 @@ msgstr "Баккъалла а лаьий хьуна дӀайаккха <b>%(obje
 
 #. Translators: If multiple authorizations where returned for a collection, this message is shown to a user
 #: TWLight/resources/views.py:268
-msgid ""
-"Multiple authorizations were returned – something's wrong. Please contact us "
-"and don't forget to mention this message."
+msgid "Multiple authorizations were returned – something's wrong. Please contact us and don't forget to mention this message."
 msgstr ""
 
 #. Translators: This message is shown when user tries to access a NOT_AVAILABLE Partner
@@ -1940,14 +1747,7 @@ msgstr ""
 #. Translators: Shown on the website's 400 page, when a user sends a bad request. Don't translate path or Phabricator.
 #: TWLight/templates/400.html:20
 #, python-format
-msgid ""
-"If you think we should know what to do with that, please email us about this "
-"error at <a class=\"twl-links\" href=\"mailto:wikipedialibrary@wikimedia.org?"
-"Subject=Wikipedia%%20Library%%20%(path)s%%20Permission%%20denied"
-"\">wikipedialibrary@wikimedia.org</a> or report it to us on <a class=\"twl-"
-"links\" href=\"https://phabricator.wikimedia.org/maniphest/task/edit/form/1/?"
-"projectPHIDs=Library-Card-Platform&title=Wikipedia%%20Library%%20%(path)s"
-"%%20Bad%%20Request\">Phabricator</a>"
+msgid "If you think we should know what to do with that, please email us about this error at <a class=\"twl-links\" href=\"mailto:wikipedialibrary@wikimedia.org?Subject=Wikipedia%%20Library%%20%(path)s%%20Permission%%20denied\">wikipedialibrary@wikimedia.org</a> or report it to us on <a class=\"twl-links\" href=\"https://phabricator.wikimedia.org/maniphest/task/edit/form/1/?projectPHIDs=Library-Card-Platform&title=Wikipedia%%20Library%%20%(path)s%%20Bad%%20Request\">Phabricator</a>"
 msgstr ""
 
 #. Translators: Alt text for an image shown on the 400 error page.
@@ -1969,15 +1769,7 @@ msgstr ""
 #. Translators: Shown on the website's 403 page, when a user attempts to navigate to a page they don't have permission to view. Don't translate path or Phabricator.
 #: TWLight/templates/403.html:20
 #, python-format
-msgid ""
-"If you think your account should be able to do that, please email us about "
-"this error at <a class=\"twl-links\" href=\"mailto:"
-"wikipedialibrary@wikimedia.org?Subject=Wikipedia%%20Library%%20%(path)s"
-"%%20Permission%%20denied\">wikipedialibrary@wikimedia.org</a> or report it "
-"to us on <a class=\"twl-links\" href=\"https://phabricator.wikimedia.org/"
-"maniphest/task/edit/form/1/?projectPHIDs=Library-Card-"
-"Platform&title=Wikipedia%%20Library%%20%(path)s%%20Permission%%20denied"
-"\">Phabricator</a>"
+msgid "If you think your account should be able to do that, please email us about this error at <a class=\"twl-links\" href=\"mailto:wikipedialibrary@wikimedia.org?Subject=Wikipedia%%20Library%%20%(path)s%%20Permission%%20denied\">wikipedialibrary@wikimedia.org</a> or report it to us on <a class=\"twl-links\" href=\"https://phabricator.wikimedia.org/maniphest/task/edit/form/1/?projectPHIDs=Library-Card-Platform&title=Wikipedia%%20Library%%20%(path)s%%20Permission%%20denied\">Phabricator</a>"
 msgstr ""
 
 #. Translators: Shown on the website's 404 page, when a user attempts to navigate to a page that doesn't exist.
@@ -1993,14 +1785,7 @@ msgstr ""
 #. Translators: Shown on the website's 404 page, when a user attempts to navigate to a page that doesn't exist. Don't translate path or Phabricator.
 #: TWLight/templates/404.html:19
 #, python-format
-msgid ""
-"If you are certain that something should be here, please email us about this "
-"error at <a class=\"twl-links\" href=\"mailto:wikipedialibrary@wikimedia.org?"
-"Subject=Wikipedia%%20Library%%20%(path)s%%20Not%%20found\"> "
-"wikipedialibrary@wikimedia.org</a> or report it to us on <a class=\"twl-links"
-"\" href=\"https://phabricator.wikimedia.org/maniphest/task/edit/form/1/?"
-"projectPHIDs=Library-Card-Platform&title=Wikipedia%%20Library%%20%(path)s"
-"%%20Not%%20found\">Phabricator</a>"
+msgid "If you are certain that something should be here, please email us about this error at <a class=\"twl-links\" href=\"mailto:wikipedialibrary@wikimedia.org?Subject=Wikipedia%%20Library%%20%(path)s%%20Not%%20found\"> wikipedialibrary@wikimedia.org</a> or report it to us on <a class=\"twl-links\" href=\"https://phabricator.wikimedia.org/maniphest/task/edit/form/1/?projectPHIDs=Library-Card-Platform&title=Wikipedia%%20Library%%20%(path)s%%20Not%%20found\">Phabricator</a>"
 msgstr ""
 
 #. Translators: Alt text for an image shown on the 404 error page.
@@ -2015,32 +1800,18 @@ msgstr ""
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:20
-msgid ""
-"This platform is our central tool for facilitating access to our available "
-"collections. Here you can see which partnerships are available, search their "
-"contents, and apply for and access the ones you’re interested in."
+msgid "This platform is our central tool for facilitating access to our available collections. Here you can see which partnerships are available, search their contents, and apply for and access the ones you’re interested in."
 msgstr ""
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/). Wikimedia Foundation should not be translated.
 #: TWLight/templates/about.html:29
-msgid ""
-"All users receive immediate access to some collections, which can be browsed "
-"by clicking the 'Access collection' buttons or using the search bar at the "
-"top of the page. Other collections require an application before access is "
-"granted, and may be accessed directly or via an individual login or access "
-"code. Volunteer coordinators, who have signed non-disclosure agreements with "
-"the Wikimedia Foundation, review these applications and work with publishers "
-"to get you your free access."
+msgid "All users receive immediate access to some collections, which can be browsed by clicking the 'Access collection' buttons or using the search bar at the top of the page. Other collections require an application before access is granted, and may be accessed directly or via an individual login or access code. Volunteer coordinators, who have signed non-disclosure agreements with the Wikimedia Foundation, review these applications and work with publishers to get you your free access."
 msgstr ""
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/). Don't translate terms_url.
 #: TWLight/templates/about.html:43
 #, python-format
-msgid ""
-"For more information about how your information is stored and reviewed "
-"please see our <a class=\"twl-links\" href=\"%(terms_url)s\"> terms of use "
-"and privacy policy</a>. Accounts you apply for are also subject to the Terms "
-"of Use provided by each partner’s platform; please review them."
+msgid "For more information about how your information is stored and reviewed please see our <a class=\"twl-links\" href=\"%(terms_url)s\"> terms of use and privacy policy</a>. Accounts you apply for are also subject to the Terms of Use provided by each partner’s platform; please review them."
 msgstr ""
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
@@ -2050,12 +1821,7 @@ msgstr ""
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/). Wikimedia Foundation should not be translated.
 #: TWLight/templates/about.html:55
-msgid ""
-"Any active editor in good standing can receive access. For publishers with "
-"limited numbers of accounts, applications are reviewed based on the editor’s "
-"needs and contributions. If you think you could use access to one of our "
-"partner resources and are an active editor in any project supported by the "
-"Wikimedia Foundation, please apply."
+msgid "Any active editor in good standing can receive access. For publishers with limited numbers of accounts, applications are reviewed based on the editor’s needs and contributions. If you think you could use access to one of our partner resources and are an active editor in any project supported by the Wikimedia Foundation, please apply."
 msgstr ""
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
@@ -2085,23 +1851,12 @@ msgstr ""
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/)
 #: TWLight/templates/about.html:89
-msgid ""
-"If you are applying for an available collection, please first check that you "
-"don't already have access through another library or institution. If you do, "
-"please consider using that access rather than taking up a seat for this "
-"resource in The Wikipedia Library."
+msgid "If you are applying for an available collection, please first check that you don't already have access through another library or institution. If you do, please consider using that access rather than taking up a seat for this resource in The Wikipedia Library."
 msgstr ""
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/)
 #: TWLight/templates/about.html:99
-msgid ""
-"If your account is blocked on one or more Wikimedia projects, you may still "
-"be granted access to The Wikipedia Library. You will need to contact the "
-"Wikipedia Library team, who will review your blocks. If you have been "
-"blocked for content issues, most notably copyright violations, or have "
-"multiple long-term blocks, we may decline your request. Additionally, if "
-"your block status changes after being approved, you will need to request "
-"another review."
+msgid "If your account is blocked on one or more Wikimedia projects, you may still be granted access to The Wikipedia Library. You will need to contact the Wikipedia Library team, who will review your blocks. If you have been blocked for content issues, most notably copyright violations, or have multiple long-term blocks, we may decline your request. Additionally, if your block status changes after being approved, you will need to request another review."
 msgstr ""
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
@@ -2136,9 +1891,7 @@ msgstr ""
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:136
-msgid ""
-"Share their account logins or passwords with others, or sell their access to "
-"other parties"
+msgid "Share their account logins or passwords with others, or sell their access to other parties"
 msgstr ""
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
@@ -2148,23 +1901,17 @@ msgstr ""
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:144
-msgid ""
-"Systematically make printed or electronic copies of multiple extracts of "
-"restricted content available for any purpose"
+msgid "Systematically make printed or electronic copies of multiple extracts of restricted content available for any purpose"
 msgstr ""
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/). Stub is a technical term for a short Wikipedia article, use the appropriate Wikipedia term in your language.
 #: TWLight/templates/about.html:148
-msgid ""
-"Datamine metadata without permission, in order, for instance, to use "
-"metadata for auto-created stub articles"
+msgid "Datamine metadata without permission, in order, for instance, to use metadata for auto-created stub articles"
 msgstr ""
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:154
-msgid ""
-"Respecting these agreements allows us to continue growing the partnerships "
-"available to the community."
+msgid "Respecting these agreements allows us to continue growing the partnerships available to the community."
 msgstr ""
 
 #. Translators: This is the heading for a section on the About page (https://wikipedialibrary.wmflabs.org/about/).
@@ -2174,41 +1921,22 @@ msgstr ""
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:164
-msgid ""
-"EZProxy is a proxy server used to authenticate users for many Wikipedia "
-"Library partners. Users sign into EZProxy via the Library Card platform to "
-"verify that they are authorized users, and then the server accesses "
-"requested resources using its own IP address."
+msgid "EZProxy is a proxy server used to authenticate users for many Wikipedia Library partners. Users sign into EZProxy via the Library Card platform to verify that they are authorized users, and then the server accesses requested resources using its own IP address."
 msgstr ""
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:173
-msgid ""
-"You may notice that when accessing resources via EZProxy that URLs are "
-"dynamically rewritten. This is why we recommend logging in via the Library "
-"Card platform rather than going directly to the unproxied partner website. "
-"When in doubt, check the URL for ‘idm.oclc’. If it’s there, then you’re "
-"connected via EZProxy."
+msgid "You may notice that when accessing resources via EZProxy that URLs are dynamically rewritten. This is why we recommend logging in via the Library Card platform rather than going directly to the unproxied partner website. When in doubt, check the URL for ‘idm.oclc’. If it’s there, then you’re connected via EZProxy."
 msgstr ""
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:182
-msgid ""
-"Typically once you’ve logged in your session will remain active in your "
-"browser for up to two hours after you’ve finished searching. Note that use "
-"of EZProxy requires you to enable cookies. If you are having problems you "
-"should also try clearing your cache and restarting your browser."
+msgid "Typically once you’ve logged in your session will remain active in your browser for up to two hours after you’ve finished searching. Note that use of EZProxy requires you to enable cookies. If you are having problems you should also try clearing your cache and restarting your browser."
 msgstr ""
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/)
 #: TWLight/templates/about.html:193
-msgid ""
-"The Library Bundle is a collection of resources for which no application is "
-"required. If you meet the criteria laid out above, you will be authorized "
-"for access automatically upon logging in to the platform. Only some of our "
-"content is currently included in the Library Bundle, however we hope to "
-"expand the collection as more publishers become comfortable with "
-"participating. All Bundle content is accessed via EZProxy."
+msgid "The Library Bundle is a collection of resources for which no application is required. If you meet the criteria laid out above, you will be authorized for access automatically upon logging in to the platform. Only some of our content is currently included in the Library Bundle, however we hope to expand the collection as more publishers become comfortable with participating. All Bundle content is accessed via EZProxy."
 msgstr ""
 
 #. Translators: This is the heading for a section on the About page (https://wikipedialibrary.wmflabs.org/about/).
@@ -2218,12 +1946,7 @@ msgstr ""
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:206
-msgid ""
-"Citation practices vary by project and even by article. Generally, we "
-"support editors citing where they found information, in a form that allows "
-"others to check it for themselves. That often means providing both original "
-"source details as well as a link to the partner database in which the source "
-"was found."
+msgid "Citation practices vary by project and even by article. Generally, we support editors citing where they found information, in a form that allows others to check it for themselves. That often means providing both original source details as well as a link to the partner database in which the source was found."
 msgstr ""
 
 #. Translators: This is the heading for a section on the About page (https://wikipedialibrary.wmflabs.org/about/).
@@ -2235,9 +1958,7 @@ msgstr "ЗӀене довла тхоьца"
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:218
 #, python-format
-msgid ""
-"If you have questions, need help, or want to volunteer to help, please see "
-"our <a class=\"twl-links\" href=\"%(contact_url)s\">contact page</a>."
+msgid "If you have questions, need help, or want to volunteer to help, please see our <a class=\"twl-links\" href=\"%(contact_url)s\">contact page</a>."
 msgstr ""
 
 #. Translators: This is the title of the panel box detailing the contact information for the Wikipedia Library team.
@@ -2277,9 +1998,7 @@ msgstr "Википедин библиотекин Twitter"
 #. Translators: This is the text that appears at the bottom of the contact us form directing users to the suggestions form.
 #: TWLight/templates/contact.html:48
 #, python-format
-msgid ""
-"(If you would like to suggest a partner, <a class=\"twl-links\" href="
-"\"%(suggest)s\"><strong>go here</strong></a>.)"
+msgid "(If you would like to suggest a partner, <a class=\"twl-links\" href=\"%(suggest)s\"><strong>go here</strong></a>.)"
 msgstr ""
 
 #. Translators: On a special 'link to search' page, this message is shown if JavaScript is disabled.
@@ -2337,9 +2056,7 @@ msgstr "Википедин библиотека"
 #. Translators: Information about The Wikipedia Library.
 #: TWLight/templates/login_partial.html:53 TWLight/templates/new_base.html:21
 #, python-format
-msgid ""
-"More than 100 of the world's top subscription-only databases, with content "
-"in %(no_of_languages)s languages, free for Wikipedians of all backgrounds"
+msgid "More than 100 of the world's top subscription-only databases, with content in %(no_of_languages)s languages, free for Wikipedians of all backgrounds"
 msgstr ""
 
 #. Translators: Information about The Wikipedia Library.
@@ -2348,9 +2065,7 @@ msgid "Meet these criteria for automatic access"
 msgstr ""
 
 #: TWLight/templates/login_partial.html:69
-msgid ""
-"These criteria grant you access to certain collections but not all. Some "
-"collections are accessible on a per application basis only."
+msgid "These criteria grant you access to certain collections but not all. Some collections are accessible on a per application basis only."
 msgstr ""
 
 #: TWLight/templates/login_partial.html:89
@@ -2360,29 +2075,19 @@ msgstr "Википедин аккаунтаца чугӀо"
 #. Translators: Shown if the current user doesn't have a registered email on their account. Don't translate contact_us_url or email_url.
 #: TWLight/templates/message_partial.html:15
 #, python-format
-msgid ""
-"You don't have an email on file. We can't finalize your access to partner "
-"resources, and you won't be able to <a class=\"twl-links\" href="
-"\"%(contact_us_url)s\">contact us</a> without an email. Please <a class="
-"\"twl-links\" href=\"%(email_url)s\">update your email</a>."
+msgid "You don't have an email on file. We can't finalize your access to partner resources, and you won't be able to <a class=\"twl-links\" href=\"%(contact_us_url)s\">contact us</a> without an email. Please <a class=\"twl-links\" href=\"%(email_url)s\">update your email</a>."
 msgstr ""
 
 #. Translators: Shown if the current user has requested the processing of their data should be restricted.
 #: TWLight/templates/message_partial.html:26
 #, python-format
-msgid ""
-"You have requested a restriction on the processing of your data. Most site "
-"functionality will not be available to you until you <a class=\"twl-links\" "
-"href=\"%(restrict_url)s\">lift this restriction</a>."
+msgid "You have requested a restriction on the processing of your data. Most site functionality will not be available to you until you <a class=\"twl-links\" href=\"%(restrict_url)s\">lift this restriction</a>."
 msgstr ""
 
 #. Translators: Shown if the current user has not agreed to the terms of use.
 #: TWLight/templates/message_partial.html:37
 #, python-format
-msgid ""
-"You have not agreed to the <a class=\"twl-links\" href=\"%(terms_url)s"
-"\">terms of use</a> of this site. Your applications will not be processed "
-"and you won't be able to apply or access resources you are approved for."
+msgid "You have not agreed to the <a class=\"twl-links\" href=\"%(terms_url)s\">terms of use</a> of this site. Your applications will not be processed and you won't be able to apply or access resources you are approved for."
 msgstr ""
 
 #. Translators: This link is at the bottom of every page and links to the 'About' page (https://wikipedialibrary.wmflabs.org/about/)
@@ -2429,9 +2134,7 @@ msgstr "Пароль кхосса"
 
 #. Translators: If a user goes to reset their password, this message asks them to enter their email to do so.
 #: TWLight/templates/registration/password_reset_form.html:13
-msgid ""
-"Forgot your password? Enter your email address below, and we'll email "
-"instructions for setting a new one."
+msgid "Forgot your password? Enter your email address below, and we'll email instructions for setting a new one."
 msgstr ""
 
 #. Translators: This is the label for a button that users click to update their public information.
@@ -2476,16 +2179,12 @@ msgstr ""
 
 #. Translators: This text explains how to disagree to the site's terms of use and the restrictions that will come into effect when users disagree to the terms of use.
 #: TWLight/users/forms.py:185
-msgid ""
-"By unchecking this box and clicking “Update” you may explore the site, but "
-"you will not be able to apply for access to materials or evaluate "
-"applications unless you agree with the terms of use."
+msgid "By unchecking this box and clicking “Update” you may explore the site, but you will not be able to apply for access to materials or evaluate applications unless you agree with the terms of use."
 msgstr ""
 
 #. Translators: Users click this button to set their website email address to the one linked to their Wikipedia account.
 #: TWLight/users/forms.py:211
-msgid ""
-"Use my Wikipedia email address (will be updated the next time you login)."
+msgid "Use my Wikipedia email address (will be updated the next time you login)."
 msgstr ""
 
 #. Translators: This labels a button which users click to change their email.
@@ -2496,17 +2195,8 @@ msgstr "Карлайаккха эл. пошта"
 #. Translators: Shown if the current user tried to 'favorite' a partner they can't access. Do not translate '{partner}'
 #: TWLight/users/models.py:201
 #, python-brace-format
-msgid ""
-"Cannot add partner {partner} to your favorites because you don't have access "
-"to it"
+msgid "Cannot add partner {partner} to your favorites because you don't have access to it"
 msgstr ""
-
-#. Translators: Do not translate.
-#: TWLight/users/models.py:869
-#, fuzzy, python-brace-format
-#| msgid "Username"
-msgid "{wp_username}"
-msgstr "Декъашхочун цӀе"
 
 #. Translators: This error message is shown when there's a problem with the authenticated login process.
 #: TWLight/users/oauth.py:243
@@ -2526,9 +2216,7 @@ msgstr ""
 
 #. Translators: this message is displayed to users that don't have accounts and clicked on a proxied link.
 #: TWLight/users/oauth.py:388
-msgid ""
-"To view this link you need to be an eligible library user. Please login to "
-"continue."
+msgid "To view this link you need to be an eligible library user. Please login to continue."
 msgstr ""
 
 #. Translators: This warning message is shown to users when the response received from Wikimedia OAuth servers is not a valid one.
@@ -2564,17 +2252,12 @@ msgstr ""
 
 #. Translators: If the user tries to log in, but their account does not meet certain requirements, they cannot login.
 #: TWLight/users/oauth.py:528
-msgid ""
-"Your Wikipedia account does not meet the eligibility criteria in the terms "
-"of use, so your Wikipedia Library Card Platform account cannot be activated."
+msgid "Your Wikipedia account does not meet the eligibility criteria in the terms of use, so your Wikipedia Library Card Platform account cannot be activated."
 msgstr ""
 
 #. Translators: If the user tries to log in, but their account does not meet certain requirements, they cannot login.
 #: TWLight/users/oauth.py:536
-msgid ""
-"Your Wikipedia account no longer meets the eligibility criteria in the terms "
-"of use, so you cannot be logged in. If you think you should be able to log "
-"in, please email wikipedialibrary@wikimedia.org."
+msgid "Your Wikipedia account no longer meets the eligibility criteria in the terms of use, so you cannot be logged in. If you think you should be able to log in, please email wikipedialibrary@wikimedia.org."
 msgstr ""
 
 #. Translators: this message is displayed to users with brand new accounts.
@@ -2585,10 +2268,7 @@ msgstr ""
 #. Translators: This message is displayed on the confirmation page where users can return their access to partner collections.
 #: TWLight/users/templates/users/authorization_confirm_return.html:13
 #, python-format
-msgid ""
-"You will no longer be able to access <b>%(partner)s's</b> resources via the "
-"Library Card platform, but can request access again by clicking 'renew', if "
-"you change your mind. Are you sure you want to return your access?"
+msgid "You will no longer be able to access <b>%(partner)s's</b> resources via the Library Card platform, but can request access again by clicking 'renew', if you change your mind. Are you sure you want to return your access?"
 msgstr ""
 
 #. Translators: On the MyLibrary page (https://wikipedialibrary.wmflabs.org/users/my_library), this tab shows all favorite collections a user has.
@@ -2658,10 +2338,7 @@ msgstr "Редакторех хаам"
 
 #. Translators: This is shown on editor profiles, in their profile page or on applications.
 #: TWLight/users/templates/users/editor_detail.html:59
-msgid ""
-"Information with an * was retrieved from Wikipedia directly. Other "
-"information was entered directly by users or site admins, in their preferred "
-"language."
+msgid "Information with an * was retrieved from Wikipedia directly. Other information was entered directly by users or site admins, in their preferred language."
 msgstr ""
 
 #. Translators: This distinguishes users who have been flagged as account coordinators. Don't translate username.
@@ -2672,10 +2349,7 @@ msgstr ""
 
 #. Translators: This is shown on editor profiles, under the heading for Wikipedia editor data.
 #: TWLight/users/templates/users/editor_detail_data.html:5
-msgid ""
-"This information is updated automatically from your Wikimedia account each "
-"time you log in, except for the Contributions field, where you can describe "
-"your Wikimedia editing history."
+msgid "This information is updated automatically from your Wikimedia account each time you log in, except for the Contributions field, where you can describe your Wikimedia editing history."
 msgstr ""
 
 #. Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this labels the user's username.
@@ -2705,17 +2379,13 @@ msgstr ""
 
 #. Translators: when viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this question has a yes or no answer.
 #: TWLight/users/templates/users/editor_detail_data.html:57
-msgid ""
-"at their last login, did this user meet the criteria set forth in the terms "
-"of use?"
+msgid "at their last login, did this user meet the criteria set forth in the terms of use?"
 msgstr ""
 
 #. Translators: When viewing a user's profile in an application, this message shows if the software doesn't think that the user is eligible for access. Don't translate username.
 #: TWLight/users/templates/users/editor_detail_data.html:72
 #, python-format
-msgid ""
-"%(username)s may still be eligible for access grants at the coordinators' "
-"discretion."
+msgid "%(username)s may still be eligible for access grants at the coordinators' discretion."
 msgstr ""
 
 #. Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this is the heading for a Yes/No ToU question.
@@ -2750,10 +2420,7 @@ msgstr ""
 #. Translators: This message is shown on a user's profile if their Wikimedia account is blocked on one or more projects. They may still be granted access to the Library Bundle, but need to contact Wikipedia Library staff to verify.
 #: TWLight/users/templates/users/editor_detail_data.html:137
 #, python-format
-msgid ""
-"It looks like you have an active block on your account. If you meet the "
-"other criteria you may still be permitted access to the library - please <a "
-"class=\"twl-links\" href=\"%(contact_url)s\">contact us</a>."
+msgid "It looks like you have an active block on your account. If you meet the other criteria you may still be permitted access to the library - please <a class=\"twl-links\" href=\"%(contact_url)s\">contact us</a>."
 msgstr ""
 
 #. Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this is the heading for a Yes/No program eligibility question.
@@ -2763,10 +2430,7 @@ msgstr ""
 
 #. Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this question has a Yes or No answer.
 #: TWLight/users/templates/users/editor_detail_data.html:156
-msgid ""
-"At their last login, did this user meet the criteria set forth in the "
-"Library Bundle? Note that satisfying terms of use is a prerequisite to "
-"bundle eligibility."
+msgid "At their last login, did this user meet the criteria set forth in the Library Bundle? Note that satisfying terms of use is a prerequisite to bundle eligibility."
 msgstr ""
 
 #. Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this is the heading for a Yes/No program eligibility question.
@@ -2811,18 +2475,13 @@ msgstr "Долара хаамаш"
 
 #. Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this text is in the 'Personal data' section. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/users/templates/users/editor_detail_data.html:262
-msgid ""
-"The following information is visible only to you, site administrators, "
-"publishing partners (where required), and volunteer Wikipedia Library "
-"coordinators (who have signed a Non-Disclosure Agreement)."
+msgid "The following information is visible only to you, site administrators, publishing partners (where required), and volunteer Wikipedia Library coordinators (who have signed a Non-Disclosure Agreement)."
 msgstr ""
 
 #. Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this labels a button which users can click to update or remove their personal information. Don't translate update_url.
 #: TWLight/users/templates/users/editor_detail_data.html:272
 #, python-format
-msgid ""
-"You may <a class=\"twl-links\" href=\"%(update_url)s\">update or delete</a> "
-"your data at any time."
+msgid "You may <a class=\"twl-links\" href=\"%(update_url)s\">update or delete</a> your data at any time."
 msgstr ""
 
 #. Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this labels the user's email. Don't remove the *.
@@ -2842,24 +2501,18 @@ msgstr ""
 
 #. Translators: This message tells users that they are not eligible to access The Wikipedia Library content.
 #: TWLight/users/templates/users/eligibility_modal.html:7
-msgid ""
-"Sorry, your Wikipedia account doesn’t currently qualify to access The "
-"Wikipedia Library."
+msgid "Sorry, your Wikipedia account doesn’t currently qualify to access The Wikipedia Library."
 msgstr ""
 
 #. Translators: This message tells users that they have not agreed to the terms of use, therefore are ineligible to access the content in The Wikipedia Library.
 #: TWLight/users/templates/users/eligibility_modal.html:30
 #, python-format
-msgid ""
-"Agreed with <a href=\"%(terms)s\" class=\"text-danger\"> terms of use </a>"
+msgid "Agreed with <a href=\"%(terms)s\" class=\"text-danger\"> terms of use </a>"
 msgstr ""
 
 #: TWLight/users/templates/users/eligibility_modal.html:40
 #, python-format
-msgid ""
-"It looks like you have an active block on your account. If you meet the "
-"other criteria you may still be permitted access to the library - please <a "
-"href=\"%(contact_url)s\">contact us</a>."
+msgid "It looks like you have an active block on your account. If you meet the other criteria you may still be permitted access to the library - please <a href=\"%(contact_url)s\">contact us</a>."
 msgstr ""
 
 #. Translators: Instructions to refresh a user's data.
@@ -2899,10 +2552,7 @@ msgstr "Харжа мотт"
 
 #. Translators: This text on the user page helps users naviage to the TranslateWiki Wikipedia Library Card platform translation page.
 #: TWLight/users/templates/users/language_form.html:31
-msgid ""
-"You can help translate the tool at <a class=\"twl-links\" href=\"https://"
-"translatewiki.net/wiki/Translating:Wikipedia_Library_Card_Platform"
-"\">translatewiki.net</a>."
+msgid "You can help translate the tool at <a class=\"twl-links\" href=\"https://translatewiki.net/wiki/Translating:Wikipedia_Library_Card_Platform\">translatewiki.net</a>."
 msgstr ""
 
 #. Translators: When the user starts a new application and submits the application, the user can view the application and withdraw if need be. This changes the label for the Withdraw button.
@@ -2922,9 +2572,7 @@ msgstr ""
 
 #. Translators: On the page listing applications, this text explains a user they cannot renew their application since they've already requested a renewal or there aren't any renewals available.
 #: TWLight/users/templates/users/my_applications.html:79
-msgid ""
-"Renewals are either not required, not available right now, or you have "
-"already requested a renewal."
+msgid "Renewals are either not required, not available right now, or you have already requested a renewal."
 msgstr ""
 
 #. Translators: This text is the heading of a section in a user's profile where they can change their preferences.
@@ -2988,19 +2636,12 @@ msgstr ""
 
 #. Translators: This message is displayed on the page where users can request we stop processing their data.
 #: TWLight/users/templates/users/restrict_data.html:15
-msgid ""
-"Checking this box and clicking “Restrict” will pause all processing of the "
-"data you have entered into this website. You will not be able to apply for "
-"access to resources, your applications will not be further processed, and "
-"none of your data will be altered, until you return to this page and uncheck "
-"the box. This is not the same as deleting your data."
+msgid "Checking this box and clicking “Restrict” will pause all processing of the data you have entered into this website. You will not be able to apply for access to resources, your applications will not be further processed, and none of your data will be altered, until you return to this page and uncheck the box. This is not the same as deleting your data."
 msgstr ""
 
 #. Translators: This warning message is shown to coordinators who view the data restriction page.
 #: TWLight/users/templates/users/restrict_data.html:26
-msgid ""
-"You are a coordinator on this site. If you restrict the processing of your "
-"data, your coordinator flag will be removed."
+msgid "You are a coordinator on this site. If you restrict the processing of your data, your coordinator flag will be removed."
 msgstr ""
 
 #. Translators: use the date *when you are translating*, in a language-appropriate format.
@@ -3020,24 +2661,12 @@ msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:51
-msgid ""
-"<a class=\"twl-links\" href=\"https://meta.wikimedia.org/wiki/"
-"The_Wikipedia_Library\"> The Wikipedia Library </a> has partnered with "
-"publishers around the world to allow users to access otherwise paywalled "
-"resources. This website allows Wikipedia editors to search and access these "
-"resources."
+msgid "<a class=\"twl-links\" href=\"https://meta.wikimedia.org/wiki/The_Wikipedia_Library\"> The Wikipedia Library </a> has partnered with publishers around the world to allow users to access otherwise paywalled resources. This website allows Wikipedia editors to search and access these resources."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Wikimedia Foundation should not be translated. WMF should not be translated. Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:63
-msgid ""
-"This program is administered by the Wikimedia Foundation (WMF). These terms "
-"of use and privacy notice pertain to your application for access to "
-"resources through the Wikipedia Library, your use of this website, and your "
-"access to and use of those resources. They also describe our handling of the "
-"information you provide to us in order to create and administer your "
-"Wikipedia Library account. If we make material changes to the terms, we will "
-"notify users."
+msgid "This program is administered by the Wikimedia Foundation (WMF). These terms of use and privacy notice pertain to your application for access to resources through the Wikipedia Library, your use of this website, and your access to and use of those resources. They also describe our handling of the information you provide to us in order to create and administer your Wikipedia Library account. If we make material changes to the terms, we will notify users."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
@@ -3047,37 +2676,17 @@ msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:78
-msgid ""
-"Access to resources via The Wikipedia Library is reserved for community "
-"members who have demonstrated their commitment to the Wikimedia projects, "
-"and who will use their access to these resources to improve project content. "
-"To that end, in order to be eligible for The Wikipedia Library, we require "
-"that you be registered for a user account on the projects, with at least 500 "
-"edits, six (6) months of activity, and 10+ edits in the last month. We ask "
-"that you do not request access to any publishers with a limited number of "
-"available accounts whose resources you can already access for free through "
-"your local library or university, or another institution or organization, in "
-"order to provide that opportunity to others."
+msgid "Access to resources via The Wikipedia Library is reserved for community members who have demonstrated their commitment to the Wikimedia projects, and who will use their access to these resources to improve project content. To that end, in order to be eligible for The Wikipedia Library, we require that you be registered for a user account on the projects, with at least 500 edits, six (6) months of activity, and 10+ edits in the last month. We ask that you do not request access to any publishers with a limited number of available accounts whose resources you can already access for free through your local library or university, or another institution or organization, in order to provide that opportunity to others."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:94
-msgid ""
-"Additionally, if you are currently blocked or banned from a Wikimedia "
-"project, applications to resources may be rejected or restricted. If you "
-"obtain a Wikipedia Library account, but a block or ban is subsequently "
-"instituted against you on one of the projects, you may lose access to your "
-"Wikipedia Library account."
+msgid "Additionally, if you are currently blocked or banned from a Wikimedia project, applications to resources may be rejected or restricted. If you obtain a Wikipedia Library account, but a block or ban is subsequently instituted against you on one of the projects, you may lose access to your Wikipedia Library account."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:104
-msgid ""
-"Your eligibility to access The Wikipedia Library is assessed at each login. "
-"While more than half of the library's content is provided via this automated "
-"eligibility check, access to other publisher's content may be time limited, "
-"typically lapsing after one year, after which you will usually need to apply "
-"for renewal."
+msgid "Your eligibility to access The Wikipedia Library is assessed at each login. While more than half of the library's content is provided via this automated eligibility check, access to other publisher's content may be time limited, typically lapsing after one year, after which you will usually need to apply for renewal."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
@@ -3087,47 +2696,27 @@ msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:118
-msgid ""
-"In order to apply for access to a partner resource, you must provide us with "
-"certain information, which we will use to evaluate your application. If your "
-"application is approved, we may transfer the information you have given us "
-"to the publishers whose resources you wish to access. They will either "
-"contact you with the account information directly or we will send access "
-"information to you ourselves."
+msgid "In order to apply for access to a partner resource, you must provide us with certain information, which we will use to evaluate your application. If your application is approved, we may transfer the information you have given us to the publishers whose resources you wish to access. They will either contact you with the account information directly or we will send access information to you ourselves."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:130
-msgid ""
-"In addition to the basic information you provide to us, our system will "
-"retrieve some information directly from the Wikimedia projects: your "
-"username, email address, edit count, registration date, user ID number, "
-"groups to which you belong, and any special user rights."
+msgid "In addition to the basic information you provide to us, our system will retrieve some information directly from the Wikimedia projects: your username, email address, edit count, registration date, user ID number, groups to which you belong, and any special user rights."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:140
-msgid ""
-"Each time you log in to the Wikipedia Library Card Platform, this "
-"information will be automatically updated."
+msgid "Each time you log in to the Wikipedia Library Card Platform, this information will be automatically updated."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:148
-msgid ""
-"We will ask you to provide us with some information about your history of "
-"contributions to the Wikimedia projects. Information on contribution history "
-"is optional, but will greatly assist us in evaluating your application."
+msgid "We will ask you to provide us with some information about your history of contributions to the Wikimedia projects. Information on contribution history is optional, but will greatly assist us in evaluating your application."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). WMF should not be translated. Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:157
-msgid ""
-"The information you provide when creating your account will be visible to "
-"you while on the site but not to others unless they are approved Wikipedia "
-"Library Coordinators, WMF Staff, or WMF Contractors who need access to this "
-"data in order to carry out their work with the Wikipedia Library, all of "
-"whom are subject to non-disclosure obligations."
+msgid "The information you provide when creating your account will be visible to you while on the site but not to others unless they are approved Wikipedia Library Coordinators, WMF Staff, or WMF Contractors who need access to this data in order to carry out their work with the Wikipedia Library, all of whom are subject to non-disclosure obligations."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
@@ -3137,46 +2726,32 @@ msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:171
-msgid ""
-"In order to access an individual publisher’s resources, you must agree to "
-"that publisher’s terms of use and privacy policy. You agree that you will "
-"not violate such terms and policies in connection with your use of the "
-"Wikipedia Library. Additionally, the following activities are prohibited "
-"while accessing publisher resources through the Wikipedia Library."
+msgid "In order to access an individual publisher’s resources, you must agree to that publisher’s terms of use and privacy policy. You agree that you will not violate such terms and policies in connection with your use of the Wikipedia Library. Additionally, the following activities are prohibited while accessing publisher resources through the Wikipedia Library."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:184
-msgid ""
-"Sharing your Wikipedia account, usernames, passwords, or any access codes "
-"for publisher resources with others;"
+msgid "Sharing your Wikipedia account, usernames, passwords, or any access codes for publisher resources with others;"
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:191
-msgid ""
-"Automatically scraping or downloading restricted content from publishers;"
+msgid "Automatically scraping or downloading restricted content from publishers;"
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:197
-msgid ""
-"Systematically making printed or electronic copies of multiple extracts of "
-"restricted content available for any purpose;"
+msgid "Systematically making printed or electronic copies of multiple extracts of restricted content available for any purpose;"
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:204
-msgid ""
-"Data mining metadata without permission—for example, in order to use "
-"metadata for auto-created stub articles;"
+msgid "Data mining metadata without permission—for example, in order to use metadata for auto-created stub articles;"
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:211
-msgid ""
-"Using the access you receive through the Wikipedia Library for profit by "
-"selling access to your account or resources which you have through it."
+msgid "Using the access you receive through the Wikipedia Library for profit by selling access to your account or resources which you have through it."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
@@ -3186,18 +2761,12 @@ msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:224
-msgid ""
-"Certain resources may only be accessed using an external search service, "
-"such as the EBSCO Discovery Service, or a proxy service, such as OCLC "
-"EZProxy. If you use such external search and/or proxy services, please "
-"review the applicable terms of use and privacy policies."
+msgid "Certain resources may only be accessed using an external search service, such as the EBSCO Discovery Service, or a proxy service, such as OCLC EZProxy. If you use such external search and/or proxy services, please review the applicable terms of use and privacy policies."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:234
-msgid ""
-"In addition, if you use OCLC EZProxy, please note that you may not use it "
-"for commercial purposes."
+msgid "In addition, if you use OCLC EZProxy, please note that you may not use it for commercial purposes."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
@@ -3207,120 +2776,49 @@ msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Wikimedia Foundation should not be translated. Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:245
-msgid ""
-"The Wikimedia Foundation and our service providers use your information for "
-"the legitimate purpose of providing Wikipedia Library services in support of "
-"our charitable mission. When you apply for a Wikipedia Library account, or "
-"use your Wikipedia Library account, we may routinely collect the following "
-"information: your username, email address, edit count, registration date, "
-"user ID number, groups to which you belong, and any special user rights; "
-"your name, country of residence, and/or affiliation, if required by a "
-"partner to which you are applying; your narrative description of your "
-"contributions and reasons for applying for access to partner resources; and "
-"the date you agree to these terms of use."
+msgid "The Wikimedia Foundation and our service providers use your information for the legitimate purpose of providing Wikipedia Library services in support of our charitable mission. When you apply for a Wikipedia Library account, or use your Wikipedia Library account, we may routinely collect the following information: your username, email address, edit count, registration date, user ID number, groups to which you belong, and any special user rights; your name, country of residence, and/or affiliation, if required by a partner to which you are applying; your narrative description of your contributions and reasons for applying for access to partner resources; and the date you agree to these terms of use."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:262
 #, python-format
-msgid ""
-"Each publisher who is a member of the Wikipedia Library program requires "
-"different specific information in the application. Some publishers may "
-"request only an email address, while others request more detailed data, such "
-"as your name, location, or institutional affiliation. When you complete your "
-"application, you will only be asked to supply information required by the "
-"publishers you have chosen, and each publisher will only receive the "
-"information they require for providing you with access. Please see our <a "
-"class=\"twl-links\" href=\"%(all_partners_url)s\">partner information</a> "
-"pages to learn what information is required by each publisher to gain access "
-"to their resources."
+msgid "Each publisher who is a member of the Wikipedia Library program requires different specific information in the application. Some publishers may request only an email address, while others request more detailed data, such as your name, location, or institutional affiliation. When you complete your application, you will only be asked to supply information required by the publishers you have chosen, and each publisher will only receive the information they require for providing you with access. Please see our <a class=\"twl-links\" href=\"%(all_partners_url)s\">partner information</a> pages to learn what information is required by each publisher to gain access to their resources."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Wikimedia Foundation should not be translated. Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:277
-msgid ""
-"Some Wikipedia Library pages are visible without logging in, but you will "
-"need to log in to apply or access proprietary partner resources. We use the "
-"data provided by you via OAuth and Wikimedia API calls to assess your "
-"application for access and to process approved requests."
+msgid "Some Wikipedia Library pages are visible without logging in, but you will need to log in to apply or access proprietary partner resources. We use the data provided by you via OAuth and Wikimedia API calls to assess your application for access and to process approved requests."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:288
 #, python-format
-msgid ""
-"In order to administer the Wikipedia Library program, we will retain the "
-"application data we collect from you for three years after your most recent "
-"login, unless you delete your account, as described below. You can log in "
-"and go to <a class=\"twl-links\" href=\"%(profile_url)s\">your profile page</"
-"a> in order to see the information associated with your account, and can "
-"download it in JSON format. You may access, update, restrict, or delete this "
-"information at any time, except for the information that is automatically "
-"retrieved from the projects. If you have any questions or concerns about the "
-"handling of your data, please contact <a class=\"twl-links\" href=\"mailto:"
-"wikipedialibrary@wikimedia.org?Subject=Wikipedia%%20Library%%20Card"
-"%%20account%%20deactivation\"> wikipedialibrary@wikimedia.org </a>."
+msgid "In order to administer the Wikipedia Library program, we will retain the application data we collect from you for three years after your most recent login, unless you delete your account, as described below. You can log in and go to <a class=\"twl-links\" href=\"%(profile_url)s\">your profile page</a> in order to see the information associated with your account, and can download it in JSON format. You may access, update, restrict, or delete this information at any time, except for the information that is automatically retrieved from the projects. If you have any questions or concerns about the handling of your data, please contact <a class=\"twl-links\" href=\"mailto:wikipedialibrary@wikimedia.org?Subject=Wikipedia%%20Library%%20Card%%20account%%20deactivation\"> wikipedialibrary@wikimedia.org </a>."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:305
-msgid ""
-"If you decide to disable your Wikipedia Library account, you can use the "
-"delete button on your profile to delete certain personal information "
-"associated with your account. We will delete your real name, institutional "
-"affiliation, and country of residence. Please note that the system will "
-"retain a record of your username, the publishers to which you applied or had "
-"access, and the dates of that access. Note that deletion is not reversible. "
-"Deletion of your Wikipedia Library account may also correspond with the "
-"removal of any resource access to which you were eligible or approved. If "
-"you request the deletion of account information and later wish to apply for "
-"a new account, you will need to provide the necessary information again."
+msgid "If you decide to disable your Wikipedia Library account, you can use the delete button on your profile to delete certain personal information associated with your account. We will delete your real name, institutional affiliation, and country of residence. Please note that the system will retain a record of your username, the publishers to which you applied or had access, and the dates of that access. Note that deletion is not reversible. Deletion of your Wikipedia Library account may also correspond with the removal of any resource access to which you were eligible or approved. If you request the deletion of account information and later wish to apply for a new account, you will need to provide the necessary information again."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). WMF should not be translated. Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:321
-msgid ""
-"The Wikipedia Library is run by WMF Staff, Contractors, and approved "
-"volunteer Coordinators. The data associated with your account will be shared "
-"with the WMF staff, contractors, service providers, and volunteer "
-"coordinators who need to process the information in connection with their "
-"work for the Wikipedia Library, and who are subject to confidentiality "
-"obligations. We will also use your data for internal Wikipedia Library "
-"purposes such as distributing user surveys and account notifications, and in "
-"a depersonalized or aggregated fashion for statistical analysis and "
-"administration. Finally, we will share your information with the publishers "
-"whom you specifically select in order to provide you with access to "
-"resources. Otherwise, your information will not be shared with third "
-"parties, with the exception of the circumstances described below."
+msgid "The Wikipedia Library is run by WMF Staff, Contractors, and approved volunteer Coordinators. The data associated with your account will be shared with the WMF staff, contractors, service providers, and volunteer coordinators who need to process the information in connection with their work for the Wikipedia Library, and who are subject to confidentiality obligations. We will also use your data for internal Wikipedia Library purposes such as distributing user surveys and account notifications, and in a depersonalized or aggregated fashion for statistical analysis and administration. Finally, we will share your information with the publishers whom you specifically select in order to provide you with access to resources. Otherwise, your information will not be shared with third parties, with the exception of the circumstances described below."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). WMF should not be translated.
 #: TWLight/users/templates/users/terms.html:338
-msgid ""
-"We may disclose any collected information when required by law, when we have "
-"your permission, when needed to protect our rights, privacy, safety, users, "
-"or the general public, and when necessary to enforce these terms, WMF’s "
-"general <a class=\"twl-links\" href=\"https://foundation.wikimedia.org/wiki/"
-"Terms_of_Use\">Terms of Use</a>, or any other WMF policy."
+msgid "We may disclose any collected information when required by law, when we have your permission, when needed to protect our rights, privacy, safety, users, or the general public, and when necessary to enforce these terms, WMF’s general <a class=\"twl-links\" href=\"https://foundation.wikimedia.org/wiki/Terms_of_Use\">Terms of Use</a>, or any other WMF policy."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:349
-msgid ""
-"We take the security of your personal data seriously, and take reasonable "
-"precautions to ensure your data is protected. These precautions include "
-"access controls to limit who has access to your data and security "
-"technologies to protect data stored on the server. However, we cannot "
-"guarantee the safety of your data as it is transmitted and stored."
+msgid "We take the security of your personal data seriously, and take reasonable precautions to ensure your data is protected. These precautions include access controls to limit who has access to your data and security technologies to protect data stored on the server. However, we cannot guarantee the safety of your data as it is transmitted and stored."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:360
-msgid ""
-"Please note that these terms do not control the use and handling of your "
-"data by the publishers and service providers whose resources you access or "
-"apply to access. Please read their individual privacy policies for that "
-"information."
+msgid "Please note that these terms do not control the use and handling of your data by the publishers and service providers whose resources you access or apply to access. Please read their individual privacy policies for that information."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
@@ -3330,34 +2828,17 @@ msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Wikimedia Foundation should not be translated. Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:373
-msgid ""
-"The Wikimedia Foundation is a nonprofit organization based in San Francisco, "
-"California. The Wikipedia Library program provides access to resources held "
-"by publishers in multiple countries. If you apply for a Wikipedia Library "
-"account (whether you are inside or outside of the United States), you "
-"understand that your personal data will be collected, transferred, stored, "
-"processed, disclosed and otherwise used in the U.S. as described in this "
-"privacy policy. You also understand that your information may be transferred "
-"by us from the U.S. to other countries, which may have different or less "
-"stringent data protection laws than your country, in connection with "
-"providing services to you, including evaluating your application and "
-"securing access to your chosen publishers (locations for each publisher are "
-"outlined on their respective partner information pages)."
+msgid "The Wikimedia Foundation is a nonprofit organization based in San Francisco, California. The Wikipedia Library program provides access to resources held by publishers in multiple countries. If you apply for a Wikipedia Library account (whether you are inside or outside of the United States), you understand that your personal data will be collected, transferred, stored, processed, disclosed and otherwise used in the U.S. as described in this privacy policy. You also understand that your information may be transferred by us from the U.S. to other countries, which may have different or less stringent data protection laws than your country, in connection with providing services to you, including evaluating your application and securing access to your chosen publishers (locations for each publisher are outlined on their respective partner information pages)."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:392
-msgid ""
-"Please note that in the event of any differences in meaning or "
-"interpretation between the original English version of these terms and a "
-"translation, the original English version takes precedence."
+msgid "Please note that in the event of any differences in meaning or interpretation between the original English version of these terms and a translation, the original English version takes precedence."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Wikimedia Foundation should not be translated.
 #: TWLight/users/templates/users/terms.html:403
-msgid ""
-"See also the <a class=\"twl-links\" href=\"https://wikimediafoundation.org/"
-"wiki/Privacy_policy\">Wikimedia Foundation Privacy Policy</a>."
+msgid "See also the <a class=\"twl-links\" href=\"https://wikimediafoundation.org/wiki/Privacy_policy\">Wikimedia Foundation Privacy Policy</a>."
 msgstr ""
 
 #. Translators: This is the second to last line of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
@@ -3377,11 +2858,7 @@ msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:426
-msgid ""
-"By checking this box and clicking “Submit”, you agree that you have read the "
-"above terms and that you will adhere to the terms of use in your application "
-"to and use of the The Wikipedia Library, and the publishers’ services to "
-"which you gain access through The Wikipedia Library program."
+msgid "By checking this box and clicking “Submit”, you agree that you have read the above terms and that you will adhere to the terms of use in your application to and use of the The Wikipedia Library, and the publishers’ services to which you gain access through The Wikipedia Library program."
 msgstr ""
 
 #: TWLight/users/templates/users/user_collection_tile.html:32
@@ -3434,29 +2911,18 @@ msgstr ""
 
 #. Translators: This message is displayed on the page where users can request the deletion of their data.
 #: TWLight/users/templates/users/user_confirm_delete.html:17
-msgid ""
-"<b>Warning:</b> Performing this action will delete your Wikipedia Library "
-"Card user account and all associated applications. This process is not "
-"reversible. You may lose any partner accounts you were granted, and will not "
-"be able to renew those accounts or apply for new ones."
+msgid "<b>Warning:</b> Performing this action will delete your Wikipedia Library Card user account and all associated applications. This process is not reversible. You may lose any partner accounts you were granted, and will not be able to renew those accounts or apply for new ones."
 msgstr ""
 
 #. Translators: this should show up for people who log in with a username/password and not OAuth, so we don't know what their Wikipedia identity is.
-#.
 #: TWLight/users/templates/users/user_detail.html:12
 #, python-format
-msgid ""
-"Hi, %(username)s! You don't have a Wikipedia editor profile attached to your "
-"account here, so you are probably a site administrator."
+msgid "Hi, %(username)s! You don't have a Wikipedia editor profile attached to your account here, so you are probably a site administrator."
 msgstr ""
 
 #. Translators: In the unlikely scenario that someone is able to register an account without using OAuth (thus leaving us without some of the information required for applications), users will see this message, encouraging them to re-register.
 #: TWLight/users/templates/users/user_detail.html:20
-msgid ""
-"If you aren't a site administrator, something weird has happened. You won't "
-"be able to apply for access without a Wikipedia editor profile. You should "
-"log out and create a new account by logging in via OAuth, or contact a site "
-"administrator for help."
+msgid "If you aren't a site administrator, something weird has happened. You won't be able to apply for access without a Wikipedia editor profile. You should log out and create a new account by logging in via OAuth, or contact a site administrator for help."
 msgstr ""
 
 #. Translators: Labels a sections where coordinators can select their email preferences.
@@ -3467,17 +2933,12 @@ msgstr ""
 #. Translators: This message is shown on user's own profile page, encouraging them to make sure their information is up to date, so that account coordinators can use the information to judge applications.
 #: TWLight/users/views.py:176
 #, python-brace-format
-msgid ""
-"Please <a class='twl-links' href='{url}'>update your contributions</a> to "
-"Wikipedia to help coordinators evaluate your applications."
+msgid "Please <a class='twl-links' href='{url}'>update your contributions</a> to Wikipedia to help coordinators evaluate your applications."
 msgstr ""
 
 #. Translators: Coordinators are shown this message when they unselect all three types of reminder email options under preferences.
 #: TWLight/users/views.py:288
-msgid ""
-"You have chosen not to receive reminder emails. As a coordinator, you should "
-"receive at least one type of reminder emails, so consider changing your "
-"preferences."
+msgid "You have chosen not to receive reminder emails. As a coordinator, you should receive at least one type of reminder emails, so consider changing your preferences."
 msgstr ""
 
 #. Translators: Coordinators are shown this message when they make changes to their reminder email options under preferences.
@@ -3511,9 +2972,7 @@ msgstr ""
 
 #. Translators: If the user has not filled out their email, they can browse the website but cannot apply for access to resources.
 #: TWLight/users/views.py:487
-msgid ""
-"Your email is blank. You can still explore the site, but you won't be able "
-"to apply for access to partner resources without an email."
+msgid "Your email is blank. You can still explore the site, but you won't be able to apply for access to partner resources without an email."
 msgstr ""
 
 #. Translators: This message is shown once the access to a partner has successfully been returned.
@@ -3546,31 +3005,3 @@ msgstr ""
 msgid "10+ edits in the last 30 days"
 msgstr ""
 
-#: tests/shunit/data/bad_i18n_comment_1.py:3
-#: tests/shunit/data/bad_i18n_newline_1.py:5
-msgid "1"
-msgstr ""
-
-#. Translators: Lorem ipsum dolor sit amet, consectetur adipiscing elit. Mauris vitae ipsum ut purus faucibus pretium. Proin tempus neque et aliquet consectetur. Ut egestas sapien in consectetur sagittis. Mauris neque lacus, dapibus non viverra vitae, interdum ut aenean ipsum.
-#. Translators: Lorem ipsum dolor sit amet, consectetur adipiscing elit. Mauris vitae ipsum ut purus faucibus pretium. Proin tempus neque et aliquet consectetur. Ut egestas sapien in consectetur sagittis. Mauris neque lacus, dapibus non.
-#: tests/shunit/data/bad_i18n_comment_2.py:4
-#: tests/shunit/data/bad_i18n_newline_2.py:5 tests/shunit/data/good_i18n_1.py:2
-#: tests/shunit/data/good_i18n_2.py:2
-msgid "2"
-msgstr ""
-
-#: tests/shunit/data/bad_i18n_newline_3.py:5
-msgid "3"
-msgstr ""
-
-#: tests/shunit/data/bad_i18n_newline_4.py:5
-msgid "4"
-msgstr ""
-
-#: tests/shunit/data/bad_i18n_newline_5.py:5
-msgid "5"
-msgstr ""
-
-#: tests/shunit/data/bad_i18n_newline_6.py:5
-msgid "6"
-msgstr ""

--- a/locale/cy/LC_MESSAGES/django.po
+++ b/locale/cy/LC_MESSAGES/django.po
@@ -6,18 +6,18 @@
 # Author: Robin Owain
 msgid ""
 msgstr ""
+""
 "Project-Id-Version: Wikipedia Library Card Platform - Website\n"
-"Report-Msgid-Bugs-To: wikipedialibrary@wikimedia.org\n"
+"Report-Msgid-Bugs-To: translatewiki.net\n"
 "POT-Creation-Date: 2024-07-11 20:54+0000\n"
-"PO-Revision-Date: 2024-07-11 12:30:13+0000\n"
+"PO-Revision-Date: 2024-07-15 12:29:13+0000\n"
 "Language: cy\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "X-POT-Import-Date: 2024-06-25 18:44:08+0000\n"
 "X-Translation-Project: translatewiki.net <https://translatewiki.net>\n"
 "X-Generator: MediaWiki 1.43.0-alpha; Translate 2024-07-16\n"
-"Plural-Forms: nplurals=6; plural=(n == 0) ? 0 : ( (n == 1) ? 1 : ( (n == "
-"2) ? 2 : ( (n == 3) ? 3 : ( (n == 6) ? 4 : 5 ) ) ) );\n"
+"Plural-Forms: nplurals=6; plural=(n == 0) ? 0 : ( (n == 1) ? 1 : ( (n == 2) ? 2 : ( (n == 3) ? 3 : ( (n == 6) ? 4 : 5 ) ) ) );\n"
 
 #. Translators: Labels the button users click to apply for a partner's resources.
 #. Translators: On the page where users can apply for multiple partners, this text labels the button, which when clicked submits the selections.
@@ -42,12 +42,8 @@ msgstr "Amdanoch chi"
 #. Translators: This note appears in a section of a form where we ask users to enter info (like country of residence) when applying for resource access.
 #: TWLight/applications/forms.py:179
 #, python-brace-format
-msgid ""
-"<p><small><i>Your personal data will be processed according to our <a "
-"class='twl-links' href='{terms_url}'> privacy policy</a>.</i></small></p>"
-msgstr ""
-"<p><small><i>Bydd eich data personol yn cael ei brosesu yn unol a'n <a "
-"class='twl-links' href='{terms_url}'>polisi preifatrwydd</a>.</i></small></p>"
+msgid "<p><small><i>Your personal data will be processed according to our <a class='twl-links' href='{terms_url}'> privacy policy</a>.</i></small></p>"
+msgstr "<p><small><i>Bydd eich data personol yn cael ei brosesu yn unol a'n <a class='twl-links' href='{terms_url}'>polisi preifatrwydd</a>.</i></small></p>"
 
 #. Translators: This is the title of the application form page, where users enter information required for the application. It lets the user know which partner application they are entering data for. {partner}
 #: TWLight/applications/forms.py:189
@@ -88,9 +84,7 @@ msgstr "E-bost eich cyfrif ar wefan y partner"
 #. Translators: This labels a choice field where users will have to select the number of months they wish to have their access for as part of the application renewal confirmation.
 #. Translators: When filling out an application, users may be required to enter the length of the account (expiry) they wish to have for proxy partners.
 #: TWLight/applications/forms.py:339 TWLight/applications/helpers.py:100
-msgid ""
-"The number of months you wish to have this access for before renewal is "
-"required"
+msgid "The number of months you wish to have this access for before renewal is required"
 msgstr ""
 
 #. Translators: When filling out an application, users may need to specify their name
@@ -179,9 +173,7 @@ msgstr "E-bost"
 
 #. Translators: This comment is added to pending applications when our terms of use change.
 #: TWLight/applications/management/commands/notify_applicants_tou_changes.py:54
-msgid ""
-"Our terms of use have changed. Your applications will not be processed until "
-"you log in and agree to our updated terms."
+msgid "Our terms of use have changed. Your applications will not be processed until you log in and agree to our updated terms."
 msgstr ""
 
 #. Translators: This is the status of an application that has not yet been reviewed.
@@ -248,23 +240,17 @@ msgstr "URL mynediad: {access_url}"
 
 #. Translators: This text goes into account approval emails in the case that we need to send the user's details to a publisher for manual account setup.
 #: TWLight/applications/models.py:331
-msgid ""
-"You can expect to receive access details within a week or two once it has "
-"been processed."
+msgid "You can expect to receive access details within a week or two once it has been processed."
 msgstr ""
 
 #. Translators: This comment is added to open applications when a partner joins the Library Bundle, which does not require applications.
 #: TWLight/applications/signals.py:247
-msgid ""
-"This partner joined the Library Bundle, which does not require applications. "
-"This application will be marked as invalid."
+msgid "This partner joined the Library Bundle, which does not require applications. This application will be marked as invalid."
 msgstr ""
 
 #. Translators: This is shown to users if the application is to a partner for which we have run out of available accounts. The application is therefore on a 'waitlist', and will be reviewed when more accounts are available.
 #: TWLight/applications/templates/applications/application_evaluation.html:29
-msgid ""
-"This application is on the waitlist because this partner does not have any "
-"access grants available at this time."
+msgid "This application is on the waitlist because this partner does not have any access grants available at this time."
 msgstr ""
 
 #. Translators: This message is shown on pages where coordinators can see personal information about applicants.
@@ -272,9 +258,7 @@ msgstr ""
 #: TWLight/applications/templates/applications/application_list_include.html:6
 #: TWLight/applications/templates/applications/send_partner.html:45
 #: TWLight/resources/templates/resources/partner_users.html:18
-msgid ""
-"Coordinators: This page may contain personal information such as real names "
-"and email addresses. Please remember that this information is confidential."
+msgid "Coordinators: This page may contain personal information such as real names and email addresses. Please remember that this information is confidential."
 msgstr ""
 
 #. Translators: This is the title of the application page shown to users who are a coordinator, and are able to accept or reject the application.
@@ -284,9 +268,7 @@ msgstr "Gwerthuso'r cais"
 
 #. Translators: This text is shown to coordinators on application pages if the applicant has restricted processing of their data.
 #: TWLight/applications/templates/applications/application_evaluation.html:42
-msgid ""
-"This user has requested a restriction on the processing of their data, so "
-"you cannot change the status of their application."
+msgid "This user has requested a restriction on the processing of their data, so you cannot change the status of their application."
 msgstr ""
 
 #. Translators: This is the title of the application page shown to users who are not a coordinator.
@@ -360,9 +342,7 @@ msgstr "Anhysbys"
 
 #. Translators: This is the text displayed to coordinators when an applicant has no country of residence in their profile.
 #: TWLight/applications/templates/applications/application_evaluation.html:123
-msgid ""
-"Please request the applicant add their country of residence to their profile "
-"before proceeding further."
+msgid "Please request the applicant add their country of residence to their profile before proceeding further."
 msgstr ""
 
 #. Translators: This labels the section of an application showing the total number of accounts available for a partner or their collection.
@@ -373,9 +353,7 @@ msgstr "Cyfrifon ar gael"
 #. Translators: This labels the section of an application showing whether the user had agreed to the terms of use or not.
 #: TWLight/applications/templates/applications/application_evaluation.html:145
 #, python-format
-msgid ""
-"Has agreed to the site's <a class=\"twl-links\" href=\"%(terms_url)s\">terms "
-"of use</a>?"
+msgid "Has agreed to the site's <a class=\"twl-links\" href=\"%(terms_url)s\">terms of use</a>?"
 msgstr ""
 
 #. Translators: Displayed to coordinators when they've agreed to the terms of use.
@@ -411,9 +389,7 @@ msgstr "Na"
 
 #. Translators: This is the text displayed to coordinators when an applicant has not agreed to the terms of use.
 #: TWLight/applications/templates/applications/application_evaluation.html:159
-msgid ""
-"Please request the applicant agree to the site's terms of use before "
-"approving this application."
+msgid "Please request the applicant agree to the site's terms of use before approving this application."
 msgstr ""
 
 #. Translators: This labels the section of an application containing the user's motivation for wanting access to this resource.
@@ -434,8 +410,7 @@ msgstr "Adnewyddu'r grant mynediad presennol?"
 #. Translators: This message is shown next to the 'Renewal of existing access grant?' label if the application is a renewal. Don't translate HTML tags or parent_url.
 #: TWLight/applications/templates/applications/application_evaluation.html:195
 #, python-format
-msgid ""
-"Yes (<a class=\"twl-links\" href=\"%(parent_url)s\">previous application</a>)"
+msgid "Yes (<a class=\"twl-links\" href=\"%(parent_url)s\">previous application</a>)"
 msgstr "Ydy (<a class=\"twl-links\" href=\"%(parent_url)s\">y cyn-gais</a>)"
 
 #. Translators: This labels the section of the application showing the length of access remaining on the user's previous authorization.
@@ -470,9 +445,7 @@ msgstr "Ychwanegu sylw"
 
 #. Translators: On an application page, this text tells users that the comments posted on the application are visible to coordinators and the submitting user only.
 #: TWLight/applications/templates/applications/application_evaluation.html:297
-msgid ""
-"Comments are visible to all coordinators and to the editor who submitted "
-"this application."
+msgid "Comments are visible to all coordinators and to the editor who submitted this application."
 msgstr ""
 
 #. Translators: This is the title of the section of an application page which lists information about the user who submitted the application.
@@ -684,12 +657,7 @@ msgstr "Gosod statws"
 
 #: TWLight/applications/templates/applications/apply.html:20
 #, python-format
-msgid ""
-"If your application is successful we may share your email address with "
-"%(partner)s. This is required to set up your access to their resources. By "
-"submitting this form you agree to allow your email address to be shared with "
-"%(partner)s if your application is successful, for the purposes of account "
-"setup."
+msgid "If your application is successful we may share your email address with %(partner)s. This is required to set up your access to their resources. By submitting this form you agree to allow your email address to be shared with %(partner)s if your application is successful, for the purposes of account setup."
 msgstr ""
 
 #. Translators: This message is displayed on the page where users can confirm their renewal. Please do not translate partner.
@@ -718,9 +686,7 @@ msgstr "Pa adnoddau ydych angen mynediad iddynt?"
 
 #. Translators: This text explains that Library Bundle partners are not shown in this list.
 #: TWLight/applications/templates/applications/request_for_application.html:26
-msgid ""
-"Library Bundle partners are not shown as eligibility is determined "
-"automatically."
+msgid "Library Bundle partners are not shown as eligibility is determined automatically."
 msgstr ""
 
 #. Translators: On the page where users can apply for multiple partners, this message shows next to the partner name, taking them to the full application page when clicked.
@@ -735,10 +701,7 @@ msgstr "nid ychwanegwyd gwybodaeth am y partner hyd yma."
 
 #. Translators: the HTML is so that the word 'waitlisted' will look the same as it does in the page above; please translate 'waitlisted' the same way you did elsewhere in this file.
 #: TWLight/applications/templates/applications/request_for_application.html:74
-msgid ""
-"You can apply to <span class=\"badge badge-warning\">Waitlisted</span> "
-"partners, but they don't have access grants available right now. We will "
-"process those applications when access becomes available."
+msgid "You can apply to <span class=\"badge badge-warning\">Waitlisted</span> partners, but they don't have access grants available right now. We will process those applications when access becomes available."
 msgstr ""
 
 #. Translators: On the page where coordinators can see approved applications which have not had their details sent to the partner, this message shows when there are applications ready to be processed.
@@ -760,9 +723,7 @@ msgstr ""
 #. Translators: This message is shown when applications exceed the number of accounts available.
 #: TWLight/applications/templates/applications/send_partner.html:54
 #, python-format
-msgid ""
-"Application(s) for %(object)s, if sent, will exceed the total available "
-"accounts for the partner. Please proceed at your own discretion."
+msgid "Application(s) for %(object)s, if sent, will exceed the total available accounts for the partner. Please proceed at your own discretion."
 msgstr ""
 
 #. Translators: When viewing the list of applications ready to be sent for a particular partner, this is instructions for the coordinator to click the 'mark as sent' button after they have sent the information.
@@ -783,9 +744,7 @@ msgstr[5] ""
 
 #. Translators: When viewing the list of applications ready to be sent for a particular partner, this message shows if there is no information about who the applications should be sent to. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/applications/templates/applications/send_partner.html:89
-msgid ""
-"Whoops, we don't have any listed contacts. Please notify Wikipedia Library "
-"administrators."
+msgid "Whoops, we don't have any listed contacts. Please notify Wikipedia Library administrators."
 msgstr ""
 
 #. Translators: When viewing the list of applications ready to be sent for a particular partner, this is the title of the section containing the information about those applications.
@@ -801,9 +760,7 @@ msgstr "Marcio fel wedi'i ddanfon"
 
 #. Translators: This text guides coordinators in using the code sending interface for approved applications.
 #: TWLight/applications/templates/applications/send_partner.html:152
-msgid ""
-"Use the dropdown menus to denote which editor will receive each code. Access "
-"codes will be sent to users automatically."
+msgid "Use the dropdown menus to denote which editor will receive each code. Access codes will be sent to users automatically."
 msgstr ""
 
 #. Translators: This labels a drop-down selection where staff can assign an access code to a user.
@@ -819,18 +776,13 @@ msgstr ""
 #. Translators: When a user applies for a set of resources, they receive this message if none are currently available. They are instead placed on a 'waitlist' for later approval.
 #. Translators: When a user renews their resource, they receive this message if none are currently available. They are instead placed on a 'waitlist' for later approval.
 #: TWLight/applications/views.py:140 TWLight/applications/views.py:1282
-msgid ""
-"This partner does not have any access grants available at this time. You may "
-"still apply for access; your application will be reviewed when access grants "
-"become available."
+msgid "This partner does not have any access grants available at this time. You may still apply for access; your application will be reviewed when access grants become available."
 msgstr ""
 
 #. Translators: This message is shown to users once they've successfully submitted their application for review.
 #: TWLight/applications/views.py:163
 #, python-brace-format
-msgid ""
-"Your application has been submitted for review. Head over to <a "
-"href='{applications_url}'>My Applications</a> to view the status."
+msgid "Your application has been submitted for review. Head over to <a href='{applications_url}'>My Applications</a> to view the status."
 msgstr ""
 
 #. Translators: This text is displayed to users when the user has chosen to restrict data and is trying to apply for multiple partners
@@ -879,16 +831,12 @@ msgstr ""
 
 #. Translators: After a coordinator has changed the status of an application to APPROVED, if the corresponding partner/collection is waitlisted this message appears.
 #: TWLight/applications/views.py:756
-msgid ""
-"Cannot approve application as partner with proxy authorization method is "
-"waitlisted."
+msgid "Cannot approve application as partner with proxy authorization method is waitlisted."
 msgstr ""
 
 #. Translators: After a coordinator has changed the status of an application to APPROVED, if the corresponding partner/collection has no accounts for distribution, this message appears.
 #: TWLight/applications/views.py:780
-msgid ""
-"Cannot approve application as partner with proxy authorization method is "
-"waitlisted and (or) has zero accounts available for distribution."
+msgid "Cannot approve application as partner with proxy authorization method is waitlisted and (or) has zero accounts available for distribution."
 msgstr ""
 
 #. Translators: This message appears on an "access denied" screen that stops users who attempt to authorize an editor to access a resource during a time period for which they are already authorized.
@@ -899,11 +847,7 @@ msgstr ""
 #. Translators: This message is shown to users when they access an application page of a now Bundle partner (new applications aren't allowed for Bundle partners and the status of old applications cannot be modified)
 #: TWLight/applications/views.py:857
 #, python-brace-format
-msgid ""
-"This application cannot be modified since this partner is now part of our <a "
-"href='{bundle}'>bundle access</a>. If you are eligible, you can access this "
-"resource from <a href='{library}'>your library</a>. <a "
-"href='{contact}'>Contact us</a> if you have any questions."
+msgid "This application cannot be modified since this partner is now part of our <a href='{bundle}'>bundle access</a>. If you are eligible, you can access this resource from <a href='{library}'>your library</a>. <a href='{contact}'>Contact us</a> if you have any questions."
 msgstr ""
 
 #. Translators: this lets a reviewer set the status of a single application.
@@ -913,9 +857,7 @@ msgstr ""
 
 #. Translators: This warning is message is shown to applicants when the number of pending applications is greater than the number of accounts available.
 #: TWLight/applications/views.py:891
-msgid ""
-"There are more pending applications than available accounts. Your "
-"application might get waitlisted."
+msgid "There are more pending applications than available accounts. Your application might get waitlisted."
 msgstr ""
 
 #. Translators: this message is shown to coordinators who attempt to change an application's Status from INVALID to any other Status.
@@ -935,11 +877,7 @@ msgstr ""
 
 #. Translators: After a coordinator has changed the status of a number of applications to APPROVED, if the corresponding partner(s) is/are waitlisted or has no accounts for distribution, this message appears.
 #: TWLight/applications/views.py:1051
-msgid ""
-"Cannot approve application(s) {} as partner(s) with proxy authorization "
-"method is/are waitlisted and (or) has/have not enough accounts available. If "
-"not enough accounts are available, prioritise the applications and then "
-"approve applications equal to the accounts available."
+msgid "Cannot approve application(s) {} as partner(s) with proxy authorization method is/are waitlisted and (or) has/have not enough accounts available. If not enough accounts are available, prioritise the applications and then approve applications equal to the accounts available."
 msgstr ""
 
 #. Translators: This message is shown to coordinators who attempt to assign the same access code to multiple users.
@@ -954,9 +892,7 @@ msgstr ""
 
 #. Translators: When a user tries to renew their resource, they receive this message if the partner is not available.
 #: TWLight/applications/views.py:1272
-msgid ""
-"Cannot renew application at this time as partner is not available. Please "
-"check back later, or contact us for more information."
+msgid "Cannot renew application at this time as partner is not available. Please check back later, or contact us for more information."
 msgstr ""
 
 #. Translators: This message is displayed when an attempt by a user to renew an application has been denied for some reason.
@@ -967,16 +903,12 @@ msgstr ""
 
 #. Translators: If a user requests the renewal of their account, but it wasn't renewed, this message is shown to them.
 #: TWLight/applications/views.py:1385
-msgid ""
-"This object cannot be renewed. (This probably means that you have already "
-"requested that it be renewed.)"
+msgid "This object cannot be renewed. (This probably means that you have already requested that it be renewed.)"
 msgstr ""
 
 #. Translators: If a user requests the renewal of their account, this message is shown to them.
 #: TWLight/applications/views.py:1395
-msgid ""
-"Your renewal request has been received. A coordinator will review your "
-"request."
+msgid "Your renewal request has been received. A coordinator will review your request."
 msgstr ""
 
 #. Translators: This labels a textfield where users can enter their email ID.
@@ -986,9 +918,7 @@ msgstr "Eich e-bost"
 
 #. Translators: This is the help text for the email field in the contact us form letting users know the field is updated by value pulled from their respective user profiles.
 #: TWLight/emails/forms.py:21
-msgid ""
-"This field is automatically updated with the email from your <a class='twl-"
-"links' href='{}'>user profile</a>."
+msgid "This field is automatically updated with the email from your <a class='twl-links' href='{}'>user profile</a>."
 msgstr ""
 
 #. Translators: This labels a textfield where users can enter their email message.
@@ -1012,19 +942,13 @@ msgstr "Cyflwyno"
 #. Translators: This email is sent to users with their access code. Don't translate Jinja variables in curly braces like user or partner. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/access_code_email-body-html.html:5
 #, python-format
-msgid ""
-"<p>Your approved application to %(partner)s has now been finalised. Your "
-"access code or login details can be found below:</p> <p><b>%(access_code)s</"
-"b></p> <p>%(user_instructions)s</p>"
+msgid "<p>Your approved application to %(partner)s has now been finalised. Your access code or login details can be found below:</p> <p><b>%(access_code)s</b></p> <p>%(user_instructions)s</p>"
 msgstr ""
 
 #. Translators: This email is sent to users with their access code. Don't translate Jinja variables in curly braces like user or partner. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/access_code_email-body-text.html:3
 #, python-format
-msgid ""
-"Your approved application to %(partner)s has now been finalised. Your access "
-"code or login details can be found below: %(access_code)s "
-"%(user_instructions)s"
+msgid "Your approved application to %(partner)s has now been finalised. Your access code or login details can be found below: %(access_code)s %(user_instructions)s"
 msgstr ""
 
 #. Translators: This is the subject line of an email sent to users with their access code.
@@ -1035,23 +959,13 @@ msgstr ""
 #. Translators: This email is sent to users when their application is approved. Don't translate Jinja variables in curly braces like user or partner; don't translate html tags either. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/approval_notification-body-html.html:5
 #, python-format
-msgid ""
-"<p>Dear %(user)s,</p> <p>Thank you for applying for access to %(partner)s "
-"resources through The Wikipedia Library. We are happy to inform you that "
-"your application has been approved.</p> <p>%(user_instructions)s</p> <p>You "
-"can view the collections you're authorized to access at My Library: "
-"%(link)s</p> <p>Cheers!</p> <p>The Wikipedia Library</p>"
+msgid "<p>Dear %(user)s,</p> <p>Thank you for applying for access to %(partner)s resources through The Wikipedia Library. We are happy to inform you that your application has been approved.</p> <p>%(user_instructions)s</p> <p>You can view the collections you're authorized to access at My Library: %(link)s</p> <p>Cheers!</p> <p>The Wikipedia Library</p>"
 msgstr ""
 
 #. Translators: This email is sent to users when their application is approved. Don't translate Jinja variables in curly braces like user or partner. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/approval_notification-body-text.html:3
 #, python-format
-msgid ""
-"Dear %(user)s, Thank you for applying for access to %(partner)s resources "
-"through The Wikipedia Library. We are happy to inform you that your "
-"application has been approved. %(user_instructions)s You can view the "
-"collections you're authorized to access at My Library: %(link)s Cheers! The "
-"Wikipedia Library"
+msgid "Dear %(user)s, Thank you for applying for access to %(partner)s resources through The Wikipedia Library. We are happy to inform you that your application has been approved. %(user_instructions)s You can view the collections you're authorized to access at My Library: %(link)s Cheers! The Wikipedia Library"
 msgstr ""
 
 #. Translators: This is the subject of an email which is sent to users when their application has been approved. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
@@ -1062,26 +976,14 @@ msgstr ""
 #. Translators: This email is sent to coordinators when a comment is left on an application they are processing. Don't translate Jinja variables in curly braces like user or partner. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/comment_notification_coordinator-body-html.html:5
 #, python-format
-msgid ""
-"<p style=\"color: #500050\">%(submit_date)s - %(commenter)s</p> "
-"<blockquote><p>%(comment)s</p></blockquote> <p>Please reply to these at: <a "
-"href=\"%(app_url)s\">%(app_url)s</a></p> <p>Best,</p> <p>The Wikipedia "
-"Library</p>"
-msgstr ""
-"<p style=\"color: #500050\">%(submit_date)s - %(commenter)s</p> "
-"<blockquote><p>%(comment)s</p></blockquote> <p>Atebwch y rhain yn: <a href="
-"\"%(app_url)s\">%(app_url)s</a> os gwelwch yn dda.</p> <p>Cofion,</p> <p>Y "
-"Llyfrgell Wiicipedia</p>"
+msgid "<p style=\"color: #500050\">%(submit_date)s - %(commenter)s</p> <blockquote><p>%(comment)s</p></blockquote> <p>Please reply to these at: <a href=\"%(app_url)s\">%(app_url)s</a></p> <p>Best,</p> <p>The Wikipedia Library</p>"
+msgstr "<p style=\"color: #500050\">%(submit_date)s - %(commenter)s</p> <blockquote><p>%(comment)s</p></blockquote> <p>Atebwch y rhain yn: <a href=\"%(app_url)s\">%(app_url)s</a> os gwelwch yn dda.</p> <p>Cofion,</p> <p>Y Llyfrgell Wiicipedia</p>"
 
 #. Translators: This email is sent to coordinators when a comment is left on an application they are processing. Don't translate Jinja variables in curly braces like user or partner. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/comment_notification_coordinator-body-text.html:3
 #, python-format
-msgid ""
-"%(submit_date)s - %(commenter)s %(comment)s Please reply to this at: "
-"%(app_url)s Best, The Wikipedia Library"
-msgstr ""
-"%(submit_date)s - %(commenter)s %(comment)s Atebwch hwn yn: %(app_url)s "
-"Cofion, Y Llyfrgell Wicipedia"
+msgid "%(submit_date)s - %(commenter)s %(comment)s Please reply to this at: %(app_url)s Best, The Wikipedia Library"
+msgstr "%(submit_date)s - %(commenter)s %(comment)s Atebwch hwn yn: %(app_url)s Cofion, Y Llyfrgell Wicipedia"
 
 #. Translators: This is the subject line of an email sent to coordinators when a comment is left on an application they processed.
 #: TWLight/emails/templates/emails/comment_notification_coordinator-subject.html:3
@@ -1091,19 +993,13 @@ msgstr "Sylw newydd ar gais Llyfrgell Wicipedia a broseswyd gennych"
 #. Translators: This email is sent to users when they receive a comment on their application. Don't translate Jinja variables in curly braces like user or partner; don't translate html tags either. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/comment_notification_editors-body-html.html:5
 #, python-format
-msgid ""
-"<p style=\"color: #500050\">%(submit_date)s - %(commenter)s</p> "
-"<blockquote><p>%(comment)s</p></blockquote> <p>Please reply to these at <a "
-"href=\"%(app_url)s\">%(app_url)s</a> so we can evaluate your application.</"
-"p> <p>Best,</p> <p>The Wikipedia Library</p>"
+msgid "<p style=\"color: #500050\">%(submit_date)s - %(commenter)s</p> <blockquote><p>%(comment)s</p></blockquote> <p>Please reply to these at <a href=\"%(app_url)s\">%(app_url)s</a> so we can evaluate your application.</p> <p>Best,</p> <p>The Wikipedia Library</p>"
 msgstr ""
 
 #. Translators: This email is sent to users when they receive a comment on their application. Don't translate Jinja variables in curly braces like user or partner. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/comment_notification_editors-body-text.html:3
 #, python-format
-msgid ""
-"%(submit_date)s - %(commenter)s %(comment)s Please reply to these at: "
-"%(app_url)s so we can evaluate your application. Best, The Wikipedia Library"
+msgid "%(submit_date)s - %(commenter)s %(comment)s Please reply to these at: %(app_url)s so we can evaluate your application. Best, The Wikipedia Library"
 msgstr ""
 
 #. Translators: This is the subject line of an email sent to users who have a comment added to one of their applications. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
@@ -1114,18 +1010,13 @@ msgstr ""
 #. Translators: This email is sent to users when an application they commented on receives another comment. Don't translate Jinja variables in curly braces like app_url; don't translate html tags either. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/comment_notification_others-body-html.html:5
 #, python-format
-msgid ""
-"<p style=\"color: #500050\">%(submit_date)s - %(commenter)s</p> "
-"<blockquote><p>%(comment)s</p></blockquote> See it at <a href=\"%(app_url)s"
-"\">%(app_url)s</a>. Thanks for helping review Wikipedia Library applications!"
+msgid "<p style=\"color: #500050\">%(submit_date)s - %(commenter)s</p> <blockquote><p>%(comment)s</p></blockquote> See it at <a href=\"%(app_url)s\">%(app_url)s</a>. Thanks for helping review Wikipedia Library applications!"
 msgstr ""
 
 #. Translators: This email is sent to users when an application they commented on receives another comment. Don't translate Jinja variables in curly braces like app_url. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/comment_notification_others-body-text.html:3
 #, python-format
-msgid ""
-"%(submit_date)s - %(commenter)s %(comment)s See it at: %(app_url)s Thanks "
-"for helping review Wikipedia Library applications!"
+msgid "%(submit_date)s - %(commenter)s %(comment)s See it at: %(app_url)s Thanks for helping review Wikipedia Library applications!"
 msgstr ""
 
 #. Translators: This is the subject line of an email sent to users who have a comment added to an application they also commented on. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
@@ -1136,10 +1027,7 @@ msgstr ""
 #. Translators: This text is part of a scheduled reminder email sent to coordinators who have applications requiring action. Don't translate Jinja variables in curly braces like total_apps, or user.
 #: TWLight/emails/templates/emails/coordinator_reminder_notification-body-html.html:5
 #, python-format
-msgid ""
-"<p>Dear %(user)s,</p> <p>Our records indicate that you are the designated "
-"coordinator for partners that have a total of %(total_apps)s applications.</"
-"p>"
+msgid "<p>Dear %(user)s,</p> <p>Our records indicate that you are the designated coordinator for partners that have a total of %(total_apps)s applications.</p>"
 msgstr ""
 
 #. Translators: Breakdown as in 'cost breakdown'; analysis.
@@ -1190,31 +1078,19 @@ msgstr[5] ""
 #. Translators: This text is part of a scheduled reminder email sent to coordinators who have applications requiring action. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library). Don't translate Jinja variables in curly braces like link; don't translate email addresses or html tags either.
 #: TWLight/emails/templates/emails/coordinator_reminder_notification-body-html.html:39
 #, python-format
-msgid ""
-"<p>This is a gentle reminder that you may review applications at <a href="
-"\"%(link)s\">%(link)s</a>.</p> <p>You can customise your reminders under "
-"'preferences' in your user profile.</p> <p>If you received this message in "
-"error, drop us a line at wikipedialibrary@wikimedia.org.</p> <p>Thanks for "
-"helping review Wikipedia Library applications!</p>"
+msgid "<p>This is a gentle reminder that you may review applications at <a href=\"%(link)s\">%(link)s</a>.</p> <p>You can customise your reminders under 'preferences' in your user profile.</p> <p>If you received this message in error, drop us a line at wikipedialibrary@wikimedia.org.</p> <p>Thanks for helping review Wikipedia Library applications!</p>"
 msgstr ""
 
 #. Translators: This text is part of a scheduled reminder email sent to coordinators who have applications requiring action. Don't translate Jinja variables in curly braces like total_apps, or user.
 #: TWLight/emails/templates/emails/coordinator_reminder_notification-body-text.html:3
 #, python-format
-msgid ""
-"Dear %(user)s, Our records indicate that you are the designated coordinator "
-"for partners that have a total of %(total_apps)s applications."
+msgid "Dear %(user)s, Our records indicate that you are the designated coordinator for partners that have a total of %(total_apps)s applications."
 msgstr ""
 
 #. Translators: This text is part of a scheduled reminder email sent to coordinators who have applications requiring action. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library). Don't translate Jinja variables in curly braces like link; don't translate the email address either.
 #: TWLight/emails/templates/emails/coordinator_reminder_notification-body-text.html:38
 #, python-format
-msgid ""
-"This is a gentle reminder that you may review applications at: %(link)s. You "
-"can customise your reminders under 'preferences' in your user profile. If "
-"you received this message in error, drop us a line at: "
-"wikipedialibrary@wikimedia.org Thanks for helping review Wikipedia Library "
-"applications!"
+msgid "This is a gentle reminder that you may review applications at: %(link)s. You can customise your reminders under 'preferences' in your user profile. If you received this message in error, drop us a line at: wikipedialibrary@wikimedia.org Thanks for helping review Wikipedia Library applications!"
 msgstr ""
 
 #. Translators: This is the subject line of a scheduled reminder email sent to coordinators who have applications to review. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library). Do not translate items in curly braces.
@@ -1225,22 +1101,13 @@ msgstr ""
 #. Translators: This email is sent to users when their application is rejected. Don't translate Jinja variables in curly braces like user or partner; don't translate html tags either. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/rejection_notification-body-html.html:5
 #, python-format
-msgid ""
-"<p>Dear %(user)s,</p> <p>Thank you for applying for access to %(partner)s "
-"resources through The Wikipedia Library. Unfortunately at this time your "
-"application has not been approved. You can view your application and review "
-"comments at <a href=\"%(app_url)s\">%(app_url)s</a>.</p> <p>Best,</p> <p>The "
-"Wikipedia Library</p>"
+msgid "<p>Dear %(user)s,</p> <p>Thank you for applying for access to %(partner)s resources through The Wikipedia Library. Unfortunately at this time your application has not been approved. You can view your application and review comments at <a href=\"%(app_url)s\">%(app_url)s</a>.</p> <p>Best,</p> <p>The Wikipedia Library</p>"
 msgstr ""
 
 #. Translators: This email is sent to users when their application is rejected. Don't translate Jinja variables in curly braces like user or partner. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/rejection_notification-body-text.html:3
 #, python-format
-msgid ""
-"Dear %(user)s, Thank you for applying for access to %(partner)s resources "
-"through The Wikipedia Library. Unfortunately at this time your application "
-"has not been approved. You can view your application and review comments at: "
-"%(app_url)s Best, The Wikipedia Library"
+msgid "Dear %(user)s, Thank you for applying for access to %(partner)s resources through The Wikipedia Library. Unfortunately at this time your application has not been approved. You can view your application and review comments at: %(app_url)s Best, The Wikipedia Library"
 msgstr ""
 
 #. Translators: This is the subject of an email which is sent to users when their application has been rejected. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
@@ -1251,25 +1118,13 @@ msgstr ""
 #. Translators: This email is sent to users when they have an account that is soon to expire. Don't translate Jinja variables in curly braces like partner_name or partner_link; don't translate html tags either. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/user_renewal_notice-body-html.html:5
 #, python-format
-msgid ""
-"<p>Dear %(user)s,</p> <p>According to our records, your access to "
-"%(partner_name)s will soon expire and you may lose access. If you want to "
-"continue making use of your free account, you can request renewal of your "
-"account by clicking the 'Renew' or 'Extend' button at %(partner_link)s.</p> "
-"<p>Best,</p> <p>The Wikipedia Library</p> <p>You can disable these emails in "
-"your user page preferences: https://wikipedialibrary.wmflabs.org/users/</p>"
+msgid "<p>Dear %(user)s,</p> <p>According to our records, your access to %(partner_name)s will soon expire and you may lose access. If you want to continue making use of your free account, you can request renewal of your account by clicking the 'Renew' or 'Extend' button at %(partner_link)s.</p> <p>Best,</p> <p>The Wikipedia Library</p> <p>You can disable these emails in your user page preferences: https://wikipedialibrary.wmflabs.org/users/</p>"
 msgstr ""
 
 #. Translators: This email is sent to users when they have an account that is soon to expire. Don't translate Jinja variables in curly braces like partner_name or partner_link; don't translate html tags either. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/user_renewal_notice-body-text.html:3
 #, python-format
-msgid ""
-"Dear %(user)s, According to our records, your access to %(partner_name)s "
-"will soon expire and you may lose access. If you want to continue making use "
-"of your free account, you can request renewal of your account by clicking "
-"the Renew button at %(partner_link)s. Best, The Wikipedia Library You can "
-"disable these emails in your user page preferences: https://wikipedialibrary."
-"wmflabs.org/users/"
+msgid "Dear %(user)s, According to our records, your access to %(partner_name)s will soon expire and you may lose access. If you want to continue making use of your free account, you can request renewal of your account by clicking the Renew button at %(partner_link)s. Best, The Wikipedia Library You can disable these emails in your user page preferences: https://wikipedialibrary.wmflabs.org/users/"
 msgstr ""
 
 #. Translators: This is the subject of an email sent to users when they have an account that is soon to expire. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
@@ -1280,24 +1135,13 @@ msgstr ""
 #. Translators: This email is sent to users when their application is waitlisted because there are no more accounts available. Don't translate Jinja variables in curly braces like user or partner; don't translate html tags either. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/waitlist_notification-body-html.html:5
 #, python-format
-msgid ""
-"<p>Dear %(user)s,</p> <p>Thank you for applying for access to %(partner)s "
-"resources through The Wikipedia Library. There are no accounts currently "
-"available so your application has been waitlisted. Your application will be "
-"evaluated if/when more accounts become available. You can see all available "
-"resources at <a href=\"%(link)s\">%(link)s</a>.</p> <p>Best,</p> <p>The "
-"Wikipedia Library</p>"
+msgid "<p>Dear %(user)s,</p> <p>Thank you for applying for access to %(partner)s resources through The Wikipedia Library. There are no accounts currently available so your application has been waitlisted. Your application will be evaluated if/when more accounts become available. You can see all available resources at <a href=\"%(link)s\">%(link)s</a>.</p> <p>Best,</p> <p>The Wikipedia Library</p>"
 msgstr ""
 
 #. Translators: This email is sent to users when their application is waitlisted because there are no more accounts available. Don't translate Jinja variables in curly braces like user or partner. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/waitlist_notification-body-text.html:3
 #, python-format
-msgid ""
-"Dear %(user)s, Thank you for applying for access to %(partner)s resources "
-"through The Wikipedia Library. There are no accounts currently available so "
-"your application has been waitlisted. Your application will be evaluated if/"
-"when more accounts become available. You can see all available resources at: "
-"%(link)s Best, The Wikipedia Library"
+msgid "Dear %(user)s, Thank you for applying for access to %(partner)s resources through The Wikipedia Library. There are no accounts currently available so your application has been waitlisted. Your application will be evaluated if/when more accounts become available. You can see all available resources at: %(link)s Best, The Wikipedia Library"
 msgstr ""
 
 #. Translators: This is the subject of an email sent to users when their application is waitlisted because there are no more accounts available. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
@@ -1459,17 +1303,14 @@ msgstr "Ddim ar gael"
 #: TWLight/resources/templates/resources/filter_section.html:14
 #: TWLight/templates/about.html:12
 #: TWLight/users/templates/users/filter_section.html:13
-msgid ""
-"The Wikipedia Library allows active editors to access a wide range of "
-"collections of paywalled reliable sources for free!"
+msgid "The Wikipedia Library allows active editors to access a wide range of collections of paywalled reliable sources for free!"
 msgstr ""
 
 #. Translators: On the Browse Partners page (https://wikipedialibrary.wmflabs.org/partners/), this introduces users to The Wikipedia Library.
 #. Translators: On the MyLibrary page (https://wikipedialibrary.wmflabs.org/users/my_library), this introduces users to The Wikipedia Library.
 #: TWLight/resources/templates/resources/filter_section.html:17
 #: TWLight/users/templates/users/filter_section.html:15
-msgid ""
-"Start with the search bar at the top or browse publisher websites directly."
+msgid "Start with the search bar at the top or browse publisher websites directly."
 msgstr ""
 
 #. Translators: On the Browse Partners page (https://wikipedialibrary.wmflabs.org/partners/), this appears below introductory text and links to the 'About' page (https://wikipedialibrary.wmflabs.org/about/)
@@ -1543,52 +1384,38 @@ msgstr "Yn ôl at bartneriaid"
 #. Translators: If we have no available accounts for a partner, the coordinator can change the application system to a waiting list.
 #: TWLight/resources/templates/resources/partner_detail.html:36
 #: TWLight/resources/templates/resources/partner_detail_apply.html:17
-msgid ""
-"There are no access grants available for this partner at this time. You can "
-"still apply for access; applications will be processed when access is "
-"available."
+msgid "There are no access grants available for this partner at this time. You can still apply for access; applications will be processed when access is available."
 msgstr ""
 
 #. Translators: This text links to the minimum user requirements and terms of use on the partner page.
 #: TWLight/resources/templates/resources/partner_detail.html:48
 #: TWLight/resources/templates/resources/partner_detail_apply.html:29
 #, python-format
-msgid ""
-"Before applying, please review the <strong><a class=\"twl-links\" href="
-"\"%(about)s#req\">minimum requirements</a></strong> for access and our "
-"<strong><a class=\"twl-links\" href=\"%(terms)s\">terms of use</a></strong>."
+msgid "Before applying, please review the <strong><a class=\"twl-links\" href=\"%(about)s#req\">minimum requirements</a></strong> for access and our <strong><a class=\"twl-links\" href=\"%(terms)s\">terms of use</a></strong>."
 msgstr ""
 
 #. Translators: This text refers to the page containing the content a user is authorized to access.
 #: TWLight/resources/templates/resources/partner_detail.html:69
 #, python-format
-msgid ""
-"View the status of your access in <strong><a class=\"twl-links\" href="
-"\"%(library_url)s\">My Library</a></strong> page."
+msgid "View the status of your access in <strong><a class=\"twl-links\" href=\"%(library_url)s\">My Library</a></strong> page."
 msgstr ""
 
 #. Translators: This message is shown when a user has open applications, linking to their respective applications page.
 #: TWLight/resources/templates/resources/partner_detail.html:78
 #, python-format
-msgid ""
-"View the status of your application(s) on your <strong><a class=\"twl-links"
-"\" href=\"%(applications_url)s\">My Applications</a></strong> page."
+msgid "View the status of your application(s) on your <strong><a class=\"twl-links\" href=\"%(applications_url)s\">My Applications</a></strong> page."
 msgstr ""
 
 #. Translators: This message is shown when a user has authorizations, linking to their respective collections page.
 #: TWLight/resources/templates/resources/partner_detail_apply.html:50
 #, python-format
-msgid ""
-"View the status of your access on your <strong><a href=\"%(library_url)s\" "
-"class=\"twl-links\">My Library</a></strong> page."
+msgid "View the status of your access on your <strong><a href=\"%(library_url)s\" class=\"twl-links\">My Library</a></strong> page."
 msgstr ""
 
 #. Translators: This message is shown when a user has open applications, linking to their respective applications page.
 #: TWLight/resources/templates/resources/partner_detail_apply.html:60
 #, python-format
-msgid ""
-"View the status of your application(s) on your <strong><a href="
-"\"%(applications_url)s\">My Applications</a></strong> page."
+msgid "View the status of your application(s) on your <strong><a href=\"%(applications_url)s\">My Applications</a></strong> page."
 msgstr ""
 
 #. Translators: One the partner detail page, this text labels the button which coordinators can click to remove a partner from waitlisted status.
@@ -1618,10 +1445,7 @@ msgstr ""
 
 #. Translators: If no account coordinator is assigned to a partner, the Wikipedia Library team will coordinate signups. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/resources/templates/resources/partner_detail_apply.html:112
-msgid ""
-"The Wikipedia Library team will process this application. Want to help? <a "
-"class=\"twl-links\" href=\"https://en.wikipedia.org/wiki/Wikipedia:"
-"The_Wikipedia_Library/Coordinators/Signup\">Sign up as a coordinator.</a>"
+msgid "The Wikipedia Library team will process this application. Want to help? <a class=\"twl-links\" href=\"https://en.wikipedia.org/wiki/Wikipedia:The_Wikipedia_Library/Coordinators/Signup\">Sign up as a coordinator.</a>"
 msgstr ""
 
 #. Translators: This text labels a button coordinators can click to view a list of users who have applied for access for a particular partner
@@ -1651,18 +1475,13 @@ msgstr ""
 
 #. Translators: Text shown to authenticated, bundle eligible users when they visit a Bundle partner page.
 #: TWLight/resources/templates/resources/partner_detail_apply.html:138
-msgid ""
-"You are eligible to access Library Bundle partners. Click the button above "
-"to access the collection."
+msgid "You are eligible to access Library Bundle partners. Click the button above to access the collection."
 msgstr ""
 
 #. Translators: Text shown to authenticated, bundle ineligible users when they visit a Bundle partner page.
 #: TWLight/resources/templates/resources/partner_detail_apply.html:152
 #, python-format
-msgid ""
-"You are not eligible to access Library Bundle partners. Visit the <a class="
-"\"twl-links\" href=\"%(homepage)s\">homepage</a> to check the eligibility "
-"criteria."
+msgid "You are not eligible to access Library Bundle partners. Visit the <a class=\"twl-links\" href=\"%(homepage)s\">homepage</a> to check the eligibility criteria."
 msgstr ""
 
 #. Translators: Buttton prompting users to log in.
@@ -1674,10 +1493,7 @@ msgstr "Mewngofnodi"
 #. Translators: Text shown to unauthenticated users when they visit a Bundle partner page.
 #: TWLight/resources/templates/resources/partner_detail_apply.html:168
 #, python-format
-msgid ""
-"This resource is part of our <a class=\"twl-links\" href=\"%(about)s"
-"\">Library Bundle</a>, which you can access if you meet our minimum "
-"eligibility criteria. Log in to find out if you are eligible."
+msgid "This resource is part of our <a class=\"twl-links\" href=\"%(about)s\">Library Bundle</a>, which you can access if you meet our minimum eligibility criteria. Log in to find out if you are eligible."
 msgstr ""
 
 #. Translators: This is the label for a number which shows the total active accounts for one partner. (e.g. https://wikipedialibrary.wmflabs.org/partners/8/).
@@ -1728,26 +1544,19 @@ msgstr ""
 #. Translators: If a partner has specified the excerpt limit both in words and percentage, this message will display the percentage of words and the number of words on the partner page.
 #: TWLight/resources/templates/resources/partner_detail_timeline.html:99
 #, python-format
-msgid ""
-"%(object)s allows a maximum of %(excerpt_limit)s words or "
-"%(excerpt_limit_percentage)s%% of an article be excerpted into a Wikipedia "
-"article."
+msgid "%(object)s allows a maximum of %(excerpt_limit)s words or %(excerpt_limit_percentage)s%% of an article be excerpted into a Wikipedia article."
 msgstr ""
 
 #. Translators: If a partner has specified the excerpt limit in words, this message will display the number of words on the partner page.
 #: TWLight/resources/templates/resources/partner_detail_timeline.html:106
 #, python-format
-msgid ""
-"%(object)s allows a maximum of %(excerpt_limit)s words be excerpted into a "
-"Wikipedia article."
+msgid "%(object)s allows a maximum of %(excerpt_limit)s words be excerpted into a Wikipedia article."
 msgstr ""
 
 #. Translators: If a partner has specified the excerpt limit in percentage, this message will display the percentage of words on the partner page.
 #: TWLight/resources/templates/resources/partner_detail_timeline.html:113
 #, python-format
-msgid ""
-"%(object)s allows a maximum of %(excerpt_limit_percentage)s%% of an article "
-"be excerpted into a Wikipedia article."
+msgid "%(object)s allows a maximum of %(excerpt_limit_percentage)s%% of an article be excerpted into a Wikipedia article."
 msgstr ""
 
 #. Translators: If a partner has other requirements for access, this text shows as the title for that information field. (e.g. https://wikipedialibrary.wmflabs.org/partners/10/).
@@ -1758,9 +1567,7 @@ msgstr ""
 #. Translators: If a user must agree to a Terms of Use document, they see this message, and must enter the name of the resource. Don't translate publisher or url.
 #: TWLight/resources/templates/resources/partner_detail_timeline.html:140
 #, python-format
-msgid ""
-"%(publisher)s requires that you agree with its <a href=\"%(url)s\">terms of "
-"use</a>."
+msgid "%(publisher)s requires that you agree with its <a href=\"%(url)s\">terms of use</a>."
 msgstr ""
 
 #. Translators: If a user must provide their real name to apply to a partner, they see this message, and must enter the name of the resource. Don't translate publisher.
@@ -1784,17 +1591,13 @@ msgstr ""
 #. Translators: If a user must select a specific resource to apply for, they see this message, and must enter the name of the resource. Don't translate publisher.
 #: TWLight/resources/templates/resources/partner_detail_timeline.html:177
 #, python-format
-msgid ""
-"%(publisher)s requires that you specify a particular title that you want to "
-"access."
+msgid "%(publisher)s requires that you specify a particular title that you want to access."
 msgstr ""
 
 #. Translators: If a user must register on the partner website before applying, they see this message. Don't translate partner.
 #: TWLight/resources/templates/resources/partner_detail_timeline.html:187
 #, python-format
-msgid ""
-"%(publisher)s requires that you sign up for an account before applying for "
-"access."
+msgid "%(publisher)s requires that you sign up for an account before applying for access."
 msgstr ""
 
 #. Translators: If a partner has their location listed, this message is a label for that location
@@ -1921,9 +1724,7 @@ msgstr ""
 
 #. Translators: If multiple authorizations where returned for a collection, this message is shown to a user
 #: TWLight/resources/views.py:268
-msgid ""
-"Multiple authorizations were returned – something's wrong. Please contact us "
-"and don't forget to mention this message."
+msgid "Multiple authorizations were returned – something's wrong. Please contact us and don't forget to mention this message."
 msgstr ""
 
 #. Translators: This message is shown when user tries to access a NOT_AVAILABLE Partner
@@ -1964,14 +1765,7 @@ msgstr ""
 #. Translators: Shown on the website's 400 page, when a user sends a bad request. Don't translate path or Phabricator.
 #: TWLight/templates/400.html:20
 #, python-format
-msgid ""
-"If you think we should know what to do with that, please email us about this "
-"error at <a class=\"twl-links\" href=\"mailto:wikipedialibrary@wikimedia.org?"
-"Subject=Wikipedia%%20Library%%20%(path)s%%20Permission%%20denied"
-"\">wikipedialibrary@wikimedia.org</a> or report it to us on <a class=\"twl-"
-"links\" href=\"https://phabricator.wikimedia.org/maniphest/task/edit/form/1/?"
-"projectPHIDs=Library-Card-Platform&title=Wikipedia%%20Library%%20%(path)s"
-"%%20Bad%%20Request\">Phabricator</a>"
+msgid "If you think we should know what to do with that, please email us about this error at <a class=\"twl-links\" href=\"mailto:wikipedialibrary@wikimedia.org?Subject=Wikipedia%%20Library%%20%(path)s%%20Permission%%20denied\">wikipedialibrary@wikimedia.org</a> or report it to us on <a class=\"twl-links\" href=\"https://phabricator.wikimedia.org/maniphest/task/edit/form/1/?projectPHIDs=Library-Card-Platform&title=Wikipedia%%20Library%%20%(path)s%%20Bad%%20Request\">Phabricator</a>"
 msgstr ""
 
 #. Translators: Alt text for an image shown on the 400 error page.
@@ -1993,15 +1787,7 @@ msgstr ""
 #. Translators: Shown on the website's 403 page, when a user attempts to navigate to a page they don't have permission to view. Don't translate path or Phabricator.
 #: TWLight/templates/403.html:20
 #, python-format
-msgid ""
-"If you think your account should be able to do that, please email us about "
-"this error at <a class=\"twl-links\" href=\"mailto:"
-"wikipedialibrary@wikimedia.org?Subject=Wikipedia%%20Library%%20%(path)s"
-"%%20Permission%%20denied\">wikipedialibrary@wikimedia.org</a> or report it "
-"to us on <a class=\"twl-links\" href=\"https://phabricator.wikimedia.org/"
-"maniphest/task/edit/form/1/?projectPHIDs=Library-Card-"
-"Platform&title=Wikipedia%%20Library%%20%(path)s%%20Permission%%20denied"
-"\">Phabricator</a>"
+msgid "If you think your account should be able to do that, please email us about this error at <a class=\"twl-links\" href=\"mailto:wikipedialibrary@wikimedia.org?Subject=Wikipedia%%20Library%%20%(path)s%%20Permission%%20denied\">wikipedialibrary@wikimedia.org</a> or report it to us on <a class=\"twl-links\" href=\"https://phabricator.wikimedia.org/maniphest/task/edit/form/1/?projectPHIDs=Library-Card-Platform&title=Wikipedia%%20Library%%20%(path)s%%20Permission%%20denied\">Phabricator</a>"
 msgstr ""
 
 #. Translators: Shown on the website's 404 page, when a user attempts to navigate to a page that doesn't exist.
@@ -2017,14 +1803,7 @@ msgstr ""
 #. Translators: Shown on the website's 404 page, when a user attempts to navigate to a page that doesn't exist. Don't translate path or Phabricator.
 #: TWLight/templates/404.html:19
 #, python-format
-msgid ""
-"If you are certain that something should be here, please email us about this "
-"error at <a class=\"twl-links\" href=\"mailto:wikipedialibrary@wikimedia.org?"
-"Subject=Wikipedia%%20Library%%20%(path)s%%20Not%%20found\"> "
-"wikipedialibrary@wikimedia.org</a> or report it to us on <a class=\"twl-links"
-"\" href=\"https://phabricator.wikimedia.org/maniphest/task/edit/form/1/?"
-"projectPHIDs=Library-Card-Platform&title=Wikipedia%%20Library%%20%(path)s"
-"%%20Not%%20found\">Phabricator</a>"
+msgid "If you are certain that something should be here, please email us about this error at <a class=\"twl-links\" href=\"mailto:wikipedialibrary@wikimedia.org?Subject=Wikipedia%%20Library%%20%(path)s%%20Not%%20found\"> wikipedialibrary@wikimedia.org</a> or report it to us on <a class=\"twl-links\" href=\"https://phabricator.wikimedia.org/maniphest/task/edit/form/1/?projectPHIDs=Library-Card-Platform&title=Wikipedia%%20Library%%20%(path)s%%20Not%%20found\">Phabricator</a>"
 msgstr ""
 
 #. Translators: Alt text for an image shown on the 404 error page.
@@ -2039,32 +1818,18 @@ msgstr "Ynglŷn â'r Llyfrgell Wicipedia"
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:20
-msgid ""
-"This platform is our central tool for facilitating access to our available "
-"collections. Here you can see which partnerships are available, search their "
-"contents, and apply for and access the ones you’re interested in."
+msgid "This platform is our central tool for facilitating access to our available collections. Here you can see which partnerships are available, search their contents, and apply for and access the ones you’re interested in."
 msgstr ""
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/). Wikimedia Foundation should not be translated.
 #: TWLight/templates/about.html:29
-msgid ""
-"All users receive immediate access to some collections, which can be browsed "
-"by clicking the 'Access collection' buttons or using the search bar at the "
-"top of the page. Other collections require an application before access is "
-"granted, and may be accessed directly or via an individual login or access "
-"code. Volunteer coordinators, who have signed non-disclosure agreements with "
-"the Wikimedia Foundation, review these applications and work with publishers "
-"to get you your free access."
+msgid "All users receive immediate access to some collections, which can be browsed by clicking the 'Access collection' buttons or using the search bar at the top of the page. Other collections require an application before access is granted, and may be accessed directly or via an individual login or access code. Volunteer coordinators, who have signed non-disclosure agreements with the Wikimedia Foundation, review these applications and work with publishers to get you your free access."
 msgstr ""
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/). Don't translate terms_url.
 #: TWLight/templates/about.html:43
 #, python-format
-msgid ""
-"For more information about how your information is stored and reviewed "
-"please see our <a class=\"twl-links\" href=\"%(terms_url)s\"> terms of use "
-"and privacy policy</a>. Accounts you apply for are also subject to the Terms "
-"of Use provided by each partner’s platform; please review them."
+msgid "For more information about how your information is stored and reviewed please see our <a class=\"twl-links\" href=\"%(terms_url)s\"> terms of use and privacy policy</a>. Accounts you apply for are also subject to the Terms of Use provided by each partner’s platform; please review them."
 msgstr ""
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
@@ -2074,12 +1839,7 @@ msgstr ""
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/). Wikimedia Foundation should not be translated.
 #: TWLight/templates/about.html:55
-msgid ""
-"Any active editor in good standing can receive access. For publishers with "
-"limited numbers of accounts, applications are reviewed based on the editor’s "
-"needs and contributions. If you think you could use access to one of our "
-"partner resources and are an active editor in any project supported by the "
-"Wikimedia Foundation, please apply."
+msgid "Any active editor in good standing can receive access. For publishers with limited numbers of accounts, applications are reviewed based on the editor’s needs and contributions. If you think you could use access to one of our partner resources and are an active editor in any project supported by the Wikimedia Foundation, please apply."
 msgstr ""
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
@@ -2109,23 +1869,12 @@ msgstr ""
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/)
 #: TWLight/templates/about.html:89
-msgid ""
-"If you are applying for an available collection, please first check that you "
-"don't already have access through another library or institution. If you do, "
-"please consider using that access rather than taking up a seat for this "
-"resource in The Wikipedia Library."
+msgid "If you are applying for an available collection, please first check that you don't already have access through another library or institution. If you do, please consider using that access rather than taking up a seat for this resource in The Wikipedia Library."
 msgstr ""
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/)
 #: TWLight/templates/about.html:99
-msgid ""
-"If your account is blocked on one or more Wikimedia projects, you may still "
-"be granted access to The Wikipedia Library. You will need to contact the "
-"Wikipedia Library team, who will review your blocks. If you have been "
-"blocked for content issues, most notably copyright violations, or have "
-"multiple long-term blocks, we may decline your request. Additionally, if "
-"your block status changes after being approved, you will need to request "
-"another review."
+msgid "If your account is blocked on one or more Wikimedia projects, you may still be granted access to The Wikipedia Library. You will need to contact the Wikipedia Library team, who will review your blocks. If you have been blocked for content issues, most notably copyright violations, or have multiple long-term blocks, we may decline your request. Additionally, if your block status changes after being approved, you will need to request another review."
 msgstr ""
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
@@ -2160,9 +1909,7 @@ msgstr ""
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:136
-msgid ""
-"Share their account logins or passwords with others, or sell their access to "
-"other parties"
+msgid "Share their account logins or passwords with others, or sell their access to other parties"
 msgstr ""
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
@@ -2172,23 +1919,17 @@ msgstr ""
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:144
-msgid ""
-"Systematically make printed or electronic copies of multiple extracts of "
-"restricted content available for any purpose"
+msgid "Systematically make printed or electronic copies of multiple extracts of restricted content available for any purpose"
 msgstr ""
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/). Stub is a technical term for a short Wikipedia article, use the appropriate Wikipedia term in your language.
 #: TWLight/templates/about.html:148
-msgid ""
-"Datamine metadata without permission, in order, for instance, to use "
-"metadata for auto-created stub articles"
+msgid "Datamine metadata without permission, in order, for instance, to use metadata for auto-created stub articles"
 msgstr ""
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:154
-msgid ""
-"Respecting these agreements allows us to continue growing the partnerships "
-"available to the community."
+msgid "Respecting these agreements allows us to continue growing the partnerships available to the community."
 msgstr ""
 
 #. Translators: This is the heading for a section on the About page (https://wikipedialibrary.wmflabs.org/about/).
@@ -2198,41 +1939,22 @@ msgstr "EZProxy"
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:164
-msgid ""
-"EZProxy is a proxy server used to authenticate users for many Wikipedia "
-"Library partners. Users sign into EZProxy via the Library Card platform to "
-"verify that they are authorized users, and then the server accesses "
-"requested resources using its own IP address."
+msgid "EZProxy is a proxy server used to authenticate users for many Wikipedia Library partners. Users sign into EZProxy via the Library Card platform to verify that they are authorized users, and then the server accesses requested resources using its own IP address."
 msgstr ""
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:173
-msgid ""
-"You may notice that when accessing resources via EZProxy that URLs are "
-"dynamically rewritten. This is why we recommend logging in via the Library "
-"Card platform rather than going directly to the unproxied partner website. "
-"When in doubt, check the URL for ‘idm.oclc’. If it’s there, then you’re "
-"connected via EZProxy."
+msgid "You may notice that when accessing resources via EZProxy that URLs are dynamically rewritten. This is why we recommend logging in via the Library Card platform rather than going directly to the unproxied partner website. When in doubt, check the URL for ‘idm.oclc’. If it’s there, then you’re connected via EZProxy."
 msgstr ""
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:182
-msgid ""
-"Typically once you’ve logged in your session will remain active in your "
-"browser for up to two hours after you’ve finished searching. Note that use "
-"of EZProxy requires you to enable cookies. If you are having problems you "
-"should also try clearing your cache and restarting your browser."
+msgid "Typically once you’ve logged in your session will remain active in your browser for up to two hours after you’ve finished searching. Note that use of EZProxy requires you to enable cookies. If you are having problems you should also try clearing your cache and restarting your browser."
 msgstr ""
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/)
 #: TWLight/templates/about.html:193
-msgid ""
-"The Library Bundle is a collection of resources for which no application is "
-"required. If you meet the criteria laid out above, you will be authorized "
-"for access automatically upon logging in to the platform. Only some of our "
-"content is currently included in the Library Bundle, however we hope to "
-"expand the collection as more publishers become comfortable with "
-"participating. All Bundle content is accessed via EZProxy."
+msgid "The Library Bundle is a collection of resources for which no application is required. If you meet the criteria laid out above, you will be authorized for access automatically upon logging in to the platform. Only some of our content is currently included in the Library Bundle, however we hope to expand the collection as more publishers become comfortable with participating. All Bundle content is accessed via EZProxy."
 msgstr ""
 
 #. Translators: This is the heading for a section on the About page (https://wikipedialibrary.wmflabs.org/about/).
@@ -2242,12 +1964,7 @@ msgstr ""
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:206
-msgid ""
-"Citation practices vary by project and even by article. Generally, we "
-"support editors citing where they found information, in a form that allows "
-"others to check it for themselves. That often means providing both original "
-"source details as well as a link to the partner database in which the source "
-"was found."
+msgid "Citation practices vary by project and even by article. Generally, we support editors citing where they found information, in a form that allows others to check it for themselves. That often means providing both original source details as well as a link to the partner database in which the source was found."
 msgstr ""
 
 #. Translators: This is the heading for a section on the About page (https://wikipedialibrary.wmflabs.org/about/).
@@ -2259,9 +1976,7 @@ msgstr "Cysylltwch â ni"
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:218
 #, python-format
-msgid ""
-"If you have questions, need help, or want to volunteer to help, please see "
-"our <a class=\"twl-links\" href=\"%(contact_url)s\">contact page</a>."
+msgid "If you have questions, need help, or want to volunteer to help, please see our <a class=\"twl-links\" href=\"%(contact_url)s\">contact page</a>."
 msgstr ""
 
 #. Translators: This is the title of the panel box detailing the contact information for the Wikipedia Library team.
@@ -2301,9 +2016,7 @@ msgstr "Tudalen X Llyfrgell Wicipedia"
 #. Translators: This is the text that appears at the bottom of the contact us form directing users to the suggestions form.
 #: TWLight/templates/contact.html:48
 #, python-format
-msgid ""
-"(If you would like to suggest a partner, <a class=\"twl-links\" href="
-"\"%(suggest)s\"><strong>go here</strong></a>.)"
+msgid "(If you would like to suggest a partner, <a class=\"twl-links\" href=\"%(suggest)s\"><strong>go here</strong></a>.)"
 msgstr ""
 
 #. Translators: On a special 'link to search' page, this message is shown if JavaScript is disabled.
@@ -2360,9 +2073,7 @@ msgstr "Y Llyfrgell Wicipedia"
 #. Translators: Information about The Wikipedia Library.
 #: TWLight/templates/login_partial.html:53 TWLight/templates/new_base.html:21
 #, python-format
-msgid ""
-"More than 100 of the world's top subscription-only databases, with content "
-"in %(no_of_languages)s languages, free for Wikipedians of all backgrounds"
+msgid "More than 100 of the world's top subscription-only databases, with content in %(no_of_languages)s languages, free for Wikipedians of all backgrounds"
 msgstr ""
 
 #. Translators: Information about The Wikipedia Library.
@@ -2371,9 +2082,7 @@ msgid "Meet these criteria for automatic access"
 msgstr ""
 
 #: TWLight/templates/login_partial.html:69
-msgid ""
-"These criteria grant you access to certain collections but not all. Some "
-"collections are accessible on a per application basis only."
+msgid "These criteria grant you access to certain collections but not all. Some collections are accessible on a per application basis only."
 msgstr ""
 
 #: TWLight/templates/login_partial.html:89
@@ -2383,29 +2092,19 @@ msgstr "Mewngofnodi ag Wicipedia"
 #. Translators: Shown if the current user doesn't have a registered email on their account. Don't translate contact_us_url or email_url.
 #: TWLight/templates/message_partial.html:15
 #, python-format
-msgid ""
-"You don't have an email on file. We can't finalize your access to partner "
-"resources, and you won't be able to <a class=\"twl-links\" href="
-"\"%(contact_us_url)s\">contact us</a> without an email. Please <a class="
-"\"twl-links\" href=\"%(email_url)s\">update your email</a>."
+msgid "You don't have an email on file. We can't finalize your access to partner resources, and you won't be able to <a class=\"twl-links\" href=\"%(contact_us_url)s\">contact us</a> without an email. Please <a class=\"twl-links\" href=\"%(email_url)s\">update your email</a>."
 msgstr ""
 
 #. Translators: Shown if the current user has requested the processing of their data should be restricted.
 #: TWLight/templates/message_partial.html:26
 #, python-format
-msgid ""
-"You have requested a restriction on the processing of your data. Most site "
-"functionality will not be available to you until you <a class=\"twl-links\" "
-"href=\"%(restrict_url)s\">lift this restriction</a>."
+msgid "You have requested a restriction on the processing of your data. Most site functionality will not be available to you until you <a class=\"twl-links\" href=\"%(restrict_url)s\">lift this restriction</a>."
 msgstr ""
 
 #. Translators: Shown if the current user has not agreed to the terms of use.
 #: TWLight/templates/message_partial.html:37
 #, python-format
-msgid ""
-"You have not agreed to the <a class=\"twl-links\" href=\"%(terms_url)s"
-"\">terms of use</a> of this site. Your applications will not be processed "
-"and you won't be able to apply or access resources you are approved for."
+msgid "You have not agreed to the <a class=\"twl-links\" href=\"%(terms_url)s\">terms of use</a> of this site. Your applications will not be processed and you won't be able to apply or access resources you are approved for."
 msgstr ""
 
 #. Translators: This link is at the bottom of every page and links to the 'About' page (https://wikipedialibrary.wmflabs.org/about/)
@@ -2452,9 +2151,7 @@ msgstr "Ailosod cyfrinair"
 
 #. Translators: If a user goes to reset their password, this message asks them to enter their email to do so.
 #: TWLight/templates/registration/password_reset_form.html:13
-msgid ""
-"Forgot your password? Enter your email address below, and we'll email "
-"instructions for setting a new one."
+msgid "Forgot your password? Enter your email address below, and we'll email instructions for setting a new one."
 msgstr ""
 
 #. Translators: This is the label for a button that users click to update their public information.
@@ -2499,16 +2196,12 @@ msgstr "Rwy'n cytuno â'r telerau defnydd"
 
 #. Translators: This text explains how to disagree to the site's terms of use and the restrictions that will come into effect when users disagree to the terms of use.
 #: TWLight/users/forms.py:185
-msgid ""
-"By unchecking this box and clicking “Update” you may explore the site, but "
-"you will not be able to apply for access to materials or evaluate "
-"applications unless you agree with the terms of use."
+msgid "By unchecking this box and clicking “Update” you may explore the site, but you will not be able to apply for access to materials or evaluate applications unless you agree with the terms of use."
 msgstr ""
 
 #. Translators: Users click this button to set their website email address to the one linked to their Wikipedia account.
 #: TWLight/users/forms.py:211
-msgid ""
-"Use my Wikipedia email address (will be updated the next time you login)."
+msgid "Use my Wikipedia email address (will be updated the next time you login)."
 msgstr ""
 
 #. Translators: This labels a button which users click to change their email.
@@ -2519,17 +2212,8 @@ msgstr "Diweddaru e-bost"
 #. Translators: Shown if the current user tried to 'favorite' a partner they can't access. Do not translate '{partner}'
 #: TWLight/users/models.py:201
 #, python-brace-format
-msgid ""
-"Cannot add partner {partner} to your favorites because you don't have access "
-"to it"
+msgid "Cannot add partner {partner} to your favorites because you don't have access to it"
 msgstr ""
-
-#. Translators: Do not translate.
-#: TWLight/users/models.py:869
-#, fuzzy, python-brace-format
-#| msgid "Username"
-msgid "{wp_username}"
-msgstr "Enw defnyddiwr"
 
 #. Translators: This error message is shown when there's a problem with the authenticated login process.
 #: TWLight/users/oauth.py:243
@@ -2549,9 +2233,7 @@ msgstr ""
 
 #. Translators: this message is displayed to users that don't have accounts and clicked on a proxied link.
 #: TWLight/users/oauth.py:388
-msgid ""
-"To view this link you need to be an eligible library user. Please login to "
-"continue."
+msgid "To view this link you need to be an eligible library user. Please login to continue."
 msgstr ""
 
 #. Translators: This warning message is shown to users when the response received from Wikimedia OAuth servers is not a valid one.
@@ -2587,17 +2269,12 @@ msgstr ""
 
 #. Translators: If the user tries to log in, but their account does not meet certain requirements, they cannot login.
 #: TWLight/users/oauth.py:528
-msgid ""
-"Your Wikipedia account does not meet the eligibility criteria in the terms "
-"of use, so your Wikipedia Library Card Platform account cannot be activated."
+msgid "Your Wikipedia account does not meet the eligibility criteria in the terms of use, so your Wikipedia Library Card Platform account cannot be activated."
 msgstr ""
 
 #. Translators: If the user tries to log in, but their account does not meet certain requirements, they cannot login.
 #: TWLight/users/oauth.py:536
-msgid ""
-"Your Wikipedia account no longer meets the eligibility criteria in the terms "
-"of use, so you cannot be logged in. If you think you should be able to log "
-"in, please email wikipedialibrary@wikimedia.org."
+msgid "Your Wikipedia account no longer meets the eligibility criteria in the terms of use, so you cannot be logged in. If you think you should be able to log in, please email wikipedialibrary@wikimedia.org."
 msgstr ""
 
 #. Translators: this message is displayed to users with brand new accounts.
@@ -2608,10 +2285,7 @@ msgstr "Croeso! Cytunwch â'r telerau defnydd os gwelwch yn dda."
 #. Translators: This message is displayed on the confirmation page where users can return their access to partner collections.
 #: TWLight/users/templates/users/authorization_confirm_return.html:13
 #, python-format
-msgid ""
-"You will no longer be able to access <b>%(partner)s's</b> resources via the "
-"Library Card platform, but can request access again by clicking 'renew', if "
-"you change your mind. Are you sure you want to return your access?"
+msgid "You will no longer be able to access <b>%(partner)s's</b> resources via the Library Card platform, but can request access again by clicking 'renew', if you change your mind. Are you sure you want to return your access?"
 msgstr ""
 
 #. Translators: On the MyLibrary page (https://wikipedialibrary.wmflabs.org/users/my_library), this tab shows all favorite collections a user has.
@@ -2681,10 +2355,7 @@ msgstr "Data golygydd"
 
 #. Translators: This is shown on editor profiles, in their profile page or on applications.
 #: TWLight/users/templates/users/editor_detail.html:59
-msgid ""
-"Information with an * was retrieved from Wikipedia directly. Other "
-"information was entered directly by users or site admins, in their preferred "
-"language."
+msgid "Information with an * was retrieved from Wikipedia directly. Other information was entered directly by users or site admins, in their preferred language."
 msgstr ""
 
 #. Translators: This distinguishes users who have been flagged as account coordinators. Don't translate username.
@@ -2695,10 +2366,7 @@ msgstr ""
 
 #. Translators: This is shown on editor profiles, under the heading for Wikipedia editor data.
 #: TWLight/users/templates/users/editor_detail_data.html:5
-msgid ""
-"This information is updated automatically from your Wikimedia account each "
-"time you log in, except for the Contributions field, where you can describe "
-"your Wikimedia editing history."
+msgid "This information is updated automatically from your Wikimedia account each time you log in, except for the Contributions field, where you can describe your Wikimedia editing history."
 msgstr ""
 
 #. Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this labels the user's username.
@@ -2728,17 +2396,13 @@ msgstr ""
 
 #. Translators: when viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this question has a yes or no answer.
 #: TWLight/users/templates/users/editor_detail_data.html:57
-msgid ""
-"at their last login, did this user meet the criteria set forth in the terms "
-"of use?"
+msgid "at their last login, did this user meet the criteria set forth in the terms of use?"
 msgstr ""
 
 #. Translators: When viewing a user's profile in an application, this message shows if the software doesn't think that the user is eligible for access. Don't translate username.
 #: TWLight/users/templates/users/editor_detail_data.html:72
 #, python-format
-msgid ""
-"%(username)s may still be eligible for access grants at the coordinators' "
-"discretion."
+msgid "%(username)s may still be eligible for access grants at the coordinators' discretion."
 msgstr ""
 
 #. Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this is the heading for a Yes/No ToU question.
@@ -2773,10 +2437,7 @@ msgstr ""
 #. Translators: This message is shown on a user's profile if their Wikimedia account is blocked on one or more projects. They may still be granted access to the Library Bundle, but need to contact Wikipedia Library staff to verify.
 #: TWLight/users/templates/users/editor_detail_data.html:137
 #, python-format
-msgid ""
-"It looks like you have an active block on your account. If you meet the "
-"other criteria you may still be permitted access to the library - please <a "
-"class=\"twl-links\" href=\"%(contact_url)s\">contact us</a>."
+msgid "It looks like you have an active block on your account. If you meet the other criteria you may still be permitted access to the library - please <a class=\"twl-links\" href=\"%(contact_url)s\">contact us</a>."
 msgstr ""
 
 #. Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this is the heading for a Yes/No program eligibility question.
@@ -2786,10 +2447,7 @@ msgstr ""
 
 #. Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this question has a Yes or No answer.
 #: TWLight/users/templates/users/editor_detail_data.html:156
-msgid ""
-"At their last login, did this user meet the criteria set forth in the "
-"Library Bundle? Note that satisfying terms of use is a prerequisite to "
-"bundle eligibility."
+msgid "At their last login, did this user meet the criteria set forth in the Library Bundle? Note that satisfying terms of use is a prerequisite to bundle eligibility."
 msgstr ""
 
 #. Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this is the heading for a Yes/No program eligibility question.
@@ -2834,18 +2492,13 @@ msgstr "Data personol"
 
 #. Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this text is in the 'Personal data' section. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/users/templates/users/editor_detail_data.html:262
-msgid ""
-"The following information is visible only to you, site administrators, "
-"publishing partners (where required), and volunteer Wikipedia Library "
-"coordinators (who have signed a Non-Disclosure Agreement)."
+msgid "The following information is visible only to you, site administrators, publishing partners (where required), and volunteer Wikipedia Library coordinators (who have signed a Non-Disclosure Agreement)."
 msgstr ""
 
 #. Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this labels a button which users can click to update or remove their personal information. Don't translate update_url.
 #: TWLight/users/templates/users/editor_detail_data.html:272
 #, python-format
-msgid ""
-"You may <a class=\"twl-links\" href=\"%(update_url)s\">update or delete</a> "
-"your data at any time."
+msgid "You may <a class=\"twl-links\" href=\"%(update_url)s\">update or delete</a> your data at any time."
 msgstr ""
 
 #. Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this labels the user's email. Don't remove the *.
@@ -2865,24 +2518,18 @@ msgstr "Cysylltiad sefydliadol"
 
 #. Translators: This message tells users that they are not eligible to access The Wikipedia Library content.
 #: TWLight/users/templates/users/eligibility_modal.html:7
-msgid ""
-"Sorry, your Wikipedia account doesn’t currently qualify to access The "
-"Wikipedia Library."
+msgid "Sorry, your Wikipedia account doesn’t currently qualify to access The Wikipedia Library."
 msgstr ""
 
 #. Translators: This message tells users that they have not agreed to the terms of use, therefore are ineligible to access the content in The Wikipedia Library.
 #: TWLight/users/templates/users/eligibility_modal.html:30
 #, python-format
-msgid ""
-"Agreed with <a href=\"%(terms)s\" class=\"text-danger\"> terms of use </a>"
+msgid "Agreed with <a href=\"%(terms)s\" class=\"text-danger\"> terms of use </a>"
 msgstr ""
 
 #: TWLight/users/templates/users/eligibility_modal.html:40
 #, python-format
-msgid ""
-"It looks like you have an active block on your account. If you meet the "
-"other criteria you may still be permitted access to the library - please <a "
-"href=\"%(contact_url)s\">contact us</a>."
+msgid "It looks like you have an active block on your account. If you meet the other criteria you may still be permitted access to the library - please <a href=\"%(contact_url)s\">contact us</a>."
 msgstr ""
 
 #. Translators: Instructions to refresh a user's data.
@@ -2922,10 +2569,7 @@ msgstr "Gosod iaith"
 
 #. Translators: This text on the user page helps users naviage to the TranslateWiki Wikipedia Library Card platform translation page.
 #: TWLight/users/templates/users/language_form.html:31
-msgid ""
-"You can help translate the tool at <a class=\"twl-links\" href=\"https://"
-"translatewiki.net/wiki/Translating:Wikipedia_Library_Card_Platform"
-"\">translatewiki.net</a>."
+msgid "You can help translate the tool at <a class=\"twl-links\" href=\"https://translatewiki.net/wiki/Translating:Wikipedia_Library_Card_Platform\">translatewiki.net</a>."
 msgstr ""
 
 #. Translators: When the user starts a new application and submits the application, the user can view the application and withdraw if need be. This changes the label for the Withdraw button.
@@ -2945,12 +2589,8 @@ msgstr "Gofynwch am adnewyddiad"
 
 #. Translators: On the page listing applications, this text explains a user they cannot renew their application since they've already requested a renewal or there aren't any renewals available.
 #: TWLight/users/templates/users/my_applications.html:79
-msgid ""
-"Renewals are either not required, not available right now, or you have "
-"already requested a renewal."
-msgstr ""
-"Nid oes angen adnewyddiadau, ddim ar gael ar hyn o bryd, neu rydych eisioes "
-"wedi gofyn am adnewyddiad."
+msgid "Renewals are either not required, not available right now, or you have already requested a renewal."
+msgstr "Nid oes angen adnewyddiadau, ddim ar gael ar hyn o bryd, neu rydych eisioes wedi gofyn am adnewyddiad."
 
 #. Translators: This text is the heading of a section in a user's profile where they can change their preferences.
 #: TWLight/users/templates/users/preferences.html:6
@@ -3013,19 +2653,12 @@ msgstr "Cyfyngu prosesu data"
 
 #. Translators: This message is displayed on the page where users can request we stop processing their data.
 #: TWLight/users/templates/users/restrict_data.html:15
-msgid ""
-"Checking this box and clicking “Restrict” will pause all processing of the "
-"data you have entered into this website. You will not be able to apply for "
-"access to resources, your applications will not be further processed, and "
-"none of your data will be altered, until you return to this page and uncheck "
-"the box. This is not the same as deleting your data."
+msgid "Checking this box and clicking “Restrict” will pause all processing of the data you have entered into this website. You will not be able to apply for access to resources, your applications will not be further processed, and none of your data will be altered, until you return to this page and uncheck the box. This is not the same as deleting your data."
 msgstr ""
 
 #. Translators: This warning message is shown to coordinators who view the data restriction page.
 #: TWLight/users/templates/users/restrict_data.html:26
-msgid ""
-"You are a coordinator on this site. If you restrict the processing of your "
-"data, your coordinator flag will be removed."
+msgid "You are a coordinator on this site. If you restrict the processing of your data, your coordinator flag will be removed."
 msgstr ""
 
 #. Translators: use the date *when you are translating*, in a language-appropriate format.
@@ -3045,24 +2678,12 @@ msgstr "Telerau Defnydd a Datganiad Preifatrwydd Cerdyn Llyfrgell Wicipedia"
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:51
-msgid ""
-"<a class=\"twl-links\" href=\"https://meta.wikimedia.org/wiki/"
-"The_Wikipedia_Library\"> The Wikipedia Library </a> has partnered with "
-"publishers around the world to allow users to access otherwise paywalled "
-"resources. This website allows Wikipedia editors to search and access these "
-"resources."
+msgid "<a class=\"twl-links\" href=\"https://meta.wikimedia.org/wiki/The_Wikipedia_Library\"> The Wikipedia Library </a> has partnered with publishers around the world to allow users to access otherwise paywalled resources. This website allows Wikipedia editors to search and access these resources."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Wikimedia Foundation should not be translated. WMF should not be translated. Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:63
-msgid ""
-"This program is administered by the Wikimedia Foundation (WMF). These terms "
-"of use and privacy notice pertain to your application for access to "
-"resources through the Wikipedia Library, your use of this website, and your "
-"access to and use of those resources. They also describe our handling of the "
-"information you provide to us in order to create and administer your "
-"Wikipedia Library account. If we make material changes to the terms, we will "
-"notify users."
+msgid "This program is administered by the Wikimedia Foundation (WMF). These terms of use and privacy notice pertain to your application for access to resources through the Wikipedia Library, your use of this website, and your access to and use of those resources. They also describe our handling of the information you provide to us in order to create and administer your Wikipedia Library account. If we make material changes to the terms, we will notify users."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
@@ -3072,37 +2693,17 @@ msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:78
-msgid ""
-"Access to resources via The Wikipedia Library is reserved for community "
-"members who have demonstrated their commitment to the Wikimedia projects, "
-"and who will use their access to these resources to improve project content. "
-"To that end, in order to be eligible for The Wikipedia Library, we require "
-"that you be registered for a user account on the projects, with at least 500 "
-"edits, six (6) months of activity, and 10+ edits in the last month. We ask "
-"that you do not request access to any publishers with a limited number of "
-"available accounts whose resources you can already access for free through "
-"your local library or university, or another institution or organization, in "
-"order to provide that opportunity to others."
+msgid "Access to resources via The Wikipedia Library is reserved for community members who have demonstrated their commitment to the Wikimedia projects, and who will use their access to these resources to improve project content. To that end, in order to be eligible for The Wikipedia Library, we require that you be registered for a user account on the projects, with at least 500 edits, six (6) months of activity, and 10+ edits in the last month. We ask that you do not request access to any publishers with a limited number of available accounts whose resources you can already access for free through your local library or university, or another institution or organization, in order to provide that opportunity to others."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:94
-msgid ""
-"Additionally, if you are currently blocked or banned from a Wikimedia "
-"project, applications to resources may be rejected or restricted. If you "
-"obtain a Wikipedia Library account, but a block or ban is subsequently "
-"instituted against you on one of the projects, you may lose access to your "
-"Wikipedia Library account."
+msgid "Additionally, if you are currently blocked or banned from a Wikimedia project, applications to resources may be rejected or restricted. If you obtain a Wikipedia Library account, but a block or ban is subsequently instituted against you on one of the projects, you may lose access to your Wikipedia Library account."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:104
-msgid ""
-"Your eligibility to access The Wikipedia Library is assessed at each login. "
-"While more than half of the library's content is provided via this automated "
-"eligibility check, access to other publisher's content may be time limited, "
-"typically lapsing after one year, after which you will usually need to apply "
-"for renewal."
+msgid "Your eligibility to access The Wikipedia Library is assessed at each login. While more than half of the library's content is provided via this automated eligibility check, access to other publisher's content may be time limited, typically lapsing after one year, after which you will usually need to apply for renewal."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
@@ -3112,47 +2713,27 @@ msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:118
-msgid ""
-"In order to apply for access to a partner resource, you must provide us with "
-"certain information, which we will use to evaluate your application. If your "
-"application is approved, we may transfer the information you have given us "
-"to the publishers whose resources you wish to access. They will either "
-"contact you with the account information directly or we will send access "
-"information to you ourselves."
+msgid "In order to apply for access to a partner resource, you must provide us with certain information, which we will use to evaluate your application. If your application is approved, we may transfer the information you have given us to the publishers whose resources you wish to access. They will either contact you with the account information directly or we will send access information to you ourselves."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:130
-msgid ""
-"In addition to the basic information you provide to us, our system will "
-"retrieve some information directly from the Wikimedia projects: your "
-"username, email address, edit count, registration date, user ID number, "
-"groups to which you belong, and any special user rights."
+msgid "In addition to the basic information you provide to us, our system will retrieve some information directly from the Wikimedia projects: your username, email address, edit count, registration date, user ID number, groups to which you belong, and any special user rights."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:140
-msgid ""
-"Each time you log in to the Wikipedia Library Card Platform, this "
-"information will be automatically updated."
+msgid "Each time you log in to the Wikipedia Library Card Platform, this information will be automatically updated."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:148
-msgid ""
-"We will ask you to provide us with some information about your history of "
-"contributions to the Wikimedia projects. Information on contribution history "
-"is optional, but will greatly assist us in evaluating your application."
+msgid "We will ask you to provide us with some information about your history of contributions to the Wikimedia projects. Information on contribution history is optional, but will greatly assist us in evaluating your application."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). WMF should not be translated. Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:157
-msgid ""
-"The information you provide when creating your account will be visible to "
-"you while on the site but not to others unless they are approved Wikipedia "
-"Library Coordinators, WMF Staff, or WMF Contractors who need access to this "
-"data in order to carry out their work with the Wikipedia Library, all of "
-"whom are subject to non-disclosure obligations."
+msgid "The information you provide when creating your account will be visible to you while on the site but not to others unless they are approved Wikipedia Library Coordinators, WMF Staff, or WMF Contractors who need access to this data in order to carry out their work with the Wikipedia Library, all of whom are subject to non-disclosure obligations."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
@@ -3162,46 +2743,32 @@ msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:171
-msgid ""
-"In order to access an individual publisher’s resources, you must agree to "
-"that publisher’s terms of use and privacy policy. You agree that you will "
-"not violate such terms and policies in connection with your use of the "
-"Wikipedia Library. Additionally, the following activities are prohibited "
-"while accessing publisher resources through the Wikipedia Library."
+msgid "In order to access an individual publisher’s resources, you must agree to that publisher’s terms of use and privacy policy. You agree that you will not violate such terms and policies in connection with your use of the Wikipedia Library. Additionally, the following activities are prohibited while accessing publisher resources through the Wikipedia Library."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:184
-msgid ""
-"Sharing your Wikipedia account, usernames, passwords, or any access codes "
-"for publisher resources with others;"
+msgid "Sharing your Wikipedia account, usernames, passwords, or any access codes for publisher resources with others;"
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:191
-msgid ""
-"Automatically scraping or downloading restricted content from publishers;"
+msgid "Automatically scraping or downloading restricted content from publishers;"
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:197
-msgid ""
-"Systematically making printed or electronic copies of multiple extracts of "
-"restricted content available for any purpose;"
+msgid "Systematically making printed or electronic copies of multiple extracts of restricted content available for any purpose;"
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:204
-msgid ""
-"Data mining metadata without permission—for example, in order to use "
-"metadata for auto-created stub articles;"
+msgid "Data mining metadata without permission—for example, in order to use metadata for auto-created stub articles;"
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:211
-msgid ""
-"Using the access you receive through the Wikipedia Library for profit by "
-"selling access to your account or resources which you have through it."
+msgid "Using the access you receive through the Wikipedia Library for profit by selling access to your account or resources which you have through it."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
@@ -3211,18 +2778,12 @@ msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:224
-msgid ""
-"Certain resources may only be accessed using an external search service, "
-"such as the EBSCO Discovery Service, or a proxy service, such as OCLC "
-"EZProxy. If you use such external search and/or proxy services, please "
-"review the applicable terms of use and privacy policies."
+msgid "Certain resources may only be accessed using an external search service, such as the EBSCO Discovery Service, or a proxy service, such as OCLC EZProxy. If you use such external search and/or proxy services, please review the applicable terms of use and privacy policies."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:234
-msgid ""
-"In addition, if you use OCLC EZProxy, please note that you may not use it "
-"for commercial purposes."
+msgid "In addition, if you use OCLC EZProxy, please note that you may not use it for commercial purposes."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
@@ -3232,120 +2793,49 @@ msgstr "Cadw a Thrin Data"
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Wikimedia Foundation should not be translated. Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:245
-msgid ""
-"The Wikimedia Foundation and our service providers use your information for "
-"the legitimate purpose of providing Wikipedia Library services in support of "
-"our charitable mission. When you apply for a Wikipedia Library account, or "
-"use your Wikipedia Library account, we may routinely collect the following "
-"information: your username, email address, edit count, registration date, "
-"user ID number, groups to which you belong, and any special user rights; "
-"your name, country of residence, and/or affiliation, if required by a "
-"partner to which you are applying; your narrative description of your "
-"contributions and reasons for applying for access to partner resources; and "
-"the date you agree to these terms of use."
+msgid "The Wikimedia Foundation and our service providers use your information for the legitimate purpose of providing Wikipedia Library services in support of our charitable mission. When you apply for a Wikipedia Library account, or use your Wikipedia Library account, we may routinely collect the following information: your username, email address, edit count, registration date, user ID number, groups to which you belong, and any special user rights; your name, country of residence, and/or affiliation, if required by a partner to which you are applying; your narrative description of your contributions and reasons for applying for access to partner resources; and the date you agree to these terms of use."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:262
 #, python-format
-msgid ""
-"Each publisher who is a member of the Wikipedia Library program requires "
-"different specific information in the application. Some publishers may "
-"request only an email address, while others request more detailed data, such "
-"as your name, location, or institutional affiliation. When you complete your "
-"application, you will only be asked to supply information required by the "
-"publishers you have chosen, and each publisher will only receive the "
-"information they require for providing you with access. Please see our <a "
-"class=\"twl-links\" href=\"%(all_partners_url)s\">partner information</a> "
-"pages to learn what information is required by each publisher to gain access "
-"to their resources."
+msgid "Each publisher who is a member of the Wikipedia Library program requires different specific information in the application. Some publishers may request only an email address, while others request more detailed data, such as your name, location, or institutional affiliation. When you complete your application, you will only be asked to supply information required by the publishers you have chosen, and each publisher will only receive the information they require for providing you with access. Please see our <a class=\"twl-links\" href=\"%(all_partners_url)s\">partner information</a> pages to learn what information is required by each publisher to gain access to their resources."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Wikimedia Foundation should not be translated. Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:277
-msgid ""
-"Some Wikipedia Library pages are visible without logging in, but you will "
-"need to log in to apply or access proprietary partner resources. We use the "
-"data provided by you via OAuth and Wikimedia API calls to assess your "
-"application for access and to process approved requests."
+msgid "Some Wikipedia Library pages are visible without logging in, but you will need to log in to apply or access proprietary partner resources. We use the data provided by you via OAuth and Wikimedia API calls to assess your application for access and to process approved requests."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:288
 #, python-format
-msgid ""
-"In order to administer the Wikipedia Library program, we will retain the "
-"application data we collect from you for three years after your most recent "
-"login, unless you delete your account, as described below. You can log in "
-"and go to <a class=\"twl-links\" href=\"%(profile_url)s\">your profile page</"
-"a> in order to see the information associated with your account, and can "
-"download it in JSON format. You may access, update, restrict, or delete this "
-"information at any time, except for the information that is automatically "
-"retrieved from the projects. If you have any questions or concerns about the "
-"handling of your data, please contact <a class=\"twl-links\" href=\"mailto:"
-"wikipedialibrary@wikimedia.org?Subject=Wikipedia%%20Library%%20Card"
-"%%20account%%20deactivation\"> wikipedialibrary@wikimedia.org </a>."
+msgid "In order to administer the Wikipedia Library program, we will retain the application data we collect from you for three years after your most recent login, unless you delete your account, as described below. You can log in and go to <a class=\"twl-links\" href=\"%(profile_url)s\">your profile page</a> in order to see the information associated with your account, and can download it in JSON format. You may access, update, restrict, or delete this information at any time, except for the information that is automatically retrieved from the projects. If you have any questions or concerns about the handling of your data, please contact <a class=\"twl-links\" href=\"mailto:wikipedialibrary@wikimedia.org?Subject=Wikipedia%%20Library%%20Card%%20account%%20deactivation\"> wikipedialibrary@wikimedia.org </a>."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:305
-msgid ""
-"If you decide to disable your Wikipedia Library account, you can use the "
-"delete button on your profile to delete certain personal information "
-"associated with your account. We will delete your real name, institutional "
-"affiliation, and country of residence. Please note that the system will "
-"retain a record of your username, the publishers to which you applied or had "
-"access, and the dates of that access. Note that deletion is not reversible. "
-"Deletion of your Wikipedia Library account may also correspond with the "
-"removal of any resource access to which you were eligible or approved. If "
-"you request the deletion of account information and later wish to apply for "
-"a new account, you will need to provide the necessary information again."
+msgid "If you decide to disable your Wikipedia Library account, you can use the delete button on your profile to delete certain personal information associated with your account. We will delete your real name, institutional affiliation, and country of residence. Please note that the system will retain a record of your username, the publishers to which you applied or had access, and the dates of that access. Note that deletion is not reversible. Deletion of your Wikipedia Library account may also correspond with the removal of any resource access to which you were eligible or approved. If you request the deletion of account information and later wish to apply for a new account, you will need to provide the necessary information again."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). WMF should not be translated. Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:321
-msgid ""
-"The Wikipedia Library is run by WMF Staff, Contractors, and approved "
-"volunteer Coordinators. The data associated with your account will be shared "
-"with the WMF staff, contractors, service providers, and volunteer "
-"coordinators who need to process the information in connection with their "
-"work for the Wikipedia Library, and who are subject to confidentiality "
-"obligations. We will also use your data for internal Wikipedia Library "
-"purposes such as distributing user surveys and account notifications, and in "
-"a depersonalized or aggregated fashion for statistical analysis and "
-"administration. Finally, we will share your information with the publishers "
-"whom you specifically select in order to provide you with access to "
-"resources. Otherwise, your information will not be shared with third "
-"parties, with the exception of the circumstances described below."
+msgid "The Wikipedia Library is run by WMF Staff, Contractors, and approved volunteer Coordinators. The data associated with your account will be shared with the WMF staff, contractors, service providers, and volunteer coordinators who need to process the information in connection with their work for the Wikipedia Library, and who are subject to confidentiality obligations. We will also use your data for internal Wikipedia Library purposes such as distributing user surveys and account notifications, and in a depersonalized or aggregated fashion for statistical analysis and administration. Finally, we will share your information with the publishers whom you specifically select in order to provide you with access to resources. Otherwise, your information will not be shared with third parties, with the exception of the circumstances described below."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). WMF should not be translated.
 #: TWLight/users/templates/users/terms.html:338
-msgid ""
-"We may disclose any collected information when required by law, when we have "
-"your permission, when needed to protect our rights, privacy, safety, users, "
-"or the general public, and when necessary to enforce these terms, WMF’s "
-"general <a class=\"twl-links\" href=\"https://foundation.wikimedia.org/wiki/"
-"Terms_of_Use\">Terms of Use</a>, or any other WMF policy."
+msgid "We may disclose any collected information when required by law, when we have your permission, when needed to protect our rights, privacy, safety, users, or the general public, and when necessary to enforce these terms, WMF’s general <a class=\"twl-links\" href=\"https://foundation.wikimedia.org/wiki/Terms_of_Use\">Terms of Use</a>, or any other WMF policy."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:349
-msgid ""
-"We take the security of your personal data seriously, and take reasonable "
-"precautions to ensure your data is protected. These precautions include "
-"access controls to limit who has access to your data and security "
-"technologies to protect data stored on the server. However, we cannot "
-"guarantee the safety of your data as it is transmitted and stored."
+msgid "We take the security of your personal data seriously, and take reasonable precautions to ensure your data is protected. These precautions include access controls to limit who has access to your data and security technologies to protect data stored on the server. However, we cannot guarantee the safety of your data as it is transmitted and stored."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:360
-msgid ""
-"Please note that these terms do not control the use and handling of your "
-"data by the publishers and service providers whose resources you access or "
-"apply to access. Please read their individual privacy policies for that "
-"information."
+msgid "Please note that these terms do not control the use and handling of your data by the publishers and service providers whose resources you access or apply to access. Please read their individual privacy policies for that information."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
@@ -3355,34 +2845,17 @@ msgstr "Nodyn Pwysig"
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Wikimedia Foundation should not be translated. Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:373
-msgid ""
-"The Wikimedia Foundation is a nonprofit organization based in San Francisco, "
-"California. The Wikipedia Library program provides access to resources held "
-"by publishers in multiple countries. If you apply for a Wikipedia Library "
-"account (whether you are inside or outside of the United States), you "
-"understand that your personal data will be collected, transferred, stored, "
-"processed, disclosed and otherwise used in the U.S. as described in this "
-"privacy policy. You also understand that your information may be transferred "
-"by us from the U.S. to other countries, which may have different or less "
-"stringent data protection laws than your country, in connection with "
-"providing services to you, including evaluating your application and "
-"securing access to your chosen publishers (locations for each publisher are "
-"outlined on their respective partner information pages)."
+msgid "The Wikimedia Foundation is a nonprofit organization based in San Francisco, California. The Wikipedia Library program provides access to resources held by publishers in multiple countries. If you apply for a Wikipedia Library account (whether you are inside or outside of the United States), you understand that your personal data will be collected, transferred, stored, processed, disclosed and otherwise used in the U.S. as described in this privacy policy. You also understand that your information may be transferred by us from the U.S. to other countries, which may have different or less stringent data protection laws than your country, in connection with providing services to you, including evaluating your application and securing access to your chosen publishers (locations for each publisher are outlined on their respective partner information pages)."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:392
-msgid ""
-"Please note that in the event of any differences in meaning or "
-"interpretation between the original English version of these terms and a "
-"translation, the original English version takes precedence."
+msgid "Please note that in the event of any differences in meaning or interpretation between the original English version of these terms and a translation, the original English version takes precedence."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Wikimedia Foundation should not be translated.
 #: TWLight/users/templates/users/terms.html:403
-msgid ""
-"See also the <a class=\"twl-links\" href=\"https://wikimediafoundation.org/"
-"wiki/Privacy_policy\">Wikimedia Foundation Privacy Policy</a>."
+msgid "See also the <a class=\"twl-links\" href=\"https://wikimediafoundation.org/wiki/Privacy_policy\">Wikimedia Foundation Privacy Policy</a>."
 msgstr ""
 
 #. Translators: This is the second to last line of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
@@ -3402,11 +2875,7 @@ msgstr "Sefydliad Wicimedia"
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:426
-msgid ""
-"By checking this box and clicking “Submit”, you agree that you have read the "
-"above terms and that you will adhere to the terms of use in your application "
-"to and use of the The Wikipedia Library, and the publishers’ services to "
-"which you gain access through The Wikipedia Library program."
+msgid "By checking this box and clicking “Submit”, you agree that you have read the above terms and that you will adhere to the terms of use in your application to and use of the The Wikipedia Library, and the publishers’ services to which you gain access through The Wikipedia Library program."
 msgstr ""
 
 #: TWLight/users/templates/users/user_collection_tile.html:32
@@ -3459,29 +2928,18 @@ msgstr "Dileu'r holl ddata"
 
 #. Translators: This message is displayed on the page where users can request the deletion of their data.
 #: TWLight/users/templates/users/user_confirm_delete.html:17
-msgid ""
-"<b>Warning:</b> Performing this action will delete your Wikipedia Library "
-"Card user account and all associated applications. This process is not "
-"reversible. You may lose any partner accounts you were granted, and will not "
-"be able to renew those accounts or apply for new ones."
+msgid "<b>Warning:</b> Performing this action will delete your Wikipedia Library Card user account and all associated applications. This process is not reversible. You may lose any partner accounts you were granted, and will not be able to renew those accounts or apply for new ones."
 msgstr ""
 
 #. Translators: this should show up for people who log in with a username/password and not OAuth, so we don't know what their Wikipedia identity is.
-#.
 #: TWLight/users/templates/users/user_detail.html:12
 #, python-format
-msgid ""
-"Hi, %(username)s! You don't have a Wikipedia editor profile attached to your "
-"account here, so you are probably a site administrator."
+msgid "Hi, %(username)s! You don't have a Wikipedia editor profile attached to your account here, so you are probably a site administrator."
 msgstr ""
 
 #. Translators: In the unlikely scenario that someone is able to register an account without using OAuth (thus leaving us without some of the information required for applications), users will see this message, encouraging them to re-register.
 #: TWLight/users/templates/users/user_detail.html:20
-msgid ""
-"If you aren't a site administrator, something weird has happened. You won't "
-"be able to apply for access without a Wikipedia editor profile. You should "
-"log out and create a new account by logging in via OAuth, or contact a site "
-"administrator for help."
+msgid "If you aren't a site administrator, something weird has happened. You won't be able to apply for access without a Wikipedia editor profile. You should log out and create a new account by logging in via OAuth, or contact a site administrator for help."
 msgstr ""
 
 #. Translators: Labels a sections where coordinators can select their email preferences.
@@ -3492,17 +2950,12 @@ msgstr "Cydlynwyr yn unig"
 #. Translators: This message is shown on user's own profile page, encouraging them to make sure their information is up to date, so that account coordinators can use the information to judge applications.
 #: TWLight/users/views.py:176
 #, python-brace-format
-msgid ""
-"Please <a class='twl-links' href='{url}'>update your contributions</a> to "
-"Wikipedia to help coordinators evaluate your applications."
+msgid "Please <a class='twl-links' href='{url}'>update your contributions</a> to Wikipedia to help coordinators evaluate your applications."
 msgstr ""
 
 #. Translators: Coordinators are shown this message when they unselect all three types of reminder email options under preferences.
 #: TWLight/users/views.py:288
-msgid ""
-"You have chosen not to receive reminder emails. As a coordinator, you should "
-"receive at least one type of reminder emails, so consider changing your "
-"preferences."
+msgid "You have chosen not to receive reminder emails. As a coordinator, you should receive at least one type of reminder emails, so consider changing your preferences."
 msgstr ""
 
 #. Translators: Coordinators are shown this message when they make changes to their reminder email options under preferences.
@@ -3536,9 +2989,7 @@ msgstr ""
 
 #. Translators: If the user has not filled out their email, they can browse the website but cannot apply for access to resources.
 #: TWLight/users/views.py:487
-msgid ""
-"Your email is blank. You can still explore the site, but you won't be able "
-"to apply for access to partner resources without an email."
+msgid "Your email is blank. You can still explore the site, but you won't be able to apply for access to partner resources without an email."
 msgstr ""
 
 #. Translators: This message is shown once the access to a partner has successfully been returned.
@@ -3571,31 +3022,3 @@ msgstr "Dim blociau gweithredol"
 msgid "10+ edits in the last 30 days"
 msgstr "10+ golygiad yn ystod y 30 diwrnod diwethaf"
 
-#: tests/shunit/data/bad_i18n_comment_1.py:3
-#: tests/shunit/data/bad_i18n_newline_1.py:5
-msgid "1"
-msgstr ""
-
-#. Translators: Lorem ipsum dolor sit amet, consectetur adipiscing elit. Mauris vitae ipsum ut purus faucibus pretium. Proin tempus neque et aliquet consectetur. Ut egestas sapien in consectetur sagittis. Mauris neque lacus, dapibus non viverra vitae, interdum ut aenean ipsum.
-#. Translators: Lorem ipsum dolor sit amet, consectetur adipiscing elit. Mauris vitae ipsum ut purus faucibus pretium. Proin tempus neque et aliquet consectetur. Ut egestas sapien in consectetur sagittis. Mauris neque lacus, dapibus non.
-#: tests/shunit/data/bad_i18n_comment_2.py:4
-#: tests/shunit/data/bad_i18n_newline_2.py:5 tests/shunit/data/good_i18n_1.py:2
-#: tests/shunit/data/good_i18n_2.py:2
-msgid "2"
-msgstr ""
-
-#: tests/shunit/data/bad_i18n_newline_3.py:5
-msgid "3"
-msgstr ""
-
-#: tests/shunit/data/bad_i18n_newline_4.py:5
-msgid "4"
-msgstr ""
-
-#: tests/shunit/data/bad_i18n_newline_5.py:5
-msgid "5"
-msgstr ""
-
-#: tests/shunit/data/bad_i18n_newline_6.py:5
-msgid "6"
-msgstr ""

--- a/locale/da/LC_MESSAGES/django.po
+++ b/locale/da/LC_MESSAGES/django.po
@@ -13,10 +13,11 @@
 # Author: Sarrus
 msgid ""
 msgstr ""
+""
 "Project-Id-Version: Wikipedia Library Card Platform - Website\n"
-"Report-Msgid-Bugs-To: wikipedialibrary@wikimedia.org\n"
+"Report-Msgid-Bugs-To: translatewiki.net\n"
 "POT-Creation-Date: 2024-07-11 20:54+0000\n"
-"PO-Revision-Date: 2024-07-11 12:30:13+0000\n"
+"PO-Revision-Date: 2024-07-15 12:29:13+0000\n"
 "Language: da\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
@@ -48,12 +49,8 @@ msgstr "Om dig"
 #. Translators: This note appears in a section of a form where we ask users to enter info (like country of residence) when applying for resource access.
 #: TWLight/applications/forms.py:179
 #, python-brace-format
-msgid ""
-"<p><small><i>Your personal data will be processed according to our <a "
-"class='twl-links' href='{terms_url}'> privacy policy</a>.</i></small></p>"
-msgstr ""
-"<p><small><i>Dine personlige data vil blive behandlet i forhold til vores <a "
-"class='twl-links' href='{terms_url}'>privatlivs politik</a>.</i></small></p>"
+msgid "<p><small><i>Your personal data will be processed according to our <a class='twl-links' href='{terms_url}'> privacy policy</a>.</i></small></p>"
+msgstr "<p><small><i>Dine personlige data vil blive behandlet i forhold til vores <a class='twl-links' href='{terms_url}'>privatlivs politik</a>.</i></small></p>"
 
 #. Translators: This is the title of the application form page, where users enter information required for the application. It lets the user know which partner application they are entering data for. {partner}
 #: TWLight/applications/forms.py:189
@@ -94,11 +91,8 @@ msgstr "E-mailadressen for din konto på partneres website"
 #. Translators: This labels a choice field where users will have to select the number of months they wish to have their access for as part of the application renewal confirmation.
 #. Translators: When filling out an application, users may be required to enter the length of the account (expiry) they wish to have for proxy partners.
 #: TWLight/applications/forms.py:339 TWLight/applications/helpers.py:100
-msgid ""
-"The number of months you wish to have this access for before renewal is "
-"required"
-msgstr ""
-"Antallet af måneder du ønsker at have denne adgang før fornyelse er påkrævet"
+msgid "The number of months you wish to have this access for before renewal is required"
+msgstr "Antallet af måneder du ønsker at have denne adgang før fornyelse er påkrævet"
 
 #. Translators: When filling out an application, users may need to specify their name
 #: TWLight/applications/helpers.py:81
@@ -186,9 +180,7 @@ msgstr "E-mail"
 
 #. Translators: This comment is added to pending applications when our terms of use change.
 #: TWLight/applications/management/commands/notify_applicants_tou_changes.py:54
-msgid ""
-"Our terms of use have changed. Your applications will not be processed until "
-"you log in and agree to our updated terms."
+msgid "Our terms of use have changed. Your applications will not be processed until you log in and agree to our updated terms."
 msgstr ""
 
 #. Translators: This is the status of an application that has not yet been reviewed.
@@ -255,25 +247,17 @@ msgstr "AdgangsURL: {access_url}"
 
 #. Translators: This text goes into account approval emails in the case that we need to send the user's details to a publisher for manual account setup.
 #: TWLight/applications/models.py:331
-msgid ""
-"You can expect to receive access details within a week or two once it has "
-"been processed."
-msgstr ""
-"Du kan forvente at modtage adgangsoplysninger inden for en uge eller to, når "
-"de er blevet behandlet."
+msgid "You can expect to receive access details within a week or two once it has been processed."
+msgstr "Du kan forvente at modtage adgangsoplysninger inden for en uge eller to, når de er blevet behandlet."
 
 #. Translators: This comment is added to open applications when a partner joins the Library Bundle, which does not require applications.
 #: TWLight/applications/signals.py:247
-msgid ""
-"This partner joined the Library Bundle, which does not require applications. "
-"This application will be marked as invalid."
+msgid "This partner joined the Library Bundle, which does not require applications. This application will be marked as invalid."
 msgstr ""
 
 #. Translators: This is shown to users if the application is to a partner for which we have run out of available accounts. The application is therefore on a 'waitlist', and will be reviewed when more accounts are available.
 #: TWLight/applications/templates/applications/application_evaluation.html:29
-msgid ""
-"This application is on the waitlist because this partner does not have any "
-"access grants available at this time."
+msgid "This application is on the waitlist because this partner does not have any access grants available at this time."
 msgstr ""
 
 #. Translators: This message is shown on pages where coordinators can see personal information about applicants.
@@ -281,9 +265,7 @@ msgstr ""
 #: TWLight/applications/templates/applications/application_list_include.html:6
 #: TWLight/applications/templates/applications/send_partner.html:45
 #: TWLight/resources/templates/resources/partner_users.html:18
-msgid ""
-"Coordinators: This page may contain personal information such as real names "
-"and email addresses. Please remember that this information is confidential."
+msgid "Coordinators: This page may contain personal information such as real names and email addresses. Please remember that this information is confidential."
 msgstr ""
 
 #. Translators: This is the title of the application page shown to users who are a coordinator, and are able to accept or reject the application.
@@ -293,9 +275,7 @@ msgstr "Evaluer ansøgning"
 
 #. Translators: This text is shown to coordinators on application pages if the applicant has restricted processing of their data.
 #: TWLight/applications/templates/applications/application_evaluation.html:42
-msgid ""
-"This user has requested a restriction on the processing of their data, so "
-"you cannot change the status of their application."
+msgid "This user has requested a restriction on the processing of their data, so you cannot change the status of their application."
 msgstr ""
 
 #. Translators: This is the title of the application page shown to users who are not a coordinator.
@@ -370,9 +350,7 @@ msgstr "Ukendt"
 
 #. Translators: This is the text displayed to coordinators when an applicant has no country of residence in their profile.
 #: TWLight/applications/templates/applications/application_evaluation.html:123
-msgid ""
-"Please request the applicant add their country of residence to their profile "
-"before proceeding further."
+msgid "Please request the applicant add their country of residence to their profile before proceeding further."
 msgstr ""
 
 #. Translators: This labels the section of an application showing the total number of accounts available for a partner or their collection.
@@ -383,9 +361,7 @@ msgstr "Konti tilgængelige"
 #. Translators: This labels the section of an application showing whether the user had agreed to the terms of use or not.
 #: TWLight/applications/templates/applications/application_evaluation.html:145
 #, python-format
-msgid ""
-"Has agreed to the site's <a class=\"twl-links\" href=\"%(terms_url)s\">terms "
-"of use</a>?"
+msgid "Has agreed to the site's <a class=\"twl-links\" href=\"%(terms_url)s\">terms of use</a>?"
 msgstr ""
 
 #. Translators: Displayed to coordinators when they've agreed to the terms of use.
@@ -421,9 +397,7 @@ msgstr "Nej"
 
 #. Translators: This is the text displayed to coordinators when an applicant has not agreed to the terms of use.
 #: TWLight/applications/templates/applications/application_evaluation.html:159
-msgid ""
-"Please request the applicant agree to the site's terms of use before "
-"approving this application."
+msgid "Please request the applicant agree to the site's terms of use before approving this application."
 msgstr ""
 
 #. Translators: This labels the section of an application containing the user's motivation for wanting access to this resource.
@@ -444,10 +418,8 @@ msgstr ""
 #. Translators: This message is shown next to the 'Renewal of existing access grant?' label if the application is a renewal. Don't translate HTML tags or parent_url.
 #: TWLight/applications/templates/applications/application_evaluation.html:195
 #, python-format
-msgid ""
-"Yes (<a class=\"twl-links\" href=\"%(parent_url)s\">previous application</a>)"
-msgstr ""
-"Ja (<a class=\"twl-links\" href=\"%(parent_url)s\">tidligere ansøgning</a>)"
+msgid "Yes (<a class=\"twl-links\" href=\"%(parent_url)s\">previous application</a>)"
+msgstr "Ja (<a class=\"twl-links\" href=\"%(parent_url)s\">tidligere ansøgning</a>)"
 
 #. Translators: This labels the section of the application showing the length of access remaining on the user's previous authorization.
 #: TWLight/applications/templates/applications/application_evaluation.html:208
@@ -482,9 +454,7 @@ msgstr "Tilføj kommentar"
 
 #. Translators: On an application page, this text tells users that the comments posted on the application are visible to coordinators and the submitting user only.
 #: TWLight/applications/templates/applications/application_evaluation.html:297
-msgid ""
-"Comments are visible to all coordinators and to the editor who submitted "
-"this application."
+msgid "Comments are visible to all coordinators and to the editor who submitted this application."
 msgstr ""
 
 #. Translators: This is the title of the section of an application page which lists information about the user who submitted the application.
@@ -699,12 +669,7 @@ msgstr ""
 
 #: TWLight/applications/templates/applications/apply.html:20
 #, python-format
-msgid ""
-"If your application is successful we may share your email address with "
-"%(partner)s. This is required to set up your access to their resources. By "
-"submitting this form you agree to allow your email address to be shared with "
-"%(partner)s if your application is successful, for the purposes of account "
-"setup."
+msgid "If your application is successful we may share your email address with %(partner)s. This is required to set up your access to their resources. By submitting this form you agree to allow your email address to be shared with %(partner)s if your application is successful, for the purposes of account setup."
 msgstr ""
 
 #. Translators: This message is displayed on the page where users can confirm their renewal. Please do not translate partner.
@@ -733,9 +698,7 @@ msgstr "Hvilke ressource kunne du tænke dig at tilgå?"
 
 #. Translators: This text explains that Library Bundle partners are not shown in this list.
 #: TWLight/applications/templates/applications/request_for_application.html:26
-msgid ""
-"Library Bundle partners are not shown as eligibility is determined "
-"automatically."
+msgid "Library Bundle partners are not shown as eligibility is determined automatically."
 msgstr ""
 
 #. Translators: On the page where users can apply for multiple partners, this message shows next to the partner name, taking them to the full application page when clicked.
@@ -750,10 +713,7 @@ msgstr ""
 
 #. Translators: the HTML is so that the word 'waitlisted' will look the same as it does in the page above; please translate 'waitlisted' the same way you did elsewhere in this file.
 #: TWLight/applications/templates/applications/request_for_application.html:74
-msgid ""
-"You can apply to <span class=\"badge badge-warning\">Waitlisted</span> "
-"partners, but they don't have access grants available right now. We will "
-"process those applications when access becomes available."
+msgid "You can apply to <span class=\"badge badge-warning\">Waitlisted</span> partners, but they don't have access grants available right now. We will process those applications when access becomes available."
 msgstr ""
 
 #. Translators: On the page where coordinators can see approved applications which have not had their details sent to the partner, this message shows when there are applications ready to be processed.
@@ -775,9 +735,7 @@ msgstr ""
 #. Translators: This message is shown when applications exceed the number of accounts available.
 #: TWLight/applications/templates/applications/send_partner.html:54
 #, python-format
-msgid ""
-"Application(s) for %(object)s, if sent, will exceed the total available "
-"accounts for the partner. Please proceed at your own discretion."
+msgid "Application(s) for %(object)s, if sent, will exceed the total available accounts for the partner. Please proceed at your own discretion."
 msgstr ""
 
 #. Translators: When viewing the list of applications ready to be sent for a particular partner, this is instructions for the coordinator to click the 'mark as sent' button after they have sent the information.
@@ -794,9 +752,7 @@ msgstr[1] "Contacts"
 
 #. Translators: When viewing the list of applications ready to be sent for a particular partner, this message shows if there is no information about who the applications should be sent to. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/applications/templates/applications/send_partner.html:89
-msgid ""
-"Whoops, we don't have any listed contacts. Please notify Wikipedia Library "
-"administrators."
+msgid "Whoops, we don't have any listed contacts. Please notify Wikipedia Library administrators."
 msgstr ""
 
 #. Translators: When viewing the list of applications ready to be sent for a particular partner, this is the title of the section containing the information about those applications.
@@ -812,9 +768,7 @@ msgstr "Marker som sendt"
 
 #. Translators: This text guides coordinators in using the code sending interface for approved applications.
 #: TWLight/applications/templates/applications/send_partner.html:152
-msgid ""
-"Use the dropdown menus to denote which editor will receive each code. Access "
-"codes will be sent to users automatically."
+msgid "Use the dropdown menus to denote which editor will receive each code. Access codes will be sent to users automatically."
 msgstr ""
 
 #. Translators: This labels a drop-down selection where staff can assign an access code to a user.
@@ -830,18 +784,13 @@ msgstr ""
 #. Translators: When a user applies for a set of resources, they receive this message if none are currently available. They are instead placed on a 'waitlist' for later approval.
 #. Translators: When a user renews their resource, they receive this message if none are currently available. They are instead placed on a 'waitlist' for later approval.
 #: TWLight/applications/views.py:140 TWLight/applications/views.py:1282
-msgid ""
-"This partner does not have any access grants available at this time. You may "
-"still apply for access; your application will be reviewed when access grants "
-"become available."
+msgid "This partner does not have any access grants available at this time. You may still apply for access; your application will be reviewed when access grants become available."
 msgstr ""
 
 #. Translators: This message is shown to users once they've successfully submitted their application for review.
 #: TWLight/applications/views.py:163
 #, python-brace-format
-msgid ""
-"Your application has been submitted for review. Head over to <a "
-"href='{applications_url}'>My Applications</a> to view the status."
+msgid "Your application has been submitted for review. Head over to <a href='{applications_url}'>My Applications</a> to view the status."
 msgstr ""
 
 #. Translators: This text is displayed to users when the user has chosen to restrict data and is trying to apply for multiple partners
@@ -890,16 +839,12 @@ msgstr "Sendte ansøgninger"
 
 #. Translators: After a coordinator has changed the status of an application to APPROVED, if the corresponding partner/collection is waitlisted this message appears.
 #: TWLight/applications/views.py:756
-msgid ""
-"Cannot approve application as partner with proxy authorization method is "
-"waitlisted."
+msgid "Cannot approve application as partner with proxy authorization method is waitlisted."
 msgstr ""
 
 #. Translators: After a coordinator has changed the status of an application to APPROVED, if the corresponding partner/collection has no accounts for distribution, this message appears.
 #: TWLight/applications/views.py:780
-msgid ""
-"Cannot approve application as partner with proxy authorization method is "
-"waitlisted and (or) has zero accounts available for distribution."
+msgid "Cannot approve application as partner with proxy authorization method is waitlisted and (or) has zero accounts available for distribution."
 msgstr ""
 
 #. Translators: This message appears on an "access denied" screen that stops users who attempt to authorize an editor to access a resource during a time period for which they are already authorized.
@@ -910,11 +855,7 @@ msgstr ""
 #. Translators: This message is shown to users when they access an application page of a now Bundle partner (new applications aren't allowed for Bundle partners and the status of old applications cannot be modified)
 #: TWLight/applications/views.py:857
 #, python-brace-format
-msgid ""
-"This application cannot be modified since this partner is now part of our <a "
-"href='{bundle}'>bundle access</a>. If you are eligible, you can access this "
-"resource from <a href='{library}'>your library</a>. <a "
-"href='{contact}'>Contact us</a> if you have any questions."
+msgid "This application cannot be modified since this partner is now part of our <a href='{bundle}'>bundle access</a>. If you are eligible, you can access this resource from <a href='{library}'>your library</a>. <a href='{contact}'>Contact us</a> if you have any questions."
 msgstr ""
 
 #. Translators: this lets a reviewer set the status of a single application.
@@ -924,9 +865,7 @@ msgstr ""
 
 #. Translators: This warning is message is shown to applicants when the number of pending applications is greater than the number of accounts available.
 #: TWLight/applications/views.py:891
-msgid ""
-"There are more pending applications than available accounts. Your "
-"application might get waitlisted."
+msgid "There are more pending applications than available accounts. Your application might get waitlisted."
 msgstr ""
 
 #. Translators: this message is shown to coordinators who attempt to change an application's Status from INVALID to any other Status.
@@ -946,11 +885,7 @@ msgstr ""
 
 #. Translators: After a coordinator has changed the status of a number of applications to APPROVED, if the corresponding partner(s) is/are waitlisted or has no accounts for distribution, this message appears.
 #: TWLight/applications/views.py:1051
-msgid ""
-"Cannot approve application(s) {} as partner(s) with proxy authorization "
-"method is/are waitlisted and (or) has/have not enough accounts available. If "
-"not enough accounts are available, prioritise the applications and then "
-"approve applications equal to the accounts available."
+msgid "Cannot approve application(s) {} as partner(s) with proxy authorization method is/are waitlisted and (or) has/have not enough accounts available. If not enough accounts are available, prioritise the applications and then approve applications equal to the accounts available."
 msgstr ""
 
 #. Translators: This message is shown to coordinators who attempt to assign the same access code to multiple users.
@@ -965,9 +900,7 @@ msgstr "Alle valgte ansøgninger er blevet markeret som sendt."
 
 #. Translators: When a user tries to renew their resource, they receive this message if the partner is not available.
 #: TWLight/applications/views.py:1272
-msgid ""
-"Cannot renew application at this time as partner is not available. Please "
-"check back later, or contact us for more information."
+msgid "Cannot renew application at this time as partner is not available. Please check back later, or contact us for more information."
 msgstr ""
 
 #. Translators: This message is displayed when an attempt by a user to renew an application has been denied for some reason.
@@ -978,16 +911,12 @@ msgstr ""
 
 #. Translators: If a user requests the renewal of their account, but it wasn't renewed, this message is shown to them.
 #: TWLight/applications/views.py:1385
-msgid ""
-"This object cannot be renewed. (This probably means that you have already "
-"requested that it be renewed.)"
+msgid "This object cannot be renewed. (This probably means that you have already requested that it be renewed.)"
 msgstr ""
 
 #. Translators: If a user requests the renewal of their account, this message is shown to them.
 #: TWLight/applications/views.py:1395
-msgid ""
-"Your renewal request has been received. A coordinator will review your "
-"request."
+msgid "Your renewal request has been received. A coordinator will review your request."
 msgstr ""
 
 #. Translators: This labels a textfield where users can enter their email ID.
@@ -997,9 +926,7 @@ msgstr "Din e-mail"
 
 #. Translators: This is the help text for the email field in the contact us form letting users know the field is updated by value pulled from their respective user profiles.
 #: TWLight/emails/forms.py:21
-msgid ""
-"This field is automatically updated with the email from your <a class='twl-"
-"links' href='{}'>user profile</a>."
+msgid "This field is automatically updated with the email from your <a class='twl-links' href='{}'>user profile</a>."
 msgstr ""
 
 #. Translators: This labels a textfield where users can enter their email message.
@@ -1023,19 +950,13 @@ msgstr "Indsend"
 #. Translators: This email is sent to users with their access code. Don't translate Jinja variables in curly braces like user or partner. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/access_code_email-body-html.html:5
 #, python-format
-msgid ""
-"<p>Your approved application to %(partner)s has now been finalised. Your "
-"access code or login details can be found below:</p> <p><b>%(access_code)s</"
-"b></p> <p>%(user_instructions)s</p>"
+msgid "<p>Your approved application to %(partner)s has now been finalised. Your access code or login details can be found below:</p> <p><b>%(access_code)s</b></p> <p>%(user_instructions)s</p>"
 msgstr ""
 
 #. Translators: This email is sent to users with their access code. Don't translate Jinja variables in curly braces like user or partner. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/access_code_email-body-text.html:3
 #, python-format
-msgid ""
-"Your approved application to %(partner)s has now been finalised. Your access "
-"code or login details can be found below: %(access_code)s "
-"%(user_instructions)s"
+msgid "Your approved application to %(partner)s has now been finalised. Your access code or login details can be found below: %(access_code)s %(user_instructions)s"
 msgstr ""
 
 #. Translators: This is the subject line of an email sent to users with their access code.
@@ -1046,23 +967,13 @@ msgstr "Din adgangskode til Wikipedia biblioteket"
 #. Translators: This email is sent to users when their application is approved. Don't translate Jinja variables in curly braces like user or partner; don't translate html tags either. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/approval_notification-body-html.html:5
 #, python-format
-msgid ""
-"<p>Dear %(user)s,</p> <p>Thank you for applying for access to %(partner)s "
-"resources through The Wikipedia Library. We are happy to inform you that "
-"your application has been approved.</p> <p>%(user_instructions)s</p> <p>You "
-"can view the collections you're authorized to access at My Library: "
-"%(link)s</p> <p>Cheers!</p> <p>The Wikipedia Library</p>"
+msgid "<p>Dear %(user)s,</p> <p>Thank you for applying for access to %(partner)s resources through The Wikipedia Library. We are happy to inform you that your application has been approved.</p> <p>%(user_instructions)s</p> <p>You can view the collections you're authorized to access at My Library: %(link)s</p> <p>Cheers!</p> <p>The Wikipedia Library</p>"
 msgstr ""
 
 #. Translators: This email is sent to users when their application is approved. Don't translate Jinja variables in curly braces like user or partner. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/approval_notification-body-text.html:3
 #, python-format
-msgid ""
-"Dear %(user)s, Thank you for applying for access to %(partner)s resources "
-"through The Wikipedia Library. We are happy to inform you that your "
-"application has been approved. %(user_instructions)s You can view the "
-"collections you're authorized to access at My Library: %(link)s Cheers! The "
-"Wikipedia Library"
+msgid "Dear %(user)s, Thank you for applying for access to %(partner)s resources through The Wikipedia Library. We are happy to inform you that your application has been approved. %(user_instructions)s You can view the collections you're authorized to access at My Library: %(link)s Cheers! The Wikipedia Library"
 msgstr ""
 
 #. Translators: This is the subject of an email which is sent to users when their application has been approved. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
@@ -1073,19 +984,13 @@ msgstr "Din Wikipedia bibliotek ansøgning er blevet godkendt."
 #. Translators: This email is sent to coordinators when a comment is left on an application they are processing. Don't translate Jinja variables in curly braces like user or partner. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/comment_notification_coordinator-body-html.html:5
 #, python-format
-msgid ""
-"<p style=\"color: #500050\">%(submit_date)s - %(commenter)s</p> "
-"<blockquote><p>%(comment)s</p></blockquote> <p>Please reply to these at: <a "
-"href=\"%(app_url)s\">%(app_url)s</a></p> <p>Best,</p> <p>The Wikipedia "
-"Library</p>"
+msgid "<p style=\"color: #500050\">%(submit_date)s - %(commenter)s</p> <blockquote><p>%(comment)s</p></blockquote> <p>Please reply to these at: <a href=\"%(app_url)s\">%(app_url)s</a></p> <p>Best,</p> <p>The Wikipedia Library</p>"
 msgstr ""
 
 #. Translators: This email is sent to coordinators when a comment is left on an application they are processing. Don't translate Jinja variables in curly braces like user or partner. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/comment_notification_coordinator-body-text.html:3
 #, python-format
-msgid ""
-"%(submit_date)s - %(commenter)s %(comment)s Please reply to this at: "
-"%(app_url)s Best, The Wikipedia Library"
+msgid "%(submit_date)s - %(commenter)s %(comment)s Please reply to this at: %(app_url)s Best, The Wikipedia Library"
 msgstr ""
 
 #. Translators: This is the subject line of an email sent to coordinators when a comment is left on an application they processed.
@@ -1096,19 +1001,13 @@ msgstr ""
 #. Translators: This email is sent to users when they receive a comment on their application. Don't translate Jinja variables in curly braces like user or partner; don't translate html tags either. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/comment_notification_editors-body-html.html:5
 #, python-format
-msgid ""
-"<p style=\"color: #500050\">%(submit_date)s - %(commenter)s</p> "
-"<blockquote><p>%(comment)s</p></blockquote> <p>Please reply to these at <a "
-"href=\"%(app_url)s\">%(app_url)s</a> so we can evaluate your application.</"
-"p> <p>Best,</p> <p>The Wikipedia Library</p>"
+msgid "<p style=\"color: #500050\">%(submit_date)s - %(commenter)s</p> <blockquote><p>%(comment)s</p></blockquote> <p>Please reply to these at <a href=\"%(app_url)s\">%(app_url)s</a> so we can evaluate your application.</p> <p>Best,</p> <p>The Wikipedia Library</p>"
 msgstr ""
 
 #. Translators: This email is sent to users when they receive a comment on their application. Don't translate Jinja variables in curly braces like user or partner. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/comment_notification_editors-body-text.html:3
 #, python-format
-msgid ""
-"%(submit_date)s - %(commenter)s %(comment)s Please reply to these at: "
-"%(app_url)s so we can evaluate your application. Best, The Wikipedia Library"
+msgid "%(submit_date)s - %(commenter)s %(comment)s Please reply to these at: %(app_url)s so we can evaluate your application. Best, The Wikipedia Library"
 msgstr ""
 
 #. Translators: This is the subject line of an email sent to users who have a comment added to one of their applications. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
@@ -1119,18 +1018,13 @@ msgstr "Ny kommentar på din Wikipedia bibliotek ansøgning"
 #. Translators: This email is sent to users when an application they commented on receives another comment. Don't translate Jinja variables in curly braces like app_url; don't translate html tags either. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/comment_notification_others-body-html.html:5
 #, python-format
-msgid ""
-"<p style=\"color: #500050\">%(submit_date)s - %(commenter)s</p> "
-"<blockquote><p>%(comment)s</p></blockquote> See it at <a href=\"%(app_url)s"
-"\">%(app_url)s</a>. Thanks for helping review Wikipedia Library applications!"
+msgid "<p style=\"color: #500050\">%(submit_date)s - %(commenter)s</p> <blockquote><p>%(comment)s</p></blockquote> See it at <a href=\"%(app_url)s\">%(app_url)s</a>. Thanks for helping review Wikipedia Library applications!"
 msgstr ""
 
 #. Translators: This email is sent to users when an application they commented on receives another comment. Don't translate Jinja variables in curly braces like app_url. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/comment_notification_others-body-text.html:3
 #, python-format
-msgid ""
-"%(submit_date)s - %(commenter)s %(comment)s See it at: %(app_url)s Thanks "
-"for helping review Wikipedia Library applications!"
+msgid "%(submit_date)s - %(commenter)s %(comment)s See it at: %(app_url)s Thanks for helping review Wikipedia Library applications!"
 msgstr ""
 
 #. Translators: This is the subject line of an email sent to users who have a comment added to an application they also commented on. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
@@ -1141,10 +1035,7 @@ msgstr ""
 #. Translators: This text is part of a scheduled reminder email sent to coordinators who have applications requiring action. Don't translate Jinja variables in curly braces like total_apps, or user.
 #: TWLight/emails/templates/emails/coordinator_reminder_notification-body-html.html:5
 #, python-format
-msgid ""
-"<p>Dear %(user)s,</p> <p>Our records indicate that you are the designated "
-"coordinator for partners that have a total of %(total_apps)s applications.</"
-"p>"
+msgid "<p>Dear %(user)s,</p> <p>Our records indicate that you are the designated coordinator for partners that have a total of %(total_apps)s applications.</p>"
 msgstr ""
 
 #. Translators: Breakdown as in 'cost breakdown'; analysis.
@@ -1183,31 +1074,19 @@ msgstr[1] "Antal godkendte ansøgninger"
 #. Translators: This text is part of a scheduled reminder email sent to coordinators who have applications requiring action. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library). Don't translate Jinja variables in curly braces like link; don't translate email addresses or html tags either.
 #: TWLight/emails/templates/emails/coordinator_reminder_notification-body-html.html:39
 #, python-format
-msgid ""
-"<p>This is a gentle reminder that you may review applications at <a href="
-"\"%(link)s\">%(link)s</a>.</p> <p>You can customise your reminders under "
-"'preferences' in your user profile.</p> <p>If you received this message in "
-"error, drop us a line at wikipedialibrary@wikimedia.org.</p> <p>Thanks for "
-"helping review Wikipedia Library applications!</p>"
+msgid "<p>This is a gentle reminder that you may review applications at <a href=\"%(link)s\">%(link)s</a>.</p> <p>You can customise your reminders under 'preferences' in your user profile.</p> <p>If you received this message in error, drop us a line at wikipedialibrary@wikimedia.org.</p> <p>Thanks for helping review Wikipedia Library applications!</p>"
 msgstr ""
 
 #. Translators: This text is part of a scheduled reminder email sent to coordinators who have applications requiring action. Don't translate Jinja variables in curly braces like total_apps, or user.
 #: TWLight/emails/templates/emails/coordinator_reminder_notification-body-text.html:3
 #, python-format
-msgid ""
-"Dear %(user)s, Our records indicate that you are the designated coordinator "
-"for partners that have a total of %(total_apps)s applications."
+msgid "Dear %(user)s, Our records indicate that you are the designated coordinator for partners that have a total of %(total_apps)s applications."
 msgstr ""
 
 #. Translators: This text is part of a scheduled reminder email sent to coordinators who have applications requiring action. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library). Don't translate Jinja variables in curly braces like link; don't translate the email address either.
 #: TWLight/emails/templates/emails/coordinator_reminder_notification-body-text.html:38
 #, python-format
-msgid ""
-"This is a gentle reminder that you may review applications at: %(link)s. You "
-"can customise your reminders under 'preferences' in your user profile. If "
-"you received this message in error, drop us a line at: "
-"wikipedialibrary@wikimedia.org Thanks for helping review Wikipedia Library "
-"applications!"
+msgid "This is a gentle reminder that you may review applications at: %(link)s. You can customise your reminders under 'preferences' in your user profile. If you received this message in error, drop us a line at: wikipedialibrary@wikimedia.org Thanks for helping review Wikipedia Library applications!"
 msgstr ""
 
 #. Translators: This is the subject line of a scheduled reminder email sent to coordinators who have applications to review. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library). Do not translate items in curly braces.
@@ -1218,22 +1097,13 @@ msgstr ""
 #. Translators: This email is sent to users when their application is rejected. Don't translate Jinja variables in curly braces like user or partner; don't translate html tags either. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/rejection_notification-body-html.html:5
 #, python-format
-msgid ""
-"<p>Dear %(user)s,</p> <p>Thank you for applying for access to %(partner)s "
-"resources through The Wikipedia Library. Unfortunately at this time your "
-"application has not been approved. You can view your application and review "
-"comments at <a href=\"%(app_url)s\">%(app_url)s</a>.</p> <p>Best,</p> <p>The "
-"Wikipedia Library</p>"
+msgid "<p>Dear %(user)s,</p> <p>Thank you for applying for access to %(partner)s resources through The Wikipedia Library. Unfortunately at this time your application has not been approved. You can view your application and review comments at <a href=\"%(app_url)s\">%(app_url)s</a>.</p> <p>Best,</p> <p>The Wikipedia Library</p>"
 msgstr ""
 
 #. Translators: This email is sent to users when their application is rejected. Don't translate Jinja variables in curly braces like user or partner. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/rejection_notification-body-text.html:3
 #, python-format
-msgid ""
-"Dear %(user)s, Thank you for applying for access to %(partner)s resources "
-"through The Wikipedia Library. Unfortunately at this time your application "
-"has not been approved. You can view your application and review comments at: "
-"%(app_url)s Best, The Wikipedia Library"
+msgid "Dear %(user)s, Thank you for applying for access to %(partner)s resources through The Wikipedia Library. Unfortunately at this time your application has not been approved. You can view your application and review comments at: %(app_url)s Best, The Wikipedia Library"
 msgstr ""
 
 #. Translators: This is the subject of an email which is sent to users when their application has been rejected. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
@@ -1244,25 +1114,13 @@ msgstr "Din ansøgning til Wikipediabiblioteket"
 #. Translators: This email is sent to users when they have an account that is soon to expire. Don't translate Jinja variables in curly braces like partner_name or partner_link; don't translate html tags either. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/user_renewal_notice-body-html.html:5
 #, python-format
-msgid ""
-"<p>Dear %(user)s,</p> <p>According to our records, your access to "
-"%(partner_name)s will soon expire and you may lose access. If you want to "
-"continue making use of your free account, you can request renewal of your "
-"account by clicking the 'Renew' or 'Extend' button at %(partner_link)s.</p> "
-"<p>Best,</p> <p>The Wikipedia Library</p> <p>You can disable these emails in "
-"your user page preferences: https://wikipedialibrary.wmflabs.org/users/</p>"
+msgid "<p>Dear %(user)s,</p> <p>According to our records, your access to %(partner_name)s will soon expire and you may lose access. If you want to continue making use of your free account, you can request renewal of your account by clicking the 'Renew' or 'Extend' button at %(partner_link)s.</p> <p>Best,</p> <p>The Wikipedia Library</p> <p>You can disable these emails in your user page preferences: https://wikipedialibrary.wmflabs.org/users/</p>"
 msgstr ""
 
 #. Translators: This email is sent to users when they have an account that is soon to expire. Don't translate Jinja variables in curly braces like partner_name or partner_link; don't translate html tags either. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/user_renewal_notice-body-text.html:3
 #, python-format
-msgid ""
-"Dear %(user)s, According to our records, your access to %(partner_name)s "
-"will soon expire and you may lose access. If you want to continue making use "
-"of your free account, you can request renewal of your account by clicking "
-"the Renew button at %(partner_link)s. Best, The Wikipedia Library You can "
-"disable these emails in your user page preferences: https://wikipedialibrary."
-"wmflabs.org/users/"
+msgid "Dear %(user)s, According to our records, your access to %(partner_name)s will soon expire and you may lose access. If you want to continue making use of your free account, you can request renewal of your account by clicking the Renew button at %(partner_link)s. Best, The Wikipedia Library You can disable these emails in your user page preferences: https://wikipedialibrary.wmflabs.org/users/"
 msgstr ""
 
 #. Translators: This is the subject of an email sent to users when they have an account that is soon to expire. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
@@ -1273,24 +1131,13 @@ msgstr "Din adgangskode til Wikipedia biblioteket udløber måske snart"
 #. Translators: This email is sent to users when their application is waitlisted because there are no more accounts available. Don't translate Jinja variables in curly braces like user or partner; don't translate html tags either. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/waitlist_notification-body-html.html:5
 #, python-format
-msgid ""
-"<p>Dear %(user)s,</p> <p>Thank you for applying for access to %(partner)s "
-"resources through The Wikipedia Library. There are no accounts currently "
-"available so your application has been waitlisted. Your application will be "
-"evaluated if/when more accounts become available. You can see all available "
-"resources at <a href=\"%(link)s\">%(link)s</a>.</p> <p>Best,</p> <p>The "
-"Wikipedia Library</p>"
+msgid "<p>Dear %(user)s,</p> <p>Thank you for applying for access to %(partner)s resources through The Wikipedia Library. There are no accounts currently available so your application has been waitlisted. Your application will be evaluated if/when more accounts become available. You can see all available resources at <a href=\"%(link)s\">%(link)s</a>.</p> <p>Best,</p> <p>The Wikipedia Library</p>"
 msgstr ""
 
 #. Translators: This email is sent to users when their application is waitlisted because there are no more accounts available. Don't translate Jinja variables in curly braces like user or partner. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/waitlist_notification-body-text.html:3
 #, python-format
-msgid ""
-"Dear %(user)s, Thank you for applying for access to %(partner)s resources "
-"through The Wikipedia Library. There are no accounts currently available so "
-"your application has been waitlisted. Your application will be evaluated if/"
-"when more accounts become available. You can see all available resources at: "
-"%(link)s Best, The Wikipedia Library"
+msgid "Dear %(user)s, Thank you for applying for access to %(partner)s resources through The Wikipedia Library. There are no accounts currently available so your application has been waitlisted. Your application will be evaluated if/when more accounts become available. You can see all available resources at: %(link)s Best, The Wikipedia Library"
 msgstr ""
 
 #. Translators: This is the subject of an email sent to users when their application is waitlisted because there are no more accounts available. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
@@ -1307,8 +1154,7 @@ msgstr ""
 #. Translators: This message is shown to non-wikipedia editors who attempt to post data to suggestion form.
 #: TWLight/emails/views.py:59 TWLight/resources/views.py:555
 msgid "You must be a Wikipedia editor to do that."
-msgstr ""
-"Du skal være logget ind som en Wikipedia skribent for at kunne gøre dette."
+msgstr "Du skal være logget ind som en Wikipedia skribent for at kunne gøre dette."
 
 #. Translators: When a user is being authenticated to access proxied resources, and the request's missing the editor's username, this error text is displayed.
 #: TWLight/ezproxy/views.py:35
@@ -1456,17 +1302,14 @@ msgstr "Ikke tilgængelig"
 #: TWLight/resources/templates/resources/filter_section.html:14
 #: TWLight/templates/about.html:12
 #: TWLight/users/templates/users/filter_section.html:13
-msgid ""
-"The Wikipedia Library allows active editors to access a wide range of "
-"collections of paywalled reliable sources for free!"
+msgid "The Wikipedia Library allows active editors to access a wide range of collections of paywalled reliable sources for free!"
 msgstr ""
 
 #. Translators: On the Browse Partners page (https://wikipedialibrary.wmflabs.org/partners/), this introduces users to The Wikipedia Library.
 #. Translators: On the MyLibrary page (https://wikipedialibrary.wmflabs.org/users/my_library), this introduces users to The Wikipedia Library.
 #: TWLight/resources/templates/resources/filter_section.html:17
 #: TWLight/users/templates/users/filter_section.html:15
-msgid ""
-"Start with the search bar at the top or browse publisher websites directly."
+msgid "Start with the search bar at the top or browse publisher websites directly."
 msgstr ""
 
 #. Translators: On the Browse Partners page (https://wikipedialibrary.wmflabs.org/partners/), this appears below introductory text and links to the 'About' page (https://wikipedialibrary.wmflabs.org/about/)
@@ -1542,52 +1385,38 @@ msgstr "Tilbage til partner"
 #. Translators: If we have no available accounts for a partner, the coordinator can change the application system to a waiting list.
 #: TWLight/resources/templates/resources/partner_detail.html:36
 #: TWLight/resources/templates/resources/partner_detail_apply.html:17
-msgid ""
-"There are no access grants available for this partner at this time. You can "
-"still apply for access; applications will be processed when access is "
-"available."
+msgid "There are no access grants available for this partner at this time. You can still apply for access; applications will be processed when access is available."
 msgstr ""
 
 #. Translators: This text links to the minimum user requirements and terms of use on the partner page.
 #: TWLight/resources/templates/resources/partner_detail.html:48
 #: TWLight/resources/templates/resources/partner_detail_apply.html:29
 #, python-format
-msgid ""
-"Before applying, please review the <strong><a class=\"twl-links\" href="
-"\"%(about)s#req\">minimum requirements</a></strong> for access and our "
-"<strong><a class=\"twl-links\" href=\"%(terms)s\">terms of use</a></strong>."
+msgid "Before applying, please review the <strong><a class=\"twl-links\" href=\"%(about)s#req\">minimum requirements</a></strong> for access and our <strong><a class=\"twl-links\" href=\"%(terms)s\">terms of use</a></strong>."
 msgstr ""
 
 #. Translators: This text refers to the page containing the content a user is authorized to access.
 #: TWLight/resources/templates/resources/partner_detail.html:69
 #, python-format
-msgid ""
-"View the status of your access in <strong><a class=\"twl-links\" href="
-"\"%(library_url)s\">My Library</a></strong> page."
+msgid "View the status of your access in <strong><a class=\"twl-links\" href=\"%(library_url)s\">My Library</a></strong> page."
 msgstr ""
 
 #. Translators: This message is shown when a user has open applications, linking to their respective applications page.
 #: TWLight/resources/templates/resources/partner_detail.html:78
 #, python-format
-msgid ""
-"View the status of your application(s) on your <strong><a class=\"twl-links"
-"\" href=\"%(applications_url)s\">My Applications</a></strong> page."
+msgid "View the status of your application(s) on your <strong><a class=\"twl-links\" href=\"%(applications_url)s\">My Applications</a></strong> page."
 msgstr ""
 
 #. Translators: This message is shown when a user has authorizations, linking to their respective collections page.
 #: TWLight/resources/templates/resources/partner_detail_apply.html:50
 #, python-format
-msgid ""
-"View the status of your access on your <strong><a href=\"%(library_url)s\" "
-"class=\"twl-links\">My Library</a></strong> page."
+msgid "View the status of your access on your <strong><a href=\"%(library_url)s\" class=\"twl-links\">My Library</a></strong> page."
 msgstr ""
 
 #. Translators: This message is shown when a user has open applications, linking to their respective applications page.
 #: TWLight/resources/templates/resources/partner_detail_apply.html:60
 #, python-format
-msgid ""
-"View the status of your application(s) on your <strong><a href="
-"\"%(applications_url)s\">My Applications</a></strong> page."
+msgid "View the status of your application(s) on your <strong><a href=\"%(applications_url)s\">My Applications</a></strong> page."
 msgstr ""
 
 #. Translators: One the partner detail page, this text labels the button which coordinators can click to remove a partner from waitlisted status.
@@ -1617,10 +1446,7 @@ msgstr ""
 
 #. Translators: If no account coordinator is assigned to a partner, the Wikipedia Library team will coordinate signups. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/resources/templates/resources/partner_detail_apply.html:112
-msgid ""
-"The Wikipedia Library team will process this application. Want to help? <a "
-"class=\"twl-links\" href=\"https://en.wikipedia.org/wiki/Wikipedia:"
-"The_Wikipedia_Library/Coordinators/Signup\">Sign up as a coordinator.</a>"
+msgid "The Wikipedia Library team will process this application. Want to help? <a class=\"twl-links\" href=\"https://en.wikipedia.org/wiki/Wikipedia:The_Wikipedia_Library/Coordinators/Signup\">Sign up as a coordinator.</a>"
 msgstr ""
 
 #. Translators: This text labels a button coordinators can click to view a list of users who have applied for access for a particular partner
@@ -1650,18 +1476,13 @@ msgstr ""
 
 #. Translators: Text shown to authenticated, bundle eligible users when they visit a Bundle partner page.
 #: TWLight/resources/templates/resources/partner_detail_apply.html:138
-msgid ""
-"You are eligible to access Library Bundle partners. Click the button above "
-"to access the collection."
+msgid "You are eligible to access Library Bundle partners. Click the button above to access the collection."
 msgstr ""
 
 #. Translators: Text shown to authenticated, bundle ineligible users when they visit a Bundle partner page.
 #: TWLight/resources/templates/resources/partner_detail_apply.html:152
 #, python-format
-msgid ""
-"You are not eligible to access Library Bundle partners. Visit the <a class="
-"\"twl-links\" href=\"%(homepage)s\">homepage</a> to check the eligibility "
-"criteria."
+msgid "You are not eligible to access Library Bundle partners. Visit the <a class=\"twl-links\" href=\"%(homepage)s\">homepage</a> to check the eligibility criteria."
 msgstr ""
 
 #. Translators: Buttton prompting users to log in.
@@ -1673,10 +1494,7 @@ msgstr "Log på"
 #. Translators: Text shown to unauthenticated users when they visit a Bundle partner page.
 #: TWLight/resources/templates/resources/partner_detail_apply.html:168
 #, python-format
-msgid ""
-"This resource is part of our <a class=\"twl-links\" href=\"%(about)s"
-"\">Library Bundle</a>, which you can access if you meet our minimum "
-"eligibility criteria. Log in to find out if you are eligible."
+msgid "This resource is part of our <a class=\"twl-links\" href=\"%(about)s\">Library Bundle</a>, which you can access if you meet our minimum eligibility criteria. Log in to find out if you are eligible."
 msgstr ""
 
 #. Translators: This is the label for a number which shows the total active accounts for one partner. (e.g. https://wikipedialibrary.wmflabs.org/partners/8/).
@@ -1727,26 +1545,19 @@ msgstr ""
 #. Translators: If a partner has specified the excerpt limit both in words and percentage, this message will display the percentage of words and the number of words on the partner page.
 #: TWLight/resources/templates/resources/partner_detail_timeline.html:99
 #, python-format
-msgid ""
-"%(object)s allows a maximum of %(excerpt_limit)s words or "
-"%(excerpt_limit_percentage)s%% of an article be excerpted into a Wikipedia "
-"article."
+msgid "%(object)s allows a maximum of %(excerpt_limit)s words or %(excerpt_limit_percentage)s%% of an article be excerpted into a Wikipedia article."
 msgstr ""
 
 #. Translators: If a partner has specified the excerpt limit in words, this message will display the number of words on the partner page.
 #: TWLight/resources/templates/resources/partner_detail_timeline.html:106
 #, python-format
-msgid ""
-"%(object)s allows a maximum of %(excerpt_limit)s words be excerpted into a "
-"Wikipedia article."
+msgid "%(object)s allows a maximum of %(excerpt_limit)s words be excerpted into a Wikipedia article."
 msgstr ""
 
 #. Translators: If a partner has specified the excerpt limit in percentage, this message will display the percentage of words on the partner page.
 #: TWLight/resources/templates/resources/partner_detail_timeline.html:113
 #, python-format
-msgid ""
-"%(object)s allows a maximum of %(excerpt_limit_percentage)s%% of an article "
-"be excerpted into a Wikipedia article."
+msgid "%(object)s allows a maximum of %(excerpt_limit_percentage)s%% of an article be excerpted into a Wikipedia article."
 msgstr ""
 
 #. Translators: If a partner has other requirements for access, this text shows as the title for that information field. (e.g. https://wikipedialibrary.wmflabs.org/partners/10/).
@@ -1757,9 +1568,7 @@ msgstr "Specielle krav for ansøgere"
 #. Translators: If a user must agree to a Terms of Use document, they see this message, and must enter the name of the resource. Don't translate publisher or url.
 #: TWLight/resources/templates/resources/partner_detail_timeline.html:140
 #, python-format
-msgid ""
-"%(publisher)s requires that you agree with its <a href=\"%(url)s\">terms of "
-"use</a>."
+msgid "%(publisher)s requires that you agree with its <a href=\"%(url)s\">terms of use</a>."
 msgstr ""
 
 #. Translators: If a user must provide their real name to apply to a partner, they see this message, and must enter the name of the resource. Don't translate publisher.
@@ -1783,17 +1592,13 @@ msgstr ""
 #. Translators: If a user must select a specific resource to apply for, they see this message, and must enter the name of the resource. Don't translate publisher.
 #: TWLight/resources/templates/resources/partner_detail_timeline.html:177
 #, python-format
-msgid ""
-"%(publisher)s requires that you specify a particular title that you want to "
-"access."
+msgid "%(publisher)s requires that you specify a particular title that you want to access."
 msgstr ""
 
 #. Translators: If a user must register on the partner website before applying, they see this message. Don't translate partner.
 #: TWLight/resources/templates/resources/partner_detail_timeline.html:187
 #, python-format
-msgid ""
-"%(publisher)s requires that you sign up for an account before applying for "
-"access."
+msgid "%(publisher)s requires that you sign up for an account before applying for access."
 msgstr ""
 
 #. Translators: If a partner has their location listed, this message is a label for that location
@@ -1921,9 +1726,7 @@ msgstr ""
 
 #. Translators: If multiple authorizations where returned for a collection, this message is shown to a user
 #: TWLight/resources/views.py:268
-msgid ""
-"Multiple authorizations were returned – something's wrong. Please contact us "
-"and don't forget to mention this message."
+msgid "Multiple authorizations were returned – something's wrong. Please contact us and don't forget to mention this message."
 msgstr ""
 
 #. Translators: This message is shown when user tries to access a NOT_AVAILABLE Partner
@@ -1964,14 +1767,7 @@ msgstr "Beklager; vi aner ikke hvad vi skal gøre med dette."
 #. Translators: Shown on the website's 400 page, when a user sends a bad request. Don't translate path or Phabricator.
 #: TWLight/templates/400.html:20
 #, python-format
-msgid ""
-"If you think we should know what to do with that, please email us about this "
-"error at <a class=\"twl-links\" href=\"mailto:wikipedialibrary@wikimedia.org?"
-"Subject=Wikipedia%%20Library%%20%(path)s%%20Permission%%20denied"
-"\">wikipedialibrary@wikimedia.org</a> or report it to us on <a class=\"twl-"
-"links\" href=\"https://phabricator.wikimedia.org/maniphest/task/edit/form/1/?"
-"projectPHIDs=Library-Card-Platform&title=Wikipedia%%20Library%%20%(path)s"
-"%%20Bad%%20Request\">Phabricator</a>"
+msgid "If you think we should know what to do with that, please email us about this error at <a class=\"twl-links\" href=\"mailto:wikipedialibrary@wikimedia.org?Subject=Wikipedia%%20Library%%20%(path)s%%20Permission%%20denied\">wikipedialibrary@wikimedia.org</a> or report it to us on <a class=\"twl-links\" href=\"https://phabricator.wikimedia.org/maniphest/task/edit/form/1/?projectPHIDs=Library-Card-Platform&title=Wikipedia%%20Library%%20%(path)s%%20Bad%%20Request\">Phabricator</a>"
 msgstr ""
 
 #. Translators: Alt text for an image shown on the 400 error page.
@@ -1993,15 +1789,7 @@ msgstr "Beklager; du har ikke tilladelse til at gøre dette."
 #. Translators: Shown on the website's 403 page, when a user attempts to navigate to a page they don't have permission to view. Don't translate path or Phabricator.
 #: TWLight/templates/403.html:20
 #, python-format
-msgid ""
-"If you think your account should be able to do that, please email us about "
-"this error at <a class=\"twl-links\" href=\"mailto:"
-"wikipedialibrary@wikimedia.org?Subject=Wikipedia%%20Library%%20%(path)s"
-"%%20Permission%%20denied\">wikipedialibrary@wikimedia.org</a> or report it "
-"to us on <a class=\"twl-links\" href=\"https://phabricator.wikimedia.org/"
-"maniphest/task/edit/form/1/?projectPHIDs=Library-Card-"
-"Platform&title=Wikipedia%%20Library%%20%(path)s%%20Permission%%20denied"
-"\">Phabricator</a>"
+msgid "If you think your account should be able to do that, please email us about this error at <a class=\"twl-links\" href=\"mailto:wikipedialibrary@wikimedia.org?Subject=Wikipedia%%20Library%%20%(path)s%%20Permission%%20denied\">wikipedialibrary@wikimedia.org</a> or report it to us on <a class=\"twl-links\" href=\"https://phabricator.wikimedia.org/maniphest/task/edit/form/1/?projectPHIDs=Library-Card-Platform&title=Wikipedia%%20Library%%20%(path)s%%20Permission%%20denied\">Phabricator</a>"
 msgstr ""
 
 #. Translators: Shown on the website's 404 page, when a user attempts to navigate to a page that doesn't exist.
@@ -2017,14 +1805,7 @@ msgstr "Beklager; men det kan vi ikke finde."
 #. Translators: Shown on the website's 404 page, when a user attempts to navigate to a page that doesn't exist. Don't translate path or Phabricator.
 #: TWLight/templates/404.html:19
 #, python-format
-msgid ""
-"If you are certain that something should be here, please email us about this "
-"error at <a class=\"twl-links\" href=\"mailto:wikipedialibrary@wikimedia.org?"
-"Subject=Wikipedia%%20Library%%20%(path)s%%20Not%%20found\"> "
-"wikipedialibrary@wikimedia.org</a> or report it to us on <a class=\"twl-links"
-"\" href=\"https://phabricator.wikimedia.org/maniphest/task/edit/form/1/?"
-"projectPHIDs=Library-Card-Platform&title=Wikipedia%%20Library%%20%(path)s"
-"%%20Not%%20found\">Phabricator</a>"
+msgid "If you are certain that something should be here, please email us about this error at <a class=\"twl-links\" href=\"mailto:wikipedialibrary@wikimedia.org?Subject=Wikipedia%%20Library%%20%(path)s%%20Not%%20found\"> wikipedialibrary@wikimedia.org</a> or report it to us on <a class=\"twl-links\" href=\"https://phabricator.wikimedia.org/maniphest/task/edit/form/1/?projectPHIDs=Library-Card-Platform&title=Wikipedia%%20Library%%20%(path)s%%20Not%%20found\">Phabricator</a>"
 msgstr ""
 
 #. Translators: Alt text for an image shown on the 404 error page.
@@ -2039,32 +1820,18 @@ msgstr "Om Wikipedia biblioteket"
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:20
-msgid ""
-"This platform is our central tool for facilitating access to our available "
-"collections. Here you can see which partnerships are available, search their "
-"contents, and apply for and access the ones you’re interested in."
+msgid "This platform is our central tool for facilitating access to our available collections. Here you can see which partnerships are available, search their contents, and apply for and access the ones you’re interested in."
 msgstr ""
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/). Wikimedia Foundation should not be translated.
 #: TWLight/templates/about.html:29
-msgid ""
-"All users receive immediate access to some collections, which can be browsed "
-"by clicking the 'Access collection' buttons or using the search bar at the "
-"top of the page. Other collections require an application before access is "
-"granted, and may be accessed directly or via an individual login or access "
-"code. Volunteer coordinators, who have signed non-disclosure agreements with "
-"the Wikimedia Foundation, review these applications and work with publishers "
-"to get you your free access."
+msgid "All users receive immediate access to some collections, which can be browsed by clicking the 'Access collection' buttons or using the search bar at the top of the page. Other collections require an application before access is granted, and may be accessed directly or via an individual login or access code. Volunteer coordinators, who have signed non-disclosure agreements with the Wikimedia Foundation, review these applications and work with publishers to get you your free access."
 msgstr ""
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/). Don't translate terms_url.
 #: TWLight/templates/about.html:43
 #, python-format
-msgid ""
-"For more information about how your information is stored and reviewed "
-"please see our <a class=\"twl-links\" href=\"%(terms_url)s\"> terms of use "
-"and privacy policy</a>. Accounts you apply for are also subject to the Terms "
-"of Use provided by each partner’s platform; please review them."
+msgid "For more information about how your information is stored and reviewed please see our <a class=\"twl-links\" href=\"%(terms_url)s\"> terms of use and privacy policy</a>. Accounts you apply for are also subject to the Terms of Use provided by each partner’s platform; please review them."
 msgstr ""
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
@@ -2074,12 +1841,7 @@ msgstr "Hvem kan få adgang?"
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/). Wikimedia Foundation should not be translated.
 #: TWLight/templates/about.html:55
-msgid ""
-"Any active editor in good standing can receive access. For publishers with "
-"limited numbers of accounts, applications are reviewed based on the editor’s "
-"needs and contributions. If you think you could use access to one of our "
-"partner resources and are an active editor in any project supported by the "
-"Wikimedia Foundation, please apply."
+msgid "Any active editor in good standing can receive access. For publishers with limited numbers of accounts, applications are reviewed based on the editor’s needs and contributions. If you think you could use access to one of our partner resources and are an active editor in any project supported by the Wikimedia Foundation, please apply."
 msgstr ""
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
@@ -2100,36 +1862,21 @@ msgstr "Du har lavet mindst 500 redigeringer til Wikimedia-projekter"
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:79
 msgid "You have made at least 10 edits to Wikimedia projects in the last month"
-msgstr ""
-"Du har udført mindst 10 redigeringer til Wikimedia projekter den seneste "
-"måned"
+msgstr "Du har udført mindst 10 redigeringer til Wikimedia projekter den seneste måned"
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:83
 msgid "You are not currently blocked from editing a Wikimedia project"
-msgstr ""
-"Du er på nuværende tidspunkt ikke blokeret fra at redigere et Wikipedia "
-"projekt"
+msgstr "Du er på nuværende tidspunkt ikke blokeret fra at redigere et Wikipedia projekt"
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/)
 #: TWLight/templates/about.html:89
-msgid ""
-"If you are applying for an available collection, please first check that you "
-"don't already have access through another library or institution. If you do, "
-"please consider using that access rather than taking up a seat for this "
-"resource in The Wikipedia Library."
+msgid "If you are applying for an available collection, please first check that you don't already have access through another library or institution. If you do, please consider using that access rather than taking up a seat for this resource in The Wikipedia Library."
 msgstr ""
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/)
 #: TWLight/templates/about.html:99
-msgid ""
-"If your account is blocked on one or more Wikimedia projects, you may still "
-"be granted access to The Wikipedia Library. You will need to contact the "
-"Wikipedia Library team, who will review your blocks. If you have been "
-"blocked for content issues, most notably copyright violations, or have "
-"multiple long-term blocks, we may decline your request. Additionally, if "
-"your block status changes after being approved, you will need to request "
-"another review."
+msgid "If your account is blocked on one or more Wikimedia projects, you may still be granted access to The Wikipedia Library. You will need to contact the Wikipedia Library team, who will review your blocks. If you have been blocked for content issues, most notably copyright violations, or have multiple long-term blocks, we may decline your request. Additionally, if your block status changes after being approved, you will need to request another review."
 msgstr ""
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
@@ -2164,9 +1911,7 @@ msgstr "Godkendte skribenter <i>bør ikke</i>:"
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:136
-msgid ""
-"Share their account logins or passwords with others, or sell their access to "
-"other parties"
+msgid "Share their account logins or passwords with others, or sell their access to other parties"
 msgstr ""
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
@@ -2176,23 +1921,17 @@ msgstr ""
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:144
-msgid ""
-"Systematically make printed or electronic copies of multiple extracts of "
-"restricted content available for any purpose"
+msgid "Systematically make printed or electronic copies of multiple extracts of restricted content available for any purpose"
 msgstr ""
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/). Stub is a technical term for a short Wikipedia article, use the appropriate Wikipedia term in your language.
 #: TWLight/templates/about.html:148
-msgid ""
-"Datamine metadata without permission, in order, for instance, to use "
-"metadata for auto-created stub articles"
+msgid "Datamine metadata without permission, in order, for instance, to use metadata for auto-created stub articles"
 msgstr ""
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:154
-msgid ""
-"Respecting these agreements allows us to continue growing the partnerships "
-"available to the community."
+msgid "Respecting these agreements allows us to continue growing the partnerships available to the community."
 msgstr ""
 
 #. Translators: This is the heading for a section on the About page (https://wikipedialibrary.wmflabs.org/about/).
@@ -2202,41 +1941,22 @@ msgstr ""
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:164
-msgid ""
-"EZProxy is a proxy server used to authenticate users for many Wikipedia "
-"Library partners. Users sign into EZProxy via the Library Card platform to "
-"verify that they are authorized users, and then the server accesses "
-"requested resources using its own IP address."
+msgid "EZProxy is a proxy server used to authenticate users for many Wikipedia Library partners. Users sign into EZProxy via the Library Card platform to verify that they are authorized users, and then the server accesses requested resources using its own IP address."
 msgstr ""
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:173
-msgid ""
-"You may notice that when accessing resources via EZProxy that URLs are "
-"dynamically rewritten. This is why we recommend logging in via the Library "
-"Card platform rather than going directly to the unproxied partner website. "
-"When in doubt, check the URL for ‘idm.oclc’. If it’s there, then you’re "
-"connected via EZProxy."
+msgid "You may notice that when accessing resources via EZProxy that URLs are dynamically rewritten. This is why we recommend logging in via the Library Card platform rather than going directly to the unproxied partner website. When in doubt, check the URL for ‘idm.oclc’. If it’s there, then you’re connected via EZProxy."
 msgstr ""
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:182
-msgid ""
-"Typically once you’ve logged in your session will remain active in your "
-"browser for up to two hours after you’ve finished searching. Note that use "
-"of EZProxy requires you to enable cookies. If you are having problems you "
-"should also try clearing your cache and restarting your browser."
+msgid "Typically once you’ve logged in your session will remain active in your browser for up to two hours after you’ve finished searching. Note that use of EZProxy requires you to enable cookies. If you are having problems you should also try clearing your cache and restarting your browser."
 msgstr ""
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/)
 #: TWLight/templates/about.html:193
-msgid ""
-"The Library Bundle is a collection of resources for which no application is "
-"required. If you meet the criteria laid out above, you will be authorized "
-"for access automatically upon logging in to the platform. Only some of our "
-"content is currently included in the Library Bundle, however we hope to "
-"expand the collection as more publishers become comfortable with "
-"participating. All Bundle content is accessed via EZProxy."
+msgid "The Library Bundle is a collection of resources for which no application is required. If you meet the criteria laid out above, you will be authorized for access automatically upon logging in to the platform. Only some of our content is currently included in the Library Bundle, however we hope to expand the collection as more publishers become comfortable with participating. All Bundle content is accessed via EZProxy."
 msgstr ""
 
 #. Translators: This is the heading for a section on the About page (https://wikipedialibrary.wmflabs.org/about/).
@@ -2246,12 +1966,7 @@ msgstr ""
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:206
-msgid ""
-"Citation practices vary by project and even by article. Generally, we "
-"support editors citing where they found information, in a form that allows "
-"others to check it for themselves. That often means providing both original "
-"source details as well as a link to the partner database in which the source "
-"was found."
+msgid "Citation practices vary by project and even by article. Generally, we support editors citing where they found information, in a form that allows others to check it for themselves. That often means providing both original source details as well as a link to the partner database in which the source was found."
 msgstr ""
 
 #. Translators: This is the heading for a section on the About page (https://wikipedialibrary.wmflabs.org/about/).
@@ -2263,9 +1978,7 @@ msgstr "Kontakt os"
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:218
 #, python-format
-msgid ""
-"If you have questions, need help, or want to volunteer to help, please see "
-"our <a class=\"twl-links\" href=\"%(contact_url)s\">contact page</a>."
+msgid "If you have questions, need help, or want to volunteer to help, please see our <a class=\"twl-links\" href=\"%(contact_url)s\">contact page</a>."
 msgstr ""
 
 #. Translators: This is the title of the panel box detailing the contact information for the Wikipedia Library team.
@@ -2305,9 +2018,7 @@ msgstr "Wikipedia bibliotek twitterside"
 #. Translators: This is the text that appears at the bottom of the contact us form directing users to the suggestions form.
 #: TWLight/templates/contact.html:48
 #, python-format
-msgid ""
-"(If you would like to suggest a partner, <a class=\"twl-links\" href="
-"\"%(suggest)s\"><strong>go here</strong></a>.)"
+msgid "(If you would like to suggest a partner, <a class=\"twl-links\" href=\"%(suggest)s\"><strong>go here</strong></a>.)"
 msgstr ""
 
 #. Translators: On a special 'link to search' page, this message is shown if JavaScript is disabled.
@@ -2365,9 +2076,7 @@ msgstr "Wikipedia biblioteket"
 #. Translators: Information about The Wikipedia Library.
 #: TWLight/templates/login_partial.html:53 TWLight/templates/new_base.html:21
 #, python-format
-msgid ""
-"More than 100 of the world's top subscription-only databases, with content "
-"in %(no_of_languages)s languages, free for Wikipedians of all backgrounds"
+msgid "More than 100 of the world's top subscription-only databases, with content in %(no_of_languages)s languages, free for Wikipedians of all backgrounds"
 msgstr ""
 
 #. Translators: Information about The Wikipedia Library.
@@ -2376,9 +2085,7 @@ msgid "Meet these criteria for automatic access"
 msgstr ""
 
 #: TWLight/templates/login_partial.html:69
-msgid ""
-"These criteria grant you access to certain collections but not all. Some "
-"collections are accessible on a per application basis only."
+msgid "These criteria grant you access to certain collections but not all. Some collections are accessible on a per application basis only."
 msgstr ""
 
 #: TWLight/templates/login_partial.html:89
@@ -2388,29 +2095,19 @@ msgstr "Log ind med Wikipedia"
 #. Translators: Shown if the current user doesn't have a registered email on their account. Don't translate contact_us_url or email_url.
 #: TWLight/templates/message_partial.html:15
 #, python-format
-msgid ""
-"You don't have an email on file. We can't finalize your access to partner "
-"resources, and you won't be able to <a class=\"twl-links\" href="
-"\"%(contact_us_url)s\">contact us</a> without an email. Please <a class="
-"\"twl-links\" href=\"%(email_url)s\">update your email</a>."
+msgid "You don't have an email on file. We can't finalize your access to partner resources, and you won't be able to <a class=\"twl-links\" href=\"%(contact_us_url)s\">contact us</a> without an email. Please <a class=\"twl-links\" href=\"%(email_url)s\">update your email</a>."
 msgstr ""
 
 #. Translators: Shown if the current user has requested the processing of their data should be restricted.
 #: TWLight/templates/message_partial.html:26
 #, python-format
-msgid ""
-"You have requested a restriction on the processing of your data. Most site "
-"functionality will not be available to you until you <a class=\"twl-links\" "
-"href=\"%(restrict_url)s\">lift this restriction</a>."
+msgid "You have requested a restriction on the processing of your data. Most site functionality will not be available to you until you <a class=\"twl-links\" href=\"%(restrict_url)s\">lift this restriction</a>."
 msgstr ""
 
 #. Translators: Shown if the current user has not agreed to the terms of use.
 #: TWLight/templates/message_partial.html:37
 #, python-format
-msgid ""
-"You have not agreed to the <a class=\"twl-links\" href=\"%(terms_url)s"
-"\">terms of use</a> of this site. Your applications will not be processed "
-"and you won't be able to apply or access resources you are approved for."
+msgid "You have not agreed to the <a class=\"twl-links\" href=\"%(terms_url)s\">terms of use</a> of this site. Your applications will not be processed and you won't be able to apply or access resources you are approved for."
 msgstr ""
 
 #. Translators: This link is at the bottom of every page and links to the 'About' page (https://wikipedialibrary.wmflabs.org/about/)
@@ -2457,9 +2154,7 @@ msgstr "Nulstil adgangskode"
 
 #. Translators: If a user goes to reset their password, this message asks them to enter their email to do so.
 #: TWLight/templates/registration/password_reset_form.html:13
-msgid ""
-"Forgot your password? Enter your email address below, and we'll email "
-"instructions for setting a new one."
+msgid "Forgot your password? Enter your email address below, and we'll email instructions for setting a new one."
 msgstr ""
 
 #. Translators: This is the label for a button that users click to update their public information.
@@ -2508,22 +2203,13 @@ msgstr "Jeg er enig med anvendelsesvilkårene"
 #. Translators: This text explains how to disagree to the site's terms of use and the restrictions that will come into effect when users disagree to the terms of use.
 #: TWLight/users/forms.py:185
 #, fuzzy
-msgid ""
-"By unchecking this box and clicking “Update” you may explore the site, but "
-"you will not be able to apply for access to materials or evaluate "
-"applications unless you agree with the terms of use."
-msgstr ""
-"E-mailadressefeltet er tomt. Du har stadigvæk mulighed for at gennemse "
-"sitet, men du vil ikke have mulighed for at ansøge om adgang til partner-"
-"ressourcer uden en e-mailadresse."
+msgid "By unchecking this box and clicking “Update” you may explore the site, but you will not be able to apply for access to materials or evaluate applications unless you agree with the terms of use."
+msgstr "E-mailadressefeltet er tomt. Du har stadigvæk mulighed for at gennemse sitet, men du vil ikke have mulighed for at ansøge om adgang til partner-ressourcer uden en e-mailadresse."
 
 #. Translators: Users click this button to set their website email address to the one linked to their Wikipedia account.
 #: TWLight/users/forms.py:211
-msgid ""
-"Use my Wikipedia email address (will be updated the next time you login)."
-msgstr ""
-"Brug min Wikipedia emailadresse (vil blive opdateret næste gang du logger "
-"på)."
+msgid "Use my Wikipedia email address (will be updated the next time you login)."
+msgstr "Brug min Wikipedia emailadresse (vil blive opdateret næste gang du logger på)."
 
 #. Translators: This labels a button which users click to change their email.
 #: TWLight/users/forms.py:232
@@ -2533,17 +2219,8 @@ msgstr "Opdater e-mail"
 #. Translators: Shown if the current user tried to 'favorite' a partner they can't access. Do not translate '{partner}'
 #: TWLight/users/models.py:201
 #, python-brace-format
-msgid ""
-"Cannot add partner {partner} to your favorites because you don't have access "
-"to it"
+msgid "Cannot add partner {partner} to your favorites because you don't have access to it"
 msgstr ""
-
-#. Translators: Do not translate.
-#: TWLight/users/models.py:869
-#, fuzzy, python-brace-format
-#| msgid "Username"
-msgid "{wp_username}"
-msgstr "Brugernavn"
 
 #. Translators: This error message is shown when there's a problem with the authenticated login process.
 #: TWLight/users/oauth.py:243
@@ -2563,9 +2240,7 @@ msgstr ""
 
 #. Translators: this message is displayed to users that don't have accounts and clicked on a proxied link.
 #: TWLight/users/oauth.py:388
-msgid ""
-"To view this link you need to be an eligible library user. Please login to "
-"continue."
+msgid "To view this link you need to be an eligible library user. Please login to continue."
 msgstr ""
 
 #. Translators: This warning message is shown to users when the response received from Wikimedia OAuth servers is not a valid one.
@@ -2601,17 +2276,12 @@ msgstr "Brugeroplysninger"
 
 #. Translators: If the user tries to log in, but their account does not meet certain requirements, they cannot login.
 #: TWLight/users/oauth.py:528
-msgid ""
-"Your Wikipedia account does not meet the eligibility criteria in the terms "
-"of use, so your Wikipedia Library Card Platform account cannot be activated."
+msgid "Your Wikipedia account does not meet the eligibility criteria in the terms of use, so your Wikipedia Library Card Platform account cannot be activated."
 msgstr ""
 
 #. Translators: If the user tries to log in, but their account does not meet certain requirements, they cannot login.
 #: TWLight/users/oauth.py:536
-msgid ""
-"Your Wikipedia account no longer meets the eligibility criteria in the terms "
-"of use, so you cannot be logged in. If you think you should be able to log "
-"in, please email wikipedialibrary@wikimedia.org."
+msgid "Your Wikipedia account no longer meets the eligibility criteria in the terms of use, so you cannot be logged in. If you think you should be able to log in, please email wikipedialibrary@wikimedia.org."
 msgstr ""
 
 #. Translators: this message is displayed to users with brand new accounts.
@@ -2622,10 +2292,7 @@ msgstr ""
 #. Translators: This message is displayed on the confirmation page where users can return their access to partner collections.
 #: TWLight/users/templates/users/authorization_confirm_return.html:13
 #, python-format
-msgid ""
-"You will no longer be able to access <b>%(partner)s's</b> resources via the "
-"Library Card platform, but can request access again by clicking 'renew', if "
-"you change your mind. Are you sure you want to return your access?"
+msgid "You will no longer be able to access <b>%(partner)s's</b> resources via the Library Card platform, but can request access again by clicking 'renew', if you change your mind. Are you sure you want to return your access?"
 msgstr ""
 
 #. Translators: On the MyLibrary page (https://wikipedialibrary.wmflabs.org/users/my_library), this tab shows all favorite collections a user has.
@@ -2695,14 +2362,8 @@ msgstr "Skribentdata"
 
 #. Translators: This is shown on editor profiles, in their profile page or on applications.
 #: TWLight/users/templates/users/editor_detail.html:59
-msgid ""
-"Information with an * was retrieved from Wikipedia directly. Other "
-"information was entered directly by users or site admins, in their preferred "
-"language."
-msgstr ""
-"Information med en * blev hentet direkte fra Wikipedia. Anden information "
-"blev indtastet manuelt af brugere eller administratorer på deres foretrukne "
-"sprog."
+msgid "Information with an * was retrieved from Wikipedia directly. Other information was entered directly by users or site admins, in their preferred language."
+msgstr "Information med en * blev hentet direkte fra Wikipedia. Anden information blev indtastet manuelt af brugere eller administratorer på deres foretrukne sprog."
 
 #. Translators: This distinguishes users who have been flagged as account coordinators. Don't translate username.
 #: TWLight/users/templates/users/editor_detail.html:71
@@ -2712,10 +2373,7 @@ msgstr "%(username)s har koordinator-privilegier på dette site."
 
 #. Translators: This is shown on editor profiles, under the heading for Wikipedia editor data.
 #: TWLight/users/templates/users/editor_detail_data.html:5
-msgid ""
-"This information is updated automatically from your Wikimedia account each "
-"time you log in, except for the Contributions field, where you can describe "
-"your Wikimedia editing history."
+msgid "This information is updated automatically from your Wikimedia account each time you log in, except for the Contributions field, where you can describe your Wikimedia editing history."
 msgstr ""
 
 #. Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this labels the user's username.
@@ -2745,17 +2403,13 @@ msgstr "Opfylder vilkårene for anvendelse?"
 
 #. Translators: when viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this question has a yes or no answer.
 #: TWLight/users/templates/users/editor_detail_data.html:57
-msgid ""
-"at their last login, did this user meet the criteria set forth in the terms "
-"of use?"
+msgid "at their last login, did this user meet the criteria set forth in the terms of use?"
 msgstr ""
 
 #. Translators: When viewing a user's profile in an application, this message shows if the software doesn't think that the user is eligible for access. Don't translate username.
 #: TWLight/users/templates/users/editor_detail_data.html:72
 #, python-format
-msgid ""
-"%(username)s may still be eligible for access grants at the coordinators' "
-"discretion."
+msgid "%(username)s may still be eligible for access grants at the coordinators' discretion."
 msgstr ""
 
 #. Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this is the heading for a Yes/No ToU question.
@@ -2791,10 +2445,7 @@ msgstr ""
 #. Translators: This message is shown on a user's profile if their Wikimedia account is blocked on one or more projects. They may still be granted access to the Library Bundle, but need to contact Wikipedia Library staff to verify.
 #: TWLight/users/templates/users/editor_detail_data.html:137
 #, python-format
-msgid ""
-"It looks like you have an active block on your account. If you meet the "
-"other criteria you may still be permitted access to the library - please <a "
-"class=\"twl-links\" href=\"%(contact_url)s\">contact us</a>."
+msgid "It looks like you have an active block on your account. If you meet the other criteria you may still be permitted access to the library - please <a class=\"twl-links\" href=\"%(contact_url)s\">contact us</a>."
 msgstr ""
 
 #. Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this is the heading for a Yes/No program eligibility question.
@@ -2804,10 +2455,7 @@ msgstr ""
 
 #. Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this question has a Yes or No answer.
 #: TWLight/users/templates/users/editor_detail_data.html:156
-msgid ""
-"At their last login, did this user meet the criteria set forth in the "
-"Library Bundle? Note that satisfying terms of use is a prerequisite to "
-"bundle eligibility."
+msgid "At their last login, did this user meet the criteria set forth in the Library Bundle? Note that satisfying terms of use is a prerequisite to bundle eligibility."
 msgstr ""
 
 #. Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this is the heading for a Yes/No program eligibility question.
@@ -2852,18 +2500,13 @@ msgstr ""
 
 #. Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this text is in the 'Personal data' section. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/users/templates/users/editor_detail_data.html:262
-msgid ""
-"The following information is visible only to you, site administrators, "
-"publishing partners (where required), and volunteer Wikipedia Library "
-"coordinators (who have signed a Non-Disclosure Agreement)."
+msgid "The following information is visible only to you, site administrators, publishing partners (where required), and volunteer Wikipedia Library coordinators (who have signed a Non-Disclosure Agreement)."
 msgstr ""
 
 #. Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this labels a button which users can click to update or remove their personal information. Don't translate update_url.
 #: TWLight/users/templates/users/editor_detail_data.html:272
 #, python-format
-msgid ""
-"You may <a class=\"twl-links\" href=\"%(update_url)s\">update or delete</a> "
-"your data at any time."
+msgid "You may <a class=\"twl-links\" href=\"%(update_url)s\">update or delete</a> your data at any time."
 msgstr ""
 
 #. Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this labels the user's email. Don't remove the *.
@@ -2883,24 +2526,18 @@ msgstr "Institutionel tilknytning"
 
 #. Translators: This message tells users that they are not eligible to access The Wikipedia Library content.
 #: TWLight/users/templates/users/eligibility_modal.html:7
-msgid ""
-"Sorry, your Wikipedia account doesn’t currently qualify to access The "
-"Wikipedia Library."
+msgid "Sorry, your Wikipedia account doesn’t currently qualify to access The Wikipedia Library."
 msgstr ""
 
 #. Translators: This message tells users that they have not agreed to the terms of use, therefore are ineligible to access the content in The Wikipedia Library.
 #: TWLight/users/templates/users/eligibility_modal.html:30
 #, python-format
-msgid ""
-"Agreed with <a href=\"%(terms)s\" class=\"text-danger\"> terms of use </a>"
+msgid "Agreed with <a href=\"%(terms)s\" class=\"text-danger\"> terms of use </a>"
 msgstr ""
 
 #: TWLight/users/templates/users/eligibility_modal.html:40
 #, python-format
-msgid ""
-"It looks like you have an active block on your account. If you meet the "
-"other criteria you may still be permitted access to the library - please <a "
-"href=\"%(contact_url)s\">contact us</a>."
+msgid "It looks like you have an active block on your account. If you meet the other criteria you may still be permitted access to the library - please <a href=\"%(contact_url)s\">contact us</a>."
 msgstr ""
 
 #. Translators: Instructions to refresh a user's data.
@@ -2940,10 +2577,7 @@ msgstr "Vælg sprog"
 
 #. Translators: This text on the user page helps users naviage to the TranslateWiki Wikipedia Library Card platform translation page.
 #: TWLight/users/templates/users/language_form.html:31
-msgid ""
-"You can help translate the tool at <a class=\"twl-links\" href=\"https://"
-"translatewiki.net/wiki/Translating:Wikipedia_Library_Card_Platform"
-"\">translatewiki.net</a>."
+msgid "You can help translate the tool at <a class=\"twl-links\" href=\"https://translatewiki.net/wiki/Translating:Wikipedia_Library_Card_Platform\">translatewiki.net</a>."
 msgstr ""
 
 #. Translators: When the user starts a new application and submits the application, the user can view the application and withdraw if need be. This changes the label for the Withdraw button.
@@ -2963,9 +2597,7 @@ msgstr "Anmod fornyelse"
 
 #. Translators: On the page listing applications, this text explains a user they cannot renew their application since they've already requested a renewal or there aren't any renewals available.
 #: TWLight/users/templates/users/my_applications.html:79
-msgid ""
-"Renewals are either not required, not available right now, or you have "
-"already requested a renewal."
+msgid "Renewals are either not required, not available right now, or you have already requested a renewal."
 msgstr ""
 
 #. Translators: This text is the heading of a section in a user's profile where they can change their preferences.
@@ -3029,19 +2661,12 @@ msgstr ""
 
 #. Translators: This message is displayed on the page where users can request we stop processing their data.
 #: TWLight/users/templates/users/restrict_data.html:15
-msgid ""
-"Checking this box and clicking “Restrict” will pause all processing of the "
-"data you have entered into this website. You will not be able to apply for "
-"access to resources, your applications will not be further processed, and "
-"none of your data will be altered, until you return to this page and uncheck "
-"the box. This is not the same as deleting your data."
+msgid "Checking this box and clicking “Restrict” will pause all processing of the data you have entered into this website. You will not be able to apply for access to resources, your applications will not be further processed, and none of your data will be altered, until you return to this page and uncheck the box. This is not the same as deleting your data."
 msgstr ""
 
 #. Translators: This warning message is shown to coordinators who view the data restriction page.
 #: TWLight/users/templates/users/restrict_data.html:26
-msgid ""
-"You are a coordinator on this site. If you restrict the processing of your "
-"data, your coordinator flag will be removed."
+msgid "You are a coordinator on this site. If you restrict the processing of your data, your coordinator flag will be removed."
 msgstr ""
 
 #. Translators: use the date *when you are translating*, in a language-appropriate format.
@@ -3061,24 +2686,12 @@ msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:51
-msgid ""
-"<a class=\"twl-links\" href=\"https://meta.wikimedia.org/wiki/"
-"The_Wikipedia_Library\"> The Wikipedia Library </a> has partnered with "
-"publishers around the world to allow users to access otherwise paywalled "
-"resources. This website allows Wikipedia editors to search and access these "
-"resources."
+msgid "<a class=\"twl-links\" href=\"https://meta.wikimedia.org/wiki/The_Wikipedia_Library\"> The Wikipedia Library </a> has partnered with publishers around the world to allow users to access otherwise paywalled resources. This website allows Wikipedia editors to search and access these resources."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Wikimedia Foundation should not be translated. WMF should not be translated. Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:63
-msgid ""
-"This program is administered by the Wikimedia Foundation (WMF). These terms "
-"of use and privacy notice pertain to your application for access to "
-"resources through the Wikipedia Library, your use of this website, and your "
-"access to and use of those resources. They also describe our handling of the "
-"information you provide to us in order to create and administer your "
-"Wikipedia Library account. If we make material changes to the terms, we will "
-"notify users."
+msgid "This program is administered by the Wikimedia Foundation (WMF). These terms of use and privacy notice pertain to your application for access to resources through the Wikipedia Library, your use of this website, and your access to and use of those resources. They also describe our handling of the information you provide to us in order to create and administer your Wikipedia Library account. If we make material changes to the terms, we will notify users."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
@@ -3088,37 +2701,17 @@ msgstr "Krav for en Wikipedia-bibliotekskortkonto"
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:78
-msgid ""
-"Access to resources via The Wikipedia Library is reserved for community "
-"members who have demonstrated their commitment to the Wikimedia projects, "
-"and who will use their access to these resources to improve project content. "
-"To that end, in order to be eligible for The Wikipedia Library, we require "
-"that you be registered for a user account on the projects, with at least 500 "
-"edits, six (6) months of activity, and 10+ edits in the last month. We ask "
-"that you do not request access to any publishers with a limited number of "
-"available accounts whose resources you can already access for free through "
-"your local library or university, or another institution or organization, in "
-"order to provide that opportunity to others."
+msgid "Access to resources via The Wikipedia Library is reserved for community members who have demonstrated their commitment to the Wikimedia projects, and who will use their access to these resources to improve project content. To that end, in order to be eligible for The Wikipedia Library, we require that you be registered for a user account on the projects, with at least 500 edits, six (6) months of activity, and 10+ edits in the last month. We ask that you do not request access to any publishers with a limited number of available accounts whose resources you can already access for free through your local library or university, or another institution or organization, in order to provide that opportunity to others."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:94
-msgid ""
-"Additionally, if you are currently blocked or banned from a Wikimedia "
-"project, applications to resources may be rejected or restricted. If you "
-"obtain a Wikipedia Library account, but a block or ban is subsequently "
-"instituted against you on one of the projects, you may lose access to your "
-"Wikipedia Library account."
+msgid "Additionally, if you are currently blocked or banned from a Wikimedia project, applications to resources may be rejected or restricted. If you obtain a Wikipedia Library account, but a block or ban is subsequently instituted against you on one of the projects, you may lose access to your Wikipedia Library account."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:104
-msgid ""
-"Your eligibility to access The Wikipedia Library is assessed at each login. "
-"While more than half of the library's content is provided via this automated "
-"eligibility check, access to other publisher's content may be time limited, "
-"typically lapsing after one year, after which you will usually need to apply "
-"for renewal."
+msgid "Your eligibility to access The Wikipedia Library is assessed at each login. While more than half of the library's content is provided via this automated eligibility check, access to other publisher's content may be time limited, typically lapsing after one year, after which you will usually need to apply for renewal."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
@@ -3128,47 +2721,27 @@ msgstr "Ansøgning via din Wikipedia-bibliotekskortkonto"
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:118
-msgid ""
-"In order to apply for access to a partner resource, you must provide us with "
-"certain information, which we will use to evaluate your application. If your "
-"application is approved, we may transfer the information you have given us "
-"to the publishers whose resources you wish to access. They will either "
-"contact you with the account information directly or we will send access "
-"information to you ourselves."
+msgid "In order to apply for access to a partner resource, you must provide us with certain information, which we will use to evaluate your application. If your application is approved, we may transfer the information you have given us to the publishers whose resources you wish to access. They will either contact you with the account information directly or we will send access information to you ourselves."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:130
-msgid ""
-"In addition to the basic information you provide to us, our system will "
-"retrieve some information directly from the Wikimedia projects: your "
-"username, email address, edit count, registration date, user ID number, "
-"groups to which you belong, and any special user rights."
+msgid "In addition to the basic information you provide to us, our system will retrieve some information directly from the Wikimedia projects: your username, email address, edit count, registration date, user ID number, groups to which you belong, and any special user rights."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:140
-msgid ""
-"Each time you log in to the Wikipedia Library Card Platform, this "
-"information will be automatically updated."
+msgid "Each time you log in to the Wikipedia Library Card Platform, this information will be automatically updated."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:148
-msgid ""
-"We will ask you to provide us with some information about your history of "
-"contributions to the Wikimedia projects. Information on contribution history "
-"is optional, but will greatly assist us in evaluating your application."
+msgid "We will ask you to provide us with some information about your history of contributions to the Wikimedia projects. Information on contribution history is optional, but will greatly assist us in evaluating your application."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). WMF should not be translated. Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:157
-msgid ""
-"The information you provide when creating your account will be visible to "
-"you while on the site but not to others unless they are approved Wikipedia "
-"Library Coordinators, WMF Staff, or WMF Contractors who need access to this "
-"data in order to carry out their work with the Wikipedia Library, all of "
-"whom are subject to non-disclosure obligations."
+msgid "The information you provide when creating your account will be visible to you while on the site but not to others unless they are approved Wikipedia Library Coordinators, WMF Staff, or WMF Contractors who need access to this data in order to carry out their work with the Wikipedia Library, all of whom are subject to non-disclosure obligations."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
@@ -3178,46 +2751,32 @@ msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:171
-msgid ""
-"In order to access an individual publisher’s resources, you must agree to "
-"that publisher’s terms of use and privacy policy. You agree that you will "
-"not violate such terms and policies in connection with your use of the "
-"Wikipedia Library. Additionally, the following activities are prohibited "
-"while accessing publisher resources through the Wikipedia Library."
+msgid "In order to access an individual publisher’s resources, you must agree to that publisher’s terms of use and privacy policy. You agree that you will not violate such terms and policies in connection with your use of the Wikipedia Library. Additionally, the following activities are prohibited while accessing publisher resources through the Wikipedia Library."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:184
-msgid ""
-"Sharing your Wikipedia account, usernames, passwords, or any access codes "
-"for publisher resources with others;"
+msgid "Sharing your Wikipedia account, usernames, passwords, or any access codes for publisher resources with others;"
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:191
-msgid ""
-"Automatically scraping or downloading restricted content from publishers;"
+msgid "Automatically scraping or downloading restricted content from publishers;"
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:197
-msgid ""
-"Systematically making printed or electronic copies of multiple extracts of "
-"restricted content available for any purpose;"
+msgid "Systematically making printed or electronic copies of multiple extracts of restricted content available for any purpose;"
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:204
-msgid ""
-"Data mining metadata without permission—for example, in order to use "
-"metadata for auto-created stub articles;"
+msgid "Data mining metadata without permission—for example, in order to use metadata for auto-created stub articles;"
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:211
-msgid ""
-"Using the access you receive through the Wikipedia Library for profit by "
-"selling access to your account or resources which you have through it."
+msgid "Using the access you receive through the Wikipedia Library for profit by selling access to your account or resources which you have through it."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
@@ -3227,18 +2786,12 @@ msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:224
-msgid ""
-"Certain resources may only be accessed using an external search service, "
-"such as the EBSCO Discovery Service, or a proxy service, such as OCLC "
-"EZProxy. If you use such external search and/or proxy services, please "
-"review the applicable terms of use and privacy policies."
+msgid "Certain resources may only be accessed using an external search service, such as the EBSCO Discovery Service, or a proxy service, such as OCLC EZProxy. If you use such external search and/or proxy services, please review the applicable terms of use and privacy policies."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:234
-msgid ""
-"In addition, if you use OCLC EZProxy, please note that you may not use it "
-"for commercial purposes."
+msgid "In addition, if you use OCLC EZProxy, please note that you may not use it for commercial purposes."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
@@ -3248,120 +2801,49 @@ msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Wikimedia Foundation should not be translated. Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:245
-msgid ""
-"The Wikimedia Foundation and our service providers use your information for "
-"the legitimate purpose of providing Wikipedia Library services in support of "
-"our charitable mission. When you apply for a Wikipedia Library account, or "
-"use your Wikipedia Library account, we may routinely collect the following "
-"information: your username, email address, edit count, registration date, "
-"user ID number, groups to which you belong, and any special user rights; "
-"your name, country of residence, and/or affiliation, if required by a "
-"partner to which you are applying; your narrative description of your "
-"contributions and reasons for applying for access to partner resources; and "
-"the date you agree to these terms of use."
+msgid "The Wikimedia Foundation and our service providers use your information for the legitimate purpose of providing Wikipedia Library services in support of our charitable mission. When you apply for a Wikipedia Library account, or use your Wikipedia Library account, we may routinely collect the following information: your username, email address, edit count, registration date, user ID number, groups to which you belong, and any special user rights; your name, country of residence, and/or affiliation, if required by a partner to which you are applying; your narrative description of your contributions and reasons for applying for access to partner resources; and the date you agree to these terms of use."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:262
 #, python-format
-msgid ""
-"Each publisher who is a member of the Wikipedia Library program requires "
-"different specific information in the application. Some publishers may "
-"request only an email address, while others request more detailed data, such "
-"as your name, location, or institutional affiliation. When you complete your "
-"application, you will only be asked to supply information required by the "
-"publishers you have chosen, and each publisher will only receive the "
-"information they require for providing you with access. Please see our <a "
-"class=\"twl-links\" href=\"%(all_partners_url)s\">partner information</a> "
-"pages to learn what information is required by each publisher to gain access "
-"to their resources."
+msgid "Each publisher who is a member of the Wikipedia Library program requires different specific information in the application. Some publishers may request only an email address, while others request more detailed data, such as your name, location, or institutional affiliation. When you complete your application, you will only be asked to supply information required by the publishers you have chosen, and each publisher will only receive the information they require for providing you with access. Please see our <a class=\"twl-links\" href=\"%(all_partners_url)s\">partner information</a> pages to learn what information is required by each publisher to gain access to their resources."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Wikimedia Foundation should not be translated. Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:277
-msgid ""
-"Some Wikipedia Library pages are visible without logging in, but you will "
-"need to log in to apply or access proprietary partner resources. We use the "
-"data provided by you via OAuth and Wikimedia API calls to assess your "
-"application for access and to process approved requests."
+msgid "Some Wikipedia Library pages are visible without logging in, but you will need to log in to apply or access proprietary partner resources. We use the data provided by you via OAuth and Wikimedia API calls to assess your application for access and to process approved requests."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:288
 #, python-format
-msgid ""
-"In order to administer the Wikipedia Library program, we will retain the "
-"application data we collect from you for three years after your most recent "
-"login, unless you delete your account, as described below. You can log in "
-"and go to <a class=\"twl-links\" href=\"%(profile_url)s\">your profile page</"
-"a> in order to see the information associated with your account, and can "
-"download it in JSON format. You may access, update, restrict, or delete this "
-"information at any time, except for the information that is automatically "
-"retrieved from the projects. If you have any questions or concerns about the "
-"handling of your data, please contact <a class=\"twl-links\" href=\"mailto:"
-"wikipedialibrary@wikimedia.org?Subject=Wikipedia%%20Library%%20Card"
-"%%20account%%20deactivation\"> wikipedialibrary@wikimedia.org </a>."
+msgid "In order to administer the Wikipedia Library program, we will retain the application data we collect from you for three years after your most recent login, unless you delete your account, as described below. You can log in and go to <a class=\"twl-links\" href=\"%(profile_url)s\">your profile page</a> in order to see the information associated with your account, and can download it in JSON format. You may access, update, restrict, or delete this information at any time, except for the information that is automatically retrieved from the projects. If you have any questions or concerns about the handling of your data, please contact <a class=\"twl-links\" href=\"mailto:wikipedialibrary@wikimedia.org?Subject=Wikipedia%%20Library%%20Card%%20account%%20deactivation\"> wikipedialibrary@wikimedia.org </a>."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:305
-msgid ""
-"If you decide to disable your Wikipedia Library account, you can use the "
-"delete button on your profile to delete certain personal information "
-"associated with your account. We will delete your real name, institutional "
-"affiliation, and country of residence. Please note that the system will "
-"retain a record of your username, the publishers to which you applied or had "
-"access, and the dates of that access. Note that deletion is not reversible. "
-"Deletion of your Wikipedia Library account may also correspond with the "
-"removal of any resource access to which you were eligible or approved. If "
-"you request the deletion of account information and later wish to apply for "
-"a new account, you will need to provide the necessary information again."
+msgid "If you decide to disable your Wikipedia Library account, you can use the delete button on your profile to delete certain personal information associated with your account. We will delete your real name, institutional affiliation, and country of residence. Please note that the system will retain a record of your username, the publishers to which you applied or had access, and the dates of that access. Note that deletion is not reversible. Deletion of your Wikipedia Library account may also correspond with the removal of any resource access to which you were eligible or approved. If you request the deletion of account information and later wish to apply for a new account, you will need to provide the necessary information again."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). WMF should not be translated. Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:321
-msgid ""
-"The Wikipedia Library is run by WMF Staff, Contractors, and approved "
-"volunteer Coordinators. The data associated with your account will be shared "
-"with the WMF staff, contractors, service providers, and volunteer "
-"coordinators who need to process the information in connection with their "
-"work for the Wikipedia Library, and who are subject to confidentiality "
-"obligations. We will also use your data for internal Wikipedia Library "
-"purposes such as distributing user surveys and account notifications, and in "
-"a depersonalized or aggregated fashion for statistical analysis and "
-"administration. Finally, we will share your information with the publishers "
-"whom you specifically select in order to provide you with access to "
-"resources. Otherwise, your information will not be shared with third "
-"parties, with the exception of the circumstances described below."
+msgid "The Wikipedia Library is run by WMF Staff, Contractors, and approved volunteer Coordinators. The data associated with your account will be shared with the WMF staff, contractors, service providers, and volunteer coordinators who need to process the information in connection with their work for the Wikipedia Library, and who are subject to confidentiality obligations. We will also use your data for internal Wikipedia Library purposes such as distributing user surveys and account notifications, and in a depersonalized or aggregated fashion for statistical analysis and administration. Finally, we will share your information with the publishers whom you specifically select in order to provide you with access to resources. Otherwise, your information will not be shared with third parties, with the exception of the circumstances described below."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). WMF should not be translated.
 #: TWLight/users/templates/users/terms.html:338
-msgid ""
-"We may disclose any collected information when required by law, when we have "
-"your permission, when needed to protect our rights, privacy, safety, users, "
-"or the general public, and when necessary to enforce these terms, WMF’s "
-"general <a class=\"twl-links\" href=\"https://foundation.wikimedia.org/wiki/"
-"Terms_of_Use\">Terms of Use</a>, or any other WMF policy."
+msgid "We may disclose any collected information when required by law, when we have your permission, when needed to protect our rights, privacy, safety, users, or the general public, and when necessary to enforce these terms, WMF’s general <a class=\"twl-links\" href=\"https://foundation.wikimedia.org/wiki/Terms_of_Use\">Terms of Use</a>, or any other WMF policy."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:349
-msgid ""
-"We take the security of your personal data seriously, and take reasonable "
-"precautions to ensure your data is protected. These precautions include "
-"access controls to limit who has access to your data and security "
-"technologies to protect data stored on the server. However, we cannot "
-"guarantee the safety of your data as it is transmitted and stored."
+msgid "We take the security of your personal data seriously, and take reasonable precautions to ensure your data is protected. These precautions include access controls to limit who has access to your data and security technologies to protect data stored on the server. However, we cannot guarantee the safety of your data as it is transmitted and stored."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:360
-msgid ""
-"Please note that these terms do not control the use and handling of your "
-"data by the publishers and service providers whose resources you access or "
-"apply to access. Please read their individual privacy policies for that "
-"information."
+msgid "Please note that these terms do not control the use and handling of your data by the publishers and service providers whose resources you access or apply to access. Please read their individual privacy policies for that information."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
@@ -3372,34 +2854,17 @@ msgstr "Importeret"
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Wikimedia Foundation should not be translated. Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:373
-msgid ""
-"The Wikimedia Foundation is a nonprofit organization based in San Francisco, "
-"California. The Wikipedia Library program provides access to resources held "
-"by publishers in multiple countries. If you apply for a Wikipedia Library "
-"account (whether you are inside or outside of the United States), you "
-"understand that your personal data will be collected, transferred, stored, "
-"processed, disclosed and otherwise used in the U.S. as described in this "
-"privacy policy. You also understand that your information may be transferred "
-"by us from the U.S. to other countries, which may have different or less "
-"stringent data protection laws than your country, in connection with "
-"providing services to you, including evaluating your application and "
-"securing access to your chosen publishers (locations for each publisher are "
-"outlined on their respective partner information pages)."
+msgid "The Wikimedia Foundation is a nonprofit organization based in San Francisco, California. The Wikipedia Library program provides access to resources held by publishers in multiple countries. If you apply for a Wikipedia Library account (whether you are inside or outside of the United States), you understand that your personal data will be collected, transferred, stored, processed, disclosed and otherwise used in the U.S. as described in this privacy policy. You also understand that your information may be transferred by us from the U.S. to other countries, which may have different or less stringent data protection laws than your country, in connection with providing services to you, including evaluating your application and securing access to your chosen publishers (locations for each publisher are outlined on their respective partner information pages)."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:392
-msgid ""
-"Please note that in the event of any differences in meaning or "
-"interpretation between the original English version of these terms and a "
-"translation, the original English version takes precedence."
+msgid "Please note that in the event of any differences in meaning or interpretation between the original English version of these terms and a translation, the original English version takes precedence."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Wikimedia Foundation should not be translated.
 #: TWLight/users/templates/users/terms.html:403
-msgid ""
-"See also the <a class=\"twl-links\" href=\"https://wikimediafoundation.org/"
-"wiki/Privacy_policy\">Wikimedia Foundation Privacy Policy</a>."
+msgid "See also the <a class=\"twl-links\" href=\"https://wikimediafoundation.org/wiki/Privacy_policy\">Wikimedia Foundation Privacy Policy</a>."
 msgstr ""
 
 #. Translators: This is the second to last line of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
@@ -3420,11 +2885,7 @@ msgstr "Wikimedia-stiftensels privatlivspolitik"
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:426
-msgid ""
-"By checking this box and clicking “Submit”, you agree that you have read the "
-"above terms and that you will adhere to the terms of use in your application "
-"to and use of the The Wikipedia Library, and the publishers’ services to "
-"which you gain access through The Wikipedia Library program."
+msgid "By checking this box and clicking “Submit”, you agree that you have read the above terms and that you will adhere to the terms of use in your application to and use of the The Wikipedia Library, and the publishers’ services to which you gain access through The Wikipedia Library program."
 msgstr ""
 
 #: TWLight/users/templates/users/user_collection_tile.html:32
@@ -3477,29 +2938,18 @@ msgstr "Slet al data"
 
 #. Translators: This message is displayed on the page where users can request the deletion of their data.
 #: TWLight/users/templates/users/user_confirm_delete.html:17
-msgid ""
-"<b>Warning:</b> Performing this action will delete your Wikipedia Library "
-"Card user account and all associated applications. This process is not "
-"reversible. You may lose any partner accounts you were granted, and will not "
-"be able to renew those accounts or apply for new ones."
+msgid "<b>Warning:</b> Performing this action will delete your Wikipedia Library Card user account and all associated applications. This process is not reversible. You may lose any partner accounts you were granted, and will not be able to renew those accounts or apply for new ones."
 msgstr ""
 
 #. Translators: this should show up for people who log in with a username/password and not OAuth, so we don't know what their Wikipedia identity is.
-#.
 #: TWLight/users/templates/users/user_detail.html:12
 #, python-format
-msgid ""
-"Hi, %(username)s! You don't have a Wikipedia editor profile attached to your "
-"account here, so you are probably a site administrator."
+msgid "Hi, %(username)s! You don't have a Wikipedia editor profile attached to your account here, so you are probably a site administrator."
 msgstr ""
 
 #. Translators: In the unlikely scenario that someone is able to register an account without using OAuth (thus leaving us without some of the information required for applications), users will see this message, encouraging them to re-register.
 #: TWLight/users/templates/users/user_detail.html:20
-msgid ""
-"If you aren't a site administrator, something weird has happened. You won't "
-"be able to apply for access without a Wikipedia editor profile. You should "
-"log out and create a new account by logging in via OAuth, or contact a site "
-"administrator for help."
+msgid "If you aren't a site administrator, something weird has happened. You won't be able to apply for access without a Wikipedia editor profile. You should log out and create a new account by logging in via OAuth, or contact a site administrator for help."
 msgstr ""
 
 #. Translators: Labels a sections where coordinators can select their email preferences.
@@ -3510,17 +2960,12 @@ msgstr ""
 #. Translators: This message is shown on user's own profile page, encouraging them to make sure their information is up to date, so that account coordinators can use the information to judge applications.
 #: TWLight/users/views.py:176
 #, python-brace-format
-msgid ""
-"Please <a class='twl-links' href='{url}'>update your contributions</a> to "
-"Wikipedia to help coordinators evaluate your applications."
+msgid "Please <a class='twl-links' href='{url}'>update your contributions</a> to Wikipedia to help coordinators evaluate your applications."
 msgstr ""
 
 #. Translators: Coordinators are shown this message when they unselect all three types of reminder email options under preferences.
 #: TWLight/users/views.py:288
-msgid ""
-"You have chosen not to receive reminder emails. As a coordinator, you should "
-"receive at least one type of reminder emails, so consider changing your "
-"preferences."
+msgid "You have chosen not to receive reminder emails. As a coordinator, you should receive at least one type of reminder emails, so consider changing your preferences."
 msgstr ""
 
 #. Translators: Coordinators are shown this message when they make changes to their reminder email options under preferences.
@@ -3555,13 +3000,8 @@ msgstr "Din email adresse er blevet ændret til {email}."
 
 #. Translators: If the user has not filled out their email, they can browse the website but cannot apply for access to resources.
 #: TWLight/users/views.py:487
-msgid ""
-"Your email is blank. You can still explore the site, but you won't be able "
-"to apply for access to partner resources without an email."
-msgstr ""
-"E-mailadressefeltet er tomt. Du har stadigvæk mulighed for at gennemse "
-"sitet, men du vil ikke have mulighed for at ansøge om adgang til partner-"
-"ressourcer uden en e-mailadresse."
+msgid "Your email is blank. You can still explore the site, but you won't be able to apply for access to partner resources without an email."
+msgstr "E-mailadressefeltet er tomt. Du har stadigvæk mulighed for at gennemse sitet, men du vil ikke have mulighed for at ansøge om adgang til partner-ressourcer uden en e-mailadresse."
 
 #. Translators: This message is shown once the access to a partner has successfully been returned.
 #: TWLight/users/views.py:801
@@ -3595,31 +3035,3 @@ msgstr "Ingen aktive blokeringer"
 msgid "10+ edits in the last 30 days"
 msgstr "10+ redigeringer den seneste måned"
 
-#: tests/shunit/data/bad_i18n_comment_1.py:3
-#: tests/shunit/data/bad_i18n_newline_1.py:5
-msgid "1"
-msgstr ""
-
-#. Translators: Lorem ipsum dolor sit amet, consectetur adipiscing elit. Mauris vitae ipsum ut purus faucibus pretium. Proin tempus neque et aliquet consectetur. Ut egestas sapien in consectetur sagittis. Mauris neque lacus, dapibus non viverra vitae, interdum ut aenean ipsum.
-#. Translators: Lorem ipsum dolor sit amet, consectetur adipiscing elit. Mauris vitae ipsum ut purus faucibus pretium. Proin tempus neque et aliquet consectetur. Ut egestas sapien in consectetur sagittis. Mauris neque lacus, dapibus non.
-#: tests/shunit/data/bad_i18n_comment_2.py:4
-#: tests/shunit/data/bad_i18n_newline_2.py:5 tests/shunit/data/good_i18n_1.py:2
-#: tests/shunit/data/good_i18n_2.py:2
-msgid "2"
-msgstr ""
-
-#: tests/shunit/data/bad_i18n_newline_3.py:5
-msgid "3"
-msgstr ""
-
-#: tests/shunit/data/bad_i18n_newline_4.py:5
-msgid "4"
-msgstr ""
-
-#: tests/shunit/data/bad_i18n_newline_5.py:5
-msgid "5"
-msgstr ""
-
-#: tests/shunit/data/bad_i18n_newline_6.py:5
-msgid "6"
-msgstr ""

--- a/locale/de/LC_MESSAGES/django.po
+++ b/locale/de/LC_MESSAGES/django.po
@@ -31,10 +31,11 @@
 # Author: Umlaut
 msgid ""
 msgstr ""
+""
 "Project-Id-Version: Wikipedia Library Card Platform - Website\n"
-"Report-Msgid-Bugs-To: wikipedialibrary@wikimedia.org\n"
+"Report-Msgid-Bugs-To: translatewiki.net\n"
 "POT-Creation-Date: 2024-07-11 20:55+0000\n"
-"PO-Revision-Date: 2024-07-11 12:30:13+0000\n"
+"PO-Revision-Date: 2024-07-15 12:29:13+0000\n"
 "Language: de\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
@@ -66,12 +67,8 @@ msgstr "Persönliche Angaben"
 #. Translators: This note appears in a section of a form where we ask users to enter info (like country of residence) when applying for resource access.
 #: TWLight/applications/forms.py:179
 #, python-brace-format
-msgid ""
-"<p><small><i>Your personal data will be processed according to our <a "
-"class='twl-links' href='{terms_url}'> privacy policy</a>.</i></small></p>"
-msgstr ""
-"<p><small><i>Personenbezogene Daten werden gemäß den <a class='twl-links'  "
-"href='{terms_url}'> Datenschutzrichtlinien</a> verarbeitet.</i></small></p>"
+msgid "<p><small><i>Your personal data will be processed according to our <a class='twl-links' href='{terms_url}'> privacy policy</a>.</i></small></p>"
+msgstr "<p><small><i>Personenbezogene Daten werden gemäß den <a class='twl-links'  href='{terms_url}'> Datenschutzrichtlinien</a> verarbeitet.</i></small></p>"
 
 #. Translators: This is the title of the application form page, where users enter information required for the application. It lets the user know which partner application they are entering data for. {partner}
 #: TWLight/applications/forms.py:189
@@ -112,12 +109,8 @@ msgstr "Die E-Mail-Addresse für deinen Account auf der Website des Partners."
 #. Translators: This labels a choice field where users will have to select the number of months they wish to have their access for as part of the application renewal confirmation.
 #. Translators: When filling out an application, users may be required to enter the length of the account (expiry) they wish to have for proxy partners.
 #: TWLight/applications/forms.py:339 TWLight/applications/helpers.py:100
-msgid ""
-"The number of months you wish to have this access for before renewal is "
-"required"
-msgstr ""
-"Die Anzahl an Monaten, für die du Zugriff haben möchtest, bevor dieser "
-"erneuert werden muss."
+msgid "The number of months you wish to have this access for before renewal is required"
+msgstr "Die Anzahl an Monaten, für die du Zugriff haben möchtest, bevor dieser erneuert werden muss."
 
 #. Translators: When filling out an application, users may need to specify their name
 #: TWLight/applications/helpers.py:81
@@ -205,12 +198,8 @@ msgstr "E-Mail"
 
 #. Translators: This comment is added to pending applications when our terms of use change.
 #: TWLight/applications/management/commands/notify_applicants_tou_changes.py:54
-msgid ""
-"Our terms of use have changed. Your applications will not be processed until "
-"you log in and agree to our updated terms."
-msgstr ""
-"Unsere Nutzungsbedingungen haben sich geändert. Deine Bewerbungen werden "
-"erst bearbeitet, wenn du dich anmeldest und den neuen Bedingungen zustimmst."
+msgid "Our terms of use have changed. Your applications will not be processed until you log in and agree to our updated terms."
+msgstr "Unsere Nutzungsbedingungen haben sich geändert. Deine Bewerbungen werden erst bearbeitet, wenn du dich anmeldest und den neuen Bedingungen zustimmst."
 
 #. Translators: This is the status of an application that has not yet been reviewed.
 #: TWLight/applications/models.py:54
@@ -276,42 +265,26 @@ msgstr "Zugriffs-URL: {access_url}"
 
 #. Translators: This text goes into account approval emails in the case that we need to send the user's details to a publisher for manual account setup.
 #: TWLight/applications/models.py:331
-msgid ""
-"You can expect to receive access details within a week or two once it has "
-"been processed."
-msgstr ""
-"Du wirst voraussichtlich eine bis zwei Wochen nach der Bearbeitung die "
-"Zugangsdaten erhalten."
+msgid "You can expect to receive access details within a week or two once it has been processed."
+msgstr "Du wirst voraussichtlich eine bis zwei Wochen nach der Bearbeitung die Zugangsdaten erhalten."
 
 #. Translators: This comment is added to open applications when a partner joins the Library Bundle, which does not require applications.
 #: TWLight/applications/signals.py:247
-msgid ""
-"This partner joined the Library Bundle, which does not require applications. "
-"This application will be marked as invalid."
-msgstr ""
-"Dieser Partner gehört zum Zugangspaket, für das man sich nicht bewerben "
-"muss. Diese Bewerbung hier wird daher als ungültig markiert."
+msgid "This partner joined the Library Bundle, which does not require applications. This application will be marked as invalid."
+msgstr "Dieser Partner gehört zum Zugangspaket, für das man sich nicht bewerben muss. Diese Bewerbung hier wird daher als ungültig markiert."
 
 #. Translators: This is shown to users if the application is to a partner for which we have run out of available accounts. The application is therefore on a 'waitlist', and will be reviewed when more accounts are available.
 #: TWLight/applications/templates/applications/application_evaluation.html:29
-msgid ""
-"This application is on the waitlist because this partner does not have any "
-"access grants available at this time."
-msgstr ""
-"Diese Bewerbung ist auf der Warteliste, weil für den Partner zurzeit keine "
-"Zugänge zur Verfügung stehen."
+msgid "This application is on the waitlist because this partner does not have any access grants available at this time."
+msgstr "Diese Bewerbung ist auf der Warteliste, weil für den Partner zurzeit keine Zugänge zur Verfügung stehen."
 
 #. Translators: This message is shown on pages where coordinators can see personal information about applicants.
 #: TWLight/applications/templates/applications/application_evaluation.html:36
 #: TWLight/applications/templates/applications/application_list_include.html:6
 #: TWLight/applications/templates/applications/send_partner.html:45
 #: TWLight/resources/templates/resources/partner_users.html:18
-msgid ""
-"Coordinators: This page may contain personal information such as real names "
-"and email addresses. Please remember that this information is confidential."
-msgstr ""
-"Diese Seite kann persönliche Informationen wie echte Namen und E-Mail-"
-"Adressen enthalten. Diese Informationen sind vertraulich."
+msgid "Coordinators: This page may contain personal information such as real names and email addresses. Please remember that this information is confidential."
+msgstr "Diese Seite kann persönliche Informationen wie echte Namen und E-Mail-Adressen enthalten. Diese Informationen sind vertraulich."
 
 #. Translators: This is the title of the application page shown to users who are a coordinator, and are able to accept or reject the application.
 #: TWLight/applications/templates/applications/application_evaluation.html:39
@@ -320,12 +293,8 @@ msgstr "Antrag prüfen"
 
 #. Translators: This text is shown to coordinators on application pages if the applicant has restricted processing of their data.
 #: TWLight/applications/templates/applications/application_evaluation.html:42
-msgid ""
-"This user has requested a restriction on the processing of their data, so "
-"you cannot change the status of their application."
-msgstr ""
-"Diese Person hat eine Einschränkung der Datenverarbeitung gewünscht, sodass "
-"du den Status dieses Antrags nicht ändern kannst."
+msgid "This user has requested a restriction on the processing of their data, so you cannot change the status of their application."
+msgstr "Diese Person hat eine Einschränkung der Datenverarbeitung gewünscht, sodass du den Status dieses Antrags nicht ändern kannst."
 
 #. Translators: This is the title of the application page shown to users who are not a coordinator.
 #: TWLight/applications/templates/applications/application_evaluation.html:48
@@ -398,12 +367,8 @@ msgstr "Unbekannt"
 
 #. Translators: This is the text displayed to coordinators when an applicant has no country of residence in their profile.
 #: TWLight/applications/templates/applications/application_evaluation.html:123
-msgid ""
-"Please request the applicant add their country of residence to their profile "
-"before proceeding further."
-msgstr ""
-"Bewerber müssen in ihrem Profil das Land ergänzen, in dem sie wohnen, bevor "
-"sie fortfahren können."
+msgid "Please request the applicant add their country of residence to their profile before proceeding further."
+msgstr "Bewerber müssen in ihrem Profil das Land ergänzen, in dem sie wohnen, bevor sie fortfahren können."
 
 #. Translators: This labels the section of an application showing the total number of accounts available for a partner or their collection.
 #: TWLight/applications/templates/applications/application_evaluation.html:134
@@ -413,12 +378,8 @@ msgstr "Verfügbare Zugänge"
 #. Translators: This labels the section of an application showing whether the user had agreed to the terms of use or not.
 #: TWLight/applications/templates/applications/application_evaluation.html:145
 #, python-format
-msgid ""
-"Has agreed to the site's <a class=\"twl-links\" href=\"%(terms_url)s\">terms "
-"of use</a>?"
-msgstr ""
-"Wurde den <a class=\"twl-links\" href=\"%(terms_url)s\">Nutzungsbedingungen</"
-"a> zugestimmt?"
+msgid "Has agreed to the site's <a class=\"twl-links\" href=\"%(terms_url)s\">terms of use</a>?"
+msgstr "Wurde den <a class=\"twl-links\" href=\"%(terms_url)s\">Nutzungsbedingungen</a> zugestimmt?"
 
 #. Translators: Displayed to coordinators when they've agreed to the terms of use.
 #. Translators: Displayed if the user has agreed to the terms of use.
@@ -453,12 +414,8 @@ msgstr "Nein"
 
 #. Translators: This is the text displayed to coordinators when an applicant has not agreed to the terms of use.
 #: TWLight/applications/templates/applications/application_evaluation.html:159
-msgid ""
-"Please request the applicant agree to the site's terms of use before "
-"approving this application."
-msgstr ""
-"Bewerber müssen den Nutzungsbedingungen der Seite zustimmen, bevor die "
-"Bewerbung bestätigt werden kann."
+msgid "Please request the applicant agree to the site's terms of use before approving this application."
+msgstr "Bewerber müssen den Nutzungsbedingungen der Seite zustimmen, bevor die Bewerbung bestätigt werden kann."
 
 #. Translators: This labels the section of an application containing the user's motivation for wanting access to this resource.
 #: TWLight/applications/templates/applications/application_evaluation.html:176
@@ -478,10 +435,8 @@ msgstr "Ist dies die Erneuerung einer bestehenden Zugangsberechtigung?"
 #. Translators: This message is shown next to the 'Renewal of existing access grant?' label if the application is a renewal. Don't translate HTML tags or parent_url.
 #: TWLight/applications/templates/applications/application_evaluation.html:195
 #, python-format
-msgid ""
-"Yes (<a class=\"twl-links\" href=\"%(parent_url)s\">previous application</a>)"
-msgstr ""
-"Ja (<a class=\"twl-links\" href=\"%(parent_url)s\">vorherige Bewerbung</a>)"
+msgid "Yes (<a class=\"twl-links\" href=\"%(parent_url)s\">previous application</a>)"
+msgstr "Ja (<a class=\"twl-links\" href=\"%(parent_url)s\">vorherige Bewerbung</a>)"
 
 #. Translators: This labels the section of the application showing the length of access remaining on the user's previous authorization.
 #: TWLight/applications/templates/applications/application_evaluation.html:208
@@ -501,8 +456,7 @@ msgstr "Aktuelle Bewerbungen in den letzten 90 Tagen"
 #. Translators: This text is shown to Coordinators when applicant has not made any application in the last 90 days.
 #: TWLight/applications/templates/applications/application_evaluation.html:264
 msgid "No applications were made in last 90 days by the applicant"
-msgstr ""
-"In den letzten 90 Tagen hat der Bewerber keine neuen Bewerbungen eingereicht"
+msgstr "In den letzten 90 Tagen hat der Bewerber keine neuen Bewerbungen eingereicht"
 
 #. Translators: This is the title of the section of an application page which contains the comment thread between the user and account coordinator.
 #: TWLight/applications/templates/applications/application_evaluation.html:268
@@ -516,12 +470,8 @@ msgstr "Kommentar hinzufügen"
 
 #. Translators: On an application page, this text tells users that the comments posted on the application are visible to coordinators and the submitting user only.
 #: TWLight/applications/templates/applications/application_evaluation.html:297
-msgid ""
-"Comments are visible to all coordinators and to the editor who submitted "
-"this application."
-msgstr ""
-"Kommentare können von allen Koordinatoren und der anfragenden Person, die "
-"diese Bewerbung gesendet hat, gesehen werden."
+msgid "Comments are visible to all coordinators and to the editor who submitted this application."
+msgstr "Kommentare können von allen Koordinatoren und der anfragenden Person, die diese Bewerbung gesendet hat, gesehen werden."
 
 #. Translators: This is the title of the section of an application page which lists information about the user who submitted the application.
 #. Translators: On the page where coordinators can view data on applications to a partner they coordinate, this is a table column heading for the username.
@@ -734,25 +684,14 @@ msgstr "Status ändern"
 
 #: TWLight/applications/templates/applications/apply.html:20
 #, python-format
-msgid ""
-"If your application is successful we may share your email address with "
-"%(partner)s. This is required to set up your access to their resources. By "
-"submitting this form you agree to allow your email address to be shared with "
-"%(partner)s if your application is successful, for the purposes of account "
-"setup."
-msgstr ""
-"Wenn deine Bewerbung erfolgreich ist, geben wir ggf. deine E-Mail-Adresse an "
-"%(partner)s weiter. Dies ist erforderlich, um den Zugang zu den Ressourcen "
-"einzurichten. Mit dem Absenden dieses Formulars erklärst du sich damit "
-"einverstanden, dass deine E-Mail-Adresse an %(partner)s weitergegeben wird, "
-"wenn deine Bewerbung erfolgreich ist, um dein Konto einzurichten."
+msgid "If your application is successful we may share your email address with %(partner)s. This is required to set up your access to their resources. By submitting this form you agree to allow your email address to be shared with %(partner)s if your application is successful, for the purposes of account setup."
+msgstr "Wenn deine Bewerbung erfolgreich ist, geben wir ggf. deine E-Mail-Adresse an %(partner)s weiter. Dies ist erforderlich, um den Zugang zu den Ressourcen einzurichten. Mit dem Absenden dieses Formulars erklärst du sich damit einverstanden, dass deine E-Mail-Adresse an %(partner)s weitergegeben wird, wenn deine Bewerbung erfolgreich ist, um dein Konto einzurichten."
 
 #. Translators: This message is displayed on the page where users can confirm their renewal. Please do not translate partner.
 #: TWLight/applications/templates/applications/confirm_renewal.html:23
 #, python-format
 msgid "Click 'confirm' to renew your application for %(partner)s"
-msgstr ""
-"Klick auf „Bestätigen“ um deine Bewerbung für %(partner)s zu erneueren."
+msgstr "Klick auf „Bestätigen“ um deine Bewerbung für %(partner)s zu erneueren."
 
 #. Translators: Labels the submit button requesting confirmation of application renewal.
 #. Translators: This is the button coordinators click to confirm deletion of a suggestion.
@@ -774,12 +713,8 @@ msgstr "Auf welche Ressourcen möchtest du zugreifen?"
 
 #. Translators: This text explains that Library Bundle partners are not shown in this list.
 #: TWLight/applications/templates/applications/request_for_application.html:26
-msgid ""
-"Library Bundle partners are not shown as eligibility is determined "
-"automatically."
-msgstr ""
-"Library Bundle-Partner werden nicht angezeigt, da die Berechtigung "
-"automatisch ermittelt wird."
+msgid "Library Bundle partners are not shown as eligibility is determined automatically."
+msgstr "Library Bundle-Partner werden nicht angezeigt, da die Berechtigung automatisch ermittelt wird."
 
 #. Translators: On the page where users can apply for multiple partners, this message shows next to the partner name, taking them to the full application page when clicked.
 #: TWLight/applications/templates/applications/request_for_application.html:48
@@ -793,21 +728,13 @@ msgstr "Es wurden noch keine Partnerinformationen hinzugefügt."
 
 #. Translators: the HTML is so that the word 'waitlisted' will look the same as it does in the page above; please translate 'waitlisted' the same way you did elsewhere in this file.
 #: TWLight/applications/templates/applications/request_for_application.html:74
-msgid ""
-"You can apply to <span class=\"badge badge-warning\">Waitlisted</span> "
-"partners, but they don't have access grants available right now. We will "
-"process those applications when access becomes available."
-msgstr ""
-"Du kannst dich bei <span class=\"badge badge-warning\">Partnern mit "
-"Wartelisten</span> bewerben. Diese haben aktuell keine Zugänge verfügbar. "
-"Wir werden jene Bewerbungen berücksichtigen, wenn Zugänge wieder verfügbar "
-"sind."
+msgid "You can apply to <span class=\"badge badge-warning\">Waitlisted</span> partners, but they don't have access grants available right now. We will process those applications when access becomes available."
+msgstr "Du kannst dich bei <span class=\"badge badge-warning\">Partnern mit Wartelisten</span> bewerben. Diese haben aktuell keine Zugänge verfügbar. Wir werden jene Bewerbungen berücksichtigen, wenn Zugänge wieder verfügbar sind."
 
 #. Translators: On the page where coordinators can see approved applications which have not had their details sent to the partner, this message shows when there are applications ready to be processed.
 #: TWLight/applications/templates/applications/send.html:10
 msgid "Partners with approved, unsent applications"
-msgstr ""
-"Partner mit bestätigten Bewerbungen, an die Daten noch nicht gesendet wurden"
+msgstr "Partner mit bestätigten Bewerbungen, an die Daten noch nicht gesendet wurden"
 
 #. Translators: On the page where coordinators can see approved applications which have not had their details sent to the partner, this message shows when no such applications exist or all have already been sent.
 #: TWLight/applications/templates/applications/send.html:23
@@ -823,19 +750,13 @@ msgstr "Bewerbungsdaten für %(object)s"
 #. Translators: This message is shown when applications exceed the number of accounts available.
 #: TWLight/applications/templates/applications/send_partner.html:54
 #, python-format
-msgid ""
-"Application(s) for %(object)s, if sent, will exceed the total available "
-"accounts for the partner. Please proceed at your own discretion."
-msgstr ""
-"Die Anträge für %(object)s würden die maximal verfügbaren Accounts für "
-"diesen Partner übersteigen. Fortsetzung nach eigenem Ermessen."
+msgid "Application(s) for %(object)s, if sent, will exceed the total available accounts for the partner. Please proceed at your own discretion."
+msgstr "Die Anträge für %(object)s würden die maximal verfügbaren Accounts für diesen Partner übersteigen. Fortsetzung nach eigenem Ermessen."
 
 #. Translators: When viewing the list of applications ready to be sent for a particular partner, this is instructions for the coordinator to click the 'mark as sent' button after they have sent the information.
 #: TWLight/applications/templates/applications/send_partner.html:65
 msgid "When you've processed the data below, click the 'mark as sent' button."
-msgstr ""
-"Wenn du die unten stehenden Daten versendet hast, klicke auf „Als gesendet "
-"markieren“"
+msgstr "Wenn du die unten stehenden Daten versendet hast, klicke auf „Als gesendet markieren“"
 
 #. Translators: When viewing the list of applications ready to be sent for a particular partner, this is the title of the section containing contact information for the people applications should be sent to.
 #: TWLight/applications/templates/applications/send_partner.html:71
@@ -846,12 +767,8 @@ msgstr[1] "Kontakte"
 
 #. Translators: When viewing the list of applications ready to be sent for a particular partner, this message shows if there is no information about who the applications should be sent to. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/applications/templates/applications/send_partner.html:89
-msgid ""
-"Whoops, we don't have any listed contacts. Please notify Wikipedia Library "
-"administrators."
-msgstr ""
-"Wir haben leider keine Konftaktinformationen verfügbar. Bitte informiere die "
-"Administratoren von „The Wikipedia Library”."
+msgid "Whoops, we don't have any listed contacts. Please notify Wikipedia Library administrators."
+msgstr "Wir haben leider keine Konftaktinformationen verfügbar. Bitte informiere die Administratoren von „The Wikipedia Library”."
 
 #. Translators: When viewing the list of applications ready to be sent for a particular partner, this is the title of the section containing the information about those applications.
 #: TWLight/applications/templates/applications/send_partner.html:94
@@ -866,12 +783,8 @@ msgstr "Als gesendet markieren"
 
 #. Translators: This text guides coordinators in using the code sending interface for approved applications.
 #: TWLight/applications/templates/applications/send_partner.html:152
-msgid ""
-"Use the dropdown menus to denote which editor will receive each code. Access "
-"codes will be sent to users automatically."
-msgstr ""
-"Verwende das Dropdown-Menü um festzulegen, welcher Person welchen Code "
-"erhält. Zugangsberechtigungen werden den Nutzern automatisch zugesendet."
+msgid "Use the dropdown menus to denote which editor will receive each code. Access codes will be sent to users automatically."
+msgstr "Verwende das Dropdown-Menü um festzulegen, welcher Person welchen Code erhält. Zugangsberechtigungen werden den Nutzern automatisch zugesendet."
 
 #. Translators: This labels a drop-down selection where staff can assign an access code to a user.
 #: TWLight/applications/templates/applications/send_partner.html:173
@@ -881,32 +794,19 @@ msgstr "Code auswählen:"
 #. Translators: When viewing the list of applications ready to be sent for a particular partner, this message shows when there are none to show the coordinator.
 #: TWLight/applications/templates/applications/send_partner.html:192
 msgid "There are no approved, unsent applications."
-msgstr ""
-"Es gibt keine bestätigten Bewerbungen, an die Daten noch nicht gesendet "
-"wurden."
+msgstr "Es gibt keine bestätigten Bewerbungen, an die Daten noch nicht gesendet wurden."
 
 #. Translators: When a user applies for a set of resources, they receive this message if none are currently available. They are instead placed on a 'waitlist' for later approval.
 #. Translators: When a user renews their resource, they receive this message if none are currently available. They are instead placed on a 'waitlist' for later approval.
 #: TWLight/applications/views.py:140 TWLight/applications/views.py:1282
-msgid ""
-"This partner does not have any access grants available at this time. You may "
-"still apply for access; your application will be reviewed when access grants "
-"become available."
-msgstr ""
-"Dieser Partner bietet zurzeit keine freien Zugänge an. Du kannst dich "
-"trotzdem bewerben; wir bearbeiten die Bewerbung, sobald Zugänge wieder "
-"verfügbar sind."
+msgid "This partner does not have any access grants available at this time. You may still apply for access; your application will be reviewed when access grants become available."
+msgstr "Dieser Partner bietet zurzeit keine freien Zugänge an. Du kannst dich trotzdem bewerben; wir bearbeiten die Bewerbung, sobald Zugänge wieder verfügbar sind."
 
 #. Translators: This message is shown to users once they've successfully submitted their application for review.
 #: TWLight/applications/views.py:163
 #, python-brace-format
-msgid ""
-"Your application has been submitted for review. Head over to <a "
-"href='{applications_url}'>My Applications</a> to view the status."
-msgstr ""
-"Deine Bewerbung wurde zur Überprüfung abgesendet. Du kannst den Status "
-"deiner Bewerbungen <a href='{applications_url}'>unter diesem Link</a> "
-"einsehen."
+msgid "Your application has been submitted for review. Head over to <a href='{applications_url}'>My Applications</a> to view the status."
+msgstr "Deine Bewerbung wurde zur Überprüfung abgesendet. Du kannst den Status deiner Bewerbungen <a href='{applications_url}'>unter diesem Link</a> einsehen."
 
 #. Translators: This text is displayed to users when the user has chosen to restrict data and is trying to apply for multiple partners
 #: TWLight/applications/views.py:276
@@ -916,8 +816,7 @@ msgstr "Der Text in diesem Feld ist eingeschränkt sichtbar."
 #. Translators: This message is shown to user when he tries to apply to same partner more than once
 #: TWLight/applications/views.py:372
 msgid "You already have an application for this Partner."
-msgstr ""
-"Du hast dich bereits für einen Zugang zur Plattform dieses Partners beworben."
+msgstr "Du hast dich bereits für einen Zugang zur Plattform dieses Partners beworben."
 
 #. Translators: Editor = wikipedia editor, gender unknown.
 #: TWLight/applications/views.py:469 TWLight/applications/views.py:548
@@ -955,22 +854,13 @@ msgstr "Gesendete Bewerbungen"
 
 #. Translators: After a coordinator has changed the status of an application to APPROVED, if the corresponding partner/collection is waitlisted this message appears.
 #: TWLight/applications/views.py:756
-msgid ""
-"Cannot approve application as partner with proxy authorization method is "
-"waitlisted."
-msgstr ""
-"Die Bewerbung kann nicht bestätigt werden, weil noch Partner mit Proxy-"
-"Authorisierung auf der Warteliste stehen."
+msgid "Cannot approve application as partner with proxy authorization method is waitlisted."
+msgstr "Die Bewerbung kann nicht bestätigt werden, weil noch Partner mit Proxy-Authorisierung auf der Warteliste stehen."
 
 #. Translators: After a coordinator has changed the status of an application to APPROVED, if the corresponding partner/collection has no accounts for distribution, this message appears.
 #: TWLight/applications/views.py:780
-msgid ""
-"Cannot approve application as partner with proxy authorization method is "
-"waitlisted and (or) has zero accounts available for distribution."
-msgstr ""
-"Die Bewerbung kann nicht bestätigt werden, weil noch Partner mit Proxy-"
-"Authorisierung auf der Warteliste und/oder keine Zugänge zur Verfügung "
-"stehen."
+msgid "Cannot approve application as partner with proxy authorization method is waitlisted and (or) has zero accounts available for distribution."
+msgstr "Die Bewerbung kann nicht bestätigt werden, weil noch Partner mit Proxy-Authorisierung auf der Warteliste und/oder keine Zugänge zur Verfügung stehen."
 
 #. Translators: This message appears on an "access denied" screen that stops users who attempt to authorize an editor to access a resource during a time period for which they are already authorized.
 #: TWLight/applications/views.py:803
@@ -980,17 +870,8 @@ msgstr "Du hast versucht, eine doppelte Authorisierung zu erstellen."
 #. Translators: This message is shown to users when they access an application page of a now Bundle partner (new applications aren't allowed for Bundle partners and the status of old applications cannot be modified)
 #: TWLight/applications/views.py:857
 #, python-brace-format
-msgid ""
-"This application cannot be modified since this partner is now part of our <a "
-"href='{bundle}'>bundle access</a>. If you are eligible, you can access this "
-"resource from <a href='{library}'>your library</a>. <a "
-"href='{contact}'>Contact us</a> if you have any questions."
-msgstr ""
-"Diese Bewerbung kann nicht bearbeitet werden, da der Partner jetzt Teil "
-"unseres <a href='{bundle}'>Zugangspaketes</a> ist. Falls du "
-"zugangsberechtigt sein solltest, kannst du auf diese Sammlung unter <a "
-"href='{library}'>Meine Sammlungen</a> zugreifen. <a "
-"href='{contact}'>Kontaktiere uns</a>, wenn du Fragen haben solltest."
+msgid "This application cannot be modified since this partner is now part of our <a href='{bundle}'>bundle access</a>. If you are eligible, you can access this resource from <a href='{library}'>your library</a>. <a href='{contact}'>Contact us</a> if you have any questions."
+msgstr "Diese Bewerbung kann nicht bearbeitet werden, da der Partner jetzt Teil unseres <a href='{bundle}'>Zugangspaketes</a> ist. Falls du zugangsberechtigt sein solltest, kannst du auf diese Sammlung unter <a href='{library}'>Meine Sammlungen</a> zugreifen. <a href='{contact}'>Kontaktiere uns</a>, wenn du Fragen haben solltest."
 
 #. Translators: this lets a reviewer set the status of a single application.
 #: TWLight/applications/views.py:873
@@ -999,18 +880,13 @@ msgstr "Status der Bewerbung wählen"
 
 #. Translators: This warning is message is shown to applicants when the number of pending applications is greater than the number of accounts available.
 #: TWLight/applications/views.py:891
-msgid ""
-"There are more pending applications than available accounts. Your "
-"application might get waitlisted."
-msgstr ""
-"Derzeit gibt es mehr Bewerbungen als freie Zugänge. Deine Bewerbung wird "
-"ggfs. auf die Warteliste gesetzt."
+msgid "There are more pending applications than available accounts. Your application might get waitlisted."
+msgstr "Derzeit gibt es mehr Bewerbungen als freie Zugänge. Deine Bewerbung wird ggfs. auf die Warteliste gesetzt."
 
 #. Translators: this message is shown to coordinators who attempt to change an application's Status from INVALID to any other Status.
 #: TWLight/applications/views.py:904
 msgid "Status of INVALID applications cannot be changed."
-msgstr ""
-"Der Status von INVALID (ungültigen) Bewerbungen kann nicht verändert werden."
+msgstr "Der Status von INVALID (ungültigen) Bewerbungen kann nicht verändert werden."
 
 #. Translators: When a coordinator is batch editing (https://wikipedialibrary.wmflabs.org/applications/list/), they receive this message if they click Set Status without selecting any applications.
 #: TWLight/applications/views.py:940
@@ -1024,17 +900,8 @@ msgstr "Batchupdate von Bewerbung(en) {} erfolgreich."
 
 #. Translators: After a coordinator has changed the status of a number of applications to APPROVED, if the corresponding partner(s) is/are waitlisted or has no accounts for distribution, this message appears.
 #: TWLight/applications/views.py:1051
-msgid ""
-"Cannot approve application(s) {} as partner(s) with proxy authorization "
-"method is/are waitlisted and (or) has/have not enough accounts available. If "
-"not enough accounts are available, prioritise the applications and then "
-"approve applications equal to the accounts available."
-msgstr ""
-"Die Bewerbung kann oder die Bewerbungen können {} nicht bestätigt werden, "
-"weil Partner mit Proxy-Authorisierung auf der Warteliste und/oder keine "
-"Zugänge zur Verfügung stehen. Im letzteren Falle priorisiere bitte die "
-"Bewerbungen und bestätige sie dann entsprechend der zur Verfügung stehenden "
-"Anzahl."
+msgid "Cannot approve application(s) {} as partner(s) with proxy authorization method is/are waitlisted and (or) has/have not enough accounts available. If not enough accounts are available, prioritise the applications and then approve applications equal to the accounts available."
+msgstr "Die Bewerbung kann oder die Bewerbungen können {} nicht bestätigt werden, weil Partner mit Proxy-Authorisierung auf der Warteliste und/oder keine Zugänge zur Verfügung stehen. Im letzteren Falle priorisiere bitte die Bewerbungen und bestätige sie dann entsprechend der zur Verfügung stehenden Anzahl."
 
 #. Translators: This message is shown to coordinators who attempt to assign the same access code to multiple users.
 #: TWLight/applications/views.py:1191
@@ -1048,13 +915,8 @@ msgstr "Alle gewählten Bewerbungen wurden als gesendet markiert."
 
 #. Translators: When a user tries to renew their resource, they receive this message if the partner is not available.
 #: TWLight/applications/views.py:1272
-msgid ""
-"Cannot renew application at this time as partner is not available. Please "
-"check back later, or contact us for more information."
-msgstr ""
-"Die Bewerbung kann nicht erneuert werden, da der Partner nicht mehr "
-"verfügbar ist. Bitte schau später noch einmal vorbei oder kontaktiere uns, "
-"um mehr Informationen zu erhalten."
+msgid "Cannot renew application at this time as partner is not available. Please check back later, or contact us for more information."
+msgstr "Die Bewerbung kann nicht erneuert werden, da der Partner nicht mehr verfügbar ist. Bitte schau später noch einmal vorbei oder kontaktiere uns, um mehr Informationen zu erhalten."
 
 #. Translators: This message is displayed when an attempt by a user to renew an application has been denied for some reason.
 #: TWLight/applications/views.py:1308
@@ -1064,21 +926,13 @@ msgstr "Der Versuch, die unbestätigte App #{pk} zu erneuern, wurde abgelehnt."
 
 #. Translators: If a user requests the renewal of their account, but it wasn't renewed, this message is shown to them.
 #: TWLight/applications/views.py:1385
-msgid ""
-"This object cannot be renewed. (This probably means that you have already "
-"requested that it be renewed.)"
-msgstr ""
-"Dieses Objekt kann nicht erneuert werden. (Das bedeutet wahrscheinlich, dass "
-"du schon eine Erneuerung angefragt hast.)"
+msgid "This object cannot be renewed. (This probably means that you have already requested that it be renewed.)"
+msgstr "Dieses Objekt kann nicht erneuert werden. (Das bedeutet wahrscheinlich, dass du schon eine Erneuerung angefragt hast.)"
 
 #. Translators: If a user requests the renewal of their account, this message is shown to them.
 #: TWLight/applications/views.py:1395
-msgid ""
-"Your renewal request has been received. A coordinator will review your "
-"request."
-msgstr ""
-"Deine Erneuerungsanfrage wurde empfangen. Ein Koordinator wird deine Anfrage "
-"prüfen."
+msgid "Your renewal request has been received. A coordinator will review your request."
+msgstr "Deine Erneuerungsanfrage wurde empfangen. Ein Koordinator wird deine Anfrage prüfen."
 
 #. Translators: This labels a textfield where users can enter their email ID.
 #: TWLight/emails/forms.py:18
@@ -1087,12 +941,8 @@ msgstr "Deine E-Mail-Addresse"
 
 #. Translators: This is the help text for the email field in the contact us form letting users know the field is updated by value pulled from their respective user profiles.
 #: TWLight/emails/forms.py:21
-msgid ""
-"This field is automatically updated with the email from your <a class='twl-"
-"links' href='{}'>user profile</a>."
-msgstr ""
-"Dieses Feld wird automatisch mit deiner E-Mail-Adresse aus deinem <a "
-"class='twl-links' href='{}'>Profil</a> ausgefüllt."
+msgid "This field is automatically updated with the email from your <a class='twl-links' href='{}'>user profile</a>."
+msgstr "Dieses Feld wird automatisch mit deiner E-Mail-Adresse aus deinem <a class='twl-links' href='{}'>Profil</a> ausgefüllt."
 
 #. Translators: This labels a textfield where users can enter their email message.
 #: TWLight/emails/forms.py:26
@@ -1115,26 +965,14 @@ msgstr "Absenden"
 #. Translators: This email is sent to users with their access code. Don't translate Jinja variables in curly braces like user or partner. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/access_code_email-body-html.html:5
 #, python-format
-msgid ""
-"<p>Your approved application to %(partner)s has now been finalised. Your "
-"access code or login details can be found below:</p> <p><b>%(access_code)s</"
-"b></p> <p>%(user_instructions)s</p>"
-msgstr ""
-"<p>Deine Bewerbung für %(partner)s wurde erfolgreich bearbeitet. Deinen "
-"Zugangscode bzw. deine Login-Daten findest du unten:</p> <p><b>"
-"%(access_code)s</b></p> <p>%(user_instructions)s</p>"
+msgid "<p>Your approved application to %(partner)s has now been finalised. Your access code or login details can be found below:</p> <p><b>%(access_code)s</b></p> <p>%(user_instructions)s</p>"
+msgstr "<p>Deine Bewerbung für %(partner)s wurde erfolgreich bearbeitet. Deinen Zugangscode bzw. deine Login-Daten findest du unten:</p> <p><b>%(access_code)s</b></p> <p>%(user_instructions)s</p>"
 
 #. Translators: This email is sent to users with their access code. Don't translate Jinja variables in curly braces like user or partner. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/access_code_email-body-text.html:3
 #, python-format
-msgid ""
-"Your approved application to %(partner)s has now been finalised. Your access "
-"code or login details can be found below: %(access_code)s "
-"%(user_instructions)s"
-msgstr ""
-"Deine Bewerbung für %(partner)s wurde erfolgreich bearbeitet. Dein "
-"Zugangscode bzw. deine Login-Daten kannst du hier finden: %(access_code)s "
-"%(user_instructions)s"
+msgid "Your approved application to %(partner)s has now been finalised. Your access code or login details can be found below: %(access_code)s %(user_instructions)s"
+msgstr "Deine Bewerbung für %(partner)s wurde erfolgreich bearbeitet. Dein Zugangscode bzw. deine Login-Daten kannst du hier finden: %(access_code)s %(user_instructions)s"
 
 #. Translators: This is the subject line of an email sent to users with their access code.
 #: TWLight/emails/templates/emails/access_code_email-subject.html:3
@@ -1144,33 +982,14 @@ msgstr "Dein Wikipedia-Library-Zugangscode"
 #. Translators: This email is sent to users when their application is approved. Don't translate Jinja variables in curly braces like user or partner; don't translate html tags either. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/approval_notification-body-html.html:5
 #, python-format
-msgid ""
-"<p>Dear %(user)s,</p> <p>Thank you for applying for access to %(partner)s "
-"resources through The Wikipedia Library. We are happy to inform you that "
-"your application has been approved.</p> <p>%(user_instructions)s</p> <p>You "
-"can view the collections you're authorized to access at My Library: "
-"%(link)s</p> <p>Cheers!</p> <p>The Wikipedia Library</p>"
-msgstr ""
-"<p>Hallo %(user)s!</p> <p>Danke für deine Bewerbung für einen Zugang zu "
-"%(partner)s über „The Wikipedia Library“. Deine Bewerbung war erfolgreich. </"
-"p> <p>%(user_instructions)s</p> <p>Du kannst die zugänglichen Inhalte in "
-"„Meine Zugänge“ einsehen: %(link)s</p> <p>Herzlich willkommen!</p> <p>The "
-"Wikipedia Library</p>"
+msgid "<p>Dear %(user)s,</p> <p>Thank you for applying for access to %(partner)s resources through The Wikipedia Library. We are happy to inform you that your application has been approved.</p> <p>%(user_instructions)s</p> <p>You can view the collections you're authorized to access at My Library: %(link)s</p> <p>Cheers!</p> <p>The Wikipedia Library</p>"
+msgstr "<p>Hallo %(user)s!</p> <p>Danke für deine Bewerbung für einen Zugang zu %(partner)s über „The Wikipedia Library“. Deine Bewerbung war erfolgreich. </p> <p>%(user_instructions)s</p> <p>Du kannst die zugänglichen Inhalte in „Meine Zugänge“ einsehen: %(link)s</p> <p>Herzlich willkommen!</p> <p>The Wikipedia Library</p>"
 
 #. Translators: This email is sent to users when their application is approved. Don't translate Jinja variables in curly braces like user or partner. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/approval_notification-body-text.html:3
 #, python-format
-msgid ""
-"Dear %(user)s, Thank you for applying for access to %(partner)s resources "
-"through The Wikipedia Library. We are happy to inform you that your "
-"application has been approved. %(user_instructions)s You can view the "
-"collections you're authorized to access at My Library: %(link)s Cheers! The "
-"Wikipedia Library"
-msgstr ""
-"Hallo %(user)s! Danke für deine Bewerbung für einen Zugang zu %(partner)s "
-"über „The Wikipedia Library“. Deine Bewerbung wurde erfolgreich angenommen.  "
-"%(user_instructions)s Du kannst deine zugängliche Literatur in „Meine "
-"Zugänge“ einsehen: %(link)s Willkommen! The Wikipedia Library"
+msgid "Dear %(user)s, Thank you for applying for access to %(partner)s resources through The Wikipedia Library. We are happy to inform you that your application has been approved. %(user_instructions)s You can view the collections you're authorized to access at My Library: %(link)s Cheers! The Wikipedia Library"
+msgstr "Hallo %(user)s! Danke für deine Bewerbung für einen Zugang zu %(partner)s über „The Wikipedia Library“. Deine Bewerbung wurde erfolgreich angenommen.  %(user_instructions)s Du kannst deine zugängliche Literatur in „Meine Zugänge“ einsehen: %(link)s Willkommen! The Wikipedia Library"
 
 #. Translators: This is the subject of an email which is sent to users when their application has been approved. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/approval_notification-subject.html:4
@@ -1180,58 +999,31 @@ msgstr "Deine Bewerbung bei „The Wikipedia Library“ wurde bestätigt"
 #. Translators: This email is sent to coordinators when a comment is left on an application they are processing. Don't translate Jinja variables in curly braces like user or partner. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/comment_notification_coordinator-body-html.html:5
 #, python-format
-msgid ""
-"<p style=\"color: #500050\">%(submit_date)s - %(commenter)s</p> "
-"<blockquote><p>%(comment)s</p></blockquote> <p>Please reply to these at: <a "
-"href=\"%(app_url)s\">%(app_url)s</a></p> <p>Best,</p> <p>The Wikipedia "
-"Library</p>"
-msgstr ""
-"<p style=\"color: #500050\">%(submit_date)s - %(commenter)s</p> "
-"<blockquote><p>%(comment)s</p></blockquote> <p>Bitte antworten an: <a href="
-"\"%(app_url)s\">%(app_url)s</a></p> <p>Liebe Grüße,</p> <p>The Wikipedia "
-"Library</p>"
+msgid "<p style=\"color: #500050\">%(submit_date)s - %(commenter)s</p> <blockquote><p>%(comment)s</p></blockquote> <p>Please reply to these at: <a href=\"%(app_url)s\">%(app_url)s</a></p> <p>Best,</p> <p>The Wikipedia Library</p>"
+msgstr "<p style=\"color: #500050\">%(submit_date)s - %(commenter)s</p> <blockquote><p>%(comment)s</p></blockquote> <p>Bitte antworten an: <a href=\"%(app_url)s\">%(app_url)s</a></p> <p>Liebe Grüße,</p> <p>The Wikipedia Library</p>"
 
 #. Translators: This email is sent to coordinators when a comment is left on an application they are processing. Don't translate Jinja variables in curly braces like user or partner. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/comment_notification_coordinator-body-text.html:3
 #, python-format
-msgid ""
-"%(submit_date)s - %(commenter)s %(comment)s Please reply to this at: "
-"%(app_url)s Best, The Wikipedia Library"
-msgstr ""
-"%(submit_date)s – %(commenter)s %(comment)s Bitte antworte unter: "
-"%(app_url)s Liebe Grüße, The Wikipedia Library"
+msgid "%(submit_date)s - %(commenter)s %(comment)s Please reply to this at: %(app_url)s Best, The Wikipedia Library"
+msgstr "%(submit_date)s – %(commenter)s %(comment)s Bitte antworte unter: %(app_url)s Liebe Grüße, The Wikipedia Library"
 
 #. Translators: This is the subject line of an email sent to coordinators when a comment is left on an application they processed.
 #: TWLight/emails/templates/emails/comment_notification_coordinator-subject.html:3
 msgid "New comment on a Wikipedia Library application you processed"
-msgstr ""
-"Neue Kommentare zu einer The-Wikipedia-Library-Bewerbung vorhanden, die du "
-"bearbeitet hast"
+msgstr "Neue Kommentare zu einer The-Wikipedia-Library-Bewerbung vorhanden, die du bearbeitet hast"
 
 #. Translators: This email is sent to users when they receive a comment on their application. Don't translate Jinja variables in curly braces like user or partner; don't translate html tags either. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/comment_notification_editors-body-html.html:5
 #, python-format
-msgid ""
-"<p style=\"color: #500050\">%(submit_date)s - %(commenter)s</p> "
-"<blockquote><p>%(comment)s</p></blockquote> <p>Please reply to these at <a "
-"href=\"%(app_url)s\">%(app_url)s</a> so we can evaluate your application.</"
-"p> <p>Best,</p> <p>The Wikipedia Library</p>"
-msgstr ""
-"<p style=\"color: #500050\">%(submit_date)s – %(commenter)s</p> "
-"<blockquote><p>%(comment)s</p></blockquote> <p>Bitte antworte dazu auf <a "
-"href=\"%(app_url)s\">%(app_url)s</a>, sodass wir deine Bewerbung beurteilen "
-"können.</p> <p>Mit freundlichen Grüßen</p> <p>The Wikipedia Library</p>"
+msgid "<p style=\"color: #500050\">%(submit_date)s - %(commenter)s</p> <blockquote><p>%(comment)s</p></blockquote> <p>Please reply to these at <a href=\"%(app_url)s\">%(app_url)s</a> so we can evaluate your application.</p> <p>Best,</p> <p>The Wikipedia Library</p>"
+msgstr "<p style=\"color: #500050\">%(submit_date)s – %(commenter)s</p> <blockquote><p>%(comment)s</p></blockquote> <p>Bitte antworte dazu auf <a href=\"%(app_url)s\">%(app_url)s</a>, sodass wir deine Bewerbung beurteilen können.</p> <p>Mit freundlichen Grüßen</p> <p>The Wikipedia Library</p>"
 
 #. Translators: This email is sent to users when they receive a comment on their application. Don't translate Jinja variables in curly braces like user or partner. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/comment_notification_editors-body-text.html:3
 #, python-format
-msgid ""
-"%(submit_date)s - %(commenter)s %(comment)s Please reply to these at: "
-"%(app_url)s so we can evaluate your application. Best, The Wikipedia Library"
-msgstr ""
-"%(submit_date)s - %(commenter)s %(comment)s Bitte antworte dazu hier: "
-"%(app_url)s , sodass wir deine Bewerbung beurteilen können. </p> <p>Mit "
-"freundlichen Grüßen</p> <p>The Wikipedia Library</p>"
+msgid "%(submit_date)s - %(commenter)s %(comment)s Please reply to these at: %(app_url)s so we can evaluate your application. Best, The Wikipedia Library"
+msgstr "%(submit_date)s - %(commenter)s %(comment)s Bitte antworte dazu hier: %(app_url)s , sodass wir deine Bewerbung beurteilen können. </p> <p>Mit freundlichen Grüßen</p> <p>The Wikipedia Library</p>"
 
 #. Translators: This is the subject line of an email sent to users who have a comment added to one of their applications. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/comment_notification_editors-subject.html:3
@@ -1241,45 +1033,25 @@ msgstr "Neuer Kommentar zu deiner Bewerbung bei „The Wikipedia Library“"
 #. Translators: This email is sent to users when an application they commented on receives another comment. Don't translate Jinja variables in curly braces like app_url; don't translate html tags either. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/comment_notification_others-body-html.html:5
 #, python-format
-msgid ""
-"<p style=\"color: #500050\">%(submit_date)s - %(commenter)s</p> "
-"<blockquote><p>%(comment)s</p></blockquote> See it at <a href=\"%(app_url)s"
-"\">%(app_url)s</a>. Thanks for helping review Wikipedia Library applications!"
-msgstr ""
-"<p style=\"color: #500050\">%(submit_date)s – %(commenter)s</p> "
-"<blockquote><p>%(comment)s</p></blockquote> Schau dir bitte dies an: <a href="
-"\"%(app_url)s\">%(app_url)s</a>. Vielen Dank für deine Unterstützung, "
-"Bewerbungen für „The Wikipedia Library“ zu bewerten!"
+msgid "<p style=\"color: #500050\">%(submit_date)s - %(commenter)s</p> <blockquote><p>%(comment)s</p></blockquote> See it at <a href=\"%(app_url)s\">%(app_url)s</a>. Thanks for helping review Wikipedia Library applications!"
+msgstr "<p style=\"color: #500050\">%(submit_date)s – %(commenter)s</p> <blockquote><p>%(comment)s</p></blockquote> Schau dir bitte dies an: <a href=\"%(app_url)s\">%(app_url)s</a>. Vielen Dank für deine Unterstützung, Bewerbungen für „The Wikipedia Library“ zu bewerten!"
 
 #. Translators: This email is sent to users when an application they commented on receives another comment. Don't translate Jinja variables in curly braces like app_url. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/comment_notification_others-body-text.html:3
 #, python-format
-msgid ""
-"%(submit_date)s - %(commenter)s %(comment)s See it at: %(app_url)s Thanks "
-"for helping review Wikipedia Library applications!"
-msgstr ""
-"%(submit_date)s – %(commenter)s %(comment)s Schau dir bitte dies an:  "
-"%(app_url)s Vielen Dank für deine Unterstützung, Bewerbungen für „The "
-"Wikipedia Library“ zu bewerten!"
+msgid "%(submit_date)s - %(commenter)s %(comment)s See it at: %(app_url)s Thanks for helping review Wikipedia Library applications!"
+msgstr "%(submit_date)s – %(commenter)s %(comment)s Schau dir bitte dies an:  %(app_url)s Vielen Dank für deine Unterstützung, Bewerbungen für „The Wikipedia Library“ zu bewerten!"
 
 #. Translators: This is the subject line of an email sent to users who have a comment added to an application they also commented on. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/comment_notification_others-subject.html:4
 msgid "New comment on a Wikipedia Library application you commented on"
-msgstr ""
-"Neuer Kommentar zu einer Bewerbung bei „The Wikipedia Library“, die du "
-"kommentiert hast."
+msgstr "Neuer Kommentar zu einer Bewerbung bei „The Wikipedia Library“, die du kommentiert hast."
 
 #. Translators: This text is part of a scheduled reminder email sent to coordinators who have applications requiring action. Don't translate Jinja variables in curly braces like total_apps, or user.
 #: TWLight/emails/templates/emails/coordinator_reminder_notification-body-html.html:5
 #, python-format
-msgid ""
-"<p>Dear %(user)s,</p> <p>Our records indicate that you are the designated "
-"coordinator for partners that have a total of %(total_apps)s applications.</"
-"p>"
-msgstr ""
-"<p>Hallo %(user)s!</p> <p>Gemäß unseren Unterlagen müsstest du der passende "
-"Koordinator für unsere Partner mit insgesamt %(total_apps)s Bewerbungen sein."
-"</p>"
+msgid "<p>Dear %(user)s,</p> <p>Our records indicate that you are the designated coordinator for partners that have a total of %(total_apps)s applications.</p>"
+msgstr "<p>Hallo %(user)s!</p> <p>Gemäß unseren Unterlagen müsstest du der passende Koordinator für unsere Partner mit insgesamt %(total_apps)s Bewerbungen sein.</p>"
 
 #. Translators: Breakdown as in 'cost breakdown'; analysis.
 #: TWLight/emails/templates/emails/coordinator_reminder_notification-body-html.html:11
@@ -1317,47 +1089,20 @@ msgstr[1] "%(counter)s bestätigte Bewerbungen."
 #. Translators: This text is part of a scheduled reminder email sent to coordinators who have applications requiring action. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library). Don't translate Jinja variables in curly braces like link; don't translate email addresses or html tags either.
 #: TWLight/emails/templates/emails/coordinator_reminder_notification-body-html.html:39
 #, python-format
-msgid ""
-"<p>This is a gentle reminder that you may review applications at <a href="
-"\"%(link)s\">%(link)s</a>.</p> <p>You can customise your reminders under "
-"'preferences' in your user profile.</p> <p>If you received this message in "
-"error, drop us a line at wikipedialibrary@wikimedia.org.</p> <p>Thanks for "
-"helping review Wikipedia Library applications!</p>"
-msgstr ""
-"<p>Dies ist eine freundliche Erinnerung daran, dass du auf <a href=\"%(link)s"
-"\">%(link)s</a> Bewerbungen beurteilen kannst.</p> <p>Du kannst deine "
-"Erinnerungen unter „Einstellungen“ in deinem Profil anpassen.</p> "
-"<p>Solltest du diese Nachricht irrtümlich erhalten haben, schreib uns bitte "
-"eine kurze Nachricht an wikipedialibrary@wikimedia.org.</p> <p>Vielen Dank "
-"für deine Unterstützung, Bewerbungen für „The Wikipedia Library“ zu bewerten!"
-"</p>"
+msgid "<p>This is a gentle reminder that you may review applications at <a href=\"%(link)s\">%(link)s</a>.</p> <p>You can customise your reminders under 'preferences' in your user profile.</p> <p>If you received this message in error, drop us a line at wikipedialibrary@wikimedia.org.</p> <p>Thanks for helping review Wikipedia Library applications!</p>"
+msgstr "<p>Dies ist eine freundliche Erinnerung daran, dass du auf <a href=\"%(link)s\">%(link)s</a> Bewerbungen beurteilen kannst.</p> <p>Du kannst deine Erinnerungen unter „Einstellungen“ in deinem Profil anpassen.</p> <p>Solltest du diese Nachricht irrtümlich erhalten haben, schreib uns bitte eine kurze Nachricht an wikipedialibrary@wikimedia.org.</p> <p>Vielen Dank für deine Unterstützung, Bewerbungen für „The Wikipedia Library“ zu bewerten!</p>"
 
 #. Translators: This text is part of a scheduled reminder email sent to coordinators who have applications requiring action. Don't translate Jinja variables in curly braces like total_apps, or user.
 #: TWLight/emails/templates/emails/coordinator_reminder_notification-body-text.html:3
 #, python-format
-msgid ""
-"Dear %(user)s, Our records indicate that you are the designated coordinator "
-"for partners that have a total of %(total_apps)s applications."
-msgstr ""
-"Hallo %(user)s! Gemäß unseren Unterlagen müsstest du der passende "
-"Koordinator für unsere Partner mit insgesamt %(total_apps)s Bewerbungen sein."
+msgid "Dear %(user)s, Our records indicate that you are the designated coordinator for partners that have a total of %(total_apps)s applications."
+msgstr "Hallo %(user)s! Gemäß unseren Unterlagen müsstest du der passende Koordinator für unsere Partner mit insgesamt %(total_apps)s Bewerbungen sein."
 
 #. Translators: This text is part of a scheduled reminder email sent to coordinators who have applications requiring action. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library). Don't translate Jinja variables in curly braces like link; don't translate the email address either.
 #: TWLight/emails/templates/emails/coordinator_reminder_notification-body-text.html:38
 #, python-format
-msgid ""
-"This is a gentle reminder that you may review applications at: %(link)s. You "
-"can customise your reminders under 'preferences' in your user profile. If "
-"you received this message in error, drop us a line at: "
-"wikipedialibrary@wikimedia.org Thanks for helping review Wikipedia Library "
-"applications!"
-msgstr ""
-"Dies ist eine freundliche Erinnerung daran, dass du auf  %(link)s "
-"Bewerbungen beurteilen kannst. Du kannst deine Erinnerungen unter "
-"„Einstellungen“ in deinem Profil anpassen. Solltest du diese Nachricht "
-"irrtümlich erhalten haben, schreib uns bitte eine kurze Nachricht an "
-"wikipedialibrary@wikimedia.org. Vielen Dank für deine Unterstützung, "
-"Bewerbungen für „The Wikipedia Library“ zu bewerten!"
+msgid "This is a gentle reminder that you may review applications at: %(link)s. You can customise your reminders under 'preferences' in your user profile. If you received this message in error, drop us a line at: wikipedialibrary@wikimedia.org Thanks for helping review Wikipedia Library applications!"
+msgstr "Dies ist eine freundliche Erinnerung daran, dass du auf  %(link)s Bewerbungen beurteilen kannst. Du kannst deine Erinnerungen unter „Einstellungen“ in deinem Profil anpassen. Solltest du diese Nachricht irrtümlich erhalten haben, schreib uns bitte eine kurze Nachricht an wikipedialibrary@wikimedia.org. Vielen Dank für deine Unterstützung, Bewerbungen für „The Wikipedia Library“ zu bewerten!"
 
 #. Translators: This is the subject line of a scheduled reminder email sent to coordinators who have applications to review. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library). Do not translate items in curly braces.
 #: TWLight/emails/templates/emails/coordinator_reminder_notification-subject.html:4
@@ -1367,33 +1112,14 @@ msgstr "Bewerbungen bei „The Wikipedia Library“ warten auf deine Überprüfu
 #. Translators: This email is sent to users when their application is rejected. Don't translate Jinja variables in curly braces like user or partner; don't translate html tags either. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/rejection_notification-body-html.html:5
 #, python-format
-msgid ""
-"<p>Dear %(user)s,</p> <p>Thank you for applying for access to %(partner)s "
-"resources through The Wikipedia Library. Unfortunately at this time your "
-"application has not been approved. You can view your application and review "
-"comments at <a href=\"%(app_url)s\">%(app_url)s</a>.</p> <p>Best,</p> <p>The "
-"Wikipedia Library</p>"
-msgstr ""
-"<p>Hallo %(user)s!</p> <p>Vielen Dank für deine Bewerbung auf den Zugang zu "
-"%(partner)s auf „The Wikipedia Library“. Bedauerlicherweise war deine "
-"Bewerbung aktuell nicht erfolgreich. Du kannst deine Bewerbung sowie "
-"Kommentare dazu hier einsehen: <a href=\"%(app_url)s\">%(app_url)s</a>.</p> "
-"<p>Mit freundlichen Grüßen</p> <p>The Wikipedia Library</p>"
+msgid "<p>Dear %(user)s,</p> <p>Thank you for applying for access to %(partner)s resources through The Wikipedia Library. Unfortunately at this time your application has not been approved. You can view your application and review comments at <a href=\"%(app_url)s\">%(app_url)s</a>.</p> <p>Best,</p> <p>The Wikipedia Library</p>"
+msgstr "<p>Hallo %(user)s!</p> <p>Vielen Dank für deine Bewerbung auf den Zugang zu %(partner)s auf „The Wikipedia Library“. Bedauerlicherweise war deine Bewerbung aktuell nicht erfolgreich. Du kannst deine Bewerbung sowie Kommentare dazu hier einsehen: <a href=\"%(app_url)s\">%(app_url)s</a>.</p> <p>Mit freundlichen Grüßen</p> <p>The Wikipedia Library</p>"
 
 #. Translators: This email is sent to users when their application is rejected. Don't translate Jinja variables in curly braces like user or partner. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/rejection_notification-body-text.html:3
 #, python-format
-msgid ""
-"Dear %(user)s, Thank you for applying for access to %(partner)s resources "
-"through The Wikipedia Library. Unfortunately at this time your application "
-"has not been approved. You can view your application and review comments at: "
-"%(app_url)s Best, The Wikipedia Library"
-msgstr ""
-"Hallo %(user)s! Vielen Dank für deine Bewerbung auf den Zugang zu "
-"%(partner)s auf „The Wikipedia Library“. Bedauerlicherweise war deine "
-"Bewerbung aktuell nicht erfolgreich. Du kannst deine Bewerbung sowie "
-"Kommentare dazu hier einsehen: <a href=\"%(app_url)s\">%(app_url)s. Mit "
-"freundlichen Grüßen, The Wikipedia Library"
+msgid "Dear %(user)s, Thank you for applying for access to %(partner)s resources through The Wikipedia Library. Unfortunately at this time your application has not been approved. You can view your application and review comments at: %(app_url)s Best, The Wikipedia Library"
+msgstr "Hallo %(user)s! Vielen Dank für deine Bewerbung auf den Zugang zu %(partner)s auf „The Wikipedia Library“. Bedauerlicherweise war deine Bewerbung aktuell nicht erfolgreich. Du kannst deine Bewerbung sowie Kommentare dazu hier einsehen: <a href=\"%(app_url)s\">%(app_url)s. Mit freundlichen Grüßen, The Wikipedia Library"
 
 #. Translators: This is the subject of an email which is sent to users when their application has been rejected. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/rejection_notification-subject.html:4
@@ -1403,40 +1129,14 @@ msgstr "Deine Bewerbung bei „The Wikipedia Library“"
 #. Translators: This email is sent to users when they have an account that is soon to expire. Don't translate Jinja variables in curly braces like partner_name or partner_link; don't translate html tags either. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/user_renewal_notice-body-html.html:5
 #, python-format
-msgid ""
-"<p>Dear %(user)s,</p> <p>According to our records, your access to "
-"%(partner_name)s will soon expire and you may lose access. If you want to "
-"continue making use of your free account, you can request renewal of your "
-"account by clicking the 'Renew' or 'Extend' button at %(partner_link)s.</p> "
-"<p>Best,</p> <p>The Wikipedia Library</p> <p>You can disable these emails in "
-"your user page preferences: https://wikipedialibrary.wmflabs.org/users/</p>"
-msgstr ""
-"<p>Hallo %(user)s!</p> <p>Gemäß unseren Unterlagen müsste dein Zugang zu "
-"%(partner_name)s demnächst ablaufen und du könntest dein Konto dort "
-"verlieren. Falls du weiterhin deinen kostenlosen Zugang verwenden möchtest, "
-"kannst du eine Aktualisierung deines Kontos über den „Erneuern“-Button auf "
-"%(partner_link)s beantragen.</p> <p>Mit freundlichen Grüßen</p> <p>The "
-"Wikipedia Library</p> <p>Du kannst derartige E-Mails in deinen Einstellungen "
-"deaktivieren: https://wikipedialibrary.wmflabs.org/users/</p>"
+msgid "<p>Dear %(user)s,</p> <p>According to our records, your access to %(partner_name)s will soon expire and you may lose access. If you want to continue making use of your free account, you can request renewal of your account by clicking the 'Renew' or 'Extend' button at %(partner_link)s.</p> <p>Best,</p> <p>The Wikipedia Library</p> <p>You can disable these emails in your user page preferences: https://wikipedialibrary.wmflabs.org/users/</p>"
+msgstr "<p>Hallo %(user)s!</p> <p>Gemäß unseren Unterlagen müsste dein Zugang zu %(partner_name)s demnächst ablaufen und du könntest dein Konto dort verlieren. Falls du weiterhin deinen kostenlosen Zugang verwenden möchtest, kannst du eine Aktualisierung deines Kontos über den „Erneuern“-Button auf %(partner_link)s beantragen.</p> <p>Mit freundlichen Grüßen</p> <p>The Wikipedia Library</p> <p>Du kannst derartige E-Mails in deinen Einstellungen deaktivieren: https://wikipedialibrary.wmflabs.org/users/</p>"
 
 #. Translators: This email is sent to users when they have an account that is soon to expire. Don't translate Jinja variables in curly braces like partner_name or partner_link; don't translate html tags either. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/user_renewal_notice-body-text.html:3
 #, python-format
-msgid ""
-"Dear %(user)s, According to our records, your access to %(partner_name)s "
-"will soon expire and you may lose access. If you want to continue making use "
-"of your free account, you can request renewal of your account by clicking "
-"the Renew button at %(partner_link)s. Best, The Wikipedia Library You can "
-"disable these emails in your user page preferences: https://wikipedialibrary."
-"wmflabs.org/users/"
-msgstr ""
-"Hallo %(user)s! Gemäß unseren Unterlagen müsste dein Zugang zu "
-"%(partner_name)s demnächst ablaufen und du dein Konto dort möglicherweise "
-"verlieren. Falls du weiterhin deinen kostenlosen Zugang verwenden möchtest, "
-"kannst du eine Aktualisierung deines Kontos über den „Erneuern“-Button auf "
-"%(partner_link)s beantragen. Mit freundlichen Grüßen, The Wikipedia Library "
-"Du kannst derartige E-Mails in deinen Einstellungen deaktivieren: https://"
-"wikipedialibrary.wmflabs.org/users/"
+msgid "Dear %(user)s, According to our records, your access to %(partner_name)s will soon expire and you may lose access. If you want to continue making use of your free account, you can request renewal of your account by clicking the Renew button at %(partner_link)s. Best, The Wikipedia Library You can disable these emails in your user page preferences: https://wikipedialibrary.wmflabs.org/users/"
+msgstr "Hallo %(user)s! Gemäß unseren Unterlagen müsste dein Zugang zu %(partner_name)s demnächst ablaufen und du dein Konto dort möglicherweise verlieren. Falls du weiterhin deinen kostenlosen Zugang verwenden möchtest, kannst du eine Aktualisierung deines Kontos über den „Erneuern“-Button auf %(partner_link)s beantragen. Mit freundlichen Grüßen, The Wikipedia Library Du kannst derartige E-Mails in deinen Einstellungen deaktivieren: https://wikipedialibrary.wmflabs.org/users/"
 
 #. Translators: This is the subject of an email sent to users when they have an account that is soon to expire. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/user_renewal_notice-subject.html:4
@@ -1446,49 +1146,24 @@ msgstr "Dein Zugang auf „The Wikipedia Library“ läuft demnächst aus"
 #. Translators: This email is sent to users when their application is waitlisted because there are no more accounts available. Don't translate Jinja variables in curly braces like user or partner; don't translate html tags either. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/waitlist_notification-body-html.html:5
 #, python-format
-msgid ""
-"<p>Dear %(user)s,</p> <p>Thank you for applying for access to %(partner)s "
-"resources through The Wikipedia Library. There are no accounts currently "
-"available so your application has been waitlisted. Your application will be "
-"evaluated if/when more accounts become available. You can see all available "
-"resources at <a href=\"%(link)s\">%(link)s</a>.</p> <p>Best,</p> <p>The "
-"Wikipedia Library</p>"
-msgstr ""
-"<p>Hallo %(user)s!</p> <p>Danke für deine Bewerbung für einen Zugang zu "
-"%(partner)s über „The Wikipedia Library“. Aktuell sind keine Zugänge "
-"verfügbar, sodass wir dich auf die Warteliste gesetzt haben. Deine Bewerbung "
-"wird beurteilt, sobald weitere Zugänge zur Verfügung stehen. Du kannst die "
-"zugänglichen Inhalte in „Meine Zugänge“ einsehen: %(link)s</p> <p>Liebe "
-"Grüße</p> <p>The Wikipedia Library</p>"
+msgid "<p>Dear %(user)s,</p> <p>Thank you for applying for access to %(partner)s resources through The Wikipedia Library. There are no accounts currently available so your application has been waitlisted. Your application will be evaluated if/when more accounts become available. You can see all available resources at <a href=\"%(link)s\">%(link)s</a>.</p> <p>Best,</p> <p>The Wikipedia Library</p>"
+msgstr "<p>Hallo %(user)s!</p> <p>Danke für deine Bewerbung für einen Zugang zu %(partner)s über „The Wikipedia Library“. Aktuell sind keine Zugänge verfügbar, sodass wir dich auf die Warteliste gesetzt haben. Deine Bewerbung wird beurteilt, sobald weitere Zugänge zur Verfügung stehen. Du kannst die zugänglichen Inhalte in „Meine Zugänge“ einsehen: %(link)s</p> <p>Liebe Grüße</p> <p>The Wikipedia Library</p>"
 
 #. Translators: This email is sent to users when their application is waitlisted because there are no more accounts available. Don't translate Jinja variables in curly braces like user or partner. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/waitlist_notification-body-text.html:3
 #, python-format
-msgid ""
-"Dear %(user)s, Thank you for applying for access to %(partner)s resources "
-"through The Wikipedia Library. There are no accounts currently available so "
-"your application has been waitlisted. Your application will be evaluated if/"
-"when more accounts become available. You can see all available resources at: "
-"%(link)s Best, The Wikipedia Library"
-msgstr ""
-"Hallo %(user)s! Vielen Dank für deine Bewerbung auf die Inhalte von "
-"%(partner)s über „The Wikipedia Library“. Aktuell sind keine Zugänge "
-"verfügbar, sodass wir dich auf die Warteliste gesetzt haben. Deine Bewerbung "
-"wird beurteilt, sobald weitere Zugänge zur Verfügung stehen. Einen Überblick "
-"über alle aktuell verfügbaren Inhalte erhältst du auf: %(link)s Liebe Grüße, "
-"The Wikipedia Library"
+msgid "Dear %(user)s, Thank you for applying for access to %(partner)s resources through The Wikipedia Library. There are no accounts currently available so your application has been waitlisted. Your application will be evaluated if/when more accounts become available. You can see all available resources at: %(link)s Best, The Wikipedia Library"
+msgstr "Hallo %(user)s! Vielen Dank für deine Bewerbung auf die Inhalte von %(partner)s über „The Wikipedia Library“. Aktuell sind keine Zugänge verfügbar, sodass wir dich auf die Warteliste gesetzt haben. Deine Bewerbung wird beurteilt, sobald weitere Zugänge zur Verfügung stehen. Einen Überblick über alle aktuell verfügbaren Inhalte erhältst du auf: %(link)s Liebe Grüße, The Wikipedia Library"
 
 #. Translators: This is the subject of an email sent to users when their application is waitlisted because there are no more accounts available. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/waitlist_notification-subject.html:4
 msgid "Your Wikipedia Library application has been waitlisted"
-msgstr ""
-"Deine Bewerbung bei „The Wikipedia Library“ wurde auf die Warteliste gesetzt."
+msgstr "Deine Bewerbung bei „The Wikipedia Library“ wurde auf die Warteliste gesetzt."
 
 #. Translators: Shown to users when they successfully submit a new message using the contact us form.
 #: TWLight/emails/views.py:51
 msgid "Your message has been sent. We'll get back to you soon!"
-msgstr ""
-"Deine Nachricht wurde abgeschickt. Wir werden uns demnächst bei dir melden."
+msgstr "Deine Nachricht wurde abgeschickt. Wir werden uns demnächst bei dir melden."
 
 #. Translators: This message is shown to non-wikipedia editors who attempt to post data to the contact us form.
 #. Translators: This message is shown to non-wikipedia editors who attempt to post data to suggestion form.
@@ -1639,23 +1314,15 @@ msgstr "Nicht verfügbar"
 #: TWLight/resources/templates/resources/filter_section.html:14
 #: TWLight/templates/about.html:12
 #: TWLight/users/templates/users/filter_section.html:13
-msgid ""
-"The Wikipedia Library allows active editors to access a wide range of "
-"collections of paywalled reliable sources for free!"
-msgstr ""
-"The Wikipedia Library ermöglicht Aktiven der Wikimedia-Projekte den "
-"kostenlosen Zugang zu einer Vielzahl von Sammlungen mit kostenpflichtigen, "
-"zuverlässigen Quellen!"
+msgid "The Wikipedia Library allows active editors to access a wide range of collections of paywalled reliable sources for free!"
+msgstr "The Wikipedia Library ermöglicht Aktiven der Wikimedia-Projekte den kostenlosen Zugang zu einer Vielzahl von Sammlungen mit kostenpflichtigen, zuverlässigen Quellen!"
 
 #. Translators: On the Browse Partners page (https://wikipedialibrary.wmflabs.org/partners/), this introduces users to The Wikipedia Library.
 #. Translators: On the MyLibrary page (https://wikipedialibrary.wmflabs.org/users/my_library), this introduces users to The Wikipedia Library.
 #: TWLight/resources/templates/resources/filter_section.html:17
 #: TWLight/users/templates/users/filter_section.html:15
-msgid ""
-"Start with the search bar at the top or browse publisher websites directly."
-msgstr ""
-"Beginne mit der Suchleiste oben oder durchsuche direkt die Websites der "
-"Verlage."
+msgid "Start with the search bar at the top or browse publisher websites directly."
+msgstr "Beginne mit der Suchleiste oben oder durchsuche direkt die Websites der Verlage."
 
 #. Translators: On the Browse Partners page (https://wikipedialibrary.wmflabs.org/partners/), this appears below introductory text and links to the 'About' page (https://wikipedialibrary.wmflabs.org/about/)
 #. Translators: On the MyLibrary page (https://wikipedialibrary.wmflabs.org/users/my_library), this appears below introductory text and links to the 'About' page (https://wikipedialibrary.wmflabs.org/about/)
@@ -1728,68 +1395,39 @@ msgstr "Zurück zu den Partnern"
 #. Translators: If we have no available accounts for a partner, the coordinator can change the application system to a waiting list.
 #: TWLight/resources/templates/resources/partner_detail.html:36
 #: TWLight/resources/templates/resources/partner_detail_apply.html:17
-msgid ""
-"There are no access grants available for this partner at this time. You can "
-"still apply for access; applications will be processed when access is "
-"available."
-msgstr ""
-"Derzeit sind keine Zugänge für diesen Partner verfügbar. Du kannst dich "
-"dennoch bewerben. Deine Bewerbung wird erst bearbeitet, wenn wieder Zugänge "
-"verfügbar werden."
+msgid "There are no access grants available for this partner at this time. You can still apply for access; applications will be processed when access is available."
+msgstr "Derzeit sind keine Zugänge für diesen Partner verfügbar. Du kannst dich dennoch bewerben. Deine Bewerbung wird erst bearbeitet, wenn wieder Zugänge verfügbar werden."
 
 #. Translators: This text links to the minimum user requirements and terms of use on the partner page.
 #: TWLight/resources/templates/resources/partner_detail.html:48
 #: TWLight/resources/templates/resources/partner_detail_apply.html:29
 #, python-format
-msgid ""
-"Before applying, please review the <strong><a class=\"twl-links\" href="
-"\"%(about)s#req\">minimum requirements</a></strong> for access and our "
-"<strong><a class=\"twl-links\" href=\"%(terms)s\">terms of use</a></strong>."
-msgstr ""
-"Überprüfe bitte vor deiner Bewerbung die <strong><a class=\"twl-links\" href="
-"\"%(about)s#req\">Mindestanforderungen</a></strong> für den Zugriff und lies "
-"unsere <strong><a class=\"twl-links\" href=\"%(terms)s"
-"\">Nutzungsbedingungen</a></strong>."
+msgid "Before applying, please review the <strong><a class=\"twl-links\" href=\"%(about)s#req\">minimum requirements</a></strong> for access and our <strong><a class=\"twl-links\" href=\"%(terms)s\">terms of use</a></strong>."
+msgstr "Überprüfe bitte vor deiner Bewerbung die <strong><a class=\"twl-links\" href=\"%(about)s#req\">Mindestanforderungen</a></strong> für den Zugriff und lies unsere <strong><a class=\"twl-links\" href=\"%(terms)s\">Nutzungsbedingungen</a></strong>."
 
 #. Translators: This text refers to the page containing the content a user is authorized to access.
 #: TWLight/resources/templates/resources/partner_detail.html:69
 #, python-format
-msgid ""
-"View the status of your access in <strong><a class=\"twl-links\" href="
-"\"%(library_url)s\">My Library</a></strong> page."
-msgstr ""
-"Schau dir den Status deines Zuganges auf <strong><a class=\"twl-links\" href="
-"\"%(library_url)s\">Meine Zugänge</a></strong> an."
+msgid "View the status of your access in <strong><a class=\"twl-links\" href=\"%(library_url)s\">My Library</a></strong> page."
+msgstr "Schau dir den Status deines Zuganges auf <strong><a class=\"twl-links\" href=\"%(library_url)s\">Meine Zugänge</a></strong> an."
 
 #. Translators: This message is shown when a user has open applications, linking to their respective applications page.
 #: TWLight/resources/templates/resources/partner_detail.html:78
 #, python-format
-msgid ""
-"View the status of your application(s) on your <strong><a class=\"twl-links"
-"\" href=\"%(applications_url)s\">My Applications</a></strong> page."
-msgstr ""
-"Schau dir den Status deiner Bewerbungen auf <strong><a class=\"twl-links\" "
-"href=\"%(applications_url)s\">Meine Bewerbungen</a></strong> an."
+msgid "View the status of your application(s) on your <strong><a class=\"twl-links\" href=\"%(applications_url)s\">My Applications</a></strong> page."
+msgstr "Schau dir den Status deiner Bewerbungen auf <strong><a class=\"twl-links\" href=\"%(applications_url)s\">Meine Bewerbungen</a></strong> an."
 
 #. Translators: This message is shown when a user has authorizations, linking to their respective collections page.
 #: TWLight/resources/templates/resources/partner_detail_apply.html:50
 #, python-format
-msgid ""
-"View the status of your access on your <strong><a href=\"%(library_url)s\" "
-"class=\"twl-links\">My Library</a></strong> page."
-msgstr ""
-"Schau dir den Status deines Zuganges auf <strong><a href=\"%(library_url)s"
-"\">Meine Zugänge</a></strong> an."
+msgid "View the status of your access on your <strong><a href=\"%(library_url)s\" class=\"twl-links\">My Library</a></strong> page."
+msgstr "Schau dir den Status deines Zuganges auf <strong><a href=\"%(library_url)s\">Meine Zugänge</a></strong> an."
 
 #. Translators: This message is shown when a user has open applications, linking to their respective applications page.
 #: TWLight/resources/templates/resources/partner_detail_apply.html:60
 #, python-format
-msgid ""
-"View the status of your application(s) on your <strong><a href="
-"\"%(applications_url)s\">My Applications</a></strong> page."
-msgstr ""
-"Schau dir den Status deiner Bewerbungen auf <strong><a href="
-"\"%(applications_url)s\">Meine Zugänge</a></strong> an."
+msgid "View the status of your application(s) on your <strong><a href=\"%(applications_url)s\">My Applications</a></strong> page."
+msgstr "Schau dir den Status deiner Bewerbungen auf <strong><a href=\"%(applications_url)s\">Meine Zugänge</a></strong> an."
 
 #. Translators: One the partner detail page, this text labels the button which coordinators can click to remove a partner from waitlisted status.
 #: TWLight/resources/templates/resources/partner_detail_apply.html:73
@@ -1804,8 +1442,7 @@ msgstr "Auf die Warteliste setzen"
 #: TWLight/resources/templates/resources/partner_detail_apply.html:86
 #, python-format
 msgid "<strong>%(coordinator)s</strong> processes applications to %(partner)s."
-msgstr ""
-"<strong>%(coordinator)s</strong> übergibt die Bewerbungen an %(partner)s."
+msgstr "<strong>%(coordinator)s</strong> übergibt die Bewerbungen an %(partner)s."
 
 #. Translators: When a coordinator is assigned to a partner, their details are shown on the page. This text labels a link to their Talk page on Wikipedia, and should be translated to the text used for Talk pages in the language you are translating to.
 #: TWLight/resources/templates/resources/partner_detail_apply.html:95
@@ -1819,15 +1456,8 @@ msgstr "Spezial:E-Mail senden"
 
 #. Translators: If no account coordinator is assigned to a partner, the Wikipedia Library team will coordinate signups. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/resources/templates/resources/partner_detail_apply.html:112
-msgid ""
-"The Wikipedia Library team will process this application. Want to help? <a "
-"class=\"twl-links\" href=\"https://en.wikipedia.org/wiki/Wikipedia:"
-"The_Wikipedia_Library/Coordinators/Signup\">Sign up as a coordinator.</a>"
-msgstr ""
-"Das Team von „The Wikipedia Library“ wird deine Bewerbung nun bearbeiten. "
-"Möchtest du uns künftig enger unterstützen? <a class=\"twl-links\" href="
-"\"https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Coordinators/Signup"
-"\">Bewirb dich für koordinierende Tätigkeiten.</a>"
+msgid "The Wikipedia Library team will process this application. Want to help? <a class=\"twl-links\" href=\"https://en.wikipedia.org/wiki/Wikipedia:The_Wikipedia_Library/Coordinators/Signup\">Sign up as a coordinator.</a>"
+msgstr "Das Team von „The Wikipedia Library“ wird deine Bewerbung nun bearbeiten. Möchtest du uns künftig enger unterstützen? <a class=\"twl-links\" href=\"https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Coordinators/Signup\">Bewirb dich für koordinierende Tätigkeiten.</a>"
 
 #. Translators: This text labels a button coordinators can click to view a list of users who have applied for access for a particular partner
 #: TWLight/resources/templates/resources/partner_detail_apply.html:121
@@ -1856,25 +1486,14 @@ msgstr "Zugriff auf das Zugangspaket"
 
 #. Translators: Text shown to authenticated, bundle eligible users when they visit a Bundle partner page.
 #: TWLight/resources/templates/resources/partner_detail_apply.html:138
-msgid ""
-"You are eligible to access Library Bundle partners. Click the button above "
-"to access the collection."
-msgstr ""
-"Du bist berechtigt, auf die Inhalte der Partner des Zugangspaketes "
-"zuzugreifen. Klicke auf den Button direkt über diesem Text, um den auf die "
-"Sammlungen aufzurufen."
+msgid "You are eligible to access Library Bundle partners. Click the button above to access the collection."
+msgstr "Du bist berechtigt, auf die Inhalte der Partner des Zugangspaketes zuzugreifen. Klicke auf den Button direkt über diesem Text, um den auf die Sammlungen aufzurufen."
 
 #. Translators: Text shown to authenticated, bundle ineligible users when they visit a Bundle partner page.
 #: TWLight/resources/templates/resources/partner_detail_apply.html:152
 #, python-format
-msgid ""
-"You are not eligible to access Library Bundle partners. Visit the <a class="
-"\"twl-links\" href=\"%(homepage)s\">homepage</a> to check the eligibility "
-"criteria."
-msgstr ""
-"Du bist nicht berechtigt, auf die Inhalte der Partner des Zugangspaketes "
-"zuzugreifen. Überprüfe auf der <a class=\"twl-links\" href=\"%(homepage)s"
-"\">Startseite</a> die Kriterien für den Zugang."
+msgid "You are not eligible to access Library Bundle partners. Visit the <a class=\"twl-links\" href=\"%(homepage)s\">homepage</a> to check the eligibility criteria."
+msgstr "Du bist nicht berechtigt, auf die Inhalte der Partner des Zugangspaketes zuzugreifen. Überprüfe auf der <a class=\"twl-links\" href=\"%(homepage)s\">Startseite</a> die Kriterien für den Zugang."
 
 #. Translators: Buttton prompting users to log in.
 #: TWLight/resources/templates/resources/partner_detail_apply.html:160
@@ -1885,15 +1504,8 @@ msgstr "Anmelden"
 #. Translators: Text shown to unauthenticated users when they visit a Bundle partner page.
 #: TWLight/resources/templates/resources/partner_detail_apply.html:168
 #, python-format
-msgid ""
-"This resource is part of our <a class=\"twl-links\" href=\"%(about)s"
-"\">Library Bundle</a>, which you can access if you meet our minimum "
-"eligibility criteria. Log in to find out if you are eligible."
-msgstr ""
-"Dieser Inhalt ist Teil des Zugangs zum <a class=\"twl-links\" href="
-"\"%(about)s\">Zugangspaket</a>, den du bei Erfüllen der minimalen "
-"Zugangskriterien erhalten kannst. Bitte melde dich an um herauszufinden, ob "
-"du zugangsberechtigt bist."
+msgid "This resource is part of our <a class=\"twl-links\" href=\"%(about)s\">Library Bundle</a>, which you can access if you meet our minimum eligibility criteria. Log in to find out if you are eligible."
+msgstr "Dieser Inhalt ist Teil des Zugangs zum <a class=\"twl-links\" href=\"%(about)s\">Zugangspaket</a>, den du bei Erfüllen der minimalen Zugangskriterien erhalten kannst. Bitte melde dich an um herauszufinden, ob du zugangsberechtigt bist."
 
 #. Translators: This is the label for a number which shows the total active accounts for one partner. (e.g. https://wikipedialibrary.wmflabs.org/partners/8/).
 #: TWLight/resources/templates/resources/partner_detail_stats.html:21
@@ -1943,34 +1555,20 @@ msgstr "Maximale Größe des exzerpierbaren Inhalts"
 #. Translators: If a partner has specified the excerpt limit both in words and percentage, this message will display the percentage of words and the number of words on the partner page.
 #: TWLight/resources/templates/resources/partner_detail_timeline.html:99
 #, python-format
-msgid ""
-"%(object)s allows a maximum of %(excerpt_limit)s words or "
-"%(excerpt_limit_percentage)s%% of an article be excerpted into a Wikipedia "
-"article."
-msgstr ""
-"%(object)s erlaubt ein Maximum an %(excerpt_limit)s Wörtern oder "
-"%(excerpt_limit_percentage)s%% eines Artikels als Exzerpt für die Benutzung "
-"in Wikipedia-Artikeln."
+msgid "%(object)s allows a maximum of %(excerpt_limit)s words or %(excerpt_limit_percentage)s%% of an article be excerpted into a Wikipedia article."
+msgstr "%(object)s erlaubt ein Maximum an %(excerpt_limit)s Wörtern oder %(excerpt_limit_percentage)s%% eines Artikels als Exzerpt für die Benutzung in Wikipedia-Artikeln."
 
 #. Translators: If a partner has specified the excerpt limit in words, this message will display the number of words on the partner page.
 #: TWLight/resources/templates/resources/partner_detail_timeline.html:106
 #, python-format
-msgid ""
-"%(object)s allows a maximum of %(excerpt_limit)s words be excerpted into a "
-"Wikipedia article."
-msgstr ""
-"%(object)s erlaubt ein Maximum an %(excerpt_limit)s Wörtern als Exzerpt für "
-"die Benutzung in Wikipedia-Artikeln."
+msgid "%(object)s allows a maximum of %(excerpt_limit)s words be excerpted into a Wikipedia article."
+msgstr "%(object)s erlaubt ein Maximum an %(excerpt_limit)s Wörtern als Exzerpt für die Benutzung in Wikipedia-Artikeln."
 
 #. Translators: If a partner has specified the excerpt limit in percentage, this message will display the percentage of words on the partner page.
 #: TWLight/resources/templates/resources/partner_detail_timeline.html:113
 #, python-format
-msgid ""
-"%(object)s allows a maximum of %(excerpt_limit_percentage)s%% of an article "
-"be excerpted into a Wikipedia article."
-msgstr ""
-"%(object)s erlaubt ein Maximum %(excerpt_limit_percentage)s%% eines Artikels "
-"als Exzerpt für die Benutzung in Wikipedia-Artikeln."
+msgid "%(object)s allows a maximum of %(excerpt_limit_percentage)s%% of an article be excerpted into a Wikipedia article."
+msgstr "%(object)s erlaubt ein Maximum %(excerpt_limit_percentage)s%% eines Artikels als Exzerpt für die Benutzung in Wikipedia-Artikeln."
 
 #. Translators: If a partner has other requirements for access, this text shows as the title for that information field. (e.g. https://wikipedialibrary.wmflabs.org/partners/10/).
 #: TWLight/resources/templates/resources/partner_detail_timeline.html:132
@@ -1980,12 +1578,8 @@ msgstr "Spezielle Anforderungen an Bewerbungen"
 #. Translators: If a user must agree to a Terms of Use document, they see this message, and must enter the name of the resource. Don't translate publisher or url.
 #: TWLight/resources/templates/resources/partner_detail_timeline.html:140
 #, python-format
-msgid ""
-"%(publisher)s requires that you agree with its <a href=\"%(url)s\">terms of "
-"use</a>."
-msgstr ""
-"%(publisher)s benötigt die Zustimmung zu den <a href=\"%(url)s"
-"\">Nutzungsbedingungen</a>."
+msgid "%(publisher)s requires that you agree with its <a href=\"%(url)s\">terms of use</a>."
+msgstr "%(publisher)s benötigt die Zustimmung zu den <a href=\"%(url)s\">Nutzungsbedingungen</a>."
 
 #. Translators: If a user must provide their real name to apply to a partner, they see this message, and must enter the name of the resource. Don't translate publisher.
 #: TWLight/resources/templates/resources/partner_detail_timeline.html:150
@@ -2008,22 +1602,14 @@ msgstr "%(publisher)s benötigt die Angabe deines zugehörigen Institution."
 #. Translators: If a user must select a specific resource to apply for, they see this message, and must enter the name of the resource. Don't translate publisher.
 #: TWLight/resources/templates/resources/partner_detail_timeline.html:177
 #, python-format
-msgid ""
-"%(publisher)s requires that you specify a particular title that you want to "
-"access."
-msgstr ""
-"%(publisher)s benötigt die Angabe eines bestimmten Werktitels, zu dem du "
-"Zugang erhalten möchtest."
+msgid "%(publisher)s requires that you specify a particular title that you want to access."
+msgstr "%(publisher)s benötigt die Angabe eines bestimmten Werktitels, zu dem du Zugang erhalten möchtest."
 
 #. Translators: If a user must register on the partner website before applying, they see this message. Don't translate partner.
 #: TWLight/resources/templates/resources/partner_detail_timeline.html:187
 #, python-format
-msgid ""
-"%(publisher)s requires that you sign up for an account before applying for "
-"access."
-msgstr ""
-"%(publisher)s benötigt die Einrichtung eines Kontos, bevor du dich auf einen "
-"Zugang bewerben kannst."
+msgid "%(publisher)s requires that you sign up for an account before applying for access."
+msgstr "%(publisher)s benötigt die Einrichtung eines Kontos, bevor du dich auf einen Zugang bewerben kannst."
 
 #. Translators: If a partner has their location listed, this message is a label for that location
 #: TWLight/resources/templates/resources/partner_detail_timeline.html:206
@@ -2149,12 +1735,8 @@ msgstr "Bist du sicher, <b>%(object)s</b> löschen zu wollen?"
 
 #. Translators: If multiple authorizations where returned for a collection, this message is shown to a user
 #: TWLight/resources/views.py:268
-msgid ""
-"Multiple authorizations were returned – something's wrong. Please contact us "
-"and don't forget to mention this message."
-msgstr ""
-"Mehrere Autorisierungen sind zurückgekommen – irgendwas ging schief. Bitte "
-"kontaktiere uns und erwähne dabei diesen Hinweis."
+msgid "Multiple authorizations were returned – something's wrong. Please contact us and don't forget to mention this message."
+msgstr "Mehrere Autorisierungen sind zurückgekommen – irgendwas ging schief. Bitte kontaktiere uns und erwähne dabei diesen Hinweis."
 
 #. Translators: This message is shown when user tries to access a NOT_AVAILABLE Partner
 #: TWLight/resources/views.py:316
@@ -2194,23 +1776,8 @@ msgstr "Entschuldigung, wir wissen nicht, was wir damit tun soll. (Fehler 400)"
 #. Translators: Shown on the website's 400 page, when a user sends a bad request. Don't translate path or Phabricator.
 #: TWLight/templates/400.html:20
 #, python-format
-msgid ""
-"If you think we should know what to do with that, please email us about this "
-"error at <a class=\"twl-links\" href=\"mailto:wikipedialibrary@wikimedia.org?"
-"Subject=Wikipedia%%20Library%%20%(path)s%%20Permission%%20denied"
-"\">wikipedialibrary@wikimedia.org</a> or report it to us on <a class=\"twl-"
-"links\" href=\"https://phabricator.wikimedia.org/maniphest/task/edit/form/1/?"
-"projectPHIDs=Library-Card-Platform&title=Wikipedia%%20Library%%20%(path)s"
-"%%20Bad%%20Request\">Phabricator</a>"
-msgstr ""
-"Falls du meinst, wir sollten wissen, was hier hätte passieren sollen, maile "
-"uns den Fehler bitte an: <a class=\"twl-links\" href=\"mailto:"
-"wikipedialibrary@wikimedia.org?Subject=Wikipedia%%20Library%%20%(path)s"
-"%%20Permission%%20denied\">wikipedialibrary@wikimedia.org</a> oder melde den "
-"Fehler im <a class=\"twl-links\" href=\"https://phabricator.wikimedia.org/"
-"maniphest/task/edit/form/1/?projectPHIDs=Library-Card-"
-"Platform&title=Wikipedia%%20Library%%20%(path)s%%20Bad%%20Request"
-"\">Phabricator</a>"
+msgid "If you think we should know what to do with that, please email us about this error at <a class=\"twl-links\" href=\"mailto:wikipedialibrary@wikimedia.org?Subject=Wikipedia%%20Library%%20%(path)s%%20Permission%%20denied\">wikipedialibrary@wikimedia.org</a> or report it to us on <a class=\"twl-links\" href=\"https://phabricator.wikimedia.org/maniphest/task/edit/form/1/?projectPHIDs=Library-Card-Platform&title=Wikipedia%%20Library%%20%(path)s%%20Bad%%20Request\">Phabricator</a>"
+msgstr "Falls du meinst, wir sollten wissen, was hier hätte passieren sollen, maile uns den Fehler bitte an: <a class=\"twl-links\" href=\"mailto:wikipedialibrary@wikimedia.org?Subject=Wikipedia%%20Library%%20%(path)s%%20Permission%%20denied\">wikipedialibrary@wikimedia.org</a> oder melde den Fehler im <a class=\"twl-links\" href=\"https://phabricator.wikimedia.org/maniphest/task/edit/form/1/?projectPHIDs=Library-Card-Platform&title=Wikipedia%%20Library%%20%(path)s%%20Bad%%20Request\">Phabricator</a>"
 
 #. Translators: Alt text for an image shown on the 400 error page.
 #. Translators: Alt text for an image shown on the 403 error page.
@@ -2231,23 +1798,8 @@ msgstr "Entschuldigung, leider darfst du das nicht tun. (Fehler 403)"
 #. Translators: Shown on the website's 403 page, when a user attempts to navigate to a page they don't have permission to view. Don't translate path or Phabricator.
 #: TWLight/templates/403.html:20
 #, python-format
-msgid ""
-"If you think your account should be able to do that, please email us about "
-"this error at <a class=\"twl-links\" href=\"mailto:"
-"wikipedialibrary@wikimedia.org?Subject=Wikipedia%%20Library%%20%(path)s"
-"%%20Permission%%20denied\">wikipedialibrary@wikimedia.org</a> or report it "
-"to us on <a class=\"twl-links\" href=\"https://phabricator.wikimedia.org/"
-"maniphest/task/edit/form/1/?projectPHIDs=Library-Card-"
-"Platform&title=Wikipedia%%20Library%%20%(path)s%%20Permission%%20denied"
-"\">Phabricator</a>"
-msgstr ""
-"Falls du der Meinung bist, du dürftest das doch tun, maile den Fehler an <a "
-"class=\"twl-links\" href=\"mailto:wikipedialibrary@wikimedia.org?"
-"Subject=Wikipedia%%20Library%%20%(path)s%%20Permission%%20denied"
-"\">wikipedialibrary@wikimedia.org</a> oder melde es im <a class=\"twl-links"
-"\" href=\"https://phabricator.wikimedia.org/maniphest/task/edit/form/1/?"
-"projectPHIDs=Library-Card-Platform&title=Wikipedia%%20Library%%20%(path)s"
-"%%20Permission%%20denied\">Phabricator</a>"
+msgid "If you think your account should be able to do that, please email us about this error at <a class=\"twl-links\" href=\"mailto:wikipedialibrary@wikimedia.org?Subject=Wikipedia%%20Library%%20%(path)s%%20Permission%%20denied\">wikipedialibrary@wikimedia.org</a> or report it to us on <a class=\"twl-links\" href=\"https://phabricator.wikimedia.org/maniphest/task/edit/form/1/?projectPHIDs=Library-Card-Platform&title=Wikipedia%%20Library%%20%(path)s%%20Permission%%20denied\">Phabricator</a>"
+msgstr "Falls du der Meinung bist, du dürftest das doch tun, maile den Fehler an <a class=\"twl-links\" href=\"mailto:wikipedialibrary@wikimedia.org?Subject=Wikipedia%%20Library%%20%(path)s%%20Permission%%20denied\">wikipedialibrary@wikimedia.org</a> oder melde es im <a class=\"twl-links\" href=\"https://phabricator.wikimedia.org/maniphest/task/edit/form/1/?projectPHIDs=Library-Card-Platform&title=Wikipedia%%20Library%%20%(path)s%%20Permission%%20denied\">Phabricator</a>"
 
 #. Translators: Shown on the website's 404 page, when a user attempts to navigate to a page that doesn't exist.
 #: TWLight/templates/404.html:11
@@ -2262,22 +1814,8 @@ msgstr "Entschuldigung, wir können das nicht finden. (Fehler 404)"
 #. Translators: Shown on the website's 404 page, when a user attempts to navigate to a page that doesn't exist. Don't translate path or Phabricator.
 #: TWLight/templates/404.html:19
 #, python-format
-msgid ""
-"If you are certain that something should be here, please email us about this "
-"error at <a class=\"twl-links\" href=\"mailto:wikipedialibrary@wikimedia.org?"
-"Subject=Wikipedia%%20Library%%20%(path)s%%20Not%%20found\"> "
-"wikipedialibrary@wikimedia.org</a> or report it to us on <a class=\"twl-links"
-"\" href=\"https://phabricator.wikimedia.org/maniphest/task/edit/form/1/?"
-"projectPHIDs=Library-Card-Platform&title=Wikipedia%%20Library%%20%(path)s"
-"%%20Not%%20found\">Phabricator</a>"
-msgstr ""
-"Wenn du der Meinung bist, hier hätte etwas stehen sollen, so melde den "
-"Fehler per Mail an <a class=\"twl-links\" href=\"mailto:"
-"wikipedialibrary@wikimedia.org?Subject=Wikipedia%%20Library%%20%(path)s"
-"%%20Not%%20found\"> wikipedialibrary@wikimedia.org</a> oder melde es im <a "
-"class=\"twl-links\" href=\"https://phabricator.wikimedia.org/maniphest/task/"
-"edit/form/1/?projectPHIDs=Library-Card-Platform&title=Wikipedia%%20Library"
-"%%20%(path)s%%20Not%%20found\">Phabricator</a>"
+msgid "If you are certain that something should be here, please email us about this error at <a class=\"twl-links\" href=\"mailto:wikipedialibrary@wikimedia.org?Subject=Wikipedia%%20Library%%20%(path)s%%20Not%%20found\"> wikipedialibrary@wikimedia.org</a> or report it to us on <a class=\"twl-links\" href=\"https://phabricator.wikimedia.org/maniphest/task/edit/form/1/?projectPHIDs=Library-Card-Platform&title=Wikipedia%%20Library%%20%(path)s%%20Not%%20found\">Phabricator</a>"
+msgstr "Wenn du der Meinung bist, hier hätte etwas stehen sollen, so melde den Fehler per Mail an <a class=\"twl-links\" href=\"mailto:wikipedialibrary@wikimedia.org?Subject=Wikipedia%%20Library%%20%(path)s%%20Not%%20found\"> wikipedialibrary@wikimedia.org</a> oder melde es im <a class=\"twl-links\" href=\"https://phabricator.wikimedia.org/maniphest/task/edit/form/1/?projectPHIDs=Library-Card-Platform&title=Wikipedia%%20Library%%20%(path)s%%20Not%%20found\">Phabricator</a>"
 
 #. Translators: Alt text for an image shown on the 404 error page.
 #: TWLight/templates/404.html:32
@@ -2291,50 +1829,19 @@ msgstr "Über „The Wikipedia Library“"
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:20
-msgid ""
-"This platform is our central tool for facilitating access to our available "
-"collections. Here you can see which partnerships are available, search their "
-"contents, and apply for and access the ones you’re interested in."
-msgstr ""
-"Diese Plattform ist unser zentrales Instrument zur Erleichterung des Zugangs "
-"zu unseren verfügbaren Sammlungen. Hier kannst du sehen, welche "
-"Partnerschaften verfügbar sind, deren Inhalte durchsuchen und sich für die "
-"Partnerschaften, die dich interessieren, bewerben und darauf zugreifen."
+msgid "This platform is our central tool for facilitating access to our available collections. Here you can see which partnerships are available, search their contents, and apply for and access the ones you’re interested in."
+msgstr "Diese Plattform ist unser zentrales Instrument zur Erleichterung des Zugangs zu unseren verfügbaren Sammlungen. Hier kannst du sehen, welche Partnerschaften verfügbar sind, deren Inhalte durchsuchen und sich für die Partnerschaften, die dich interessieren, bewerben und darauf zugreifen."
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/). Wikimedia Foundation should not be translated.
 #: TWLight/templates/about.html:29
-msgid ""
-"All users receive immediate access to some collections, which can be browsed "
-"by clicking the 'Access collection' buttons or using the search bar at the "
-"top of the page. Other collections require an application before access is "
-"granted, and may be accessed directly or via an individual login or access "
-"code. Volunteer coordinators, who have signed non-disclosure agreements with "
-"the Wikimedia Foundation, review these applications and work with publishers "
-"to get you your free access."
-msgstr ""
-"Alle Nutzer erhalten sofortigen Zugang zu einigen Sammlungen, die durch "
-"Anklicken der Schaltflächen „Zugang zur Sammlung“ oder über die Suchleiste "
-"oben auf der Seite durchsucht werden können. Für andere Sammlungen ist ein "
-"Antrag erforderlich, bevor der Zugang gewährt wird. Der Zugang kann direkt "
-"oder über ein individuelles Login oder einen Zugangscode erfolgen. "
-"Ehrenamtliche Koordinatoren, die Vertraulichkeitsvereinbarungen mit der "
-"Wikimedia Foundation unterzeichnet haben, prüfen diese Anträge und arbeiten "
-"mit den Verlegern zusammen, um dir den kostenlosen Zugang zu ermöglichen."
+msgid "All users receive immediate access to some collections, which can be browsed by clicking the 'Access collection' buttons or using the search bar at the top of the page. Other collections require an application before access is granted, and may be accessed directly or via an individual login or access code. Volunteer coordinators, who have signed non-disclosure agreements with the Wikimedia Foundation, review these applications and work with publishers to get you your free access."
+msgstr "Alle Nutzer erhalten sofortigen Zugang zu einigen Sammlungen, die durch Anklicken der Schaltflächen „Zugang zur Sammlung“ oder über die Suchleiste oben auf der Seite durchsucht werden können. Für andere Sammlungen ist ein Antrag erforderlich, bevor der Zugang gewährt wird. Der Zugang kann direkt oder über ein individuelles Login oder einen Zugangscode erfolgen. Ehrenamtliche Koordinatoren, die Vertraulichkeitsvereinbarungen mit der Wikimedia Foundation unterzeichnet haben, prüfen diese Anträge und arbeiten mit den Verlegern zusammen, um dir den kostenlosen Zugang zu ermöglichen."
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/). Don't translate terms_url.
 #: TWLight/templates/about.html:43
 #, python-format
-msgid ""
-"For more information about how your information is stored and reviewed "
-"please see our <a class=\"twl-links\" href=\"%(terms_url)s\"> terms of use "
-"and privacy policy</a>. Accounts you apply for are also subject to the Terms "
-"of Use provided by each partner’s platform; please review them."
-msgstr ""
-"Mehr Informationen über die Speicherung und Verarbeitung deiner Daten auf "
-"der Seite findest du in <a class=\"twl-links\" href=\"%(terms_url)s"
-"\">unseren Nutzungsbedingungen und unserer Datenschutzerklärung</a>. Für die "
-"Zugänge, auf die du dich beworben hast, gelten auch die Nutzungsbedingungen "
-"der Plattformen der jeweiligen Partner; bitte informiere dich bei ihnen."
+msgid "For more information about how your information is stored and reviewed please see our <a class=\"twl-links\" href=\"%(terms_url)s\"> terms of use and privacy policy</a>. Accounts you apply for are also subject to the Terms of Use provided by each partner’s platform; please review them."
+msgstr "Mehr Informationen über die Speicherung und Verarbeitung deiner Daten auf der Seite findest du in <a class=\"twl-links\" href=\"%(terms_url)s\">unseren Nutzungsbedingungen und unserer Datenschutzerklärung</a>. Für die Zugänge, auf die du dich beworben hast, gelten auch die Nutzungsbedingungen der Plattformen der jeweiligen Partner; bitte informiere dich bei ihnen."
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:51
@@ -2343,26 +1850,13 @@ msgstr "Wer kann Zugriff erhalten?"
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/). Wikimedia Foundation should not be translated.
 #: TWLight/templates/about.html:55
-msgid ""
-"Any active editor in good standing can receive access. For publishers with "
-"limited numbers of accounts, applications are reviewed based on the editor’s "
-"needs and contributions. If you think you could use access to one of our "
-"partner resources and are an active editor in any project supported by the "
-"Wikimedia Foundation, please apply."
-msgstr ""
-"Alle aktiven Personen, die aktiv zu den Wikimedia-Projekten beitragen, "
-"können einen Zugang erhalten. Für Verlage mit einer begrenzten Anzahl an "
-"Zugängen werden die Bewerbungen anhand der Bedarfe und Beiträge beurteilt. "
-"Wenn du der Meinung bist, dass du den Zugang zum Inhalt unserer Partner gut "
-"nutzen könntest, und selbst aktiv in einem Wikimedia-Projekt beiträgst, "
-"bitte bewirb dich gern."
+msgid "Any active editor in good standing can receive access. For publishers with limited numbers of accounts, applications are reviewed based on the editor’s needs and contributions. If you think you could use access to one of our partner resources and are an active editor in any project supported by the Wikimedia Foundation, please apply."
+msgstr "Alle aktiven Personen, die aktiv zu den Wikimedia-Projekten beitragen, können einen Zugang erhalten. Für Verlage mit einer begrenzten Anzahl an Zugängen werden die Bewerbungen anhand der Bedarfe und Beiträge beurteilt. Wenn du der Meinung bist, dass du den Zugang zum Inhalt unserer Partner gut nutzen könntest, und selbst aktiv in einem Wikimedia-Projekt beiträgst, bitte bewirb dich gern."
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:65
 msgid "Any editor can use the library if they meet a few basic requirements:"
-msgstr ""
-"Du kannst The Wikipedia Library nutzen, wenn du die folgenden Anforderungen "
-"erfüllst:"
+msgstr "Du kannst The Wikipedia Library nutzen, wenn du die folgenden Anforderungen erfüllst:"
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:71
@@ -2372,15 +1866,12 @@ msgstr "Dein Konto existiert seit mindestens sechs Monaten."
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:75
 msgid "You have made a minimum of 500 edits to Wikimedia projects"
-msgstr ""
-"Du hast mindestens 500 Bearbeitungen zu den Wikimedia-Projekten beigetragen."
+msgstr "Du hast mindestens 500 Bearbeitungen zu den Wikimedia-Projekten beigetragen."
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:79
 msgid "You have made at least 10 edits to Wikimedia projects in the last month"
-msgstr ""
-"Du hast mindestens 10 Bearbeitungen innerhalb des letzten Monats zu den "
-"Wikimedia-Projekten beigetragen."
+msgstr "Du hast mindestens 10 Bearbeitungen innerhalb des letzten Monats zu den Wikimedia-Projekten beigetragen."
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:83
@@ -2389,38 +1880,13 @@ msgstr "Du bist derzeit in keinem Wikimedia-Projekt gesperrt."
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/)
 #: TWLight/templates/about.html:89
-msgid ""
-"If you are applying for an available collection, please first check that you "
-"don't already have access through another library or institution. If you do, "
-"please consider using that access rather than taking up a seat for this "
-"resource in The Wikipedia Library."
-msgstr ""
-"Wenn du dich für eine verfügbare Sammlung bewerben möchtest, prüfe bitte "
-"zunächst, ob du nicht bereits über eine andere Bibliothek oder Institution "
-"Zugang hast. Falls dies der Fall ist, ziehe bitte in Erwägung, diesen Zugang "
-"zu nutzen, anstatt einen Zugang für diesen Partner über The Wikipedia "
-"Library zu beanspruchen."
+msgid "If you are applying for an available collection, please first check that you don't already have access through another library or institution. If you do, please consider using that access rather than taking up a seat for this resource in The Wikipedia Library."
+msgstr "Wenn du dich für eine verfügbare Sammlung bewerben möchtest, prüfe bitte zunächst, ob du nicht bereits über eine andere Bibliothek oder Institution Zugang hast. Falls dies der Fall ist, ziehe bitte in Erwägung, diesen Zugang zu nutzen, anstatt einen Zugang für diesen Partner über The Wikipedia Library zu beanspruchen."
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/)
 #: TWLight/templates/about.html:99
-msgid ""
-"If your account is blocked on one or more Wikimedia projects, you may still "
-"be granted access to The Wikipedia Library. You will need to contact the "
-"Wikipedia Library team, who will review your blocks. If you have been "
-"blocked for content issues, most notably copyright violations, or have "
-"multiple long-term blocks, we may decline your request. Additionally, if "
-"your block status changes after being approved, you will need to request "
-"another review."
-msgstr ""
-"Falls dein Konto in einem oder mehreren Wikimedia-Projekten gesperrt ist, "
-"kannst du unter Umständen immer noch Zugang zu The Wikipedia Library "
-"erhalten. In diesem Fall musst du dich dann an das Team von The Wikipedia "
-"Library wenden, das die Sperren begutachten wird. Sofern du aufgrund von "
-"Problemen bei der Inhaltsarbeit gesperrt sein solltest (insbesondere bei "
-"Urheberrechtsverletzungen) oder mehrfach langfristige Sperren hattest, wird "
-"deine Anfrage wahrscheinlich abgelehnt. Außerdem musst du eine neue "
-"Bearbeitung deines Zuganges beantragen, sofern sich dein Sperrstatus nach "
-"der Bestätigung geändert haben sollte."
+msgid "If your account is blocked on one or more Wikimedia projects, you may still be granted access to The Wikipedia Library. You will need to contact the Wikipedia Library team, who will review your blocks. If you have been blocked for content issues, most notably copyright violations, or have multiple long-term blocks, we may decline your request. Additionally, if your block status changes after being approved, you will need to request another review."
+msgstr "Falls dein Konto in einem oder mehreren Wikimedia-Projekten gesperrt ist, kannst du unter Umständen immer noch Zugang zu The Wikipedia Library erhalten. In diesem Fall musst du dich dann an das Team von The Wikipedia Library wenden, das die Sperren begutachten wird. Sofern du aufgrund von Problemen bei der Inhaltsarbeit gesperrt sein solltest (insbesondere bei Urheberrechtsverletzungen) oder mehrfach langfristige Sperren hattest, wird deine Anfrage wahrscheinlich abgelehnt. Außerdem musst du eine neue Bearbeitung deines Zuganges beantragen, sofern sich dein Sperrstatus nach der Bestätigung geändert haben sollte."
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:110
@@ -2454,12 +1920,8 @@ msgstr "Bestätigte Autoren <i>sollten nicht</i>:"
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:136
-msgid ""
-"Share their account logins or passwords with others, or sell their access to "
-"other parties"
-msgstr ""
-"Ihre Zugangsdaten oder Passwörter mit anderen teilen oder den Zugang an "
-"Dritte verkaufen."
+msgid "Share their account logins or passwords with others, or sell their access to other parties"
+msgstr "Ihre Zugangsdaten oder Passwörter mit anderen teilen oder den Zugang an Dritte verkaufen."
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:140
@@ -2468,29 +1930,18 @@ msgstr "Massenhaft Inhalte unserer Partner abfragen oder herunterladen."
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:144
-msgid ""
-"Systematically make printed or electronic copies of multiple extracts of "
-"restricted content available for any purpose"
-msgstr ""
-"Systematisch gedruckte oder digitale Kopien von umfangreichen Exzerpten oder "
-"zugangsbeschränkten Inhalten erstellen, für keinerlei Zwecke."
+msgid "Systematically make printed or electronic copies of multiple extracts of restricted content available for any purpose"
+msgstr "Systematisch gedruckte oder digitale Kopien von umfangreichen Exzerpten oder zugangsbeschränkten Inhalten erstellen, für keinerlei Zwecke."
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/). Stub is a technical term for a short Wikipedia article, use the appropriate Wikipedia term in your language.
 #: TWLight/templates/about.html:148
-msgid ""
-"Datamine metadata without permission, in order, for instance, to use "
-"metadata for auto-created stub articles"
-msgstr ""
-"Metadaten ohne Erlaubnis sammeln, bspw. für automatisch generierte Stubs."
+msgid "Datamine metadata without permission, in order, for instance, to use metadata for auto-created stub articles"
+msgstr "Metadaten ohne Erlaubnis sammeln, bspw. für automatisch generierte Stubs."
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:154
-msgid ""
-"Respecting these agreements allows us to continue growing the partnerships "
-"available to the community."
-msgstr ""
-"Nur mit Einhaltung dieser Vereinbarungen wird es uns möglich sein, die "
-"Partnerschaften für die Community weiter auszubauen."
+msgid "Respecting these agreements allows us to continue growing the partnerships available to the community."
+msgstr "Nur mit Einhaltung dieser Vereinbarungen wird es uns möglich sein, die Partnerschaften für die Community weiter auszubauen."
 
 #. Translators: This is the heading for a section on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:160
@@ -2499,64 +1950,23 @@ msgstr "EZProxy"
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:164
-msgid ""
-"EZProxy is a proxy server used to authenticate users for many Wikipedia "
-"Library partners. Users sign into EZProxy via the Library Card platform to "
-"verify that they are authorized users, and then the server accesses "
-"requested resources using its own IP address."
-msgstr ""
-"EZProxy ist ein Proxy-Server, den wir für die Authentifizierung unserer "
-"Nutzer gegenüber den Partner von „The Wikipedia Library“ verwenden. Die "
-"Anmeldung zum EZProxy wird über unsere Plattform bestätigt, danach ruft der "
-"Server die angefragten Inhalte über eine eigene IP-Adresse auf."
+msgid "EZProxy is a proxy server used to authenticate users for many Wikipedia Library partners. Users sign into EZProxy via the Library Card platform to verify that they are authorized users, and then the server accesses requested resources using its own IP address."
+msgstr "EZProxy ist ein Proxy-Server, den wir für die Authentifizierung unserer Nutzer gegenüber den Partner von „The Wikipedia Library“ verwenden. Die Anmeldung zum EZProxy wird über unsere Plattform bestätigt, danach ruft der Server die angefragten Inhalte über eine eigene IP-Adresse auf."
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:173
-msgid ""
-"You may notice that when accessing resources via EZProxy that URLs are "
-"dynamically rewritten. This is why we recommend logging in via the Library "
-"Card platform rather than going directly to the unproxied partner website. "
-"When in doubt, check the URL for ‘idm.oclc’. If it’s there, then you’re "
-"connected via EZProxy."
-msgstr ""
-"Du wirst beim Aufrufen der Inhalte über EZPRoxy vielleicht feststellen, dass "
-"die URLs dynamisch aktualisiert werden. Aus diesem Grund empfehlen wir die "
-"Anmeldung über unsere Plattform, statt diese ohne Proxy auf der Website des "
-"Partners aufzurufen. Sollte es Unklarheiten in der Verwendung des Proxys "
-"geben, dann überprüfe, ob die URL „idm.oclc“ enthält. Sollte dies der Fall "
-"sein, dann bist du über EZProxy mit den Inhalten verbunden."
+msgid "You may notice that when accessing resources via EZProxy that URLs are dynamically rewritten. This is why we recommend logging in via the Library Card platform rather than going directly to the unproxied partner website. When in doubt, check the URL for ‘idm.oclc’. If it’s there, then you’re connected via EZProxy."
+msgstr "Du wirst beim Aufrufen der Inhalte über EZPRoxy vielleicht feststellen, dass die URLs dynamisch aktualisiert werden. Aus diesem Grund empfehlen wir die Anmeldung über unsere Plattform, statt diese ohne Proxy auf der Website des Partners aufzurufen. Sollte es Unklarheiten in der Verwendung des Proxys geben, dann überprüfe, ob die URL „idm.oclc“ enthält. Sollte dies der Fall sein, dann bist du über EZProxy mit den Inhalten verbunden."
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:182
-msgid ""
-"Typically once you’ve logged in your session will remain active in your "
-"browser for up to two hours after you’ve finished searching. Note that use "
-"of EZProxy requires you to enable cookies. If you are having problems you "
-"should also try clearing your cache and restarting your browser."
-msgstr ""
-"Üblicherweise bleibst du in dieser Browsersession für weitere zwei Stunden "
-"nach dem Ende deiner Suche hier eingeloggt. Bitte beachte, dass EZPRoxy die "
-"Aktivierung von Cookies verlangt. Solltest du Probleme damit haben, könnte "
-"das Löschen des Caches oder Neustarten deines Browser diese vielleicht "
-"beheben."
+msgid "Typically once you’ve logged in your session will remain active in your browser for up to two hours after you’ve finished searching. Note that use of EZProxy requires you to enable cookies. If you are having problems you should also try clearing your cache and restarting your browser."
+msgstr "Üblicherweise bleibst du in dieser Browsersession für weitere zwei Stunden nach dem Ende deiner Suche hier eingeloggt. Bitte beachte, dass EZPRoxy die Aktivierung von Cookies verlangt. Solltest du Probleme damit haben, könnte das Löschen des Caches oder Neustarten deines Browser diese vielleicht beheben."
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/)
 #: TWLight/templates/about.html:193
-msgid ""
-"The Library Bundle is a collection of resources for which no application is "
-"required. If you meet the criteria laid out above, you will be authorized "
-"for access automatically upon logging in to the platform. Only some of our "
-"content is currently included in the Library Bundle, however we hope to "
-"expand the collection as more publishers become comfortable with "
-"participating. All Bundle content is accessed via EZProxy."
-msgstr ""
-"Das Zugangspaket ist eine Sammlung an Inhalten, für die keine weiteren "
-"Bewerbungen benötigt werden. Falls du die oben dargelegten Kriterien "
-"erfüllst, erhältst du nach Anmeldung hier auf der Plattform automatisch "
-"Zugang dazu. Bisher ist nur ein Teil unserer Partnerschaften im Zugangspaket "
-"verfügbar, wir hoffen jedoch die Sammlung zu erweitern und mehr Verlage zur "
-"Beteiligung zu motivieren. Alle Inhalte werden dabei über EZProxy zur "
-"Verfügung gestellt."
+msgid "The Library Bundle is a collection of resources for which no application is required. If you meet the criteria laid out above, you will be authorized for access automatically upon logging in to the platform. Only some of our content is currently included in the Library Bundle, however we hope to expand the collection as more publishers become comfortable with participating. All Bundle content is accessed via EZProxy."
+msgstr "Das Zugangspaket ist eine Sammlung an Inhalten, für die keine weiteren Bewerbungen benötigt werden. Falls du die oben dargelegten Kriterien erfüllst, erhältst du nach Anmeldung hier auf der Plattform automatisch Zugang dazu. Bisher ist nur ein Teil unserer Partnerschaften im Zugangspaket verfügbar, wir hoffen jedoch die Sammlung zu erweitern und mehr Verlage zur Beteiligung zu motivieren. Alle Inhalte werden dabei über EZProxy zur Verfügung gestellt."
 
 #. Translators: This is the heading for a section on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:202
@@ -2565,21 +1975,8 @@ msgstr "Richtlinien für Belege"
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:206
-msgid ""
-"Citation practices vary by project and even by article. Generally, we "
-"support editors citing where they found information, in a form that allows "
-"others to check it for themselves. That often means providing both original "
-"source details as well as a link to the partner database in which the source "
-"was found."
-msgstr ""
-"Die Angabe von Belegen kann je nach Wikimedia-Projekt oder sogar je nach "
-"Artikel unterschiedlich sein. Allgemein empfehlen wir den Herkunftsort der "
-"Information beim Belegen anzugeben, damit andere die Angaben selbst "
-"überprüfen können. Üblicherweise sind dabei sowohl Details zur "
-"ursprünglichen Quelle als auch die Datenbank unseres Partners, in der die "
-"Quelle gefunden wurde, anzugeben. Bitte verlinke nicht auf einen Link über "
-"deinen Proxyzugang, da Dritte darauf keinen Zugriff haben. In der "
-"deutschsprachigen Wikipedia unterbindet dies sogar ein Filter."
+msgid "Citation practices vary by project and even by article. Generally, we support editors citing where they found information, in a form that allows others to check it for themselves. That often means providing both original source details as well as a link to the partner database in which the source was found."
+msgstr "Die Angabe von Belegen kann je nach Wikimedia-Projekt oder sogar je nach Artikel unterschiedlich sein. Allgemein empfehlen wir den Herkunftsort der Information beim Belegen anzugeben, damit andere die Angaben selbst überprüfen können. Üblicherweise sind dabei sowohl Details zur ursprünglichen Quelle als auch die Datenbank unseres Partners, in der die Quelle gefunden wurde, anzugeben. Bitte verlinke nicht auf einen Link über deinen Proxyzugang, da Dritte darauf keinen Zugriff haben. In der deutschsprachigen Wikipedia unterbindet dies sogar ein Filter."
 
 #. Translators: This is the heading for a section on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #. Translators: This link is at the bottom of every page and can be clicked by users to contact the wikipedia library team.
@@ -2590,13 +1987,8 @@ msgstr "Kontaktiere uns"
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:218
 #, python-format
-msgid ""
-"If you have questions, need help, or want to volunteer to help, please see "
-"our <a class=\"twl-links\" href=\"%(contact_url)s\">contact page</a>."
-msgstr ""
-"Falls du Fragen haben solltest, Hilfe benötigst oder uns ehrenamtlich "
-"unterstützen möchtest, schau bitte auf der <a class=\"twl-links\" href="
-"\"%(contact_url)s\">Kontaktseite</a> vorbei."
+msgid "If you have questions, need help, or want to volunteer to help, please see our <a class=\"twl-links\" href=\"%(contact_url)s\">contact page</a>."
+msgstr "Falls du Fragen haben solltest, Hilfe benötigst oder uns ehrenamtlich unterstützen möchtest, schau bitte auf der <a class=\"twl-links\" href=\"%(contact_url)s\">Kontaktseite</a> vorbei."
 
 #. Translators: This is the title of the panel box detailing the contact information for the Wikipedia Library team.
 #: TWLight/templates/contact.html:14
@@ -2635,19 +2027,13 @@ msgstr "The-Wikipedia-Library-Twitter-Seite"
 #. Translators: This is the text that appears at the bottom of the contact us form directing users to the suggestions form.
 #: TWLight/templates/contact.html:48
 #, python-format
-msgid ""
-"(If you would like to suggest a partner, <a class=\"twl-links\" href="
-"\"%(suggest)s\"><strong>go here</strong></a>.)"
-msgstr ""
-"(Wenn du einen Partner vorschlagen möchtest, <a class=\"twl-links\" href="
-"\"%(suggest)s\"><strong>klicke hier</strong></a>.)"
+msgid "(If you would like to suggest a partner, <a class=\"twl-links\" href=\"%(suggest)s\"><strong>go here</strong></a>.)"
+msgstr "(Wenn du einen Partner vorschlagen möchtest, <a class=\"twl-links\" href=\"%(suggest)s\"><strong>klicke hier</strong></a>.)"
 
 #. Translators: On a special 'link to search' page, this message is shown if JavaScript is disabled.
 #: TWLight/templates/eds_search_endpoint.html:7
 msgid "JavaScript is disabled; use the button below to continue."
-msgstr ""
-"JavaScript ist deaktiviert; verwende bitte die Schaltfläche unten, um "
-"fortzufahren."
+msgstr "JavaScript ist deaktiviert; verwende bitte die Schaltfläche unten, um fortzufahren."
 
 #. Translators: Alt text for the Wikipedia Library shown in the top left of all pages.
 #: TWLight/templates/header_partial_b4.html:14
@@ -2698,13 +2084,8 @@ msgstr " The Wikipedia Library"
 #. Translators: Information about The Wikipedia Library.
 #: TWLight/templates/login_partial.html:53 TWLight/templates/new_base.html:21
 #, python-format
-msgid ""
-"More than 100 of the world's top subscription-only databases, with content "
-"in %(no_of_languages)s languages, free for Wikipedians of all backgrounds"
-msgstr ""
-"Mehr als 100 der weltweit besten abonnementpflichtigen Datenbanken mit "
-"Inhalt in %(no_of_languages)s Sprachen, kostenlos für Aktive der Wikimedia-"
-"Projekte!"
+msgid "More than 100 of the world's top subscription-only databases, with content in %(no_of_languages)s languages, free for Wikipedians of all backgrounds"
+msgstr "Mehr als 100 der weltweit besten abonnementpflichtigen Datenbanken mit Inhalt in %(no_of_languages)s Sprachen, kostenlos für Aktive der Wikimedia-Projekte!"
 
 #. Translators: Information about The Wikipedia Library.
 #: TWLight/templates/login_partial.html:64
@@ -2712,13 +2093,8 @@ msgid "Meet these criteria for automatic access"
 msgstr "Wenn du diese Kriterien erfüllst, erhältst du automatischen Zugang."
 
 #: TWLight/templates/login_partial.html:69
-msgid ""
-"These criteria grant you access to certain collections but not all. Some "
-"collections are accessible on a per application basis only."
-msgstr ""
-"Diese Kriterien gewähren automatischen Zugang zu bestimmten Sammlungen, aber "
-"nicht zu allen. Einige Sammlungen sind nach entsprechender Anfrage "
-"zugänglich."
+msgid "These criteria grant you access to certain collections but not all. Some collections are accessible on a per application basis only."
+msgstr "Diese Kriterien gewähren automatischen Zugang zu bestimmten Sammlungen, aber nicht zu allen. Einige Sammlungen sind nach entsprechender Anfrage zugänglich."
 
 #: TWLight/templates/login_partial.html:89
 msgid "Login via Wikipedia"
@@ -2727,41 +2103,20 @@ msgstr "Mit Wikipedia anmelden"
 #. Translators: Shown if the current user doesn't have a registered email on their account. Don't translate contact_us_url or email_url.
 #: TWLight/templates/message_partial.html:15
 #, python-format
-msgid ""
-"You don't have an email on file. We can't finalize your access to partner "
-"resources, and you won't be able to <a class=\"twl-links\" href="
-"\"%(contact_us_url)s\">contact us</a> without an email. Please <a class="
-"\"twl-links\" href=\"%(email_url)s\">update your email</a>."
-msgstr ""
-"Du hast keine E-Mail hinterlegt. Wir können deinen Zugang zu Partnerinhalten "
-"nicht abschließen, und du kannst uns ohne E-Mail nicht <a class=\"twl-links"
-"\" href=\"%(contact_us_url)s\">kontaktieren</a>. Bitte <a href="
-"\"%(email_url)s\">aktualisiere deine E-Mail</a>."
+msgid "You don't have an email on file. We can't finalize your access to partner resources, and you won't be able to <a class=\"twl-links\" href=\"%(contact_us_url)s\">contact us</a> without an email. Please <a class=\"twl-links\" href=\"%(email_url)s\">update your email</a>."
+msgstr "Du hast keine E-Mail hinterlegt. Wir können deinen Zugang zu Partnerinhalten nicht abschließen, und du kannst uns ohne E-Mail nicht <a class=\"twl-links\" href=\"%(contact_us_url)s\">kontaktieren</a>. Bitte <a href=\"%(email_url)s\">aktualisiere deine E-Mail</a>."
 
 #. Translators: Shown if the current user has requested the processing of their data should be restricted.
 #: TWLight/templates/message_partial.html:26
 #, python-format
-msgid ""
-"You have requested a restriction on the processing of your data. Most site "
-"functionality will not be available to you until you <a class=\"twl-links\" "
-"href=\"%(restrict_url)s\">lift this restriction</a>."
-msgstr ""
-"Du hast die Verarbeitung der Daten eingeschränkt. Die meisten Funktionen der "
-"Seite werden damit nicht mehr verfügbar sein, sofern du dies nicht <a class="
-"\"twl-links\" href=\"%(restrict_url)s\">wieder aufhebst</a>."
+msgid "You have requested a restriction on the processing of your data. Most site functionality will not be available to you until you <a class=\"twl-links\" href=\"%(restrict_url)s\">lift this restriction</a>."
+msgstr "Du hast die Verarbeitung der Daten eingeschränkt. Die meisten Funktionen der Seite werden damit nicht mehr verfügbar sein, sofern du dies nicht <a class=\"twl-links\" href=\"%(restrict_url)s\">wieder aufhebst</a>."
 
 #. Translators: Shown if the current user has not agreed to the terms of use.
 #: TWLight/templates/message_partial.html:37
 #, python-format
-msgid ""
-"You have not agreed to the <a class=\"twl-links\" href=\"%(terms_url)s"
-"\">terms of use</a> of this site. Your applications will not be processed "
-"and you won't be able to apply or access resources you are approved for."
-msgstr ""
-"Du hast nicht den <a class=\"twl-links\" href=\"%(terms_url)s"
-"\">Nutzungsbedingungen</a> dieser Seite zugestimmt. Deine Bewerbung kann "
-"damit nicht weiterverarbeitet verwenden und du wirst dich nicht auf die "
-"Inhalte bewerben oder zugreifen können, für die du bestätigt wurdest."
+msgid "You have not agreed to the <a class=\"twl-links\" href=\"%(terms_url)s\">terms of use</a> of this site. Your applications will not be processed and you won't be able to apply or access resources you are approved for."
+msgstr "Du hast nicht den <a class=\"twl-links\" href=\"%(terms_url)s\">Nutzungsbedingungen</a> dieser Seite zugestimmt. Deine Bewerbung kann damit nicht weiterverarbeitet verwenden und du wirst dich nicht auf die Inhalte bewerben oder zugreifen können, für die du bestätigt wurdest."
 
 #. Translators: This link is at the bottom of every page and links to the 'About' page (https://wikipedialibrary.wmflabs.org/about/)
 #: TWLight/templates/new_base.html:107
@@ -2807,12 +2162,8 @@ msgstr "Passwort zurücksetzen"
 
 #. Translators: If a user goes to reset their password, this message asks them to enter their email to do so.
 #: TWLight/templates/registration/password_reset_form.html:13
-msgid ""
-"Forgot your password? Enter your email address below, and we'll email "
-"instructions for setting a new one."
-msgstr ""
-"Passwort vergessen? Bitte E-Mail-Adresse eintragen. Wir senden dann weitere "
-"Informationen zum Setzen eines neuen Passworts zu."
+msgid "Forgot your password? Enter your email address below, and we'll email instructions for setting a new one."
+msgstr "Passwort vergessen? Bitte E-Mail-Adresse eintragen. Wir senden dann weitere Informationen zum Setzen eines neuen Passworts zu."
 
 #. Translators: This is the label for a button that users click to update their public information.
 #: TWLight/users/forms.py:36
@@ -2822,9 +2173,7 @@ msgstr "Profil aktualisieren"
 #. Translators: This labels a field where users can describe their activity on Wikipedia in a small biography.
 #: TWLight/users/forms.py:45
 msgid "Describe your contributions to Wikipedia: topics edited, et cetera."
-msgstr ""
-"Beschreibe deine Mitarbeit in Wikipedia, zum Beispiel welche Themenfelder du "
-"bearbeitest."
+msgstr "Beschreibe deine Mitarbeit in Wikipedia, zum Beispiel welche Themenfelder du bearbeitest."
 
 #. Translators: In the preferences section (Emails) of a user profile, this text labels the checkbox users can (un)click to change if they wish to receive account renewal notices or not.
 #: TWLight/users/forms.py:98
@@ -2858,23 +2207,13 @@ msgstr "Ich stimme den Nutzungsbedingungen zu"
 
 #. Translators: This text explains how to disagree to the site's terms of use and the restrictions that will come into effect when users disagree to the terms of use.
 #: TWLight/users/forms.py:185
-msgid ""
-"By unchecking this box and clicking “Update” you may explore the site, but "
-"you will not be able to apply for access to materials or evaluate "
-"applications unless you agree with the terms of use."
-msgstr ""
-"Wenn du das Häkchen hier entfernst und „Update“ anklickst, kannst du die "
-"Seite zwar noch weiter erkunden, kannst dich aber nicht mehr auf Zugänge "
-"bewerben oder Bewerbungen beurteilen, solange bis du den Nutzungsbedingungen "
-"wieder zustimmst."
+msgid "By unchecking this box and clicking “Update” you may explore the site, but you will not be able to apply for access to materials or evaluate applications unless you agree with the terms of use."
+msgstr "Wenn du das Häkchen hier entfernst und „Update“ anklickst, kannst du die Seite zwar noch weiter erkunden, kannst dich aber nicht mehr auf Zugänge bewerben oder Bewerbungen beurteilen, solange bis du den Nutzungsbedingungen wieder zustimmst."
 
 #. Translators: Users click this button to set their website email address to the one linked to their Wikipedia account.
 #: TWLight/users/forms.py:211
-msgid ""
-"Use my Wikipedia email address (will be updated the next time you login)."
-msgstr ""
-"Benutze meine Wikimail-Adresse (wird aktualisiert, wenn du dich das nächste "
-"Mal einloggst)"
+msgid "Use my Wikipedia email address (will be updated the next time you login)."
+msgstr "Benutze meine Wikimail-Adresse (wird aktualisiert, wenn du dich das nächste Mal einloggst)"
 
 #. Translators: This labels a button which users click to change their email.
 #: TWLight/users/forms.py:232
@@ -2884,19 +2223,8 @@ msgstr "E-Mail-Adresse aktualisieren"
 #. Translators: Shown if the current user tried to 'favorite' a partner they can't access. Do not translate '{partner}'
 #: TWLight/users/models.py:201
 #, python-brace-format
-msgid ""
-"Cannot add partner {partner} to your favorites because you don't have access "
-"to it"
-msgstr ""
-"Du kannst Partner {partner} nicht zu deinen Favoriten hinzufügen, weil du "
-"keinen Zugriff darauf hast"
-
-#. Translators: Do not translate.
-#: TWLight/users/models.py:869
-#, fuzzy, python-brace-format
-#| msgid "Username"
-msgid "{wp_username}"
-msgstr "Name deines Kontos"
+msgid "Cannot add partner {partner} to your favorites because you don't have access to it"
+msgstr "Du kannst Partner {partner} nicht zu deinen Favoriten hinzufügen, weil du keinen Zugriff darauf hast"
 
 #. Translators: This error message is shown when there's a problem with the authenticated login process.
 #: TWLight/users/oauth.py:243
@@ -2912,18 +2240,12 @@ msgstr "{domain} ist keine zugelassene Domain."
 #. Translators: This warning message is shown to users when OAuth handshaker can't be initiated.
 #: TWLight/users/oauth.py:364
 msgid "Handshaker not initiated, please try logging in again."
-msgstr ""
-"Die Authentifizierung über den OAuth-Handshaker wurde nicht gestartet, bitte "
-"logge dich erneut ein."
+msgstr "Die Authentifizierung über den OAuth-Handshaker wurde nicht gestartet, bitte logge dich erneut ein."
 
 #. Translators: this message is displayed to users that don't have accounts and clicked on a proxied link.
 #: TWLight/users/oauth.py:388
-msgid ""
-"To view this link you need to be an eligible library user. Please login to "
-"continue."
-msgstr ""
-"Um diesen Link anzuzeigen, musst du ein berechtigter Bibliotheksbenutzer "
-"sein. Bitte melde dich an, um fortzufahren."
+msgid "To view this link you need to be an eligible library user. Please login to continue."
+msgstr "Um diesen Link anzuzeigen, musst du ein berechtigter Bibliotheksbenutzer sein. Bitte melde dich an, um fortzufahren."
 
 #. Translators: This warning message is shown to users when the response received from Wikimedia OAuth servers is not a valid one.
 #: TWLight/users/oauth.py:430
@@ -2948,9 +2270,7 @@ msgstr "Kein Zugangstoken."
 #. Translators: This message is shown when the OAuth login process fails.
 #: TWLight/users/oauth.py:498
 msgid "Access token generation failed, please try logging in again."
-msgstr ""
-"Die Generierung des Zugangstokens ist fehlgeschlagen, bitte versuche dich "
-"erneut anzumelden."
+msgstr "Die Generierung des Zugangstokens ist fehlgeschlagen, bitte versuche dich erneut anzumelden."
 
 #. Translators: This message is shown when more information is available on another page. Do not translate {issue}
 #: TWLight/users/oauth.py:507
@@ -2960,24 +2280,13 @@ msgstr "Siehe {issue} für weitere Informationen"
 
 #. Translators: If the user tries to log in, but their account does not meet certain requirements, they cannot login.
 #: TWLight/users/oauth.py:528
-msgid ""
-"Your Wikipedia account does not meet the eligibility criteria in the terms "
-"of use, so your Wikipedia Library Card Platform account cannot be activated."
-msgstr ""
-"Dein Wikipedia-Konto erfüllt nicht die Zugänglichkeitskriterien in den "
-"Nutzungsbedinungen, sodass dein Zugang zu „The Wikipedia Library“ nicht "
-"aktiviert werden kann."
+msgid "Your Wikipedia account does not meet the eligibility criteria in the terms of use, so your Wikipedia Library Card Platform account cannot be activated."
+msgstr "Dein Wikipedia-Konto erfüllt nicht die Zugänglichkeitskriterien in den Nutzungsbedinungen, sodass dein Zugang zu „The Wikipedia Library“ nicht aktiviert werden kann."
 
 #. Translators: If the user tries to log in, but their account does not meet certain requirements, they cannot login.
 #: TWLight/users/oauth.py:536
-msgid ""
-"Your Wikipedia account no longer meets the eligibility criteria in the terms "
-"of use, so you cannot be logged in. If you think you should be able to log "
-"in, please email wikipedialibrary@wikimedia.org."
-msgstr ""
-"Dein Wikipedia-Konto erfüllt nicht mehr die Zugänglichkeitskriterien in den "
-"Nutzungsbedingungen, sodass du dich nicht einloggen kannst. Sollte dies ein "
-"Fehler sein, schreib bitte eine E-Mail an wikipedialibrary@wikimedia.org."
+msgid "Your Wikipedia account no longer meets the eligibility criteria in the terms of use, so you cannot be logged in. If you think you should be able to log in, please email wikipedialibrary@wikimedia.org."
+msgstr "Dein Wikipedia-Konto erfüllt nicht mehr die Zugänglichkeitskriterien in den Nutzungsbedingungen, sodass du dich nicht einloggen kannst. Sollte dies ein Fehler sein, schreib bitte eine E-Mail an wikipedialibrary@wikimedia.org."
 
 #. Translators: this message is displayed to users with brand new accounts.
 #: TWLight/users/oauth.py:549
@@ -2987,15 +2296,8 @@ msgstr "Willkommen! Bitte stimme den Nutzungsbedingungen zu."
 #. Translators: This message is displayed on the confirmation page where users can return their access to partner collections.
 #: TWLight/users/templates/users/authorization_confirm_return.html:13
 #, python-format
-msgid ""
-"You will no longer be able to access <b>%(partner)s's</b> resources via the "
-"Library Card platform, but can request access again by clicking 'renew', if "
-"you change your mind. Are you sure you want to return your access?"
-msgstr ""
-"Du kannst nicht mehr einen Zugang zu den Inhalten von <b>%(partner)s's</b> "
-"über „The Wikipedia Library“ erhalten, aber du kannst über den Button "
-"„Erneuern“ erneut einen Zugang erhalten, sofern du es dir anders überlegt "
-"hast. Bist du dir sicher, dass du den Zugang zurückgeben willst?"
+msgid "You will no longer be able to access <b>%(partner)s's</b> resources via the Library Card platform, but can request access again by clicking 'renew', if you change your mind. Are you sure you want to return your access?"
+msgstr "Du kannst nicht mehr einen Zugang zu den Inhalten von <b>%(partner)s's</b> über „The Wikipedia Library“ erhalten, aber du kannst über den Button „Erneuern“ erneut einen Zugang erhalten, sofern du es dir anders überlegt hast. Bist du dir sicher, dass du den Zugang zurückgeben willst?"
 
 #. Translators: On the MyLibrary page (https://wikipedialibrary.wmflabs.org/users/my_library), this tab shows all favorite collections a user has.
 #: TWLight/users/templates/users/collections_section.html:9
@@ -3064,14 +2366,8 @@ msgstr "Autorendaten"
 
 #. Translators: This is shown on editor profiles, in their profile page or on applications.
 #: TWLight/users/templates/users/editor_detail.html:59
-msgid ""
-"Information with an * was retrieved from Wikipedia directly. Other "
-"information was entered directly by users or site admins, in their preferred "
-"language."
-msgstr ""
-"Informationen mit einem * kommen direkt von Wikipedia. Andere Informationen "
-"wurden durch den Aktiven der Wikimedia-Projekte oder den Seitenbetreiber "
-"hinzugefügt (teils in deren bevorzugter Sprache)."
+msgid "Information with an * was retrieved from Wikipedia directly. Other information was entered directly by users or site admins, in their preferred language."
+msgstr "Informationen mit einem * kommen direkt von Wikipedia. Andere Informationen wurden durch den Aktiven der Wikimedia-Projekte oder den Seitenbetreiber hinzugefügt (teils in deren bevorzugter Sprache)."
 
 #. Translators: This distinguishes users who have been flagged as account coordinators. Don't translate username.
 #: TWLight/users/templates/users/editor_detail.html:71
@@ -3081,14 +2377,8 @@ msgstr "%(username)s hat einen Koordinatorenzugriff auf dieser Seite."
 
 #. Translators: This is shown on editor profiles, under the heading for Wikipedia editor data.
 #: TWLight/users/templates/users/editor_detail_data.html:5
-msgid ""
-"This information is updated automatically from your Wikimedia account each "
-"time you log in, except for the Contributions field, where you can describe "
-"your Wikimedia editing history."
-msgstr ""
-"Diese Information wird automatisch von deinem Wikimedia-Konto bei jedem "
-"Login übernommen. Ausgenommen ist das Beitrags-Feld, wo du deine Wikimedia-"
-"Aktivitäten selber beschreiben kannst."
+msgid "This information is updated automatically from your Wikimedia account each time you log in, except for the Contributions field, where you can describe your Wikimedia editing history."
+msgstr "Diese Information wird automatisch von deinem Wikimedia-Konto bei jedem Login übernommen. Ausgenommen ist das Beitrags-Feld, wo du deine Wikimedia-Aktivitäten selber beschreiben kannst."
 
 #. Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this labels the user's username.
 #: TWLight/users/templates/users/editor_detail_data.html:17
@@ -3117,22 +2407,14 @@ msgstr "Nutzungsbedingungen zugestimmt?"
 
 #. Translators: when viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this question has a yes or no answer.
 #: TWLight/users/templates/users/editor_detail_data.html:57
-msgid ""
-"at their last login, did this user meet the criteria set forth in the terms "
-"of use?"
-msgstr ""
-"Hat die Person beim letzten Einloggen die in den Nutzungsbedingungen "
-"dargelegten Kriterien erfüllt?"
+msgid "at their last login, did this user meet the criteria set forth in the terms of use?"
+msgstr "Hat die Person beim letzten Einloggen die in den Nutzungsbedingungen dargelegten Kriterien erfüllt?"
 
 #. Translators: When viewing a user's profile in an application, this message shows if the software doesn't think that the user is eligible for access. Don't translate username.
 #: TWLight/users/templates/users/editor_detail_data.html:72
 #, python-format
-msgid ""
-"%(username)s may still be eligible for access grants at the coordinators' "
-"discretion."
-msgstr ""
-"%(username)s könnte nach Einschätzung der Koordinatoren immer noch für einen "
-"Zugang geeignet sein."
+msgid "%(username)s may still be eligible for access grants at the coordinators' discretion."
+msgstr "%(username)s könnte nach Einschätzung der Koordinatoren immer noch für einen Zugang geeignet sein."
 
 #. Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this is the heading for a Yes/No ToU question.
 #: TWLight/users/templates/users/editor_detail_data.html:83
@@ -3166,15 +2448,8 @@ msgstr "(Ausnahme genehmigt)"
 #. Translators: This message is shown on a user's profile if their Wikimedia account is blocked on one or more projects. They may still be granted access to the Library Bundle, but need to contact Wikipedia Library staff to verify.
 #: TWLight/users/templates/users/editor_detail_data.html:137
 #, python-format
-msgid ""
-"It looks like you have an active block on your account. If you meet the "
-"other criteria you may still be permitted access to the library - please <a "
-"class=\"twl-links\" href=\"%(contact_url)s\">contact us</a>."
-msgstr ""
-"Es scheint so, als ob dein Konto in mindestens einem Projekt gesperrt wäre. "
-"Dein Konto kann daher nur manuell für das Zugangspaket freigeschaltet "
-"werden, bitte wende dich <a class=\"twl-links\" href=\"%(contact_url)s\">per "
-"E-Mail an uns</a>."
+msgid "It looks like you have an active block on your account. If you meet the other criteria you may still be permitted access to the library - please <a class=\"twl-links\" href=\"%(contact_url)s\">contact us</a>."
+msgstr "Es scheint so, als ob dein Konto in mindestens einem Projekt gesperrt wäre. Dein Konto kann daher nur manuell für das Zugangspaket freigeschaltet werden, bitte wende dich <a class=\"twl-links\" href=\"%(contact_url)s\">per E-Mail an uns</a>."
 
 #. Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this is the heading for a Yes/No program eligibility question.
 #: TWLight/users/templates/users/editor_detail_data.html:153
@@ -3183,15 +2458,8 @@ msgstr "Berechtigt für das Zugangspaket?"
 
 #. Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this question has a Yes or No answer.
 #: TWLight/users/templates/users/editor_detail_data.html:156
-msgid ""
-"At their last login, did this user meet the criteria set forth in the "
-"Library Bundle? Note that satisfying terms of use is a prerequisite to "
-"bundle eligibility."
-msgstr ""
-"Hatte das Konto beim letzten Einloggen die in den Nutzungsbedingungen "
-"dargelegten Kriterien erfüllt? Bitte beachte, dass die Akzeptanz der "
-"Nutzungsbedingungen eine Voraussetzung ist, um für das Zugangspaket als "
-"geeignet angesehen zu werden."
+msgid "At their last login, did this user meet the criteria set forth in the Library Bundle? Note that satisfying terms of use is a prerequisite to bundle eligibility."
+msgstr "Hatte das Konto beim letzten Einloggen die in den Nutzungsbedingungen dargelegten Kriterien erfüllt? Bitte beachte, dass die Akzeptanz der Nutzungsbedingungen eine Voraussetzung ist, um für das Zugangspaket als geeignet angesehen zu werden."
 
 #. Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this is the heading for a Yes/No program eligibility question.
 #: TWLight/users/templates/users/editor_detail_data.html:177
@@ -3235,24 +2503,14 @@ msgstr "Persönliche Daten"
 
 #. Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this text is in the 'Personal data' section. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/users/templates/users/editor_detail_data.html:262
-msgid ""
-"The following information is visible only to you, site administrators, "
-"publishing partners (where required), and volunteer Wikipedia Library "
-"coordinators (who have signed a Non-Disclosure Agreement)."
-msgstr ""
-"Folgende Informationen sind nur sichtbar für dich, die Seitenbetreiber, die "
-"Verlage (wo benötigt) sowie die Projektmitarbeitenden von „The Wikipedia "
-"Library“ (die eine Geheimhaltungsvereinbarung unterzeichnet haben)."
+msgid "The following information is visible only to you, site administrators, publishing partners (where required), and volunteer Wikipedia Library coordinators (who have signed a Non-Disclosure Agreement)."
+msgstr "Folgende Informationen sind nur sichtbar für dich, die Seitenbetreiber, die Verlage (wo benötigt) sowie die Projektmitarbeitenden von „The Wikipedia Library“ (die eine Geheimhaltungsvereinbarung unterzeichnet haben)."
 
 #. Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this labels a button which users can click to update or remove their personal information. Don't translate update_url.
 #: TWLight/users/templates/users/editor_detail_data.html:272
 #, python-format
-msgid ""
-"You may <a class=\"twl-links\" href=\"%(update_url)s\">update or delete</a> "
-"your data at any time."
-msgstr ""
-"Du kannst deine Daten jederzeit <a class=\"twl-links\" href=\"%(update_url)s"
-"\">aktualisieren oder löschen</a>."
+msgid "You may <a class=\"twl-links\" href=\"%(update_url)s\">update or delete</a> your data at any time."
+msgstr "Du kannst deine Daten jederzeit <a class=\"twl-links\" href=\"%(update_url)s\">aktualisieren oder löschen</a>."
 
 #. Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this labels the user's email. Don't remove the *.
 #: TWLight/users/templates/users/editor_detail_data.html:283
@@ -3271,32 +2529,19 @@ msgstr "Institutionszugehörigkeit"
 
 #. Translators: This message tells users that they are not eligible to access The Wikipedia Library content.
 #: TWLight/users/templates/users/eligibility_modal.html:7
-msgid ""
-"Sorry, your Wikipedia account doesn’t currently qualify to access The "
-"Wikipedia Library."
-msgstr ""
-"Leider ist dein Wikipedia-Konto derzeit nicht zum Zugang zu The Wikipedia "
-"Library berechtigt."
+msgid "Sorry, your Wikipedia account doesn’t currently qualify to access The Wikipedia Library."
+msgstr "Leider ist dein Wikipedia-Konto derzeit nicht zum Zugang zu The Wikipedia Library berechtigt."
 
 #. Translators: This message tells users that they have not agreed to the terms of use, therefore are ineligible to access the content in The Wikipedia Library.
 #: TWLight/users/templates/users/eligibility_modal.html:30
 #, python-format
-msgid ""
-"Agreed with <a href=\"%(terms)s\" class=\"text-danger\"> terms of use </a>"
-msgstr ""
-"Wurde den <a href=\"%(terms)s\" class=\"text-danger\">Nutzungsbedingungen</"
-"a> zugestimmt?"
+msgid "Agreed with <a href=\"%(terms)s\" class=\"text-danger\"> terms of use </a>"
+msgstr "Wurde den <a href=\"%(terms)s\" class=\"text-danger\">Nutzungsbedingungen</a> zugestimmt?"
 
 #: TWLight/users/templates/users/eligibility_modal.html:40
 #, python-format
-msgid ""
-"It looks like you have an active block on your account. If you meet the "
-"other criteria you may still be permitted access to the library - please <a "
-"href=\"%(contact_url)s\">contact us</a>."
-msgstr ""
-"Es scheint so, als ob dein Konto in mindestens einem Projekt gesperrt wäre. "
-"Falls du die anderen Anforderungen erfüllst, kannst du dennoch Zugang zu der "
-"Library erhalten - bitte <a href=\"%(contact_url)s\">kontaktiere uns</a>."
+msgid "It looks like you have an active block on your account. If you meet the other criteria you may still be permitted access to the library - please <a href=\"%(contact_url)s\">contact us</a>."
+msgstr "Es scheint so, als ob dein Konto in mindestens einem Projekt gesperrt wäre. Falls du die anderen Anforderungen erfüllst, kannst du dennoch Zugang zu der Library erhalten - bitte <a href=\"%(contact_url)s\">kontaktiere uns</a>."
 
 #. Translators: Instructions to refresh a user's data.
 #: TWLight/users/templates/users/eligibility_modal.html:50
@@ -3316,14 +2561,12 @@ msgstr "Legende"
 #. Translators: Text that describes a search icon.
 #: TWLight/users/templates/users/filter_section.html:45
 msgid "Collection is fully searchable via the search bar"
-msgstr ""
-"Diese Sammlung kann vollständig mittels der Suchleiste durchsucht werden"
+msgstr "Diese Sammlung kann vollständig mittels der Suchleiste durchsucht werden"
 
 #. Translators: Text that describes a search icon.
 #: TWLight/users/templates/users/filter_section.html:54
 msgid "Collection is only partially searchable via the search bar"
-msgstr ""
-"Diese Sammlung kann nur teilweise mittels der Suchleiste durchsucht werden"
+msgstr "Diese Sammlung kann nur teilweise mittels der Suchleiste durchsucht werden"
 
 #. Translators: Text that explains when there is no search icon.
 #: TWLight/users/templates/users/filter_section.html:58
@@ -3337,14 +2580,8 @@ msgstr "Sprache auswählen"
 
 #. Translators: This text on the user page helps users naviage to the TranslateWiki Wikipedia Library Card platform translation page.
 #: TWLight/users/templates/users/language_form.html:31
-msgid ""
-"You can help translate the tool at <a class=\"twl-links\" href=\"https://"
-"translatewiki.net/wiki/Translating:Wikipedia_Library_Card_Platform"
-"\">translatewiki.net</a>."
-msgstr ""
-"Du kannst bei der Übersetzung dieser Seiten auf <a class=\"twl-links\" href="
-"\"https://translatewiki.net/wiki/Translating:Wikipedia_Library_Card_Platform"
-"\">translatewiki.net</a> helfen."
+msgid "You can help translate the tool at <a class=\"twl-links\" href=\"https://translatewiki.net/wiki/Translating:Wikipedia_Library_Card_Platform\">translatewiki.net</a>."
+msgstr "Du kannst bei der Übersetzung dieser Seiten auf <a class=\"twl-links\" href=\"https://translatewiki.net/wiki/Translating:Wikipedia_Library_Card_Platform\">translatewiki.net</a> helfen."
 
 #. Translators: When the user starts a new application and submits the application, the user can view the application and withdraw if need be. This changes the label for the Withdraw button.
 #: TWLight/users/templates/users/my_applications.html:65
@@ -3363,12 +2600,8 @@ msgstr "Erneuerung beantragen"
 
 #. Translators: On the page listing applications, this text explains a user they cannot renew their application since they've already requested a renewal or there aren't any renewals available.
 #: TWLight/users/templates/users/my_applications.html:79
-msgid ""
-"Renewals are either not required, not available right now, or you have "
-"already requested a renewal."
-msgstr ""
-"Erneuerungen sind nicht erforderlich, zurzeit nicht verfügbar oder du hast "
-"schon eine Erneuerung beantragt."
+msgid "Renewals are either not required, not available right now, or you have already requested a renewal."
+msgstr "Erneuerungen sind nicht erforderlich, zurzeit nicht verfügbar oder du hast schon eine Erneuerung beantragt."
 
 #. Translators: This text is the heading of a section in a user's profile where they can change their preferences.
 #: TWLight/users/templates/users/preferences.html:6
@@ -3431,28 +2664,13 @@ msgstr "Datenverarbeitung einschränken"
 
 #. Translators: This message is displayed on the page where users can request we stop processing their data.
 #: TWLight/users/templates/users/restrict_data.html:15
-msgid ""
-"Checking this box and clicking “Restrict” will pause all processing of the "
-"data you have entered into this website. You will not be able to apply for "
-"access to resources, your applications will not be further processed, and "
-"none of your data will be altered, until you return to this page and uncheck "
-"the box. This is not the same as deleting your data."
-msgstr ""
-"Mit dem Anklicken von „Einschränken“ unterbrichst du die Verarbeitung von "
-"Daten, die du auf dieser Website eingegeben hast. In diesem Fall kannst du "
-"keinen Zugang zu Inhalten mehr beantragen, deine Bewerbungen werden nicht "
-"weiterverarbeitet und keine deiner Daten werden verändert, solange du nicht "
-"zu dieser Seite zurückkehrst und diese Auswahl wieder entfernst. Dies ist "
-"nicht dasselbe wie das Löschen deiner Daten."
+msgid "Checking this box and clicking “Restrict” will pause all processing of the data you have entered into this website. You will not be able to apply for access to resources, your applications will not be further processed, and none of your data will be altered, until you return to this page and uncheck the box. This is not the same as deleting your data."
+msgstr "Mit dem Anklicken von „Einschränken“ unterbrichst du die Verarbeitung von Daten, die du auf dieser Website eingegeben hast. In diesem Fall kannst du keinen Zugang zu Inhalten mehr beantragen, deine Bewerbungen werden nicht weiterverarbeitet und keine deiner Daten werden verändert, solange du nicht zu dieser Seite zurückkehrst und diese Auswahl wieder entfernst. Dies ist nicht dasselbe wie das Löschen deiner Daten."
 
 #. Translators: This warning message is shown to coordinators who view the data restriction page.
 #: TWLight/users/templates/users/restrict_data.html:26
-msgid ""
-"You are a coordinator on this site. If you restrict the processing of your "
-"data, your coordinator flag will be removed."
-msgstr ""
-"Du bist ein Koordinator auf dieser Seite. Solltest du die Datenübermittlung "
-"einschränken, kannst du diese Rolle nicht weiter ausüben."
+msgid "You are a coordinator on this site. If you restrict the processing of your data, your coordinator flag will be removed."
+msgstr "Du bist ein Koordinator auf dieser Seite. Solltest du die Datenübermittlung einschränken, kannst du diese Rolle nicht weiter ausüben."
 
 #. Translators: use the date *when you are translating*, in a language-appropriate format.
 #: TWLight/users/templates/users/terms.html:33
@@ -3467,43 +2685,17 @@ msgstr "Datenschutzrichtlinie der Wikimedia Foundation"
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:41
 msgid "Wikipedia Library Card Terms of Use and Privacy Statement"
-msgstr ""
-"Nutzungsbedingungen und Datenschutzerklärung der Wikipedia Library Card"
+msgstr "Nutzungsbedingungen und Datenschutzerklärung der Wikipedia Library Card"
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:51
-msgid ""
-"<a class=\"twl-links\" href=\"https://meta.wikimedia.org/wiki/"
-"The_Wikipedia_Library\"> The Wikipedia Library </a> has partnered with "
-"publishers around the world to allow users to access otherwise paywalled "
-"resources. This website allows Wikipedia editors to search and access these "
-"resources."
-msgstr ""
-"<a class=\"twl-link\" href=\"https://meta.wikimedia.org/wiki/"
-"The_Wikipedia_Library/de\"> The Wikipedia Library </a> umfasst "
-"Partnerschaften mit Verlagen aus der ganzen Welt, um Aktiven der Wikimedia-"
-"Projekte Zugang zu Inhalten zu ermöglichen, die sich sonst hinter "
-"Bezahlschranken befänden. Diese Website erlaubt es Nutzern, auf die Inhalte "
-"mehrerer Verlage gleichzeitig zuzugreifen."
+msgid "<a class=\"twl-links\" href=\"https://meta.wikimedia.org/wiki/The_Wikipedia_Library\"> The Wikipedia Library </a> has partnered with publishers around the world to allow users to access otherwise paywalled resources. This website allows Wikipedia editors to search and access these resources."
+msgstr "<a class=\"twl-link\" href=\"https://meta.wikimedia.org/wiki/The_Wikipedia_Library/de\"> The Wikipedia Library </a> umfasst Partnerschaften mit Verlagen aus der ganzen Welt, um Aktiven der Wikimedia-Projekte Zugang zu Inhalten zu ermöglichen, die sich sonst hinter Bezahlschranken befänden. Diese Website erlaubt es Nutzern, auf die Inhalte mehrerer Verlage gleichzeitig zuzugreifen."
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Wikimedia Foundation should not be translated. WMF should not be translated. Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:63
-msgid ""
-"This program is administered by the Wikimedia Foundation (WMF). These terms "
-"of use and privacy notice pertain to your application for access to "
-"resources through the Wikipedia Library, your use of this website, and your "
-"access to and use of those resources. They also describe our handling of the "
-"information you provide to us in order to create and administer your "
-"Wikipedia Library account. If we make material changes to the terms, we will "
-"notify users."
-msgstr ""
-"Das Programm wird von der Wikimedia Foundation (WMF) administriert. Diese "
-"Nutzungsbedingungen und Datenschutzrichtlinie sind gültig für deinen Zugang "
-"zu Inhalten in „The Wikipedia Library“, deine Nutzung dieser Website und "
-"deinen Zugang sowie die Nutzung der Inhalte. Sie beschreiben außerdem unsere "
-"Handhabe an Daten, die du uns übermittelst, um dein Konto bei „The Wikipedia "
-"Library“ zu erstellen und zu verwalten. Bei wesentlichen Änderungen an "
-"diesen Richtlinien informieren wir unsere Nutzer."
+msgid "This program is administered by the Wikimedia Foundation (WMF). These terms of use and privacy notice pertain to your application for access to resources through the Wikipedia Library, your use of this website, and your access to and use of those resources. They also describe our handling of the information you provide to us in order to create and administer your Wikipedia Library account. If we make material changes to the terms, we will notify users."
+msgstr "Das Programm wird von der Wikimedia Foundation (WMF) administriert. Diese Nutzungsbedingungen und Datenschutzrichtlinie sind gültig für deinen Zugang zu Inhalten in „The Wikipedia Library“, deine Nutzung dieser Website und deinen Zugang sowie die Nutzung der Inhalte. Sie beschreiben außerdem unsere Handhabe an Daten, die du uns übermittelst, um dein Konto bei „The Wikipedia Library“ zu erstellen und zu verwalten. Bei wesentlichen Änderungen an diesen Richtlinien informieren wir unsere Nutzer."
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:74
@@ -3512,61 +2704,18 @@ msgstr "Bedingungen für ein Konto bei „The Wikipedia Library“"
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:78
-msgid ""
-"Access to resources via The Wikipedia Library is reserved for community "
-"members who have demonstrated their commitment to the Wikimedia projects, "
-"and who will use their access to these resources to improve project content. "
-"To that end, in order to be eligible for The Wikipedia Library, we require "
-"that you be registered for a user account on the projects, with at least 500 "
-"edits, six (6) months of activity, and 10+ edits in the last month. We ask "
-"that you do not request access to any publishers with a limited number of "
-"available accounts whose resources you can already access for free through "
-"your local library or university, or another institution or organization, in "
-"order to provide that opportunity to others."
-msgstr ""
-"Der Zugang zu Inhalten von „The Wikipedia Library“ ist auf Community-"
-"Mitglieder mit aktivem Engagement in den Wikimedia-Projekten beschränkt, die "
-"ihre Zugänge zu diesen Inhalten zum Verbessern der Projekte verwenden. Für "
-"die Nutzung von „The Wikipedia Library“ muss daher ein Konto in den "
-"Wikimedia-Projekten registriert sein. Aktive mit mindestens 500 "
-"Bearbeitungen, sechs Monaten Aktivitäten und mindestens 10 Bearbeitungen im "
-"letzten Monat können das Angebot nutzen. Wir bitten dich darum, dich auf "
-"keine Inhalte von Verlagen zu bewerben, auf die du schon kostenfreien Zugang "
-"über eine Bibliothek, Universität oder andere Institutionen oder "
-"Organisationen in deiner Nähe hast, damit wir diesen Zugang stattdessen "
-"anderen Personen ermöglichen können."
+msgid "Access to resources via The Wikipedia Library is reserved for community members who have demonstrated their commitment to the Wikimedia projects, and who will use their access to these resources to improve project content. To that end, in order to be eligible for The Wikipedia Library, we require that you be registered for a user account on the projects, with at least 500 edits, six (6) months of activity, and 10+ edits in the last month. We ask that you do not request access to any publishers with a limited number of available accounts whose resources you can already access for free through your local library or university, or another institution or organization, in order to provide that opportunity to others."
+msgstr "Der Zugang zu Inhalten von „The Wikipedia Library“ ist auf Community-Mitglieder mit aktivem Engagement in den Wikimedia-Projekten beschränkt, die ihre Zugänge zu diesen Inhalten zum Verbessern der Projekte verwenden. Für die Nutzung von „The Wikipedia Library“ muss daher ein Konto in den Wikimedia-Projekten registriert sein. Aktive mit mindestens 500 Bearbeitungen, sechs Monaten Aktivitäten und mindestens 10 Bearbeitungen im letzten Monat können das Angebot nutzen. Wir bitten dich darum, dich auf keine Inhalte von Verlagen zu bewerben, auf die du schon kostenfreien Zugang über eine Bibliothek, Universität oder andere Institutionen oder Organisationen in deiner Nähe hast, damit wir diesen Zugang stattdessen anderen Personen ermöglichen können."
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:94
-msgid ""
-"Additionally, if you are currently blocked or banned from a Wikimedia "
-"project, applications to resources may be rejected or restricted. If you "
-"obtain a Wikipedia Library account, but a block or ban is subsequently "
-"instituted against you on one of the projects, you may lose access to your "
-"Wikipedia Library account."
-msgstr ""
-"Darüber hinaus kann es sein, dass deine Bewerbungen auf bestimmte Inhalte "
-"abgelehnt oder eingeschränkt werden, solltest du gegenwärtig in einem "
-"Wikimedia-Projekt gesperrt oder gebannt sein. Solltest du schon ein Konto "
-"bei „The Wikipedia Library“ haben und in dieser Zeit eine Sperre oder einen "
-"Bann erhalten, verlierst du unter Umständen deinen Zugang zum Konto bei „The "
-"Wikipedia Library“."
+msgid "Additionally, if you are currently blocked or banned from a Wikimedia project, applications to resources may be rejected or restricted. If you obtain a Wikipedia Library account, but a block or ban is subsequently instituted against you on one of the projects, you may lose access to your Wikipedia Library account."
+msgstr "Darüber hinaus kann es sein, dass deine Bewerbungen auf bestimmte Inhalte abgelehnt oder eingeschränkt werden, solltest du gegenwärtig in einem Wikimedia-Projekt gesperrt oder gebannt sein. Solltest du schon ein Konto bei „The Wikipedia Library“ haben und in dieser Zeit eine Sperre oder einen Bann erhalten, verlierst du unter Umständen deinen Zugang zum Konto bei „The Wikipedia Library“."
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:104
-msgid ""
-"Your eligibility to access The Wikipedia Library is assessed at each login. "
-"While more than half of the library's content is provided via this automated "
-"eligibility check, access to other publisher's content may be time limited, "
-"typically lapsing after one year, after which you will usually need to apply "
-"for renewal."
-msgstr ""
-"Deine Berechtigung zum Zugriff auf „The Wikipedia Library“ wird bei jeder "
-"Anmeldung automatisch geprüft. Während mehr als die Hälfte der Inhalte von "
-"„The Wikipedia Library“ über diese automatische Berechtigungsprüfung zur "
-"Verfügung gestellt werden, kann der Zugang zu anderen Verlagsinhalten "
-"zeitlich begrenzt sein und verfällt in der Regel nach einem Jahr, nach dem "
-"in der Regel eine Verlängerung beantragt werden kann."
+msgid "Your eligibility to access The Wikipedia Library is assessed at each login. While more than half of the library's content is provided via this automated eligibility check, access to other publisher's content may be time limited, typically lapsing after one year, after which you will usually need to apply for renewal."
+msgstr "Deine Berechtigung zum Zugriff auf „The Wikipedia Library“ wird bei jeder Anmeldung automatisch geprüft. Während mehr als die Hälfte der Inhalte von „The Wikipedia Library“ über diese automatische Berechtigungsprüfung zur Verfügung gestellt werden, kann der Zugang zu anderen Verlagsinhalten zeitlich begrenzt sein und verfällt in der Regel nach einem Jahr, nach dem in der Regel eine Verlängerung beantragt werden kann."
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:114
@@ -3575,71 +2724,28 @@ msgstr "Bewerbung über dein Konto bei „The Wikipedia Library“"
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:118
-msgid ""
-"In order to apply for access to a partner resource, you must provide us with "
-"certain information, which we will use to evaluate your application. If your "
-"application is approved, we may transfer the information you have given us "
-"to the publishers whose resources you wish to access. They will either "
-"contact you with the account information directly or we will send access "
-"information to you ourselves."
-msgstr ""
-"Für die Beurteilung deiner Bewerbung auf Inhalte unserer Partner musst du "
-"uns bestimmte Daten mitteilen. Wenn deine Bewerbung erfolgreich war, werden "
-"wir gegebenenfalls die Daten, die du mit uns für diesen Zweck geteilt "
-"hattest, an den Verlag weiterleiten, zu dem du den Zugang erhalten hast. "
-"Dafür werden die Verlage uns entweder selbst kontaktieren oder wir versenden "
-"die Daten von unserer Seite aus."
+msgid "In order to apply for access to a partner resource, you must provide us with certain information, which we will use to evaluate your application. If your application is approved, we may transfer the information you have given us to the publishers whose resources you wish to access. They will either contact you with the account information directly or we will send access information to you ourselves."
+msgstr "Für die Beurteilung deiner Bewerbung auf Inhalte unserer Partner musst du uns bestimmte Daten mitteilen. Wenn deine Bewerbung erfolgreich war, werden wir gegebenenfalls die Daten, die du mit uns für diesen Zweck geteilt hattest, an den Verlag weiterleiten, zu dem du den Zugang erhalten hast. Dafür werden die Verlage uns entweder selbst kontaktieren oder wir versenden die Daten von unserer Seite aus."
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:130
-msgid ""
-"In addition to the basic information you provide to us, our system will "
-"retrieve some information directly from the Wikimedia projects: your "
-"username, email address, edit count, registration date, user ID number, "
-"groups to which you belong, and any special user rights."
-msgstr ""
-"Über deine direkt übermittelten Angaben hinaus verarbeitet unser System "
-"einige Daten von den Wikimedia-Projekten: den Namen deines Kontos, deine "
-"ggf. hinterlegte E-Mail-Adresse, deine Bearbeitungszahl, dein "
-"Registrierungsdatum, deine Benutzeridentifikationsnummer (ID), deine "
-"Benutzergruppen sowie andere Benutzerrechte."
+msgid "In addition to the basic information you provide to us, our system will retrieve some information directly from the Wikimedia projects: your username, email address, edit count, registration date, user ID number, groups to which you belong, and any special user rights."
+msgstr "Über deine direkt übermittelten Angaben hinaus verarbeitet unser System einige Daten von den Wikimedia-Projekten: den Namen deines Kontos, deine ggf. hinterlegte E-Mail-Adresse, deine Bearbeitungszahl, dein Registrierungsdatum, deine Benutzeridentifikationsnummer (ID), deine Benutzergruppen sowie andere Benutzerrechte."
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:140
-msgid ""
-"Each time you log in to the Wikipedia Library Card Platform, this "
-"information will be automatically updated."
-msgstr ""
-"Jedes Mal, wenn du dich bei „The Wikipedia Library“ einloggst, werden diese "
-"Informationen automatisch aktualisiert."
+msgid "Each time you log in to the Wikipedia Library Card Platform, this information will be automatically updated."
+msgstr "Jedes Mal, wenn du dich bei „The Wikipedia Library“ einloggst, werden diese Informationen automatisch aktualisiert."
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:148
-msgid ""
-"We will ask you to provide us with some information about your history of "
-"contributions to the Wikimedia projects. Information on contribution history "
-"is optional, but will greatly assist us in evaluating your application."
-msgstr ""
-"Wir werden dich um ein paar Angaben zu deinen bisherigen Bearbeitungen in "
-"den Wikimedia-Projekten bitten. Diese Angabe an Daten zu deinen "
-"Bearbeitungen ist optional, würde uns aber sehr bei der Beurteilung deiner "
-"Bewerbung helfen."
+msgid "We will ask you to provide us with some information about your history of contributions to the Wikimedia projects. Information on contribution history is optional, but will greatly assist us in evaluating your application."
+msgstr "Wir werden dich um ein paar Angaben zu deinen bisherigen Bearbeitungen in den Wikimedia-Projekten bitten. Diese Angabe an Daten zu deinen Bearbeitungen ist optional, würde uns aber sehr bei der Beurteilung deiner Bewerbung helfen."
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). WMF should not be translated. Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:157
-msgid ""
-"The information you provide when creating your account will be visible to "
-"you while on the site but not to others unless they are approved Wikipedia "
-"Library Coordinators, WMF Staff, or WMF Contractors who need access to this "
-"data in order to carry out their work with the Wikipedia Library, all of "
-"whom are subject to non-disclosure obligations."
-msgstr ""
-"Die bei der Anlage deines Kontos gemachten Angaben sind für dich sichtbar, "
-"jedoch nicht für andere Nutzer der Website. Ausgenommen davon sind "
-"Koordinatoren von „The Wikipedia Library“ sowie Mitarbeitende und "
-"Vertragspartner der Wikimedia Foundation, die Zugang dazu benötigen, um ihre "
-"Arbeit in „The Wikipedia Library“ zu erledigen. Diese haben "
-"Vertraulichkeitsvereinbarungen unterschrieben."
+msgid "The information you provide when creating your account will be visible to you while on the site but not to others unless they are approved Wikipedia Library Coordinators, WMF Staff, or WMF Contractors who need access to this data in order to carry out their work with the Wikipedia Library, all of whom are subject to non-disclosure obligations."
+msgstr "Die bei der Anlage deines Kontos gemachten Angaben sind für dich sichtbar, jedoch nicht für andere Nutzer der Website. Ausgenommen davon sind Koordinatoren von „The Wikipedia Library“ sowie Mitarbeitende und Vertragspartner der Wikimedia Foundation, die Zugang dazu benötigen, um ihre Arbeit in „The Wikipedia Library“ zu erledigen. Diese haben Vertraulichkeitsvereinbarungen unterschrieben."
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:167
@@ -3648,62 +2754,33 @@ msgstr "Verwendung der Inhalte der Verlage"
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:171
-msgid ""
-"In order to access an individual publisher’s resources, you must agree to "
-"that publisher’s terms of use and privacy policy. You agree that you will "
-"not violate such terms and policies in connection with your use of the "
-"Wikipedia Library. Additionally, the following activities are prohibited "
-"while accessing publisher resources through the Wikipedia Library."
-msgstr ""
-"Um Zugang zu Inhalten unterschiedlicher Verlage zu erhalten, musst du den "
-"Nutzungsbedingungen und Datenschutzrichtlinien des jeweiligen Verlages "
-"zustimmen. Mit der Nutzung von „The Wikipedia Library“ akzeptierst du damit, "
-"dass du nicht gegen diese Richtlinien verstoßen wirst. Darüber hinaus sind "
-"folgende Handlungen bei der Verwendung der Inhalte der Verlage über „The "
-"Wikipedia Library“ verboten:"
+msgid "In order to access an individual publisher’s resources, you must agree to that publisher’s terms of use and privacy policy. You agree that you will not violate such terms and policies in connection with your use of the Wikipedia Library. Additionally, the following activities are prohibited while accessing publisher resources through the Wikipedia Library."
+msgstr "Um Zugang zu Inhalten unterschiedlicher Verlage zu erhalten, musst du den Nutzungsbedingungen und Datenschutzrichtlinien des jeweiligen Verlages zustimmen. Mit der Nutzung von „The Wikipedia Library“ akzeptierst du damit, dass du nicht gegen diese Richtlinien verstoßen wirst. Darüber hinaus sind folgende Handlungen bei der Verwendung der Inhalte der Verlage über „The Wikipedia Library“ verboten:"
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:184
-msgid ""
-"Sharing your Wikipedia account, usernames, passwords, or any access codes "
-"for publisher resources with others;"
-msgstr ""
-"Dein Wikipedia-Konto, den Namen deines Kontos, dein Passwort oder andere "
-"Formen des Zuganges zu den Inhalten des Verlages mit anderen zu teilen."
+msgid "Sharing your Wikipedia account, usernames, passwords, or any access codes for publisher resources with others;"
+msgstr "Dein Wikipedia-Konto, den Namen deines Kontos, dein Passwort oder andere Formen des Zuganges zu den Inhalten des Verlages mit anderen zu teilen."
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:191
-msgid ""
-"Automatically scraping or downloading restricted content from publishers;"
-msgstr ""
-"Automatisiert zugangsbeschränkte Inhalte der Verlage abzufragen oder "
-"herunterzuladen."
+msgid "Automatically scraping or downloading restricted content from publishers;"
+msgstr "Automatisiert zugangsbeschränkte Inhalte der Verlage abzufragen oder herunterzuladen."
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:197
-msgid ""
-"Systematically making printed or electronic copies of multiple extracts of "
-"restricted content available for any purpose;"
-msgstr ""
-"Systematisch gedruckte oder digitale Kopien von umfangreichen Exzerpeten "
-"oder zugangsbeschränkten Inhalten zu erstellen, für keinerlei Zwecke."
+msgid "Systematically making printed or electronic copies of multiple extracts of restricted content available for any purpose;"
+msgstr "Systematisch gedruckte oder digitale Kopien von umfangreichen Exzerpeten oder zugangsbeschränkten Inhalten zu erstellen, für keinerlei Zwecke."
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:204
-msgid ""
-"Data mining metadata without permission—for example, in order to use "
-"metadata for auto-created stub articles;"
-msgstr ""
-"Metadaten ohne Erlaubnis zu sammeln, bspw. für automatisch generierte Stubs."
+msgid "Data mining metadata without permission—for example, in order to use metadata for auto-created stub articles;"
+msgstr "Metadaten ohne Erlaubnis zu sammeln, bspw. für automatisch generierte Stubs."
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:211
-msgid ""
-"Using the access you receive through the Wikipedia Library for profit by "
-"selling access to your account or resources which you have through it."
-msgstr ""
-"Den Zugang über The Wikipedia Library kommerziell zu nutzen, bspw. um den "
-"Zugang oder die darüber verfügbaren Inhalte zu verkaufen."
+msgid "Using the access you receive through the Wikipedia Library for profit by selling access to your account or resources which you have through it."
+msgstr "Den Zugang über The Wikipedia Library kommerziell zu nutzen, bspw. um den Zugang oder die darüber verfügbaren Inhalte zu verkaufen."
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:220
@@ -3712,26 +2789,13 @@ msgstr "Externe Suche und Proxy-Dienste"
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:224
-msgid ""
-"Certain resources may only be accessed using an external search service, "
-"such as the EBSCO Discovery Service, or a proxy service, such as OCLC "
-"EZProxy. If you use such external search and/or proxy services, please "
-"review the applicable terms of use and privacy policies."
-msgstr ""
-"Manche Inhalte können nur über einen externen Suchdienst wie EBSCO Dicovery "
-"Service oder Proxy-Dienste wie OCLC EZProxy aufgerufen werden. Sofern du "
-"externe Suchdienste und/oder Proxy-Dienste verwendest, überprüfe bitte "
-"eigenständig die dort gültigen Nutzungsbedingungen und "
-"Datenschutzrichtlinien."
+msgid "Certain resources may only be accessed using an external search service, such as the EBSCO Discovery Service, or a proxy service, such as OCLC EZProxy. If you use such external search and/or proxy services, please review the applicable terms of use and privacy policies."
+msgstr "Manche Inhalte können nur über einen externen Suchdienst wie EBSCO Dicovery Service oder Proxy-Dienste wie OCLC EZProxy aufgerufen werden. Sofern du externe Suchdienste und/oder Proxy-Dienste verwendest, überprüfe bitte eigenständig die dort gültigen Nutzungsbedingungen und Datenschutzrichtlinien."
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:234
-msgid ""
-"In addition, if you use OCLC EZProxy, please note that you may not use it "
-"for commercial purposes."
-msgstr ""
-"Beachte darüber hinaus, dass OCLC EZProxy nicht für kommerzielle Zwecke "
-"genutzt werden darf."
+msgid "In addition, if you use OCLC EZProxy, please note that you may not use it for commercial purposes."
+msgstr "Beachte darüber hinaus, dass OCLC EZProxy nicht für kommerzielle Zwecke genutzt werden darf."
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:241
@@ -3740,206 +2804,50 @@ msgstr "Datenspeicherung und -verarbeitung"
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Wikimedia Foundation should not be translated. Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:245
-msgid ""
-"The Wikimedia Foundation and our service providers use your information for "
-"the legitimate purpose of providing Wikipedia Library services in support of "
-"our charitable mission. When you apply for a Wikipedia Library account, or "
-"use your Wikipedia Library account, we may routinely collect the following "
-"information: your username, email address, edit count, registration date, "
-"user ID number, groups to which you belong, and any special user rights; "
-"your name, country of residence, and/or affiliation, if required by a "
-"partner to which you are applying; your narrative description of your "
-"contributions and reasons for applying for access to partner resources; and "
-"the date you agree to these terms of use."
-msgstr ""
-"Die Wikimedia Foundation und unsere Dienstanbieter nutzen deine Daten für "
-"den legitimen Zweck, die Wikipedia-Bibliothek zur Unterstützung unserer "
-"gemeinnützigen Mission bereitzustellen. Wenn du dich für ein Wikipedia-"
-"Bibliotheks-Konto bewirbst oder dein Wikipedia-Bibliotheks-Konto nutzt, "
-"können wir routinemäßig die folgenden Informationen erfassen: deinen "
-"Benutzernamen, deine E-Mail-Adresse, die Anzahl der Bearbeitungen, das "
-"Registrierungsdatum, die Nummer deiner Benutzer-ID, die Gruppen, denen du "
-"angehörst, und alle speziellen Benutzerrechte; deinen Namen, dein "
-"Wohnsitzland und/oder deine Zugehörigkeit, falls dies von einem Partner, bei "
-"dem du dich bewirbst, verlangt wird; deine Beschreibung deiner Beiträge und "
-"die Gründe für die Beantragung des Zugangs zu den Ressourcen des Partners; "
-"und das Datum, an dem du diesen Nutzungsbedingungen zustimmst."
+msgid "The Wikimedia Foundation and our service providers use your information for the legitimate purpose of providing Wikipedia Library services in support of our charitable mission. When you apply for a Wikipedia Library account, or use your Wikipedia Library account, we may routinely collect the following information: your username, email address, edit count, registration date, user ID number, groups to which you belong, and any special user rights; your name, country of residence, and/or affiliation, if required by a partner to which you are applying; your narrative description of your contributions and reasons for applying for access to partner resources; and the date you agree to these terms of use."
+msgstr "Die Wikimedia Foundation und unsere Dienstanbieter nutzen deine Daten für den legitimen Zweck, die Wikipedia-Bibliothek zur Unterstützung unserer gemeinnützigen Mission bereitzustellen. Wenn du dich für ein Wikipedia-Bibliotheks-Konto bewirbst oder dein Wikipedia-Bibliotheks-Konto nutzt, können wir routinemäßig die folgenden Informationen erfassen: deinen Benutzernamen, deine E-Mail-Adresse, die Anzahl der Bearbeitungen, das Registrierungsdatum, die Nummer deiner Benutzer-ID, die Gruppen, denen du angehörst, und alle speziellen Benutzerrechte; deinen Namen, dein Wohnsitzland und/oder deine Zugehörigkeit, falls dies von einem Partner, bei dem du dich bewirbst, verlangt wird; deine Beschreibung deiner Beiträge und die Gründe für die Beantragung des Zugangs zu den Ressourcen des Partners; und das Datum, an dem du diesen Nutzungsbedingungen zustimmst."
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:262
 #, python-format
-msgid ""
-"Each publisher who is a member of the Wikipedia Library program requires "
-"different specific information in the application. Some publishers may "
-"request only an email address, while others request more detailed data, such "
-"as your name, location, or institutional affiliation. When you complete your "
-"application, you will only be asked to supply information required by the "
-"publishers you have chosen, and each publisher will only receive the "
-"information they require for providing you with access. Please see our <a "
-"class=\"twl-links\" href=\"%(all_partners_url)s\">partner information</a> "
-"pages to learn what information is required by each publisher to gain access "
-"to their resources."
-msgstr ""
-"Jeder Verlag, der Mitglied des Wikipedia-Bibliotheks-Programms ist, verlangt "
-"unterschiedliche Angaben in der Bewerbung. Manche Verlage beantragen nur "
-"eine E-Mail-Adresse, während andere detailliertere Angaben wie deinen Namen, "
-"deinen Wohnort oder deine institutionelle Zugehörigkeit verlangen. Wenn du "
-"deine Bewerbung vollständig ausfüllst, wirst du nur nach den Informationen "
-"gefragt, die die von dir ausgewählten Verlage benötigen, und jeder Verlag "
-"erhält nur die Informationen, die er benötigt, um dir Zugang zu gewähren. "
-"Auf unseren <a class=\"twl-links\" href=\"%(all_partners_url)s"
-"\">Partnerinformationen</a> erfährst du, welche Informationen die einzelnen "
-"Verlage benötigen, um dir Zugang zu ihren Ressourcen zu gewähren."
+msgid "Each publisher who is a member of the Wikipedia Library program requires different specific information in the application. Some publishers may request only an email address, while others request more detailed data, such as your name, location, or institutional affiliation. When you complete your application, you will only be asked to supply information required by the publishers you have chosen, and each publisher will only receive the information they require for providing you with access. Please see our <a class=\"twl-links\" href=\"%(all_partners_url)s\">partner information</a> pages to learn what information is required by each publisher to gain access to their resources."
+msgstr "Jeder Verlag, der Mitglied des Wikipedia-Bibliotheks-Programms ist, verlangt unterschiedliche Angaben in der Bewerbung. Manche Verlage beantragen nur eine E-Mail-Adresse, während andere detailliertere Angaben wie deinen Namen, deinen Wohnort oder deine institutionelle Zugehörigkeit verlangen. Wenn du deine Bewerbung vollständig ausfüllst, wirst du nur nach den Informationen gefragt, die die von dir ausgewählten Verlage benötigen, und jeder Verlag erhält nur die Informationen, die er benötigt, um dir Zugang zu gewähren. Auf unseren <a class=\"twl-links\" href=\"%(all_partners_url)s\">Partnerinformationen</a> erfährst du, welche Informationen die einzelnen Verlage benötigen, um dir Zugang zu ihren Ressourcen zu gewähren."
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Wikimedia Foundation should not be translated. Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:277
-msgid ""
-"Some Wikipedia Library pages are visible without logging in, but you will "
-"need to log in to apply or access proprietary partner resources. We use the "
-"data provided by you via OAuth and Wikimedia API calls to assess your "
-"application for access and to process approved requests."
-msgstr ""
-"Einige Seiten von „The Wikipedia Library“ sind auch unangemeldet sichtbar, "
-"für die Bewerbung oder den Zugang von geschützten Inhalten unserer Partner "
-"musst du dich jedoch anmelden. Wir verwenden dafür die Daten, die von dir "
-"über Abfragen über die Zugangsschnittstelle OAuth sowie die "
-"Datenbankschnittstelle „Wikimedia API“ übermittelt werden, um deine "
-"Bewerbung für einen Zugang zu beurteilen sowie bestätigte Anfragen "
-"weiterzuverarbeiten."
+msgid "Some Wikipedia Library pages are visible without logging in, but you will need to log in to apply or access proprietary partner resources. We use the data provided by you via OAuth and Wikimedia API calls to assess your application for access and to process approved requests."
+msgstr "Einige Seiten von „The Wikipedia Library“ sind auch unangemeldet sichtbar, für die Bewerbung oder den Zugang von geschützten Inhalten unserer Partner musst du dich jedoch anmelden. Wir verwenden dafür die Daten, die von dir über Abfragen über die Zugangsschnittstelle OAuth sowie die Datenbankschnittstelle „Wikimedia API“ übermittelt werden, um deine Bewerbung für einen Zugang zu beurteilen sowie bestätigte Anfragen weiterzuverarbeiten."
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:288
 #, python-format
-msgid ""
-"In order to administer the Wikipedia Library program, we will retain the "
-"application data we collect from you for three years after your most recent "
-"login, unless you delete your account, as described below. You can log in "
-"and go to <a class=\"twl-links\" href=\"%(profile_url)s\">your profile page</"
-"a> in order to see the information associated with your account, and can "
-"download it in JSON format. You may access, update, restrict, or delete this "
-"information at any time, except for the information that is automatically "
-"retrieved from the projects. If you have any questions or concerns about the "
-"handling of your data, please contact <a class=\"twl-links\" href=\"mailto:"
-"wikipedialibrary@wikimedia.org?Subject=Wikipedia%%20Library%%20Card"
-"%%20account%%20deactivation\"> wikipedialibrary@wikimedia.org </a>."
-msgstr ""
-"Für die Verwaltung von „The Wikipedia Library“ werden wir die von dir "
-"übermittelten Daten für drei Jahre nach deinem letzten Login aufbewahren, "
-"sofern du dein Konto nicht selbstständig wie unten beschrieben löschst. Als "
-"angemeldeter Nutzer kannst du auf <a class=\"twl-link\" href="
-"\"%(profile_url)s\">your profile page</a> die mit deinem Konto verknüpften "
-"Daten einsehen und im JSON-Format herunterladen. Du kannst diese Daten "
-"jederzeit aufrufen, aktualisieren, einschränken oder löschen mit Ausnahme "
-"der Daten, die automatisch von den Wikimedia-Projekten übertragen werden. "
-"Falls du Fragen oder Bedenken bezüglich unseres Umgangs mit deinen Daten "
-"haben solltest, kontaktiere bitte <a class=\"twl-link\" href=\"mailto:"
-"wikipedialibrary@wikimedia.org?Subject=Wikipedia%%20Library%%20Card"
-"%%20account%%20deactivation\"> wikipedialibrary@wikimedia.org </a>. Eine "
-"Kommunikation auf Deutsch ist möglich."
+msgid "In order to administer the Wikipedia Library program, we will retain the application data we collect from you for three years after your most recent login, unless you delete your account, as described below. You can log in and go to <a class=\"twl-links\" href=\"%(profile_url)s\">your profile page</a> in order to see the information associated with your account, and can download it in JSON format. You may access, update, restrict, or delete this information at any time, except for the information that is automatically retrieved from the projects. If you have any questions or concerns about the handling of your data, please contact <a class=\"twl-links\" href=\"mailto:wikipedialibrary@wikimedia.org?Subject=Wikipedia%%20Library%%20Card%%20account%%20deactivation\"> wikipedialibrary@wikimedia.org </a>."
+msgstr "Für die Verwaltung von „The Wikipedia Library“ werden wir die von dir übermittelten Daten für drei Jahre nach deinem letzten Login aufbewahren, sofern du dein Konto nicht selbstständig wie unten beschrieben löschst. Als angemeldeter Nutzer kannst du auf <a class=\"twl-link\" href=\"%(profile_url)s\">your profile page</a> die mit deinem Konto verknüpften Daten einsehen und im JSON-Format herunterladen. Du kannst diese Daten jederzeit aufrufen, aktualisieren, einschränken oder löschen mit Ausnahme der Daten, die automatisch von den Wikimedia-Projekten übertragen werden. Falls du Fragen oder Bedenken bezüglich unseres Umgangs mit deinen Daten haben solltest, kontaktiere bitte <a class=\"twl-link\" href=\"mailto:wikipedialibrary@wikimedia.org?Subject=Wikipedia%%20Library%%20Card%%20account%%20deactivation\"> wikipedialibrary@wikimedia.org </a>. Eine Kommunikation auf Deutsch ist möglich."
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:305
-msgid ""
-"If you decide to disable your Wikipedia Library account, you can use the "
-"delete button on your profile to delete certain personal information "
-"associated with your account. We will delete your real name, institutional "
-"affiliation, and country of residence. Please note that the system will "
-"retain a record of your username, the publishers to which you applied or had "
-"access, and the dates of that access. Note that deletion is not reversible. "
-"Deletion of your Wikipedia Library account may also correspond with the "
-"removal of any resource access to which you were eligible or approved. If "
-"you request the deletion of account information and later wish to apply for "
-"a new account, you will need to provide the necessary information again."
-msgstr ""
-"Wenn du dich entscheidest, dein Wikipedia-Bibliothekskonto zu deaktivieren, "
-"kannst du die Schaltfläche \"Löschen\" in deinem Profil verwenden, um "
-"bestimmte persönliche Informationen, die mit deinem Konto verbunden sind, zu "
-"löschen. Wir löschen deinen echten Namen, deine institutionelle "
-"Zugehörigkeit und das Land, in dem du wohnst. Bitte beachte, dass das System "
-"deinen Benutzernamen, die Verlage, bei denen du dich beworben hast oder zu "
-"denen du Zugang hattest, und die Daten dieses Zugangs aufbewahrt. Beachte, "
-"dass die Löschung nicht rückgängig gemacht werden kann. Die Löschung deines "
-"Wikipedia-Bibliothekskontos kann zudem mit dem Entzug des Zugangs zu den "
-"Ressourcen einhergehen, für die du berechtigt oder zugelassen warst. Wenn du "
-"die Löschung der Kontoinformationen beantragst und später ein neues Konto "
-"beantragen möchtest, musst du die erforderlichen Informationen erneut "
-"angeben."
+msgid "If you decide to disable your Wikipedia Library account, you can use the delete button on your profile to delete certain personal information associated with your account. We will delete your real name, institutional affiliation, and country of residence. Please note that the system will retain a record of your username, the publishers to which you applied or had access, and the dates of that access. Note that deletion is not reversible. Deletion of your Wikipedia Library account may also correspond with the removal of any resource access to which you were eligible or approved. If you request the deletion of account information and later wish to apply for a new account, you will need to provide the necessary information again."
+msgstr "Wenn du dich entscheidest, dein Wikipedia-Bibliothekskonto zu deaktivieren, kannst du die Schaltfläche \"Löschen\" in deinem Profil verwenden, um bestimmte persönliche Informationen, die mit deinem Konto verbunden sind, zu löschen. Wir löschen deinen echten Namen, deine institutionelle Zugehörigkeit und das Land, in dem du wohnst. Bitte beachte, dass das System deinen Benutzernamen, die Verlage, bei denen du dich beworben hast oder zu denen du Zugang hattest, und die Daten dieses Zugangs aufbewahrt. Beachte, dass die Löschung nicht rückgängig gemacht werden kann. Die Löschung deines Wikipedia-Bibliothekskontos kann zudem mit dem Entzug des Zugangs zu den Ressourcen einhergehen, für die du berechtigt oder zugelassen warst. Wenn du die Löschung der Kontoinformationen beantragst und später ein neues Konto beantragen möchtest, musst du die erforderlichen Informationen erneut angeben."
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). WMF should not be translated. Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:321
-msgid ""
-"The Wikipedia Library is run by WMF Staff, Contractors, and approved "
-"volunteer Coordinators. The data associated with your account will be shared "
-"with the WMF staff, contractors, service providers, and volunteer "
-"coordinators who need to process the information in connection with their "
-"work for the Wikipedia Library, and who are subject to confidentiality "
-"obligations. We will also use your data for internal Wikipedia Library "
-"purposes such as distributing user surveys and account notifications, and in "
-"a depersonalized or aggregated fashion for statistical analysis and "
-"administration. Finally, we will share your information with the publishers "
-"whom you specifically select in order to provide you with access to "
-"resources. Otherwise, your information will not be shared with third "
-"parties, with the exception of the circumstances described below."
-msgstr ""
-"„The Wikipedia Library“ wird betrieben von Mitarbeitenden und Kontraktoren "
-"der Wikimedia Foundation sowie bestätigten ehrenamtlichen Koordinatoren. Die "
-"mit deinem Konto verknüften Daten werden mit den Mitarbeitenden, "
-"Kontraktoren, Dienstleistern und ehrenamtlichen Koordinatoren geteilt, die "
-"sie im Zuge ihrer Tätigkeit für „The Wikipedia Library“ für die Verarbeitung "
-"von Informationen benötigen und Vertraulichkeitsvereinbarungen unterliegen. "
-"Wir werden außerdem deine Daten für interne Zwecke von „The Wikipedia "
-"Library“ verwenden, beispielsweise für das Verteilen von Nutzungsumfragen "
-"und Benachrichtigungen an dein Konto sowie in entpersonalisierter oder "
-"aggregierter Form für statistische Analysen oder die Administration. Darüber "
-"hinaus werden wir deine Informationen mit den Verlagen teilen, die du für "
-"dich ausgewählt hast, um dir den Zugang zu ihren Inhalten zu ermöglichen. In "
-"keinem anderen Falle werden deine Daten mit Dritten geteilt unter Ausnahme "
-"der unten beschriebenen Umstände."
+msgid "The Wikipedia Library is run by WMF Staff, Contractors, and approved volunteer Coordinators. The data associated with your account will be shared with the WMF staff, contractors, service providers, and volunteer coordinators who need to process the information in connection with their work for the Wikipedia Library, and who are subject to confidentiality obligations. We will also use your data for internal Wikipedia Library purposes such as distributing user surveys and account notifications, and in a depersonalized or aggregated fashion for statistical analysis and administration. Finally, we will share your information with the publishers whom you specifically select in order to provide you with access to resources. Otherwise, your information will not be shared with third parties, with the exception of the circumstances described below."
+msgstr "„The Wikipedia Library“ wird betrieben von Mitarbeitenden und Kontraktoren der Wikimedia Foundation sowie bestätigten ehrenamtlichen Koordinatoren. Die mit deinem Konto verknüften Daten werden mit den Mitarbeitenden, Kontraktoren, Dienstleistern und ehrenamtlichen Koordinatoren geteilt, die sie im Zuge ihrer Tätigkeit für „The Wikipedia Library“ für die Verarbeitung von Informationen benötigen und Vertraulichkeitsvereinbarungen unterliegen. Wir werden außerdem deine Daten für interne Zwecke von „The Wikipedia Library“ verwenden, beispielsweise für das Verteilen von Nutzungsumfragen und Benachrichtigungen an dein Konto sowie in entpersonalisierter oder aggregierter Form für statistische Analysen oder die Administration. Darüber hinaus werden wir deine Informationen mit den Verlagen teilen, die du für dich ausgewählt hast, um dir den Zugang zu ihren Inhalten zu ermöglichen. In keinem anderen Falle werden deine Daten mit Dritten geteilt unter Ausnahme der unten beschriebenen Umstände."
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). WMF should not be translated.
 #: TWLight/users/templates/users/terms.html:338
-msgid ""
-"We may disclose any collected information when required by law, when we have "
-"your permission, when needed to protect our rights, privacy, safety, users, "
-"or the general public, and when necessary to enforce these terms, WMF’s "
-"general <a class=\"twl-links\" href=\"https://foundation.wikimedia.org/wiki/"
-"Terms_of_Use\">Terms of Use</a>, or any other WMF policy."
-msgstr ""
-"Wir müssen unter Umständen jegliche Form gesammelter Daten offenlegen, wenn "
-"dies von Gesetzes wegen so verlangt ist, wenn wir deine Erlaubnis dafür "
-"haben, wenn es nötig ist, unsere Rechte, den Datenschutz, unsere Sicherheit, "
-"unsere Nutzer oder die Öffentlichkeit zu schützen, oder wenn es notwendig "
-"sein sollte, diese Richtlinie, die allgemeinen <a class=\"twl-link\" href="
-"\"https://foundation.wikimedia.org/wiki/Terms_of_Use\">Nutzungsbedingungen</"
-"a> oder andere Richtlinien der Wikimedia Foundation durchzusetzen."
+msgid "We may disclose any collected information when required by law, when we have your permission, when needed to protect our rights, privacy, safety, users, or the general public, and when necessary to enforce these terms, WMF’s general <a class=\"twl-links\" href=\"https://foundation.wikimedia.org/wiki/Terms_of_Use\">Terms of Use</a>, or any other WMF policy."
+msgstr "Wir müssen unter Umständen jegliche Form gesammelter Daten offenlegen, wenn dies von Gesetzes wegen so verlangt ist, wenn wir deine Erlaubnis dafür haben, wenn es nötig ist, unsere Rechte, den Datenschutz, unsere Sicherheit, unsere Nutzer oder die Öffentlichkeit zu schützen, oder wenn es notwendig sein sollte, diese Richtlinie, die allgemeinen <a class=\"twl-link\" href=\"https://foundation.wikimedia.org/wiki/Terms_of_Use\">Nutzungsbedingungen</a> oder andere Richtlinien der Wikimedia Foundation durchzusetzen."
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:349
-msgid ""
-"We take the security of your personal data seriously, and take reasonable "
-"precautions to ensure your data is protected. These precautions include "
-"access controls to limit who has access to your data and security "
-"technologies to protect data stored on the server. However, we cannot "
-"guarantee the safety of your data as it is transmitted and stored."
-msgstr ""
-"Wir nehmen den Schutz deiner personenbezogenen Daten ernst und treffen "
-"angemessene Vorsichtsmaßnahmen, um sicherzustellen, dass deine Daten "
-"geschützt werden. Diese Vorsichtsmaßnahmen umfassen Beschränkungen, wer "
-"Zugang zu deinen Daten hat, und Sicherheitstechnologien, die die Daten auf "
-"dem Server speichern. Wir können jedoch nicht die Sicherheit deiner Daten, "
-"so wie sie übermittelt und gespeichert wurden, garantieren."
+msgid "We take the security of your personal data seriously, and take reasonable precautions to ensure your data is protected. These precautions include access controls to limit who has access to your data and security technologies to protect data stored on the server. However, we cannot guarantee the safety of your data as it is transmitted and stored."
+msgstr "Wir nehmen den Schutz deiner personenbezogenen Daten ernst und treffen angemessene Vorsichtsmaßnahmen, um sicherzustellen, dass deine Daten geschützt werden. Diese Vorsichtsmaßnahmen umfassen Beschränkungen, wer Zugang zu deinen Daten hat, und Sicherheitstechnologien, die die Daten auf dem Server speichern. Wir können jedoch nicht die Sicherheit deiner Daten, so wie sie übermittelt und gespeichert wurden, garantieren."
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:360
-msgid ""
-"Please note that these terms do not control the use and handling of your "
-"data by the publishers and service providers whose resources you access or "
-"apply to access. Please read their individual privacy policies for that "
-"information."
-msgstr ""
-"Bitte beachte, dass diese Richtlinie nicht die Benutzung und Handhabung "
-"deiner Daten durch die Verlage und Dienstleister, deren Inhalte du abrufst "
-"oder auf deren Zugänge du dich bewirbst, abdeckt."
+msgid "Please note that these terms do not control the use and handling of your data by the publishers and service providers whose resources you access or apply to access. Please read their individual privacy policies for that information."
+msgstr "Bitte beachte, dass diese Richtlinie nicht die Benutzung und Handhabung deiner Daten durch die Verlage und Dienstleister, deren Inhalte du abrufst oder auf deren Zugänge du dich bewirbst, abdeckt."
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:368
@@ -3948,56 +2856,18 @@ msgstr "Wichtiger Hinweis"
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Wikimedia Foundation should not be translated. Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:373
-msgid ""
-"The Wikimedia Foundation is a nonprofit organization based in San Francisco, "
-"California. The Wikipedia Library program provides access to resources held "
-"by publishers in multiple countries. If you apply for a Wikipedia Library "
-"account (whether you are inside or outside of the United States), you "
-"understand that your personal data will be collected, transferred, stored, "
-"processed, disclosed and otherwise used in the U.S. as described in this "
-"privacy policy. You also understand that your information may be transferred "
-"by us from the U.S. to other countries, which may have different or less "
-"stringent data protection laws than your country, in connection with "
-"providing services to you, including evaluating your application and "
-"securing access to your chosen publishers (locations for each publisher are "
-"outlined on their respective partner information pages)."
-msgstr ""
-"Die Wikimedia Foundation ist eine gemeinnützige Organisation mit Sitz in San "
-"Francisco, Kalifornien. Das Programm von „The Wikipedia Library“ bietet "
-"Zugang zu Inhalten von Verlagen in verschiedenen Ländern. Sofern du dich auf "
-"einen Zugang in „The Wikipedia Library“ bewirbst, erklärst du dich damit "
-"einverstanden, dass (unabhängig davon, ob du innerhalb oder außerhalb der "
-"Vereinigten Staaten von Amerika wohnst) deine personenbezogenen Daten "
-"gesammelt, übermittelt, gespeichert, verarbeitet, offengelegt oder "
-"anderweitig in den Vereinigten Staaten von Amerika verarbeitet werden, so "
-"wie in dieser Datenschutzrichtlinie beschrieben. Du erklärst du dich "
-"ebenfalls damit einverstanden, dass deine Informationen möglicherweise von "
-"uns aus den Vereinigten Staaten von Amerika in andere Länder übermittelt "
-"werden, die andere und damit auch ggf. weniger strikte "
-"Datenschutzrichtlinien im Vergleich zu deinem Heimatland haben. Dies umfasst "
-"auch die Beurteilung deiner Bewerbung und den gesicherten Zugang zu den von "
-"dir ausgewählten Verlagen (der Standort jeden Verlags wird auf der "
-"jeweiligen Informationsseite unseres Partners angegeben)."
+msgid "The Wikimedia Foundation is a nonprofit organization based in San Francisco, California. The Wikipedia Library program provides access to resources held by publishers in multiple countries. If you apply for a Wikipedia Library account (whether you are inside or outside of the United States), you understand that your personal data will be collected, transferred, stored, processed, disclosed and otherwise used in the U.S. as described in this privacy policy. You also understand that your information may be transferred by us from the U.S. to other countries, which may have different or less stringent data protection laws than your country, in connection with providing services to you, including evaluating your application and securing access to your chosen publishers (locations for each publisher are outlined on their respective partner information pages)."
+msgstr "Die Wikimedia Foundation ist eine gemeinnützige Organisation mit Sitz in San Francisco, Kalifornien. Das Programm von „The Wikipedia Library“ bietet Zugang zu Inhalten von Verlagen in verschiedenen Ländern. Sofern du dich auf einen Zugang in „The Wikipedia Library“ bewirbst, erklärst du dich damit einverstanden, dass (unabhängig davon, ob du innerhalb oder außerhalb der Vereinigten Staaten von Amerika wohnst) deine personenbezogenen Daten gesammelt, übermittelt, gespeichert, verarbeitet, offengelegt oder anderweitig in den Vereinigten Staaten von Amerika verarbeitet werden, so wie in dieser Datenschutzrichtlinie beschrieben. Du erklärst du dich ebenfalls damit einverstanden, dass deine Informationen möglicherweise von uns aus den Vereinigten Staaten von Amerika in andere Länder übermittelt werden, die andere und damit auch ggf. weniger strikte Datenschutzrichtlinien im Vergleich zu deinem Heimatland haben. Dies umfasst auch die Beurteilung deiner Bewerbung und den gesicherten Zugang zu den von dir ausgewählten Verlagen (der Standort jeden Verlags wird auf der jeweiligen Informationsseite unseres Partners angegeben)."
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:392
-msgid ""
-"Please note that in the event of any differences in meaning or "
-"interpretation between the original English version of these terms and a "
-"translation, the original English version takes precedence."
-msgstr ""
-"Bitte beachte, dass im Falle von Unterschieden bei der Bedeutung oder "
-"Interpretation zwischen der originalen englischsprachigen Fassung dieser "
-"Nutzungsbedingungen und der Übersetzung erstere stets den Vorrang hat."
+msgid "Please note that in the event of any differences in meaning or interpretation between the original English version of these terms and a translation, the original English version takes precedence."
+msgstr "Bitte beachte, dass im Falle von Unterschieden bei der Bedeutung oder Interpretation zwischen der originalen englischsprachigen Fassung dieser Nutzungsbedingungen und der Übersetzung erstere stets den Vorrang hat."
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Wikimedia Foundation should not be translated.
 #: TWLight/users/templates/users/terms.html:403
-msgid ""
-"See also the <a class=\"twl-links\" href=\"https://wikimediafoundation.org/"
-"wiki/Privacy_policy\">Wikimedia Foundation Privacy Policy</a>."
-msgstr ""
-"Siehe auch die <a class=\"twl-link\" href=\"https://wikimediafoundation.org/"
-"wiki/Privacy_policy\">Datenschutzrichtlinie der Wikimedia Foundation</a>."
+msgid "See also the <a class=\"twl-links\" href=\"https://wikimediafoundation.org/wiki/Privacy_policy\">Wikimedia Foundation Privacy Policy</a>."
+msgstr "Siehe auch die <a class=\"twl-link\" href=\"https://wikimediafoundation.org/wiki/Privacy_policy\">Datenschutzrichtlinie der Wikimedia Foundation</a>."
 
 #. Translators: This is the second to last line of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:412
@@ -4016,17 +2886,8 @@ msgstr "Wikimedia Foundation"
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:426
-msgid ""
-"By checking this box and clicking “Submit”, you agree that you have read the "
-"above terms and that you will adhere to the terms of use in your application "
-"to and use of the The Wikipedia Library, and the publishers’ services to "
-"which you gain access through The Wikipedia Library program."
-msgstr ""
-"Mit deiner Auswahl und dem Anklicken von „Absenden“ stimmst du zu, dass du "
-"die obigen Nutzungsbedingungen gelesen hast, diese bei deiner Bewerbung "
-"sowie der Nutzung von „The Wikipedia Library“ sowie die Dienste der Verlage, "
-"zu denen du durch das Programm von „The Wikipedia Library“ Zugang erhältst, "
-"berücksichtigen wirst."
+msgid "By checking this box and clicking “Submit”, you agree that you have read the above terms and that you will adhere to the terms of use in your application to and use of the The Wikipedia Library, and the publishers’ services to which you gain access through The Wikipedia Library program."
+msgstr "Mit deiner Auswahl und dem Anklicken von „Absenden“ stimmst du zu, dass du die obigen Nutzungsbedingungen gelesen hast, diese bei deiner Bewerbung sowie der Nutzung von „The Wikipedia Library“ sowie die Dienste der Verlage, zu denen du durch das Programm von „The Wikipedia Library“ Zugang erhältst, berücksichtigen wirst."
 
 #: TWLight/users/templates/users/user_collection_tile.html:32
 msgid "Remove this collection from favorites"
@@ -4078,43 +2939,19 @@ msgstr "Lösche alle Daten."
 
 #. Translators: This message is displayed on the page where users can request the deletion of their data.
 #: TWLight/users/templates/users/user_confirm_delete.html:17
-msgid ""
-"<b>Warning:</b> Performing this action will delete your Wikipedia Library "
-"Card user account and all associated applications. This process is not "
-"reversible. You may lose any partner accounts you were granted, and will not "
-"be able to renew those accounts or apply for new ones."
-msgstr ""
-"<b>Warnung:</b> Mit dieser Aktion löschst du dein Konto bei „The Wikipedia "
-"Library“ und alle damit verknüpften Anwendungen. Dies kann nicht rückgängig "
-"gemacht werden. Du wirst voraussichtlich alle Konten bei unseren Partnern "
-"verlieren, die du erhalten hast, und kannst deine Zugänge weder erneuern, "
-"noch neue beantragen."
+msgid "<b>Warning:</b> Performing this action will delete your Wikipedia Library Card user account and all associated applications. This process is not reversible. You may lose any partner accounts you were granted, and will not be able to renew those accounts or apply for new ones."
+msgstr "<b>Warnung:</b> Mit dieser Aktion löschst du dein Konto bei „The Wikipedia Library“ und alle damit verknüpften Anwendungen. Dies kann nicht rückgängig gemacht werden. Du wirst voraussichtlich alle Konten bei unseren Partnern verlieren, die du erhalten hast, und kannst deine Zugänge weder erneuern, noch neue beantragen."
 
 #. Translators: this should show up for people who log in with a username/password and not OAuth, so we don't know what their Wikipedia identity is.
-#.
 #: TWLight/users/templates/users/user_detail.html:12
 #, python-format
-msgid ""
-"Hi, %(username)s! You don't have a Wikipedia editor profile attached to your "
-"account here, so you are probably a site administrator."
-msgstr ""
-"Hallo %(username)s! Du hast kein Konto in den Wikimedia-Projekten deinem "
-"Zugang hier zugeordnet, also bist du wahrscheinlich ein Administrator dieser "
-"Seite."
+msgid "Hi, %(username)s! You don't have a Wikipedia editor profile attached to your account here, so you are probably a site administrator."
+msgstr "Hallo %(username)s! Du hast kein Konto in den Wikimedia-Projekten deinem Zugang hier zugeordnet, also bist du wahrscheinlich ein Administrator dieser Seite."
 
 #. Translators: In the unlikely scenario that someone is able to register an account without using OAuth (thus leaving us without some of the information required for applications), users will see this message, encouraging them to re-register.
 #: TWLight/users/templates/users/user_detail.html:20
-msgid ""
-"If you aren't a site administrator, something weird has happened. You won't "
-"be able to apply for access without a Wikipedia editor profile. You should "
-"log out and create a new account by logging in via OAuth, or contact a site "
-"administrator for help."
-msgstr ""
-"Solltest du kein Administrator dieser Seite sein, ist vermutlich ein Fehler "
-"passiert. Ohne Zuordnung zu einem Konto in den Wikimedia-Projekten kannst du "
-"dich nicht für einen Zugang bewerben. Bitte melde dich ab und erstelle ein "
-"neues Konto hier, indem du dich über OAuth anmeldest oder wende dich an "
-"einen Administrator der Seite für weitere Hilfe."
+msgid "If you aren't a site administrator, something weird has happened. You won't be able to apply for access without a Wikipedia editor profile. You should log out and create a new account by logging in via OAuth, or contact a site administrator for help."
+msgstr "Solltest du kein Administrator dieser Seite sein, ist vermutlich ein Fehler passiert. Ohne Zuordnung zu einem Konto in den Wikimedia-Projekten kannst du dich nicht für einen Zugang bewerben. Bitte melde dich ab und erstelle ein neues Konto hier, indem du dich über OAuth anmeldest oder wende dich an einen Administrator der Seite für weitere Hilfe."
 
 #. Translators: Labels a sections where coordinators can select their email preferences.
 #: TWLight/users/templates/users/user_email_preferences.html:15
@@ -4124,24 +2961,13 @@ msgstr "Ausschließlich für Koordinatoren"
 #. Translators: This message is shown on user's own profile page, encouraging them to make sure their information is up to date, so that account coordinators can use the information to judge applications.
 #: TWLight/users/views.py:176
 #, python-brace-format
-msgid ""
-"Please <a class='twl-links' href='{url}'>update your contributions</a> to "
-"Wikipedia to help coordinators evaluate your applications."
-msgstr ""
-"Bitte <a class=\"twl-links\" href='{url}'>aktualisiere deine Bearbeitungen</"
-"a> in den Wikimedia-Projekten, um den Koordinatoren die Beurteilung deiner "
-"Bewerbung zu erleichtern."
+msgid "Please <a class='twl-links' href='{url}'>update your contributions</a> to Wikipedia to help coordinators evaluate your applications."
+msgstr "Bitte <a class=\"twl-links\" href='{url}'>aktualisiere deine Bearbeitungen</a> in den Wikimedia-Projekten, um den Koordinatoren die Beurteilung deiner Bewerbung zu erleichtern."
 
 #. Translators: Coordinators are shown this message when they unselect all three types of reminder email options under preferences.
 #: TWLight/users/views.py:288
-msgid ""
-"You have chosen not to receive reminder emails. As a coordinator, you should "
-"receive at least one type of reminder emails, so consider changing your "
-"preferences."
-msgstr ""
-"Du hast ausgewählt, dass du keine Erinnerungsnachrichten erhalten willst. "
-"Als Koordinator solltest du wenigstens eine Form von Erinnerungsnachrichten "
-"erhalten können. Bitte passe deine Einstellungen dementsprechend an."
+msgid "You have chosen not to receive reminder emails. As a coordinator, you should receive at least one type of reminder emails, so consider changing your preferences."
+msgstr "Du hast ausgewählt, dass du keine Erinnerungsnachrichten erhalten willst. Als Koordinator solltest du wenigstens eine Form von Erinnerungsnachrichten erhalten können. Bitte passe deine Einstellungen dementsprechend an."
 
 #. Translators: Coordinators are shown this message when they make changes to their reminder email options under preferences.
 #: TWLight/users/views.py:296
@@ -4164,9 +2990,7 @@ msgstr "Deine Angaben wurden aktualisiert."
 #. Translators: If a user tries to save the 'email change form' without entering one and checking the 'use my Wikipedia email address' checkbox, this message is presented.
 #: TWLight/users/views.py:448
 msgid "Both the values cannot be blank. Either enter a email or check the box."
-msgstr ""
-"Es können nicht beide Angaben leer sein. Bitte gib entweder eine E-Mail-"
-"Adresse an oder klicke die Box an."
+msgstr "Es können nicht beide Angaben leer sein. Bitte gib entweder eine E-Mail-Adresse an oder klicke die Box an."
 
 #. Translators: Shown to users when they successfully modify their email. Don't translate {email}.
 #: TWLight/users/views.py:476
@@ -4176,13 +3000,8 @@ msgstr "Deine E-Mail-Adresse wurde wie folgt geändert: {email}."
 
 #. Translators: If the user has not filled out their email, they can browse the website but cannot apply for access to resources.
 #: TWLight/users/views.py:487
-msgid ""
-"Your email is blank. You can still explore the site, but you won't be able "
-"to apply for access to partner resources without an email."
-msgstr ""
-"Du hast keine E-Mail-Adresse angegeben. Ohne gültige E-Mail-Adresse kannst "
-"kannst die Seite zwar weiterhin erkunden, jedoch keine Bewerbungen zu den "
-"Inhalten unserer Partner abgeben."
+msgid "Your email is blank. You can still explore the site, but you won't be able to apply for access to partner resources without an email."
+msgstr "Du hast keine E-Mail-Adresse angegeben. Ohne gültige E-Mail-Adresse kannst kannst die Seite zwar weiterhin erkunden, jedoch keine Bewerbungen zu den Inhalten unserer Partner abgeben."
 
 #. Translators: This message is shown once the access to a partner has successfully been returned.
 #: TWLight/users/views.py:801
@@ -4214,31 +3033,3 @@ msgstr "keine aktiven Sperren"
 msgid "10+ edits in the last 30 days"
 msgstr "mindestens 10 Bearbeitungen in den letzten 30 Tagen"
 
-#: tests/shunit/data/bad_i18n_comment_1.py:3
-#: tests/shunit/data/bad_i18n_newline_1.py:5
-msgid "1"
-msgstr ""
-
-#. Translators: Lorem ipsum dolor sit amet, consectetur adipiscing elit. Mauris vitae ipsum ut purus faucibus pretium. Proin tempus neque et aliquet consectetur. Ut egestas sapien in consectetur sagittis. Mauris neque lacus, dapibus non viverra vitae, interdum ut aenean ipsum.
-#. Translators: Lorem ipsum dolor sit amet, consectetur adipiscing elit. Mauris vitae ipsum ut purus faucibus pretium. Proin tempus neque et aliquet consectetur. Ut egestas sapien in consectetur sagittis. Mauris neque lacus, dapibus non.
-#: tests/shunit/data/bad_i18n_comment_2.py:4
-#: tests/shunit/data/bad_i18n_newline_2.py:5 tests/shunit/data/good_i18n_1.py:2
-#: tests/shunit/data/good_i18n_2.py:2
-msgid "2"
-msgstr ""
-
-#: tests/shunit/data/bad_i18n_newline_3.py:5
-msgid "3"
-msgstr ""
-
-#: tests/shunit/data/bad_i18n_newline_4.py:5
-msgid "4"
-msgstr ""
-
-#: tests/shunit/data/bad_i18n_newline_5.py:5
-msgid "5"
-msgstr ""
-
-#: tests/shunit/data/bad_i18n_newline_6.py:5
-msgid "6"
-msgstr ""

--- a/locale/diq/LC_MESSAGES/django.po
+++ b/locale/diq/LC_MESSAGES/django.po
@@ -8,10 +8,11 @@
 # Author: Orbot707
 msgid ""
 msgstr ""
+""
 "Project-Id-Version: Wikipedia Library Card Platform - Website\n"
-"Report-Msgid-Bugs-To: wikipedialibrary@wikimedia.org\n"
+"Report-Msgid-Bugs-To: translatewiki.net\n"
 "POT-Creation-Date: 2024-07-11 20:54+0000\n"
-"PO-Revision-Date: 2024-07-11 12:30:13+0000\n"
+"PO-Revision-Date: 2024-07-15 12:29:14+0000\n"
 "Language: diq\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
@@ -43,9 +44,7 @@ msgstr "Heqa şıma de"
 #. Translators: This note appears in a section of a form where we ask users to enter info (like country of residence) when applying for resource access.
 #: TWLight/applications/forms.py:179
 #, python-brace-format
-msgid ""
-"<p><small><i>Your personal data will be processed according to our <a "
-"class='twl-links' href='{terms_url}'> privacy policy</a>.</i></small></p>"
+msgid "<p><small><i>Your personal data will be processed according to our <a class='twl-links' href='{terms_url}'> privacy policy</a>.</i></small></p>"
 msgstr ""
 
 #. Translators: This is the title of the application form page, where users enter information required for the application. It lets the user know which partner application they are entering data for. {partner}
@@ -87,9 +86,7 @@ msgstr ""
 #. Translators: This labels a choice field where users will have to select the number of months they wish to have their access for as part of the application renewal confirmation.
 #. Translators: When filling out an application, users may be required to enter the length of the account (expiry) they wish to have for proxy partners.
 #: TWLight/applications/forms.py:339 TWLight/applications/helpers.py:100
-msgid ""
-"The number of months you wish to have this access for before renewal is "
-"required"
+msgid "The number of months you wish to have this access for before renewal is required"
 msgstr ""
 
 #. Translators: When filling out an application, users may need to specify their name
@@ -178,9 +175,7 @@ msgstr "E-poste"
 
 #. Translators: This comment is added to pending applications when our terms of use change.
 #: TWLight/applications/management/commands/notify_applicants_tou_changes.py:54
-msgid ""
-"Our terms of use have changed. Your applications will not be processed until "
-"you log in and agree to our updated terms."
+msgid "Our terms of use have changed. Your applications will not be processed until you log in and agree to our updated terms."
 msgstr ""
 
 #. Translators: This is the status of an application that has not yet been reviewed.
@@ -247,23 +242,17 @@ msgstr "URLy cırestışi: {access_url}"
 
 #. Translators: This text goes into account approval emails in the case that we need to send the user's details to a publisher for manual account setup.
 #: TWLight/applications/models.py:331
-msgid ""
-"You can expect to receive access details within a week or two once it has "
-"been processed."
+msgid "You can expect to receive access details within a week or two once it has been processed."
 msgstr ""
 
 #. Translators: This comment is added to open applications when a partner joins the Library Bundle, which does not require applications.
 #: TWLight/applications/signals.py:247
-msgid ""
-"This partner joined the Library Bundle, which does not require applications. "
-"This application will be marked as invalid."
+msgid "This partner joined the Library Bundle, which does not require applications. This application will be marked as invalid."
 msgstr ""
 
 #. Translators: This is shown to users if the application is to a partner for which we have run out of available accounts. The application is therefore on a 'waitlist', and will be reviewed when more accounts are available.
 #: TWLight/applications/templates/applications/application_evaluation.html:29
-msgid ""
-"This application is on the waitlist because this partner does not have any "
-"access grants available at this time."
+msgid "This application is on the waitlist because this partner does not have any access grants available at this time."
 msgstr ""
 
 #. Translators: This message is shown on pages where coordinators can see personal information about applicants.
@@ -271,9 +260,7 @@ msgstr ""
 #: TWLight/applications/templates/applications/application_list_include.html:6
 #: TWLight/applications/templates/applications/send_partner.html:45
 #: TWLight/resources/templates/resources/partner_users.html:18
-msgid ""
-"Coordinators: This page may contain personal information such as real names "
-"and email addresses. Please remember that this information is confidential."
+msgid "Coordinators: This page may contain personal information such as real names and email addresses. Please remember that this information is confidential."
 msgstr ""
 
 #. Translators: This is the title of the application page shown to users who are a coordinator, and are able to accept or reject the application.
@@ -283,9 +270,7 @@ msgstr ""
 
 #. Translators: This text is shown to coordinators on application pages if the applicant has restricted processing of their data.
 #: TWLight/applications/templates/applications/application_evaluation.html:42
-msgid ""
-"This user has requested a restriction on the processing of their data, so "
-"you cannot change the status of their application."
+msgid "This user has requested a restriction on the processing of their data, so you cannot change the status of their application."
 msgstr ""
 
 #. Translators: This is the title of the application page shown to users who are not a coordinator.
@@ -359,9 +344,7 @@ msgstr "Nêzanaye"
 
 #. Translators: This is the text displayed to coordinators when an applicant has no country of residence in their profile.
 #: TWLight/applications/templates/applications/application_evaluation.html:123
-msgid ""
-"Please request the applicant add their country of residence to their profile "
-"before proceeding further."
+msgid "Please request the applicant add their country of residence to their profile before proceeding further."
 msgstr ""
 
 #. Translators: This labels the section of an application showing the total number of accounts available for a partner or their collection.
@@ -372,9 +355,7 @@ msgstr "Hesabê mewcudi"
 #. Translators: This labels the section of an application showing whether the user had agreed to the terms of use or not.
 #: TWLight/applications/templates/applications/application_evaluation.html:145
 #, python-format
-msgid ""
-"Has agreed to the site's <a class=\"twl-links\" href=\"%(terms_url)s\">terms "
-"of use</a>?"
+msgid "Has agreed to the site's <a class=\"twl-links\" href=\"%(terms_url)s\">terms of use</a>?"
 msgstr ""
 
 #. Translators: Displayed to coordinators when they've agreed to the terms of use.
@@ -410,9 +391,7 @@ msgstr "Nê"
 
 #. Translators: This is the text displayed to coordinators when an applicant has not agreed to the terms of use.
 #: TWLight/applications/templates/applications/application_evaluation.html:159
-msgid ""
-"Please request the applicant agree to the site's terms of use before "
-"approving this application."
+msgid "Please request the applicant agree to the site's terms of use before approving this application."
 msgstr ""
 
 #. Translators: This labels the section of an application containing the user's motivation for wanting access to this resource.
@@ -433,8 +412,7 @@ msgstr ""
 #. Translators: This message is shown next to the 'Renewal of existing access grant?' label if the application is a renewal. Don't translate HTML tags or parent_url.
 #: TWLight/applications/templates/applications/application_evaluation.html:195
 #, python-format
-msgid ""
-"Yes (<a class=\"twl-links\" href=\"%(parent_url)s\">previous application</a>)"
+msgid "Yes (<a class=\"twl-links\" href=\"%(parent_url)s\">previous application</a>)"
 msgstr ""
 
 #. Translators: This labels the section of the application showing the length of access remaining on the user's previous authorization.
@@ -469,9 +447,7 @@ msgstr "Mışewre cı ke"
 
 #. Translators: On an application page, this text tells users that the comments posted on the application are visible to coordinators and the submitting user only.
 #: TWLight/applications/templates/applications/application_evaluation.html:297
-msgid ""
-"Comments are visible to all coordinators and to the editor who submitted "
-"this application."
+msgid "Comments are visible to all coordinators and to the editor who submitted this application."
 msgstr ""
 
 #. Translators: This is the title of the section of an application page which lists information about the user who submitted the application.
@@ -683,12 +659,7 @@ msgstr ""
 
 #: TWLight/applications/templates/applications/apply.html:20
 #, python-format
-msgid ""
-"If your application is successful we may share your email address with "
-"%(partner)s. This is required to set up your access to their resources. By "
-"submitting this form you agree to allow your email address to be shared with "
-"%(partner)s if your application is successful, for the purposes of account "
-"setup."
+msgid "If your application is successful we may share your email address with %(partner)s. This is required to set up your access to their resources. By submitting this form you agree to allow your email address to be shared with %(partner)s if your application is successful, for the purposes of account setup."
 msgstr ""
 
 #. Translators: This message is displayed on the page where users can confirm their renewal. Please do not translate partner.
@@ -717,9 +688,7 @@ msgstr ""
 
 #. Translators: This text explains that Library Bundle partners are not shown in this list.
 #: TWLight/applications/templates/applications/request_for_application.html:26
-msgid ""
-"Library Bundle partners are not shown as eligibility is determined "
-"automatically."
+msgid "Library Bundle partners are not shown as eligibility is determined automatically."
 msgstr ""
 
 #. Translators: On the page where users can apply for multiple partners, this message shows next to the partner name, taking them to the full application page when clicked.
@@ -734,10 +703,7 @@ msgstr ""
 
 #. Translators: the HTML is so that the word 'waitlisted' will look the same as it does in the page above; please translate 'waitlisted' the same way you did elsewhere in this file.
 #: TWLight/applications/templates/applications/request_for_application.html:74
-msgid ""
-"You can apply to <span class=\"badge badge-warning\">Waitlisted</span> "
-"partners, but they don't have access grants available right now. We will "
-"process those applications when access becomes available."
+msgid "You can apply to <span class=\"badge badge-warning\">Waitlisted</span> partners, but they don't have access grants available right now. We will process those applications when access becomes available."
 msgstr ""
 
 #. Translators: On the page where coordinators can see approved applications which have not had their details sent to the partner, this message shows when there are applications ready to be processed.
@@ -759,9 +725,7 @@ msgstr ""
 #. Translators: This message is shown when applications exceed the number of accounts available.
 #: TWLight/applications/templates/applications/send_partner.html:54
 #, python-format
-msgid ""
-"Application(s) for %(object)s, if sent, will exceed the total available "
-"accounts for the partner. Please proceed at your own discretion."
+msgid "Application(s) for %(object)s, if sent, will exceed the total available accounts for the partner. Please proceed at your own discretion."
 msgstr ""
 
 #. Translators: When viewing the list of applications ready to be sent for a particular partner, this is instructions for the coordinator to click the 'mark as sent' button after they have sent the information.
@@ -778,9 +742,7 @@ msgstr[1] ""
 
 #. Translators: When viewing the list of applications ready to be sent for a particular partner, this message shows if there is no information about who the applications should be sent to. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/applications/templates/applications/send_partner.html:89
-msgid ""
-"Whoops, we don't have any listed contacts. Please notify Wikipedia Library "
-"administrators."
+msgid "Whoops, we don't have any listed contacts. Please notify Wikipedia Library administrators."
 msgstr ""
 
 #. Translators: When viewing the list of applications ready to be sent for a particular partner, this is the title of the section containing the information about those applications.
@@ -796,9 +758,7 @@ msgstr "Rışiyaye nışan ke"
 
 #. Translators: This text guides coordinators in using the code sending interface for approved applications.
 #: TWLight/applications/templates/applications/send_partner.html:152
-msgid ""
-"Use the dropdown menus to denote which editor will receive each code. Access "
-"codes will be sent to users automatically."
+msgid "Use the dropdown menus to denote which editor will receive each code. Access codes will be sent to users automatically."
 msgstr ""
 
 #. Translators: This labels a drop-down selection where staff can assign an access code to a user.
@@ -814,18 +774,13 @@ msgstr ""
 #. Translators: When a user applies for a set of resources, they receive this message if none are currently available. They are instead placed on a 'waitlist' for later approval.
 #. Translators: When a user renews their resource, they receive this message if none are currently available. They are instead placed on a 'waitlist' for later approval.
 #: TWLight/applications/views.py:140 TWLight/applications/views.py:1282
-msgid ""
-"This partner does not have any access grants available at this time. You may "
-"still apply for access; your application will be reviewed when access grants "
-"become available."
+msgid "This partner does not have any access grants available at this time. You may still apply for access; your application will be reviewed when access grants become available."
 msgstr ""
 
 #. Translators: This message is shown to users once they've successfully submitted their application for review.
 #: TWLight/applications/views.py:163
 #, python-brace-format
-msgid ""
-"Your application has been submitted for review. Head over to <a "
-"href='{applications_url}'>My Applications</a> to view the status."
+msgid "Your application has been submitted for review. Head over to <a href='{applications_url}'>My Applications</a> to view the status."
 msgstr ""
 
 #. Translators: This text is displayed to users when the user has chosen to restrict data and is trying to apply for multiple partners
@@ -874,16 +829,12 @@ msgstr ""
 
 #. Translators: After a coordinator has changed the status of an application to APPROVED, if the corresponding partner/collection is waitlisted this message appears.
 #: TWLight/applications/views.py:756
-msgid ""
-"Cannot approve application as partner with proxy authorization method is "
-"waitlisted."
+msgid "Cannot approve application as partner with proxy authorization method is waitlisted."
 msgstr ""
 
 #. Translators: After a coordinator has changed the status of an application to APPROVED, if the corresponding partner/collection has no accounts for distribution, this message appears.
 #: TWLight/applications/views.py:780
-msgid ""
-"Cannot approve application as partner with proxy authorization method is "
-"waitlisted and (or) has zero accounts available for distribution."
+msgid "Cannot approve application as partner with proxy authorization method is waitlisted and (or) has zero accounts available for distribution."
 msgstr ""
 
 #. Translators: This message appears on an "access denied" screen that stops users who attempt to authorize an editor to access a resource during a time period for which they are already authorized.
@@ -894,11 +845,7 @@ msgstr ""
 #. Translators: This message is shown to users when they access an application page of a now Bundle partner (new applications aren't allowed for Bundle partners and the status of old applications cannot be modified)
 #: TWLight/applications/views.py:857
 #, python-brace-format
-msgid ""
-"This application cannot be modified since this partner is now part of our <a "
-"href='{bundle}'>bundle access</a>. If you are eligible, you can access this "
-"resource from <a href='{library}'>your library</a>. <a "
-"href='{contact}'>Contact us</a> if you have any questions."
+msgid "This application cannot be modified since this partner is now part of our <a href='{bundle}'>bundle access</a>. If you are eligible, you can access this resource from <a href='{library}'>your library</a>. <a href='{contact}'>Contact us</a> if you have any questions."
 msgstr ""
 
 #. Translators: this lets a reviewer set the status of a single application.
@@ -908,9 +855,7 @@ msgstr ""
 
 #. Translators: This warning is message is shown to applicants when the number of pending applications is greater than the number of accounts available.
 #: TWLight/applications/views.py:891
-msgid ""
-"There are more pending applications than available accounts. Your "
-"application might get waitlisted."
+msgid "There are more pending applications than available accounts. Your application might get waitlisted."
 msgstr ""
 
 #. Translators: this message is shown to coordinators who attempt to change an application's Status from INVALID to any other Status.
@@ -930,11 +875,7 @@ msgstr ""
 
 #. Translators: After a coordinator has changed the status of a number of applications to APPROVED, if the corresponding partner(s) is/are waitlisted or has no accounts for distribution, this message appears.
 #: TWLight/applications/views.py:1051
-msgid ""
-"Cannot approve application(s) {} as partner(s) with proxy authorization "
-"method is/are waitlisted and (or) has/have not enough accounts available. If "
-"not enough accounts are available, prioritise the applications and then "
-"approve applications equal to the accounts available."
+msgid "Cannot approve application(s) {} as partner(s) with proxy authorization method is/are waitlisted and (or) has/have not enough accounts available. If not enough accounts are available, prioritise the applications and then approve applications equal to the accounts available."
 msgstr ""
 
 #. Translators: This message is shown to coordinators who attempt to assign the same access code to multiple users.
@@ -949,9 +890,7 @@ msgstr ""
 
 #. Translators: When a user tries to renew their resource, they receive this message if the partner is not available.
 #: TWLight/applications/views.py:1272
-msgid ""
-"Cannot renew application at this time as partner is not available. Please "
-"check back later, or contact us for more information."
+msgid "Cannot renew application at this time as partner is not available. Please check back later, or contact us for more information."
 msgstr ""
 
 #. Translators: This message is displayed when an attempt by a user to renew an application has been denied for some reason.
@@ -962,16 +901,12 @@ msgstr ""
 
 #. Translators: If a user requests the renewal of their account, but it wasn't renewed, this message is shown to them.
 #: TWLight/applications/views.py:1385
-msgid ""
-"This object cannot be renewed. (This probably means that you have already "
-"requested that it be renewed.)"
+msgid "This object cannot be renewed. (This probably means that you have already requested that it be renewed.)"
 msgstr ""
 
 #. Translators: If a user requests the renewal of their account, this message is shown to them.
 #: TWLight/applications/views.py:1395
-msgid ""
-"Your renewal request has been received. A coordinator will review your "
-"request."
+msgid "Your renewal request has been received. A coordinator will review your request."
 msgstr ""
 
 #. Translators: This labels a textfield where users can enter their email ID.
@@ -981,9 +916,7 @@ msgstr "E-posteyê şıma"
 
 #. Translators: This is the help text for the email field in the contact us form letting users know the field is updated by value pulled from their respective user profiles.
 #: TWLight/emails/forms.py:21
-msgid ""
-"This field is automatically updated with the email from your <a class='twl-"
-"links' href='{}'>user profile</a>."
+msgid "This field is automatically updated with the email from your <a class='twl-links' href='{}'>user profile</a>."
 msgstr ""
 
 #. Translators: This labels a textfield where users can enter their email message.
@@ -1007,19 +940,13 @@ msgstr "Bırışe"
 #. Translators: This email is sent to users with their access code. Don't translate Jinja variables in curly braces like user or partner. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/access_code_email-body-html.html:5
 #, python-format
-msgid ""
-"<p>Your approved application to %(partner)s has now been finalised. Your "
-"access code or login details can be found below:</p> <p><b>%(access_code)s</"
-"b></p> <p>%(user_instructions)s</p>"
+msgid "<p>Your approved application to %(partner)s has now been finalised. Your access code or login details can be found below:</p> <p><b>%(access_code)s</b></p> <p>%(user_instructions)s</p>"
 msgstr ""
 
 #. Translators: This email is sent to users with their access code. Don't translate Jinja variables in curly braces like user or partner. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/access_code_email-body-text.html:3
 #, python-format
-msgid ""
-"Your approved application to %(partner)s has now been finalised. Your access "
-"code or login details can be found below: %(access_code)s "
-"%(user_instructions)s"
+msgid "Your approved application to %(partner)s has now been finalised. Your access code or login details can be found below: %(access_code)s %(user_instructions)s"
 msgstr ""
 
 #. Translators: This is the subject line of an email sent to users with their access code.
@@ -1030,23 +957,13 @@ msgstr ""
 #. Translators: This email is sent to users when their application is approved. Don't translate Jinja variables in curly braces like user or partner; don't translate html tags either. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/approval_notification-body-html.html:5
 #, python-format
-msgid ""
-"<p>Dear %(user)s,</p> <p>Thank you for applying for access to %(partner)s "
-"resources through The Wikipedia Library. We are happy to inform you that "
-"your application has been approved.</p> <p>%(user_instructions)s</p> <p>You "
-"can view the collections you're authorized to access at My Library: "
-"%(link)s</p> <p>Cheers!</p> <p>The Wikipedia Library</p>"
+msgid "<p>Dear %(user)s,</p> <p>Thank you for applying for access to %(partner)s resources through The Wikipedia Library. We are happy to inform you that your application has been approved.</p> <p>%(user_instructions)s</p> <p>You can view the collections you're authorized to access at My Library: %(link)s</p> <p>Cheers!</p> <p>The Wikipedia Library</p>"
 msgstr ""
 
 #. Translators: This email is sent to users when their application is approved. Don't translate Jinja variables in curly braces like user or partner. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/approval_notification-body-text.html:3
 #, python-format
-msgid ""
-"Dear %(user)s, Thank you for applying for access to %(partner)s resources "
-"through The Wikipedia Library. We are happy to inform you that your "
-"application has been approved. %(user_instructions)s You can view the "
-"collections you're authorized to access at My Library: %(link)s Cheers! The "
-"Wikipedia Library"
+msgid "Dear %(user)s, Thank you for applying for access to %(partner)s resources through The Wikipedia Library. We are happy to inform you that your application has been approved. %(user_instructions)s You can view the collections you're authorized to access at My Library: %(link)s Cheers! The Wikipedia Library"
 msgstr ""
 
 #. Translators: This is the subject of an email which is sent to users when their application has been approved. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
@@ -1057,19 +974,13 @@ msgstr ""
 #. Translators: This email is sent to coordinators when a comment is left on an application they are processing. Don't translate Jinja variables in curly braces like user or partner. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/comment_notification_coordinator-body-html.html:5
 #, python-format
-msgid ""
-"<p style=\"color: #500050\">%(submit_date)s - %(commenter)s</p> "
-"<blockquote><p>%(comment)s</p></blockquote> <p>Please reply to these at: <a "
-"href=\"%(app_url)s\">%(app_url)s</a></p> <p>Best,</p> <p>The Wikipedia "
-"Library</p>"
+msgid "<p style=\"color: #500050\">%(submit_date)s - %(commenter)s</p> <blockquote><p>%(comment)s</p></blockquote> <p>Please reply to these at: <a href=\"%(app_url)s\">%(app_url)s</a></p> <p>Best,</p> <p>The Wikipedia Library</p>"
 msgstr ""
 
 #. Translators: This email is sent to coordinators when a comment is left on an application they are processing. Don't translate Jinja variables in curly braces like user or partner. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/comment_notification_coordinator-body-text.html:3
 #, python-format
-msgid ""
-"%(submit_date)s - %(commenter)s %(comment)s Please reply to this at: "
-"%(app_url)s Best, The Wikipedia Library"
+msgid "%(submit_date)s - %(commenter)s %(comment)s Please reply to this at: %(app_url)s Best, The Wikipedia Library"
 msgstr ""
 
 #. Translators: This is the subject line of an email sent to coordinators when a comment is left on an application they processed.
@@ -1080,19 +991,13 @@ msgstr ""
 #. Translators: This email is sent to users when they receive a comment on their application. Don't translate Jinja variables in curly braces like user or partner; don't translate html tags either. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/comment_notification_editors-body-html.html:5
 #, python-format
-msgid ""
-"<p style=\"color: #500050\">%(submit_date)s - %(commenter)s</p> "
-"<blockquote><p>%(comment)s</p></blockquote> <p>Please reply to these at <a "
-"href=\"%(app_url)s\">%(app_url)s</a> so we can evaluate your application.</"
-"p> <p>Best,</p> <p>The Wikipedia Library</p>"
+msgid "<p style=\"color: #500050\">%(submit_date)s - %(commenter)s</p> <blockquote><p>%(comment)s</p></blockquote> <p>Please reply to these at <a href=\"%(app_url)s\">%(app_url)s</a> so we can evaluate your application.</p> <p>Best,</p> <p>The Wikipedia Library</p>"
 msgstr ""
 
 #. Translators: This email is sent to users when they receive a comment on their application. Don't translate Jinja variables in curly braces like user or partner. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/comment_notification_editors-body-text.html:3
 #, python-format
-msgid ""
-"%(submit_date)s - %(commenter)s %(comment)s Please reply to these at: "
-"%(app_url)s so we can evaluate your application. Best, The Wikipedia Library"
+msgid "%(submit_date)s - %(commenter)s %(comment)s Please reply to these at: %(app_url)s so we can evaluate your application. Best, The Wikipedia Library"
 msgstr ""
 
 #. Translators: This is the subject line of an email sent to users who have a comment added to one of their applications. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
@@ -1103,18 +1008,13 @@ msgstr ""
 #. Translators: This email is sent to users when an application they commented on receives another comment. Don't translate Jinja variables in curly braces like app_url; don't translate html tags either. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/comment_notification_others-body-html.html:5
 #, python-format
-msgid ""
-"<p style=\"color: #500050\">%(submit_date)s - %(commenter)s</p> "
-"<blockquote><p>%(comment)s</p></blockquote> See it at <a href=\"%(app_url)s"
-"\">%(app_url)s</a>. Thanks for helping review Wikipedia Library applications!"
+msgid "<p style=\"color: #500050\">%(submit_date)s - %(commenter)s</p> <blockquote><p>%(comment)s</p></blockquote> See it at <a href=\"%(app_url)s\">%(app_url)s</a>. Thanks for helping review Wikipedia Library applications!"
 msgstr ""
 
 #. Translators: This email is sent to users when an application they commented on receives another comment. Don't translate Jinja variables in curly braces like app_url. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/comment_notification_others-body-text.html:3
 #, python-format
-msgid ""
-"%(submit_date)s - %(commenter)s %(comment)s See it at: %(app_url)s Thanks "
-"for helping review Wikipedia Library applications!"
+msgid "%(submit_date)s - %(commenter)s %(comment)s See it at: %(app_url)s Thanks for helping review Wikipedia Library applications!"
 msgstr ""
 
 #. Translators: This is the subject line of an email sent to users who have a comment added to an application they also commented on. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
@@ -1125,10 +1025,7 @@ msgstr ""
 #. Translators: This text is part of a scheduled reminder email sent to coordinators who have applications requiring action. Don't translate Jinja variables in curly braces like total_apps, or user.
 #: TWLight/emails/templates/emails/coordinator_reminder_notification-body-html.html:5
 #, python-format
-msgid ""
-"<p>Dear %(user)s,</p> <p>Our records indicate that you are the designated "
-"coordinator for partners that have a total of %(total_apps)s applications.</"
-"p>"
+msgid "<p>Dear %(user)s,</p> <p>Our records indicate that you are the designated coordinator for partners that have a total of %(total_apps)s applications.</p>"
 msgstr ""
 
 #. Translators: Breakdown as in 'cost breakdown'; analysis.
@@ -1167,31 +1064,19 @@ msgstr[1] "Amarê mıracatanê tesdiqbiyayeyan"
 #. Translators: This text is part of a scheduled reminder email sent to coordinators who have applications requiring action. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library). Don't translate Jinja variables in curly braces like link; don't translate email addresses or html tags either.
 #: TWLight/emails/templates/emails/coordinator_reminder_notification-body-html.html:39
 #, python-format
-msgid ""
-"<p>This is a gentle reminder that you may review applications at <a href="
-"\"%(link)s\">%(link)s</a>.</p> <p>You can customise your reminders under "
-"'preferences' in your user profile.</p> <p>If you received this message in "
-"error, drop us a line at wikipedialibrary@wikimedia.org.</p> <p>Thanks for "
-"helping review Wikipedia Library applications!</p>"
+msgid "<p>This is a gentle reminder that you may review applications at <a href=\"%(link)s\">%(link)s</a>.</p> <p>You can customise your reminders under 'preferences' in your user profile.</p> <p>If you received this message in error, drop us a line at wikipedialibrary@wikimedia.org.</p> <p>Thanks for helping review Wikipedia Library applications!</p>"
 msgstr ""
 
 #. Translators: This text is part of a scheduled reminder email sent to coordinators who have applications requiring action. Don't translate Jinja variables in curly braces like total_apps, or user.
 #: TWLight/emails/templates/emails/coordinator_reminder_notification-body-text.html:3
 #, python-format
-msgid ""
-"Dear %(user)s, Our records indicate that you are the designated coordinator "
-"for partners that have a total of %(total_apps)s applications."
+msgid "Dear %(user)s, Our records indicate that you are the designated coordinator for partners that have a total of %(total_apps)s applications."
 msgstr ""
 
 #. Translators: This text is part of a scheduled reminder email sent to coordinators who have applications requiring action. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library). Don't translate Jinja variables in curly braces like link; don't translate the email address either.
 #: TWLight/emails/templates/emails/coordinator_reminder_notification-body-text.html:38
 #, python-format
-msgid ""
-"This is a gentle reminder that you may review applications at: %(link)s. You "
-"can customise your reminders under 'preferences' in your user profile. If "
-"you received this message in error, drop us a line at: "
-"wikipedialibrary@wikimedia.org Thanks for helping review Wikipedia Library "
-"applications!"
+msgid "This is a gentle reminder that you may review applications at: %(link)s. You can customise your reminders under 'preferences' in your user profile. If you received this message in error, drop us a line at: wikipedialibrary@wikimedia.org Thanks for helping review Wikipedia Library applications!"
 msgstr ""
 
 #. Translators: This is the subject line of a scheduled reminder email sent to coordinators who have applications to review. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library). Do not translate items in curly braces.
@@ -1202,22 +1087,13 @@ msgstr ""
 #. Translators: This email is sent to users when their application is rejected. Don't translate Jinja variables in curly braces like user or partner; don't translate html tags either. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/rejection_notification-body-html.html:5
 #, python-format
-msgid ""
-"<p>Dear %(user)s,</p> <p>Thank you for applying for access to %(partner)s "
-"resources through The Wikipedia Library. Unfortunately at this time your "
-"application has not been approved. You can view your application and review "
-"comments at <a href=\"%(app_url)s\">%(app_url)s</a>.</p> <p>Best,</p> <p>The "
-"Wikipedia Library</p>"
+msgid "<p>Dear %(user)s,</p> <p>Thank you for applying for access to %(partner)s resources through The Wikipedia Library. Unfortunately at this time your application has not been approved. You can view your application and review comments at <a href=\"%(app_url)s\">%(app_url)s</a>.</p> <p>Best,</p> <p>The Wikipedia Library</p>"
 msgstr ""
 
 #. Translators: This email is sent to users when their application is rejected. Don't translate Jinja variables in curly braces like user or partner. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/rejection_notification-body-text.html:3
 #, python-format
-msgid ""
-"Dear %(user)s, Thank you for applying for access to %(partner)s resources "
-"through The Wikipedia Library. Unfortunately at this time your application "
-"has not been approved. You can view your application and review comments at: "
-"%(app_url)s Best, The Wikipedia Library"
+msgid "Dear %(user)s, Thank you for applying for access to %(partner)s resources through The Wikipedia Library. Unfortunately at this time your application has not been approved. You can view your application and review comments at: %(app_url)s Best, The Wikipedia Library"
 msgstr ""
 
 #. Translators: This is the subject of an email which is sent to users when their application has been rejected. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
@@ -1228,25 +1104,13 @@ msgstr ""
 #. Translators: This email is sent to users when they have an account that is soon to expire. Don't translate Jinja variables in curly braces like partner_name or partner_link; don't translate html tags either. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/user_renewal_notice-body-html.html:5
 #, python-format
-msgid ""
-"<p>Dear %(user)s,</p> <p>According to our records, your access to "
-"%(partner_name)s will soon expire and you may lose access. If you want to "
-"continue making use of your free account, you can request renewal of your "
-"account by clicking the 'Renew' or 'Extend' button at %(partner_link)s.</p> "
-"<p>Best,</p> <p>The Wikipedia Library</p> <p>You can disable these emails in "
-"your user page preferences: https://wikipedialibrary.wmflabs.org/users/</p>"
+msgid "<p>Dear %(user)s,</p> <p>According to our records, your access to %(partner_name)s will soon expire and you may lose access. If you want to continue making use of your free account, you can request renewal of your account by clicking the 'Renew' or 'Extend' button at %(partner_link)s.</p> <p>Best,</p> <p>The Wikipedia Library</p> <p>You can disable these emails in your user page preferences: https://wikipedialibrary.wmflabs.org/users/</p>"
 msgstr ""
 
 #. Translators: This email is sent to users when they have an account that is soon to expire. Don't translate Jinja variables in curly braces like partner_name or partner_link; don't translate html tags either. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/user_renewal_notice-body-text.html:3
 #, python-format
-msgid ""
-"Dear %(user)s, According to our records, your access to %(partner_name)s "
-"will soon expire and you may lose access. If you want to continue making use "
-"of your free account, you can request renewal of your account by clicking "
-"the Renew button at %(partner_link)s. Best, The Wikipedia Library You can "
-"disable these emails in your user page preferences: https://wikipedialibrary."
-"wmflabs.org/users/"
+msgid "Dear %(user)s, According to our records, your access to %(partner_name)s will soon expire and you may lose access. If you want to continue making use of your free account, you can request renewal of your account by clicking the Renew button at %(partner_link)s. Best, The Wikipedia Library You can disable these emails in your user page preferences: https://wikipedialibrary.wmflabs.org/users/"
 msgstr ""
 
 #. Translators: This is the subject of an email sent to users when they have an account that is soon to expire. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
@@ -1257,24 +1121,13 @@ msgstr ""
 #. Translators: This email is sent to users when their application is waitlisted because there are no more accounts available. Don't translate Jinja variables in curly braces like user or partner; don't translate html tags either. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/waitlist_notification-body-html.html:5
 #, python-format
-msgid ""
-"<p>Dear %(user)s,</p> <p>Thank you for applying for access to %(partner)s "
-"resources through The Wikipedia Library. There are no accounts currently "
-"available so your application has been waitlisted. Your application will be "
-"evaluated if/when more accounts become available. You can see all available "
-"resources at <a href=\"%(link)s\">%(link)s</a>.</p> <p>Best,</p> <p>The "
-"Wikipedia Library</p>"
+msgid "<p>Dear %(user)s,</p> <p>Thank you for applying for access to %(partner)s resources through The Wikipedia Library. There are no accounts currently available so your application has been waitlisted. Your application will be evaluated if/when more accounts become available. You can see all available resources at <a href=\"%(link)s\">%(link)s</a>.</p> <p>Best,</p> <p>The Wikipedia Library</p>"
 msgstr ""
 
 #. Translators: This email is sent to users when their application is waitlisted because there are no more accounts available. Don't translate Jinja variables in curly braces like user or partner. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/waitlist_notification-body-text.html:3
 #, python-format
-msgid ""
-"Dear %(user)s, Thank you for applying for access to %(partner)s resources "
-"through The Wikipedia Library. There are no accounts currently available so "
-"your application has been waitlisted. Your application will be evaluated if/"
-"when more accounts become available. You can see all available resources at: "
-"%(link)s Best, The Wikipedia Library"
+msgid "Dear %(user)s, Thank you for applying for access to %(partner)s resources through The Wikipedia Library. There are no accounts currently available so your application has been waitlisted. Your application will be evaluated if/when more accounts become available. You can see all available resources at: %(link)s Best, The Wikipedia Library"
 msgstr ""
 
 #. Translators: This is the subject of an email sent to users when their application is waitlisted because there are no more accounts available. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
@@ -1442,17 +1295,14 @@ msgstr "Çıniyo"
 #: TWLight/resources/templates/resources/filter_section.html:14
 #: TWLight/templates/about.html:12
 #: TWLight/users/templates/users/filter_section.html:13
-msgid ""
-"The Wikipedia Library allows active editors to access a wide range of "
-"collections of paywalled reliable sources for free!"
+msgid "The Wikipedia Library allows active editors to access a wide range of collections of paywalled reliable sources for free!"
 msgstr ""
 
 #. Translators: On the Browse Partners page (https://wikipedialibrary.wmflabs.org/partners/), this introduces users to The Wikipedia Library.
 #. Translators: On the MyLibrary page (https://wikipedialibrary.wmflabs.org/users/my_library), this introduces users to The Wikipedia Library.
 #: TWLight/resources/templates/resources/filter_section.html:17
 #: TWLight/users/templates/users/filter_section.html:15
-msgid ""
-"Start with the search bar at the top or browse publisher websites directly."
+msgid "Start with the search bar at the top or browse publisher websites directly."
 msgstr ""
 
 #. Translators: On the Browse Partners page (https://wikipedialibrary.wmflabs.org/partners/), this appears below introductory text and links to the 'About' page (https://wikipedialibrary.wmflabs.org/about/)
@@ -1533,52 +1383,38 @@ msgstr ""
 #. Translators: If we have no available accounts for a partner, the coordinator can change the application system to a waiting list.
 #: TWLight/resources/templates/resources/partner_detail.html:36
 #: TWLight/resources/templates/resources/partner_detail_apply.html:17
-msgid ""
-"There are no access grants available for this partner at this time. You can "
-"still apply for access; applications will be processed when access is "
-"available."
+msgid "There are no access grants available for this partner at this time. You can still apply for access; applications will be processed when access is available."
 msgstr ""
 
 #. Translators: This text links to the minimum user requirements and terms of use on the partner page.
 #: TWLight/resources/templates/resources/partner_detail.html:48
 #: TWLight/resources/templates/resources/partner_detail_apply.html:29
 #, python-format
-msgid ""
-"Before applying, please review the <strong><a class=\"twl-links\" href="
-"\"%(about)s#req\">minimum requirements</a></strong> for access and our "
-"<strong><a class=\"twl-links\" href=\"%(terms)s\">terms of use</a></strong>."
+msgid "Before applying, please review the <strong><a class=\"twl-links\" href=\"%(about)s#req\">minimum requirements</a></strong> for access and our <strong><a class=\"twl-links\" href=\"%(terms)s\">terms of use</a></strong>."
 msgstr ""
 
 #. Translators: This text refers to the page containing the content a user is authorized to access.
 #: TWLight/resources/templates/resources/partner_detail.html:69
 #, python-format
-msgid ""
-"View the status of your access in <strong><a class=\"twl-links\" href="
-"\"%(library_url)s\">My Library</a></strong> page."
+msgid "View the status of your access in <strong><a class=\"twl-links\" href=\"%(library_url)s\">My Library</a></strong> page."
 msgstr ""
 
 #. Translators: This message is shown when a user has open applications, linking to their respective applications page.
 #: TWLight/resources/templates/resources/partner_detail.html:78
 #, python-format
-msgid ""
-"View the status of your application(s) on your <strong><a class=\"twl-links"
-"\" href=\"%(applications_url)s\">My Applications</a></strong> page."
+msgid "View the status of your application(s) on your <strong><a class=\"twl-links\" href=\"%(applications_url)s\">My Applications</a></strong> page."
 msgstr ""
 
 #. Translators: This message is shown when a user has authorizations, linking to their respective collections page.
 #: TWLight/resources/templates/resources/partner_detail_apply.html:50
 #, python-format
-msgid ""
-"View the status of your access on your <strong><a href=\"%(library_url)s\" "
-"class=\"twl-links\">My Library</a></strong> page."
+msgid "View the status of your access on your <strong><a href=\"%(library_url)s\" class=\"twl-links\">My Library</a></strong> page."
 msgstr ""
 
 #. Translators: This message is shown when a user has open applications, linking to their respective applications page.
 #: TWLight/resources/templates/resources/partner_detail_apply.html:60
 #, python-format
-msgid ""
-"View the status of your application(s) on your <strong><a href="
-"\"%(applications_url)s\">My Applications</a></strong> page."
+msgid "View the status of your application(s) on your <strong><a href=\"%(applications_url)s\">My Applications</a></strong> page."
 msgstr ""
 
 #. Translators: One the partner detail page, this text labels the button which coordinators can click to remove a partner from waitlisted status.
@@ -1608,10 +1444,7 @@ msgstr "Xısusi:Eposteyê karberi"
 
 #. Translators: If no account coordinator is assigned to a partner, the Wikipedia Library team will coordinate signups. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/resources/templates/resources/partner_detail_apply.html:112
-msgid ""
-"The Wikipedia Library team will process this application. Want to help? <a "
-"class=\"twl-links\" href=\"https://en.wikipedia.org/wiki/Wikipedia:"
-"The_Wikipedia_Library/Coordinators/Signup\">Sign up as a coordinator.</a>"
+msgid "The Wikipedia Library team will process this application. Want to help? <a class=\"twl-links\" href=\"https://en.wikipedia.org/wiki/Wikipedia:The_Wikipedia_Library/Coordinators/Signup\">Sign up as a coordinator.</a>"
 msgstr ""
 
 #. Translators: This text labels a button coordinators can click to view a list of users who have applied for access for a particular partner
@@ -1641,18 +1474,13 @@ msgstr ""
 
 #. Translators: Text shown to authenticated, bundle eligible users when they visit a Bundle partner page.
 #: TWLight/resources/templates/resources/partner_detail_apply.html:138
-msgid ""
-"You are eligible to access Library Bundle partners. Click the button above "
-"to access the collection."
+msgid "You are eligible to access Library Bundle partners. Click the button above to access the collection."
 msgstr ""
 
 #. Translators: Text shown to authenticated, bundle ineligible users when they visit a Bundle partner page.
 #: TWLight/resources/templates/resources/partner_detail_apply.html:152
 #, python-format
-msgid ""
-"You are not eligible to access Library Bundle partners. Visit the <a class="
-"\"twl-links\" href=\"%(homepage)s\">homepage</a> to check the eligibility "
-"criteria."
+msgid "You are not eligible to access Library Bundle partners. Visit the <a class=\"twl-links\" href=\"%(homepage)s\">homepage</a> to check the eligibility criteria."
 msgstr ""
 
 #. Translators: Buttton prompting users to log in.
@@ -1664,10 +1492,7 @@ msgstr "Cı kewe"
 #. Translators: Text shown to unauthenticated users when they visit a Bundle partner page.
 #: TWLight/resources/templates/resources/partner_detail_apply.html:168
 #, python-format
-msgid ""
-"This resource is part of our <a class=\"twl-links\" href=\"%(about)s"
-"\">Library Bundle</a>, which you can access if you meet our minimum "
-"eligibility criteria. Log in to find out if you are eligible."
+msgid "This resource is part of our <a class=\"twl-links\" href=\"%(about)s\">Library Bundle</a>, which you can access if you meet our minimum eligibility criteria. Log in to find out if you are eligible."
 msgstr ""
 
 #. Translators: This is the label for a number which shows the total active accounts for one partner. (e.g. https://wikipedialibrary.wmflabs.org/partners/8/).
@@ -1718,26 +1543,19 @@ msgstr ""
 #. Translators: If a partner has specified the excerpt limit both in words and percentage, this message will display the percentage of words and the number of words on the partner page.
 #: TWLight/resources/templates/resources/partner_detail_timeline.html:99
 #, python-format
-msgid ""
-"%(object)s allows a maximum of %(excerpt_limit)s words or "
-"%(excerpt_limit_percentage)s%% of an article be excerpted into a Wikipedia "
-"article."
+msgid "%(object)s allows a maximum of %(excerpt_limit)s words or %(excerpt_limit_percentage)s%% of an article be excerpted into a Wikipedia article."
 msgstr ""
 
 #. Translators: If a partner has specified the excerpt limit in words, this message will display the number of words on the partner page.
 #: TWLight/resources/templates/resources/partner_detail_timeline.html:106
 #, python-format
-msgid ""
-"%(object)s allows a maximum of %(excerpt_limit)s words be excerpted into a "
-"Wikipedia article."
+msgid "%(object)s allows a maximum of %(excerpt_limit)s words be excerpted into a Wikipedia article."
 msgstr ""
 
 #. Translators: If a partner has specified the excerpt limit in percentage, this message will display the percentage of words on the partner page.
 #: TWLight/resources/templates/resources/partner_detail_timeline.html:113
 #, python-format
-msgid ""
-"%(object)s allows a maximum of %(excerpt_limit_percentage)s%% of an article "
-"be excerpted into a Wikipedia article."
+msgid "%(object)s allows a maximum of %(excerpt_limit_percentage)s%% of an article be excerpted into a Wikipedia article."
 msgstr ""
 
 #. Translators: If a partner has other requirements for access, this text shows as the title for that information field. (e.g. https://wikipedialibrary.wmflabs.org/partners/10/).
@@ -1748,9 +1566,7 @@ msgstr ""
 #. Translators: If a user must agree to a Terms of Use document, they see this message, and must enter the name of the resource. Don't translate publisher or url.
 #: TWLight/resources/templates/resources/partner_detail_timeline.html:140
 #, python-format
-msgid ""
-"%(publisher)s requires that you agree with its <a href=\"%(url)s\">terms of "
-"use</a>."
+msgid "%(publisher)s requires that you agree with its <a href=\"%(url)s\">terms of use</a>."
 msgstr ""
 
 #. Translators: If a user must provide their real name to apply to a partner, they see this message, and must enter the name of the resource. Don't translate publisher.
@@ -1774,17 +1590,13 @@ msgstr ""
 #. Translators: If a user must select a specific resource to apply for, they see this message, and must enter the name of the resource. Don't translate publisher.
 #: TWLight/resources/templates/resources/partner_detail_timeline.html:177
 #, python-format
-msgid ""
-"%(publisher)s requires that you specify a particular title that you want to "
-"access."
+msgid "%(publisher)s requires that you specify a particular title that you want to access."
 msgstr ""
 
 #. Translators: If a user must register on the partner website before applying, they see this message. Don't translate partner.
 #: TWLight/resources/templates/resources/partner_detail_timeline.html:187
 #, python-format
-msgid ""
-"%(publisher)s requires that you sign up for an account before applying for "
-"access."
+msgid "%(publisher)s requires that you sign up for an account before applying for access."
 msgstr ""
 
 #. Translators: If a partner has their location listed, this message is a label for that location
@@ -1912,9 +1724,7 @@ msgstr ""
 
 #. Translators: If multiple authorizations where returned for a collection, this message is shown to a user
 #: TWLight/resources/views.py:268
-msgid ""
-"Multiple authorizations were returned – something's wrong. Please contact us "
-"and don't forget to mention this message."
+msgid "Multiple authorizations were returned – something's wrong. Please contact us and don't forget to mention this message."
 msgstr ""
 
 #. Translators: This message is shown when user tries to access a NOT_AVAILABLE Partner
@@ -1955,22 +1765,8 @@ msgstr ""
 #. Translators: Shown on the website's 400 page, when a user sends a bad request. Don't translate path or Phabricator.
 #: TWLight/templates/400.html:20
 #, python-format
-msgid ""
-"If you think we should know what to do with that, please email us about this "
-"error at <a class=\"twl-links\" href=\"mailto:wikipedialibrary@wikimedia.org?"
-"Subject=Wikipedia%%20Library%%20%(path)s%%20Permission%%20denied"
-"\">wikipedialibrary@wikimedia.org</a> or report it to us on <a class=\"twl-"
-"links\" href=\"https://phabricator.wikimedia.org/maniphest/task/edit/form/1/?"
-"projectPHIDs=Library-Card-Platform&title=Wikipedia%%20Library%%20%(path)s"
-"%%20Bad%%20Request\">Phabricator</a>"
-msgstr ""
-"Eke şıma fıkıriyenê, wa ma bızanime ke se bıkerime, ena xeta ma rê vacê, "
-"adresa <a class=\"twl-links\" href=\"mailto:wikipedialibrary@wikimedia.org?"
-"Subject=Wikipedia%%20Library%%20%(path)s%%20Not%%20found\"> "
-"wikipedialibrary@wikimedia.org</a> ra ma rê e-poste bırışê ya zi <a class="
-"\"twl-links\" href=\"https://phabricator.wikimedia.org/maniphest/task/edit/"
-"form/1/?projectPHIDs=Library-Card-Platform&title=Wikipedia%%20Library"
-"%%20%(path)s%%20Not%%20found\">Phabricator</a> sera ma de irtıbat kewê."
+msgid "If you think we should know what to do with that, please email us about this error at <a class=\"twl-links\" href=\"mailto:wikipedialibrary@wikimedia.org?Subject=Wikipedia%%20Library%%20%(path)s%%20Permission%%20denied\">wikipedialibrary@wikimedia.org</a> or report it to us on <a class=\"twl-links\" href=\"https://phabricator.wikimedia.org/maniphest/task/edit/form/1/?projectPHIDs=Library-Card-Platform&title=Wikipedia%%20Library%%20%(path)s%%20Bad%%20Request\">Phabricator</a>"
+msgstr "Eke şıma fıkıriyenê, wa ma bızanime ke se bıkerime, ena xeta ma rê vacê, adresa <a class=\"twl-links\" href=\"mailto:wikipedialibrary@wikimedia.org?Subject=Wikipedia%%20Library%%20%(path)s%%20Not%%20found\"> wikipedialibrary@wikimedia.org</a> ra ma rê e-poste bırışê ya zi <a class=\"twl-links\" href=\"https://phabricator.wikimedia.org/maniphest/task/edit/form/1/?projectPHIDs=Library-Card-Platform&title=Wikipedia%%20Library%%20%(path)s%%20Not%%20found\">Phabricator</a> sera ma de irtıbat kewê."
 
 #. Translators: Alt text for an image shown on the 400 error page.
 #. Translators: Alt text for an image shown on the 403 error page.
@@ -1991,23 +1787,8 @@ msgstr ""
 #. Translators: Shown on the website's 403 page, when a user attempts to navigate to a page they don't have permission to view. Don't translate path or Phabricator.
 #: TWLight/templates/403.html:20
 #, python-format
-msgid ""
-"If you think your account should be able to do that, please email us about "
-"this error at <a class=\"twl-links\" href=\"mailto:"
-"wikipedialibrary@wikimedia.org?Subject=Wikipedia%%20Library%%20%(path)s"
-"%%20Permission%%20denied\">wikipedialibrary@wikimedia.org</a> or report it "
-"to us on <a class=\"twl-links\" href=\"https://phabricator.wikimedia.org/"
-"maniphest/task/edit/form/1/?projectPHIDs=Library-Card-"
-"Platform&title=Wikipedia%%20Library%%20%(path)s%%20Permission%%20denied"
-"\">Phabricator</a>"
-msgstr ""
-"Eke şıma fıkıriyenê, wa hesabê şıma name vırazo, ena xeta ma rê vacê, adresa "
-"<a class=\"twl-links\" href=\"mailto:wikipedialibrary@wikimedia.org?"
-"Subject=Wikipedia%%20Library%%20%(path)s%%20Not%%20found\"> "
-"wikipedialibrary@wikimedia.org</a> ra ma rê e-poste bırışê ya zi <a class="
-"\"twl-links\" href=\"https://phabricator.wikimedia.org/maniphest/task/edit/"
-"form/1/?projectPHIDs=Library-Card-Platform&title=Wikipedia%%20Library"
-"%%20%(path)s%%20Not%%20found\">Phabricator</a> sera ma de irtıbat kewê."
+msgid "If you think your account should be able to do that, please email us about this error at <a class=\"twl-links\" href=\"mailto:wikipedialibrary@wikimedia.org?Subject=Wikipedia%%20Library%%20%(path)s%%20Permission%%20denied\">wikipedialibrary@wikimedia.org</a> or report it to us on <a class=\"twl-links\" href=\"https://phabricator.wikimedia.org/maniphest/task/edit/form/1/?projectPHIDs=Library-Card-Platform&title=Wikipedia%%20Library%%20%(path)s%%20Permission%%20denied\">Phabricator</a>"
+msgstr "Eke şıma fıkıriyenê, wa hesabê şıma name vırazo, ena xeta ma rê vacê, adresa <a class=\"twl-links\" href=\"mailto:wikipedialibrary@wikimedia.org?Subject=Wikipedia%%20Library%%20%(path)s%%20Not%%20found\"> wikipedialibrary@wikimedia.org</a> ra ma rê e-poste bırışê ya zi <a class=\"twl-links\" href=\"https://phabricator.wikimedia.org/maniphest/task/edit/form/1/?projectPHIDs=Library-Card-Platform&title=Wikipedia%%20Library%%20%(path)s%%20Not%%20found\">Phabricator</a> sera ma de irtıbat kewê."
 
 #. Translators: Shown on the website's 404 page, when a user attempts to navigate to a page that doesn't exist.
 #: TWLight/templates/404.html:11
@@ -2022,22 +1803,8 @@ msgstr "Mayê nêşenê ney bıvinê"
 #. Translators: Shown on the website's 404 page, when a user attempts to navigate to a page that doesn't exist. Don't translate path or Phabricator.
 #: TWLight/templates/404.html:19
 #, python-format
-msgid ""
-"If you are certain that something should be here, please email us about this "
-"error at <a class=\"twl-links\" href=\"mailto:wikipedialibrary@wikimedia.org?"
-"Subject=Wikipedia%%20Library%%20%(path)s%%20Not%%20found\"> "
-"wikipedialibrary@wikimedia.org</a> or report it to us on <a class=\"twl-links"
-"\" href=\"https://phabricator.wikimedia.org/maniphest/task/edit/form/1/?"
-"projectPHIDs=Library-Card-Platform&title=Wikipedia%%20Library%%20%(path)s"
-"%%20Not%%20found\">Phabricator</a>"
-msgstr ""
-"Eke şıma eminê, wa tiya theba bıbo, ena xeta ma rê vacê, adresa <a class="
-"\"twl-links\" href=\"mailto:wikipedialibrary@wikimedia.org?Subject=Wikipedia"
-"%%20Library%%20%(path)s%%20Not%%20found\"> wikipedialibrary@wikimedia.org</"
-"a> ra ma rê e-poste bırışê ya zi <a class=\"twl-links\" href=\"https://"
-"phabricator.wikimedia.org/maniphest/task/edit/form/1/?projectPHIDs=Library-"
-"Card-Platform&title=Wikipedia%%20Library%%20%(path)s%%20Not%%20found"
-"\">Phabricator</a> sera ma de irtıbat kewê."
+msgid "If you are certain that something should be here, please email us about this error at <a class=\"twl-links\" href=\"mailto:wikipedialibrary@wikimedia.org?Subject=Wikipedia%%20Library%%20%(path)s%%20Not%%20found\"> wikipedialibrary@wikimedia.org</a> or report it to us on <a class=\"twl-links\" href=\"https://phabricator.wikimedia.org/maniphest/task/edit/form/1/?projectPHIDs=Library-Card-Platform&title=Wikipedia%%20Library%%20%(path)s%%20Not%%20found\">Phabricator</a>"
+msgstr "Eke şıma eminê, wa tiya theba bıbo, ena xeta ma rê vacê, adresa <a class=\"twl-links\" href=\"mailto:wikipedialibrary@wikimedia.org?Subject=Wikipedia%%20Library%%20%(path)s%%20Not%%20found\"> wikipedialibrary@wikimedia.org</a> ra ma rê e-poste bırışê ya zi <a class=\"twl-links\" href=\"https://phabricator.wikimedia.org/maniphest/task/edit/form/1/?projectPHIDs=Library-Card-Platform&title=Wikipedia%%20Library%%20%(path)s%%20Not%%20found\">Phabricator</a> sera ma de irtıbat kewê."
 
 #. Translators: Alt text for an image shown on the 404 error page.
 #: TWLight/templates/404.html:32
@@ -2051,32 +1818,18 @@ msgstr ""
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:20
-msgid ""
-"This platform is our central tool for facilitating access to our available "
-"collections. Here you can see which partnerships are available, search their "
-"contents, and apply for and access the ones you’re interested in."
+msgid "This platform is our central tool for facilitating access to our available collections. Here you can see which partnerships are available, search their contents, and apply for and access the ones you’re interested in."
 msgstr ""
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/). Wikimedia Foundation should not be translated.
 #: TWLight/templates/about.html:29
-msgid ""
-"All users receive immediate access to some collections, which can be browsed "
-"by clicking the 'Access collection' buttons or using the search bar at the "
-"top of the page. Other collections require an application before access is "
-"granted, and may be accessed directly or via an individual login or access "
-"code. Volunteer coordinators, who have signed non-disclosure agreements with "
-"the Wikimedia Foundation, review these applications and work with publishers "
-"to get you your free access."
+msgid "All users receive immediate access to some collections, which can be browsed by clicking the 'Access collection' buttons or using the search bar at the top of the page. Other collections require an application before access is granted, and may be accessed directly or via an individual login or access code. Volunteer coordinators, who have signed non-disclosure agreements with the Wikimedia Foundation, review these applications and work with publishers to get you your free access."
 msgstr ""
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/). Don't translate terms_url.
 #: TWLight/templates/about.html:43
 #, python-format
-msgid ""
-"For more information about how your information is stored and reviewed "
-"please see our <a class=\"twl-links\" href=\"%(terms_url)s\"> terms of use "
-"and privacy policy</a>. Accounts you apply for are also subject to the Terms "
-"of Use provided by each partner’s platform; please review them."
+msgid "For more information about how your information is stored and reviewed please see our <a class=\"twl-links\" href=\"%(terms_url)s\"> terms of use and privacy policy</a>. Accounts you apply for are also subject to the Terms of Use provided by each partner’s platform; please review them."
 msgstr ""
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
@@ -2086,12 +1839,7 @@ msgstr ""
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/). Wikimedia Foundation should not be translated.
 #: TWLight/templates/about.html:55
-msgid ""
-"Any active editor in good standing can receive access. For publishers with "
-"limited numbers of accounts, applications are reviewed based on the editor’s "
-"needs and contributions. If you think you could use access to one of our "
-"partner resources and are an active editor in any project supported by the "
-"Wikimedia Foundation, please apply."
+msgid "Any active editor in good standing can receive access. For publishers with limited numbers of accounts, applications are reviewed based on the editor’s needs and contributions. If you think you could use access to one of our partner resources and are an active editor in any project supported by the Wikimedia Foundation, please apply."
 msgstr ""
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
@@ -2121,23 +1869,12 @@ msgstr ""
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/)
 #: TWLight/templates/about.html:89
-msgid ""
-"If you are applying for an available collection, please first check that you "
-"don't already have access through another library or institution. If you do, "
-"please consider using that access rather than taking up a seat for this "
-"resource in The Wikipedia Library."
+msgid "If you are applying for an available collection, please first check that you don't already have access through another library or institution. If you do, please consider using that access rather than taking up a seat for this resource in The Wikipedia Library."
 msgstr ""
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/)
 #: TWLight/templates/about.html:99
-msgid ""
-"If your account is blocked on one or more Wikimedia projects, you may still "
-"be granted access to The Wikipedia Library. You will need to contact the "
-"Wikipedia Library team, who will review your blocks. If you have been "
-"blocked for content issues, most notably copyright violations, or have "
-"multiple long-term blocks, we may decline your request. Additionally, if "
-"your block status changes after being approved, you will need to request "
-"another review."
+msgid "If your account is blocked on one or more Wikimedia projects, you may still be granted access to The Wikipedia Library. You will need to contact the Wikipedia Library team, who will review your blocks. If you have been blocked for content issues, most notably copyright violations, or have multiple long-term blocks, we may decline your request. Additionally, if your block status changes after being approved, you will need to request another review."
 msgstr ""
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
@@ -2172,9 +1909,7 @@ msgstr ""
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:136
-msgid ""
-"Share their account logins or passwords with others, or sell their access to "
-"other parties"
+msgid "Share their account logins or passwords with others, or sell their access to other parties"
 msgstr ""
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
@@ -2184,23 +1919,17 @@ msgstr ""
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:144
-msgid ""
-"Systematically make printed or electronic copies of multiple extracts of "
-"restricted content available for any purpose"
+msgid "Systematically make printed or electronic copies of multiple extracts of restricted content available for any purpose"
 msgstr ""
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/). Stub is a technical term for a short Wikipedia article, use the appropriate Wikipedia term in your language.
 #: TWLight/templates/about.html:148
-msgid ""
-"Datamine metadata without permission, in order, for instance, to use "
-"metadata for auto-created stub articles"
+msgid "Datamine metadata without permission, in order, for instance, to use metadata for auto-created stub articles"
 msgstr ""
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:154
-msgid ""
-"Respecting these agreements allows us to continue growing the partnerships "
-"available to the community."
+msgid "Respecting these agreements allows us to continue growing the partnerships available to the community."
 msgstr ""
 
 #. Translators: This is the heading for a section on the About page (https://wikipedialibrary.wmflabs.org/about/).
@@ -2210,41 +1939,22 @@ msgstr "EZProxy"
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:164
-msgid ""
-"EZProxy is a proxy server used to authenticate users for many Wikipedia "
-"Library partners. Users sign into EZProxy via the Library Card platform to "
-"verify that they are authorized users, and then the server accesses "
-"requested resources using its own IP address."
+msgid "EZProxy is a proxy server used to authenticate users for many Wikipedia Library partners. Users sign into EZProxy via the Library Card platform to verify that they are authorized users, and then the server accesses requested resources using its own IP address."
 msgstr ""
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:173
-msgid ""
-"You may notice that when accessing resources via EZProxy that URLs are "
-"dynamically rewritten. This is why we recommend logging in via the Library "
-"Card platform rather than going directly to the unproxied partner website. "
-"When in doubt, check the URL for ‘idm.oclc’. If it’s there, then you’re "
-"connected via EZProxy."
+msgid "You may notice that when accessing resources via EZProxy that URLs are dynamically rewritten. This is why we recommend logging in via the Library Card platform rather than going directly to the unproxied partner website. When in doubt, check the URL for ‘idm.oclc’. If it’s there, then you’re connected via EZProxy."
 msgstr ""
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:182
-msgid ""
-"Typically once you’ve logged in your session will remain active in your "
-"browser for up to two hours after you’ve finished searching. Note that use "
-"of EZProxy requires you to enable cookies. If you are having problems you "
-"should also try clearing your cache and restarting your browser."
+msgid "Typically once you’ve logged in your session will remain active in your browser for up to two hours after you’ve finished searching. Note that use of EZProxy requires you to enable cookies. If you are having problems you should also try clearing your cache and restarting your browser."
 msgstr ""
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/)
 #: TWLight/templates/about.html:193
-msgid ""
-"The Library Bundle is a collection of resources for which no application is "
-"required. If you meet the criteria laid out above, you will be authorized "
-"for access automatically upon logging in to the platform. Only some of our "
-"content is currently included in the Library Bundle, however we hope to "
-"expand the collection as more publishers become comfortable with "
-"participating. All Bundle content is accessed via EZProxy."
+msgid "The Library Bundle is a collection of resources for which no application is required. If you meet the criteria laid out above, you will be authorized for access automatically upon logging in to the platform. Only some of our content is currently included in the Library Bundle, however we hope to expand the collection as more publishers become comfortable with participating. All Bundle content is accessed via EZProxy."
 msgstr ""
 
 #. Translators: This is the heading for a section on the About page (https://wikipedialibrary.wmflabs.org/about/).
@@ -2254,12 +1964,7 @@ msgstr ""
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:206
-msgid ""
-"Citation practices vary by project and even by article. Generally, we "
-"support editors citing where they found information, in a form that allows "
-"others to check it for themselves. That often means providing both original "
-"source details as well as a link to the partner database in which the source "
-"was found."
+msgid "Citation practices vary by project and even by article. Generally, we support editors citing where they found information, in a form that allows others to check it for themselves. That often means providing both original source details as well as a link to the partner database in which the source was found."
 msgstr ""
 
 #. Translators: This is the heading for a section on the About page (https://wikipedialibrary.wmflabs.org/about/).
@@ -2271,9 +1976,7 @@ msgstr "İrtıbat"
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:218
 #, python-format
-msgid ""
-"If you have questions, need help, or want to volunteer to help, please see "
-"our <a class=\"twl-links\" href=\"%(contact_url)s\">contact page</a>."
+msgid "If you have questions, need help, or want to volunteer to help, please see our <a class=\"twl-links\" href=\"%(contact_url)s\">contact page</a>."
 msgstr ""
 
 #. Translators: This is the title of the panel box detailing the contact information for the Wikipedia Library team.
@@ -2313,9 +2016,7 @@ msgstr "Kutıbxaneyê Wikipediya Pela Twitteri"
 #. Translators: This is the text that appears at the bottom of the contact us form directing users to the suggestions form.
 #: TWLight/templates/contact.html:48
 #, python-format
-msgid ""
-"(If you would like to suggest a partner, <a class=\"twl-links\" href="
-"\"%(suggest)s\"><strong>go here</strong></a>.)"
+msgid "(If you would like to suggest a partner, <a class=\"twl-links\" href=\"%(suggest)s\"><strong>go here</strong></a>.)"
 msgstr ""
 
 #. Translators: On a special 'link to search' page, this message is shown if JavaScript is disabled.
@@ -2376,9 +2077,7 @@ msgstr "Kıtabxaneyê Wikipediya"
 #. Translators: Information about The Wikipedia Library.
 #: TWLight/templates/login_partial.html:53 TWLight/templates/new_base.html:21
 #, python-format
-msgid ""
-"More than 100 of the world's top subscription-only databases, with content "
-"in %(no_of_languages)s languages, free for Wikipedians of all backgrounds"
+msgid "More than 100 of the world's top subscription-only databases, with content in %(no_of_languages)s languages, free for Wikipedians of all backgrounds"
 msgstr ""
 
 #. Translators: Information about The Wikipedia Library.
@@ -2387,9 +2086,7 @@ msgid "Meet these criteria for automatic access"
 msgstr ""
 
 #: TWLight/templates/login_partial.html:69
-msgid ""
-"These criteria grant you access to certain collections but not all. Some "
-"collections are accessible on a per application basis only."
+msgid "These criteria grant you access to certain collections but not all. Some collections are accessible on a per application basis only."
 msgstr ""
 
 #: TWLight/templates/login_partial.html:89
@@ -2399,29 +2096,19 @@ msgstr ""
 #. Translators: Shown if the current user doesn't have a registered email on their account. Don't translate contact_us_url or email_url.
 #: TWLight/templates/message_partial.html:15
 #, python-format
-msgid ""
-"You don't have an email on file. We can't finalize your access to partner "
-"resources, and you won't be able to <a class=\"twl-links\" href="
-"\"%(contact_us_url)s\">contact us</a> without an email. Please <a class="
-"\"twl-links\" href=\"%(email_url)s\">update your email</a>."
+msgid "You don't have an email on file. We can't finalize your access to partner resources, and you won't be able to <a class=\"twl-links\" href=\"%(contact_us_url)s\">contact us</a> without an email. Please <a class=\"twl-links\" href=\"%(email_url)s\">update your email</a>."
 msgstr ""
 
 #. Translators: Shown if the current user has requested the processing of their data should be restricted.
 #: TWLight/templates/message_partial.html:26
 #, python-format
-msgid ""
-"You have requested a restriction on the processing of your data. Most site "
-"functionality will not be available to you until you <a class=\"twl-links\" "
-"href=\"%(restrict_url)s\">lift this restriction</a>."
+msgid "You have requested a restriction on the processing of your data. Most site functionality will not be available to you until you <a class=\"twl-links\" href=\"%(restrict_url)s\">lift this restriction</a>."
 msgstr ""
 
 #. Translators: Shown if the current user has not agreed to the terms of use.
 #: TWLight/templates/message_partial.html:37
 #, python-format
-msgid ""
-"You have not agreed to the <a class=\"twl-links\" href=\"%(terms_url)s"
-"\">terms of use</a> of this site. Your applications will not be processed "
-"and you won't be able to apply or access resources you are approved for."
+msgid "You have not agreed to the <a class=\"twl-links\" href=\"%(terms_url)s\">terms of use</a> of this site. Your applications will not be processed and you won't be able to apply or access resources you are approved for."
 msgstr ""
 
 #. Translators: This link is at the bottom of every page and links to the 'About' page (https://wikipedialibrary.wmflabs.org/about/)
@@ -2468,9 +2155,7 @@ msgstr ""
 
 #. Translators: If a user goes to reset their password, this message asks them to enter their email to do so.
 #: TWLight/templates/registration/password_reset_form.html:13
-msgid ""
-"Forgot your password? Enter your email address below, and we'll email "
-"instructions for setting a new one."
+msgid "Forgot your password? Enter your email address below, and we'll email instructions for setting a new one."
 msgstr ""
 
 #. Translators: This is the label for a button that users click to update their public information.
@@ -2515,16 +2200,12 @@ msgstr ""
 
 #. Translators: This text explains how to disagree to the site's terms of use and the restrictions that will come into effect when users disagree to the terms of use.
 #: TWLight/users/forms.py:185
-msgid ""
-"By unchecking this box and clicking “Update” you may explore the site, but "
-"you will not be able to apply for access to materials or evaluate "
-"applications unless you agree with the terms of use."
+msgid "By unchecking this box and clicking “Update” you may explore the site, but you will not be able to apply for access to materials or evaluate applications unless you agree with the terms of use."
 msgstr ""
 
 #. Translators: Users click this button to set their website email address to the one linked to their Wikipedia account.
 #: TWLight/users/forms.py:211
-msgid ""
-"Use my Wikipedia email address (will be updated the next time you login)."
+msgid "Use my Wikipedia email address (will be updated the next time you login)."
 msgstr ""
 
 #. Translators: This labels a button which users click to change their email.
@@ -2535,17 +2216,8 @@ msgstr "Eposta rocane ke"
 #. Translators: Shown if the current user tried to 'favorite' a partner they can't access. Do not translate '{partner}'
 #: TWLight/users/models.py:201
 #, python-brace-format
-msgid ""
-"Cannot add partner {partner} to your favorites because you don't have access "
-"to it"
+msgid "Cannot add partner {partner} to your favorites because you don't have access to it"
 msgstr ""
-
-#. Translators: Do not translate.
-#: TWLight/users/models.py:869
-#, fuzzy, python-brace-format
-#| msgid "Username"
-msgid "{wp_username}"
-msgstr "Nameyê karberi"
 
 #. Translators: This error message is shown when there's a problem with the authenticated login process.
 #: TWLight/users/oauth.py:243
@@ -2565,9 +2237,7 @@ msgstr ""
 
 #. Translators: this message is displayed to users that don't have accounts and clicked on a proxied link.
 #: TWLight/users/oauth.py:388
-msgid ""
-"To view this link you need to be an eligible library user. Please login to "
-"continue."
+msgid "To view this link you need to be an eligible library user. Please login to continue."
 msgstr ""
 
 #. Translators: This warning message is shown to users when the response received from Wikimedia OAuth servers is not a valid one.
@@ -2604,17 +2274,12 @@ msgstr "Zanışiya Karberi"
 
 #. Translators: If the user tries to log in, but their account does not meet certain requirements, they cannot login.
 #: TWLight/users/oauth.py:528
-msgid ""
-"Your Wikipedia account does not meet the eligibility criteria in the terms "
-"of use, so your Wikipedia Library Card Platform account cannot be activated."
+msgid "Your Wikipedia account does not meet the eligibility criteria in the terms of use, so your Wikipedia Library Card Platform account cannot be activated."
 msgstr ""
 
 #. Translators: If the user tries to log in, but their account does not meet certain requirements, they cannot login.
 #: TWLight/users/oauth.py:536
-msgid ""
-"Your Wikipedia account no longer meets the eligibility criteria in the terms "
-"of use, so you cannot be logged in. If you think you should be able to log "
-"in, please email wikipedialibrary@wikimedia.org."
+msgid "Your Wikipedia account no longer meets the eligibility criteria in the terms of use, so you cannot be logged in. If you think you should be able to log in, please email wikipedialibrary@wikimedia.org."
 msgstr ""
 
 #. Translators: this message is displayed to users with brand new accounts.
@@ -2625,10 +2290,7 @@ msgstr ""
 #. Translators: This message is displayed on the confirmation page where users can return their access to partner collections.
 #: TWLight/users/templates/users/authorization_confirm_return.html:13
 #, python-format
-msgid ""
-"You will no longer be able to access <b>%(partner)s's</b> resources via the "
-"Library Card platform, but can request access again by clicking 'renew', if "
-"you change your mind. Are you sure you want to return your access?"
+msgid "You will no longer be able to access <b>%(partner)s's</b> resources via the Library Card platform, but can request access again by clicking 'renew', if you change your mind. Are you sure you want to return your access?"
 msgstr ""
 
 #. Translators: On the MyLibrary page (https://wikipedialibrary.wmflabs.org/users/my_library), this tab shows all favorite collections a user has.
@@ -2701,10 +2363,7 @@ msgstr "Datay Editori"
 
 #. Translators: This is shown on editor profiles, in their profile page or on applications.
 #: TWLight/users/templates/users/editor_detail.html:59
-msgid ""
-"Information with an * was retrieved from Wikipedia directly. Other "
-"information was entered directly by users or site admins, in their preferred "
-"language."
+msgid "Information with an * was retrieved from Wikipedia directly. Other information was entered directly by users or site admins, in their preferred language."
 msgstr ""
 
 #. Translators: This distinguishes users who have been flagged as account coordinators. Don't translate username.
@@ -2715,10 +2374,7 @@ msgstr ""
 
 #. Translators: This is shown on editor profiles, under the heading for Wikipedia editor data.
 #: TWLight/users/templates/users/editor_detail_data.html:5
-msgid ""
-"This information is updated automatically from your Wikimedia account each "
-"time you log in, except for the Contributions field, where you can describe "
-"your Wikimedia editing history."
+msgid "This information is updated automatically from your Wikimedia account each time you log in, except for the Contributions field, where you can describe your Wikimedia editing history."
 msgstr ""
 
 #. Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this labels the user's username.
@@ -2748,17 +2404,13 @@ msgstr "Şertê karkerdışi seninê?"
 
 #. Translators: when viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this question has a yes or no answer.
 #: TWLight/users/templates/users/editor_detail_data.html:57
-msgid ""
-"at their last login, did this user meet the criteria set forth in the terms "
-"of use?"
+msgid "at their last login, did this user meet the criteria set forth in the terms of use?"
 msgstr ""
 
 #. Translators: When viewing a user's profile in an application, this message shows if the software doesn't think that the user is eligible for access. Don't translate username.
 #: TWLight/users/templates/users/editor_detail_data.html:72
 #, python-format
-msgid ""
-"%(username)s may still be eligible for access grants at the coordinators' "
-"discretion."
+msgid "%(username)s may still be eligible for access grants at the coordinators' discretion."
 msgstr ""
 
 #. Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this is the heading for a Yes/No ToU question.
@@ -2793,10 +2445,7 @@ msgstr ""
 #. Translators: This message is shown on a user's profile if their Wikimedia account is blocked on one or more projects. They may still be granted access to the Library Bundle, but need to contact Wikipedia Library staff to verify.
 #: TWLight/users/templates/users/editor_detail_data.html:137
 #, python-format
-msgid ""
-"It looks like you have an active block on your account. If you meet the "
-"other criteria you may still be permitted access to the library - please <a "
-"class=\"twl-links\" href=\"%(contact_url)s\">contact us</a>."
+msgid "It looks like you have an active block on your account. If you meet the other criteria you may still be permitted access to the library - please <a class=\"twl-links\" href=\"%(contact_url)s\">contact us</a>."
 msgstr ""
 
 #. Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this is the heading for a Yes/No program eligibility question.
@@ -2806,10 +2455,7 @@ msgstr "Seba paket hewle?"
 
 #. Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this question has a Yes or No answer.
 #: TWLight/users/templates/users/editor_detail_data.html:156
-msgid ""
-"At their last login, did this user meet the criteria set forth in the "
-"Library Bundle? Note that satisfying terms of use is a prerequisite to "
-"bundle eligibility."
+msgid "At their last login, did this user meet the criteria set forth in the Library Bundle? Note that satisfying terms of use is a prerequisite to bundle eligibility."
 msgstr ""
 
 #. Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this is the heading for a Yes/No program eligibility question.
@@ -2854,18 +2500,13 @@ msgstr ""
 
 #. Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this text is in the 'Personal data' section. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/users/templates/users/editor_detail_data.html:262
-msgid ""
-"The following information is visible only to you, site administrators, "
-"publishing partners (where required), and volunteer Wikipedia Library "
-"coordinators (who have signed a Non-Disclosure Agreement)."
+msgid "The following information is visible only to you, site administrators, publishing partners (where required), and volunteer Wikipedia Library coordinators (who have signed a Non-Disclosure Agreement)."
 msgstr ""
 
 #. Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this labels a button which users can click to update or remove their personal information. Don't translate update_url.
 #: TWLight/users/templates/users/editor_detail_data.html:272
 #, python-format
-msgid ""
-"You may <a class=\"twl-links\" href=\"%(update_url)s\">update or delete</a> "
-"your data at any time."
+msgid "You may <a class=\"twl-links\" href=\"%(update_url)s\">update or delete</a> your data at any time."
 msgstr ""
 
 #. Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this labels the user's email. Don't remove the *.
@@ -2885,24 +2526,18 @@ msgstr "Gıreyo enstituyal"
 
 #. Translators: This message tells users that they are not eligible to access The Wikipedia Library content.
 #: TWLight/users/templates/users/eligibility_modal.html:7
-msgid ""
-"Sorry, your Wikipedia account doesn’t currently qualify to access The "
-"Wikipedia Library."
+msgid "Sorry, your Wikipedia account doesn’t currently qualify to access The Wikipedia Library."
 msgstr ""
 
 #. Translators: This message tells users that they have not agreed to the terms of use, therefore are ineligible to access the content in The Wikipedia Library.
 #: TWLight/users/templates/users/eligibility_modal.html:30
 #, python-format
-msgid ""
-"Agreed with <a href=\"%(terms)s\" class=\"text-danger\"> terms of use </a>"
+msgid "Agreed with <a href=\"%(terms)s\" class=\"text-danger\"> terms of use </a>"
 msgstr ""
 
 #: TWLight/users/templates/users/eligibility_modal.html:40
 #, python-format
-msgid ""
-"It looks like you have an active block on your account. If you meet the "
-"other criteria you may still be permitted access to the library - please <a "
-"href=\"%(contact_url)s\">contact us</a>."
+msgid "It looks like you have an active block on your account. If you meet the other criteria you may still be permitted access to the library - please <a href=\"%(contact_url)s\">contact us</a>."
 msgstr ""
 
 #. Translators: Instructions to refresh a user's data.
@@ -2942,10 +2577,7 @@ msgstr "Zıwani eyar ke"
 
 #. Translators: This text on the user page helps users naviage to the TranslateWiki Wikipedia Library Card platform translation page.
 #: TWLight/users/templates/users/language_form.html:31
-msgid ""
-"You can help translate the tool at <a class=\"twl-links\" href=\"https://"
-"translatewiki.net/wiki/Translating:Wikipedia_Library_Card_Platform"
-"\">translatewiki.net</a>."
+msgid "You can help translate the tool at <a class=\"twl-links\" href=\"https://translatewiki.net/wiki/Translating:Wikipedia_Library_Card_Platform\">translatewiki.net</a>."
 msgstr ""
 
 #. Translators: When the user starts a new application and submits the application, the user can view the application and withdraw if need be. This changes the label for the Withdraw button.
@@ -2965,9 +2597,7 @@ msgstr "Waştışê newekerdışi"
 
 #. Translators: On the page listing applications, this text explains a user they cannot renew their application since they've already requested a renewal or there aren't any renewals available.
 #: TWLight/users/templates/users/my_applications.html:79
-msgid ""
-"Renewals are either not required, not available right now, or you have "
-"already requested a renewal."
+msgid "Renewals are either not required, not available right now, or you have already requested a renewal."
 msgstr ""
 
 #. Translators: This text is the heading of a section in a user's profile where they can change their preferences.
@@ -3031,19 +2661,12 @@ msgstr ""
 
 #. Translators: This message is displayed on the page where users can request we stop processing their data.
 #: TWLight/users/templates/users/restrict_data.html:15
-msgid ""
-"Checking this box and clicking “Restrict” will pause all processing of the "
-"data you have entered into this website. You will not be able to apply for "
-"access to resources, your applications will not be further processed, and "
-"none of your data will be altered, until you return to this page and uncheck "
-"the box. This is not the same as deleting your data."
+msgid "Checking this box and clicking “Restrict” will pause all processing of the data you have entered into this website. You will not be able to apply for access to resources, your applications will not be further processed, and none of your data will be altered, until you return to this page and uncheck the box. This is not the same as deleting your data."
 msgstr ""
 
 #. Translators: This warning message is shown to coordinators who view the data restriction page.
 #: TWLight/users/templates/users/restrict_data.html:26
-msgid ""
-"You are a coordinator on this site. If you restrict the processing of your "
-"data, your coordinator flag will be removed."
+msgid "You are a coordinator on this site. If you restrict the processing of your data, your coordinator flag will be removed."
 msgstr ""
 
 #. Translators: use the date *when you are translating*, in a language-appropriate format.
@@ -3063,24 +2686,12 @@ msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:51
-msgid ""
-"<a class=\"twl-links\" href=\"https://meta.wikimedia.org/wiki/"
-"The_Wikipedia_Library\"> The Wikipedia Library </a> has partnered with "
-"publishers around the world to allow users to access otherwise paywalled "
-"resources. This website allows Wikipedia editors to search and access these "
-"resources."
+msgid "<a class=\"twl-links\" href=\"https://meta.wikimedia.org/wiki/The_Wikipedia_Library\"> The Wikipedia Library </a> has partnered with publishers around the world to allow users to access otherwise paywalled resources. This website allows Wikipedia editors to search and access these resources."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Wikimedia Foundation should not be translated. WMF should not be translated. Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:63
-msgid ""
-"This program is administered by the Wikimedia Foundation (WMF). These terms "
-"of use and privacy notice pertain to your application for access to "
-"resources through the Wikipedia Library, your use of this website, and your "
-"access to and use of those resources. They also describe our handling of the "
-"information you provide to us in order to create and administer your "
-"Wikipedia Library account. If we make material changes to the terms, we will "
-"notify users."
+msgid "This program is administered by the Wikimedia Foundation (WMF). These terms of use and privacy notice pertain to your application for access to resources through the Wikipedia Library, your use of this website, and your access to and use of those resources. They also describe our handling of the information you provide to us in order to create and administer your Wikipedia Library account. If we make material changes to the terms, we will notify users."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
@@ -3090,37 +2701,17 @@ msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:78
-msgid ""
-"Access to resources via The Wikipedia Library is reserved for community "
-"members who have demonstrated their commitment to the Wikimedia projects, "
-"and who will use their access to these resources to improve project content. "
-"To that end, in order to be eligible for The Wikipedia Library, we require "
-"that you be registered for a user account on the projects, with at least 500 "
-"edits, six (6) months of activity, and 10+ edits in the last month. We ask "
-"that you do not request access to any publishers with a limited number of "
-"available accounts whose resources you can already access for free through "
-"your local library or university, or another institution or organization, in "
-"order to provide that opportunity to others."
+msgid "Access to resources via The Wikipedia Library is reserved for community members who have demonstrated their commitment to the Wikimedia projects, and who will use their access to these resources to improve project content. To that end, in order to be eligible for The Wikipedia Library, we require that you be registered for a user account on the projects, with at least 500 edits, six (6) months of activity, and 10+ edits in the last month. We ask that you do not request access to any publishers with a limited number of available accounts whose resources you can already access for free through your local library or university, or another institution or organization, in order to provide that opportunity to others."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:94
-msgid ""
-"Additionally, if you are currently blocked or banned from a Wikimedia "
-"project, applications to resources may be rejected or restricted. If you "
-"obtain a Wikipedia Library account, but a block or ban is subsequently "
-"instituted against you on one of the projects, you may lose access to your "
-"Wikipedia Library account."
+msgid "Additionally, if you are currently blocked or banned from a Wikimedia project, applications to resources may be rejected or restricted. If you obtain a Wikipedia Library account, but a block or ban is subsequently instituted against you on one of the projects, you may lose access to your Wikipedia Library account."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:104
-msgid ""
-"Your eligibility to access The Wikipedia Library is assessed at each login. "
-"While more than half of the library's content is provided via this automated "
-"eligibility check, access to other publisher's content may be time limited, "
-"typically lapsing after one year, after which you will usually need to apply "
-"for renewal."
+msgid "Your eligibility to access The Wikipedia Library is assessed at each login. While more than half of the library's content is provided via this automated eligibility check, access to other publisher's content may be time limited, typically lapsing after one year, after which you will usually need to apply for renewal."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
@@ -3130,47 +2721,27 @@ msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:118
-msgid ""
-"In order to apply for access to a partner resource, you must provide us with "
-"certain information, which we will use to evaluate your application. If your "
-"application is approved, we may transfer the information you have given us "
-"to the publishers whose resources you wish to access. They will either "
-"contact you with the account information directly or we will send access "
-"information to you ourselves."
+msgid "In order to apply for access to a partner resource, you must provide us with certain information, which we will use to evaluate your application. If your application is approved, we may transfer the information you have given us to the publishers whose resources you wish to access. They will either contact you with the account information directly or we will send access information to you ourselves."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:130
-msgid ""
-"In addition to the basic information you provide to us, our system will "
-"retrieve some information directly from the Wikimedia projects: your "
-"username, email address, edit count, registration date, user ID number, "
-"groups to which you belong, and any special user rights."
+msgid "In addition to the basic information you provide to us, our system will retrieve some information directly from the Wikimedia projects: your username, email address, edit count, registration date, user ID number, groups to which you belong, and any special user rights."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:140
-msgid ""
-"Each time you log in to the Wikipedia Library Card Platform, this "
-"information will be automatically updated."
+msgid "Each time you log in to the Wikipedia Library Card Platform, this information will be automatically updated."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:148
-msgid ""
-"We will ask you to provide us with some information about your history of "
-"contributions to the Wikimedia projects. Information on contribution history "
-"is optional, but will greatly assist us in evaluating your application."
+msgid "We will ask you to provide us with some information about your history of contributions to the Wikimedia projects. Information on contribution history is optional, but will greatly assist us in evaluating your application."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). WMF should not be translated. Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:157
-msgid ""
-"The information you provide when creating your account will be visible to "
-"you while on the site but not to others unless they are approved Wikipedia "
-"Library Coordinators, WMF Staff, or WMF Contractors who need access to this "
-"data in order to carry out their work with the Wikipedia Library, all of "
-"whom are subject to non-disclosure obligations."
+msgid "The information you provide when creating your account will be visible to you while on the site but not to others unless they are approved Wikipedia Library Coordinators, WMF Staff, or WMF Contractors who need access to this data in order to carry out their work with the Wikipedia Library, all of whom are subject to non-disclosure obligations."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
@@ -3180,46 +2751,32 @@ msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:171
-msgid ""
-"In order to access an individual publisher’s resources, you must agree to "
-"that publisher’s terms of use and privacy policy. You agree that you will "
-"not violate such terms and policies in connection with your use of the "
-"Wikipedia Library. Additionally, the following activities are prohibited "
-"while accessing publisher resources through the Wikipedia Library."
+msgid "In order to access an individual publisher’s resources, you must agree to that publisher’s terms of use and privacy policy. You agree that you will not violate such terms and policies in connection with your use of the Wikipedia Library. Additionally, the following activities are prohibited while accessing publisher resources through the Wikipedia Library."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:184
-msgid ""
-"Sharing your Wikipedia account, usernames, passwords, or any access codes "
-"for publisher resources with others;"
+msgid "Sharing your Wikipedia account, usernames, passwords, or any access codes for publisher resources with others;"
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:191
-msgid ""
-"Automatically scraping or downloading restricted content from publishers;"
+msgid "Automatically scraping or downloading restricted content from publishers;"
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:197
-msgid ""
-"Systematically making printed or electronic copies of multiple extracts of "
-"restricted content available for any purpose;"
+msgid "Systematically making printed or electronic copies of multiple extracts of restricted content available for any purpose;"
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:204
-msgid ""
-"Data mining metadata without permission—for example, in order to use "
-"metadata for auto-created stub articles;"
+msgid "Data mining metadata without permission—for example, in order to use metadata for auto-created stub articles;"
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:211
-msgid ""
-"Using the access you receive through the Wikipedia Library for profit by "
-"selling access to your account or resources which you have through it."
+msgid "Using the access you receive through the Wikipedia Library for profit by selling access to your account or resources which you have through it."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
@@ -3229,18 +2786,12 @@ msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:224
-msgid ""
-"Certain resources may only be accessed using an external search service, "
-"such as the EBSCO Discovery Service, or a proxy service, such as OCLC "
-"EZProxy. If you use such external search and/or proxy services, please "
-"review the applicable terms of use and privacy policies."
+msgid "Certain resources may only be accessed using an external search service, such as the EBSCO Discovery Service, or a proxy service, such as OCLC EZProxy. If you use such external search and/or proxy services, please review the applicable terms of use and privacy policies."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:234
-msgid ""
-"In addition, if you use OCLC EZProxy, please note that you may not use it "
-"for commercial purposes."
+msgid "In addition, if you use OCLC EZProxy, please note that you may not use it for commercial purposes."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
@@ -3250,120 +2801,49 @@ msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Wikimedia Foundation should not be translated. Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:245
-msgid ""
-"The Wikimedia Foundation and our service providers use your information for "
-"the legitimate purpose of providing Wikipedia Library services in support of "
-"our charitable mission. When you apply for a Wikipedia Library account, or "
-"use your Wikipedia Library account, we may routinely collect the following "
-"information: your username, email address, edit count, registration date, "
-"user ID number, groups to which you belong, and any special user rights; "
-"your name, country of residence, and/or affiliation, if required by a "
-"partner to which you are applying; your narrative description of your "
-"contributions and reasons for applying for access to partner resources; and "
-"the date you agree to these terms of use."
+msgid "The Wikimedia Foundation and our service providers use your information for the legitimate purpose of providing Wikipedia Library services in support of our charitable mission. When you apply for a Wikipedia Library account, or use your Wikipedia Library account, we may routinely collect the following information: your username, email address, edit count, registration date, user ID number, groups to which you belong, and any special user rights; your name, country of residence, and/or affiliation, if required by a partner to which you are applying; your narrative description of your contributions and reasons for applying for access to partner resources; and the date you agree to these terms of use."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:262
 #, python-format
-msgid ""
-"Each publisher who is a member of the Wikipedia Library program requires "
-"different specific information in the application. Some publishers may "
-"request only an email address, while others request more detailed data, such "
-"as your name, location, or institutional affiliation. When you complete your "
-"application, you will only be asked to supply information required by the "
-"publishers you have chosen, and each publisher will only receive the "
-"information they require for providing you with access. Please see our <a "
-"class=\"twl-links\" href=\"%(all_partners_url)s\">partner information</a> "
-"pages to learn what information is required by each publisher to gain access "
-"to their resources."
+msgid "Each publisher who is a member of the Wikipedia Library program requires different specific information in the application. Some publishers may request only an email address, while others request more detailed data, such as your name, location, or institutional affiliation. When you complete your application, you will only be asked to supply information required by the publishers you have chosen, and each publisher will only receive the information they require for providing you with access. Please see our <a class=\"twl-links\" href=\"%(all_partners_url)s\">partner information</a> pages to learn what information is required by each publisher to gain access to their resources."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Wikimedia Foundation should not be translated. Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:277
-msgid ""
-"Some Wikipedia Library pages are visible without logging in, but you will "
-"need to log in to apply or access proprietary partner resources. We use the "
-"data provided by you via OAuth and Wikimedia API calls to assess your "
-"application for access and to process approved requests."
+msgid "Some Wikipedia Library pages are visible without logging in, but you will need to log in to apply or access proprietary partner resources. We use the data provided by you via OAuth and Wikimedia API calls to assess your application for access and to process approved requests."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:288
 #, python-format
-msgid ""
-"In order to administer the Wikipedia Library program, we will retain the "
-"application data we collect from you for three years after your most recent "
-"login, unless you delete your account, as described below. You can log in "
-"and go to <a class=\"twl-links\" href=\"%(profile_url)s\">your profile page</"
-"a> in order to see the information associated with your account, and can "
-"download it in JSON format. You may access, update, restrict, or delete this "
-"information at any time, except for the information that is automatically "
-"retrieved from the projects. If you have any questions or concerns about the "
-"handling of your data, please contact <a class=\"twl-links\" href=\"mailto:"
-"wikipedialibrary@wikimedia.org?Subject=Wikipedia%%20Library%%20Card"
-"%%20account%%20deactivation\"> wikipedialibrary@wikimedia.org </a>."
+msgid "In order to administer the Wikipedia Library program, we will retain the application data we collect from you for three years after your most recent login, unless you delete your account, as described below. You can log in and go to <a class=\"twl-links\" href=\"%(profile_url)s\">your profile page</a> in order to see the information associated with your account, and can download it in JSON format. You may access, update, restrict, or delete this information at any time, except for the information that is automatically retrieved from the projects. If you have any questions or concerns about the handling of your data, please contact <a class=\"twl-links\" href=\"mailto:wikipedialibrary@wikimedia.org?Subject=Wikipedia%%20Library%%20Card%%20account%%20deactivation\"> wikipedialibrary@wikimedia.org </a>."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:305
-msgid ""
-"If you decide to disable your Wikipedia Library account, you can use the "
-"delete button on your profile to delete certain personal information "
-"associated with your account. We will delete your real name, institutional "
-"affiliation, and country of residence. Please note that the system will "
-"retain a record of your username, the publishers to which you applied or had "
-"access, and the dates of that access. Note that deletion is not reversible. "
-"Deletion of your Wikipedia Library account may also correspond with the "
-"removal of any resource access to which you were eligible or approved. If "
-"you request the deletion of account information and later wish to apply for "
-"a new account, you will need to provide the necessary information again."
+msgid "If you decide to disable your Wikipedia Library account, you can use the delete button on your profile to delete certain personal information associated with your account. We will delete your real name, institutional affiliation, and country of residence. Please note that the system will retain a record of your username, the publishers to which you applied or had access, and the dates of that access. Note that deletion is not reversible. Deletion of your Wikipedia Library account may also correspond with the removal of any resource access to which you were eligible or approved. If you request the deletion of account information and later wish to apply for a new account, you will need to provide the necessary information again."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). WMF should not be translated. Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:321
-msgid ""
-"The Wikipedia Library is run by WMF Staff, Contractors, and approved "
-"volunteer Coordinators. The data associated with your account will be shared "
-"with the WMF staff, contractors, service providers, and volunteer "
-"coordinators who need to process the information in connection with their "
-"work for the Wikipedia Library, and who are subject to confidentiality "
-"obligations. We will also use your data for internal Wikipedia Library "
-"purposes such as distributing user surveys and account notifications, and in "
-"a depersonalized or aggregated fashion for statistical analysis and "
-"administration. Finally, we will share your information with the publishers "
-"whom you specifically select in order to provide you with access to "
-"resources. Otherwise, your information will not be shared with third "
-"parties, with the exception of the circumstances described below."
+msgid "The Wikipedia Library is run by WMF Staff, Contractors, and approved volunteer Coordinators. The data associated with your account will be shared with the WMF staff, contractors, service providers, and volunteer coordinators who need to process the information in connection with their work for the Wikipedia Library, and who are subject to confidentiality obligations. We will also use your data for internal Wikipedia Library purposes such as distributing user surveys and account notifications, and in a depersonalized or aggregated fashion for statistical analysis and administration. Finally, we will share your information with the publishers whom you specifically select in order to provide you with access to resources. Otherwise, your information will not be shared with third parties, with the exception of the circumstances described below."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). WMF should not be translated.
 #: TWLight/users/templates/users/terms.html:338
-msgid ""
-"We may disclose any collected information when required by law, when we have "
-"your permission, when needed to protect our rights, privacy, safety, users, "
-"or the general public, and when necessary to enforce these terms, WMF’s "
-"general <a class=\"twl-links\" href=\"https://foundation.wikimedia.org/wiki/"
-"Terms_of_Use\">Terms of Use</a>, or any other WMF policy."
+msgid "We may disclose any collected information when required by law, when we have your permission, when needed to protect our rights, privacy, safety, users, or the general public, and when necessary to enforce these terms, WMF’s general <a class=\"twl-links\" href=\"https://foundation.wikimedia.org/wiki/Terms_of_Use\">Terms of Use</a>, or any other WMF policy."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:349
-msgid ""
-"We take the security of your personal data seriously, and take reasonable "
-"precautions to ensure your data is protected. These precautions include "
-"access controls to limit who has access to your data and security "
-"technologies to protect data stored on the server. However, we cannot "
-"guarantee the safety of your data as it is transmitted and stored."
+msgid "We take the security of your personal data seriously, and take reasonable precautions to ensure your data is protected. These precautions include access controls to limit who has access to your data and security technologies to protect data stored on the server. However, we cannot guarantee the safety of your data as it is transmitted and stored."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:360
-msgid ""
-"Please note that these terms do not control the use and handling of your "
-"data by the publishers and service providers whose resources you access or "
-"apply to access. Please read their individual privacy policies for that "
-"information."
+msgid "Please note that these terms do not control the use and handling of your data by the publishers and service providers whose resources you access or apply to access. Please read their individual privacy policies for that information."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
@@ -3373,34 +2853,17 @@ msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Wikimedia Foundation should not be translated. Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:373
-msgid ""
-"The Wikimedia Foundation is a nonprofit organization based in San Francisco, "
-"California. The Wikipedia Library program provides access to resources held "
-"by publishers in multiple countries. If you apply for a Wikipedia Library "
-"account (whether you are inside or outside of the United States), you "
-"understand that your personal data will be collected, transferred, stored, "
-"processed, disclosed and otherwise used in the U.S. as described in this "
-"privacy policy. You also understand that your information may be transferred "
-"by us from the U.S. to other countries, which may have different or less "
-"stringent data protection laws than your country, in connection with "
-"providing services to you, including evaluating your application and "
-"securing access to your chosen publishers (locations for each publisher are "
-"outlined on their respective partner information pages)."
+msgid "The Wikimedia Foundation is a nonprofit organization based in San Francisco, California. The Wikipedia Library program provides access to resources held by publishers in multiple countries. If you apply for a Wikipedia Library account (whether you are inside or outside of the United States), you understand that your personal data will be collected, transferred, stored, processed, disclosed and otherwise used in the U.S. as described in this privacy policy. You also understand that your information may be transferred by us from the U.S. to other countries, which may have different or less stringent data protection laws than your country, in connection with providing services to you, including evaluating your application and securing access to your chosen publishers (locations for each publisher are outlined on their respective partner information pages)."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:392
-msgid ""
-"Please note that in the event of any differences in meaning or "
-"interpretation between the original English version of these terms and a "
-"translation, the original English version takes precedence."
+msgid "Please note that in the event of any differences in meaning or interpretation between the original English version of these terms and a translation, the original English version takes precedence."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Wikimedia Foundation should not be translated.
 #: TWLight/users/templates/users/terms.html:403
-msgid ""
-"See also the <a class=\"twl-links\" href=\"https://wikimediafoundation.org/"
-"wiki/Privacy_policy\">Wikimedia Foundation Privacy Policy</a>."
+msgid "See also the <a class=\"twl-links\" href=\"https://wikimediafoundation.org/wiki/Privacy_policy\">Wikimedia Foundation Privacy Policy</a>."
 msgstr ""
 
 #. Translators: This is the second to last line of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
@@ -3420,11 +2883,7 @@ msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:426
-msgid ""
-"By checking this box and clicking “Submit”, you agree that you have read the "
-"above terms and that you will adhere to the terms of use in your application "
-"to and use of the The Wikipedia Library, and the publishers’ services to "
-"which you gain access through The Wikipedia Library program."
+msgid "By checking this box and clicking “Submit”, you agree that you have read the above terms and that you will adhere to the terms of use in your application to and use of the The Wikipedia Library, and the publishers’ services to which you gain access through The Wikipedia Library program."
 msgstr ""
 
 #: TWLight/users/templates/users/user_collection_tile.html:32
@@ -3479,29 +2938,18 @@ msgstr ""
 
 #. Translators: This message is displayed on the page where users can request the deletion of their data.
 #: TWLight/users/templates/users/user_confirm_delete.html:17
-msgid ""
-"<b>Warning:</b> Performing this action will delete your Wikipedia Library "
-"Card user account and all associated applications. This process is not "
-"reversible. You may lose any partner accounts you were granted, and will not "
-"be able to renew those accounts or apply for new ones."
+msgid "<b>Warning:</b> Performing this action will delete your Wikipedia Library Card user account and all associated applications. This process is not reversible. You may lose any partner accounts you were granted, and will not be able to renew those accounts or apply for new ones."
 msgstr ""
 
 #. Translators: this should show up for people who log in with a username/password and not OAuth, so we don't know what their Wikipedia identity is.
-#.
 #: TWLight/users/templates/users/user_detail.html:12
 #, python-format
-msgid ""
-"Hi, %(username)s! You don't have a Wikipedia editor profile attached to your "
-"account here, so you are probably a site administrator."
+msgid "Hi, %(username)s! You don't have a Wikipedia editor profile attached to your account here, so you are probably a site administrator."
 msgstr ""
 
 #. Translators: In the unlikely scenario that someone is able to register an account without using OAuth (thus leaving us without some of the information required for applications), users will see this message, encouraging them to re-register.
 #: TWLight/users/templates/users/user_detail.html:20
-msgid ""
-"If you aren't a site administrator, something weird has happened. You won't "
-"be able to apply for access without a Wikipedia editor profile. You should "
-"log out and create a new account by logging in via OAuth, or contact a site "
-"administrator for help."
+msgid "If you aren't a site administrator, something weird has happened. You won't be able to apply for access without a Wikipedia editor profile. You should log out and create a new account by logging in via OAuth, or contact a site administrator for help."
 msgstr ""
 
 #. Translators: Labels a sections where coordinators can select their email preferences.
@@ -3512,17 +2960,12 @@ msgstr ""
 #. Translators: This message is shown on user's own profile page, encouraging them to make sure their information is up to date, so that account coordinators can use the information to judge applications.
 #: TWLight/users/views.py:176
 #, python-brace-format
-msgid ""
-"Please <a class='twl-links' href='{url}'>update your contributions</a> to "
-"Wikipedia to help coordinators evaluate your applications."
+msgid "Please <a class='twl-links' href='{url}'>update your contributions</a> to Wikipedia to help coordinators evaluate your applications."
 msgstr ""
 
 #. Translators: Coordinators are shown this message when they unselect all three types of reminder email options under preferences.
 #: TWLight/users/views.py:288
-msgid ""
-"You have chosen not to receive reminder emails. As a coordinator, you should "
-"receive at least one type of reminder emails, so consider changing your "
-"preferences."
+msgid "You have chosen not to receive reminder emails. As a coordinator, you should receive at least one type of reminder emails, so consider changing your preferences."
 msgstr ""
 
 #. Translators: Coordinators are shown this message when they make changes to their reminder email options under preferences.
@@ -3556,9 +2999,7 @@ msgstr ""
 
 #. Translators: If the user has not filled out their email, they can browse the website but cannot apply for access to resources.
 #: TWLight/users/views.py:487
-msgid ""
-"Your email is blank. You can still explore the site, but you won't be able "
-"to apply for access to partner resources without an email."
+msgid "Your email is blank. You can still explore the site, but you won't be able to apply for access to partner resources without an email."
 msgstr ""
 
 #. Translators: This message is shown once the access to a partner has successfully been returned.
@@ -3591,31 +3032,3 @@ msgstr ""
 msgid "10+ edits in the last 30 days"
 msgstr ""
 
-#: tests/shunit/data/bad_i18n_comment_1.py:3
-#: tests/shunit/data/bad_i18n_newline_1.py:5
-msgid "1"
-msgstr ""
-
-#. Translators: Lorem ipsum dolor sit amet, consectetur adipiscing elit. Mauris vitae ipsum ut purus faucibus pretium. Proin tempus neque et aliquet consectetur. Ut egestas sapien in consectetur sagittis. Mauris neque lacus, dapibus non viverra vitae, interdum ut aenean ipsum.
-#. Translators: Lorem ipsum dolor sit amet, consectetur adipiscing elit. Mauris vitae ipsum ut purus faucibus pretium. Proin tempus neque et aliquet consectetur. Ut egestas sapien in consectetur sagittis. Mauris neque lacus, dapibus non.
-#: tests/shunit/data/bad_i18n_comment_2.py:4
-#: tests/shunit/data/bad_i18n_newline_2.py:5 tests/shunit/data/good_i18n_1.py:2
-#: tests/shunit/data/good_i18n_2.py:2
-msgid "2"
-msgstr ""
-
-#: tests/shunit/data/bad_i18n_newline_3.py:5
-msgid "3"
-msgstr ""
-
-#: tests/shunit/data/bad_i18n_newline_4.py:5
-msgid "4"
-msgstr ""
-
-#: tests/shunit/data/bad_i18n_newline_5.py:5
-msgid "5"
-msgstr ""
-
-#: tests/shunit/data/bad_i18n_newline_6.py:5
-msgid "6"
-msgstr ""

--- a/locale/en/partner_descriptions.json
+++ b/locale/en/partner_descriptions.json
@@ -116,7 +116,7 @@
 	"132_short_description": "<strong>SAGE Journals</strong> SAGE is an American independent publisher with more than 1,000 journals, from a wide range of disciplines.",
 	"133_short_description": "<strong>Edward Elgar</strong> is an independent academic and professional publisher with a strong focus on law, business and the social sciences.",
 	"134_short_description": "<strong>E-Yearbook</strong> is one of the largest online collections of scanned historical US high school, military, college and university yearbooks.<br/><strong>Note</strong>: the site's terms of use do not allow images to be re-uploaded.",
-	"135_short_description": "<strong>The Corriere della Sera</strong> is an Italian daily newspaper published in Milan. It is one of Italy's oldest and most read newspapers.",
+	"135_short_description": "<strong>The Corriere della Sera</strong> is an Italian daily newspaper published in Milan. It is one of Italy's oldest and most read newspapers. The Corriere della Sera Archives provides access to a century of historical archives.",
 	"136_short_description": "<strong>The Corriere della Sera Archives</strong> provides access to a century of historical archives from Corriere della Sera, one of Italy's oldest and most read newspapers.",
 	"137_short_description": "<strong>Wikilala</strong> is a digital repository consisting of more than 109,000 documents in printed form, including 45,000 newspapers, 32,000 journals, 4,000 books and 26,000 articles concerning the history of the Ottoman Empire from its founding to the modern times.",
 	"138_short_description": "<strong>The British Newspaper Archive</strong> provides access to searchable digitized archives of British and Irish newspapers.",

--- a/locale/en_Gb/LC_MESSAGES/django.po
+++ b/locale/en_Gb/LC_MESSAGES/django.po
@@ -18,10 +18,11 @@
 # Author: Valentine Badu
 msgid ""
 msgstr ""
+""
 "Project-Id-Version: Wikipedia Library Card Platform - Website\n"
-"Report-Msgid-Bugs-To: wikipedialibrary@wikimedia.org\n"
+"Report-Msgid-Bugs-To: translatewiki.net\n"
 "POT-Creation-Date: 2024-07-11 20:54+0000\n"
-"PO-Revision-Date: 2024-07-11 12:30:14+0000\n"
+"PO-Revision-Date: 2024-07-15 12:29:14+0000\n"
 "Language: en_gb\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
@@ -53,12 +54,8 @@ msgstr "About you"
 #. Translators: This note appears in a section of a form where we ask users to enter info (like country of residence) when applying for resource access.
 #: TWLight/applications/forms.py:179
 #, python-brace-format
-msgid ""
-"<p><small><i>Your personal data will be processed according to our <a "
-"class='twl-links' href='{terms_url}'> privacy policy</a>.</i></small></p>"
-msgstr ""
-"<p><small><i>Your personal data will be processed according to our <a "
-"class='twl-links' href='{terms_url}'>privacy policy</a>.</i></small></p>"
+msgid "<p><small><i>Your personal data will be processed according to our <a class='twl-links' href='{terms_url}'> privacy policy</a>.</i></small></p>"
+msgstr "<p><small><i>Your personal data will be processed according to our <a class='twl-links' href='{terms_url}'>privacy policy</a>.</i></small></p>"
 
 #. Translators: This is the title of the application form page, where users enter information required for the application. It lets the user know which partner application they are entering data for. {partner}
 #: TWLight/applications/forms.py:189
@@ -70,9 +67,7 @@ msgstr "Your application to {partner}"
 #: TWLight/applications/forms.py:220
 #, python-brace-format
 msgid "You must register at {url} before applying."
-msgstr ""
-"Jy moet registreer by <a href=\"{url}\">{url}</a> voordat jy kan aansoek "
-"doen."
+msgstr "Jy moet registreer by <a href=\"{url}\">{url}</a> voordat jy kan aansoek doen."
 
 #. Translators: Label of the field where coordinators can enter the username of a user
 #. Translators: This labels the column description that lists the name of the applicants.
@@ -101,12 +96,8 @@ msgstr "The email for your account on the partner's website"
 #. Translators: This labels a choice field where users will have to select the number of months they wish to have their access for as part of the application renewal confirmation.
 #. Translators: When filling out an application, users may be required to enter the length of the account (expiry) they wish to have for proxy partners.
 #: TWLight/applications/forms.py:339 TWLight/applications/helpers.py:100
-msgid ""
-"The number of months you wish to have this access for before renewal is "
-"required"
-msgstr ""
-"The number of months you wish to have this access for before renewal is "
-"required"
+msgid "The number of months you wish to have this access for before renewal is required"
+msgstr "The number of months you wish to have this access for before renewal is required"
 
 #. Translators: When filling out an application, users may need to specify their name
 #: TWLight/applications/helpers.py:81
@@ -194,12 +185,8 @@ msgstr "Email"
 
 #. Translators: This comment is added to pending applications when our terms of use change.
 #: TWLight/applications/management/commands/notify_applicants_tou_changes.py:54
-msgid ""
-"Our terms of use have changed. Your applications will not be processed until "
-"you log in and agree to our updated terms."
-msgstr ""
-"Our terms of use have changed. Your applications will not be processed until "
-"you log in and agree to our updated terms."
+msgid "Our terms of use have changed. Your applications will not be processed until you log in and agree to our updated terms."
+msgstr "Our terms of use have changed. Your applications will not be processed until you log in and agree to our updated terms."
 
 #. Translators: This is the status of an application that has not yet been reviewed.
 #: TWLight/applications/models.py:54
@@ -265,42 +252,26 @@ msgstr "Access URL: {access_url}"
 
 #. Translators: This text goes into account approval emails in the case that we need to send the user's details to a publisher for manual account setup.
 #: TWLight/applications/models.py:331
-msgid ""
-"You can expect to receive access details within a week or two once it has "
-"been processed."
-msgstr ""
-"You can expect to receive access details within a week or two once it has "
-"been processed."
+msgid "You can expect to receive access details within a week or two once it has been processed."
+msgstr "You can expect to receive access details within a week or two once it has been processed."
 
 #. Translators: This comment is added to open applications when a partner joins the Library Bundle, which does not require applications.
 #: TWLight/applications/signals.py:247
-msgid ""
-"This partner joined the Library Bundle, which does not require applications. "
-"This application will be marked as invalid."
-msgstr ""
-"This partner joined the Library Bundle, which does not require applications. "
-"This application will be marked as invalid."
+msgid "This partner joined the Library Bundle, which does not require applications. This application will be marked as invalid."
+msgstr "This partner joined the Library Bundle, which does not require applications. This application will be marked as invalid."
 
 #. Translators: This is shown to users if the application is to a partner for which we have run out of available accounts. The application is therefore on a 'waitlist', and will be reviewed when more accounts are available.
 #: TWLight/applications/templates/applications/application_evaluation.html:29
-msgid ""
-"This application is on the waitlist because this partner does not have any "
-"access grants available at this time."
-msgstr ""
-"This application is on the waitlist because this partner does not have any "
-"access grants available at this time."
+msgid "This application is on the waitlist because this partner does not have any access grants available at this time."
+msgstr "This application is on the waitlist because this partner does not have any access grants available at this time."
 
 #. Translators: This message is shown on pages where coordinators can see personal information about applicants.
 #: TWLight/applications/templates/applications/application_evaluation.html:36
 #: TWLight/applications/templates/applications/application_list_include.html:6
 #: TWLight/applications/templates/applications/send_partner.html:45
 #: TWLight/resources/templates/resources/partner_users.html:18
-msgid ""
-"Coordinators: This page may contain personal information such as real names "
-"and email addresses. Please remember that this information is confidential."
-msgstr ""
-"Coordinators: This page may contain personal information such as real names "
-"and email addresses. Please remember that this information is confidential."
+msgid "Coordinators: This page may contain personal information such as real names and email addresses. Please remember that this information is confidential."
+msgstr "Coordinators: This page may contain personal information such as real names and email addresses. Please remember that this information is confidential."
 
 #. Translators: This is the title of the application page shown to users who are a coordinator, and are able to accept or reject the application.
 #: TWLight/applications/templates/applications/application_evaluation.html:39
@@ -309,12 +280,8 @@ msgstr "Evaluate application"
 
 #. Translators: This text is shown to coordinators on application pages if the applicant has restricted processing of their data.
 #: TWLight/applications/templates/applications/application_evaluation.html:42
-msgid ""
-"This user has requested a restriction on the processing of their data, so "
-"you cannot change the status of their application."
-msgstr ""
-"This user has requested a restriction on the processing of their data, so "
-"you cannot change the status of their application."
+msgid "This user has requested a restriction on the processing of their data, so you cannot change the status of their application."
+msgstr "This user has requested a restriction on the processing of their data, so you cannot change the status of their application."
 
 #. Translators: This is the title of the application page shown to users who are not a coordinator.
 #: TWLight/applications/templates/applications/application_evaluation.html:48
@@ -387,12 +354,8 @@ msgstr "Unknown"
 
 #. Translators: This is the text displayed to coordinators when an applicant has no country of residence in their profile.
 #: TWLight/applications/templates/applications/application_evaluation.html:123
-msgid ""
-"Please request the applicant add their country of residence to their profile "
-"before proceeding further."
-msgstr ""
-"Please request the applicant add their country of residence to their profile "
-"before proceeding further."
+msgid "Please request the applicant add their country of residence to their profile before proceeding further."
+msgstr "Please request the applicant add their country of residence to their profile before proceeding further."
 
 #. Translators: This labels the section of an application showing the total number of accounts available for a partner or their collection.
 #: TWLight/applications/templates/applications/application_evaluation.html:134
@@ -403,12 +366,8 @@ msgstr "Account email"
 #. Translators: This labels the section of an application showing whether the user had agreed to the terms of use or not.
 #: TWLight/applications/templates/applications/application_evaluation.html:145
 #, python-format
-msgid ""
-"Has agreed to the site's <a class=\"twl-links\" href=\"%(terms_url)s\">terms "
-"of use</a>?"
-msgstr ""
-"Has agreed to the site's <a class=\"twl-links\" href=\"%(terms_url)s\">terms "
-"of use</a>?"
+msgid "Has agreed to the site's <a class=\"twl-links\" href=\"%(terms_url)s\">terms of use</a>?"
+msgstr "Has agreed to the site's <a class=\"twl-links\" href=\"%(terms_url)s\">terms of use</a>?"
 
 #. Translators: Displayed to coordinators when they've agreed to the terms of use.
 #. Translators: Displayed if the user has agreed to the terms of use.
@@ -443,12 +402,8 @@ msgstr "No"
 
 #. Translators: This is the text displayed to coordinators when an applicant has not agreed to the terms of use.
 #: TWLight/applications/templates/applications/application_evaluation.html:159
-msgid ""
-"Please request the applicant agree to the site's terms of use before "
-"approving this application."
-msgstr ""
-"Please request the applicant agree to the site's terms of use before "
-"approving this application."
+msgid "Please request the applicant agree to the site's terms of use before approving this application."
+msgstr "Please request the applicant agree to the site's terms of use before approving this application."
 
 #. Translators: This labels the section of an application containing the user's motivation for wanting access to this resource.
 #: TWLight/applications/templates/applications/application_evaluation.html:176
@@ -468,10 +423,8 @@ msgstr "Renewal of existing access grant?"
 #. Translators: This message is shown next to the 'Renewal of existing access grant?' label if the application is a renewal. Don't translate HTML tags or parent_url.
 #: TWLight/applications/templates/applications/application_evaluation.html:195
 #, python-format
-msgid ""
-"Yes (<a class=\"twl-links\" href=\"%(parent_url)s\">previous application</a>)"
-msgstr ""
-"Yes (<a class=\"twl-links\" href=\"%(parent_url)s\">previous application</a>)"
+msgid "Yes (<a class=\"twl-links\" href=\"%(parent_url)s\">previous application</a>)"
+msgstr "Yes (<a class=\"twl-links\" href=\"%(parent_url)s\">previous application</a>)"
 
 #. Translators: This labels the section of the application showing the length of access remaining on the user's previous authorization.
 #: TWLight/applications/templates/applications/application_evaluation.html:208
@@ -505,12 +458,8 @@ msgstr "Add comment"
 
 #. Translators: On an application page, this text tells users that the comments posted on the application are visible to coordinators and the submitting user only.
 #: TWLight/applications/templates/applications/application_evaluation.html:297
-msgid ""
-"Comments are visible to all coordinators and to the editor who submitted "
-"this application."
-msgstr ""
-"Comments are visible to all coordinators and to the editor who submitted "
-"this application."
+msgid "Comments are visible to all coordinators and to the editor who submitted this application."
+msgstr "Comments are visible to all coordinators and to the editor who submitted this application."
 
 #. Translators: This is the title of the section of an application page which lists information about the user who submitted the application.
 #. Translators: On the page where coordinators can view data on applications to a partner they coordinate, this is a table column heading for the username.
@@ -723,12 +672,7 @@ msgstr "Set status"
 
 #: TWLight/applications/templates/applications/apply.html:20
 #, python-format
-msgid ""
-"If your application is successful we may share your email address with "
-"%(partner)s. This is required to set up your access to their resources. By "
-"submitting this form you agree to allow your email address to be shared with "
-"%(partner)s if your application is successful, for the purposes of account "
-"setup."
+msgid "If your application is successful we may share your email address with %(partner)s. This is required to set up your access to their resources. By submitting this form you agree to allow your email address to be shared with %(partner)s if your application is successful, for the purposes of account setup."
 msgstr ""
 
 #. Translators: This message is displayed on the page where users can confirm their renewal. Please do not translate partner.
@@ -757,12 +701,8 @@ msgstr "What resources do you want to access?"
 
 #. Translators: This text explains that Library Bundle partners are not shown in this list.
 #: TWLight/applications/templates/applications/request_for_application.html:26
-msgid ""
-"Library Bundle partners are not shown as eligibility is determined "
-"automatically."
-msgstr ""
-"Library Bundle partners are not shown as eligibility is determined "
-"automatically."
+msgid "Library Bundle partners are not shown as eligibility is determined automatically."
+msgstr "Library Bundle partners are not shown as eligibility is determined automatically."
 
 #. Translators: On the page where users can apply for multiple partners, this message shows next to the partner name, taking them to the full application page when clicked.
 #: TWLight/applications/templates/applications/request_for_application.html:48
@@ -776,14 +716,8 @@ msgstr "No partner data has been added yet."
 
 #. Translators: the HTML is so that the word 'waitlisted' will look the same as it does in the page above; please translate 'waitlisted' the same way you did elsewhere in this file.
 #: TWLight/applications/templates/applications/request_for_application.html:74
-msgid ""
-"You can apply to <span class=\"badge badge-warning\">Waitlisted</span> "
-"partners, but they don't have access grants available right now. We will "
-"process those applications when access becomes available."
-msgstr ""
-"You can apply to <span class=\"badge badge-warning\">Waitlisted</span> "
-"partners, but they don't have access grants available right now. We will "
-"process those applications when access becomes available."
+msgid "You can apply to <span class=\"badge badge-warning\">Waitlisted</span> partners, but they don't have access grants available right now. We will process those applications when access becomes available."
+msgstr "You can apply to <span class=\"badge badge-warning\">Waitlisted</span> partners, but they don't have access grants available right now. We will process those applications when access becomes available."
 
 #. Translators: On the page where coordinators can see approved applications which have not had their details sent to the partner, this message shows when there are applications ready to be processed.
 #: TWLight/applications/templates/applications/send.html:10
@@ -804,12 +738,8 @@ msgstr "Application data for %(object)s"
 #. Translators: This message is shown when applications exceed the number of accounts available.
 #: TWLight/applications/templates/applications/send_partner.html:54
 #, python-format
-msgid ""
-"Application(s) for %(object)s, if sent, will exceed the total available "
-"accounts for the partner. Please proceed at your own discretion."
-msgstr ""
-"Application(s) for %(object)s, if sent, will exceed the total available "
-"accounts for the partner. Please proceed at your own discretion."
+msgid "Application(s) for %(object)s, if sent, will exceed the total available accounts for the partner. Please proceed at your own discretion."
+msgstr "Application(s) for %(object)s, if sent, will exceed the total available accounts for the partner. Please proceed at your own discretion."
 
 #. Translators: When viewing the list of applications ready to be sent for a particular partner, this is instructions for the coordinator to click the 'mark as sent' button after they have sent the information.
 #: TWLight/applications/templates/applications/send_partner.html:65
@@ -825,12 +755,8 @@ msgstr[1] "Contacts"
 
 #. Translators: When viewing the list of applications ready to be sent for a particular partner, this message shows if there is no information about who the applications should be sent to. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/applications/templates/applications/send_partner.html:89
-msgid ""
-"Whoops, we don't have any listed contacts. Please notify Wikipedia Library "
-"administrators."
-msgstr ""
-"Whoops, we don't have any listed contacts. Please notify Wikipedia Library "
-"administrators."
+msgid "Whoops, we don't have any listed contacts. Please notify Wikipedia Library administrators."
+msgstr "Whoops, we don't have any listed contacts. Please notify Wikipedia Library administrators."
 
 #. Translators: When viewing the list of applications ready to be sent for a particular partner, this is the title of the section containing the information about those applications.
 #: TWLight/applications/templates/applications/send_partner.html:94
@@ -845,12 +771,8 @@ msgstr "Mark as sent"
 
 #. Translators: This text guides coordinators in using the code sending interface for approved applications.
 #: TWLight/applications/templates/applications/send_partner.html:152
-msgid ""
-"Use the dropdown menus to denote which editor will receive each code. Access "
-"codes will be sent to users automatically."
-msgstr ""
-"Use the dropdown menus to denote which editor will receive each code. Access "
-"codes will be sent to users automatically."
+msgid "Use the dropdown menus to denote which editor will receive each code. Access codes will be sent to users automatically."
+msgstr "Use the dropdown menus to denote which editor will receive each code. Access codes will be sent to users automatically."
 
 #. Translators: This labels a drop-down selection where staff can assign an access code to a user.
 #: TWLight/applications/templates/applications/send_partner.html:173
@@ -865,24 +787,14 @@ msgstr "There are no approved, unsent applications."
 #. Translators: When a user applies for a set of resources, they receive this message if none are currently available. They are instead placed on a 'waitlist' for later approval.
 #. Translators: When a user renews their resource, they receive this message if none are currently available. They are instead placed on a 'waitlist' for later approval.
 #: TWLight/applications/views.py:140 TWLight/applications/views.py:1282
-msgid ""
-"This partner does not have any access grants available at this time. You may "
-"still apply for access; your application will be reviewed when access grants "
-"become available."
-msgstr ""
-"This partner does not have any access grants available at this time. You may "
-"still apply for access; your application will be reviewed when access grants "
-"become available."
+msgid "This partner does not have any access grants available at this time. You may still apply for access; your application will be reviewed when access grants become available."
+msgstr "This partner does not have any access grants available at this time. You may still apply for access; your application will be reviewed when access grants become available."
 
 #. Translators: This message is shown to users once they've successfully submitted their application for review.
 #: TWLight/applications/views.py:163
 #, python-brace-format
-msgid ""
-"Your application has been submitted for review. Head over to <a "
-"href='{applications_url}'>My Applications</a> to view the status."
-msgstr ""
-"Your application has been submitted for review. Head over to <a "
-"href='{applications_url}'>My Applications</a> to view the status."
+msgid "Your application has been submitted for review. Head over to <a href='{applications_url}'>My Applications</a> to view the status."
+msgstr "Your application has been submitted for review. Head over to <a href='{applications_url}'>My Applications</a> to view the status."
 
 #. Translators: This text is displayed to users when the user has chosen to restrict data and is trying to apply for multiple partners
 #: TWLight/applications/views.py:276
@@ -930,21 +842,13 @@ msgstr "Sent applications"
 
 #. Translators: After a coordinator has changed the status of an application to APPROVED, if the corresponding partner/collection is waitlisted this message appears.
 #: TWLight/applications/views.py:756
-msgid ""
-"Cannot approve application as partner with proxy authorization method is "
-"waitlisted."
-msgstr ""
-"Cannot approve application as partner with proxy authorisation method is "
-"waitlisted."
+msgid "Cannot approve application as partner with proxy authorization method is waitlisted."
+msgstr "Cannot approve application as partner with proxy authorisation method is waitlisted."
 
 #. Translators: After a coordinator has changed the status of an application to APPROVED, if the corresponding partner/collection has no accounts for distribution, this message appears.
 #: TWLight/applications/views.py:780
-msgid ""
-"Cannot approve application as partner with proxy authorization method is "
-"waitlisted and (or) has zero accounts available for distribution."
-msgstr ""
-"Cannot approve application as partner with proxy authorisation method is "
-"waitlisted and (or) has zero accounts available for distribution."
+msgid "Cannot approve application as partner with proxy authorization method is waitlisted and (or) has zero accounts available for distribution."
+msgstr "Cannot approve application as partner with proxy authorisation method is waitlisted and (or) has zero accounts available for distribution."
 
 #. Translators: This message appears on an "access denied" screen that stops users who attempt to authorize an editor to access a resource during a time period for which they are already authorized.
 #: TWLight/applications/views.py:803
@@ -954,16 +858,8 @@ msgstr "You attempted to create a duplicate authorisation."
 #. Translators: This message is shown to users when they access an application page of a now Bundle partner (new applications aren't allowed for Bundle partners and the status of old applications cannot be modified)
 #: TWLight/applications/views.py:857
 #, python-brace-format
-msgid ""
-"This application cannot be modified since this partner is now part of our <a "
-"href='{bundle}'>bundle access</a>. If you are eligible, you can access this "
-"resource from <a href='{library}'>your library</a>. <a "
-"href='{contact}'>Contact us</a> if you have any questions."
-msgstr ""
-"This application cannot be modified since this partner is now part of our <a "
-"href='{bundle}'>bundle access</a>. If you are eligible, you can access this "
-"resource from <a href='{library}'>your library</a>. <a "
-"href='{contact}'>Contact us</a> if you have any questions."
+msgid "This application cannot be modified since this partner is now part of our <a href='{bundle}'>bundle access</a>. If you are eligible, you can access this resource from <a href='{library}'>your library</a>. <a href='{contact}'>Contact us</a> if you have any questions."
+msgstr "This application cannot be modified since this partner is now part of our <a href='{bundle}'>bundle access</a>. If you are eligible, you can access this resource from <a href='{library}'>your library</a>. <a href='{contact}'>Contact us</a> if you have any questions."
 
 #. Translators: this lets a reviewer set the status of a single application.
 #: TWLight/applications/views.py:873
@@ -972,12 +868,8 @@ msgstr "Set application status"
 
 #. Translators: This warning is message is shown to applicants when the number of pending applications is greater than the number of accounts available.
 #: TWLight/applications/views.py:891
-msgid ""
-"There are more pending applications than available accounts. Your "
-"application might get waitlisted."
-msgstr ""
-"There are more pending applications than available accounts. Your "
-"application might get waitlisted."
+msgid "There are more pending applications than available accounts. Your application might get waitlisted."
+msgstr "There are more pending applications than available accounts. Your application might get waitlisted."
 
 #. Translators: this message is shown to coordinators who attempt to change an application's Status from INVALID to any other Status.
 #: TWLight/applications/views.py:904
@@ -996,16 +888,8 @@ msgstr "Batch update of application(s) {} successful."
 
 #. Translators: After a coordinator has changed the status of a number of applications to APPROVED, if the corresponding partner(s) is/are waitlisted or has no accounts for distribution, this message appears.
 #: TWLight/applications/views.py:1051
-msgid ""
-"Cannot approve application(s) {} as partner(s) with proxy authorization "
-"method is/are waitlisted and (or) has/have not enough accounts available. If "
-"not enough accounts are available, prioritise the applications and then "
-"approve applications equal to the accounts available."
-msgstr ""
-"Cannot approve application(s) {} as partner(s) with proxy authorisation "
-"method is/are waitlisted and (or) has/have not enough accounts available. If "
-"not enough accounts are available, prioritise the applications and then "
-"approve applications equal to the accounts available."
+msgid "Cannot approve application(s) {} as partner(s) with proxy authorization method is/are waitlisted and (or) has/have not enough accounts available. If not enough accounts are available, prioritise the applications and then approve applications equal to the accounts available."
+msgstr "Cannot approve application(s) {} as partner(s) with proxy authorisation method is/are waitlisted and (or) has/have not enough accounts available. If not enough accounts are available, prioritise the applications and then approve applications equal to the accounts available."
 
 #. Translators: This message is shown to coordinators who attempt to assign the same access code to multiple users.
 #: TWLight/applications/views.py:1191
@@ -1019,12 +903,8 @@ msgstr "All selected applications have been marked as sent."
 
 #. Translators: When a user tries to renew their resource, they receive this message if the partner is not available.
 #: TWLight/applications/views.py:1272
-msgid ""
-"Cannot renew application at this time as partner is not available. Please "
-"check back later, or contact us for more information."
-msgstr ""
-"Cannot renew application at this time as partner is not available. Please "
-"check back later, or contact us for more information."
+msgid "Cannot renew application at this time as partner is not available. Please check back later, or contact us for more information."
+msgstr "Cannot renew application at this time as partner is not available. Please check back later, or contact us for more information."
 
 #. Translators: This message is displayed when an attempt by a user to renew an application has been denied for some reason.
 #: TWLight/applications/views.py:1308
@@ -1034,21 +914,13 @@ msgstr "Attempt to renew unapproved application #{pk} has been denied"
 
 #. Translators: If a user requests the renewal of their account, but it wasn't renewed, this message is shown to them.
 #: TWLight/applications/views.py:1385
-msgid ""
-"This object cannot be renewed. (This probably means that you have already "
-"requested that it be renewed.)"
-msgstr ""
-"This object cannot be renewed. (This probably means that you have already "
-"requested that it be renewed.)"
+msgid "This object cannot be renewed. (This probably means that you have already requested that it be renewed.)"
+msgstr "This object cannot be renewed. (This probably means that you have already requested that it be renewed.)"
 
 #. Translators: If a user requests the renewal of their account, this message is shown to them.
 #: TWLight/applications/views.py:1395
-msgid ""
-"Your renewal request has been received. A coordinator will review your "
-"request."
-msgstr ""
-"Your renewal request has been received. A coordinator will review your "
-"request."
+msgid "Your renewal request has been received. A coordinator will review your request."
+msgstr "Your renewal request has been received. A coordinator will review your request."
 
 #. Translators: This labels a textfield where users can enter their email ID.
 #: TWLight/emails/forms.py:18
@@ -1057,13 +929,8 @@ msgstr "Your email"
 
 #. Translators: This is the help text for the email field in the contact us form letting users know the field is updated by value pulled from their respective user profiles.
 #: TWLight/emails/forms.py:21
-msgid ""
-"This field is automatically updated with the email from your <a class='twl-"
-"links' href='{}'>user profile</a>."
-msgstr ""
-"This field is automatically updated with the email from your <a "
-"class='contact-us-links' href='{}'>user profile</a>.<a class='twl-links' "
-"href='{}'></a>"
+msgid "This field is automatically updated with the email from your <a class='twl-links' href='{}'>user profile</a>."
+msgstr "This field is automatically updated with the email from your <a class='contact-us-links' href='{}'>user profile</a>.<a class='twl-links' href='{}'></a>"
 
 #. Translators: This labels a textfield where users can enter their email message.
 #: TWLight/emails/forms.py:26
@@ -1086,19 +953,13 @@ msgstr "Submit"
 #. Translators: This email is sent to users with their access code. Don't translate Jinja variables in curly braces like user or partner. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/access_code_email-body-html.html:5
 #, python-format
-msgid ""
-"<p>Your approved application to %(partner)s has now been finalised. Your "
-"access code or login details can be found below:</p> <p><b>%(access_code)s</"
-"b></p> <p>%(user_instructions)s</p>"
+msgid "<p>Your approved application to %(partner)s has now been finalised. Your access code or login details can be found below:</p> <p><b>%(access_code)s</b></p> <p>%(user_instructions)s</p>"
 msgstr ""
 
 #. Translators: This email is sent to users with their access code. Don't translate Jinja variables in curly braces like user or partner. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/access_code_email-body-text.html:3
 #, python-format
-msgid ""
-"Your approved application to %(partner)s has now been finalised. Your access "
-"code or login details can be found below: %(access_code)s "
-"%(user_instructions)s"
+msgid "Your approved application to %(partner)s has now been finalised. Your access code or login details can be found below: %(access_code)s %(user_instructions)s"
 msgstr ""
 
 #. Translators: This is the subject line of an email sent to users with their access code.
@@ -1109,34 +970,14 @@ msgstr "Your Wikipedia Library access code"
 #. Translators: This email is sent to users when their application is approved. Don't translate Jinja variables in curly braces like user or partner; don't translate html tags either. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/approval_notification-body-html.html:5
 #, python-format
-msgid ""
-"<p>Dear %(user)s,</p> <p>Thank you for applying for access to %(partner)s "
-"resources through The Wikipedia Library. We are happy to inform you that "
-"your application has been approved.</p> <p>%(user_instructions)s</p> <p>You "
-"can view the collections you're authorized to access at My Library: "
-"%(link)s</p> <p>Cheers!</p> <p>The Wikipedia Library</p>"
-msgstr ""
-"<p>Dear %(user)s,</p> <p>Thank you for applying for access to %(partner)s "
-"resources through The Wikipedia Library. We are happy to inform you that "
-"your application has been approved.</p> <p>%(user_instructions)s</p> <p>You "
-"can view the collections you're authorized to access at My Library: "
-"%(link)s</p> <p>Cheers!</p> <p>The Wikipedia Library</p>"
+msgid "<p>Dear %(user)s,</p> <p>Thank you for applying for access to %(partner)s resources through The Wikipedia Library. We are happy to inform you that your application has been approved.</p> <p>%(user_instructions)s</p> <p>You can view the collections you're authorized to access at My Library: %(link)s</p> <p>Cheers!</p> <p>The Wikipedia Library</p>"
+msgstr "<p>Dear %(user)s,</p> <p>Thank you for applying for access to %(partner)s resources through The Wikipedia Library. We are happy to inform you that your application has been approved.</p> <p>%(user_instructions)s</p> <p>You can view the collections you're authorized to access at My Library: %(link)s</p> <p>Cheers!</p> <p>The Wikipedia Library</p>"
 
 #. Translators: This email is sent to users when their application is approved. Don't translate Jinja variables in curly braces like user or partner. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/approval_notification-body-text.html:3
 #, python-format
-msgid ""
-"Dear %(user)s, Thank you for applying for access to %(partner)s resources "
-"through The Wikipedia Library. We are happy to inform you that your "
-"application has been approved. %(user_instructions)s You can view the "
-"collections you're authorized to access at My Library: %(link)s Cheers! The "
-"Wikipedia Library"
-msgstr ""
-"Dear %(user)s, Thank you for applying for access to %(partner)s resources "
-"through The Wikipedia Library. We are happy to inform you that your "
-"application has been approved. %(user_instructions)s You can view the "
-"collections you're authorized to access at My Library: %(link)s Cheers! The "
-"Wikipedia Library"
+msgid "Dear %(user)s, Thank you for applying for access to %(partner)s resources through The Wikipedia Library. We are happy to inform you that your application has been approved. %(user_instructions)s You can view the collections you're authorized to access at My Library: %(link)s Cheers! The Wikipedia Library"
+msgstr "Dear %(user)s, Thank you for applying for access to %(partner)s resources through The Wikipedia Library. We are happy to inform you that your application has been approved. %(user_instructions)s You can view the collections you're authorized to access at My Library: %(link)s Cheers! The Wikipedia Library"
 
 #. Translators: This is the subject of an email which is sent to users when their application has been approved. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/approval_notification-subject.html:4
@@ -1146,26 +987,14 @@ msgstr "Your Wikipedia Library application has been approved"
 #. Translators: This email is sent to coordinators when a comment is left on an application they are processing. Don't translate Jinja variables in curly braces like user or partner. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/comment_notification_coordinator-body-html.html:5
 #, python-format
-msgid ""
-"<p style=\"color: #500050\">%(submit_date)s - %(commenter)s</p> "
-"<blockquote><p>%(comment)s</p></blockquote> <p>Please reply to these at: <a "
-"href=\"%(app_url)s\">%(app_url)s</a></p> <p>Best,</p> <p>The Wikipedia "
-"Library</p>"
-msgstr ""
-"<p style=\"color: #500050\">%(submit_date)s - %(commenter)s</p> "
-"<blockquote><p>%(comment)s</p></blockquote> <p>Please reply to these at: <a "
-"href=\"%(app_url)s\">%(app_url)s</a></p> <p>Best,</p> <p>The Wikipedia "
-"Library</p>"
+msgid "<p style=\"color: #500050\">%(submit_date)s - %(commenter)s</p> <blockquote><p>%(comment)s</p></blockquote> <p>Please reply to these at: <a href=\"%(app_url)s\">%(app_url)s</a></p> <p>Best,</p> <p>The Wikipedia Library</p>"
+msgstr "<p style=\"color: #500050\">%(submit_date)s - %(commenter)s</p> <blockquote><p>%(comment)s</p></blockquote> <p>Please reply to these at: <a href=\"%(app_url)s\">%(app_url)s</a></p> <p>Best,</p> <p>The Wikipedia Library</p>"
 
 #. Translators: This email is sent to coordinators when a comment is left on an application they are processing. Don't translate Jinja variables in curly braces like user or partner. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/comment_notification_coordinator-body-text.html:3
 #, python-format
-msgid ""
-"%(submit_date)s - %(commenter)s %(comment)s Please reply to this at: "
-"%(app_url)s Best, The Wikipedia Library"
-msgstr ""
-"%(submit_date)s - %(commenter)s %(comment)s Please reply to this at: "
-"%(app_url)s Best, The Wikipedia Library"
+msgid "%(submit_date)s - %(commenter)s %(comment)s Please reply to this at: %(app_url)s Best, The Wikipedia Library"
+msgstr "%(submit_date)s - %(commenter)s %(comment)s Please reply to this at: %(app_url)s Best, The Wikipedia Library"
 
 #. Translators: This is the subject line of an email sent to coordinators when a comment is left on an application they processed.
 #: TWLight/emails/templates/emails/comment_notification_coordinator-subject.html:3
@@ -1175,23 +1004,13 @@ msgstr "New comment on a Wikipedia Library application you processed"
 #. Translators: This email is sent to users when they receive a comment on their application. Don't translate Jinja variables in curly braces like user or partner; don't translate html tags either. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/comment_notification_editors-body-html.html:5
 #, python-format
-msgid ""
-"<p style=\"color: #500050\">%(submit_date)s - %(commenter)s</p> "
-"<blockquote><p>%(comment)s</p></blockquote> <p>Please reply to these at <a "
-"href=\"%(app_url)s\">%(app_url)s</a> so we can evaluate your application.</"
-"p> <p>Best,</p> <p>The Wikipedia Library</p>"
-msgstr ""
-"<p style=\"color: #500050\">%(submit_date)s - %(commenter)s</p> "
-"<blockquote><p>%(comment)s</p></blockquote> <p>Please reply to these at <a "
-"href=\"%(app_url)s\">%(app_url)s</a> so we can evaluate your application.</"
-"p> <p>Best,</p> <p>The Wikipedia Library</p>"
+msgid "<p style=\"color: #500050\">%(submit_date)s - %(commenter)s</p> <blockquote><p>%(comment)s</p></blockquote> <p>Please reply to these at <a href=\"%(app_url)s\">%(app_url)s</a> so we can evaluate your application.</p> <p>Best,</p> <p>The Wikipedia Library</p>"
+msgstr "<p style=\"color: #500050\">%(submit_date)s - %(commenter)s</p> <blockquote><p>%(comment)s</p></blockquote> <p>Please reply to these at <a href=\"%(app_url)s\">%(app_url)s</a> so we can evaluate your application.</p> <p>Best,</p> <p>The Wikipedia Library</p>"
 
 #. Translators: This email is sent to users when they receive a comment on their application. Don't translate Jinja variables in curly braces like user or partner. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/comment_notification_editors-body-text.html:3
 #, python-format
-msgid ""
-"%(submit_date)s - %(commenter)s %(comment)s Please reply to these at: "
-"%(app_url)s so we can evaluate your application. Best, The Wikipedia Library"
+msgid "%(submit_date)s - %(commenter)s %(comment)s Please reply to these at: %(app_url)s so we can evaluate your application. Best, The Wikipedia Library"
 msgstr ""
 
 #. Translators: This is the subject line of an email sent to users who have a comment added to one of their applications. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
@@ -1202,24 +1021,14 @@ msgstr "New comment on your Wikipedia Library application"
 #. Translators: This email is sent to users when an application they commented on receives another comment. Don't translate Jinja variables in curly braces like app_url; don't translate html tags either. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/comment_notification_others-body-html.html:5
 #, python-format
-msgid ""
-"<p style=\"color: #500050\">%(submit_date)s - %(commenter)s</p> "
-"<blockquote><p>%(comment)s</p></blockquote> See it at <a href=\"%(app_url)s"
-"\">%(app_url)s</a>. Thanks for helping review Wikipedia Library applications!"
-msgstr ""
-"<p style=\"color: #500050\">%(submit_date)s - %(commenter)s</p> "
-"<blockquote><p>%(comment)s</p></blockquote> See it at <a href=\"%(app_url)s"
-"\">%(app_url)s</a>. Thanks for helping review Wikipedia Library applications!"
+msgid "<p style=\"color: #500050\">%(submit_date)s - %(commenter)s</p> <blockquote><p>%(comment)s</p></blockquote> See it at <a href=\"%(app_url)s\">%(app_url)s</a>. Thanks for helping review Wikipedia Library applications!"
+msgstr "<p style=\"color: #500050\">%(submit_date)s - %(commenter)s</p> <blockquote><p>%(comment)s</p></blockquote> See it at <a href=\"%(app_url)s\">%(app_url)s</a>. Thanks for helping review Wikipedia Library applications!"
 
 #. Translators: This email is sent to users when an application they commented on receives another comment. Don't translate Jinja variables in curly braces like app_url. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/comment_notification_others-body-text.html:3
 #, python-format
-msgid ""
-"%(submit_date)s - %(commenter)s %(comment)s See it at: %(app_url)s Thanks "
-"for helping review Wikipedia Library applications!"
-msgstr ""
-"%(submit_date)s - %(commenter)s %(comment)s See it at: %(app_url)s Thanks "
-"for helping review Wikipedia Library applications!"
+msgid "%(submit_date)s - %(commenter)s %(comment)s See it at: %(app_url)s Thanks for helping review Wikipedia Library applications!"
+msgstr "%(submit_date)s - %(commenter)s %(comment)s See it at: %(app_url)s Thanks for helping review Wikipedia Library applications!"
 
 #. Translators: This is the subject line of an email sent to users who have a comment added to an application they also commented on. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/comment_notification_others-subject.html:4
@@ -1229,10 +1038,7 @@ msgstr "New comment on a Wikipedia Library application you commented on"
 #. Translators: This text is part of a scheduled reminder email sent to coordinators who have applications requiring action. Don't translate Jinja variables in curly braces like total_apps, or user.
 #: TWLight/emails/templates/emails/coordinator_reminder_notification-body-html.html:5
 #, python-format
-msgid ""
-"<p>Dear %(user)s,</p> <p>Our records indicate that you are the designated "
-"coordinator for partners that have a total of %(total_apps)s applications.</"
-"p>"
+msgid "<p>Dear %(user)s,</p> <p>Our records indicate that you are the designated coordinator for partners that have a total of %(total_apps)s applications.</p>"
 msgstr ""
 
 #. Translators: Breakdown as in 'cost breakdown'; analysis.
@@ -1271,42 +1077,20 @@ msgstr[1] "%(counter)s approved applications."
 #. Translators: This text is part of a scheduled reminder email sent to coordinators who have applications requiring action. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library). Don't translate Jinja variables in curly braces like link; don't translate email addresses or html tags either.
 #: TWLight/emails/templates/emails/coordinator_reminder_notification-body-html.html:39
 #, python-format
-msgid ""
-"<p>This is a gentle reminder that you may review applications at <a href="
-"\"%(link)s\">%(link)s</a>.</p> <p>You can customise your reminders under "
-"'preferences' in your user profile.</p> <p>If you received this message in "
-"error, drop us a line at wikipedialibrary@wikimedia.org.</p> <p>Thanks for "
-"helping review Wikipedia Library applications!</p>"
-msgstr ""
-"<p>This is a gentle reminder that you may review applications at <a href="
-"\"%(link)s\">%(link)s</a>.</p> <p>You can customise your reminders under "
-"'preferences' in your user profile.</p> <p>If you received this message in "
-"error, drop us a line at wikipedialibrary@wikimedia.org.</p> <p>Thanks for "
-"helping review Wikipedia Library applications!</p>"
+msgid "<p>This is a gentle reminder that you may review applications at <a href=\"%(link)s\">%(link)s</a>.</p> <p>You can customise your reminders under 'preferences' in your user profile.</p> <p>If you received this message in error, drop us a line at wikipedialibrary@wikimedia.org.</p> <p>Thanks for helping review Wikipedia Library applications!</p>"
+msgstr "<p>This is a gentle reminder that you may review applications at <a href=\"%(link)s\">%(link)s</a>.</p> <p>You can customise your reminders under 'preferences' in your user profile.</p> <p>If you received this message in error, drop us a line at wikipedialibrary@wikimedia.org.</p> <p>Thanks for helping review Wikipedia Library applications!</p>"
 
 #. Translators: This text is part of a scheduled reminder email sent to coordinators who have applications requiring action. Don't translate Jinja variables in curly braces like total_apps, or user.
 #: TWLight/emails/templates/emails/coordinator_reminder_notification-body-text.html:3
 #, python-format
-msgid ""
-"Dear %(user)s, Our records indicate that you are the designated coordinator "
-"for partners that have a total of %(total_apps)s applications."
+msgid "Dear %(user)s, Our records indicate that you are the designated coordinator for partners that have a total of %(total_apps)s applications."
 msgstr ""
 
 #. Translators: This text is part of a scheduled reminder email sent to coordinators who have applications requiring action. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library). Don't translate Jinja variables in curly braces like link; don't translate the email address either.
 #: TWLight/emails/templates/emails/coordinator_reminder_notification-body-text.html:38
 #, python-format
-msgid ""
-"This is a gentle reminder that you may review applications at: %(link)s. You "
-"can customise your reminders under 'preferences' in your user profile. If "
-"you received this message in error, drop us a line at: "
-"wikipedialibrary@wikimedia.org Thanks for helping review Wikipedia Library "
-"applications!"
-msgstr ""
-"This is a gentle reminder that you may review applications at: %(link)s. You "
-"can customise your reminders under 'preferences' in your user profile. If "
-"you received this message in error, drop us a line at: "
-"wikipedialibrary@wikimedia.org Thanks for helping review Wikipedia Library "
-"applications!"
+msgid "This is a gentle reminder that you may review applications at: %(link)s. You can customise your reminders under 'preferences' in your user profile. If you received this message in error, drop us a line at: wikipedialibrary@wikimedia.org Thanks for helping review Wikipedia Library applications!"
+msgstr "This is a gentle reminder that you may review applications at: %(link)s. You can customise your reminders under 'preferences' in your user profile. If you received this message in error, drop us a line at: wikipedialibrary@wikimedia.org Thanks for helping review Wikipedia Library applications!"
 
 #. Translators: This is the subject line of a scheduled reminder email sent to coordinators who have applications to review. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library). Do not translate items in curly braces.
 #: TWLight/emails/templates/emails/coordinator_reminder_notification-subject.html:4
@@ -1316,32 +1100,14 @@ msgstr "Wikipedia Library applications await your review"
 #. Translators: This email is sent to users when their application is rejected. Don't translate Jinja variables in curly braces like user or partner; don't translate html tags either. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/rejection_notification-body-html.html:5
 #, python-format
-msgid ""
-"<p>Dear %(user)s,</p> <p>Thank you for applying for access to %(partner)s "
-"resources through The Wikipedia Library. Unfortunately at this time your "
-"application has not been approved. You can view your application and review "
-"comments at <a href=\"%(app_url)s\">%(app_url)s</a>.</p> <p>Best,</p> <p>The "
-"Wikipedia Library</p>"
-msgstr ""
-"<p>Dear %(user)s,</p> <p>Thank you for applying for access to %(partner)s "
-"resources through The Wikipedia Library. Unfortunately at this time your "
-"application has not been approved. You can view your application and review "
-"comments at <a href=\"%(app_url)s\">%(app_url)s</a>.</p> <p>Best,</p> <p>The "
-"Wikipedia Library</p>"
+msgid "<p>Dear %(user)s,</p> <p>Thank you for applying for access to %(partner)s resources through The Wikipedia Library. Unfortunately at this time your application has not been approved. You can view your application and review comments at <a href=\"%(app_url)s\">%(app_url)s</a>.</p> <p>Best,</p> <p>The Wikipedia Library</p>"
+msgstr "<p>Dear %(user)s,</p> <p>Thank you for applying for access to %(partner)s resources through The Wikipedia Library. Unfortunately at this time your application has not been approved. You can view your application and review comments at <a href=\"%(app_url)s\">%(app_url)s</a>.</p> <p>Best,</p> <p>The Wikipedia Library</p>"
 
 #. Translators: This email is sent to users when their application is rejected. Don't translate Jinja variables in curly braces like user or partner. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/rejection_notification-body-text.html:3
 #, python-format
-msgid ""
-"Dear %(user)s, Thank you for applying for access to %(partner)s resources "
-"through The Wikipedia Library. Unfortunately at this time your application "
-"has not been approved. You can view your application and review comments at: "
-"%(app_url)s Best, The Wikipedia Library"
-msgstr ""
-"Dear %(user)s, Thank you for applying for access to %(partner)s resources "
-"through The Wikipedia Library. Unfortunately at this time your application "
-"has not been approved. You can view your application and review comments at: "
-"%(app_url)s Best, The Wikipedia Library"
+msgid "Dear %(user)s, Thank you for applying for access to %(partner)s resources through The Wikipedia Library. Unfortunately at this time your application has not been approved. You can view your application and review comments at: %(app_url)s Best, The Wikipedia Library"
+msgstr "Dear %(user)s, Thank you for applying for access to %(partner)s resources through The Wikipedia Library. Unfortunately at this time your application has not been approved. You can view your application and review comments at: %(app_url)s Best, The Wikipedia Library"
 
 #. Translators: This is the subject of an email which is sent to users when their application has been rejected. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/rejection_notification-subject.html:4
@@ -1351,38 +1117,14 @@ msgstr "Your Wikipedia Library application"
 #. Translators: This email is sent to users when they have an account that is soon to expire. Don't translate Jinja variables in curly braces like partner_name or partner_link; don't translate html tags either. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/user_renewal_notice-body-html.html:5
 #, fuzzy, python-format
-msgid ""
-"<p>Dear %(user)s,</p> <p>According to our records, your access to "
-"%(partner_name)s will soon expire and you may lose access. If you want to "
-"continue making use of your free account, you can request renewal of your "
-"account by clicking the 'Renew' or 'Extend' button at %(partner_link)s.</p> "
-"<p>Best,</p> <p>The Wikipedia Library</p> <p>You can disable these emails in "
-"your user page preferences: https://wikipedialibrary.wmflabs.org/users/</p>"
-msgstr ""
-"<p>Dear %(user)s,</p> <p>According to our records, your access to "
-"%(partner_name)s will soon expire and you may lose access. If you want to "
-"continue making use of your free account, you can request renewal of your "
-"account by clicking the Renew button at %(partner_link)s.</p> <p>Best,</p> "
-"<p>The Wikipedia Library</p> <p>You can disable these emails in your user "
-"page preferences: https://wikipedialibrary.wmflabs.org/users/</p>"
+msgid "<p>Dear %(user)s,</p> <p>According to our records, your access to %(partner_name)s will soon expire and you may lose access. If you want to continue making use of your free account, you can request renewal of your account by clicking the 'Renew' or 'Extend' button at %(partner_link)s.</p> <p>Best,</p> <p>The Wikipedia Library</p> <p>You can disable these emails in your user page preferences: https://wikipedialibrary.wmflabs.org/users/</p>"
+msgstr "<p>Dear %(user)s,</p> <p>According to our records, your access to %(partner_name)s will soon expire and you may lose access. If you want to continue making use of your free account, you can request renewal of your account by clicking the Renew button at %(partner_link)s.</p> <p>Best,</p> <p>The Wikipedia Library</p> <p>You can disable these emails in your user page preferences: https://wikipedialibrary.wmflabs.org/users/</p>"
 
 #. Translators: This email is sent to users when they have an account that is soon to expire. Don't translate Jinja variables in curly braces like partner_name or partner_link; don't translate html tags either. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/user_renewal_notice-body-text.html:3
 #, python-format
-msgid ""
-"Dear %(user)s, According to our records, your access to %(partner_name)s "
-"will soon expire and you may lose access. If you want to continue making use "
-"of your free account, you can request renewal of your account by clicking "
-"the Renew button at %(partner_link)s. Best, The Wikipedia Library You can "
-"disable these emails in your user page preferences: https://wikipedialibrary."
-"wmflabs.org/users/"
-msgstr ""
-"Dear %(user)s, According to our records, your access to %(partner_name)s "
-"will soon expire and you may lose access. If you want to continue making use "
-"of your free account, you can request renewal of your account by clicking "
-"the Renew button at %(partner_link)s. Best, The Wikipedia Library You can "
-"disable these emails in your user page preferences: https://wikipedialibrary."
-"wmflabs.org/users/"
+msgid "Dear %(user)s, According to our records, your access to %(partner_name)s will soon expire and you may lose access. If you want to continue making use of your free account, you can request renewal of your account by clicking the Renew button at %(partner_link)s. Best, The Wikipedia Library You can disable these emails in your user page preferences: https://wikipedialibrary.wmflabs.org/users/"
+msgstr "Dear %(user)s, According to our records, your access to %(partner_name)s will soon expire and you may lose access. If you want to continue making use of your free account, you can request renewal of your account by clicking the Renew button at %(partner_link)s. Best, The Wikipedia Library You can disable these emails in your user page preferences: https://wikipedialibrary.wmflabs.org/users/"
 
 #. Translators: This is the subject of an email sent to users when they have an account that is soon to expire. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/user_renewal_notice-subject.html:4
@@ -1392,36 +1134,14 @@ msgstr "Your Wikipedia Library access may soon expire"
 #. Translators: This email is sent to users when their application is waitlisted because there are no more accounts available. Don't translate Jinja variables in curly braces like user or partner; don't translate html tags either. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/waitlist_notification-body-html.html:5
 #, python-format
-msgid ""
-"<p>Dear %(user)s,</p> <p>Thank you for applying for access to %(partner)s "
-"resources through The Wikipedia Library. There are no accounts currently "
-"available so your application has been waitlisted. Your application will be "
-"evaluated if/when more accounts become available. You can see all available "
-"resources at <a href=\"%(link)s\">%(link)s</a>.</p> <p>Best,</p> <p>The "
-"Wikipedia Library</p>"
-msgstr ""
-"<p>Dear %(user)s,</p> <p>Thank you for applying for access to %(partner)s "
-"resources through The Wikipedia Library. There are no accounts currently "
-"available so your application has been waitlisted. Your application will be "
-"evaluated if/when more accounts become available. You can see all available "
-"resources at <a href=\"%(link)s\">%(link)s</a>.</p> <p>Best,</p> <p>The "
-"Wikipedia Library</p>"
+msgid "<p>Dear %(user)s,</p> <p>Thank you for applying for access to %(partner)s resources through The Wikipedia Library. There are no accounts currently available so your application has been waitlisted. Your application will be evaluated if/when more accounts become available. You can see all available resources at <a href=\"%(link)s\">%(link)s</a>.</p> <p>Best,</p> <p>The Wikipedia Library</p>"
+msgstr "<p>Dear %(user)s,</p> <p>Thank you for applying for access to %(partner)s resources through The Wikipedia Library. There are no accounts currently available so your application has been waitlisted. Your application will be evaluated if/when more accounts become available. You can see all available resources at <a href=\"%(link)s\">%(link)s</a>.</p> <p>Best,</p> <p>The Wikipedia Library</p>"
 
 #. Translators: This email is sent to users when their application is waitlisted because there are no more accounts available. Don't translate Jinja variables in curly braces like user or partner. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/waitlist_notification-body-text.html:3
 #, python-format
-msgid ""
-"Dear %(user)s, Thank you for applying for access to %(partner)s resources "
-"through The Wikipedia Library. There are no accounts currently available so "
-"your application has been waitlisted. Your application will be evaluated if/"
-"when more accounts become available. You can see all available resources at: "
-"%(link)s Best, The Wikipedia Library"
-msgstr ""
-"Dear %(user)s, Thank you for applying for access to %(partner)s resources "
-"through The Wikipedia Library. There are no accounts currently available so "
-"your application has been waitlisted. Your application will be evaluated if/"
-"when more accounts become available. You can see all available resources at: "
-"%(link)s Best, The Wikipedia Library"
+msgid "Dear %(user)s, Thank you for applying for access to %(partner)s resources through The Wikipedia Library. There are no accounts currently available so your application has been waitlisted. Your application will be evaluated if/when more accounts become available. You can see all available resources at: %(link)s Best, The Wikipedia Library"
+msgstr "Dear %(user)s, Thank you for applying for access to %(partner)s resources through The Wikipedia Library. There are no accounts currently available so your application has been waitlisted. Your application will be evaluated if/when more accounts become available. You can see all available resources at: %(link)s Best, The Wikipedia Library"
 
 #. Translators: This is the subject of an email sent to users when their application is waitlisted because there are no more accounts available. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/waitlist_notification-subject.html:4
@@ -1584,17 +1304,14 @@ msgstr "Account email"
 #: TWLight/resources/templates/resources/filter_section.html:14
 #: TWLight/templates/about.html:12
 #: TWLight/users/templates/users/filter_section.html:13
-msgid ""
-"The Wikipedia Library allows active editors to access a wide range of "
-"collections of paywalled reliable sources for free!"
+msgid "The Wikipedia Library allows active editors to access a wide range of collections of paywalled reliable sources for free!"
 msgstr ""
 
 #. Translators: On the Browse Partners page (https://wikipedialibrary.wmflabs.org/partners/), this introduces users to The Wikipedia Library.
 #. Translators: On the MyLibrary page (https://wikipedialibrary.wmflabs.org/users/my_library), this introduces users to The Wikipedia Library.
 #: TWLight/resources/templates/resources/filter_section.html:17
 #: TWLight/users/templates/users/filter_section.html:15
-msgid ""
-"Start with the search bar at the top or browse publisher websites directly."
+msgid "Start with the search bar at the top or browse publisher websites directly."
 msgstr ""
 
 #. Translators: On the Browse Partners page (https://wikipedialibrary.wmflabs.org/partners/), this appears below introductory text and links to the 'About' page (https://wikipedialibrary.wmflabs.org/about/)
@@ -1673,52 +1390,38 @@ msgstr "Back to partners"
 #. Translators: If we have no available accounts for a partner, the coordinator can change the application system to a waiting list.
 #: TWLight/resources/templates/resources/partner_detail.html:36
 #: TWLight/resources/templates/resources/partner_detail_apply.html:17
-msgid ""
-"There are no access grants available for this partner at this time. You can "
-"still apply for access; applications will be processed when access is "
-"available."
+msgid "There are no access grants available for this partner at this time. You can still apply for access; applications will be processed when access is available."
 msgstr ""
 
 #. Translators: This text links to the minimum user requirements and terms of use on the partner page.
 #: TWLight/resources/templates/resources/partner_detail.html:48
 #: TWLight/resources/templates/resources/partner_detail_apply.html:29
 #, python-format
-msgid ""
-"Before applying, please review the <strong><a class=\"twl-links\" href="
-"\"%(about)s#req\">minimum requirements</a></strong> for access and our "
-"<strong><a class=\"twl-links\" href=\"%(terms)s\">terms of use</a></strong>."
+msgid "Before applying, please review the <strong><a class=\"twl-links\" href=\"%(about)s#req\">minimum requirements</a></strong> for access and our <strong><a class=\"twl-links\" href=\"%(terms)s\">terms of use</a></strong>."
 msgstr ""
 
 #. Translators: This text refers to the page containing the content a user is authorized to access.
 #: TWLight/resources/templates/resources/partner_detail.html:69
 #, python-format
-msgid ""
-"View the status of your access in <strong><a class=\"twl-links\" href="
-"\"%(library_url)s\">My Library</a></strong> page."
+msgid "View the status of your access in <strong><a class=\"twl-links\" href=\"%(library_url)s\">My Library</a></strong> page."
 msgstr ""
 
 #. Translators: This message is shown when a user has open applications, linking to their respective applications page.
 #: TWLight/resources/templates/resources/partner_detail.html:78
 #, python-format
-msgid ""
-"View the status of your application(s) on your <strong><a class=\"twl-links"
-"\" href=\"%(applications_url)s\">My Applications</a></strong> page."
+msgid "View the status of your application(s) on your <strong><a class=\"twl-links\" href=\"%(applications_url)s\">My Applications</a></strong> page."
 msgstr ""
 
 #. Translators: This message is shown when a user has authorizations, linking to their respective collections page.
 #: TWLight/resources/templates/resources/partner_detail_apply.html:50
 #, python-format
-msgid ""
-"View the status of your access on your <strong><a href=\"%(library_url)s\" "
-"class=\"twl-links\">My Library</a></strong> page."
+msgid "View the status of your access on your <strong><a href=\"%(library_url)s\" class=\"twl-links\">My Library</a></strong> page."
 msgstr ""
 
 #. Translators: This message is shown when a user has open applications, linking to their respective applications page.
 #: TWLight/resources/templates/resources/partner_detail_apply.html:60
 #, python-format
-msgid ""
-"View the status of your application(s) on your <strong><a href="
-"\"%(applications_url)s\">My Applications</a></strong> page."
+msgid "View the status of your application(s) on your <strong><a href=\"%(applications_url)s\">My Applications</a></strong> page."
 msgstr ""
 
 #. Translators: One the partner detail page, this text labels the button which coordinators can click to remove a partner from waitlisted status.
@@ -1748,10 +1451,7 @@ msgstr ""
 
 #. Translators: If no account coordinator is assigned to a partner, the Wikipedia Library team will coordinate signups. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/resources/templates/resources/partner_detail_apply.html:112
-msgid ""
-"The Wikipedia Library team will process this application. Want to help? <a "
-"class=\"twl-links\" href=\"https://en.wikipedia.org/wiki/Wikipedia:"
-"The_Wikipedia_Library/Coordinators/Signup\">Sign up as a coordinator.</a>"
+msgid "The Wikipedia Library team will process this application. Want to help? <a class=\"twl-links\" href=\"https://en.wikipedia.org/wiki/Wikipedia:The_Wikipedia_Library/Coordinators/Signup\">Sign up as a coordinator.</a>"
 msgstr ""
 
 #. Translators: This text labels a button coordinators can click to view a list of users who have applied for access for a particular partner
@@ -1781,18 +1481,13 @@ msgstr ""
 
 #. Translators: Text shown to authenticated, bundle eligible users when they visit a Bundle partner page.
 #: TWLight/resources/templates/resources/partner_detail_apply.html:138
-msgid ""
-"You are eligible to access Library Bundle partners. Click the button above "
-"to access the collection."
+msgid "You are eligible to access Library Bundle partners. Click the button above to access the collection."
 msgstr ""
 
 #. Translators: Text shown to authenticated, bundle ineligible users when they visit a Bundle partner page.
 #: TWLight/resources/templates/resources/partner_detail_apply.html:152
 #, python-format
-msgid ""
-"You are not eligible to access Library Bundle partners. Visit the <a class="
-"\"twl-links\" href=\"%(homepage)s\">homepage</a> to check the eligibility "
-"criteria."
+msgid "You are not eligible to access Library Bundle partners. Visit the <a class=\"twl-links\" href=\"%(homepage)s\">homepage</a> to check the eligibility criteria."
 msgstr ""
 
 #. Translators: Buttton prompting users to log in.
@@ -1804,10 +1499,7 @@ msgstr ""
 #. Translators: Text shown to unauthenticated users when they visit a Bundle partner page.
 #: TWLight/resources/templates/resources/partner_detail_apply.html:168
 #, python-format
-msgid ""
-"This resource is part of our <a class=\"twl-links\" href=\"%(about)s"
-"\">Library Bundle</a>, which you can access if you meet our minimum "
-"eligibility criteria. Log in to find out if you are eligible."
+msgid "This resource is part of our <a class=\"twl-links\" href=\"%(about)s\">Library Bundle</a>, which you can access if you meet our minimum eligibility criteria. Log in to find out if you are eligible."
 msgstr ""
 
 #. Translators: This is the label for a number which shows the total active accounts for one partner. (e.g. https://wikipedialibrary.wmflabs.org/partners/8/).
@@ -1858,26 +1550,19 @@ msgstr ""
 #. Translators: If a partner has specified the excerpt limit both in words and percentage, this message will display the percentage of words and the number of words on the partner page.
 #: TWLight/resources/templates/resources/partner_detail_timeline.html:99
 #, python-format
-msgid ""
-"%(object)s allows a maximum of %(excerpt_limit)s words or "
-"%(excerpt_limit_percentage)s%% of an article be excerpted into a Wikipedia "
-"article."
+msgid "%(object)s allows a maximum of %(excerpt_limit)s words or %(excerpt_limit_percentage)s%% of an article be excerpted into a Wikipedia article."
 msgstr ""
 
 #. Translators: If a partner has specified the excerpt limit in words, this message will display the number of words on the partner page.
 #: TWLight/resources/templates/resources/partner_detail_timeline.html:106
 #, python-format
-msgid ""
-"%(object)s allows a maximum of %(excerpt_limit)s words be excerpted into a "
-"Wikipedia article."
+msgid "%(object)s allows a maximum of %(excerpt_limit)s words be excerpted into a Wikipedia article."
 msgstr ""
 
 #. Translators: If a partner has specified the excerpt limit in percentage, this message will display the percentage of words on the partner page.
 #: TWLight/resources/templates/resources/partner_detail_timeline.html:113
 #, python-format
-msgid ""
-"%(object)s allows a maximum of %(excerpt_limit_percentage)s%% of an article "
-"be excerpted into a Wikipedia article."
+msgid "%(object)s allows a maximum of %(excerpt_limit_percentage)s%% of an article be excerpted into a Wikipedia article."
 msgstr ""
 
 #. Translators: If a partner has other requirements for access, this text shows as the title for that information field. (e.g. https://wikipedialibrary.wmflabs.org/partners/10/).
@@ -1888,9 +1573,7 @@ msgstr ""
 #. Translators: If a user must agree to a Terms of Use document, they see this message, and must enter the name of the resource. Don't translate publisher or url.
 #: TWLight/resources/templates/resources/partner_detail_timeline.html:140
 #, python-format
-msgid ""
-"%(publisher)s requires that you agree with its <a href=\"%(url)s\">terms of "
-"use</a>."
+msgid "%(publisher)s requires that you agree with its <a href=\"%(url)s\">terms of use</a>."
 msgstr ""
 
 #. Translators: If a user must provide their real name to apply to a partner, they see this message, and must enter the name of the resource. Don't translate publisher.
@@ -1914,17 +1597,13 @@ msgstr ""
 #. Translators: If a user must select a specific resource to apply for, they see this message, and must enter the name of the resource. Don't translate publisher.
 #: TWLight/resources/templates/resources/partner_detail_timeline.html:177
 #, python-format
-msgid ""
-"%(publisher)s requires that you specify a particular title that you want to "
-"access."
+msgid "%(publisher)s requires that you specify a particular title that you want to access."
 msgstr ""
 
 #. Translators: If a user must register on the partner website before applying, they see this message. Don't translate partner.
 #: TWLight/resources/templates/resources/partner_detail_timeline.html:187
 #, python-format
-msgid ""
-"%(publisher)s requires that you sign up for an account before applying for "
-"access."
+msgid "%(publisher)s requires that you sign up for an account before applying for access."
 msgstr ""
 
 #. Translators: If a partner has their location listed, this message is a label for that location
@@ -2052,12 +1731,8 @@ msgstr ""
 
 #. Translators: If multiple authorizations where returned for a collection, this message is shown to a user
 #: TWLight/resources/views.py:268
-msgid ""
-"Multiple authorizations were returned – something's wrong. Please contact us "
-"and don't forget to mention this message."
-msgstr ""
-"Multiple authorisations were returned – something's wrong. Please contact us "
-"and don't forget to mention this message."
+msgid "Multiple authorizations were returned – something's wrong. Please contact us and don't forget to mention this message."
+msgstr "Multiple authorisations were returned – something's wrong. Please contact us and don't forget to mention this message."
 
 #. Translators: This message is shown when user tries to access a NOT_AVAILABLE Partner
 #: TWLight/resources/views.py:316
@@ -2097,14 +1772,7 @@ msgstr ""
 #. Translators: Shown on the website's 400 page, when a user sends a bad request. Don't translate path or Phabricator.
 #: TWLight/templates/400.html:20
 #, python-format
-msgid ""
-"If you think we should know what to do with that, please email us about this "
-"error at <a class=\"twl-links\" href=\"mailto:wikipedialibrary@wikimedia.org?"
-"Subject=Wikipedia%%20Library%%20%(path)s%%20Permission%%20denied"
-"\">wikipedialibrary@wikimedia.org</a> or report it to us on <a class=\"twl-"
-"links\" href=\"https://phabricator.wikimedia.org/maniphest/task/edit/form/1/?"
-"projectPHIDs=Library-Card-Platform&title=Wikipedia%%20Library%%20%(path)s"
-"%%20Bad%%20Request\">Phabricator</a>"
+msgid "If you think we should know what to do with that, please email us about this error at <a class=\"twl-links\" href=\"mailto:wikipedialibrary@wikimedia.org?Subject=Wikipedia%%20Library%%20%(path)s%%20Permission%%20denied\">wikipedialibrary@wikimedia.org</a> or report it to us on <a class=\"twl-links\" href=\"https://phabricator.wikimedia.org/maniphest/task/edit/form/1/?projectPHIDs=Library-Card-Platform&title=Wikipedia%%20Library%%20%(path)s%%20Bad%%20Request\">Phabricator</a>"
 msgstr ""
 
 #. Translators: Alt text for an image shown on the 400 error page.
@@ -2126,15 +1794,7 @@ msgstr ""
 #. Translators: Shown on the website's 403 page, when a user attempts to navigate to a page they don't have permission to view. Don't translate path or Phabricator.
 #: TWLight/templates/403.html:20
 #, python-format
-msgid ""
-"If you think your account should be able to do that, please email us about "
-"this error at <a class=\"twl-links\" href=\"mailto:"
-"wikipedialibrary@wikimedia.org?Subject=Wikipedia%%20Library%%20%(path)s"
-"%%20Permission%%20denied\">wikipedialibrary@wikimedia.org</a> or report it "
-"to us on <a class=\"twl-links\" href=\"https://phabricator.wikimedia.org/"
-"maniphest/task/edit/form/1/?projectPHIDs=Library-Card-"
-"Platform&title=Wikipedia%%20Library%%20%(path)s%%20Permission%%20denied"
-"\">Phabricator</a>"
+msgid "If you think your account should be able to do that, please email us about this error at <a class=\"twl-links\" href=\"mailto:wikipedialibrary@wikimedia.org?Subject=Wikipedia%%20Library%%20%(path)s%%20Permission%%20denied\">wikipedialibrary@wikimedia.org</a> or report it to us on <a class=\"twl-links\" href=\"https://phabricator.wikimedia.org/maniphest/task/edit/form/1/?projectPHIDs=Library-Card-Platform&title=Wikipedia%%20Library%%20%(path)s%%20Permission%%20denied\">Phabricator</a>"
 msgstr ""
 
 #. Translators: Shown on the website's 404 page, when a user attempts to navigate to a page that doesn't exist.
@@ -2150,14 +1810,7 @@ msgstr ""
 #. Translators: Shown on the website's 404 page, when a user attempts to navigate to a page that doesn't exist. Don't translate path or Phabricator.
 #: TWLight/templates/404.html:19
 #, python-format
-msgid ""
-"If you are certain that something should be here, please email us about this "
-"error at <a class=\"twl-links\" href=\"mailto:wikipedialibrary@wikimedia.org?"
-"Subject=Wikipedia%%20Library%%20%(path)s%%20Not%%20found\"> "
-"wikipedialibrary@wikimedia.org</a> or report it to us on <a class=\"twl-links"
-"\" href=\"https://phabricator.wikimedia.org/maniphest/task/edit/form/1/?"
-"projectPHIDs=Library-Card-Platform&title=Wikipedia%%20Library%%20%(path)s"
-"%%20Not%%20found\">Phabricator</a>"
+msgid "If you are certain that something should be here, please email us about this error at <a class=\"twl-links\" href=\"mailto:wikipedialibrary@wikimedia.org?Subject=Wikipedia%%20Library%%20%(path)s%%20Not%%20found\"> wikipedialibrary@wikimedia.org</a> or report it to us on <a class=\"twl-links\" href=\"https://phabricator.wikimedia.org/maniphest/task/edit/form/1/?projectPHIDs=Library-Card-Platform&title=Wikipedia%%20Library%%20%(path)s%%20Not%%20found\">Phabricator</a>"
 msgstr ""
 
 #. Translators: Alt text for an image shown on the 404 error page.
@@ -2172,37 +1825,19 @@ msgstr ""
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:20
-msgid ""
-"This platform is our central tool for facilitating access to our available "
-"collections. Here you can see which partnerships are available, search their "
-"contents, and apply for and access the ones you’re interested in."
+msgid "This platform is our central tool for facilitating access to our available collections. Here you can see which partnerships are available, search their contents, and apply for and access the ones you’re interested in."
 msgstr ""
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/). Wikimedia Foundation should not be translated.
 #: TWLight/templates/about.html:29
-msgid ""
-"All users receive immediate access to some collections, which can be browsed "
-"by clicking the 'Access collection' buttons or using the search bar at the "
-"top of the page. Other collections require an application before access is "
-"granted, and may be accessed directly or via an individual login or access "
-"code. Volunteer coordinators, who have signed non-disclosure agreements with "
-"the Wikimedia Foundation, review these applications and work with publishers "
-"to get you your free access."
+msgid "All users receive immediate access to some collections, which can be browsed by clicking the 'Access collection' buttons or using the search bar at the top of the page. Other collections require an application before access is granted, and may be accessed directly or via an individual login or access code. Volunteer coordinators, who have signed non-disclosure agreements with the Wikimedia Foundation, review these applications and work with publishers to get you your free access."
 msgstr ""
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/). Don't translate terms_url.
 #: TWLight/templates/about.html:43
 #, python-format
-msgid ""
-"For more information about how your information is stored and reviewed "
-"please see our <a class=\"twl-links\" href=\"%(terms_url)s\"> terms of use "
-"and privacy policy</a>. Accounts you apply for are also subject to the Terms "
-"of Use provided by each partner’s platform; please review them."
-msgstr ""
-"For more information about how your information is stored and reviewed "
-"please see our <a class=\"twl-links\" href=\"%(terms_url)s\"> terms of use "
-"and privacy policy</a>. Accounts you apply for are also subject to the Terms "
-"of Use provided by each partner’s platform; please review them."
+msgid "For more information about how your information is stored and reviewed please see our <a class=\"twl-links\" href=\"%(terms_url)s\"> terms of use and privacy policy</a>. Accounts you apply for are also subject to the Terms of Use provided by each partner’s platform; please review them."
+msgstr "For more information about how your information is stored and reviewed please see our <a class=\"twl-links\" href=\"%(terms_url)s\"> terms of use and privacy policy</a>. Accounts you apply for are also subject to the Terms of Use provided by each partner’s platform; please review them."
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:51
@@ -2211,12 +1846,7 @@ msgstr ""
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/). Wikimedia Foundation should not be translated.
 #: TWLight/templates/about.html:55
-msgid ""
-"Any active editor in good standing can receive access. For publishers with "
-"limited numbers of accounts, applications are reviewed based on the editor’s "
-"needs and contributions. If you think you could use access to one of our "
-"partner resources and are an active editor in any project supported by the "
-"Wikimedia Foundation, please apply."
+msgid "Any active editor in good standing can receive access. For publishers with limited numbers of accounts, applications are reviewed based on the editor’s needs and contributions. If you think you could use access to one of our partner resources and are an active editor in any project supported by the Wikimedia Foundation, please apply."
 msgstr ""
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
@@ -2246,23 +1876,12 @@ msgstr ""
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/)
 #: TWLight/templates/about.html:89
-msgid ""
-"If you are applying for an available collection, please first check that you "
-"don't already have access through another library or institution. If you do, "
-"please consider using that access rather than taking up a seat for this "
-"resource in The Wikipedia Library."
+msgid "If you are applying for an available collection, please first check that you don't already have access through another library or institution. If you do, please consider using that access rather than taking up a seat for this resource in The Wikipedia Library."
 msgstr ""
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/)
 #: TWLight/templates/about.html:99
-msgid ""
-"If your account is blocked on one or more Wikimedia projects, you may still "
-"be granted access to The Wikipedia Library. You will need to contact the "
-"Wikipedia Library team, who will review your blocks. If you have been "
-"blocked for content issues, most notably copyright violations, or have "
-"multiple long-term blocks, we may decline your request. Additionally, if "
-"your block status changes after being approved, you will need to request "
-"another review."
+msgid "If your account is blocked on one or more Wikimedia projects, you may still be granted access to The Wikipedia Library. You will need to contact the Wikipedia Library team, who will review your blocks. If you have been blocked for content issues, most notably copyright violations, or have multiple long-term blocks, we may decline your request. Additionally, if your block status changes after being approved, you will need to request another review."
 msgstr ""
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
@@ -2297,9 +1916,7 @@ msgstr ""
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:136
-msgid ""
-"Share their account logins or passwords with others, or sell their access to "
-"other parties"
+msgid "Share their account logins or passwords with others, or sell their access to other parties"
 msgstr ""
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
@@ -2309,23 +1926,17 @@ msgstr ""
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:144
-msgid ""
-"Systematically make printed or electronic copies of multiple extracts of "
-"restricted content available for any purpose"
+msgid "Systematically make printed or electronic copies of multiple extracts of restricted content available for any purpose"
 msgstr ""
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/). Stub is a technical term for a short Wikipedia article, use the appropriate Wikipedia term in your language.
 #: TWLight/templates/about.html:148
-msgid ""
-"Datamine metadata without permission, in order, for instance, to use "
-"metadata for auto-created stub articles"
+msgid "Datamine metadata without permission, in order, for instance, to use metadata for auto-created stub articles"
 msgstr ""
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:154
-msgid ""
-"Respecting these agreements allows us to continue growing the partnerships "
-"available to the community."
+msgid "Respecting these agreements allows us to continue growing the partnerships available to the community."
 msgstr ""
 
 #. Translators: This is the heading for a section on the About page (https://wikipedialibrary.wmflabs.org/about/).
@@ -2335,41 +1946,22 @@ msgstr ""
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:164
-msgid ""
-"EZProxy is a proxy server used to authenticate users for many Wikipedia "
-"Library partners. Users sign into EZProxy via the Library Card platform to "
-"verify that they are authorized users, and then the server accesses "
-"requested resources using its own IP address."
+msgid "EZProxy is a proxy server used to authenticate users for many Wikipedia Library partners. Users sign into EZProxy via the Library Card platform to verify that they are authorized users, and then the server accesses requested resources using its own IP address."
 msgstr ""
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:173
-msgid ""
-"You may notice that when accessing resources via EZProxy that URLs are "
-"dynamically rewritten. This is why we recommend logging in via the Library "
-"Card platform rather than going directly to the unproxied partner website. "
-"When in doubt, check the URL for ‘idm.oclc’. If it’s there, then you’re "
-"connected via EZProxy."
+msgid "You may notice that when accessing resources via EZProxy that URLs are dynamically rewritten. This is why we recommend logging in via the Library Card platform rather than going directly to the unproxied partner website. When in doubt, check the URL for ‘idm.oclc’. If it’s there, then you’re connected via EZProxy."
 msgstr ""
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:182
-msgid ""
-"Typically once you’ve logged in your session will remain active in your "
-"browser for up to two hours after you’ve finished searching. Note that use "
-"of EZProxy requires you to enable cookies. If you are having problems you "
-"should also try clearing your cache and restarting your browser."
+msgid "Typically once you’ve logged in your session will remain active in your browser for up to two hours after you’ve finished searching. Note that use of EZProxy requires you to enable cookies. If you are having problems you should also try clearing your cache and restarting your browser."
 msgstr ""
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/)
 #: TWLight/templates/about.html:193
-msgid ""
-"The Library Bundle is a collection of resources for which no application is "
-"required. If you meet the criteria laid out above, you will be authorized "
-"for access automatically upon logging in to the platform. Only some of our "
-"content is currently included in the Library Bundle, however we hope to "
-"expand the collection as more publishers become comfortable with "
-"participating. All Bundle content is accessed via EZProxy."
+msgid "The Library Bundle is a collection of resources for which no application is required. If you meet the criteria laid out above, you will be authorized for access automatically upon logging in to the platform. Only some of our content is currently included in the Library Bundle, however we hope to expand the collection as more publishers become comfortable with participating. All Bundle content is accessed via EZProxy."
 msgstr ""
 
 #. Translators: This is the heading for a section on the About page (https://wikipedialibrary.wmflabs.org/about/).
@@ -2379,12 +1971,7 @@ msgstr ""
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:206
-msgid ""
-"Citation practices vary by project and even by article. Generally, we "
-"support editors citing where they found information, in a form that allows "
-"others to check it for themselves. That often means providing both original "
-"source details as well as a link to the partner database in which the source "
-"was found."
+msgid "Citation practices vary by project and even by article. Generally, we support editors citing where they found information, in a form that allows others to check it for themselves. That often means providing both original source details as well as a link to the partner database in which the source was found."
 msgstr ""
 
 #. Translators: This is the heading for a section on the About page (https://wikipedialibrary.wmflabs.org/about/).
@@ -2396,12 +1983,8 @@ msgstr "Contact us"
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:218
 #, python-format
-msgid ""
-"If you have questions, need help, or want to volunteer to help, please see "
-"our <a class=\"twl-links\" href=\"%(contact_url)s\">contact page</a>."
-msgstr ""
-"If you have questions, need help, or want to volunteer to help, please see "
-"our <a class=\"twl-links\" href=\"%(contact_url)s\">contact page</a>."
+msgid "If you have questions, need help, or want to volunteer to help, please see our <a class=\"twl-links\" href=\"%(contact_url)s\">contact page</a>."
+msgstr "If you have questions, need help, or want to volunteer to help, please see our <a class=\"twl-links\" href=\"%(contact_url)s\">contact page</a>."
 
 #. Translators: This is the title of the panel box detailing the contact information for the Wikipedia Library team.
 #: TWLight/templates/contact.html:14
@@ -2440,12 +2023,8 @@ msgstr "Wikipedia Library Twitter page"
 #. Translators: This is the text that appears at the bottom of the contact us form directing users to the suggestions form.
 #: TWLight/templates/contact.html:48
 #, python-format
-msgid ""
-"(If you would like to suggest a partner, <a class=\"twl-links\" href="
-"\"%(suggest)s\"><strong>go here</strong></a>.)"
-msgstr ""
-"(If you would like to suggest a partner, <a class=\"contact-us-links\" href="
-"\"%(suggest)s\"><strong>go here</strong></a>.)"
+msgid "(If you would like to suggest a partner, <a class=\"twl-links\" href=\"%(suggest)s\"><strong>go here</strong></a>.)"
+msgstr "(If you would like to suggest a partner, <a class=\"contact-us-links\" href=\"%(suggest)s\"><strong>go here</strong></a>.)"
 
 #. Translators: On a special 'link to search' page, this message is shown if JavaScript is disabled.
 #: TWLight/templates/eds_search_endpoint.html:7
@@ -2505,9 +2084,7 @@ msgstr "The Wikipedia Library"
 #. Translators: Information about The Wikipedia Library.
 #: TWLight/templates/login_partial.html:53 TWLight/templates/new_base.html:21
 #, python-format
-msgid ""
-"More than 100 of the world's top subscription-only databases, with content "
-"in %(no_of_languages)s languages, free for Wikipedians of all backgrounds"
+msgid "More than 100 of the world's top subscription-only databases, with content in %(no_of_languages)s languages, free for Wikipedians of all backgrounds"
 msgstr ""
 
 #. Translators: Information about The Wikipedia Library.
@@ -2516,9 +2093,7 @@ msgid "Meet these criteria for automatic access"
 msgstr ""
 
 #: TWLight/templates/login_partial.html:69
-msgid ""
-"These criteria grant you access to certain collections but not all. Some "
-"collections are accessible on a per application basis only."
+msgid "These criteria grant you access to certain collections but not all. Some collections are accessible on a per application basis only."
 msgstr ""
 
 #: TWLight/templates/login_partial.html:89
@@ -2528,33 +2103,19 @@ msgstr ""
 #. Translators: Shown if the current user doesn't have a registered email on their account. Don't translate contact_us_url or email_url.
 #: TWLight/templates/message_partial.html:15
 #, python-format
-msgid ""
-"You don't have an email on file. We can't finalize your access to partner "
-"resources, and you won't be able to <a class=\"twl-links\" href="
-"\"%(contact_us_url)s\">contact us</a> without an email. Please <a class="
-"\"twl-links\" href=\"%(email_url)s\">update your email</a>."
-msgstr ""
-"You don't have an email on file. We can't finalise your access to partner "
-"resources, and you won't be able to <a class=\"twl-links\" href="
-"\"%(contact_us_url)s\">contact us</a> without an email. Please <a class="
-"\"twl-links\" href=\"%(email_url)s\">update your email</a>."
+msgid "You don't have an email on file. We can't finalize your access to partner resources, and you won't be able to <a class=\"twl-links\" href=\"%(contact_us_url)s\">contact us</a> without an email. Please <a class=\"twl-links\" href=\"%(email_url)s\">update your email</a>."
+msgstr "You don't have an email on file. We can't finalise your access to partner resources, and you won't be able to <a class=\"twl-links\" href=\"%(contact_us_url)s\">contact us</a> without an email. Please <a class=\"twl-links\" href=\"%(email_url)s\">update your email</a>."
 
 #. Translators: Shown if the current user has requested the processing of their data should be restricted.
 #: TWLight/templates/message_partial.html:26
 #, python-format
-msgid ""
-"You have requested a restriction on the processing of your data. Most site "
-"functionality will not be available to you until you <a class=\"twl-links\" "
-"href=\"%(restrict_url)s\">lift this restriction</a>."
+msgid "You have requested a restriction on the processing of your data. Most site functionality will not be available to you until you <a class=\"twl-links\" href=\"%(restrict_url)s\">lift this restriction</a>."
 msgstr ""
 
 #. Translators: Shown if the current user has not agreed to the terms of use.
 #: TWLight/templates/message_partial.html:37
 #, python-format
-msgid ""
-"You have not agreed to the <a class=\"twl-links\" href=\"%(terms_url)s"
-"\">terms of use</a> of this site. Your applications will not be processed "
-"and you won't be able to apply or access resources you are approved for."
+msgid "You have not agreed to the <a class=\"twl-links\" href=\"%(terms_url)s\">terms of use</a> of this site. Your applications will not be processed and you won't be able to apply or access resources you are approved for."
 msgstr ""
 
 #. Translators: This link is at the bottom of every page and links to the 'About' page (https://wikipedialibrary.wmflabs.org/about/)
@@ -2602,9 +2163,7 @@ msgstr ""
 
 #. Translators: If a user goes to reset their password, this message asks them to enter their email to do so.
 #: TWLight/templates/registration/password_reset_form.html:13
-msgid ""
-"Forgot your password? Enter your email address below, and we'll email "
-"instructions for setting a new one."
+msgid "Forgot your password? Enter your email address below, and we'll email instructions for setting a new one."
 msgstr ""
 
 #. Translators: This is the label for a button that users click to update their public information.
@@ -2649,16 +2208,12 @@ msgstr ""
 
 #. Translators: This text explains how to disagree to the site's terms of use and the restrictions that will come into effect when users disagree to the terms of use.
 #: TWLight/users/forms.py:185
-msgid ""
-"By unchecking this box and clicking “Update” you may explore the site, but "
-"you will not be able to apply for access to materials or evaluate "
-"applications unless you agree with the terms of use."
+msgid "By unchecking this box and clicking “Update” you may explore the site, but you will not be able to apply for access to materials or evaluate applications unless you agree with the terms of use."
 msgstr ""
 
 #. Translators: Users click this button to set their website email address to the one linked to their Wikipedia account.
 #: TWLight/users/forms.py:211
-msgid ""
-"Use my Wikipedia email address (will be updated the next time you login)."
+msgid "Use my Wikipedia email address (will be updated the next time you login)."
 msgstr ""
 
 #. Translators: This labels a button which users click to change their email.
@@ -2669,17 +2224,8 @@ msgstr ""
 #. Translators: Shown if the current user tried to 'favorite' a partner they can't access. Do not translate '{partner}'
 #: TWLight/users/models.py:201
 #, python-brace-format
-msgid ""
-"Cannot add partner {partner} to your favorites because you don't have access "
-"to it"
+msgid "Cannot add partner {partner} to your favorites because you don't have access to it"
 msgstr ""
-
-#. Translators: Do not translate.
-#: TWLight/users/models.py:869
-#, fuzzy, python-brace-format
-#| msgid "Username"
-msgid "{wp_username}"
-msgstr "Username"
 
 #. Translators: This error message is shown when there's a problem with the authenticated login process.
 #: TWLight/users/oauth.py:243
@@ -2699,9 +2245,7 @@ msgstr ""
 
 #. Translators: this message is displayed to users that don't have accounts and clicked on a proxied link.
 #: TWLight/users/oauth.py:388
-msgid ""
-"To view this link you need to be an eligible library user. Please login to "
-"continue."
+msgid "To view this link you need to be an eligible library user. Please login to continue."
 msgstr ""
 
 #. Translators: This warning message is shown to users when the response received from Wikimedia OAuth servers is not a valid one.
@@ -2737,17 +2281,12 @@ msgstr ""
 
 #. Translators: If the user tries to log in, but their account does not meet certain requirements, they cannot login.
 #: TWLight/users/oauth.py:528
-msgid ""
-"Your Wikipedia account does not meet the eligibility criteria in the terms "
-"of use, so your Wikipedia Library Card Platform account cannot be activated."
+msgid "Your Wikipedia account does not meet the eligibility criteria in the terms of use, so your Wikipedia Library Card Platform account cannot be activated."
 msgstr ""
 
 #. Translators: If the user tries to log in, but their account does not meet certain requirements, they cannot login.
 #: TWLight/users/oauth.py:536
-msgid ""
-"Your Wikipedia account no longer meets the eligibility criteria in the terms "
-"of use, so you cannot be logged in. If you think you should be able to log "
-"in, please email wikipedialibrary@wikimedia.org."
+msgid "Your Wikipedia account no longer meets the eligibility criteria in the terms of use, so you cannot be logged in. If you think you should be able to log in, please email wikipedialibrary@wikimedia.org."
 msgstr ""
 
 #. Translators: this message is displayed to users with brand new accounts.
@@ -2758,10 +2297,7 @@ msgstr ""
 #. Translators: This message is displayed on the confirmation page where users can return their access to partner collections.
 #: TWLight/users/templates/users/authorization_confirm_return.html:13
 #, python-format
-msgid ""
-"You will no longer be able to access <b>%(partner)s's</b> resources via the "
-"Library Card platform, but can request access again by clicking 'renew', if "
-"you change your mind. Are you sure you want to return your access?"
+msgid "You will no longer be able to access <b>%(partner)s's</b> resources via the Library Card platform, but can request access again by clicking 'renew', if you change your mind. Are you sure you want to return your access?"
 msgstr ""
 
 #. Translators: On the MyLibrary page (https://wikipedialibrary.wmflabs.org/users/my_library), this tab shows all favorite collections a user has.
@@ -2834,10 +2370,7 @@ msgstr ""
 
 #. Translators: This is shown on editor profiles, in their profile page or on applications.
 #: TWLight/users/templates/users/editor_detail.html:59
-msgid ""
-"Information with an * was retrieved from Wikipedia directly. Other "
-"information was entered directly by users or site admins, in their preferred "
-"language."
+msgid "Information with an * was retrieved from Wikipedia directly. Other information was entered directly by users or site admins, in their preferred language."
 msgstr ""
 
 #. Translators: This distinguishes users who have been flagged as account coordinators. Don't translate username.
@@ -2848,10 +2381,7 @@ msgstr ""
 
 #. Translators: This is shown on editor profiles, under the heading for Wikipedia editor data.
 #: TWLight/users/templates/users/editor_detail_data.html:5
-msgid ""
-"This information is updated automatically from your Wikimedia account each "
-"time you log in, except for the Contributions field, where you can describe "
-"your Wikimedia editing history."
+msgid "This information is updated automatically from your Wikimedia account each time you log in, except for the Contributions field, where you can describe your Wikimedia editing history."
 msgstr ""
 
 #. Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this labels the user's username.
@@ -2881,17 +2411,13 @@ msgstr ""
 
 #. Translators: when viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this question has a yes or no answer.
 #: TWLight/users/templates/users/editor_detail_data.html:57
-msgid ""
-"at their last login, did this user meet the criteria set forth in the terms "
-"of use?"
+msgid "at their last login, did this user meet the criteria set forth in the terms of use?"
 msgstr ""
 
 #. Translators: When viewing a user's profile in an application, this message shows if the software doesn't think that the user is eligible for access. Don't translate username.
 #: TWLight/users/templates/users/editor_detail_data.html:72
 #, python-format
-msgid ""
-"%(username)s may still be eligible for access grants at the coordinators' "
-"discretion."
+msgid "%(username)s may still be eligible for access grants at the coordinators' discretion."
 msgstr ""
 
 #. Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this is the heading for a Yes/No ToU question.
@@ -2926,14 +2452,8 @@ msgstr ""
 #. Translators: This message is shown on a user's profile if their Wikimedia account is blocked on one or more projects. They may still be granted access to the Library Bundle, but need to contact Wikipedia Library staff to verify.
 #: TWLight/users/templates/users/editor_detail_data.html:137
 #, python-format
-msgid ""
-"It looks like you have an active block on your account. If you meet the "
-"other criteria you may still be permitted access to the library - please <a "
-"class=\"twl-links\" href=\"%(contact_url)s\">contact us</a>."
-msgstr ""
-"Ga alama kuna da toshe mai aiki akan asusunka. Idan kun cika wasu ƙa'idodin "
-"har yanzu ana iya ba ku izinin shiga ɗakin karatu - don Allah <a class=\"twl-"
-"links\" href=\"%(contact_url)s\"> tuntube mu </a>."
+msgid "It looks like you have an active block on your account. If you meet the other criteria you may still be permitted access to the library - please <a class=\"twl-links\" href=\"%(contact_url)s\">contact us</a>."
+msgstr "Ga alama kuna da toshe mai aiki akan asusunka. Idan kun cika wasu ƙa'idodin har yanzu ana iya ba ku izinin shiga ɗakin karatu - don Allah <a class=\"twl-links\" href=\"%(contact_url)s\"> tuntube mu </a>."
 
 #. Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this is the heading for a Yes/No program eligibility question.
 #: TWLight/users/templates/users/editor_detail_data.html:153
@@ -2942,10 +2462,7 @@ msgstr ""
 
 #. Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this question has a Yes or No answer.
 #: TWLight/users/templates/users/editor_detail_data.html:156
-msgid ""
-"At their last login, did this user meet the criteria set forth in the "
-"Library Bundle? Note that satisfying terms of use is a prerequisite to "
-"bundle eligibility."
+msgid "At their last login, did this user meet the criteria set forth in the Library Bundle? Note that satisfying terms of use is a prerequisite to bundle eligibility."
 msgstr ""
 
 #. Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this is the heading for a Yes/No program eligibility question.
@@ -2990,18 +2507,13 @@ msgstr ""
 
 #. Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this text is in the 'Personal data' section. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/users/templates/users/editor_detail_data.html:262
-msgid ""
-"The following information is visible only to you, site administrators, "
-"publishing partners (where required), and volunteer Wikipedia Library "
-"coordinators (who have signed a Non-Disclosure Agreement)."
+msgid "The following information is visible only to you, site administrators, publishing partners (where required), and volunteer Wikipedia Library coordinators (who have signed a Non-Disclosure Agreement)."
 msgstr ""
 
 #. Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this labels a button which users can click to update or remove their personal information. Don't translate update_url.
 #: TWLight/users/templates/users/editor_detail_data.html:272
 #, python-format
-msgid ""
-"You may <a class=\"twl-links\" href=\"%(update_url)s\">update or delete</a> "
-"your data at any time."
+msgid "You may <a class=\"twl-links\" href=\"%(update_url)s\">update or delete</a> your data at any time."
 msgstr ""
 
 #. Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this labels the user's email. Don't remove the *.
@@ -3021,26 +2533,18 @@ msgstr ""
 
 #. Translators: This message tells users that they are not eligible to access The Wikipedia Library content.
 #: TWLight/users/templates/users/eligibility_modal.html:7
-msgid ""
-"Sorry, your Wikipedia account doesn’t currently qualify to access The "
-"Wikipedia Library."
+msgid "Sorry, your Wikipedia account doesn’t currently qualify to access The Wikipedia Library."
 msgstr ""
 
 #. Translators: This message tells users that they have not agreed to the terms of use, therefore are ineligible to access the content in The Wikipedia Library.
 #: TWLight/users/templates/users/eligibility_modal.html:30
 #, python-format
-msgid ""
-"Agreed with <a href=\"%(terms)s\" class=\"text-danger\"> terms of use </a>"
-msgstr ""
-"Has agreed to the site's <a href=\"%(terms)s\" class=\"text-danger\">terms "
-"of use</a>?"
+msgid "Agreed with <a href=\"%(terms)s\" class=\"text-danger\"> terms of use </a>"
+msgstr "Has agreed to the site's <a href=\"%(terms)s\" class=\"text-danger\">terms of use</a>?"
 
 #: TWLight/users/templates/users/eligibility_modal.html:40
 #, python-format
-msgid ""
-"It looks like you have an active block on your account. If you meet the "
-"other criteria you may still be permitted access to the library - please <a "
-"href=\"%(contact_url)s\">contact us</a>."
+msgid "It looks like you have an active block on your account. If you meet the other criteria you may still be permitted access to the library - please <a href=\"%(contact_url)s\">contact us</a>."
 msgstr ""
 
 #. Translators: Instructions to refresh a user's data.
@@ -3080,10 +2584,7 @@ msgstr ""
 
 #. Translators: This text on the user page helps users naviage to the TranslateWiki Wikipedia Library Card platform translation page.
 #: TWLight/users/templates/users/language_form.html:31
-msgid ""
-"You can help translate the tool at <a class=\"twl-links\" href=\"https://"
-"translatewiki.net/wiki/Translating:Wikipedia_Library_Card_Platform"
-"\">translatewiki.net</a>."
+msgid "You can help translate the tool at <a class=\"twl-links\" href=\"https://translatewiki.net/wiki/Translating:Wikipedia_Library_Card_Platform\">translatewiki.net</a>."
 msgstr ""
 
 #. Translators: When the user starts a new application and submits the application, the user can view the application and withdraw if need be. This changes the label for the Withdraw button.
@@ -3103,9 +2604,7 @@ msgstr "Request renewal"
 
 #. Translators: On the page listing applications, this text explains a user they cannot renew their application since they've already requested a renewal or there aren't any renewals available.
 #: TWLight/users/templates/users/my_applications.html:79
-msgid ""
-"Renewals are either not required, not available right now, or you have "
-"already requested a renewal."
+msgid "Renewals are either not required, not available right now, or you have already requested a renewal."
 msgstr ""
 
 #. Translators: This text is the heading of a section in a user's profile where they can change their preferences.
@@ -3169,19 +2668,12 @@ msgstr ""
 
 #. Translators: This message is displayed on the page where users can request we stop processing their data.
 #: TWLight/users/templates/users/restrict_data.html:15
-msgid ""
-"Checking this box and clicking “Restrict” will pause all processing of the "
-"data you have entered into this website. You will not be able to apply for "
-"access to resources, your applications will not be further processed, and "
-"none of your data will be altered, until you return to this page and uncheck "
-"the box. This is not the same as deleting your data."
+msgid "Checking this box and clicking “Restrict” will pause all processing of the data you have entered into this website. You will not be able to apply for access to resources, your applications will not be further processed, and none of your data will be altered, until you return to this page and uncheck the box. This is not the same as deleting your data."
 msgstr ""
 
 #. Translators: This warning message is shown to coordinators who view the data restriction page.
 #: TWLight/users/templates/users/restrict_data.html:26
-msgid ""
-"You are a coordinator on this site. If you restrict the processing of your "
-"data, your coordinator flag will be removed."
+msgid "You are a coordinator on this site. If you restrict the processing of your data, your coordinator flag will be removed."
 msgstr ""
 
 #. Translators: use the date *when you are translating*, in a language-appropriate format.
@@ -3202,29 +2694,12 @@ msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:51
-msgid ""
-"<a class=\"twl-links\" href=\"https://meta.wikimedia.org/wiki/"
-"The_Wikipedia_Library\"> The Wikipedia Library </a> has partnered with "
-"publishers around the world to allow users to access otherwise paywalled "
-"resources. This website allows Wikipedia editors to search and access these "
-"resources."
-msgstr ""
-"<a class=\"twl-links\" href=\"https://meta.wikimedia.org/wiki/"
-"The_Wikipedia_Library\"> The Wikipedia Library </a> has partnered with "
-"publishers around the world to allow users to access otherwise paywalled "
-"resources. This website allows Wikipedia editors to search and access these "
-"resources."
+msgid "<a class=\"twl-links\" href=\"https://meta.wikimedia.org/wiki/The_Wikipedia_Library\"> The Wikipedia Library </a> has partnered with publishers around the world to allow users to access otherwise paywalled resources. This website allows Wikipedia editors to search and access these resources."
+msgstr "<a class=\"twl-links\" href=\"https://meta.wikimedia.org/wiki/The_Wikipedia_Library\"> The Wikipedia Library </a> has partnered with publishers around the world to allow users to access otherwise paywalled resources. This website allows Wikipedia editors to search and access these resources."
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Wikimedia Foundation should not be translated. WMF should not be translated. Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:63
-msgid ""
-"This program is administered by the Wikimedia Foundation (WMF). These terms "
-"of use and privacy notice pertain to your application for access to "
-"resources through the Wikipedia Library, your use of this website, and your "
-"access to and use of those resources. They also describe our handling of the "
-"information you provide to us in order to create and administer your "
-"Wikipedia Library account. If we make material changes to the terms, we will "
-"notify users."
+msgid "This program is administered by the Wikimedia Foundation (WMF). These terms of use and privacy notice pertain to your application for access to resources through the Wikipedia Library, your use of this website, and your access to and use of those resources. They also describe our handling of the information you provide to us in order to create and administer your Wikipedia Library account. If we make material changes to the terms, we will notify users."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
@@ -3234,37 +2709,17 @@ msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:78
-msgid ""
-"Access to resources via The Wikipedia Library is reserved for community "
-"members who have demonstrated their commitment to the Wikimedia projects, "
-"and who will use their access to these resources to improve project content. "
-"To that end, in order to be eligible for The Wikipedia Library, we require "
-"that you be registered for a user account on the projects, with at least 500 "
-"edits, six (6) months of activity, and 10+ edits in the last month. We ask "
-"that you do not request access to any publishers with a limited number of "
-"available accounts whose resources you can already access for free through "
-"your local library or university, or another institution or organization, in "
-"order to provide that opportunity to others."
+msgid "Access to resources via The Wikipedia Library is reserved for community members who have demonstrated their commitment to the Wikimedia projects, and who will use their access to these resources to improve project content. To that end, in order to be eligible for The Wikipedia Library, we require that you be registered for a user account on the projects, with at least 500 edits, six (6) months of activity, and 10+ edits in the last month. We ask that you do not request access to any publishers with a limited number of available accounts whose resources you can already access for free through your local library or university, or another institution or organization, in order to provide that opportunity to others."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:94
-msgid ""
-"Additionally, if you are currently blocked or banned from a Wikimedia "
-"project, applications to resources may be rejected or restricted. If you "
-"obtain a Wikipedia Library account, but a block or ban is subsequently "
-"instituted against you on one of the projects, you may lose access to your "
-"Wikipedia Library account."
+msgid "Additionally, if you are currently blocked or banned from a Wikimedia project, applications to resources may be rejected or restricted. If you obtain a Wikipedia Library account, but a block or ban is subsequently instituted against you on one of the projects, you may lose access to your Wikipedia Library account."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:104
-msgid ""
-"Your eligibility to access The Wikipedia Library is assessed at each login. "
-"While more than half of the library's content is provided via this automated "
-"eligibility check, access to other publisher's content may be time limited, "
-"typically lapsing after one year, after which you will usually need to apply "
-"for renewal."
+msgid "Your eligibility to access The Wikipedia Library is assessed at each login. While more than half of the library's content is provided via this automated eligibility check, access to other publisher's content may be time limited, typically lapsing after one year, after which you will usually need to apply for renewal."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
@@ -3275,47 +2730,27 @@ msgstr "Your Wikipedia Library access code"
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:118
-msgid ""
-"In order to apply for access to a partner resource, you must provide us with "
-"certain information, which we will use to evaluate your application. If your "
-"application is approved, we may transfer the information you have given us "
-"to the publishers whose resources you wish to access. They will either "
-"contact you with the account information directly or we will send access "
-"information to you ourselves."
+msgid "In order to apply for access to a partner resource, you must provide us with certain information, which we will use to evaluate your application. If your application is approved, we may transfer the information you have given us to the publishers whose resources you wish to access. They will either contact you with the account information directly or we will send access information to you ourselves."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:130
-msgid ""
-"In addition to the basic information you provide to us, our system will "
-"retrieve some information directly from the Wikimedia projects: your "
-"username, email address, edit count, registration date, user ID number, "
-"groups to which you belong, and any special user rights."
+msgid "In addition to the basic information you provide to us, our system will retrieve some information directly from the Wikimedia projects: your username, email address, edit count, registration date, user ID number, groups to which you belong, and any special user rights."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:140
-msgid ""
-"Each time you log in to the Wikipedia Library Card Platform, this "
-"information will be automatically updated."
+msgid "Each time you log in to the Wikipedia Library Card Platform, this information will be automatically updated."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:148
-msgid ""
-"We will ask you to provide us with some information about your history of "
-"contributions to the Wikimedia projects. Information on contribution history "
-"is optional, but will greatly assist us in evaluating your application."
+msgid "We will ask you to provide us with some information about your history of contributions to the Wikimedia projects. Information on contribution history is optional, but will greatly assist us in evaluating your application."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). WMF should not be translated. Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:157
-msgid ""
-"The information you provide when creating your account will be visible to "
-"you while on the site but not to others unless they are approved Wikipedia "
-"Library Coordinators, WMF Staff, or WMF Contractors who need access to this "
-"data in order to carry out their work with the Wikipedia Library, all of "
-"whom are subject to non-disclosure obligations."
+msgid "The information you provide when creating your account will be visible to you while on the site but not to others unless they are approved Wikipedia Library Coordinators, WMF Staff, or WMF Contractors who need access to this data in order to carry out their work with the Wikipedia Library, all of whom are subject to non-disclosure obligations."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
@@ -3325,46 +2760,32 @@ msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:171
-msgid ""
-"In order to access an individual publisher’s resources, you must agree to "
-"that publisher’s terms of use and privacy policy. You agree that you will "
-"not violate such terms and policies in connection with your use of the "
-"Wikipedia Library. Additionally, the following activities are prohibited "
-"while accessing publisher resources through the Wikipedia Library."
+msgid "In order to access an individual publisher’s resources, you must agree to that publisher’s terms of use and privacy policy. You agree that you will not violate such terms and policies in connection with your use of the Wikipedia Library. Additionally, the following activities are prohibited while accessing publisher resources through the Wikipedia Library."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:184
-msgid ""
-"Sharing your Wikipedia account, usernames, passwords, or any access codes "
-"for publisher resources with others;"
+msgid "Sharing your Wikipedia account, usernames, passwords, or any access codes for publisher resources with others;"
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:191
-msgid ""
-"Automatically scraping or downloading restricted content from publishers;"
+msgid "Automatically scraping or downloading restricted content from publishers;"
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:197
-msgid ""
-"Systematically making printed or electronic copies of multiple extracts of "
-"restricted content available for any purpose;"
+msgid "Systematically making printed or electronic copies of multiple extracts of restricted content available for any purpose;"
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:204
-msgid ""
-"Data mining metadata without permission—for example, in order to use "
-"metadata for auto-created stub articles;"
+msgid "Data mining metadata without permission—for example, in order to use metadata for auto-created stub articles;"
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:211
-msgid ""
-"Using the access you receive through the Wikipedia Library for profit by "
-"selling access to your account or resources which you have through it."
+msgid "Using the access you receive through the Wikipedia Library for profit by selling access to your account or resources which you have through it."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
@@ -3374,18 +2795,12 @@ msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:224
-msgid ""
-"Certain resources may only be accessed using an external search service, "
-"such as the EBSCO Discovery Service, or a proxy service, such as OCLC "
-"EZProxy. If you use such external search and/or proxy services, please "
-"review the applicable terms of use and privacy policies."
+msgid "Certain resources may only be accessed using an external search service, such as the EBSCO Discovery Service, or a proxy service, such as OCLC EZProxy. If you use such external search and/or proxy services, please review the applicable terms of use and privacy policies."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:234
-msgid ""
-"In addition, if you use OCLC EZProxy, please note that you may not use it "
-"for commercial purposes."
+msgid "In addition, if you use OCLC EZProxy, please note that you may not use it for commercial purposes."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
@@ -3395,131 +2810,49 @@ msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Wikimedia Foundation should not be translated. Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:245
-msgid ""
-"The Wikimedia Foundation and our service providers use your information for "
-"the legitimate purpose of providing Wikipedia Library services in support of "
-"our charitable mission. When you apply for a Wikipedia Library account, or "
-"use your Wikipedia Library account, we may routinely collect the following "
-"information: your username, email address, edit count, registration date, "
-"user ID number, groups to which you belong, and any special user rights; "
-"your name, country of residence, and/or affiliation, if required by a "
-"partner to which you are applying; your narrative description of your "
-"contributions and reasons for applying for access to partner resources; and "
-"the date you agree to these terms of use."
+msgid "The Wikimedia Foundation and our service providers use your information for the legitimate purpose of providing Wikipedia Library services in support of our charitable mission. When you apply for a Wikipedia Library account, or use your Wikipedia Library account, we may routinely collect the following information: your username, email address, edit count, registration date, user ID number, groups to which you belong, and any special user rights; your name, country of residence, and/or affiliation, if required by a partner to which you are applying; your narrative description of your contributions and reasons for applying for access to partner resources; and the date you agree to these terms of use."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:262
 #, python-format
-msgid ""
-"Each publisher who is a member of the Wikipedia Library program requires "
-"different specific information in the application. Some publishers may "
-"request only an email address, while others request more detailed data, such "
-"as your name, location, or institutional affiliation. When you complete your "
-"application, you will only be asked to supply information required by the "
-"publishers you have chosen, and each publisher will only receive the "
-"information they require for providing you with access. Please see our <a "
-"class=\"twl-links\" href=\"%(all_partners_url)s\">partner information</a> "
-"pages to learn what information is required by each publisher to gain access "
-"to their resources."
+msgid "Each publisher who is a member of the Wikipedia Library program requires different specific information in the application. Some publishers may request only an email address, while others request more detailed data, such as your name, location, or institutional affiliation. When you complete your application, you will only be asked to supply information required by the publishers you have chosen, and each publisher will only receive the information they require for providing you with access. Please see our <a class=\"twl-links\" href=\"%(all_partners_url)s\">partner information</a> pages to learn what information is required by each publisher to gain access to their resources."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Wikimedia Foundation should not be translated. Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:277
-msgid ""
-"Some Wikipedia Library pages are visible without logging in, but you will "
-"need to log in to apply or access proprietary partner resources. We use the "
-"data provided by you via OAuth and Wikimedia API calls to assess your "
-"application for access and to process approved requests."
+msgid "Some Wikipedia Library pages are visible without logging in, but you will need to log in to apply or access proprietary partner resources. We use the data provided by you via OAuth and Wikimedia API calls to assess your application for access and to process approved requests."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:288
 #, python-format
-msgid ""
-"In order to administer the Wikipedia Library program, we will retain the "
-"application data we collect from you for three years after your most recent "
-"login, unless you delete your account, as described below. You can log in "
-"and go to <a class=\"twl-links\" href=\"%(profile_url)s\">your profile page</"
-"a> in order to see the information associated with your account, and can "
-"download it in JSON format. You may access, update, restrict, or delete this "
-"information at any time, except for the information that is automatically "
-"retrieved from the projects. If you have any questions or concerns about the "
-"handling of your data, please contact <a class=\"twl-links\" href=\"mailto:"
-"wikipedialibrary@wikimedia.org?Subject=Wikipedia%%20Library%%20Card"
-"%%20account%%20deactivation\"> wikipedialibrary@wikimedia.org </a>."
-msgstr ""
-"In order to administer the Wikipedia Library program, we will retain the "
-"application data we collect from you for three years after your most recent "
-"login, unless you delete your account, as described below. You can log in "
-"and go to <a class=\"twl-links\" href=\"%(profile_url)s\">your profile page</"
-"a> in order to see the information associated with your account, and can "
-"download it in JSON format. You may access, update, restrict, or delete this "
-"information at any time, except for the information that is automatically "
-"retrieved from the projects. If you have any questions or concerns about the "
-"handling of your data, please contact <a class=\"twl-links\" href=\"mailto:"
-"wikipedialibrary@wikimedia.org?Subject=Wikipedia%%20Library%%20Card"
-"%%20account%%20deactivation\"> wikipedialibrary@wikimedia.org </a>."
+msgid "In order to administer the Wikipedia Library program, we will retain the application data we collect from you for three years after your most recent login, unless you delete your account, as described below. You can log in and go to <a class=\"twl-links\" href=\"%(profile_url)s\">your profile page</a> in order to see the information associated with your account, and can download it in JSON format. You may access, update, restrict, or delete this information at any time, except for the information that is automatically retrieved from the projects. If you have any questions or concerns about the handling of your data, please contact <a class=\"twl-links\" href=\"mailto:wikipedialibrary@wikimedia.org?Subject=Wikipedia%%20Library%%20Card%%20account%%20deactivation\"> wikipedialibrary@wikimedia.org </a>."
+msgstr "In order to administer the Wikipedia Library program, we will retain the application data we collect from you for three years after your most recent login, unless you delete your account, as described below. You can log in and go to <a class=\"twl-links\" href=\"%(profile_url)s\">your profile page</a> in order to see the information associated with your account, and can download it in JSON format. You may access, update, restrict, or delete this information at any time, except for the information that is automatically retrieved from the projects. If you have any questions or concerns about the handling of your data, please contact <a class=\"twl-links\" href=\"mailto:wikipedialibrary@wikimedia.org?Subject=Wikipedia%%20Library%%20Card%%20account%%20deactivation\"> wikipedialibrary@wikimedia.org </a>."
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:305
-msgid ""
-"If you decide to disable your Wikipedia Library account, you can use the "
-"delete button on your profile to delete certain personal information "
-"associated with your account. We will delete your real name, institutional "
-"affiliation, and country of residence. Please note that the system will "
-"retain a record of your username, the publishers to which you applied or had "
-"access, and the dates of that access. Note that deletion is not reversible. "
-"Deletion of your Wikipedia Library account may also correspond with the "
-"removal of any resource access to which you were eligible or approved. If "
-"you request the deletion of account information and later wish to apply for "
-"a new account, you will need to provide the necessary information again."
+msgid "If you decide to disable your Wikipedia Library account, you can use the delete button on your profile to delete certain personal information associated with your account. We will delete your real name, institutional affiliation, and country of residence. Please note that the system will retain a record of your username, the publishers to which you applied or had access, and the dates of that access. Note that deletion is not reversible. Deletion of your Wikipedia Library account may also correspond with the removal of any resource access to which you were eligible or approved. If you request the deletion of account information and later wish to apply for a new account, you will need to provide the necessary information again."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). WMF should not be translated. Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:321
-msgid ""
-"The Wikipedia Library is run by WMF Staff, Contractors, and approved "
-"volunteer Coordinators. The data associated with your account will be shared "
-"with the WMF staff, contractors, service providers, and volunteer "
-"coordinators who need to process the information in connection with their "
-"work for the Wikipedia Library, and who are subject to confidentiality "
-"obligations. We will also use your data for internal Wikipedia Library "
-"purposes such as distributing user surveys and account notifications, and in "
-"a depersonalized or aggregated fashion for statistical analysis and "
-"administration. Finally, we will share your information with the publishers "
-"whom you specifically select in order to provide you with access to "
-"resources. Otherwise, your information will not be shared with third "
-"parties, with the exception of the circumstances described below."
+msgid "The Wikipedia Library is run by WMF Staff, Contractors, and approved volunteer Coordinators. The data associated with your account will be shared with the WMF staff, contractors, service providers, and volunteer coordinators who need to process the information in connection with their work for the Wikipedia Library, and who are subject to confidentiality obligations. We will also use your data for internal Wikipedia Library purposes such as distributing user surveys and account notifications, and in a depersonalized or aggregated fashion for statistical analysis and administration. Finally, we will share your information with the publishers whom you specifically select in order to provide you with access to resources. Otherwise, your information will not be shared with third parties, with the exception of the circumstances described below."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). WMF should not be translated.
 #: TWLight/users/templates/users/terms.html:338
-msgid ""
-"We may disclose any collected information when required by law, when we have "
-"your permission, when needed to protect our rights, privacy, safety, users, "
-"or the general public, and when necessary to enforce these terms, WMF’s "
-"general <a class=\"twl-links\" href=\"https://foundation.wikimedia.org/wiki/"
-"Terms_of_Use\">Terms of Use</a>, or any other WMF policy."
+msgid "We may disclose any collected information when required by law, when we have your permission, when needed to protect our rights, privacy, safety, users, or the general public, and when necessary to enforce these terms, WMF’s general <a class=\"twl-links\" href=\"https://foundation.wikimedia.org/wiki/Terms_of_Use\">Terms of Use</a>, or any other WMF policy."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:349
-msgid ""
-"We take the security of your personal data seriously, and take reasonable "
-"precautions to ensure your data is protected. These precautions include "
-"access controls to limit who has access to your data and security "
-"technologies to protect data stored on the server. However, we cannot "
-"guarantee the safety of your data as it is transmitted and stored."
+msgid "We take the security of your personal data seriously, and take reasonable precautions to ensure your data is protected. These precautions include access controls to limit who has access to your data and security technologies to protect data stored on the server. However, we cannot guarantee the safety of your data as it is transmitted and stored."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:360
-msgid ""
-"Please note that these terms do not control the use and handling of your "
-"data by the publishers and service providers whose resources you access or "
-"apply to access. Please read their individual privacy policies for that "
-"information."
+msgid "Please note that these terms do not control the use and handling of your data by the publishers and service providers whose resources you access or apply to access. Please read their individual privacy policies for that information."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
@@ -3529,37 +2862,18 @@ msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Wikimedia Foundation should not be translated. Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:373
-msgid ""
-"The Wikimedia Foundation is a nonprofit organization based in San Francisco, "
-"California. The Wikipedia Library program provides access to resources held "
-"by publishers in multiple countries. If you apply for a Wikipedia Library "
-"account (whether you are inside or outside of the United States), you "
-"understand that your personal data will be collected, transferred, stored, "
-"processed, disclosed and otherwise used in the U.S. as described in this "
-"privacy policy. You also understand that your information may be transferred "
-"by us from the U.S. to other countries, which may have different or less "
-"stringent data protection laws than your country, in connection with "
-"providing services to you, including evaluating your application and "
-"securing access to your chosen publishers (locations for each publisher are "
-"outlined on their respective partner information pages)."
+msgid "The Wikimedia Foundation is a nonprofit organization based in San Francisco, California. The Wikipedia Library program provides access to resources held by publishers in multiple countries. If you apply for a Wikipedia Library account (whether you are inside or outside of the United States), you understand that your personal data will be collected, transferred, stored, processed, disclosed and otherwise used in the U.S. as described in this privacy policy. You also understand that your information may be transferred by us from the U.S. to other countries, which may have different or less stringent data protection laws than your country, in connection with providing services to you, including evaluating your application and securing access to your chosen publishers (locations for each publisher are outlined on their respective partner information pages)."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:392
-msgid ""
-"Please note that in the event of any differences in meaning or "
-"interpretation between the original English version of these terms and a "
-"translation, the original English version takes precedence."
+msgid "Please note that in the event of any differences in meaning or interpretation between the original English version of these terms and a translation, the original English version takes precedence."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Wikimedia Foundation should not be translated.
 #: TWLight/users/templates/users/terms.html:403
-msgid ""
-"See also the <a class=\"twl-links\" href=\"https://wikimediafoundation.org/"
-"wiki/Privacy_policy\">Wikimedia Foundation Privacy Policy</a>."
-msgstr ""
-"Hwɛ nso <class=\" twl- links\" href=\" https// wikimediafoundation.org/ "
-"wiki/ privacy_ policy\"> Wikipedia Foundation privacy policy</a>."
+msgid "See also the <a class=\"twl-links\" href=\"https://wikimediafoundation.org/wiki/Privacy_policy\">Wikimedia Foundation Privacy Policy</a>."
+msgstr "Hwɛ nso <class=\" twl- links\" href=\" https// wikimediafoundation.org/ wiki/ privacy_ policy\"> Wikipedia Foundation privacy policy</a>."
 
 #. Translators: This is the second to last line of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:412
@@ -3578,11 +2892,7 @@ msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:426
-msgid ""
-"By checking this box and clicking “Submit”, you agree that you have read the "
-"above terms and that you will adhere to the terms of use in your application "
-"to and use of the The Wikipedia Library, and the publishers’ services to "
-"which you gain access through The Wikipedia Library program."
+msgid "By checking this box and clicking “Submit”, you agree that you have read the above terms and that you will adhere to the terms of use in your application to and use of the The Wikipedia Library, and the publishers’ services to which you gain access through The Wikipedia Library program."
 msgstr ""
 
 #: TWLight/users/templates/users/user_collection_tile.html:32
@@ -3636,29 +2946,18 @@ msgstr ""
 
 #. Translators: This message is displayed on the page where users can request the deletion of their data.
 #: TWLight/users/templates/users/user_confirm_delete.html:17
-msgid ""
-"<b>Warning:</b> Performing this action will delete your Wikipedia Library "
-"Card user account and all associated applications. This process is not "
-"reversible. You may lose any partner accounts you were granted, and will not "
-"be able to renew those accounts or apply for new ones."
+msgid "<b>Warning:</b> Performing this action will delete your Wikipedia Library Card user account and all associated applications. This process is not reversible. You may lose any partner accounts you were granted, and will not be able to renew those accounts or apply for new ones."
 msgstr ""
 
 #. Translators: this should show up for people who log in with a username/password and not OAuth, so we don't know what their Wikipedia identity is.
-#.
 #: TWLight/users/templates/users/user_detail.html:12
 #, python-format
-msgid ""
-"Hi, %(username)s! You don't have a Wikipedia editor profile attached to your "
-"account here, so you are probably a site administrator."
+msgid "Hi, %(username)s! You don't have a Wikipedia editor profile attached to your account here, so you are probably a site administrator."
 msgstr ""
 
 #. Translators: In the unlikely scenario that someone is able to register an account without using OAuth (thus leaving us without some of the information required for applications), users will see this message, encouraging them to re-register.
 #: TWLight/users/templates/users/user_detail.html:20
-msgid ""
-"If you aren't a site administrator, something weird has happened. You won't "
-"be able to apply for access without a Wikipedia editor profile. You should "
-"log out and create a new account by logging in via OAuth, or contact a site "
-"administrator for help."
+msgid "If you aren't a site administrator, something weird has happened. You won't be able to apply for access without a Wikipedia editor profile. You should log out and create a new account by logging in via OAuth, or contact a site administrator for help."
 msgstr ""
 
 #. Translators: Labels a sections where coordinators can select their email preferences.
@@ -3669,17 +2968,12 @@ msgstr ""
 #. Translators: This message is shown on user's own profile page, encouraging them to make sure their information is up to date, so that account coordinators can use the information to judge applications.
 #: TWLight/users/views.py:176
 #, python-brace-format
-msgid ""
-"Please <a class='twl-links' href='{url}'>update your contributions</a> to "
-"Wikipedia to help coordinators evaluate your applications."
+msgid "Please <a class='twl-links' href='{url}'>update your contributions</a> to Wikipedia to help coordinators evaluate your applications."
 msgstr ""
 
 #. Translators: Coordinators are shown this message when they unselect all three types of reminder email options under preferences.
 #: TWLight/users/views.py:288
-msgid ""
-"You have chosen not to receive reminder emails. As a coordinator, you should "
-"receive at least one type of reminder emails, so consider changing your "
-"preferences."
+msgid "You have chosen not to receive reminder emails. As a coordinator, you should receive at least one type of reminder emails, so consider changing your preferences."
 msgstr ""
 
 #. Translators: Coordinators are shown this message when they make changes to their reminder email options under preferences.
@@ -3713,9 +3007,7 @@ msgstr ""
 
 #. Translators: If the user has not filled out their email, they can browse the website but cannot apply for access to resources.
 #: TWLight/users/views.py:487
-msgid ""
-"Your email is blank. You can still explore the site, but you won't be able "
-"to apply for access to partner resources without an email."
+msgid "Your email is blank. You can still explore the site, but you won't be able to apply for access to partner resources without an email."
 msgstr ""
 
 #. Translators: This message is shown once the access to a partner has successfully been returned.
@@ -3748,31 +3040,3 @@ msgstr ""
 msgid "10+ edits in the last 30 days"
 msgstr ""
 
-#: tests/shunit/data/bad_i18n_comment_1.py:3
-#: tests/shunit/data/bad_i18n_newline_1.py:5
-msgid "1"
-msgstr ""
-
-#. Translators: Lorem ipsum dolor sit amet, consectetur adipiscing elit. Mauris vitae ipsum ut purus faucibus pretium. Proin tempus neque et aliquet consectetur. Ut egestas sapien in consectetur sagittis. Mauris neque lacus, dapibus non viverra vitae, interdum ut aenean ipsum.
-#. Translators: Lorem ipsum dolor sit amet, consectetur adipiscing elit. Mauris vitae ipsum ut purus faucibus pretium. Proin tempus neque et aliquet consectetur. Ut egestas sapien in consectetur sagittis. Mauris neque lacus, dapibus non.
-#: tests/shunit/data/bad_i18n_comment_2.py:4
-#: tests/shunit/data/bad_i18n_newline_2.py:5 tests/shunit/data/good_i18n_1.py:2
-#: tests/shunit/data/good_i18n_2.py:2
-msgid "2"
-msgstr ""
-
-#: tests/shunit/data/bad_i18n_newline_3.py:5
-msgid "3"
-msgstr ""
-
-#: tests/shunit/data/bad_i18n_newline_4.py:5
-msgid "4"
-msgstr ""
-
-#: tests/shunit/data/bad_i18n_newline_5.py:5
-msgid "5"
-msgstr ""
-
-#: tests/shunit/data/bad_i18n_newline_6.py:5
-msgid "6"
-msgstr ""

--- a/locale/eo/LC_MESSAGES/django.po
+++ b/locale/eo/LC_MESSAGES/django.po
@@ -14,10 +14,11 @@
 # Author: YvesNevelsteen
 msgid ""
 msgstr ""
+""
 "Project-Id-Version: Wikipedia Library Card Platform - Website\n"
-"Report-Msgid-Bugs-To: wikipedialibrary@wikimedia.org\n"
+"Report-Msgid-Bugs-To: translatewiki.net\n"
 "POT-Creation-Date: 2024-07-11 20:54+0000\n"
-"PO-Revision-Date: 2024-07-11 12:30:14+0000\n"
+"PO-Revision-Date: 2024-07-15 12:29:14+0000\n"
 "Language: eo\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
@@ -49,12 +50,8 @@ msgstr "Pri vi"
 #. Translators: This note appears in a section of a form where we ask users to enter info (like country of residence) when applying for resource access.
 #: TWLight/applications/forms.py:179
 #, python-brace-format
-msgid ""
-"<p><small><i>Your personal data will be processed according to our <a "
-"class='twl-links' href='{terms_url}'> privacy policy</a>.</i></small></p>"
-msgstr ""
-"<p><small><i>Via privata informo estos prilaborata konforme al nia <a "
-"class='twl-links' href='{terms_url}'> privateca politiko</a>.</i></small></p>"
+msgid "<p><small><i>Your personal data will be processed according to our <a class='twl-links' href='{terms_url}'> privacy policy</a>.</i></small></p>"
+msgstr "<p><small><i>Via privata informo estos prilaborata konforme al nia <a class='twl-links' href='{terms_url}'> privateca politiko</a>.</i></small></p>"
 
 #. Translators: This is the title of the application form page, where users enter information required for the application. It lets the user know which partner application they are entering data for. {partner}
 #: TWLight/applications/forms.py:189
@@ -96,9 +93,7 @@ msgstr "La retpoŝta adreso por via konto ĉe partnera retejo"
 #. Translators: This labels a choice field where users will have to select the number of months they wish to have their access for as part of the application renewal confirmation.
 #. Translators: When filling out an application, users may be required to enter the length of the account (expiry) they wish to have for proxy partners.
 #: TWLight/applications/forms.py:339 TWLight/applications/helpers.py:100
-msgid ""
-"The number of months you wish to have this access for before renewal is "
-"required"
+msgid "The number of months you wish to have this access for before renewal is required"
 msgstr "Dum kiom da monatoj vi dezirus havi enirpermeson antaŭ ol renovigi ĝin"
 
 #. Translators: When filling out an application, users may need to specify their name
@@ -187,9 +182,7 @@ msgstr "Retpoŝta adreso"
 
 #. Translators: This comment is added to pending applications when our terms of use change.
 #: TWLight/applications/management/commands/notify_applicants_tou_changes.py:54
-msgid ""
-"Our terms of use have changed. Your applications will not be processed until "
-"you log in and agree to our updated terms."
+msgid "Our terms of use have changed. Your applications will not be processed until you log in and agree to our updated terms."
 msgstr ""
 
 #. Translators: This is the status of an application that has not yet been reviewed.
@@ -256,23 +249,17 @@ msgstr ""
 
 #. Translators: This text goes into account approval emails in the case that we need to send the user's details to a publisher for manual account setup.
 #: TWLight/applications/models.py:331
-msgid ""
-"You can expect to receive access details within a week or two once it has "
-"been processed."
+msgid "You can expect to receive access details within a week or two once it has been processed."
 msgstr ""
 
 #. Translators: This comment is added to open applications when a partner joins the Library Bundle, which does not require applications.
 #: TWLight/applications/signals.py:247
-msgid ""
-"This partner joined the Library Bundle, which does not require applications. "
-"This application will be marked as invalid."
+msgid "This partner joined the Library Bundle, which does not require applications. This application will be marked as invalid."
 msgstr ""
 
 #. Translators: This is shown to users if the application is to a partner for which we have run out of available accounts. The application is therefore on a 'waitlist', and will be reviewed when more accounts are available.
 #: TWLight/applications/templates/applications/application_evaluation.html:29
-msgid ""
-"This application is on the waitlist because this partner does not have any "
-"access grants available at this time."
+msgid "This application is on the waitlist because this partner does not have any access grants available at this time."
 msgstr ""
 
 #. Translators: This message is shown on pages where coordinators can see personal information about applicants.
@@ -280,9 +267,7 @@ msgstr ""
 #: TWLight/applications/templates/applications/application_list_include.html:6
 #: TWLight/applications/templates/applications/send_partner.html:45
 #: TWLight/resources/templates/resources/partner_users.html:18
-msgid ""
-"Coordinators: This page may contain personal information such as real names "
-"and email addresses. Please remember that this information is confidential."
+msgid "Coordinators: This page may contain personal information such as real names and email addresses. Please remember that this information is confidential."
 msgstr ""
 
 #. Translators: This is the title of the application page shown to users who are a coordinator, and are able to accept or reject the application.
@@ -292,9 +277,7 @@ msgstr ""
 
 #. Translators: This text is shown to coordinators on application pages if the applicant has restricted processing of their data.
 #: TWLight/applications/templates/applications/application_evaluation.html:42
-msgid ""
-"This user has requested a restriction on the processing of their data, so "
-"you cannot change the status of their application."
+msgid "This user has requested a restriction on the processing of their data, so you cannot change the status of their application."
 msgstr ""
 
 #. Translators: This is the title of the application page shown to users who are not a coordinator.
@@ -369,9 +352,7 @@ msgstr "Nekonata"
 
 #. Translators: This is the text displayed to coordinators when an applicant has no country of residence in their profile.
 #: TWLight/applications/templates/applications/application_evaluation.html:123
-msgid ""
-"Please request the applicant add their country of residence to their profile "
-"before proceeding further."
+msgid "Please request the applicant add their country of residence to their profile before proceeding further."
 msgstr ""
 
 #. Translators: This labels the section of an application showing the total number of accounts available for a partner or their collection.
@@ -383,9 +364,7 @@ msgstr "Disponaj kontoj:"
 #. Translators: This labels the section of an application showing whether the user had agreed to the terms of use or not.
 #: TWLight/applications/templates/applications/application_evaluation.html:145
 #, python-format
-msgid ""
-"Has agreed to the site's <a class=\"twl-links\" href=\"%(terms_url)s\">terms "
-"of use</a>?"
+msgid "Has agreed to the site's <a class=\"twl-links\" href=\"%(terms_url)s\">terms of use</a>?"
 msgstr ""
 
 #. Translators: Displayed to coordinators when they've agreed to the terms of use.
@@ -421,9 +400,7 @@ msgstr "Ne"
 
 #. Translators: This is the text displayed to coordinators when an applicant has not agreed to the terms of use.
 #: TWLight/applications/templates/applications/application_evaluation.html:159
-msgid ""
-"Please request the applicant agree to the site's terms of use before "
-"approving this application."
+msgid "Please request the applicant agree to the site's terms of use before approving this application."
 msgstr ""
 
 #. Translators: This labels the section of an application containing the user's motivation for wanting access to this resource.
@@ -444,8 +421,7 @@ msgstr ""
 #. Translators: This message is shown next to the 'Renewal of existing access grant?' label if the application is a renewal. Don't translate HTML tags or parent_url.
 #: TWLight/applications/templates/applications/application_evaluation.html:195
 #, python-format
-msgid ""
-"Yes (<a class=\"twl-links\" href=\"%(parent_url)s\">previous application</a>)"
+msgid "Yes (<a class=\"twl-links\" href=\"%(parent_url)s\">previous application</a>)"
 msgstr ""
 
 #. Translators: This labels the section of the application showing the length of access remaining on the user's previous authorization.
@@ -482,9 +458,7 @@ msgstr "Komenti"
 
 #. Translators: On an application page, this text tells users that the comments posted on the application are visible to coordinators and the submitting user only.
 #: TWLight/applications/templates/applications/application_evaluation.html:297
-msgid ""
-"Comments are visible to all coordinators and to the editor who submitted "
-"this application."
+msgid "Comments are visible to all coordinators and to the editor who submitted this application."
 msgstr ""
 
 #. Translators: This is the title of the section of an application page which lists information about the user who submitted the application.
@@ -699,12 +673,7 @@ msgstr "Ŝanĝi staton"
 
 #: TWLight/applications/templates/applications/apply.html:20
 #, python-format
-msgid ""
-"If your application is successful we may share your email address with "
-"%(partner)s. This is required to set up your access to their resources. By "
-"submitting this form you agree to allow your email address to be shared with "
-"%(partner)s if your application is successful, for the purposes of account "
-"setup."
+msgid "If your application is successful we may share your email address with %(partner)s. This is required to set up your access to their resources. By submitting this form you agree to allow your email address to be shared with %(partner)s if your application is successful, for the purposes of account setup."
 msgstr ""
 
 #. Translators: This message is displayed on the page where users can confirm their renewal. Please do not translate partner.
@@ -733,9 +702,7 @@ msgstr ""
 
 #. Translators: This text explains that Library Bundle partners are not shown in this list.
 #: TWLight/applications/templates/applications/request_for_application.html:26
-msgid ""
-"Library Bundle partners are not shown as eligibility is determined "
-"automatically."
+msgid "Library Bundle partners are not shown as eligibility is determined automatically."
 msgstr ""
 
 #. Translators: On the page where users can apply for multiple partners, this message shows next to the partner name, taking them to the full application page when clicked.
@@ -750,10 +717,7 @@ msgstr ""
 
 #. Translators: the HTML is so that the word 'waitlisted' will look the same as it does in the page above; please translate 'waitlisted' the same way you did elsewhere in this file.
 #: TWLight/applications/templates/applications/request_for_application.html:74
-msgid ""
-"You can apply to <span class=\"badge badge-warning\">Waitlisted</span> "
-"partners, but they don't have access grants available right now. We will "
-"process those applications when access becomes available."
+msgid "You can apply to <span class=\"badge badge-warning\">Waitlisted</span> partners, but they don't have access grants available right now. We will process those applications when access becomes available."
 msgstr ""
 
 #. Translators: On the page where coordinators can see approved applications which have not had their details sent to the partner, this message shows when there are applications ready to be processed.
@@ -775,9 +739,7 @@ msgstr ""
 #. Translators: This message is shown when applications exceed the number of accounts available.
 #: TWLight/applications/templates/applications/send_partner.html:54
 #, python-format
-msgid ""
-"Application(s) for %(object)s, if sent, will exceed the total available "
-"accounts for the partner. Please proceed at your own discretion."
+msgid "Application(s) for %(object)s, if sent, will exceed the total available accounts for the partner. Please proceed at your own discretion."
 msgstr ""
 
 #. Translators: When viewing the list of applications ready to be sent for a particular partner, this is instructions for the coordinator to click the 'mark as sent' button after they have sent the information.
@@ -794,9 +756,7 @@ msgstr[1] "Kontaktoj"
 
 #. Translators: When viewing the list of applications ready to be sent for a particular partner, this message shows if there is no information about who the applications should be sent to. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/applications/templates/applications/send_partner.html:89
-msgid ""
-"Whoops, we don't have any listed contacts. Please notify Wikipedia Library "
-"administrators."
+msgid "Whoops, we don't have any listed contacts. Please notify Wikipedia Library administrators."
 msgstr ""
 
 #. Translators: When viewing the list of applications ready to be sent for a particular partner, this is the title of the section containing the information about those applications.
@@ -812,9 +772,7 @@ msgstr "Marki kiel senditan"
 
 #. Translators: This text guides coordinators in using the code sending interface for approved applications.
 #: TWLight/applications/templates/applications/send_partner.html:152
-msgid ""
-"Use the dropdown menus to denote which editor will receive each code. Access "
-"codes will be sent to users automatically."
+msgid "Use the dropdown menus to denote which editor will receive each code. Access codes will be sent to users automatically."
 msgstr ""
 
 #. Translators: This labels a drop-down selection where staff can assign an access code to a user.
@@ -830,18 +788,13 @@ msgstr ""
 #. Translators: When a user applies for a set of resources, they receive this message if none are currently available. They are instead placed on a 'waitlist' for later approval.
 #. Translators: When a user renews their resource, they receive this message if none are currently available. They are instead placed on a 'waitlist' for later approval.
 #: TWLight/applications/views.py:140 TWLight/applications/views.py:1282
-msgid ""
-"This partner does not have any access grants available at this time. You may "
-"still apply for access; your application will be reviewed when access grants "
-"become available."
+msgid "This partner does not have any access grants available at this time. You may still apply for access; your application will be reviewed when access grants become available."
 msgstr ""
 
 #. Translators: This message is shown to users once they've successfully submitted their application for review.
 #: TWLight/applications/views.py:163
 #, python-brace-format
-msgid ""
-"Your application has been submitted for review. Head over to <a "
-"href='{applications_url}'>My Applications</a> to view the status."
+msgid "Your application has been submitted for review. Head over to <a href='{applications_url}'>My Applications</a> to view the status."
 msgstr ""
 
 #. Translators: This text is displayed to users when the user has chosen to restrict data and is trying to apply for multiple partners
@@ -890,16 +843,12 @@ msgstr ""
 
 #. Translators: After a coordinator has changed the status of an application to APPROVED, if the corresponding partner/collection is waitlisted this message appears.
 #: TWLight/applications/views.py:756
-msgid ""
-"Cannot approve application as partner with proxy authorization method is "
-"waitlisted."
+msgid "Cannot approve application as partner with proxy authorization method is waitlisted."
 msgstr ""
 
 #. Translators: After a coordinator has changed the status of an application to APPROVED, if the corresponding partner/collection has no accounts for distribution, this message appears.
 #: TWLight/applications/views.py:780
-msgid ""
-"Cannot approve application as partner with proxy authorization method is "
-"waitlisted and (or) has zero accounts available for distribution."
+msgid "Cannot approve application as partner with proxy authorization method is waitlisted and (or) has zero accounts available for distribution."
 msgstr ""
 
 #. Translators: This message appears on an "access denied" screen that stops users who attempt to authorize an editor to access a resource during a time period for which they are already authorized.
@@ -910,11 +859,7 @@ msgstr ""
 #. Translators: This message is shown to users when they access an application page of a now Bundle partner (new applications aren't allowed for Bundle partners and the status of old applications cannot be modified)
 #: TWLight/applications/views.py:857
 #, python-brace-format
-msgid ""
-"This application cannot be modified since this partner is now part of our <a "
-"href='{bundle}'>bundle access</a>. If you are eligible, you can access this "
-"resource from <a href='{library}'>your library</a>. <a "
-"href='{contact}'>Contact us</a> if you have any questions."
+msgid "This application cannot be modified since this partner is now part of our <a href='{bundle}'>bundle access</a>. If you are eligible, you can access this resource from <a href='{library}'>your library</a>. <a href='{contact}'>Contact us</a> if you have any questions."
 msgstr ""
 
 #. Translators: this lets a reviewer set the status of a single application.
@@ -924,9 +869,7 @@ msgstr ""
 
 #. Translators: This warning is message is shown to applicants when the number of pending applications is greater than the number of accounts available.
 #: TWLight/applications/views.py:891
-msgid ""
-"There are more pending applications than available accounts. Your "
-"application might get waitlisted."
+msgid "There are more pending applications than available accounts. Your application might get waitlisted."
 msgstr ""
 
 #. Translators: this message is shown to coordinators who attempt to change an application's Status from INVALID to any other Status.
@@ -946,11 +889,7 @@ msgstr ""
 
 #. Translators: After a coordinator has changed the status of a number of applications to APPROVED, if the corresponding partner(s) is/are waitlisted or has no accounts for distribution, this message appears.
 #: TWLight/applications/views.py:1051
-msgid ""
-"Cannot approve application(s) {} as partner(s) with proxy authorization "
-"method is/are waitlisted and (or) has/have not enough accounts available. If "
-"not enough accounts are available, prioritise the applications and then "
-"approve applications equal to the accounts available."
+msgid "Cannot approve application(s) {} as partner(s) with proxy authorization method is/are waitlisted and (or) has/have not enough accounts available. If not enough accounts are available, prioritise the applications and then approve applications equal to the accounts available."
 msgstr ""
 
 #. Translators: This message is shown to coordinators who attempt to assign the same access code to multiple users.
@@ -965,9 +904,7 @@ msgstr ""
 
 #. Translators: When a user tries to renew their resource, they receive this message if the partner is not available.
 #: TWLight/applications/views.py:1272
-msgid ""
-"Cannot renew application at this time as partner is not available. Please "
-"check back later, or contact us for more information."
+msgid "Cannot renew application at this time as partner is not available. Please check back later, or contact us for more information."
 msgstr ""
 
 #. Translators: This message is displayed when an attempt by a user to renew an application has been denied for some reason.
@@ -978,16 +915,12 @@ msgstr ""
 
 #. Translators: If a user requests the renewal of their account, but it wasn't renewed, this message is shown to them.
 #: TWLight/applications/views.py:1385
-msgid ""
-"This object cannot be renewed. (This probably means that you have already "
-"requested that it be renewed.)"
+msgid "This object cannot be renewed. (This probably means that you have already requested that it be renewed.)"
 msgstr ""
 
 #. Translators: If a user requests the renewal of their account, this message is shown to them.
 #: TWLight/applications/views.py:1395
-msgid ""
-"Your renewal request has been received. A coordinator will review your "
-"request."
+msgid "Your renewal request has been received. A coordinator will review your request."
 msgstr ""
 
 #. Translators: This labels a textfield where users can enter their email ID.
@@ -997,9 +930,7 @@ msgstr "Via retpoŝta adreso"
 
 #. Translators: This is the help text for the email field in the contact us form letting users know the field is updated by value pulled from their respective user profiles.
 #: TWLight/emails/forms.py:21
-msgid ""
-"This field is automatically updated with the email from your <a class='twl-"
-"links' href='{}'>user profile</a>."
+msgid "This field is automatically updated with the email from your <a class='twl-links' href='{}'>user profile</a>."
 msgstr ""
 
 #. Translators: This labels a textfield where users can enter their email message.
@@ -1023,19 +954,13 @@ msgstr "Sendi"
 #. Translators: This email is sent to users with their access code. Don't translate Jinja variables in curly braces like user or partner. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/access_code_email-body-html.html:5
 #, python-format
-msgid ""
-"<p>Your approved application to %(partner)s has now been finalised. Your "
-"access code or login details can be found below:</p> <p><b>%(access_code)s</"
-"b></p> <p>%(user_instructions)s</p>"
+msgid "<p>Your approved application to %(partner)s has now been finalised. Your access code or login details can be found below:</p> <p><b>%(access_code)s</b></p> <p>%(user_instructions)s</p>"
 msgstr ""
 
 #. Translators: This email is sent to users with their access code. Don't translate Jinja variables in curly braces like user or partner. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/access_code_email-body-text.html:3
 #, python-format
-msgid ""
-"Your approved application to %(partner)s has now been finalised. Your access "
-"code or login details can be found below: %(access_code)s "
-"%(user_instructions)s"
+msgid "Your approved application to %(partner)s has now been finalised. Your access code or login details can be found below: %(access_code)s %(user_instructions)s"
 msgstr ""
 
 #. Translators: This is the subject line of an email sent to users with their access code.
@@ -1046,23 +971,13 @@ msgstr ""
 #. Translators: This email is sent to users when their application is approved. Don't translate Jinja variables in curly braces like user or partner; don't translate html tags either. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/approval_notification-body-html.html:5
 #, python-format
-msgid ""
-"<p>Dear %(user)s,</p> <p>Thank you for applying for access to %(partner)s "
-"resources through The Wikipedia Library. We are happy to inform you that "
-"your application has been approved.</p> <p>%(user_instructions)s</p> <p>You "
-"can view the collections you're authorized to access at My Library: "
-"%(link)s</p> <p>Cheers!</p> <p>The Wikipedia Library</p>"
+msgid "<p>Dear %(user)s,</p> <p>Thank you for applying for access to %(partner)s resources through The Wikipedia Library. We are happy to inform you that your application has been approved.</p> <p>%(user_instructions)s</p> <p>You can view the collections you're authorized to access at My Library: %(link)s</p> <p>Cheers!</p> <p>The Wikipedia Library</p>"
 msgstr ""
 
 #. Translators: This email is sent to users when their application is approved. Don't translate Jinja variables in curly braces like user or partner. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/approval_notification-body-text.html:3
 #, python-format
-msgid ""
-"Dear %(user)s, Thank you for applying for access to %(partner)s resources "
-"through The Wikipedia Library. We are happy to inform you that your "
-"application has been approved. %(user_instructions)s You can view the "
-"collections you're authorized to access at My Library: %(link)s Cheers! The "
-"Wikipedia Library"
+msgid "Dear %(user)s, Thank you for applying for access to %(partner)s resources through The Wikipedia Library. We are happy to inform you that your application has been approved. %(user_instructions)s You can view the collections you're authorized to access at My Library: %(link)s Cheers! The Wikipedia Library"
 msgstr ""
 
 #. Translators: This is the subject of an email which is sent to users when their application has been approved. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
@@ -1073,19 +988,13 @@ msgstr ""
 #. Translators: This email is sent to coordinators when a comment is left on an application they are processing. Don't translate Jinja variables in curly braces like user or partner. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/comment_notification_coordinator-body-html.html:5
 #, python-format
-msgid ""
-"<p style=\"color: #500050\">%(submit_date)s - %(commenter)s</p> "
-"<blockquote><p>%(comment)s</p></blockquote> <p>Please reply to these at: <a "
-"href=\"%(app_url)s\">%(app_url)s</a></p> <p>Best,</p> <p>The Wikipedia "
-"Library</p>"
+msgid "<p style=\"color: #500050\">%(submit_date)s - %(commenter)s</p> <blockquote><p>%(comment)s</p></blockquote> <p>Please reply to these at: <a href=\"%(app_url)s\">%(app_url)s</a></p> <p>Best,</p> <p>The Wikipedia Library</p>"
 msgstr ""
 
 #. Translators: This email is sent to coordinators when a comment is left on an application they are processing. Don't translate Jinja variables in curly braces like user or partner. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/comment_notification_coordinator-body-text.html:3
 #, python-format
-msgid ""
-"%(submit_date)s - %(commenter)s %(comment)s Please reply to this at: "
-"%(app_url)s Best, The Wikipedia Library"
+msgid "%(submit_date)s - %(commenter)s %(comment)s Please reply to this at: %(app_url)s Best, The Wikipedia Library"
 msgstr ""
 
 #. Translators: This is the subject line of an email sent to coordinators when a comment is left on an application they processed.
@@ -1096,19 +1005,13 @@ msgstr ""
 #. Translators: This email is sent to users when they receive a comment on their application. Don't translate Jinja variables in curly braces like user or partner; don't translate html tags either. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/comment_notification_editors-body-html.html:5
 #, python-format
-msgid ""
-"<p style=\"color: #500050\">%(submit_date)s - %(commenter)s</p> "
-"<blockquote><p>%(comment)s</p></blockquote> <p>Please reply to these at <a "
-"href=\"%(app_url)s\">%(app_url)s</a> so we can evaluate your application.</"
-"p> <p>Best,</p> <p>The Wikipedia Library</p>"
+msgid "<p style=\"color: #500050\">%(submit_date)s - %(commenter)s</p> <blockquote><p>%(comment)s</p></blockquote> <p>Please reply to these at <a href=\"%(app_url)s\">%(app_url)s</a> so we can evaluate your application.</p> <p>Best,</p> <p>The Wikipedia Library</p>"
 msgstr ""
 
 #. Translators: This email is sent to users when they receive a comment on their application. Don't translate Jinja variables in curly braces like user or partner. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/comment_notification_editors-body-text.html:3
 #, python-format
-msgid ""
-"%(submit_date)s - %(commenter)s %(comment)s Please reply to these at: "
-"%(app_url)s so we can evaluate your application. Best, The Wikipedia Library"
+msgid "%(submit_date)s - %(commenter)s %(comment)s Please reply to these at: %(app_url)s so we can evaluate your application. Best, The Wikipedia Library"
 msgstr ""
 
 #. Translators: This is the subject line of an email sent to users who have a comment added to one of their applications. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
@@ -1119,18 +1022,13 @@ msgstr ""
 #. Translators: This email is sent to users when an application they commented on receives another comment. Don't translate Jinja variables in curly braces like app_url; don't translate html tags either. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/comment_notification_others-body-html.html:5
 #, python-format
-msgid ""
-"<p style=\"color: #500050\">%(submit_date)s - %(commenter)s</p> "
-"<blockquote><p>%(comment)s</p></blockquote> See it at <a href=\"%(app_url)s"
-"\">%(app_url)s</a>. Thanks for helping review Wikipedia Library applications!"
+msgid "<p style=\"color: #500050\">%(submit_date)s - %(commenter)s</p> <blockquote><p>%(comment)s</p></blockquote> See it at <a href=\"%(app_url)s\">%(app_url)s</a>. Thanks for helping review Wikipedia Library applications!"
 msgstr ""
 
 #. Translators: This email is sent to users when an application they commented on receives another comment. Don't translate Jinja variables in curly braces like app_url. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/comment_notification_others-body-text.html:3
 #, python-format
-msgid ""
-"%(submit_date)s - %(commenter)s %(comment)s See it at: %(app_url)s Thanks "
-"for helping review Wikipedia Library applications!"
+msgid "%(submit_date)s - %(commenter)s %(comment)s See it at: %(app_url)s Thanks for helping review Wikipedia Library applications!"
 msgstr ""
 
 #. Translators: This is the subject line of an email sent to users who have a comment added to an application they also commented on. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
@@ -1141,10 +1039,7 @@ msgstr ""
 #. Translators: This text is part of a scheduled reminder email sent to coordinators who have applications requiring action. Don't translate Jinja variables in curly braces like total_apps, or user.
 #: TWLight/emails/templates/emails/coordinator_reminder_notification-body-html.html:5
 #, python-format
-msgid ""
-"<p>Dear %(user)s,</p> <p>Our records indicate that you are the designated "
-"coordinator for partners that have a total of %(total_apps)s applications.</"
-"p>"
+msgid "<p>Dear %(user)s,</p> <p>Our records indicate that you are the designated coordinator for partners that have a total of %(total_apps)s applications.</p>"
 msgstr ""
 
 #. Translators: Breakdown as in 'cost breakdown'; analysis.
@@ -1183,31 +1078,19 @@ msgstr[1] "Apliko"
 #. Translators: This text is part of a scheduled reminder email sent to coordinators who have applications requiring action. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library). Don't translate Jinja variables in curly braces like link; don't translate email addresses or html tags either.
 #: TWLight/emails/templates/emails/coordinator_reminder_notification-body-html.html:39
 #, python-format
-msgid ""
-"<p>This is a gentle reminder that you may review applications at <a href="
-"\"%(link)s\">%(link)s</a>.</p> <p>You can customise your reminders under "
-"'preferences' in your user profile.</p> <p>If you received this message in "
-"error, drop us a line at wikipedialibrary@wikimedia.org.</p> <p>Thanks for "
-"helping review Wikipedia Library applications!</p>"
+msgid "<p>This is a gentle reminder that you may review applications at <a href=\"%(link)s\">%(link)s</a>.</p> <p>You can customise your reminders under 'preferences' in your user profile.</p> <p>If you received this message in error, drop us a line at wikipedialibrary@wikimedia.org.</p> <p>Thanks for helping review Wikipedia Library applications!</p>"
 msgstr ""
 
 #. Translators: This text is part of a scheduled reminder email sent to coordinators who have applications requiring action. Don't translate Jinja variables in curly braces like total_apps, or user.
 #: TWLight/emails/templates/emails/coordinator_reminder_notification-body-text.html:3
 #, python-format
-msgid ""
-"Dear %(user)s, Our records indicate that you are the designated coordinator "
-"for partners that have a total of %(total_apps)s applications."
+msgid "Dear %(user)s, Our records indicate that you are the designated coordinator for partners that have a total of %(total_apps)s applications."
 msgstr ""
 
 #. Translators: This text is part of a scheduled reminder email sent to coordinators who have applications requiring action. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library). Don't translate Jinja variables in curly braces like link; don't translate the email address either.
 #: TWLight/emails/templates/emails/coordinator_reminder_notification-body-text.html:38
 #, python-format
-msgid ""
-"This is a gentle reminder that you may review applications at: %(link)s. You "
-"can customise your reminders under 'preferences' in your user profile. If "
-"you received this message in error, drop us a line at: "
-"wikipedialibrary@wikimedia.org Thanks for helping review Wikipedia Library "
-"applications!"
+msgid "This is a gentle reminder that you may review applications at: %(link)s. You can customise your reminders under 'preferences' in your user profile. If you received this message in error, drop us a line at: wikipedialibrary@wikimedia.org Thanks for helping review Wikipedia Library applications!"
 msgstr ""
 
 #. Translators: This is the subject line of a scheduled reminder email sent to coordinators who have applications to review. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library). Do not translate items in curly braces.
@@ -1218,22 +1101,13 @@ msgstr ""
 #. Translators: This email is sent to users when their application is rejected. Don't translate Jinja variables in curly braces like user or partner; don't translate html tags either. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/rejection_notification-body-html.html:5
 #, python-format
-msgid ""
-"<p>Dear %(user)s,</p> <p>Thank you for applying for access to %(partner)s "
-"resources through The Wikipedia Library. Unfortunately at this time your "
-"application has not been approved. You can view your application and review "
-"comments at <a href=\"%(app_url)s\">%(app_url)s</a>.</p> <p>Best,</p> <p>The "
-"Wikipedia Library</p>"
+msgid "<p>Dear %(user)s,</p> <p>Thank you for applying for access to %(partner)s resources through The Wikipedia Library. Unfortunately at this time your application has not been approved. You can view your application and review comments at <a href=\"%(app_url)s\">%(app_url)s</a>.</p> <p>Best,</p> <p>The Wikipedia Library</p>"
 msgstr ""
 
 #. Translators: This email is sent to users when their application is rejected. Don't translate Jinja variables in curly braces like user or partner. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/rejection_notification-body-text.html:3
 #, python-format
-msgid ""
-"Dear %(user)s, Thank you for applying for access to %(partner)s resources "
-"through The Wikipedia Library. Unfortunately at this time your application "
-"has not been approved. You can view your application and review comments at: "
-"%(app_url)s Best, The Wikipedia Library"
+msgid "Dear %(user)s, Thank you for applying for access to %(partner)s resources through The Wikipedia Library. Unfortunately at this time your application has not been approved. You can view your application and review comments at: %(app_url)s Best, The Wikipedia Library"
 msgstr ""
 
 #. Translators: This is the subject of an email which is sent to users when their application has been rejected. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
@@ -1245,25 +1119,13 @@ msgstr "La Teamo de Vikipedia Biblioteko"
 #. Translators: This email is sent to users when they have an account that is soon to expire. Don't translate Jinja variables in curly braces like partner_name or partner_link; don't translate html tags either. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/user_renewal_notice-body-html.html:5
 #, python-format
-msgid ""
-"<p>Dear %(user)s,</p> <p>According to our records, your access to "
-"%(partner_name)s will soon expire and you may lose access. If you want to "
-"continue making use of your free account, you can request renewal of your "
-"account by clicking the 'Renew' or 'Extend' button at %(partner_link)s.</p> "
-"<p>Best,</p> <p>The Wikipedia Library</p> <p>You can disable these emails in "
-"your user page preferences: https://wikipedialibrary.wmflabs.org/users/</p>"
+msgid "<p>Dear %(user)s,</p> <p>According to our records, your access to %(partner_name)s will soon expire and you may lose access. If you want to continue making use of your free account, you can request renewal of your account by clicking the 'Renew' or 'Extend' button at %(partner_link)s.</p> <p>Best,</p> <p>The Wikipedia Library</p> <p>You can disable these emails in your user page preferences: https://wikipedialibrary.wmflabs.org/users/</p>"
 msgstr ""
 
 #. Translators: This email is sent to users when they have an account that is soon to expire. Don't translate Jinja variables in curly braces like partner_name or partner_link; don't translate html tags either. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/user_renewal_notice-body-text.html:3
 #, python-format
-msgid ""
-"Dear %(user)s, According to our records, your access to %(partner_name)s "
-"will soon expire and you may lose access. If you want to continue making use "
-"of your free account, you can request renewal of your account by clicking "
-"the Renew button at %(partner_link)s. Best, The Wikipedia Library You can "
-"disable these emails in your user page preferences: https://wikipedialibrary."
-"wmflabs.org/users/"
+msgid "Dear %(user)s, According to our records, your access to %(partner_name)s will soon expire and you may lose access. If you want to continue making use of your free account, you can request renewal of your account by clicking the Renew button at %(partner_link)s. Best, The Wikipedia Library You can disable these emails in your user page preferences: https://wikipedialibrary.wmflabs.org/users/"
 msgstr ""
 
 #. Translators: This is the subject of an email sent to users when they have an account that is soon to expire. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
@@ -1274,24 +1136,13 @@ msgstr ""
 #. Translators: This email is sent to users when their application is waitlisted because there are no more accounts available. Don't translate Jinja variables in curly braces like user or partner; don't translate html tags either. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/waitlist_notification-body-html.html:5
 #, python-format
-msgid ""
-"<p>Dear %(user)s,</p> <p>Thank you for applying for access to %(partner)s "
-"resources through The Wikipedia Library. There are no accounts currently "
-"available so your application has been waitlisted. Your application will be "
-"evaluated if/when more accounts become available. You can see all available "
-"resources at <a href=\"%(link)s\">%(link)s</a>.</p> <p>Best,</p> <p>The "
-"Wikipedia Library</p>"
+msgid "<p>Dear %(user)s,</p> <p>Thank you for applying for access to %(partner)s resources through The Wikipedia Library. There are no accounts currently available so your application has been waitlisted. Your application will be evaluated if/when more accounts become available. You can see all available resources at <a href=\"%(link)s\">%(link)s</a>.</p> <p>Best,</p> <p>The Wikipedia Library</p>"
 msgstr ""
 
 #. Translators: This email is sent to users when their application is waitlisted because there are no more accounts available. Don't translate Jinja variables in curly braces like user or partner. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/waitlist_notification-body-text.html:3
 #, python-format
-msgid ""
-"Dear %(user)s, Thank you for applying for access to %(partner)s resources "
-"through The Wikipedia Library. There are no accounts currently available so "
-"your application has been waitlisted. Your application will be evaluated if/"
-"when more accounts become available. You can see all available resources at: "
-"%(link)s Best, The Wikipedia Library"
+msgid "Dear %(user)s, Thank you for applying for access to %(partner)s resources through The Wikipedia Library. There are no accounts currently available so your application has been waitlisted. Your application will be evaluated if/when more accounts become available. You can see all available resources at: %(link)s Best, The Wikipedia Library"
 msgstr ""
 
 #. Translators: This is the subject of an email sent to users when their application is waitlisted because there are no more accounts available. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
@@ -1458,17 +1309,14 @@ msgstr "Ne dispona"
 #: TWLight/resources/templates/resources/filter_section.html:14
 #: TWLight/templates/about.html:12
 #: TWLight/users/templates/users/filter_section.html:13
-msgid ""
-"The Wikipedia Library allows active editors to access a wide range of "
-"collections of paywalled reliable sources for free!"
+msgid "The Wikipedia Library allows active editors to access a wide range of collections of paywalled reliable sources for free!"
 msgstr ""
 
 #. Translators: On the Browse Partners page (https://wikipedialibrary.wmflabs.org/partners/), this introduces users to The Wikipedia Library.
 #. Translators: On the MyLibrary page (https://wikipedialibrary.wmflabs.org/users/my_library), this introduces users to The Wikipedia Library.
 #: TWLight/resources/templates/resources/filter_section.html:17
 #: TWLight/users/templates/users/filter_section.html:15
-msgid ""
-"Start with the search bar at the top or browse publisher websites directly."
+msgid "Start with the search bar at the top or browse publisher websites directly."
 msgstr ""
 
 #. Translators: On the Browse Partners page (https://wikipedialibrary.wmflabs.org/partners/), this appears below introductory text and links to the 'About' page (https://wikipedialibrary.wmflabs.org/about/)
@@ -1550,52 +1398,38 @@ msgstr "Sendita al partnero"
 #. Translators: If we have no available accounts for a partner, the coordinator can change the application system to a waiting list.
 #: TWLight/resources/templates/resources/partner_detail.html:36
 #: TWLight/resources/templates/resources/partner_detail_apply.html:17
-msgid ""
-"There are no access grants available for this partner at this time. You can "
-"still apply for access; applications will be processed when access is "
-"available."
+msgid "There are no access grants available for this partner at this time. You can still apply for access; applications will be processed when access is available."
 msgstr ""
 
 #. Translators: This text links to the minimum user requirements and terms of use on the partner page.
 #: TWLight/resources/templates/resources/partner_detail.html:48
 #: TWLight/resources/templates/resources/partner_detail_apply.html:29
 #, python-format
-msgid ""
-"Before applying, please review the <strong><a class=\"twl-links\" href="
-"\"%(about)s#req\">minimum requirements</a></strong> for access and our "
-"<strong><a class=\"twl-links\" href=\"%(terms)s\">terms of use</a></strong>."
+msgid "Before applying, please review the <strong><a class=\"twl-links\" href=\"%(about)s#req\">minimum requirements</a></strong> for access and our <strong><a class=\"twl-links\" href=\"%(terms)s\">terms of use</a></strong>."
 msgstr ""
 
 #. Translators: This text refers to the page containing the content a user is authorized to access.
 #: TWLight/resources/templates/resources/partner_detail.html:69
 #, python-format
-msgid ""
-"View the status of your access in <strong><a class=\"twl-links\" href="
-"\"%(library_url)s\">My Library</a></strong> page."
+msgid "View the status of your access in <strong><a class=\"twl-links\" href=\"%(library_url)s\">My Library</a></strong> page."
 msgstr ""
 
 #. Translators: This message is shown when a user has open applications, linking to their respective applications page.
 #: TWLight/resources/templates/resources/partner_detail.html:78
 #, python-format
-msgid ""
-"View the status of your application(s) on your <strong><a class=\"twl-links"
-"\" href=\"%(applications_url)s\">My Applications</a></strong> page."
+msgid "View the status of your application(s) on your <strong><a class=\"twl-links\" href=\"%(applications_url)s\">My Applications</a></strong> page."
 msgstr ""
 
 #. Translators: This message is shown when a user has authorizations, linking to their respective collections page.
 #: TWLight/resources/templates/resources/partner_detail_apply.html:50
 #, python-format
-msgid ""
-"View the status of your access on your <strong><a href=\"%(library_url)s\" "
-"class=\"twl-links\">My Library</a></strong> page."
+msgid "View the status of your access on your <strong><a href=\"%(library_url)s\" class=\"twl-links\">My Library</a></strong> page."
 msgstr ""
 
 #. Translators: This message is shown when a user has open applications, linking to their respective applications page.
 #: TWLight/resources/templates/resources/partner_detail_apply.html:60
 #, python-format
-msgid ""
-"View the status of your application(s) on your <strong><a href="
-"\"%(applications_url)s\">My Applications</a></strong> page."
+msgid "View the status of your application(s) on your <strong><a href=\"%(applications_url)s\">My Applications</a></strong> page."
 msgstr ""
 
 #. Translators: One the partner detail page, this text labels the button which coordinators can click to remove a partner from waitlisted status.
@@ -1625,10 +1459,7 @@ msgstr ""
 
 #. Translators: If no account coordinator is assigned to a partner, the Wikipedia Library team will coordinate signups. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/resources/templates/resources/partner_detail_apply.html:112
-msgid ""
-"The Wikipedia Library team will process this application. Want to help? <a "
-"class=\"twl-links\" href=\"https://en.wikipedia.org/wiki/Wikipedia:"
-"The_Wikipedia_Library/Coordinators/Signup\">Sign up as a coordinator.</a>"
+msgid "The Wikipedia Library team will process this application. Want to help? <a class=\"twl-links\" href=\"https://en.wikipedia.org/wiki/Wikipedia:The_Wikipedia_Library/Coordinators/Signup\">Sign up as a coordinator.</a>"
 msgstr ""
 
 #. Translators: This text labels a button coordinators can click to view a list of users who have applied for access for a particular partner
@@ -1660,18 +1491,13 @@ msgstr "Biblioteka Fasko"
 
 #. Translators: Text shown to authenticated, bundle eligible users when they visit a Bundle partner page.
 #: TWLight/resources/templates/resources/partner_detail_apply.html:138
-msgid ""
-"You are eligible to access Library Bundle partners. Click the button above "
-"to access the collection."
+msgid "You are eligible to access Library Bundle partners. Click the button above to access the collection."
 msgstr ""
 
 #. Translators: Text shown to authenticated, bundle ineligible users when they visit a Bundle partner page.
 #: TWLight/resources/templates/resources/partner_detail_apply.html:152
 #, python-format
-msgid ""
-"You are not eligible to access Library Bundle partners. Visit the <a class="
-"\"twl-links\" href=\"%(homepage)s\">homepage</a> to check the eligibility "
-"criteria."
+msgid "You are not eligible to access Library Bundle partners. Visit the <a class=\"twl-links\" href=\"%(homepage)s\">homepage</a> to check the eligibility criteria."
 msgstr ""
 
 #. Translators: Buttton prompting users to log in.
@@ -1683,10 +1509,7 @@ msgstr "Ensaluti"
 #. Translators: Text shown to unauthenticated users when they visit a Bundle partner page.
 #: TWLight/resources/templates/resources/partner_detail_apply.html:168
 #, python-format
-msgid ""
-"This resource is part of our <a class=\"twl-links\" href=\"%(about)s"
-"\">Library Bundle</a>, which you can access if you meet our minimum "
-"eligibility criteria. Log in to find out if you are eligible."
+msgid "This resource is part of our <a class=\"twl-links\" href=\"%(about)s\">Library Bundle</a>, which you can access if you meet our minimum eligibility criteria. Log in to find out if you are eligible."
 msgstr ""
 
 #. Translators: This is the label for a number which shows the total active accounts for one partner. (e.g. https://wikipedialibrary.wmflabs.org/partners/8/).
@@ -1737,26 +1560,19 @@ msgstr ""
 #. Translators: If a partner has specified the excerpt limit both in words and percentage, this message will display the percentage of words and the number of words on the partner page.
 #: TWLight/resources/templates/resources/partner_detail_timeline.html:99
 #, python-format
-msgid ""
-"%(object)s allows a maximum of %(excerpt_limit)s words or "
-"%(excerpt_limit_percentage)s%% of an article be excerpted into a Wikipedia "
-"article."
+msgid "%(object)s allows a maximum of %(excerpt_limit)s words or %(excerpt_limit_percentage)s%% of an article be excerpted into a Wikipedia article."
 msgstr ""
 
 #. Translators: If a partner has specified the excerpt limit in words, this message will display the number of words on the partner page.
 #: TWLight/resources/templates/resources/partner_detail_timeline.html:106
 #, python-format
-msgid ""
-"%(object)s allows a maximum of %(excerpt_limit)s words be excerpted into a "
-"Wikipedia article."
+msgid "%(object)s allows a maximum of %(excerpt_limit)s words be excerpted into a Wikipedia article."
 msgstr ""
 
 #. Translators: If a partner has specified the excerpt limit in percentage, this message will display the percentage of words on the partner page.
 #: TWLight/resources/templates/resources/partner_detail_timeline.html:113
 #, python-format
-msgid ""
-"%(object)s allows a maximum of %(excerpt_limit_percentage)s%% of an article "
-"be excerpted into a Wikipedia article."
+msgid "%(object)s allows a maximum of %(excerpt_limit_percentage)s%% of an article be excerpted into a Wikipedia article."
 msgstr ""
 
 #. Translators: If a partner has other requirements for access, this text shows as the title for that information field. (e.g. https://wikipedialibrary.wmflabs.org/partners/10/).
@@ -1767,9 +1583,7 @@ msgstr ""
 #. Translators: If a user must agree to a Terms of Use document, they see this message, and must enter the name of the resource. Don't translate publisher or url.
 #: TWLight/resources/templates/resources/partner_detail_timeline.html:140
 #, python-format
-msgid ""
-"%(publisher)s requires that you agree with its <a href=\"%(url)s\">terms of "
-"use</a>."
+msgid "%(publisher)s requires that you agree with its <a href=\"%(url)s\">terms of use</a>."
 msgstr ""
 
 #. Translators: If a user must provide their real name to apply to a partner, they see this message, and must enter the name of the resource. Don't translate publisher.
@@ -1793,17 +1607,13 @@ msgstr ""
 #. Translators: If a user must select a specific resource to apply for, they see this message, and must enter the name of the resource. Don't translate publisher.
 #: TWLight/resources/templates/resources/partner_detail_timeline.html:177
 #, python-format
-msgid ""
-"%(publisher)s requires that you specify a particular title that you want to "
-"access."
+msgid "%(publisher)s requires that you specify a particular title that you want to access."
 msgstr ""
 
 #. Translators: If a user must register on the partner website before applying, they see this message. Don't translate partner.
 #: TWLight/resources/templates/resources/partner_detail_timeline.html:187
 #, python-format
-msgid ""
-"%(publisher)s requires that you sign up for an account before applying for "
-"access."
+msgid "%(publisher)s requires that you sign up for an account before applying for access."
 msgstr ""
 
 #. Translators: If a partner has their location listed, this message is a label for that location
@@ -1932,9 +1742,7 @@ msgstr "Ĉu vi certas ke vi volas forigi <b>%(object)s</b>?"
 
 #. Translators: If multiple authorizations where returned for a collection, this message is shown to a user
 #: TWLight/resources/views.py:268
-msgid ""
-"Multiple authorizations were returned – something's wrong. Please contact us "
-"and don't forget to mention this message."
+msgid "Multiple authorizations were returned – something's wrong. Please contact us and don't forget to mention this message."
 msgstr ""
 
 #. Translators: This message is shown when user tries to access a NOT_AVAILABLE Partner
@@ -1975,14 +1783,7 @@ msgstr ""
 #. Translators: Shown on the website's 400 page, when a user sends a bad request. Don't translate path or Phabricator.
 #: TWLight/templates/400.html:20
 #, python-format
-msgid ""
-"If you think we should know what to do with that, please email us about this "
-"error at <a class=\"twl-links\" href=\"mailto:wikipedialibrary@wikimedia.org?"
-"Subject=Wikipedia%%20Library%%20%(path)s%%20Permission%%20denied"
-"\">wikipedialibrary@wikimedia.org</a> or report it to us on <a class=\"twl-"
-"links\" href=\"https://phabricator.wikimedia.org/maniphest/task/edit/form/1/?"
-"projectPHIDs=Library-Card-Platform&title=Wikipedia%%20Library%%20%(path)s"
-"%%20Bad%%20Request\">Phabricator</a>"
+msgid "If you think we should know what to do with that, please email us about this error at <a class=\"twl-links\" href=\"mailto:wikipedialibrary@wikimedia.org?Subject=Wikipedia%%20Library%%20%(path)s%%20Permission%%20denied\">wikipedialibrary@wikimedia.org</a> or report it to us on <a class=\"twl-links\" href=\"https://phabricator.wikimedia.org/maniphest/task/edit/form/1/?projectPHIDs=Library-Card-Platform&title=Wikipedia%%20Library%%20%(path)s%%20Bad%%20Request\">Phabricator</a>"
 msgstr ""
 
 #. Translators: Alt text for an image shown on the 400 error page.
@@ -2004,15 +1805,7 @@ msgstr "Domaĝe, vi ne havas permeson por tion fari."
 #. Translators: Shown on the website's 403 page, when a user attempts to navigate to a page they don't have permission to view. Don't translate path or Phabricator.
 #: TWLight/templates/403.html:20
 #, python-format
-msgid ""
-"If you think your account should be able to do that, please email us about "
-"this error at <a class=\"twl-links\" href=\"mailto:"
-"wikipedialibrary@wikimedia.org?Subject=Wikipedia%%20Library%%20%(path)s"
-"%%20Permission%%20denied\">wikipedialibrary@wikimedia.org</a> or report it "
-"to us on <a class=\"twl-links\" href=\"https://phabricator.wikimedia.org/"
-"maniphest/task/edit/form/1/?projectPHIDs=Library-Card-"
-"Platform&title=Wikipedia%%20Library%%20%(path)s%%20Permission%%20denied"
-"\">Phabricator</a>"
+msgid "If you think your account should be able to do that, please email us about this error at <a class=\"twl-links\" href=\"mailto:wikipedialibrary@wikimedia.org?Subject=Wikipedia%%20Library%%20%(path)s%%20Permission%%20denied\">wikipedialibrary@wikimedia.org</a> or report it to us on <a class=\"twl-links\" href=\"https://phabricator.wikimedia.org/maniphest/task/edit/form/1/?projectPHIDs=Library-Card-Platform&title=Wikipedia%%20Library%%20%(path)s%%20Permission%%20denied\">Phabricator</a>"
 msgstr ""
 
 #. Translators: Shown on the website's 404 page, when a user attempts to navigate to a page that doesn't exist.
@@ -2028,14 +1821,7 @@ msgstr "Domaĝe, ni ne povas trovi tiun."
 #. Translators: Shown on the website's 404 page, when a user attempts to navigate to a page that doesn't exist. Don't translate path or Phabricator.
 #: TWLight/templates/404.html:19
 #, python-format
-msgid ""
-"If you are certain that something should be here, please email us about this "
-"error at <a class=\"twl-links\" href=\"mailto:wikipedialibrary@wikimedia.org?"
-"Subject=Wikipedia%%20Library%%20%(path)s%%20Not%%20found\"> "
-"wikipedialibrary@wikimedia.org</a> or report it to us on <a class=\"twl-links"
-"\" href=\"https://phabricator.wikimedia.org/maniphest/task/edit/form/1/?"
-"projectPHIDs=Library-Card-Platform&title=Wikipedia%%20Library%%20%(path)s"
-"%%20Not%%20found\">Phabricator</a>"
+msgid "If you are certain that something should be here, please email us about this error at <a class=\"twl-links\" href=\"mailto:wikipedialibrary@wikimedia.org?Subject=Wikipedia%%20Library%%20%(path)s%%20Not%%20found\"> wikipedialibrary@wikimedia.org</a> or report it to us on <a class=\"twl-links\" href=\"https://phabricator.wikimedia.org/maniphest/task/edit/form/1/?projectPHIDs=Library-Card-Platform&title=Wikipedia%%20Library%%20%(path)s%%20Not%%20found\">Phabricator</a>"
 msgstr ""
 
 #. Translators: Alt text for an image shown on the 404 error page.
@@ -2050,32 +1836,18 @@ msgstr "Pri la Vikipedia Biblioteko"
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:20
-msgid ""
-"This platform is our central tool for facilitating access to our available "
-"collections. Here you can see which partnerships are available, search their "
-"contents, and apply for and access the ones you’re interested in."
+msgid "This platform is our central tool for facilitating access to our available collections. Here you can see which partnerships are available, search their contents, and apply for and access the ones you’re interested in."
 msgstr ""
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/). Wikimedia Foundation should not be translated.
 #: TWLight/templates/about.html:29
-msgid ""
-"All users receive immediate access to some collections, which can be browsed "
-"by clicking the 'Access collection' buttons or using the search bar at the "
-"top of the page. Other collections require an application before access is "
-"granted, and may be accessed directly or via an individual login or access "
-"code. Volunteer coordinators, who have signed non-disclosure agreements with "
-"the Wikimedia Foundation, review these applications and work with publishers "
-"to get you your free access."
+msgid "All users receive immediate access to some collections, which can be browsed by clicking the 'Access collection' buttons or using the search bar at the top of the page. Other collections require an application before access is granted, and may be accessed directly or via an individual login or access code. Volunteer coordinators, who have signed non-disclosure agreements with the Wikimedia Foundation, review these applications and work with publishers to get you your free access."
 msgstr ""
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/). Don't translate terms_url.
 #: TWLight/templates/about.html:43
 #, python-format
-msgid ""
-"For more information about how your information is stored and reviewed "
-"please see our <a class=\"twl-links\" href=\"%(terms_url)s\"> terms of use "
-"and privacy policy</a>. Accounts you apply for are also subject to the Terms "
-"of Use provided by each partner’s platform; please review them."
+msgid "For more information about how your information is stored and reviewed please see our <a class=\"twl-links\" href=\"%(terms_url)s\"> terms of use and privacy policy</a>. Accounts you apply for are also subject to the Terms of Use provided by each partner’s platform; please review them."
 msgstr ""
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
@@ -2085,12 +1857,7 @@ msgstr ""
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/). Wikimedia Foundation should not be translated.
 #: TWLight/templates/about.html:55
-msgid ""
-"Any active editor in good standing can receive access. For publishers with "
-"limited numbers of accounts, applications are reviewed based on the editor’s "
-"needs and contributions. If you think you could use access to one of our "
-"partner resources and are an active editor in any project supported by the "
-"Wikimedia Foundation, please apply."
+msgid "Any active editor in good standing can receive access. For publishers with limited numbers of accounts, applications are reviewed based on the editor’s needs and contributions. If you think you could use access to one of our partner resources and are an active editor in any project supported by the Wikimedia Foundation, please apply."
 msgstr ""
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
@@ -2120,23 +1887,12 @@ msgstr ""
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/)
 #: TWLight/templates/about.html:89
-msgid ""
-"If you are applying for an available collection, please first check that you "
-"don't already have access through another library or institution. If you do, "
-"please consider using that access rather than taking up a seat for this "
-"resource in The Wikipedia Library."
+msgid "If you are applying for an available collection, please first check that you don't already have access through another library or institution. If you do, please consider using that access rather than taking up a seat for this resource in The Wikipedia Library."
 msgstr ""
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/)
 #: TWLight/templates/about.html:99
-msgid ""
-"If your account is blocked on one or more Wikimedia projects, you may still "
-"be granted access to The Wikipedia Library. You will need to contact the "
-"Wikipedia Library team, who will review your blocks. If you have been "
-"blocked for content issues, most notably copyright violations, or have "
-"multiple long-term blocks, we may decline your request. Additionally, if "
-"your block status changes after being approved, you will need to request "
-"another review."
+msgid "If your account is blocked on one or more Wikimedia projects, you may still be granted access to The Wikipedia Library. You will need to contact the Wikipedia Library team, who will review your blocks. If you have been blocked for content issues, most notably copyright violations, or have multiple long-term blocks, we may decline your request. Additionally, if your block status changes after being approved, you will need to request another review."
 msgstr ""
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
@@ -2171,9 +1927,7 @@ msgstr ""
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:136
-msgid ""
-"Share their account logins or passwords with others, or sell their access to "
-"other parties"
+msgid "Share their account logins or passwords with others, or sell their access to other parties"
 msgstr ""
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
@@ -2183,23 +1937,17 @@ msgstr ""
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:144
-msgid ""
-"Systematically make printed or electronic copies of multiple extracts of "
-"restricted content available for any purpose"
+msgid "Systematically make printed or electronic copies of multiple extracts of restricted content available for any purpose"
 msgstr ""
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/). Stub is a technical term for a short Wikipedia article, use the appropriate Wikipedia term in your language.
 #: TWLight/templates/about.html:148
-msgid ""
-"Datamine metadata without permission, in order, for instance, to use "
-"metadata for auto-created stub articles"
+msgid "Datamine metadata without permission, in order, for instance, to use metadata for auto-created stub articles"
 msgstr ""
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:154
-msgid ""
-"Respecting these agreements allows us to continue growing the partnerships "
-"available to the community."
+msgid "Respecting these agreements allows us to continue growing the partnerships available to the community."
 msgstr ""
 
 #. Translators: This is the heading for a section on the About page (https://wikipedialibrary.wmflabs.org/about/).
@@ -2210,41 +1958,22 @@ msgstr "Peranto"
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:164
-msgid ""
-"EZProxy is a proxy server used to authenticate users for many Wikipedia "
-"Library partners. Users sign into EZProxy via the Library Card platform to "
-"verify that they are authorized users, and then the server accesses "
-"requested resources using its own IP address."
+msgid "EZProxy is a proxy server used to authenticate users for many Wikipedia Library partners. Users sign into EZProxy via the Library Card platform to verify that they are authorized users, and then the server accesses requested resources using its own IP address."
 msgstr ""
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:173
-msgid ""
-"You may notice that when accessing resources via EZProxy that URLs are "
-"dynamically rewritten. This is why we recommend logging in via the Library "
-"Card platform rather than going directly to the unproxied partner website. "
-"When in doubt, check the URL for ‘idm.oclc’. If it’s there, then you’re "
-"connected via EZProxy."
+msgid "You may notice that when accessing resources via EZProxy that URLs are dynamically rewritten. This is why we recommend logging in via the Library Card platform rather than going directly to the unproxied partner website. When in doubt, check the URL for ‘idm.oclc’. If it’s there, then you’re connected via EZProxy."
 msgstr ""
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:182
-msgid ""
-"Typically once you’ve logged in your session will remain active in your "
-"browser for up to two hours after you’ve finished searching. Note that use "
-"of EZProxy requires you to enable cookies. If you are having problems you "
-"should also try clearing your cache and restarting your browser."
+msgid "Typically once you’ve logged in your session will remain active in your browser for up to two hours after you’ve finished searching. Note that use of EZProxy requires you to enable cookies. If you are having problems you should also try clearing your cache and restarting your browser."
 msgstr ""
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/)
 #: TWLight/templates/about.html:193
-msgid ""
-"The Library Bundle is a collection of resources for which no application is "
-"required. If you meet the criteria laid out above, you will be authorized "
-"for access automatically upon logging in to the platform. Only some of our "
-"content is currently included in the Library Bundle, however we hope to "
-"expand the collection as more publishers become comfortable with "
-"participating. All Bundle content is accessed via EZProxy."
+msgid "The Library Bundle is a collection of resources for which no application is required. If you meet the criteria laid out above, you will be authorized for access automatically upon logging in to the platform. Only some of our content is currently included in the Library Bundle, however we hope to expand the collection as more publishers become comfortable with participating. All Bundle content is accessed via EZProxy."
 msgstr ""
 
 #. Translators: This is the heading for a section on the About page (https://wikipedialibrary.wmflabs.org/about/).
@@ -2254,12 +1983,7 @@ msgstr ""
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:206
-msgid ""
-"Citation practices vary by project and even by article. Generally, we "
-"support editors citing where they found information, in a form that allows "
-"others to check it for themselves. That often means providing both original "
-"source details as well as a link to the partner database in which the source "
-"was found."
+msgid "Citation practices vary by project and even by article. Generally, we support editors citing where they found information, in a form that allows others to check it for themselves. That often means providing both original source details as well as a link to the partner database in which the source was found."
 msgstr ""
 
 #. Translators: This is the heading for a section on the About page (https://wikipedialibrary.wmflabs.org/about/).
@@ -2271,9 +1995,7 @@ msgstr "Kontakti nin"
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:218
 #, python-format
-msgid ""
-"If you have questions, need help, or want to volunteer to help, please see "
-"our <a class=\"twl-links\" href=\"%(contact_url)s\">contact page</a>."
+msgid "If you have questions, need help, or want to volunteer to help, please see our <a class=\"twl-links\" href=\"%(contact_url)s\">contact page</a>."
 msgstr ""
 
 #. Translators: This is the title of the panel box detailing the contact information for the Wikipedia Library team.
@@ -2313,9 +2035,7 @@ msgstr "Twitter-paĝo de Vikimedia Biblioteko"
 #. Translators: This is the text that appears at the bottom of the contact us form directing users to the suggestions form.
 #: TWLight/templates/contact.html:48
 #, python-format
-msgid ""
-"(If you would like to suggest a partner, <a class=\"twl-links\" href="
-"\"%(suggest)s\"><strong>go here</strong></a>.)"
+msgid "(If you would like to suggest a partner, <a class=\"twl-links\" href=\"%(suggest)s\"><strong>go here</strong></a>.)"
 msgstr ""
 
 #. Translators: On a special 'link to search' page, this message is shown if JavaScript is disabled.
@@ -2377,9 +2097,7 @@ msgstr "La Vikipedia Biblioteko"
 #. Translators: Information about The Wikipedia Library.
 #: TWLight/templates/login_partial.html:53 TWLight/templates/new_base.html:21
 #, python-format
-msgid ""
-"More than 100 of the world's top subscription-only databases, with content "
-"in %(no_of_languages)s languages, free for Wikipedians of all backgrounds"
+msgid "More than 100 of the world's top subscription-only databases, with content in %(no_of_languages)s languages, free for Wikipedians of all backgrounds"
 msgstr ""
 
 #. Translators: Information about The Wikipedia Library.
@@ -2388,9 +2106,7 @@ msgid "Meet these criteria for automatic access"
 msgstr ""
 
 #: TWLight/templates/login_partial.html:69
-msgid ""
-"These criteria grant you access to certain collections but not all. Some "
-"collections are accessible on a per application basis only."
+msgid "These criteria grant you access to certain collections but not all. Some collections are accessible on a per application basis only."
 msgstr ""
 
 #: TWLight/templates/login_partial.html:89
@@ -2400,29 +2116,19 @@ msgstr ""
 #. Translators: Shown if the current user doesn't have a registered email on their account. Don't translate contact_us_url or email_url.
 #: TWLight/templates/message_partial.html:15
 #, python-format
-msgid ""
-"You don't have an email on file. We can't finalize your access to partner "
-"resources, and you won't be able to <a class=\"twl-links\" href="
-"\"%(contact_us_url)s\">contact us</a> without an email. Please <a class="
-"\"twl-links\" href=\"%(email_url)s\">update your email</a>."
+msgid "You don't have an email on file. We can't finalize your access to partner resources, and you won't be able to <a class=\"twl-links\" href=\"%(contact_us_url)s\">contact us</a> without an email. Please <a class=\"twl-links\" href=\"%(email_url)s\">update your email</a>."
 msgstr ""
 
 #. Translators: Shown if the current user has requested the processing of their data should be restricted.
 #: TWLight/templates/message_partial.html:26
 #, python-format
-msgid ""
-"You have requested a restriction on the processing of your data. Most site "
-"functionality will not be available to you until you <a class=\"twl-links\" "
-"href=\"%(restrict_url)s\">lift this restriction</a>."
+msgid "You have requested a restriction on the processing of your data. Most site functionality will not be available to you until you <a class=\"twl-links\" href=\"%(restrict_url)s\">lift this restriction</a>."
 msgstr ""
 
 #. Translators: Shown if the current user has not agreed to the terms of use.
 #: TWLight/templates/message_partial.html:37
 #, python-format
-msgid ""
-"You have not agreed to the <a class=\"twl-links\" href=\"%(terms_url)s"
-"\">terms of use</a> of this site. Your applications will not be processed "
-"and you won't be able to apply or access resources you are approved for."
+msgid "You have not agreed to the <a class=\"twl-links\" href=\"%(terms_url)s\">terms of use</a> of this site. Your applications will not be processed and you won't be able to apply or access resources you are approved for."
 msgstr ""
 
 #. Translators: This link is at the bottom of every page and links to the 'About' page (https://wikipedialibrary.wmflabs.org/about/)
@@ -2469,9 +2175,7 @@ msgstr "Refari pasvorton"
 
 #. Translators: If a user goes to reset their password, this message asks them to enter their email to do so.
 #: TWLight/templates/registration/password_reset_form.html:13
-msgid ""
-"Forgot your password? Enter your email address below, and we'll email "
-"instructions for setting a new one."
+msgid "Forgot your password? Enter your email address below, and we'll email instructions for setting a new one."
 msgstr ""
 
 #. Translators: This is the label for a button that users click to update their public information.
@@ -2517,16 +2221,12 @@ msgstr ""
 
 #. Translators: This text explains how to disagree to the site's terms of use and the restrictions that will come into effect when users disagree to the terms of use.
 #: TWLight/users/forms.py:185
-msgid ""
-"By unchecking this box and clicking “Update” you may explore the site, but "
-"you will not be able to apply for access to materials or evaluate "
-"applications unless you agree with the terms of use."
+msgid "By unchecking this box and clicking “Update” you may explore the site, but you will not be able to apply for access to materials or evaluate applications unless you agree with the terms of use."
 msgstr ""
 
 #. Translators: Users click this button to set their website email address to the one linked to their Wikipedia account.
 #: TWLight/users/forms.py:211
-msgid ""
-"Use my Wikipedia email address (will be updated the next time you login)."
+msgid "Use my Wikipedia email address (will be updated the next time you login)."
 msgstr ""
 
 #. Translators: This labels a button which users click to change their email.
@@ -2537,17 +2237,8 @@ msgstr "Ĝisdatigi retpoŝtan adreson"
 #. Translators: Shown if the current user tried to 'favorite' a partner they can't access. Do not translate '{partner}'
 #: TWLight/users/models.py:201
 #, python-brace-format
-msgid ""
-"Cannot add partner {partner} to your favorites because you don't have access "
-"to it"
+msgid "Cannot add partner {partner} to your favorites because you don't have access to it"
 msgstr ""
-
-#. Translators: Do not translate.
-#: TWLight/users/models.py:869
-#, fuzzy, python-brace-format
-#| msgid "Username"
-msgid "{wp_username}"
-msgstr "Uzantnomo"
 
 #. Translators: This error message is shown when there's a problem with the authenticated login process.
 #: TWLight/users/oauth.py:243
@@ -2567,9 +2258,7 @@ msgstr ""
 
 #. Translators: this message is displayed to users that don't have accounts and clicked on a proxied link.
 #: TWLight/users/oauth.py:388
-msgid ""
-"To view this link you need to be an eligible library user. Please login to "
-"continue."
+msgid "To view this link you need to be an eligible library user. Please login to continue."
 msgstr ""
 
 #. Translators: This warning message is shown to users when the response received from Wikimedia OAuth servers is not a valid one.
@@ -2605,17 +2294,12 @@ msgstr "Informo pri uzanto"
 
 #. Translators: If the user tries to log in, but their account does not meet certain requirements, they cannot login.
 #: TWLight/users/oauth.py:528
-msgid ""
-"Your Wikipedia account does not meet the eligibility criteria in the terms "
-"of use, so your Wikipedia Library Card Platform account cannot be activated."
+msgid "Your Wikipedia account does not meet the eligibility criteria in the terms of use, so your Wikipedia Library Card Platform account cannot be activated."
 msgstr ""
 
 #. Translators: If the user tries to log in, but their account does not meet certain requirements, they cannot login.
 #: TWLight/users/oauth.py:536
-msgid ""
-"Your Wikipedia account no longer meets the eligibility criteria in the terms "
-"of use, so you cannot be logged in. If you think you should be able to log "
-"in, please email wikipedialibrary@wikimedia.org."
+msgid "Your Wikipedia account no longer meets the eligibility criteria in the terms of use, so you cannot be logged in. If you think you should be able to log in, please email wikipedialibrary@wikimedia.org."
 msgstr ""
 
 #. Translators: this message is displayed to users with brand new accounts.
@@ -2626,10 +2310,7 @@ msgstr ""
 #. Translators: This message is displayed on the confirmation page where users can return their access to partner collections.
 #: TWLight/users/templates/users/authorization_confirm_return.html:13
 #, python-format
-msgid ""
-"You will no longer be able to access <b>%(partner)s's</b> resources via the "
-"Library Card platform, but can request access again by clicking 'renew', if "
-"you change your mind. Are you sure you want to return your access?"
+msgid "You will no longer be able to access <b>%(partner)s's</b> resources via the Library Card platform, but can request access again by clicking 'renew', if you change your mind. Are you sure you want to return your access?"
 msgstr ""
 
 #. Translators: On the MyLibrary page (https://wikipedialibrary.wmflabs.org/users/my_library), this tab shows all favorite collections a user has.
@@ -2701,10 +2382,7 @@ msgstr ""
 
 #. Translators: This is shown on editor profiles, in their profile page or on applications.
 #: TWLight/users/templates/users/editor_detail.html:59
-msgid ""
-"Information with an * was retrieved from Wikipedia directly. Other "
-"information was entered directly by users or site admins, in their preferred "
-"language."
+msgid "Information with an * was retrieved from Wikipedia directly. Other information was entered directly by users or site admins, in their preferred language."
 msgstr ""
 
 #. Translators: This distinguishes users who have been flagged as account coordinators. Don't translate username.
@@ -2715,10 +2393,7 @@ msgstr ""
 
 #. Translators: This is shown on editor profiles, under the heading for Wikipedia editor data.
 #: TWLight/users/templates/users/editor_detail_data.html:5
-msgid ""
-"This information is updated automatically from your Wikimedia account each "
-"time you log in, except for the Contributions field, where you can describe "
-"your Wikimedia editing history."
+msgid "This information is updated automatically from your Wikimedia account each time you log in, except for the Contributions field, where you can describe your Wikimedia editing history."
 msgstr ""
 
 #. Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this labels the user's username.
@@ -2748,17 +2423,13 @@ msgstr ""
 
 #. Translators: when viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this question has a yes or no answer.
 #: TWLight/users/templates/users/editor_detail_data.html:57
-msgid ""
-"at their last login, did this user meet the criteria set forth in the terms "
-"of use?"
+msgid "at their last login, did this user meet the criteria set forth in the terms of use?"
 msgstr ""
 
 #. Translators: When viewing a user's profile in an application, this message shows if the software doesn't think that the user is eligible for access. Don't translate username.
 #: TWLight/users/templates/users/editor_detail_data.html:72
 #, python-format
-msgid ""
-"%(username)s may still be eligible for access grants at the coordinators' "
-"discretion."
+msgid "%(username)s may still be eligible for access grants at the coordinators' discretion."
 msgstr ""
 
 #. Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this is the heading for a Yes/No ToU question.
@@ -2793,10 +2464,7 @@ msgstr ""
 #. Translators: This message is shown on a user's profile if their Wikimedia account is blocked on one or more projects. They may still be granted access to the Library Bundle, but need to contact Wikipedia Library staff to verify.
 #: TWLight/users/templates/users/editor_detail_data.html:137
 #, python-format
-msgid ""
-"It looks like you have an active block on your account. If you meet the "
-"other criteria you may still be permitted access to the library - please <a "
-"class=\"twl-links\" href=\"%(contact_url)s\">contact us</a>."
+msgid "It looks like you have an active block on your account. If you meet the other criteria you may still be permitted access to the library - please <a class=\"twl-links\" href=\"%(contact_url)s\">contact us</a>."
 msgstr ""
 
 #. Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this is the heading for a Yes/No program eligibility question.
@@ -2806,10 +2474,7 @@ msgstr ""
 
 #. Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this question has a Yes or No answer.
 #: TWLight/users/templates/users/editor_detail_data.html:156
-msgid ""
-"At their last login, did this user meet the criteria set forth in the "
-"Library Bundle? Note that satisfying terms of use is a prerequisite to "
-"bundle eligibility."
+msgid "At their last login, did this user meet the criteria set forth in the Library Bundle? Note that satisfying terms of use is a prerequisite to bundle eligibility."
 msgstr ""
 
 #. Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this is the heading for a Yes/No program eligibility question.
@@ -2854,18 +2519,13 @@ msgstr ""
 
 #. Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this text is in the 'Personal data' section. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/users/templates/users/editor_detail_data.html:262
-msgid ""
-"The following information is visible only to you, site administrators, "
-"publishing partners (where required), and volunteer Wikipedia Library "
-"coordinators (who have signed a Non-Disclosure Agreement)."
+msgid "The following information is visible only to you, site administrators, publishing partners (where required), and volunteer Wikipedia Library coordinators (who have signed a Non-Disclosure Agreement)."
 msgstr ""
 
 #. Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this labels a button which users can click to update or remove their personal information. Don't translate update_url.
 #: TWLight/users/templates/users/editor_detail_data.html:272
 #, python-format
-msgid ""
-"You may <a class=\"twl-links\" href=\"%(update_url)s\">update or delete</a> "
-"your data at any time."
+msgid "You may <a class=\"twl-links\" href=\"%(update_url)s\">update or delete</a> your data at any time."
 msgstr ""
 
 #. Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this labels the user's email. Don't remove the *.
@@ -2886,24 +2546,18 @@ msgstr ""
 
 #. Translators: This message tells users that they are not eligible to access The Wikipedia Library content.
 #: TWLight/users/templates/users/eligibility_modal.html:7
-msgid ""
-"Sorry, your Wikipedia account doesn’t currently qualify to access The "
-"Wikipedia Library."
+msgid "Sorry, your Wikipedia account doesn’t currently qualify to access The Wikipedia Library."
 msgstr ""
 
 #. Translators: This message tells users that they have not agreed to the terms of use, therefore are ineligible to access the content in The Wikipedia Library.
 #: TWLight/users/templates/users/eligibility_modal.html:30
 #, python-format
-msgid ""
-"Agreed with <a href=\"%(terms)s\" class=\"text-danger\"> terms of use </a>"
+msgid "Agreed with <a href=\"%(terms)s\" class=\"text-danger\"> terms of use </a>"
 msgstr ""
 
 #: TWLight/users/templates/users/eligibility_modal.html:40
 #, python-format
-msgid ""
-"It looks like you have an active block on your account. If you meet the "
-"other criteria you may still be permitted access to the library - please <a "
-"href=\"%(contact_url)s\">contact us</a>."
+msgid "It looks like you have an active block on your account. If you meet the other criteria you may still be permitted access to the library - please <a href=\"%(contact_url)s\">contact us</a>."
 msgstr ""
 
 #. Translators: Instructions to refresh a user's data.
@@ -2943,10 +2597,7 @@ msgstr "Ŝanĝi lingvon"
 
 #. Translators: This text on the user page helps users naviage to the TranslateWiki Wikipedia Library Card platform translation page.
 #: TWLight/users/templates/users/language_form.html:31
-msgid ""
-"You can help translate the tool at <a class=\"twl-links\" href=\"https://"
-"translatewiki.net/wiki/Translating:Wikipedia_Library_Card_Platform"
-"\">translatewiki.net</a>."
+msgid "You can help translate the tool at <a class=\"twl-links\" href=\"https://translatewiki.net/wiki/Translating:Wikipedia_Library_Card_Platform\">translatewiki.net</a>."
 msgstr ""
 
 #. Translators: When the user starts a new application and submits the application, the user can view the application and withdraw if need be. This changes the label for the Withdraw button.
@@ -2966,9 +2617,7 @@ msgstr ""
 
 #. Translators: On the page listing applications, this text explains a user they cannot renew their application since they've already requested a renewal or there aren't any renewals available.
 #: TWLight/users/templates/users/my_applications.html:79
-msgid ""
-"Renewals are either not required, not available right now, or you have "
-"already requested a renewal."
+msgid "Renewals are either not required, not available right now, or you have already requested a renewal."
 msgstr ""
 
 #. Translators: This text is the heading of a section in a user's profile where they can change their preferences.
@@ -3035,19 +2684,12 @@ msgstr ""
 
 #. Translators: This message is displayed on the page where users can request we stop processing their data.
 #: TWLight/users/templates/users/restrict_data.html:15
-msgid ""
-"Checking this box and clicking “Restrict” will pause all processing of the "
-"data you have entered into this website. You will not be able to apply for "
-"access to resources, your applications will not be further processed, and "
-"none of your data will be altered, until you return to this page and uncheck "
-"the box. This is not the same as deleting your data."
+msgid "Checking this box and clicking “Restrict” will pause all processing of the data you have entered into this website. You will not be able to apply for access to resources, your applications will not be further processed, and none of your data will be altered, until you return to this page and uncheck the box. This is not the same as deleting your data."
 msgstr ""
 
 #. Translators: This warning message is shown to coordinators who view the data restriction page.
 #: TWLight/users/templates/users/restrict_data.html:26
-msgid ""
-"You are a coordinator on this site. If you restrict the processing of your "
-"data, your coordinator flag will be removed."
+msgid "You are a coordinator on this site. If you restrict the processing of your data, your coordinator flag will be removed."
 msgstr ""
 
 #. Translators: use the date *when you are translating*, in a language-appropriate format.
@@ -3067,24 +2709,12 @@ msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:51
-msgid ""
-"<a class=\"twl-links\" href=\"https://meta.wikimedia.org/wiki/"
-"The_Wikipedia_Library\"> The Wikipedia Library </a> has partnered with "
-"publishers around the world to allow users to access otherwise paywalled "
-"resources. This website allows Wikipedia editors to search and access these "
-"resources."
+msgid "<a class=\"twl-links\" href=\"https://meta.wikimedia.org/wiki/The_Wikipedia_Library\"> The Wikipedia Library </a> has partnered with publishers around the world to allow users to access otherwise paywalled resources. This website allows Wikipedia editors to search and access these resources."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Wikimedia Foundation should not be translated. WMF should not be translated. Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:63
-msgid ""
-"This program is administered by the Wikimedia Foundation (WMF). These terms "
-"of use and privacy notice pertain to your application for access to "
-"resources through the Wikipedia Library, your use of this website, and your "
-"access to and use of those resources. They also describe our handling of the "
-"information you provide to us in order to create and administer your "
-"Wikipedia Library account. If we make material changes to the terms, we will "
-"notify users."
+msgid "This program is administered by the Wikimedia Foundation (WMF). These terms of use and privacy notice pertain to your application for access to resources through the Wikipedia Library, your use of this website, and your access to and use of those resources. They also describe our handling of the information you provide to us in order to create and administer your Wikipedia Library account. If we make material changes to the terms, we will notify users."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
@@ -3094,37 +2724,17 @@ msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:78
-msgid ""
-"Access to resources via The Wikipedia Library is reserved for community "
-"members who have demonstrated their commitment to the Wikimedia projects, "
-"and who will use their access to these resources to improve project content. "
-"To that end, in order to be eligible for The Wikipedia Library, we require "
-"that you be registered for a user account on the projects, with at least 500 "
-"edits, six (6) months of activity, and 10+ edits in the last month. We ask "
-"that you do not request access to any publishers with a limited number of "
-"available accounts whose resources you can already access for free through "
-"your local library or university, or another institution or organization, in "
-"order to provide that opportunity to others."
+msgid "Access to resources via The Wikipedia Library is reserved for community members who have demonstrated their commitment to the Wikimedia projects, and who will use their access to these resources to improve project content. To that end, in order to be eligible for The Wikipedia Library, we require that you be registered for a user account on the projects, with at least 500 edits, six (6) months of activity, and 10+ edits in the last month. We ask that you do not request access to any publishers with a limited number of available accounts whose resources you can already access for free through your local library or university, or another institution or organization, in order to provide that opportunity to others."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:94
-msgid ""
-"Additionally, if you are currently blocked or banned from a Wikimedia "
-"project, applications to resources may be rejected or restricted. If you "
-"obtain a Wikipedia Library account, but a block or ban is subsequently "
-"instituted against you on one of the projects, you may lose access to your "
-"Wikipedia Library account."
+msgid "Additionally, if you are currently blocked or banned from a Wikimedia project, applications to resources may be rejected or restricted. If you obtain a Wikipedia Library account, but a block or ban is subsequently instituted against you on one of the projects, you may lose access to your Wikipedia Library account."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:104
-msgid ""
-"Your eligibility to access The Wikipedia Library is assessed at each login. "
-"While more than half of the library's content is provided via this automated "
-"eligibility check, access to other publisher's content may be time limited, "
-"typically lapsing after one year, after which you will usually need to apply "
-"for renewal."
+msgid "Your eligibility to access The Wikipedia Library is assessed at each login. While more than half of the library's content is provided via this automated eligibility check, access to other publisher's content may be time limited, typically lapsing after one year, after which you will usually need to apply for renewal."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
@@ -3134,47 +2744,27 @@ msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:118
-msgid ""
-"In order to apply for access to a partner resource, you must provide us with "
-"certain information, which we will use to evaluate your application. If your "
-"application is approved, we may transfer the information you have given us "
-"to the publishers whose resources you wish to access. They will either "
-"contact you with the account information directly or we will send access "
-"information to you ourselves."
+msgid "In order to apply for access to a partner resource, you must provide us with certain information, which we will use to evaluate your application. If your application is approved, we may transfer the information you have given us to the publishers whose resources you wish to access. They will either contact you with the account information directly or we will send access information to you ourselves."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:130
-msgid ""
-"In addition to the basic information you provide to us, our system will "
-"retrieve some information directly from the Wikimedia projects: your "
-"username, email address, edit count, registration date, user ID number, "
-"groups to which you belong, and any special user rights."
+msgid "In addition to the basic information you provide to us, our system will retrieve some information directly from the Wikimedia projects: your username, email address, edit count, registration date, user ID number, groups to which you belong, and any special user rights."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:140
-msgid ""
-"Each time you log in to the Wikipedia Library Card Platform, this "
-"information will be automatically updated."
+msgid "Each time you log in to the Wikipedia Library Card Platform, this information will be automatically updated."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:148
-msgid ""
-"We will ask you to provide us with some information about your history of "
-"contributions to the Wikimedia projects. Information on contribution history "
-"is optional, but will greatly assist us in evaluating your application."
+msgid "We will ask you to provide us with some information about your history of contributions to the Wikimedia projects. Information on contribution history is optional, but will greatly assist us in evaluating your application."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). WMF should not be translated. Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:157
-msgid ""
-"The information you provide when creating your account will be visible to "
-"you while on the site but not to others unless they are approved Wikipedia "
-"Library Coordinators, WMF Staff, or WMF Contractors who need access to this "
-"data in order to carry out their work with the Wikipedia Library, all of "
-"whom are subject to non-disclosure obligations."
+msgid "The information you provide when creating your account will be visible to you while on the site but not to others unless they are approved Wikipedia Library Coordinators, WMF Staff, or WMF Contractors who need access to this data in order to carry out their work with the Wikipedia Library, all of whom are subject to non-disclosure obligations."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
@@ -3184,46 +2774,32 @@ msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:171
-msgid ""
-"In order to access an individual publisher’s resources, you must agree to "
-"that publisher’s terms of use and privacy policy. You agree that you will "
-"not violate such terms and policies in connection with your use of the "
-"Wikipedia Library. Additionally, the following activities are prohibited "
-"while accessing publisher resources through the Wikipedia Library."
+msgid "In order to access an individual publisher’s resources, you must agree to that publisher’s terms of use and privacy policy. You agree that you will not violate such terms and policies in connection with your use of the Wikipedia Library. Additionally, the following activities are prohibited while accessing publisher resources through the Wikipedia Library."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:184
-msgid ""
-"Sharing your Wikipedia account, usernames, passwords, or any access codes "
-"for publisher resources with others;"
+msgid "Sharing your Wikipedia account, usernames, passwords, or any access codes for publisher resources with others;"
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:191
-msgid ""
-"Automatically scraping or downloading restricted content from publishers;"
+msgid "Automatically scraping or downloading restricted content from publishers;"
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:197
-msgid ""
-"Systematically making printed or electronic copies of multiple extracts of "
-"restricted content available for any purpose;"
+msgid "Systematically making printed or electronic copies of multiple extracts of restricted content available for any purpose;"
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:204
-msgid ""
-"Data mining metadata without permission—for example, in order to use "
-"metadata for auto-created stub articles;"
+msgid "Data mining metadata without permission—for example, in order to use metadata for auto-created stub articles;"
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:211
-msgid ""
-"Using the access you receive through the Wikipedia Library for profit by "
-"selling access to your account or resources which you have through it."
+msgid "Using the access you receive through the Wikipedia Library for profit by selling access to your account or resources which you have through it."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
@@ -3233,18 +2809,12 @@ msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:224
-msgid ""
-"Certain resources may only be accessed using an external search service, "
-"such as the EBSCO Discovery Service, or a proxy service, such as OCLC "
-"EZProxy. If you use such external search and/or proxy services, please "
-"review the applicable terms of use and privacy policies."
+msgid "Certain resources may only be accessed using an external search service, such as the EBSCO Discovery Service, or a proxy service, such as OCLC EZProxy. If you use such external search and/or proxy services, please review the applicable terms of use and privacy policies."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:234
-msgid ""
-"In addition, if you use OCLC EZProxy, please note that you may not use it "
-"for commercial purposes."
+msgid "In addition, if you use OCLC EZProxy, please note that you may not use it for commercial purposes."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
@@ -3254,120 +2824,49 @@ msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Wikimedia Foundation should not be translated. Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:245
-msgid ""
-"The Wikimedia Foundation and our service providers use your information for "
-"the legitimate purpose of providing Wikipedia Library services in support of "
-"our charitable mission. When you apply for a Wikipedia Library account, or "
-"use your Wikipedia Library account, we may routinely collect the following "
-"information: your username, email address, edit count, registration date, "
-"user ID number, groups to which you belong, and any special user rights; "
-"your name, country of residence, and/or affiliation, if required by a "
-"partner to which you are applying; your narrative description of your "
-"contributions and reasons for applying for access to partner resources; and "
-"the date you agree to these terms of use."
+msgid "The Wikimedia Foundation and our service providers use your information for the legitimate purpose of providing Wikipedia Library services in support of our charitable mission. When you apply for a Wikipedia Library account, or use your Wikipedia Library account, we may routinely collect the following information: your username, email address, edit count, registration date, user ID number, groups to which you belong, and any special user rights; your name, country of residence, and/or affiliation, if required by a partner to which you are applying; your narrative description of your contributions and reasons for applying for access to partner resources; and the date you agree to these terms of use."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:262
 #, python-format
-msgid ""
-"Each publisher who is a member of the Wikipedia Library program requires "
-"different specific information in the application. Some publishers may "
-"request only an email address, while others request more detailed data, such "
-"as your name, location, or institutional affiliation. When you complete your "
-"application, you will only be asked to supply information required by the "
-"publishers you have chosen, and each publisher will only receive the "
-"information they require for providing you with access. Please see our <a "
-"class=\"twl-links\" href=\"%(all_partners_url)s\">partner information</a> "
-"pages to learn what information is required by each publisher to gain access "
-"to their resources."
+msgid "Each publisher who is a member of the Wikipedia Library program requires different specific information in the application. Some publishers may request only an email address, while others request more detailed data, such as your name, location, or institutional affiliation. When you complete your application, you will only be asked to supply information required by the publishers you have chosen, and each publisher will only receive the information they require for providing you with access. Please see our <a class=\"twl-links\" href=\"%(all_partners_url)s\">partner information</a> pages to learn what information is required by each publisher to gain access to their resources."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Wikimedia Foundation should not be translated. Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:277
-msgid ""
-"Some Wikipedia Library pages are visible without logging in, but you will "
-"need to log in to apply or access proprietary partner resources. We use the "
-"data provided by you via OAuth and Wikimedia API calls to assess your "
-"application for access and to process approved requests."
+msgid "Some Wikipedia Library pages are visible without logging in, but you will need to log in to apply or access proprietary partner resources. We use the data provided by you via OAuth and Wikimedia API calls to assess your application for access and to process approved requests."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:288
 #, python-format
-msgid ""
-"In order to administer the Wikipedia Library program, we will retain the "
-"application data we collect from you for three years after your most recent "
-"login, unless you delete your account, as described below. You can log in "
-"and go to <a class=\"twl-links\" href=\"%(profile_url)s\">your profile page</"
-"a> in order to see the information associated with your account, and can "
-"download it in JSON format. You may access, update, restrict, or delete this "
-"information at any time, except for the information that is automatically "
-"retrieved from the projects. If you have any questions or concerns about the "
-"handling of your data, please contact <a class=\"twl-links\" href=\"mailto:"
-"wikipedialibrary@wikimedia.org?Subject=Wikipedia%%20Library%%20Card"
-"%%20account%%20deactivation\"> wikipedialibrary@wikimedia.org </a>."
+msgid "In order to administer the Wikipedia Library program, we will retain the application data we collect from you for three years after your most recent login, unless you delete your account, as described below. You can log in and go to <a class=\"twl-links\" href=\"%(profile_url)s\">your profile page</a> in order to see the information associated with your account, and can download it in JSON format. You may access, update, restrict, or delete this information at any time, except for the information that is automatically retrieved from the projects. If you have any questions or concerns about the handling of your data, please contact <a class=\"twl-links\" href=\"mailto:wikipedialibrary@wikimedia.org?Subject=Wikipedia%%20Library%%20Card%%20account%%20deactivation\"> wikipedialibrary@wikimedia.org </a>."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:305
-msgid ""
-"If you decide to disable your Wikipedia Library account, you can use the "
-"delete button on your profile to delete certain personal information "
-"associated with your account. We will delete your real name, institutional "
-"affiliation, and country of residence. Please note that the system will "
-"retain a record of your username, the publishers to which you applied or had "
-"access, and the dates of that access. Note that deletion is not reversible. "
-"Deletion of your Wikipedia Library account may also correspond with the "
-"removal of any resource access to which you were eligible or approved. If "
-"you request the deletion of account information and later wish to apply for "
-"a new account, you will need to provide the necessary information again."
+msgid "If you decide to disable your Wikipedia Library account, you can use the delete button on your profile to delete certain personal information associated with your account. We will delete your real name, institutional affiliation, and country of residence. Please note that the system will retain a record of your username, the publishers to which you applied or had access, and the dates of that access. Note that deletion is not reversible. Deletion of your Wikipedia Library account may also correspond with the removal of any resource access to which you were eligible or approved. If you request the deletion of account information and later wish to apply for a new account, you will need to provide the necessary information again."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). WMF should not be translated. Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:321
-msgid ""
-"The Wikipedia Library is run by WMF Staff, Contractors, and approved "
-"volunteer Coordinators. The data associated with your account will be shared "
-"with the WMF staff, contractors, service providers, and volunteer "
-"coordinators who need to process the information in connection with their "
-"work for the Wikipedia Library, and who are subject to confidentiality "
-"obligations. We will also use your data for internal Wikipedia Library "
-"purposes such as distributing user surveys and account notifications, and in "
-"a depersonalized or aggregated fashion for statistical analysis and "
-"administration. Finally, we will share your information with the publishers "
-"whom you specifically select in order to provide you with access to "
-"resources. Otherwise, your information will not be shared with third "
-"parties, with the exception of the circumstances described below."
+msgid "The Wikipedia Library is run by WMF Staff, Contractors, and approved volunteer Coordinators. The data associated with your account will be shared with the WMF staff, contractors, service providers, and volunteer coordinators who need to process the information in connection with their work for the Wikipedia Library, and who are subject to confidentiality obligations. We will also use your data for internal Wikipedia Library purposes such as distributing user surveys and account notifications, and in a depersonalized or aggregated fashion for statistical analysis and administration. Finally, we will share your information with the publishers whom you specifically select in order to provide you with access to resources. Otherwise, your information will not be shared with third parties, with the exception of the circumstances described below."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). WMF should not be translated.
 #: TWLight/users/templates/users/terms.html:338
-msgid ""
-"We may disclose any collected information when required by law, when we have "
-"your permission, when needed to protect our rights, privacy, safety, users, "
-"or the general public, and when necessary to enforce these terms, WMF’s "
-"general <a class=\"twl-links\" href=\"https://foundation.wikimedia.org/wiki/"
-"Terms_of_Use\">Terms of Use</a>, or any other WMF policy."
+msgid "We may disclose any collected information when required by law, when we have your permission, when needed to protect our rights, privacy, safety, users, or the general public, and when necessary to enforce these terms, WMF’s general <a class=\"twl-links\" href=\"https://foundation.wikimedia.org/wiki/Terms_of_Use\">Terms of Use</a>, or any other WMF policy."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:349
-msgid ""
-"We take the security of your personal data seriously, and take reasonable "
-"precautions to ensure your data is protected. These precautions include "
-"access controls to limit who has access to your data and security "
-"technologies to protect data stored on the server. However, we cannot "
-"guarantee the safety of your data as it is transmitted and stored."
+msgid "We take the security of your personal data seriously, and take reasonable precautions to ensure your data is protected. These precautions include access controls to limit who has access to your data and security technologies to protect data stored on the server. However, we cannot guarantee the safety of your data as it is transmitted and stored."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:360
-msgid ""
-"Please note that these terms do not control the use and handling of your "
-"data by the publishers and service providers whose resources you access or "
-"apply to access. Please read their individual privacy policies for that "
-"information."
+msgid "Please note that these terms do not control the use and handling of your data by the publishers and service providers whose resources you access or apply to access. Please read their individual privacy policies for that information."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
@@ -3378,34 +2877,17 @@ msgstr "Enportita"
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Wikimedia Foundation should not be translated. Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:373
-msgid ""
-"The Wikimedia Foundation is a nonprofit organization based in San Francisco, "
-"California. The Wikipedia Library program provides access to resources held "
-"by publishers in multiple countries. If you apply for a Wikipedia Library "
-"account (whether you are inside or outside of the United States), you "
-"understand that your personal data will be collected, transferred, stored, "
-"processed, disclosed and otherwise used in the U.S. as described in this "
-"privacy policy. You also understand that your information may be transferred "
-"by us from the U.S. to other countries, which may have different or less "
-"stringent data protection laws than your country, in connection with "
-"providing services to you, including evaluating your application and "
-"securing access to your chosen publishers (locations for each publisher are "
-"outlined on their respective partner information pages)."
+msgid "The Wikimedia Foundation is a nonprofit organization based in San Francisco, California. The Wikipedia Library program provides access to resources held by publishers in multiple countries. If you apply for a Wikipedia Library account (whether you are inside or outside of the United States), you understand that your personal data will be collected, transferred, stored, processed, disclosed and otherwise used in the U.S. as described in this privacy policy. You also understand that your information may be transferred by us from the U.S. to other countries, which may have different or less stringent data protection laws than your country, in connection with providing services to you, including evaluating your application and securing access to your chosen publishers (locations for each publisher are outlined on their respective partner information pages)."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:392
-msgid ""
-"Please note that in the event of any differences in meaning or "
-"interpretation between the original English version of these terms and a "
-"translation, the original English version takes precedence."
+msgid "Please note that in the event of any differences in meaning or interpretation between the original English version of these terms and a translation, the original English version takes precedence."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Wikimedia Foundation should not be translated.
 #: TWLight/users/templates/users/terms.html:403
-msgid ""
-"See also the <a class=\"twl-links\" href=\"https://wikimediafoundation.org/"
-"wiki/Privacy_policy\">Wikimedia Foundation Privacy Policy</a>."
+msgid "See also the <a class=\"twl-links\" href=\"https://wikimediafoundation.org/wiki/Privacy_policy\">Wikimedia Foundation Privacy Policy</a>."
 msgstr ""
 
 #. Translators: This is the second to last line of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
@@ -3426,11 +2908,7 @@ msgstr "Vikipediaj grupoj"
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:426
-msgid ""
-"By checking this box and clicking “Submit”, you agree that you have read the "
-"above terms and that you will adhere to the terms of use in your application "
-"to and use of the The Wikipedia Library, and the publishers’ services to "
-"which you gain access through The Wikipedia Library program."
+msgid "By checking this box and clicking “Submit”, you agree that you have read the above terms and that you will adhere to the terms of use in your application to and use of the The Wikipedia Library, and the publishers’ services to which you gain access through The Wikipedia Library program."
 msgstr ""
 
 #: TWLight/users/templates/users/user_collection_tile.html:32
@@ -3485,29 +2963,18 @@ msgstr "Forigi ĉiun datenon"
 
 #. Translators: This message is displayed on the page where users can request the deletion of their data.
 #: TWLight/users/templates/users/user_confirm_delete.html:17
-msgid ""
-"<b>Warning:</b> Performing this action will delete your Wikipedia Library "
-"Card user account and all associated applications. This process is not "
-"reversible. You may lose any partner accounts you were granted, and will not "
-"be able to renew those accounts or apply for new ones."
+msgid "<b>Warning:</b> Performing this action will delete your Wikipedia Library Card user account and all associated applications. This process is not reversible. You may lose any partner accounts you were granted, and will not be able to renew those accounts or apply for new ones."
 msgstr ""
 
 #. Translators: this should show up for people who log in with a username/password and not OAuth, so we don't know what their Wikipedia identity is.
-#.
 #: TWLight/users/templates/users/user_detail.html:12
 #, python-format
-msgid ""
-"Hi, %(username)s! You don't have a Wikipedia editor profile attached to your "
-"account here, so you are probably a site administrator."
+msgid "Hi, %(username)s! You don't have a Wikipedia editor profile attached to your account here, so you are probably a site administrator."
 msgstr ""
 
 #. Translators: In the unlikely scenario that someone is able to register an account without using OAuth (thus leaving us without some of the information required for applications), users will see this message, encouraging them to re-register.
 #: TWLight/users/templates/users/user_detail.html:20
-msgid ""
-"If you aren't a site administrator, something weird has happened. You won't "
-"be able to apply for access without a Wikipedia editor profile. You should "
-"log out and create a new account by logging in via OAuth, or contact a site "
-"administrator for help."
+msgid "If you aren't a site administrator, something weird has happened. You won't be able to apply for access without a Wikipedia editor profile. You should log out and create a new account by logging in via OAuth, or contact a site administrator for help."
 msgstr ""
 
 #. Translators: Labels a sections where coordinators can select their email preferences.
@@ -3518,17 +2985,12 @@ msgstr ""
 #. Translators: This message is shown on user's own profile page, encouraging them to make sure their information is up to date, so that account coordinators can use the information to judge applications.
 #: TWLight/users/views.py:176
 #, python-brace-format
-msgid ""
-"Please <a class='twl-links' href='{url}'>update your contributions</a> to "
-"Wikipedia to help coordinators evaluate your applications."
+msgid "Please <a class='twl-links' href='{url}'>update your contributions</a> to Wikipedia to help coordinators evaluate your applications."
 msgstr ""
 
 #. Translators: Coordinators are shown this message when they unselect all three types of reminder email options under preferences.
 #: TWLight/users/views.py:288
-msgid ""
-"You have chosen not to receive reminder emails. As a coordinator, you should "
-"receive at least one type of reminder emails, so consider changing your "
-"preferences."
+msgid "You have chosen not to receive reminder emails. As a coordinator, you should receive at least one type of reminder emails, so consider changing your preferences."
 msgstr ""
 
 #. Translators: Coordinators are shown this message when they make changes to their reminder email options under preferences.
@@ -3562,9 +3024,7 @@ msgstr ""
 
 #. Translators: If the user has not filled out their email, they can browse the website but cannot apply for access to resources.
 #: TWLight/users/views.py:487
-msgid ""
-"Your email is blank. You can still explore the site, but you won't be able "
-"to apply for access to partner resources without an email."
+msgid "Your email is blank. You can still explore the site, but you won't be able to apply for access to partner resources without an email."
 msgstr ""
 
 #. Translators: This message is shown once the access to a partner has successfully been returned.
@@ -3599,31 +3059,3 @@ msgstr ""
 msgid "10+ edits in the last 30 days"
 msgstr ""
 
-#: tests/shunit/data/bad_i18n_comment_1.py:3
-#: tests/shunit/data/bad_i18n_newline_1.py:5
-msgid "1"
-msgstr ""
-
-#. Translators: Lorem ipsum dolor sit amet, consectetur adipiscing elit. Mauris vitae ipsum ut purus faucibus pretium. Proin tempus neque et aliquet consectetur. Ut egestas sapien in consectetur sagittis. Mauris neque lacus, dapibus non viverra vitae, interdum ut aenean ipsum.
-#. Translators: Lorem ipsum dolor sit amet, consectetur adipiscing elit. Mauris vitae ipsum ut purus faucibus pretium. Proin tempus neque et aliquet consectetur. Ut egestas sapien in consectetur sagittis. Mauris neque lacus, dapibus non.
-#: tests/shunit/data/bad_i18n_comment_2.py:4
-#: tests/shunit/data/bad_i18n_newline_2.py:5 tests/shunit/data/good_i18n_1.py:2
-#: tests/shunit/data/good_i18n_2.py:2
-msgid "2"
-msgstr ""
-
-#: tests/shunit/data/bad_i18n_newline_3.py:5
-msgid "3"
-msgstr ""
-
-#: tests/shunit/data/bad_i18n_newline_4.py:5
-msgid "4"
-msgstr ""
-
-#: tests/shunit/data/bad_i18n_newline_5.py:5
-msgid "5"
-msgstr ""
-
-#: tests/shunit/data/bad_i18n_newline_6.py:5
-msgid "6"
-msgstr ""

--- a/locale/es/LC_MESSAGES/django.po
+++ b/locale/es/LC_MESSAGES/django.po
@@ -33,10 +33,11 @@
 # Author: Whytheonlyone
 msgid ""
 msgstr ""
+""
 "Project-Id-Version: Wikipedia Library Card Platform - Website\n"
-"Report-Msgid-Bugs-To: wikipedialibrary@wikimedia.org\n"
+"Report-Msgid-Bugs-To: translatewiki.net\n"
 "POT-Creation-Date: 2024-07-11 20:54+0000\n"
-"PO-Revision-Date: 2024-07-11 12:30:14+0000\n"
+"PO-Revision-Date: 2024-07-15 12:29:14+0000\n"
 "Language: es\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
@@ -68,13 +69,8 @@ msgstr "Acerca de ti"
 #. Translators: This note appears in a section of a form where we ask users to enter info (like country of residence) when applying for resource access.
 #: TWLight/applications/forms.py:179
 #, python-brace-format
-msgid ""
-"<p><small><i>Your personal data will be processed according to our <a "
-"class='twl-links' href='{terms_url}'> privacy policy</a>.</i></small></p>"
-msgstr ""
-"<p><small><i>Tus datos personales serán procesados de acuerdo con nuestra <a "
-"class='twl-links' href='{terms_url}'>política de privacidad</a>.</i></"
-"small></p>"
+msgid "<p><small><i>Your personal data will be processed according to our <a class='twl-links' href='{terms_url}'> privacy policy</a>.</i></small></p>"
+msgstr "<p><small><i>Tus datos personales serán procesados de acuerdo con nuestra <a class='twl-links' href='{terms_url}'>política de privacidad</a>.</i></small></p>"
 
 #. Translators: This is the title of the application form page, where users enter information required for the application. It lets the user know which partner application they are entering data for. {partner}
 #: TWLight/applications/forms.py:189
@@ -115,12 +111,8 @@ msgstr "El correo electrónico de tu cuenta en el sitio web del socio"
 #. Translators: This labels a choice field where users will have to select the number of months they wish to have their access for as part of the application renewal confirmation.
 #. Translators: When filling out an application, users may be required to enter the length of the account (expiry) they wish to have for proxy partners.
 #: TWLight/applications/forms.py:339 TWLight/applications/helpers.py:100
-msgid ""
-"The number of months you wish to have this access for before renewal is "
-"required"
-msgstr ""
-"El número de meses que requieres el acceso antes de que sea necesaria una "
-"renovación"
+msgid "The number of months you wish to have this access for before renewal is required"
+msgstr "El número de meses que requieres el acceso antes de que sea necesaria una renovación"
 
 #. Translators: When filling out an application, users may need to specify their name
 #: TWLight/applications/helpers.py:81
@@ -208,13 +200,8 @@ msgstr "Correo electrónico"
 
 #. Translators: This comment is added to pending applications when our terms of use change.
 #: TWLight/applications/management/commands/notify_applicants_tou_changes.py:54
-msgid ""
-"Our terms of use have changed. Your applications will not be processed until "
-"you log in and agree to our updated terms."
-msgstr ""
-"Nuestras condiciones de uso han cambiado. Tus solicitudes no serán "
-"procesadas hasta que inicies sesión y aceptes las condiciones de uso "
-"actualizadas."
+msgid "Our terms of use have changed. Your applications will not be processed until you log in and agree to our updated terms."
+msgstr "Nuestras condiciones de uso han cambiado. Tus solicitudes no serán procesadas hasta que inicies sesión y aceptes las condiciones de uso actualizadas."
 
 #. Translators: This is the status of an application that has not yet been reviewed.
 #: TWLight/applications/models.py:54
@@ -280,43 +267,26 @@ msgstr "URL de acceso: {access_url}"
 
 #. Translators: This text goes into account approval emails in the case that we need to send the user's details to a publisher for manual account setup.
 #: TWLight/applications/models.py:331
-msgid ""
-"You can expect to receive access details within a week or two once it has "
-"been processed."
-msgstr ""
-"Puedes esperar a recibir detalles de acceso dentro de una semana o dos una "
-"vez que haya sido procesada."
+msgid "You can expect to receive access details within a week or two once it has been processed."
+msgstr "Puedes esperar a recibir detalles de acceso dentro de una semana o dos una vez que haya sido procesada."
 
 #. Translators: This comment is added to open applications when a partner joins the Library Bundle, which does not require applications.
 #: TWLight/applications/signals.py:247
-msgid ""
-"This partner joined the Library Bundle, which does not require applications. "
-"This application will be marked as invalid."
-msgstr ""
-"Este socio se ha unido a el Library Bundle, que no requiere de solicitudes "
-"individuales. Esta solicitud se marcará como inválida."
+msgid "This partner joined the Library Bundle, which does not require applications. This application will be marked as invalid."
+msgstr "Este socio se ha unido a el Library Bundle, que no requiere de solicitudes individuales. Esta solicitud se marcará como inválida."
 
 #. Translators: This is shown to users if the application is to a partner for which we have run out of available accounts. The application is therefore on a 'waitlist', and will be reviewed when more accounts are available.
 #: TWLight/applications/templates/applications/application_evaluation.html:29
-msgid ""
-"This application is on the waitlist because this partner does not have any "
-"access grants available at this time."
-msgstr ""
-"Esta aplicación está en la lista de espera porque este socio no tiene "
-"permisos de acceso disponibles en este momento."
+msgid "This application is on the waitlist because this partner does not have any access grants available at this time."
+msgstr "Esta aplicación está en la lista de espera porque este socio no tiene permisos de acceso disponibles en este momento."
 
 #. Translators: This message is shown on pages where coordinators can see personal information about applicants.
 #: TWLight/applications/templates/applications/application_evaluation.html:36
 #: TWLight/applications/templates/applications/application_list_include.html:6
 #: TWLight/applications/templates/applications/send_partner.html:45
 #: TWLight/resources/templates/resources/partner_users.html:18
-msgid ""
-"Coordinators: This page may contain personal information such as real names "
-"and email addresses. Please remember that this information is confidential."
-msgstr ""
-"Coordinadores: Esta página puede contener información personal como nombres "
-"reales y direcciones de correo electrónico. Por favor recuerda que esta "
-"información es confidencial."
+msgid "Coordinators: This page may contain personal information such as real names and email addresses. Please remember that this information is confidential."
+msgstr "Coordinadores: Esta página puede contener información personal como nombres reales y direcciones de correo electrónico. Por favor recuerda que esta información es confidencial."
 
 #. Translators: This is the title of the application page shown to users who are a coordinator, and are able to accept or reject the application.
 #: TWLight/applications/templates/applications/application_evaluation.html:39
@@ -325,12 +295,8 @@ msgstr "Evaluar solicitud"
 
 #. Translators: This text is shown to coordinators on application pages if the applicant has restricted processing of their data.
 #: TWLight/applications/templates/applications/application_evaluation.html:42
-msgid ""
-"This user has requested a restriction on the processing of their data, so "
-"you cannot change the status of their application."
-msgstr ""
-"Este usuario ha solicitado una restricción en el procesamiento de sus datos, "
-"así que no puedes cambiar el estatus de su aplicación."
+msgid "This user has requested a restriction on the processing of their data, so you cannot change the status of their application."
+msgstr "Este usuario ha solicitado una restricción en el procesamiento de sus datos, así que no puedes cambiar el estatus de su aplicación."
 
 #. Translators: This is the title of the application page shown to users who are not a coordinator.
 #: TWLight/applications/templates/applications/application_evaluation.html:48
@@ -403,12 +369,8 @@ msgstr "Desconocido"
 
 #. Translators: This is the text displayed to coordinators when an applicant has no country of residence in their profile.
 #: TWLight/applications/templates/applications/application_evaluation.html:123
-msgid ""
-"Please request the applicant add their country of residence to their profile "
-"before proceeding further."
-msgstr ""
-"Favor de pedir al solicitante que añada su país de residencia a su perfil "
-"ante de poder proceder."
+msgid "Please request the applicant add their country of residence to their profile before proceeding further."
+msgstr "Favor de pedir al solicitante que añada su país de residencia a su perfil ante de poder proceder."
 
 #. Translators: This labels the section of an application showing the total number of accounts available for a partner or their collection.
 #: TWLight/applications/templates/applications/application_evaluation.html:134
@@ -418,12 +380,8 @@ msgstr "Cuentas disponibles:"
 #. Translators: This labels the section of an application showing whether the user had agreed to the terms of use or not.
 #: TWLight/applications/templates/applications/application_evaluation.html:145
 #, python-format
-msgid ""
-"Has agreed to the site's <a class=\"twl-links\" href=\"%(terms_url)s\">terms "
-"of use</a>?"
-msgstr ""
-"¿Ha aceptado las <a class=\"twl-links\" href=\"%(terms_url)s\">condiciones "
-"de uso</a> del sitio?"
+msgid "Has agreed to the site's <a class=\"twl-links\" href=\"%(terms_url)s\">terms of use</a>?"
+msgstr "¿Ha aceptado las <a class=\"twl-links\" href=\"%(terms_url)s\">condiciones de uso</a> del sitio?"
 
 #. Translators: Displayed to coordinators when they've agreed to the terms of use.
 #. Translators: Displayed if the user has agreed to the terms of use.
@@ -458,12 +416,8 @@ msgstr "No"
 
 #. Translators: This is the text displayed to coordinators when an applicant has not agreed to the terms of use.
 #: TWLight/applications/templates/applications/application_evaluation.html:159
-msgid ""
-"Please request the applicant agree to the site's terms of use before "
-"approving this application."
-msgstr ""
-"Favor de pedir al solicitante que acepte las condiciones de uso antes de "
-"aprobar esta solicitud."
+msgid "Please request the applicant agree to the site's terms of use before approving this application."
+msgstr "Favor de pedir al solicitante que acepte las condiciones de uso antes de aprobar esta solicitud."
 
 #. Translators: This labels the section of an application containing the user's motivation for wanting access to this resource.
 #: TWLight/applications/templates/applications/application_evaluation.html:176
@@ -483,10 +437,8 @@ msgstr "¿Renovación de un permiso de acceso existente?"
 #. Translators: This message is shown next to the 'Renewal of existing access grant?' label if the application is a renewal. Don't translate HTML tags or parent_url.
 #: TWLight/applications/templates/applications/application_evaluation.html:195
 #, python-format
-msgid ""
-"Yes (<a class=\"twl-links\" href=\"%(parent_url)s\">previous application</a>)"
-msgstr ""
-"Sí (<a class=\"twl-links\" href=\"%(parent_url)s\">aplicación anterior</a>)"
+msgid "Yes (<a class=\"twl-links\" href=\"%(parent_url)s\">previous application</a>)"
+msgstr "Sí (<a class=\"twl-links\" href=\"%(parent_url)s\">aplicación anterior</a>)"
 
 #. Translators: This labels the section of the application showing the length of access remaining on the user's previous authorization.
 #: TWLight/applications/templates/applications/application_evaluation.html:208
@@ -506,8 +458,7 @@ msgstr "Solicitudes recientes (últimos 90 días)"
 #. Translators: This text is shown to Coordinators when applicant has not made any application in the last 90 days.
 #: TWLight/applications/templates/applications/application_evaluation.html:264
 msgid "No applications were made in last 90 days by the applicant"
-msgstr ""
-"Ninguna solicitud ha sido realizada por el usuario en los últimos 90 días"
+msgstr "Ninguna solicitud ha sido realizada por el usuario en los últimos 90 días"
 
 #. Translators: This is the title of the section of an application page which contains the comment thread between the user and account coordinator.
 #: TWLight/applications/templates/applications/application_evaluation.html:268
@@ -521,12 +472,8 @@ msgstr "Añadir comentario"
 
 #. Translators: On an application page, this text tells users that the comments posted on the application are visible to coordinators and the submitting user only.
 #: TWLight/applications/templates/applications/application_evaluation.html:297
-msgid ""
-"Comments are visible to all coordinators and to the editor who submitted "
-"this application."
-msgstr ""
-"Los comentarios son visibles para todos los coordinadores y para el editor "
-"que presentó esta solicitud."
+msgid "Comments are visible to all coordinators and to the editor who submitted this application."
+msgstr "Los comentarios son visibles para todos los coordinadores y para el editor que presentó esta solicitud."
 
 #. Translators: This is the title of the section of an application page which lists information about the user who submitted the application.
 #. Translators: On the page where coordinators can view data on applications to a partner they coordinate, this is a table column heading for the username.
@@ -738,18 +685,8 @@ msgstr "Establecer estado"
 
 #: TWLight/applications/templates/applications/apply.html:20
 #, python-format
-msgid ""
-"If your application is successful we may share your email address with "
-"%(partner)s. This is required to set up your access to their resources. By "
-"submitting this form you agree to allow your email address to be shared with "
-"%(partner)s if your application is successful, for the purposes of account "
-"setup."
-msgstr ""
-"Si su solicitud es exitosa, podemos compartir su dirección de correo "
-"electrónico con %(partner)s. Esto es necesario para configurar su acceso a "
-"sus recursos. Al enviar este formulario, acepta permitir que su dirección de "
-"correo electrónico se comparta con %(partner)s si su solicitud es exitosa, "
-"para fines de configuración de la cuenta."
+msgid "If your application is successful we may share your email address with %(partner)s. This is required to set up your access to their resources. By submitting this form you agree to allow your email address to be shared with %(partner)s if your application is successful, for the purposes of account setup."
+msgstr "Si su solicitud es exitosa, podemos compartir su dirección de correo electrónico con %(partner)s. Esto es necesario para configurar su acceso a sus recursos. Al enviar este formulario, acepta permitir que su dirección de correo electrónico se comparta con %(partner)s si su solicitud es exitosa, para fines de configuración de la cuenta."
 
 #. Translators: This message is displayed on the page where users can confirm their renewal. Please do not translate partner.
 #: TWLight/applications/templates/applications/confirm_renewal.html:23
@@ -777,12 +714,8 @@ msgstr "¿A qué recursos quieres acceder?"
 
 #. Translators: This text explains that Library Bundle partners are not shown in this list.
 #: TWLight/applications/templates/applications/request_for_application.html:26
-msgid ""
-"Library Bundle partners are not shown as eligibility is determined "
-"automatically."
-msgstr ""
-"Socios del Paquete de la Biblioteca no son mostrados ya que la elegibilidad "
-"está determinada automáticamente."
+msgid "Library Bundle partners are not shown as eligibility is determined automatically."
+msgstr "Socios del Paquete de la Biblioteca no son mostrados ya que la elegibilidad está determinada automáticamente."
 
 #. Translators: On the page where users can apply for multiple partners, this message shows next to the partner name, taking them to the full application page when clicked.
 #: TWLight/applications/templates/applications/request_for_application.html:48
@@ -796,15 +729,8 @@ msgstr "No se han añadido datos de socio todavía."
 
 #. Translators: the HTML is so that the word 'waitlisted' will look the same as it does in the page above; please translate 'waitlisted' the same way you did elsewhere in this file.
 #: TWLight/applications/templates/applications/request_for_application.html:74
-msgid ""
-"You can apply to <span class=\"badge badge-warning\">Waitlisted</span> "
-"partners, but they don't have access grants available right now. We will "
-"process those applications when access becomes available."
-msgstr ""
-"Puedes solicitar a los socios de la <span class=\"badge badge-warning"
-"\">lista de espera</span>, pero no tienen permisos de acceso disponibles en "
-"este momento. Procesaremos esas aplicaciones cuando el acceso esté "
-"disponible."
+msgid "You can apply to <span class=\"badge badge-warning\">Waitlisted</span> partners, but they don't have access grants available right now. We will process those applications when access becomes available."
+msgstr "Puedes solicitar a los socios de la <span class=\"badge badge-warning\">lista de espera</span>, pero no tienen permisos de acceso disponibles en este momento. Procesaremos esas aplicaciones cuando el acceso esté disponible."
 
 #. Translators: On the page where coordinators can see approved applications which have not had their details sent to the partner, this message shows when there are applications ready to be processed.
 #: TWLight/applications/templates/applications/send.html:10
@@ -825,19 +751,13 @@ msgstr "Datos de la solicitud para %(object)s"
 #. Translators: This message is shown when applications exceed the number of accounts available.
 #: TWLight/applications/templates/applications/send_partner.html:54
 #, python-format
-msgid ""
-"Application(s) for %(object)s, if sent, will exceed the total available "
-"accounts for the partner. Please proceed at your own discretion."
-msgstr ""
-"Si se envían las siguientes aplicaciones %(object)s, se va a exceder el "
-"total de cuentas disponibles para este socio. Procede a tu propia discreción."
+msgid "Application(s) for %(object)s, if sent, will exceed the total available accounts for the partner. Please proceed at your own discretion."
+msgstr "Si se envían las siguientes aplicaciones %(object)s, se va a exceder el total de cuentas disponibles para este socio. Procede a tu propia discreción."
 
 #. Translators: When viewing the list of applications ready to be sent for a particular partner, this is instructions for the coordinator to click the 'mark as sent' button after they have sent the information.
 #: TWLight/applications/templates/applications/send_partner.html:65
 msgid "When you've processed the data below, click the 'mark as sent' button."
-msgstr ""
-"Cuando termines de procesar los datos de abajo, haz clic en el botón de "
-"'marcar como enviado'."
+msgstr "Cuando termines de procesar los datos de abajo, haz clic en el botón de 'marcar como enviado'."
 
 #. Translators: When viewing the list of applications ready to be sent for a particular partner, this is the title of the section containing contact information for the people applications should be sent to.
 #: TWLight/applications/templates/applications/send_partner.html:71
@@ -848,12 +768,8 @@ msgstr[1] "Contactos"
 
 #. Translators: When viewing the list of applications ready to be sent for a particular partner, this message shows if there is no information about who the applications should be sent to. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/applications/templates/applications/send_partner.html:89
-msgid ""
-"Whoops, we don't have any listed contacts. Please notify Wikipedia Library "
-"administrators."
-msgstr ""
-"Ups, no tenemos ningún contacto listado. Favor de notificar a los "
-"administradores de Wikipedia Library."
+msgid "Whoops, we don't have any listed contacts. Please notify Wikipedia Library administrators."
+msgstr "Ups, no tenemos ningún contacto listado. Favor de notificar a los administradores de Wikipedia Library."
 
 #. Translators: When viewing the list of applications ready to be sent for a particular partner, this is the title of the section containing the information about those applications.
 #: TWLight/applications/templates/applications/send_partner.html:94
@@ -868,12 +784,8 @@ msgstr "Marcar como enviado"
 
 #. Translators: This text guides coordinators in using the code sending interface for approved applications.
 #: TWLight/applications/templates/applications/send_partner.html:152
-msgid ""
-"Use the dropdown menus to denote which editor will receive each code. Access "
-"codes will be sent to users automatically."
-msgstr ""
-"Usa los menús desplegables para denotar qué editor recibirá cada código. Los "
-"códigos de acceso serán enviados a los usuarios automáticamente."
+msgid "Use the dropdown menus to denote which editor will receive each code. Access codes will be sent to users automatically."
+msgstr "Usa los menús desplegables para denotar qué editor recibirá cada código. Los códigos de acceso serán enviados a los usuarios automáticamente."
 
 #. Translators: This labels a drop-down selection where staff can assign an access code to a user.
 #: TWLight/applications/templates/applications/send_partner.html:173
@@ -888,24 +800,14 @@ msgstr "No hay solicitudes sin aprobación y sin enviar."
 #. Translators: When a user applies for a set of resources, they receive this message if none are currently available. They are instead placed on a 'waitlist' for later approval.
 #. Translators: When a user renews their resource, they receive this message if none are currently available. They are instead placed on a 'waitlist' for later approval.
 #: TWLight/applications/views.py:140 TWLight/applications/views.py:1282
-msgid ""
-"This partner does not have any access grants available at this time. You may "
-"still apply for access; your application will be reviewed when access grants "
-"become available."
-msgstr ""
-"Este socio no tiene permisos de accesos disponibles por el momento. De todas "
-"maneras puedes solicitar acceso; tu solicitud será revisada cuando los "
-"permisos de acceso se encuentren disponibles."
+msgid "This partner does not have any access grants available at this time. You may still apply for access; your application will be reviewed when access grants become available."
+msgstr "Este socio no tiene permisos de accesos disponibles por el momento. De todas maneras puedes solicitar acceso; tu solicitud será revisada cuando los permisos de acceso se encuentren disponibles."
 
 #. Translators: This message is shown to users once they've successfully submitted their application for review.
 #: TWLight/applications/views.py:163
 #, python-brace-format
-msgid ""
-"Your application has been submitted for review. Head over to <a "
-"href='{applications_url}'>My Applications</a> to view the status."
-msgstr ""
-"Tu solicitud ha sido sometida a revisión. Navega a <a href="
-"\"{applications_url}\">Mis Solicitudes</a> para ver el estado."
+msgid "Your application has been submitted for review. Head over to <a href='{applications_url}'>My Applications</a> to view the status."
+msgstr "Tu solicitud ha sido sometida a revisión. Navega a <a href=\"{applications_url}\">Mis Solicitudes</a> para ver el estado."
 
 #. Translators: This text is displayed to users when the user has chosen to restrict data and is trying to apply for multiple partners
 #: TWLight/applications/views.py:276
@@ -953,22 +855,13 @@ msgstr "Solicitudes enviadas"
 
 #. Translators: After a coordinator has changed the status of an application to APPROVED, if the corresponding partner/collection is waitlisted this message appears.
 #: TWLight/applications/views.py:756
-msgid ""
-"Cannot approve application as partner with proxy authorization method is "
-"waitlisted."
-msgstr ""
-"No se puede aprobar la solicitud, ya que el socio con autorización via proxy "
-"se encuentra en la lista de espera."
+msgid "Cannot approve application as partner with proxy authorization method is waitlisted."
+msgstr "No se puede aprobar la solicitud, ya que el socio con autorización via proxy se encuentra en la lista de espera."
 
 #. Translators: After a coordinator has changed the status of an application to APPROVED, if the corresponding partner/collection has no accounts for distribution, this message appears.
 #: TWLight/applications/views.py:780
-msgid ""
-"Cannot approve application as partner with proxy authorization method is "
-"waitlisted and (or) has zero accounts available for distribution."
-msgstr ""
-"No se puede aprobar la solicitud debido a que el socio con método de "
-"autorización vía proxy tiene una lista de espera y/o tiene cero cuentas "
-"disponibles para distribución."
+msgid "Cannot approve application as partner with proxy authorization method is waitlisted and (or) has zero accounts available for distribution."
+msgstr "No se puede aprobar la solicitud debido a que el socio con método de autorización vía proxy tiene una lista de espera y/o tiene cero cuentas disponibles para distribución."
 
 #. Translators: This message appears on an "access denied" screen that stops users who attempt to authorize an editor to access a resource during a time period for which they are already authorized.
 #: TWLight/applications/views.py:803
@@ -978,16 +871,8 @@ msgstr "Intentaste crear una autorización duplicada."
 #. Translators: This message is shown to users when they access an application page of a now Bundle partner (new applications aren't allowed for Bundle partners and the status of old applications cannot be modified)
 #: TWLight/applications/views.py:857
 #, python-brace-format
-msgid ""
-"This application cannot be modified since this partner is now part of our <a "
-"href='{bundle}'>bundle access</a>. If you are eligible, you can access this "
-"resource from <a href='{library}'>your library</a>. <a "
-"href='{contact}'>Contact us</a> if you have any questions."
-msgstr ""
-"Esta solicitud no puede ser modificada debido a que el socio es ahora parte "
-"de nuestro <a href='{bundle}'>acceso de paquete</a>. Si eres elegible, "
-"puedes acceder a este recurso desde <a href='{library}'>tu biblioteca</a>. "
-"<a href='{contact}'>Contáctanos</a> si tienes alguna duda."
+msgid "This application cannot be modified since this partner is now part of our <a href='{bundle}'>bundle access</a>. If you are eligible, you can access this resource from <a href='{library}'>your library</a>. <a href='{contact}'>Contact us</a> if you have any questions."
+msgstr "Esta solicitud no puede ser modificada debido a que el socio es ahora parte de nuestro <a href='{bundle}'>acceso de paquete</a>. Si eres elegible, puedes acceder a este recurso desde <a href='{library}'>tu biblioteca</a>. <a href='{contact}'>Contáctanos</a> si tienes alguna duda."
 
 #. Translators: this lets a reviewer set the status of a single application.
 #: TWLight/applications/views.py:873
@@ -996,12 +881,8 @@ msgstr "Modificar estado de la solicitud"
 
 #. Translators: This warning is message is shown to applicants when the number of pending applications is greater than the number of accounts available.
 #: TWLight/applications/views.py:891
-msgid ""
-"There are more pending applications than available accounts. Your "
-"application might get waitlisted."
-msgstr ""
-"Hay más solicitudes que cuentas disponibles. Tu solicitud podría quedar en "
-"la lista de espera."
+msgid "There are more pending applications than available accounts. Your application might get waitlisted."
+msgstr "Hay más solicitudes que cuentas disponibles. Tu solicitud podría quedar en la lista de espera."
 
 #. Translators: this message is shown to coordinators who attempt to change an application's Status from INVALID to any other Status.
 #: TWLight/applications/views.py:904
@@ -1020,17 +901,8 @@ msgstr "Actualización en lote de solicitudes {} exitoso."
 
 #. Translators: After a coordinator has changed the status of a number of applications to APPROVED, if the corresponding partner(s) is/are waitlisted or has no accounts for distribution, this message appears.
 #: TWLight/applications/views.py:1051
-msgid ""
-"Cannot approve application(s) {} as partner(s) with proxy authorization "
-"method is/are waitlisted and (or) has/have not enough accounts available. If "
-"not enough accounts are available, prioritise the applications and then "
-"approve applications equal to the accounts available."
-msgstr ""
-"No se puede aprovar la(s) solicitud(es) {} como socio(s) con el método de "
-"autorización de proxy si está en la waitlist y/o no tiene suficientes "
-"cuentas disponibles. Si no están disponibles suficientes cuentas, prioriza "
-"las solicitudes y luego aprueba solicitudes equivalentes a las cuentas "
-"disponibles."
+msgid "Cannot approve application(s) {} as partner(s) with proxy authorization method is/are waitlisted and (or) has/have not enough accounts available. If not enough accounts are available, prioritise the applications and then approve applications equal to the accounts available."
+msgstr "No se puede aprovar la(s) solicitud(es) {} como socio(s) con el método de autorización de proxy si está en la waitlist y/o no tiene suficientes cuentas disponibles. Si no están disponibles suficientes cuentas, prioriza las solicitudes y luego aprueba solicitudes equivalentes a las cuentas disponibles."
 
 #. Translators: This message is shown to coordinators who attempt to assign the same access code to multiple users.
 #: TWLight/applications/views.py:1191
@@ -1044,13 +916,8 @@ msgstr "Todas las solicitudes han sido marcadas como enviadas."
 
 #. Translators: When a user tries to renew their resource, they receive this message if the partner is not available.
 #: TWLight/applications/views.py:1272
-msgid ""
-"Cannot renew application at this time as partner is not available. Please "
-"check back later, or contact us for more information."
-msgstr ""
-"No se puede renovar la solicitud en este momento porque el socio no se "
-"encuentra disponible. Favor de revisar más tarde, o contáctanos para mayor "
-"información."
+msgid "Cannot renew application at this time as partner is not available. Please check back later, or contact us for more information."
+msgstr "No se puede renovar la solicitud en este momento porque el socio no se encuentra disponible. Favor de revisar más tarde, o contáctanos para mayor información."
 
 #. Translators: This message is displayed when an attempt by a user to renew an application has been denied for some reason.
 #: TWLight/applications/views.py:1308
@@ -1060,21 +927,13 @@ msgstr "El intento de renovar la solicitud no aprobada #{pk} ha sido denegada"
 
 #. Translators: If a user requests the renewal of their account, but it wasn't renewed, this message is shown to them.
 #: TWLight/applications/views.py:1385
-msgid ""
-"This object cannot be renewed. (This probably means that you have already "
-"requested that it be renewed.)"
-msgstr ""
-"Este objeto no puede ser renovado. (Esto probablemente significa que ya has "
-"solicitado su renovación.)"
+msgid "This object cannot be renewed. (This probably means that you have already requested that it be renewed.)"
+msgstr "Este objeto no puede ser renovado. (Esto probablemente significa que ya has solicitado su renovación.)"
 
 #. Translators: If a user requests the renewal of their account, this message is shown to them.
 #: TWLight/applications/views.py:1395
-msgid ""
-"Your renewal request has been received. A coordinator will review your "
-"request."
-msgstr ""
-"Tu petición de renovación ha sido recibida. Un coordinador revisará la "
-"petición."
+msgid "Your renewal request has been received. A coordinator will review your request."
+msgstr "Tu petición de renovación ha sido recibida. Un coordinador revisará la petición."
 
 #. Translators: This labels a textfield where users can enter their email ID.
 #: TWLight/emails/forms.py:18
@@ -1083,12 +942,8 @@ msgstr "Tu email"
 
 #. Translators: This is the help text for the email field in the contact us form letting users know the field is updated by value pulled from their respective user profiles.
 #: TWLight/emails/forms.py:21
-msgid ""
-"This field is automatically updated with the email from your <a class='twl-"
-"links' href='{}'>user profile</a>."
-msgstr ""
-"Este campo es actualizado automáticamente con el correo electrónico de tu <a "
-"class='twl-links' href='{}'>perfil de usuario</a>."
+msgid "This field is automatically updated with the email from your <a class='twl-links' href='{}'>user profile</a>."
+msgstr "Este campo es actualizado automáticamente con el correo electrónico de tu <a class='twl-links' href='{}'>perfil de usuario</a>."
 
 #. Translators: This labels a textfield where users can enter their email message.
 #: TWLight/emails/forms.py:26
@@ -1111,26 +966,14 @@ msgstr "Enviar"
 #. Translators: This email is sent to users with their access code. Don't translate Jinja variables in curly braces like user or partner. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/access_code_email-body-html.html:5
 #, python-format
-msgid ""
-"<p>Your approved application to %(partner)s has now been finalised. Your "
-"access code or login details can be found below:</p> <p><b>%(access_code)s</"
-"b></p> <p>%(user_instructions)s</p>"
-msgstr ""
-"<p> Tu solicitud aprobada a %(partner)s ha sido finalizada. Tu código de "
-"acceso o información de inicio de sesión la encontrarás abajo: </p>\n"
-"<p><b>%(access_code)s</b></p> <p>%(user_instructions)s</p>"
+msgid "<p>Your approved application to %(partner)s has now been finalised. Your access code or login details can be found below:</p> <p><b>%(access_code)s</b></p> <p>%(user_instructions)s</p>"
+msgstr "<p> Tu solicitud aprobada a %(partner)s ha sido finalizada. Tu código de acceso o información de inicio de sesión la encontrarás abajo: </p>\n<p><b>%(access_code)s</b></p> <p>%(user_instructions)s</p>"
 
 #. Translators: This email is sent to users with their access code. Don't translate Jinja variables in curly braces like user or partner. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/access_code_email-body-text.html:3
 #, python-format
-msgid ""
-"Your approved application to %(partner)s has now been finalised. Your access "
-"code or login details can be found below: %(access_code)s "
-"%(user_instructions)s"
-msgstr ""
-"Tu solicitud aprobada a %(partner)s ha sido finalizada. Tu código de acceso "
-"o información de inicio de sesión la encontrarás abajo:\n"
-"%(access_code)s %(user_instructions)s"
+msgid "Your approved application to %(partner)s has now been finalised. Your access code or login details can be found below: %(access_code)s %(user_instructions)s"
+msgstr "Tu solicitud aprobada a %(partner)s ha sido finalizada. Tu código de acceso o información de inicio de sesión la encontrarás abajo:\n%(access_code)s %(user_instructions)s"
 
 #. Translators: This is the subject line of an email sent to users with their access code.
 #: TWLight/emails/templates/emails/access_code_email-subject.html:3
@@ -1140,34 +983,14 @@ msgstr "Tu código de acceso de la Wikipedia Library"
 #. Translators: This email is sent to users when their application is approved. Don't translate Jinja variables in curly braces like user or partner; don't translate html tags either. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/approval_notification-body-html.html:5
 #, python-format
-msgid ""
-"<p>Dear %(user)s,</p> <p>Thank you for applying for access to %(partner)s "
-"resources through The Wikipedia Library. We are happy to inform you that "
-"your application has been approved.</p> <p>%(user_instructions)s</p> <p>You "
-"can view the collections you're authorized to access at My Library: "
-"%(link)s</p> <p>Cheers!</p> <p>The Wikipedia Library</p>"
-msgstr ""
-"<p>Estimado %(user)s,</p> <p> Gracias por solicitar acceso a %(partner)s a "
-"través de La Biblioteca de Wikipedia. Estamos contentos de informarte que tu "
-"solicitud ha sido aprobada. </p> <p>%(user_instructions)s</p> <p> Puedes ver "
-"las colecciones a los que estás autorizado para acceder en Mi Biblioteca: "
-"%(link)s</p>  <p>¡Saludos!</p> <p>La Biblioteca de Wikipedia</p>"
+msgid "<p>Dear %(user)s,</p> <p>Thank you for applying for access to %(partner)s resources through The Wikipedia Library. We are happy to inform you that your application has been approved.</p> <p>%(user_instructions)s</p> <p>You can view the collections you're authorized to access at My Library: %(link)s</p> <p>Cheers!</p> <p>The Wikipedia Library</p>"
+msgstr "<p>Estimado %(user)s,</p> <p> Gracias por solicitar acceso a %(partner)s a través de La Biblioteca de Wikipedia. Estamos contentos de informarte que tu solicitud ha sido aprobada. </p> <p>%(user_instructions)s</p> <p> Puedes ver las colecciones a los que estás autorizado para acceder en Mi Biblioteca: %(link)s</p>  <p>¡Saludos!</p> <p>La Biblioteca de Wikipedia</p>"
 
 #. Translators: This email is sent to users when their application is approved. Don't translate Jinja variables in curly braces like user or partner. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/approval_notification-body-text.html:3
 #, python-format
-msgid ""
-"Dear %(user)s, Thank you for applying for access to %(partner)s resources "
-"through The Wikipedia Library. We are happy to inform you that your "
-"application has been approved. %(user_instructions)s You can view the "
-"collections you're authorized to access at My Library: %(link)s Cheers! The "
-"Wikipedia Library"
-msgstr ""
-"Estimado %(user)s, Gracias por solicitar acceso a %(partner)s a través de la "
-"Biblioteca de Wikipedia. Estamos contentos de informarte que tu solicitud ha "
-"sido aprobada. %(user_instructions)s Puedes ver las colecciones a las que "
-"estás autorizado de acceder en Mi Biblioteca: %(link)s ¡Saludos! La "
-"Biblioteca de Wikipedia"
+msgid "Dear %(user)s, Thank you for applying for access to %(partner)s resources through The Wikipedia Library. We are happy to inform you that your application has been approved. %(user_instructions)s You can view the collections you're authorized to access at My Library: %(link)s Cheers! The Wikipedia Library"
+msgstr "Estimado %(user)s, Gracias por solicitar acceso a %(partner)s a través de la Biblioteca de Wikipedia. Estamos contentos de informarte que tu solicitud ha sido aprobada. %(user_instructions)s Puedes ver las colecciones a las que estás autorizado de acceder en Mi Biblioteca: %(link)s ¡Saludos! La Biblioteca de Wikipedia"
 
 #. Translators: This is the subject of an email which is sent to users when their application has been approved. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/approval_notification-subject.html:4
@@ -1177,58 +1000,31 @@ msgstr "Tu solicitud de la Wikipedia Library ha sido aprobada"
 #. Translators: This email is sent to coordinators when a comment is left on an application they are processing. Don't translate Jinja variables in curly braces like user or partner. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/comment_notification_coordinator-body-html.html:5
 #, python-format
-msgid ""
-"<p style=\"color: #500050\">%(submit_date)s - %(commenter)s</p> "
-"<blockquote><p>%(comment)s</p></blockquote> <p>Please reply to these at: <a "
-"href=\"%(app_url)s\">%(app_url)s</a></p> <p>Best,</p> <p>The Wikipedia "
-"Library</p>"
-msgstr ""
-"<p style=\"color: #500050\">%(submit_date)s - %(commenter)s</p> "
-"<blockquote><p>%(comment)s</p></blockquote> <p>Favor de contestar en: <a "
-"href=\"%(app_url)s\">%(app_url)s</a></p> <p>Saludos,</p> <p>La Biblioteca de "
-"Wikipedia</p>"
+msgid "<p style=\"color: #500050\">%(submit_date)s - %(commenter)s</p> <blockquote><p>%(comment)s</p></blockquote> <p>Please reply to these at: <a href=\"%(app_url)s\">%(app_url)s</a></p> <p>Best,</p> <p>The Wikipedia Library</p>"
+msgstr "<p style=\"color: #500050\">%(submit_date)s - %(commenter)s</p> <blockquote><p>%(comment)s</p></blockquote> <p>Favor de contestar en: <a href=\"%(app_url)s\">%(app_url)s</a></p> <p>Saludos,</p> <p>La Biblioteca de Wikipedia</p>"
 
 #. Translators: This email is sent to coordinators when a comment is left on an application they are processing. Don't translate Jinja variables in curly braces like user or partner. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/comment_notification_coordinator-body-text.html:3
 #, python-format
-msgid ""
-"%(submit_date)s - %(commenter)s %(comment)s Please reply to this at: "
-"%(app_url)s Best, The Wikipedia Library"
-msgstr ""
-"%(submit_date)s - %(commenter)s %(comment)s Responde a este comentario en: "
-"%(app_url)s Atentamente, La Biblioteca de Wikipedia"
+msgid "%(submit_date)s - %(commenter)s %(comment)s Please reply to this at: %(app_url)s Best, The Wikipedia Library"
+msgstr "%(submit_date)s - %(commenter)s %(comment)s Responde a este comentario en: %(app_url)s Atentamente, La Biblioteca de Wikipedia"
 
 #. Translators: This is the subject line of an email sent to coordinators when a comment is left on an application they processed.
 #: TWLight/emails/templates/emails/comment_notification_coordinator-subject.html:3
 msgid "New comment on a Wikipedia Library application you processed"
-msgstr ""
-"Hay un comentario nuevo en una solicitud que procesaste de la Biblioteca de "
-"Wikipedia"
+msgstr "Hay un comentario nuevo en una solicitud que procesaste de la Biblioteca de Wikipedia"
 
 #. Translators: This email is sent to users when they receive a comment on their application. Don't translate Jinja variables in curly braces like user or partner; don't translate html tags either. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/comment_notification_editors-body-html.html:5
 #, python-format
-msgid ""
-"<p style=\"color: #500050\">%(submit_date)s - %(commenter)s</p> "
-"<blockquote><p>%(comment)s</p></blockquote> <p>Please reply to these at <a "
-"href=\"%(app_url)s\">%(app_url)s</a> so we can evaluate your application.</"
-"p> <p>Best,</p> <p>The Wikipedia Library</p>"
-msgstr ""
-"<p style=\"color: #500050\">%(submit_date)s - %(commenter)s</p> "
-"<blockquote><p>%(comment)s</p></blockquote> <p>Favor de contestar en <a href="
-"\"%(app_url)s\">%(app_url)s</a> para que podamos evaluar tu solicitud.</p> "
-"<p>Saludos,</p> <p>La Biblioteca de Wikipedia</p>"
+msgid "<p style=\"color: #500050\">%(submit_date)s - %(commenter)s</p> <blockquote><p>%(comment)s</p></blockquote> <p>Please reply to these at <a href=\"%(app_url)s\">%(app_url)s</a> so we can evaluate your application.</p> <p>Best,</p> <p>The Wikipedia Library</p>"
+msgstr "<p style=\"color: #500050\">%(submit_date)s - %(commenter)s</p> <blockquote><p>%(comment)s</p></blockquote> <p>Favor de contestar en <a href=\"%(app_url)s\">%(app_url)s</a> para que podamos evaluar tu solicitud.</p> <p>Saludos,</p> <p>La Biblioteca de Wikipedia</p>"
 
 #. Translators: This email is sent to users when they receive a comment on their application. Don't translate Jinja variables in curly braces like user or partner. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/comment_notification_editors-body-text.html:3
 #, python-format
-msgid ""
-"%(submit_date)s - %(commenter)s %(comment)s Please reply to these at: "
-"%(app_url)s so we can evaluate your application. Best, The Wikipedia Library"
-msgstr ""
-"%(submit_date)s - %(commenter)s %(comment)s Por favor responde a estos "
-"comentarios en: %(app_url)s para que podamos evaluar tu solicitud. "
-"Atentamente, La Biblioteca de Wikipedia"
+msgid "%(submit_date)s - %(commenter)s %(comment)s Please reply to these at: %(app_url)s so we can evaluate your application. Best, The Wikipedia Library"
+msgstr "%(submit_date)s - %(commenter)s %(comment)s Por favor responde a estos comentarios en: %(app_url)s para que podamos evaluar tu solicitud. Atentamente, La Biblioteca de Wikipedia"
 
 #. Translators: This is the subject line of an email sent to users who have a comment added to one of their applications. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/comment_notification_editors-subject.html:3
@@ -1238,44 +1034,25 @@ msgstr "Comentario nuevo en tu solicitud de Wikipedia Library"
 #. Translators: This email is sent to users when an application they commented on receives another comment. Don't translate Jinja variables in curly braces like app_url; don't translate html tags either. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/comment_notification_others-body-html.html:5
 #, python-format
-msgid ""
-"<p style=\"color: #500050\">%(submit_date)s - %(commenter)s</p> "
-"<blockquote><p>%(comment)s</p></blockquote> See it at <a href=\"%(app_url)s"
-"\">%(app_url)s</a>. Thanks for helping review Wikipedia Library applications!"
-msgstr ""
-"<p style=\"color: #500050\">%(submit_date)s - %(commenter)s</p> "
-"<blockquote><p>%(comment)s</p></blockquote> Ver en <a href=\"%(app_url)s\">"
-"%(app_url)s</a>. ¡Gracias por ayudar a revisar solicitudes para La "
-"Biblioteca de Wikipedia!"
+msgid "<p style=\"color: #500050\">%(submit_date)s - %(commenter)s</p> <blockquote><p>%(comment)s</p></blockquote> See it at <a href=\"%(app_url)s\">%(app_url)s</a>. Thanks for helping review Wikipedia Library applications!"
+msgstr "<p style=\"color: #500050\">%(submit_date)s - %(commenter)s</p> <blockquote><p>%(comment)s</p></blockquote> Ver en <a href=\"%(app_url)s\">%(app_url)s</a>. ¡Gracias por ayudar a revisar solicitudes para La Biblioteca de Wikipedia!"
 
 #. Translators: This email is sent to users when an application they commented on receives another comment. Don't translate Jinja variables in curly braces like app_url. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/comment_notification_others-body-text.html:3
 #, python-format
-msgid ""
-"%(submit_date)s - %(commenter)s %(comment)s See it at: %(app_url)s Thanks "
-"for helping review Wikipedia Library applications!"
-msgstr ""
-"%(submit_date)s - %(commenter)s %(comment)s Ver en: %(app_url)s ¡Gracias por "
-"ayudar a revisar las solicitudes de La Biblioteca de Wikipedia!"
+msgid "%(submit_date)s - %(commenter)s %(comment)s See it at: %(app_url)s Thanks for helping review Wikipedia Library applications!"
+msgstr "%(submit_date)s - %(commenter)s %(comment)s Ver en: %(app_url)s ¡Gracias por ayudar a revisar las solicitudes de La Biblioteca de Wikipedia!"
 
 #. Translators: This is the subject line of an email sent to users who have a comment added to an application they also commented on. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/comment_notification_others-subject.html:4
 msgid "New comment on a Wikipedia Library application you commented on"
-msgstr ""
-"Hay un nuevo comentario en una solicitud de la Biblioteca de Wikipedia que "
-"comentaste"
+msgstr "Hay un nuevo comentario en una solicitud de la Biblioteca de Wikipedia que comentaste"
 
 #. Translators: This text is part of a scheduled reminder email sent to coordinators who have applications requiring action. Don't translate Jinja variables in curly braces like total_apps, or user.
 #: TWLight/emails/templates/emails/coordinator_reminder_notification-body-html.html:5
 #, python-format
-msgid ""
-"<p>Dear %(user)s,</p> <p>Our records indicate that you are the designated "
-"coordinator for partners that have a total of %(total_apps)s applications.</"
-"p>"
-msgstr ""
-"<p>Estimado %(user)s,</p> <p>Nuestros registros nos indican que eres el "
-"coordinador designado para socios que tienen un total de %(total_apps)s "
-"solicitudes.</p>"
+msgid "<p>Dear %(user)s,</p> <p>Our records indicate that you are the designated coordinator for partners that have a total of %(total_apps)s applications.</p>"
+msgstr "<p>Estimado %(user)s,</p> <p>Nuestros registros nos indican que eres el coordinador designado para socios que tienen un total de %(total_apps)s solicitudes.</p>"
 
 #. Translators: Breakdown as in 'cost breakdown'; analysis.
 #: TWLight/emails/templates/emails/coordinator_reminder_notification-body-html.html:11
@@ -1313,45 +1090,20 @@ msgstr[1] "%(counter)s solicitudes aprobadas."
 #. Translators: This text is part of a scheduled reminder email sent to coordinators who have applications requiring action. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library). Don't translate Jinja variables in curly braces like link; don't translate email addresses or html tags either.
 #: TWLight/emails/templates/emails/coordinator_reminder_notification-body-html.html:39
 #, python-format
-msgid ""
-"<p>This is a gentle reminder that you may review applications at <a href="
-"\"%(link)s\">%(link)s</a>.</p> <p>You can customise your reminders under "
-"'preferences' in your user profile.</p> <p>If you received this message in "
-"error, drop us a line at wikipedialibrary@wikimedia.org.</p> <p>Thanks for "
-"helping review Wikipedia Library applications!</p>"
-msgstr ""
-"<p>Este es un amable recordatorio que puedes revisar solicitudes en:  <a "
-"href=\"%(link)s\">%(link)s</a>.</p> <p>Puedes personalizar tus recordatorios "
-"en la sección de 'preferencias' en tu perfil.</p> <p>Si has recibido este "
-"mensaje por error, favor de comunicarte con wikipedialibrary@wikimedia.org.</"
-"p> <p>¡Gracias por ayudar a revisar solicitudes a la Biblioteca de Wikipedia!"
-"</p>"
+msgid "<p>This is a gentle reminder that you may review applications at <a href=\"%(link)s\">%(link)s</a>.</p> <p>You can customise your reminders under 'preferences' in your user profile.</p> <p>If you received this message in error, drop us a line at wikipedialibrary@wikimedia.org.</p> <p>Thanks for helping review Wikipedia Library applications!</p>"
+msgstr "<p>Este es un amable recordatorio que puedes revisar solicitudes en:  <a href=\"%(link)s\">%(link)s</a>.</p> <p>Puedes personalizar tus recordatorios en la sección de 'preferencias' en tu perfil.</p> <p>Si has recibido este mensaje por error, favor de comunicarte con wikipedialibrary@wikimedia.org.</p> <p>¡Gracias por ayudar a revisar solicitudes a la Biblioteca de Wikipedia!</p>"
 
 #. Translators: This text is part of a scheduled reminder email sent to coordinators who have applications requiring action. Don't translate Jinja variables in curly braces like total_apps, or user.
 #: TWLight/emails/templates/emails/coordinator_reminder_notification-body-text.html:3
 #, python-format
-msgid ""
-"Dear %(user)s, Our records indicate that you are the designated coordinator "
-"for partners that have a total of %(total_apps)s applications."
-msgstr ""
-"Estimado %(user)s, Nuestros registros nos indican que eres el coordinador "
-"designado para socios que tienen un total de %(total_apps)s solicitudes."
+msgid "Dear %(user)s, Our records indicate that you are the designated coordinator for partners that have a total of %(total_apps)s applications."
+msgstr "Estimado %(user)s, Nuestros registros nos indican que eres el coordinador designado para socios que tienen un total de %(total_apps)s solicitudes."
 
 #. Translators: This text is part of a scheduled reminder email sent to coordinators who have applications requiring action. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library). Don't translate Jinja variables in curly braces like link; don't translate the email address either.
 #: TWLight/emails/templates/emails/coordinator_reminder_notification-body-text.html:38
 #, python-format
-msgid ""
-"This is a gentle reminder that you may review applications at: %(link)s. You "
-"can customise your reminders under 'preferences' in your user profile. If "
-"you received this message in error, drop us a line at: "
-"wikipedialibrary@wikimedia.org Thanks for helping review Wikipedia Library "
-"applications!"
-msgstr ""
-"Este es un amable recordatorio que puedes revisar solicitudes en: %(link)s. "
-"Puedes personalizar tus recordatorios en la sección de 'preferencias' en tu "
-"perfil. Si has recibido este mensaje por error, favor de comunicarte con "
-"wikipedialibrary@wikimedia.org. ¡Gracias por ayudar a revisar solicitudes a "
-"la Biblioteca de Wikipedia!"
+msgid "This is a gentle reminder that you may review applications at: %(link)s. You can customise your reminders under 'preferences' in your user profile. If you received this message in error, drop us a line at: wikipedialibrary@wikimedia.org Thanks for helping review Wikipedia Library applications!"
+msgstr "Este es un amable recordatorio que puedes revisar solicitudes en: %(link)s. Puedes personalizar tus recordatorios en la sección de 'preferencias' en tu perfil. Si has recibido este mensaje por error, favor de comunicarte con wikipedialibrary@wikimedia.org. ¡Gracias por ayudar a revisar solicitudes a la Biblioteca de Wikipedia!"
 
 #. Translators: This is the subject line of a scheduled reminder email sent to coordinators who have applications to review. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library). Do not translate items in curly braces.
 #: TWLight/emails/templates/emails/coordinator_reminder_notification-subject.html:4
@@ -1361,32 +1113,14 @@ msgstr "Solicitudes de la Biblioteca de Wikipedia esperan tu revisión"
 #. Translators: This email is sent to users when their application is rejected. Don't translate Jinja variables in curly braces like user or partner; don't translate html tags either. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/rejection_notification-body-html.html:5
 #, python-format
-msgid ""
-"<p>Dear %(user)s,</p> <p>Thank you for applying for access to %(partner)s "
-"resources through The Wikipedia Library. Unfortunately at this time your "
-"application has not been approved. You can view your application and review "
-"comments at <a href=\"%(app_url)s\">%(app_url)s</a>.</p> <p>Best,</p> <p>The "
-"Wikipedia Library</p>"
-msgstr ""
-"<p>Estimado %(user)s,</p> <p>Gracias por solicitar acceso a los recursos de "
-"%(partner)s a través de La Biblioteca de Wikipedia. Desafortunadamente, tu "
-"solicitud no ha sido aprobada en este momento. Puedes ver tu solicitud y "
-"revisar los comentarios en <a href=\"%(app_url)s\">%(app_url)s</a>.</p> "
-"<p>Saludos,</p> <p>La Biblioteca de Wikipedia</p>"
+msgid "<p>Dear %(user)s,</p> <p>Thank you for applying for access to %(partner)s resources through The Wikipedia Library. Unfortunately at this time your application has not been approved. You can view your application and review comments at <a href=\"%(app_url)s\">%(app_url)s</a>.</p> <p>Best,</p> <p>The Wikipedia Library</p>"
+msgstr "<p>Estimado %(user)s,</p> <p>Gracias por solicitar acceso a los recursos de %(partner)s a través de La Biblioteca de Wikipedia. Desafortunadamente, tu solicitud no ha sido aprobada en este momento. Puedes ver tu solicitud y revisar los comentarios en <a href=\"%(app_url)s\">%(app_url)s</a>.</p> <p>Saludos,</p> <p>La Biblioteca de Wikipedia</p>"
 
 #. Translators: This email is sent to users when their application is rejected. Don't translate Jinja variables in curly braces like user or partner. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/rejection_notification-body-text.html:3
 #, python-format
-msgid ""
-"Dear %(user)s, Thank you for applying for access to %(partner)s resources "
-"through The Wikipedia Library. Unfortunately at this time your application "
-"has not been approved. You can view your application and review comments at: "
-"%(app_url)s Best, The Wikipedia Library"
-msgstr ""
-"Estimado %(user)s, Gracias por solicitar acceso a los recursos de "
-"%(partner)s a través de La Biblioteca de Wikipedia. Desafortunadamente, tu "
-"solicitud no ha sido aprobada en este momento. Puedes ver tu solicitud y "
-"revisar los comentarios en %(app_url)s. Saludos, La Biblioteca de Wikipedia"
+msgid "Dear %(user)s, Thank you for applying for access to %(partner)s resources through The Wikipedia Library. Unfortunately at this time your application has not been approved. You can view your application and review comments at: %(app_url)s Best, The Wikipedia Library"
+msgstr "Estimado %(user)s, Gracias por solicitar acceso a los recursos de %(partner)s a través de La Biblioteca de Wikipedia. Desafortunadamente, tu solicitud no ha sido aprobada en este momento. Puedes ver tu solicitud y revisar los comentarios en %(app_url)s. Saludos, La Biblioteca de Wikipedia"
 
 #. Translators: This is the subject of an email which is sent to users when their application has been rejected. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/rejection_notification-subject.html:4
@@ -1396,39 +1130,14 @@ msgstr "Tu solicitud a la Wikipedia Library"
 #. Translators: This email is sent to users when they have an account that is soon to expire. Don't translate Jinja variables in curly braces like partner_name or partner_link; don't translate html tags either. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/user_renewal_notice-body-html.html:5
 #, python-format
-msgid ""
-"<p>Dear %(user)s,</p> <p>According to our records, your access to "
-"%(partner_name)s will soon expire and you may lose access. If you want to "
-"continue making use of your free account, you can request renewal of your "
-"account by clicking the 'Renew' or 'Extend' button at %(partner_link)s.</p> "
-"<p>Best,</p> <p>The Wikipedia Library</p> <p>You can disable these emails in "
-"your user page preferences: https://wikipedialibrary.wmflabs.org/users/</p>"
-msgstr ""
-"<p>Estimado %(user)s,</p> <p>De acuerdo a nuestros registros, tu acceso a "
-"%(partner_name)s expirará pronto y puedes perder el acceso. Si quieres "
-"continuar usando tu cuenta gratuita, puedes pedir la renovación de tu cuenta "
-"haciendo clic en el botón de Renovar en %(partner_link)s.</p> <p>Saludos,</"
-"p> <p>La Bibioteca de Wikipedia</p> <p>Puedes deshabilitar estos correos en "
-"la página de preferencias de tu usuario: https://wikipedialibrary.wmflabs."
-"org/users/</p>"
+msgid "<p>Dear %(user)s,</p> <p>According to our records, your access to %(partner_name)s will soon expire and you may lose access. If you want to continue making use of your free account, you can request renewal of your account by clicking the 'Renew' or 'Extend' button at %(partner_link)s.</p> <p>Best,</p> <p>The Wikipedia Library</p> <p>You can disable these emails in your user page preferences: https://wikipedialibrary.wmflabs.org/users/</p>"
+msgstr "<p>Estimado %(user)s,</p> <p>De acuerdo a nuestros registros, tu acceso a %(partner_name)s expirará pronto y puedes perder el acceso. Si quieres continuar usando tu cuenta gratuita, puedes pedir la renovación de tu cuenta haciendo clic en el botón de Renovar en %(partner_link)s.</p> <p>Saludos,</p> <p>La Bibioteca de Wikipedia</p> <p>Puedes deshabilitar estos correos en la página de preferencias de tu usuario: https://wikipedialibrary.wmflabs.org/users/</p>"
 
 #. Translators: This email is sent to users when they have an account that is soon to expire. Don't translate Jinja variables in curly braces like partner_name or partner_link; don't translate html tags either. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/user_renewal_notice-body-text.html:3
 #, python-format
-msgid ""
-"Dear %(user)s, According to our records, your access to %(partner_name)s "
-"will soon expire and you may lose access. If you want to continue making use "
-"of your free account, you can request renewal of your account by clicking "
-"the Renew button at %(partner_link)s. Best, The Wikipedia Library You can "
-"disable these emails in your user page preferences: https://wikipedialibrary."
-"wmflabs.org/users/"
-msgstr ""
-"Estimado %(user)s, De acuerdo a nuestros registros, tu acceso a "
-"%(partner_name)s expirará pronto y puedes perder el acceso. Si quieres "
-"continuar usando tu cuenta gratuita, puedes pedir la renovación de tu cuenta "
-"haciendo clic en el botón de Renovar en %(partner_link)s. Saludos, La "
-"Bibioteca de Wikipedia Puedes deshabilitar estos correos en página de "
-"preferencias de tu usuario: https://wikipedialibrary.wmflabs.org/users/"
+msgid "Dear %(user)s, According to our records, your access to %(partner_name)s will soon expire and you may lose access. If you want to continue making use of your free account, you can request renewal of your account by clicking the Renew button at %(partner_link)s. Best, The Wikipedia Library You can disable these emails in your user page preferences: https://wikipedialibrary.wmflabs.org/users/"
+msgstr "Estimado %(user)s, De acuerdo a nuestros registros, tu acceso a %(partner_name)s expirará pronto y puedes perder el acceso. Si quieres continuar usando tu cuenta gratuita, puedes pedir la renovación de tu cuenta haciendo clic en el botón de Renovar en %(partner_link)s. Saludos, La Bibioteca de Wikipedia Puedes deshabilitar estos correos en página de preferencias de tu usuario: https://wikipedialibrary.wmflabs.org/users/"
 
 #. Translators: This is the subject of an email sent to users when they have an account that is soon to expire. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/user_renewal_notice-subject.html:4
@@ -1438,43 +1147,19 @@ msgstr "Tu acceso a la Biblioteca de Wikipedia puede expirar pronto"
 #. Translators: This email is sent to users when their application is waitlisted because there are no more accounts available. Don't translate Jinja variables in curly braces like user or partner; don't translate html tags either. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/waitlist_notification-body-html.html:5
 #, python-format
-msgid ""
-"<p>Dear %(user)s,</p> <p>Thank you for applying for access to %(partner)s "
-"resources through The Wikipedia Library. There are no accounts currently "
-"available so your application has been waitlisted. Your application will be "
-"evaluated if/when more accounts become available. You can see all available "
-"resources at <a href=\"%(link)s\">%(link)s</a>.</p> <p>Best,</p> <p>The "
-"Wikipedia Library</p>"
-msgstr ""
-"<p>Estimado %(user)s,</p> <p>Gracias por solicitar acceso a los recursos de "
-"%(partner)s a través de La Biblioteca de Wikipedia. Por el momento no hay "
-"cuentas disponibles, así es que tu solicitud ha sido puesta en lista de "
-"espera. Tu solicitud será evaluada si/cuando hayan más cuentas disponibles. "
-"Puedes ver todos los recursos disponibles en <a href=\"%(link)s\">%(link)s</"
-"a>.</p> <p>Saludos,</p> <p>La Biblioteca de Wikipedia</p>"
+msgid "<p>Dear %(user)s,</p> <p>Thank you for applying for access to %(partner)s resources through The Wikipedia Library. There are no accounts currently available so your application has been waitlisted. Your application will be evaluated if/when more accounts become available. You can see all available resources at <a href=\"%(link)s\">%(link)s</a>.</p> <p>Best,</p> <p>The Wikipedia Library</p>"
+msgstr "<p>Estimado %(user)s,</p> <p>Gracias por solicitar acceso a los recursos de %(partner)s a través de La Biblioteca de Wikipedia. Por el momento no hay cuentas disponibles, así es que tu solicitud ha sido puesta en lista de espera. Tu solicitud será evaluada si/cuando hayan más cuentas disponibles. Puedes ver todos los recursos disponibles en <a href=\"%(link)s\">%(link)s</a>.</p> <p>Saludos,</p> <p>La Biblioteca de Wikipedia</p>"
 
 #. Translators: This email is sent to users when their application is waitlisted because there are no more accounts available. Don't translate Jinja variables in curly braces like user or partner. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/waitlist_notification-body-text.html:3
 #, python-format
-msgid ""
-"Dear %(user)s, Thank you for applying for access to %(partner)s resources "
-"through The Wikipedia Library. There are no accounts currently available so "
-"your application has been waitlisted. Your application will be evaluated if/"
-"when more accounts become available. You can see all available resources at: "
-"%(link)s Best, The Wikipedia Library"
-msgstr ""
-"Estimado %(user)s, Gracias por solicitar acceso a los recursos de "
-"%(partner)s a través de La Biblioteca de Wikipedia. Por el momento no hay "
-"cuentas disponibles, así es que tu solicitud ha sido puesta en lista de "
-"espera. Tu solicitud será evaluada si/cuando hayan más cuentas disponibles. "
-"Puedes ver todos los recursos disponibles en %(link)s Saludos, La Biblioteca "
-"de Wikipedia"
+msgid "Dear %(user)s, Thank you for applying for access to %(partner)s resources through The Wikipedia Library. There are no accounts currently available so your application has been waitlisted. Your application will be evaluated if/when more accounts become available. You can see all available resources at: %(link)s Best, The Wikipedia Library"
+msgstr "Estimado %(user)s, Gracias por solicitar acceso a los recursos de %(partner)s a través de La Biblioteca de Wikipedia. Por el momento no hay cuentas disponibles, así es que tu solicitud ha sido puesta en lista de espera. Tu solicitud será evaluada si/cuando hayan más cuentas disponibles. Puedes ver todos los recursos disponibles en %(link)s Saludos, La Biblioteca de Wikipedia"
 
 #. Translators: This is the subject of an email sent to users when their application is waitlisted because there are no more accounts available. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/waitlist_notification-subject.html:4
 msgid "Your Wikipedia Library application has been waitlisted"
-msgstr ""
-"Tu solicitud a la Biblioteca de Wikipedia ha sido puesta en lista de espera"
+msgstr "Tu solicitud a la Biblioteca de Wikipedia ha sido puesta en lista de espera"
 
 #. Translators: Shown to users when they successfully submit a new message using the contact us form.
 #: TWLight/emails/views.py:51
@@ -1630,22 +1315,15 @@ msgstr "No Disponible"
 #: TWLight/resources/templates/resources/filter_section.html:14
 #: TWLight/templates/about.html:12
 #: TWLight/users/templates/users/filter_section.html:13
-msgid ""
-"The Wikipedia Library allows active editors to access a wide range of "
-"collections of paywalled reliable sources for free!"
-msgstr ""
-"La biblioteca de Wikipedia permite a los editores activos acceder a una "
-"amplia gama de colecciones de fuentes confiables de pago de forma gratuita!"
+msgid "The Wikipedia Library allows active editors to access a wide range of collections of paywalled reliable sources for free!"
+msgstr "La biblioteca de Wikipedia permite a los editores activos acceder a una amplia gama de colecciones de fuentes confiables de pago de forma gratuita!"
 
 #. Translators: On the Browse Partners page (https://wikipedialibrary.wmflabs.org/partners/), this introduces users to The Wikipedia Library.
 #. Translators: On the MyLibrary page (https://wikipedialibrary.wmflabs.org/users/my_library), this introduces users to The Wikipedia Library.
 #: TWLight/resources/templates/resources/filter_section.html:17
 #: TWLight/users/templates/users/filter_section.html:15
-msgid ""
-"Start with the search bar at the top or browse publisher websites directly."
-msgstr ""
-"Comience con la barra de búsqueda en la parte superior o explore los sitios "
-"web de los editores directamente."
+msgid "Start with the search bar at the top or browse publisher websites directly."
+msgstr "Comience con la barra de búsqueda en la parte superior o explore los sitios web de los editores directamente."
 
 #. Translators: On the Browse Partners page (https://wikipedialibrary.wmflabs.org/partners/), this appears below introductory text and links to the 'About' page (https://wikipedialibrary.wmflabs.org/about/)
 #. Translators: On the MyLibrary page (https://wikipedialibrary.wmflabs.org/users/my_library), this appears below introductory text and links to the 'About' page (https://wikipedialibrary.wmflabs.org/about/)
@@ -1718,68 +1396,39 @@ msgstr "Volver a Socios"
 #. Translators: If we have no available accounts for a partner, the coordinator can change the application system to a waiting list.
 #: TWLight/resources/templates/resources/partner_detail.html:36
 #: TWLight/resources/templates/resources/partner_detail_apply.html:17
-msgid ""
-"There are no access grants available for this partner at this time. You can "
-"still apply for access; applications will be processed when access is "
-"available."
-msgstr ""
-"Por el momento, no hay accesos disponibles para este socio. Todavía puedes "
-"solicitar acceso; tu solicitudes serán procesadas cuando el acceso se "
-"encuentre disponible."
+msgid "There are no access grants available for this partner at this time. You can still apply for access; applications will be processed when access is available."
+msgstr "Por el momento, no hay accesos disponibles para este socio. Todavía puedes solicitar acceso; tu solicitudes serán procesadas cuando el acceso se encuentre disponible."
 
 #. Translators: This text links to the minimum user requirements and terms of use on the partner page.
 #: TWLight/resources/templates/resources/partner_detail.html:48
 #: TWLight/resources/templates/resources/partner_detail_apply.html:29
 #, python-format
-msgid ""
-"Before applying, please review the <strong><a class=\"twl-links\" href="
-"\"%(about)s#req\">minimum requirements</a></strong> for access and our "
-"<strong><a class=\"twl-links\" href=\"%(terms)s\">terms of use</a></strong>."
-msgstr ""
-"Antes de aplicar, favor de revisar los <strong><a class=\"twl-links\" href="
-"\"%(about)s#req\">requerimientos mínimos</a></strong> de acceso y nuestras "
-"<strong><a class=\"twl-links\" href=\"%(terms)s\">condiciones de uso</a></"
-"strong>."
+msgid "Before applying, please review the <strong><a class=\"twl-links\" href=\"%(about)s#req\">minimum requirements</a></strong> for access and our <strong><a class=\"twl-links\" href=\"%(terms)s\">terms of use</a></strong>."
+msgstr "Antes de aplicar, favor de revisar los <strong><a class=\"twl-links\" href=\"%(about)s#req\">requerimientos mínimos</a></strong> de acceso y nuestras <strong><a class=\"twl-links\" href=\"%(terms)s\">condiciones de uso</a></strong>."
 
 #. Translators: This text refers to the page containing the content a user is authorized to access.
 #: TWLight/resources/templates/resources/partner_detail.html:69
 #, python-format
-msgid ""
-"View the status of your access in <strong><a class=\"twl-links\" href="
-"\"%(library_url)s\">My Library</a></strong> page."
-msgstr ""
-"Ver el estado de tus accesos en <strong><a class=\"twl-links\" href="
-"\"%(library_url)s\">Mi Biblioteca</a></strong>."
+msgid "View the status of your access in <strong><a class=\"twl-links\" href=\"%(library_url)s\">My Library</a></strong> page."
+msgstr "Ver el estado de tus accesos en <strong><a class=\"twl-links\" href=\"%(library_url)s\">Mi Biblioteca</a></strong>."
 
 #. Translators: This message is shown when a user has open applications, linking to their respective applications page.
 #: TWLight/resources/templates/resources/partner_detail.html:78
 #, python-format
-msgid ""
-"View the status of your application(s) on your <strong><a class=\"twl-links"
-"\" href=\"%(applications_url)s\">My Applications</a></strong> page."
-msgstr ""
-"Ver el estado de tus solicitudes en <strong><a class=\"twl-links\" href="
-"\"%(applications_url)s\">Mis Solicitudes</a></strong>."
+msgid "View the status of your application(s) on your <strong><a class=\"twl-links\" href=\"%(applications_url)s\">My Applications</a></strong> page."
+msgstr "Ver el estado de tus solicitudes en <strong><a class=\"twl-links\" href=\"%(applications_url)s\">Mis Solicitudes</a></strong>."
 
 #. Translators: This message is shown when a user has authorizations, linking to their respective collections page.
 #: TWLight/resources/templates/resources/partner_detail_apply.html:50
 #, python-format
-msgid ""
-"View the status of your access on your <strong><a href=\"%(library_url)s\" "
-"class=\"twl-links\">My Library</a></strong> page."
-msgstr ""
-"Ver el estado de tus accesos en <strong><a href=\"%(library_url)s\" class="
-"\"twl-links\">Mi Biblioteca</a></strong>."
+msgid "View the status of your access on your <strong><a href=\"%(library_url)s\" class=\"twl-links\">My Library</a></strong> page."
+msgstr "Ver el estado de tus accesos en <strong><a href=\"%(library_url)s\" class=\"twl-links\">Mi Biblioteca</a></strong>."
 
 #. Translators: This message is shown when a user has open applications, linking to their respective applications page.
 #: TWLight/resources/templates/resources/partner_detail_apply.html:60
 #, python-format
-msgid ""
-"View the status of your application(s) on your <strong><a href="
-"\"%(applications_url)s\">My Applications</a></strong> page."
-msgstr ""
-"Ver el estado de tus solicitudes en <strong><a href=\"%(applications_url)s"
-"\">Mis Solicitudes</a></strong>."
+msgid "View the status of your application(s) on your <strong><a href=\"%(applications_url)s\">My Applications</a></strong> page."
+msgstr "Ver el estado de tus solicitudes en <strong><a href=\"%(applications_url)s\">Mis Solicitudes</a></strong>."
 
 #. Translators: One the partner detail page, this text labels the button which coordinators can click to remove a partner from waitlisted status.
 #: TWLight/resources/templates/resources/partner_detail_apply.html:73
@@ -1808,15 +1457,8 @@ msgstr "Página Special:EmailUser"
 
 #. Translators: If no account coordinator is assigned to a partner, the Wikipedia Library team will coordinate signups. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/resources/templates/resources/partner_detail_apply.html:112
-msgid ""
-"The Wikipedia Library team will process this application. Want to help? <a "
-"class=\"twl-links\" href=\"https://en.wikipedia.org/wiki/Wikipedia:"
-"The_Wikipedia_Library/Coordinators/Signup\">Sign up as a coordinator.</a>"
-msgstr ""
-"El equipo de la Biblioteca de Wikipedia procesará esta solicitud. ¿Quieres "
-"ayudar? <a class=\"twl-links\" href=\"https://en.wikipedia.org/wiki/"
-"Wikipedia:The_Wikipedia_Library/Coordinators/Signup\">Registrate como "
-"coordinador.</a>"
+msgid "The Wikipedia Library team will process this application. Want to help? <a class=\"twl-links\" href=\"https://en.wikipedia.org/wiki/Wikipedia:The_Wikipedia_Library/Coordinators/Signup\">Sign up as a coordinator.</a>"
+msgstr "El equipo de la Biblioteca de Wikipedia procesará esta solicitud. ¿Quieres ayudar? <a class=\"twl-links\" href=\"https://en.wikipedia.org/wiki/Wikipedia:The_Wikipedia_Library/Coordinators/Signup\">Registrate como coordinador.</a>"
 
 #. Translators: This text labels a button coordinators can click to view a list of users who have applied for access for a particular partner
 #: TWLight/resources/templates/resources/partner_detail_apply.html:121
@@ -1845,24 +1487,14 @@ msgstr "Acceso al paquete de biblioteca"
 
 #. Translators: Text shown to authenticated, bundle eligible users when they visit a Bundle partner page.
 #: TWLight/resources/templates/resources/partner_detail_apply.html:138
-msgid ""
-"You are eligible to access Library Bundle partners. Click the button above "
-"to access the collection."
-msgstr ""
-"Eres elegible para acceder a los socios del Paquete de Biblioteca. Haz clic "
-"en el botón de arriba para acceder a la colección."
+msgid "You are eligible to access Library Bundle partners. Click the button above to access the collection."
+msgstr "Eres elegible para acceder a los socios del Paquete de Biblioteca. Haz clic en el botón de arriba para acceder a la colección."
 
 #. Translators: Text shown to authenticated, bundle ineligible users when they visit a Bundle partner page.
 #: TWLight/resources/templates/resources/partner_detail_apply.html:152
 #, python-format
-msgid ""
-"You are not eligible to access Library Bundle partners. Visit the <a class="
-"\"twl-links\" href=\"%(homepage)s\">homepage</a> to check the eligibility "
-"criteria."
-msgstr ""
-"No eres elegible para acceder a los socios del Paquete de Biblioteca. Visita "
-"<a class=\"twl-links\" href=\"%(homepage)s\">homepage</a> para revisar los "
-"criterios de elegibilidad."
+msgid "You are not eligible to access Library Bundle partners. Visit the <a class=\"twl-links\" href=\"%(homepage)s\">homepage</a> to check the eligibility criteria."
+msgstr "No eres elegible para acceder a los socios del Paquete de Biblioteca. Visita <a class=\"twl-links\" href=\"%(homepage)s\">homepage</a> para revisar los criterios de elegibilidad."
 
 #. Translators: Buttton prompting users to log in.
 #: TWLight/resources/templates/resources/partner_detail_apply.html:160
@@ -1873,14 +1505,8 @@ msgstr "Iniciar sesión"
 #. Translators: Text shown to unauthenticated users when they visit a Bundle partner page.
 #: TWLight/resources/templates/resources/partner_detail_apply.html:168
 #, python-format
-msgid ""
-"This resource is part of our <a class=\"twl-links\" href=\"%(about)s"
-"\">Library Bundle</a>, which you can access if you meet our minimum "
-"eligibility criteria. Log in to find out if you are eligible."
-msgstr ""
-"Este recurso es parte de nuestro  <a class=\"twl-links\" href=\"%(about)s"
-"\">Paquete de Biblioteca</a>, al cual puedes acceder si cubres los criterios "
-"de elegibilidad mínimos. Inicia sesión para averiguar si eres elegible."
+msgid "This resource is part of our <a class=\"twl-links\" href=\"%(about)s\">Library Bundle</a>, which you can access if you meet our minimum eligibility criteria. Log in to find out if you are eligible."
+msgstr "Este recurso es parte de nuestro  <a class=\"twl-links\" href=\"%(about)s\">Paquete de Biblioteca</a>, al cual puedes acceder si cubres los criterios de elegibilidad mínimos. Inicia sesión para averiguar si eres elegible."
 
 #. Translators: This is the label for a number which shows the total active accounts for one partner. (e.g. https://wikipedialibrary.wmflabs.org/partners/8/).
 #: TWLight/resources/templates/resources/partner_detail_stats.html:21
@@ -1930,34 +1556,20 @@ msgstr "Límite de extracción"
 #. Translators: If a partner has specified the excerpt limit both in words and percentage, this message will display the percentage of words and the number of words on the partner page.
 #: TWLight/resources/templates/resources/partner_detail_timeline.html:99
 #, python-format
-msgid ""
-"%(object)s allows a maximum of %(excerpt_limit)s words or "
-"%(excerpt_limit_percentage)s%% of an article be excerpted into a Wikipedia "
-"article."
-msgstr ""
-"%(object)s permite un máximo de %(excerpt_limit)s palabras o el "
-"%(excerpt_limit_percentage)s%% del contenido de un artículo extraído a un "
-"artículo de Wikipedia."
+msgid "%(object)s allows a maximum of %(excerpt_limit)s words or %(excerpt_limit_percentage)s%% of an article be excerpted into a Wikipedia article."
+msgstr "%(object)s permite un máximo de %(excerpt_limit)s palabras o el %(excerpt_limit_percentage)s%% del contenido de un artículo extraído a un artículo de Wikipedia."
 
 #. Translators: If a partner has specified the excerpt limit in words, this message will display the number of words on the partner page.
 #: TWLight/resources/templates/resources/partner_detail_timeline.html:106
 #, python-format
-msgid ""
-"%(object)s allows a maximum of %(excerpt_limit)s words be excerpted into a "
-"Wikipedia article."
-msgstr ""
-"%(object)s permite un máximo de %(excerpt_limit)s palabras extraídas hacia "
-"un artículo de Wikipedia."
+msgid "%(object)s allows a maximum of %(excerpt_limit)s words be excerpted into a Wikipedia article."
+msgstr "%(object)s permite un máximo de %(excerpt_limit)s palabras extraídas hacia un artículo de Wikipedia."
 
 #. Translators: If a partner has specified the excerpt limit in percentage, this message will display the percentage of words on the partner page.
 #: TWLight/resources/templates/resources/partner_detail_timeline.html:113
 #, python-format
-msgid ""
-"%(object)s allows a maximum of %(excerpt_limit_percentage)s%% of an article "
-"be excerpted into a Wikipedia article."
-msgstr ""
-"%(object)s permite un máximo de %(excerpt_limit_percentage)s%% del contenido "
-"de un artículo extraído hacia un artículo de Wikipedia."
+msgid "%(object)s allows a maximum of %(excerpt_limit_percentage)s%% of an article be excerpted into a Wikipedia article."
+msgstr "%(object)s permite un máximo de %(excerpt_limit_percentage)s%% del contenido de un artículo extraído hacia un artículo de Wikipedia."
 
 #. Translators: If a partner has other requirements for access, this text shows as the title for that information field. (e.g. https://wikipedialibrary.wmflabs.org/partners/10/).
 #: TWLight/resources/templates/resources/partner_detail_timeline.html:132
@@ -1967,12 +1579,8 @@ msgstr "Requisitos especiales para solicitantes"
 #. Translators: If a user must agree to a Terms of Use document, they see this message, and must enter the name of the resource. Don't translate publisher or url.
 #: TWLight/resources/templates/resources/partner_detail_timeline.html:140
 #, python-format
-msgid ""
-"%(publisher)s requires that you agree with its <a href=\"%(url)s\">terms of "
-"use</a>."
-msgstr ""
-"%(publisher)s requiere que hayas aceptado sus <a href=\"%(url)s"
-"\">condiciones de uso</a>."
+msgid "%(publisher)s requires that you agree with its <a href=\"%(url)s\">terms of use</a>."
+msgstr "%(publisher)s requiere que hayas aceptado sus <a href=\"%(url)s\">condiciones de uso</a>."
 
 #. Translators: If a user must provide their real name to apply to a partner, they see this message, and must enter the name of the resource. Don't translate publisher.
 #: TWLight/resources/templates/resources/partner_detail_timeline.html:150
@@ -1995,18 +1603,13 @@ msgstr "%(publisher)s requiere que proporciones tu afiliación institucional."
 #. Translators: If a user must select a specific resource to apply for, they see this message, and must enter the name of the resource. Don't translate publisher.
 #: TWLight/resources/templates/resources/partner_detail_timeline.html:177
 #, python-format
-msgid ""
-"%(publisher)s requires that you specify a particular title that you want to "
-"access."
-msgstr ""
-"%(publisher)s requiere que especifiques el título al que quieres acceder."
+msgid "%(publisher)s requires that you specify a particular title that you want to access."
+msgstr "%(publisher)s requiere que especifiques el título al que quieres acceder."
 
 #. Translators: If a user must register on the partner website before applying, they see this message. Don't translate partner.
 #: TWLight/resources/templates/resources/partner_detail_timeline.html:187
 #, python-format
-msgid ""
-"%(publisher)s requires that you sign up for an account before applying for "
-"access."
+msgid "%(publisher)s requires that you sign up for an account before applying for access."
 msgstr "%(publisher)s requiere que crees una cuenta antes de solicitar acceso."
 
 #. Translators: If a partner has their location listed, this message is a label for that location
@@ -2133,12 +1736,8 @@ msgstr "¿Estás seguro que quieres eliminar <b>%(object)s</b>?"
 
 #. Translators: If multiple authorizations where returned for a collection, this message is shown to a user
 #: TWLight/resources/views.py:268
-msgid ""
-"Multiple authorizations were returned – something's wrong. Please contact us "
-"and don't forget to mention this message."
-msgstr ""
-"Múltiples autorizaciones fueron devueltas – hay algo mal aquí. Favor de "
-"contactarnos y no olvides mencionar este mensaje."
+msgid "Multiple authorizations were returned – something's wrong. Please contact us and don't forget to mention this message."
+msgstr "Múltiples autorizaciones fueron devueltas – hay algo mal aquí. Favor de contactarnos y no olvides mencionar este mensaje."
 
 #. Translators: This message is shown when user tries to access a NOT_AVAILABLE Partner
 #: TWLight/resources/views.py:316
@@ -2178,22 +1777,8 @@ msgstr "Lo sentimos, no sabemos qué hacer con eso."
 #. Translators: Shown on the website's 400 page, when a user sends a bad request. Don't translate path or Phabricator.
 #: TWLight/templates/400.html:20
 #, python-format
-msgid ""
-"If you think we should know what to do with that, please email us about this "
-"error at <a class=\"twl-links\" href=\"mailto:wikipedialibrary@wikimedia.org?"
-"Subject=Wikipedia%%20Library%%20%(path)s%%20Permission%%20denied"
-"\">wikipedialibrary@wikimedia.org</a> or report it to us on <a class=\"twl-"
-"links\" href=\"https://phabricator.wikimedia.org/maniphest/task/edit/form/1/?"
-"projectPHIDs=Library-Card-Platform&title=Wikipedia%%20Library%%20%(path)s"
-"%%20Bad%%20Request\">Phabricator</a>"
-msgstr ""
-"Si piensas que tendríamos que saber qué hacer con esto, favor de enviar un "
-"correo a <a class=\"twl-links\" href=\"mailto:wikipedialibrary@wikimedia.org?"
-"Subject=Wikipedia%%20Library%%20%(path)s%%20Permission%%20denied"
-"\">wikipedialibrary@wikimedia.org</a> o reportarlo en <a class=\"twl-links\" "
-"href=\"https://phabricator.wikimedia.org/maniphest/task/edit/form/1/?"
-"projectPHIDs=Library-Card-Platform&title=Wikipedia%%20Library%%20%(path)s"
-"%%20Bad%%20Request\">Phabricator</a>"
+msgid "If you think we should know what to do with that, please email us about this error at <a class=\"twl-links\" href=\"mailto:wikipedialibrary@wikimedia.org?Subject=Wikipedia%%20Library%%20%(path)s%%20Permission%%20denied\">wikipedialibrary@wikimedia.org</a> or report it to us on <a class=\"twl-links\" href=\"https://phabricator.wikimedia.org/maniphest/task/edit/form/1/?projectPHIDs=Library-Card-Platform&title=Wikipedia%%20Library%%20%(path)s%%20Bad%%20Request\">Phabricator</a>"
+msgstr "Si piensas que tendríamos que saber qué hacer con esto, favor de enviar un correo a <a class=\"twl-links\" href=\"mailto:wikipedialibrary@wikimedia.org?Subject=Wikipedia%%20Library%%20%(path)s%%20Permission%%20denied\">wikipedialibrary@wikimedia.org</a> o reportarlo en <a class=\"twl-links\" href=\"https://phabricator.wikimedia.org/maniphest/task/edit/form/1/?projectPHIDs=Library-Card-Platform&title=Wikipedia%%20Library%%20%(path)s%%20Bad%%20Request\">Phabricator</a>"
 
 #. Translators: Alt text for an image shown on the 400 error page.
 #. Translators: Alt text for an image shown on the 403 error page.
@@ -2214,23 +1799,8 @@ msgstr "Lo sentimos, no estás autorizado para realizar eso."
 #. Translators: Shown on the website's 403 page, when a user attempts to navigate to a page they don't have permission to view. Don't translate path or Phabricator.
 #: TWLight/templates/403.html:20
 #, python-format
-msgid ""
-"If you think your account should be able to do that, please email us about "
-"this error at <a class=\"twl-links\" href=\"mailto:"
-"wikipedialibrary@wikimedia.org?Subject=Wikipedia%%20Library%%20%(path)s"
-"%%20Permission%%20denied\">wikipedialibrary@wikimedia.org</a> or report it "
-"to us on <a class=\"twl-links\" href=\"https://phabricator.wikimedia.org/"
-"maniphest/task/edit/form/1/?projectPHIDs=Library-Card-"
-"Platform&title=Wikipedia%%20Library%%20%(path)s%%20Permission%%20denied"
-"\">Phabricator</a>"
-msgstr ""
-"Si piensas que tu cuenta debería ser capaz de hacer esto, favor de enviar un "
-"correo a <a class=\"twl-links\" href=\"mailto:wikipedialibrary@wikimedia.org?"
-"Subject=Wikipedia%%20Library%%20%(path)s%%20Permission%%20denied"
-"\">wikipedialibrary@wikimedia.org</a> o repórtalo en <a class=\"twl-links\" "
-"href=\"https://phabricator.wikimedia.org/maniphest/task/edit/form/1/?"
-"projectPHIDs=Library-Card-Platform&title=Wikipedia%%20Library%%20%(path)s"
-"%%20Permission%%20denied\">Phabricator</a>"
+msgid "If you think your account should be able to do that, please email us about this error at <a class=\"twl-links\" href=\"mailto:wikipedialibrary@wikimedia.org?Subject=Wikipedia%%20Library%%20%(path)s%%20Permission%%20denied\">wikipedialibrary@wikimedia.org</a> or report it to us on <a class=\"twl-links\" href=\"https://phabricator.wikimedia.org/maniphest/task/edit/form/1/?projectPHIDs=Library-Card-Platform&title=Wikipedia%%20Library%%20%(path)s%%20Permission%%20denied\">Phabricator</a>"
+msgstr "Si piensas que tu cuenta debería ser capaz de hacer esto, favor de enviar un correo a <a class=\"twl-links\" href=\"mailto:wikipedialibrary@wikimedia.org?Subject=Wikipedia%%20Library%%20%(path)s%%20Permission%%20denied\">wikipedialibrary@wikimedia.org</a> o repórtalo en <a class=\"twl-links\" href=\"https://phabricator.wikimedia.org/maniphest/task/edit/form/1/?projectPHIDs=Library-Card-Platform&title=Wikipedia%%20Library%%20%(path)s%%20Permission%%20denied\">Phabricator</a>"
 
 #. Translators: Shown on the website's 404 page, when a user attempts to navigate to a page that doesn't exist.
 #: TWLight/templates/404.html:11
@@ -2245,22 +1815,8 @@ msgstr "No se puede encontrar el recurso."
 #. Translators: Shown on the website's 404 page, when a user attempts to navigate to a page that doesn't exist. Don't translate path or Phabricator.
 #: TWLight/templates/404.html:19
 #, python-format
-msgid ""
-"If you are certain that something should be here, please email us about this "
-"error at <a class=\"twl-links\" href=\"mailto:wikipedialibrary@wikimedia.org?"
-"Subject=Wikipedia%%20Library%%20%(path)s%%20Not%%20found\"> "
-"wikipedialibrary@wikimedia.org</a> or report it to us on <a class=\"twl-links"
-"\" href=\"https://phabricator.wikimedia.org/maniphest/task/edit/form/1/?"
-"projectPHIDs=Library-Card-Platform&title=Wikipedia%%20Library%%20%(path)s"
-"%%20Not%%20found\">Phabricator</a>"
-msgstr ""
-"Si estás seguro que algo debería estar aquí, favor de mandar un correo de "
-"este error a <a class=\"twl-links\" href=\"mailto:wikipedialibrary@wikimedia."
-"org?Subject=Wikipedia%%20Library%%20%(path)s%%20Not%%20found\"></a> o "
-"repórtalo en <a class=\"twl-links\" href=\"https://phabricator.wikimedia.org/"
-"maniphest/task/edit/form/1/?projectPHIDs=Library-Card-"
-"Platform&title=Wikipedia%%20Library%%20%(path)s%%20Not%%20found"
-"\">Phabricator</a>"
+msgid "If you are certain that something should be here, please email us about this error at <a class=\"twl-links\" href=\"mailto:wikipedialibrary@wikimedia.org?Subject=Wikipedia%%20Library%%20%(path)s%%20Not%%20found\"> wikipedialibrary@wikimedia.org</a> or report it to us on <a class=\"twl-links\" href=\"https://phabricator.wikimedia.org/maniphest/task/edit/form/1/?projectPHIDs=Library-Card-Platform&title=Wikipedia%%20Library%%20%(path)s%%20Not%%20found\">Phabricator</a>"
+msgstr "Si estás seguro que algo debería estar aquí, favor de mandar un correo de este error a <a class=\"twl-links\" href=\"mailto:wikipedialibrary@wikimedia.org?Subject=Wikipedia%%20Library%%20%(path)s%%20Not%%20found\"></a> o repórtalo en <a class=\"twl-links\" href=\"https://phabricator.wikimedia.org/maniphest/task/edit/form/1/?projectPHIDs=Library-Card-Platform&title=Wikipedia%%20Library%%20%(path)s%%20Not%%20found\">Phabricator</a>"
 
 #. Translators: Alt text for an image shown on the 404 error page.
 #: TWLight/templates/404.html:32
@@ -2274,50 +1830,19 @@ msgstr "Acerca de Wikipedia Library"
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:20
-msgid ""
-"This platform is our central tool for facilitating access to our available "
-"collections. Here you can see which partnerships are available, search their "
-"contents, and apply for and access the ones you’re interested in."
-msgstr ""
-"Esta plataforma es nuestra herramienta central para facilitar el acceso a "
-"nuestras colecciones disponibles. Aquí puedes ver qué socios están "
-"disponibles, buscar sus contenidos, solicitar y acceder a las que te "
-"interesen."
+msgid "This platform is our central tool for facilitating access to our available collections. Here you can see which partnerships are available, search their contents, and apply for and access the ones you’re interested in."
+msgstr "Esta plataforma es nuestra herramienta central para facilitar el acceso a nuestras colecciones disponibles. Aquí puedes ver qué socios están disponibles, buscar sus contenidos, solicitar y acceder a las que te interesen."
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/). Wikimedia Foundation should not be translated.
 #: TWLight/templates/about.html:29
-msgid ""
-"All users receive immediate access to some collections, which can be browsed "
-"by clicking the 'Access collection' buttons or using the search bar at the "
-"top of the page. Other collections require an application before access is "
-"granted, and may be accessed directly or via an individual login or access "
-"code. Volunteer coordinators, who have signed non-disclosure agreements with "
-"the Wikimedia Foundation, review these applications and work with publishers "
-"to get you your free access."
-msgstr ""
-"Todos los usuarios reciben acceso inmediato a algunas colecciones, que se "
-"pueden explorar haciendo clic en los botones 'Acceder a la colección' o "
-"usando la barra de búsqueda en la parte superior de la página. Otras "
-"colecciones requieren una aplicación antes de que se otorgue el acceso, y se "
-"puede acceder a ellas directamente o mediante un inicio de sesión individual "
-"o un código de acceso. Los coordinadores voluntarios, que han firmado "
-"acuerdos de confidencialidad con la Fundación Wikimedia, revisan estas "
-"aplicaciones y trabajan con los editores para obtener su acceso gratuito."
+msgid "All users receive immediate access to some collections, which can be browsed by clicking the 'Access collection' buttons or using the search bar at the top of the page. Other collections require an application before access is granted, and may be accessed directly or via an individual login or access code. Volunteer coordinators, who have signed non-disclosure agreements with the Wikimedia Foundation, review these applications and work with publishers to get you your free access."
+msgstr "Todos los usuarios reciben acceso inmediato a algunas colecciones, que se pueden explorar haciendo clic en los botones 'Acceder a la colección' o usando la barra de búsqueda en la parte superior de la página. Otras colecciones requieren una aplicación antes de que se otorgue el acceso, y se puede acceder a ellas directamente o mediante un inicio de sesión individual o un código de acceso. Los coordinadores voluntarios, que han firmado acuerdos de confidencialidad con la Fundación Wikimedia, revisan estas aplicaciones y trabajan con los editores para obtener su acceso gratuito."
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/). Don't translate terms_url.
 #: TWLight/templates/about.html:43
 #, python-format
-msgid ""
-"For more information about how your information is stored and reviewed "
-"please see our <a class=\"twl-links\" href=\"%(terms_url)s\"> terms of use "
-"and privacy policy</a>. Accounts you apply for are also subject to the Terms "
-"of Use provided by each partner’s platform; please review them."
-msgstr ""
-"Para más información de cómo se almacena y revisa tu información, favor de "
-"ver nuestras <a class=\"twl-links\" href=\"%(terms_url)s\">condiciones de "
-"uso y políticas de privacidad</a>. Las cuentas a las que aplicas también "
-"están sujetas a las condiciones de uso proporcionadas por la plataforma de "
-"cada socio; favor de revisarlas."
+msgid "For more information about how your information is stored and reviewed please see our <a class=\"twl-links\" href=\"%(terms_url)s\"> terms of use and privacy policy</a>. Accounts you apply for are also subject to the Terms of Use provided by each partner’s platform; please review them."
+msgstr "Para más información de cómo se almacena y revisa tu información, favor de ver nuestras <a class=\"twl-links\" href=\"%(terms_url)s\">condiciones de uso y políticas de privacidad</a>. Las cuentas a las que aplicas también están sujetas a las condiciones de uso proporcionadas por la plataforma de cada socio; favor de revisarlas."
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:51
@@ -2326,25 +1851,13 @@ msgstr "¿Quiénes pueden recibir acceso?"
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/). Wikimedia Foundation should not be translated.
 #: TWLight/templates/about.html:55
-msgid ""
-"Any active editor in good standing can receive access. For publishers with "
-"limited numbers of accounts, applications are reviewed based on the editor’s "
-"needs and contributions. If you think you could use access to one of our "
-"partner resources and are an active editor in any project supported by the "
-"Wikimedia Foundation, please apply."
-msgstr ""
-"Cualquier editor en en buen estado puede recibir acceso. Para publicaciones "
-"con número limitado de cuentas, las solicitudes son revisadas con base en "
-"las necesidades y contribuciones del editor. Si piensas que necesitas "
-"acceder a uno de los recursos de nuestros socios y eres un editor activo en "
-"cualquier proyecto respaldado por la Fundación Wikimedia, favor de aplicar."
+msgid "Any active editor in good standing can receive access. For publishers with limited numbers of accounts, applications are reviewed based on the editor’s needs and contributions. If you think you could use access to one of our partner resources and are an active editor in any project supported by the Wikimedia Foundation, please apply."
+msgstr "Cualquier editor en en buen estado puede recibir acceso. Para publicaciones con número limitado de cuentas, las solicitudes son revisadas con base en las necesidades y contribuciones del editor. Si piensas que necesitas acceder a uno de los recursos de nuestros socios y eres un editor activo en cualquier proyecto respaldado por la Fundación Wikimedia, favor de aplicar."
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:65
 msgid "Any editor can use the library if they meet a few basic requirements:"
-msgstr ""
-"Cualquier editor puede usar la biblioteca si cumplen con los siguientes "
-"requisitos básicos:"
+msgstr "Cualquier editor puede usar la biblioteca si cumplen con los siguientes requisitos básicos:"
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:71
@@ -2354,14 +1867,12 @@ msgstr "Tienes una cuenta de al menos 6 meses de antigüedad"
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:75
 msgid "You have made a minimum of 500 edits to Wikimedia projects"
-msgstr ""
-"Debes haber realizado un mínimo de 500 ediciones en proyectos de Wikimedia"
+msgstr "Debes haber realizado un mínimo de 500 ediciones en proyectos de Wikimedia"
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:79
 msgid "You have made at least 10 edits to Wikimedia projects in the last month"
-msgstr ""
-"Has hecho al menos 10 ediciones a proyectos de Wikimedia en el último mes"
+msgstr "Has hecho al menos 10 ediciones a proyectos de Wikimedia en el último mes"
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:83
@@ -2370,35 +1881,13 @@ msgstr "No estás actualmente bloqueado de editar un proyecto de Wikimedia"
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/)
 #: TWLight/templates/about.html:89
-msgid ""
-"If you are applying for an available collection, please first check that you "
-"don't already have access through another library or institution. If you do, "
-"please consider using that access rather than taking up a seat for this "
-"resource in The Wikipedia Library."
-msgstr ""
-"Si estás solicitando una colección disponible, por favor primero revisa que "
-"aún no tengas acceso a través de otra biblioteca o institución. Si lo "
-"tienes, por favor considera usar ese acceso en vez de utilizar este recurso "
-"en La Biblioteca de Wikipedia."
+msgid "If you are applying for an available collection, please first check that you don't already have access through another library or institution. If you do, please consider using that access rather than taking up a seat for this resource in The Wikipedia Library."
+msgstr "Si estás solicitando una colección disponible, por favor primero revisa que aún no tengas acceso a través de otra biblioteca o institución. Si lo tienes, por favor considera usar ese acceso en vez de utilizar este recurso en La Biblioteca de Wikipedia."
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/)
 #: TWLight/templates/about.html:99
-msgid ""
-"If your account is blocked on one or more Wikimedia projects, you may still "
-"be granted access to The Wikipedia Library. You will need to contact the "
-"Wikipedia Library team, who will review your blocks. If you have been "
-"blocked for content issues, most notably copyright violations, or have "
-"multiple long-term blocks, we may decline your request. Additionally, if "
-"your block status changes after being approved, you will need to request "
-"another review."
-msgstr ""
-"Si tu cuenta está bloqueada en uno o más proyectos de Wikimedia, todavía se "
-"te puede dar acceso a La Biblioteca de Wikipedia. Necesitas comunicarte con "
-"el equipo de La Biblioteca de Wikipedia, que revisará tus bloqueos. Si has "
-"sido bloqueado por problemas de contenido, principalmente violaciones de "
-"copyright, o tienes múltiples bloqueos de largo plazo, puede ser que "
-"neguemos tu petición. Adicionalmente, si tu estado de bloqueo cambia después "
-"de ser aprobado, necesitarás pedir otra revisión."
+msgid "If your account is blocked on one or more Wikimedia projects, you may still be granted access to The Wikipedia Library. You will need to contact the Wikipedia Library team, who will review your blocks. If you have been blocked for content issues, most notably copyright violations, or have multiple long-term blocks, we may decline your request. Additionally, if your block status changes after being approved, you will need to request another review."
+msgstr "Si tu cuenta está bloqueada en uno o más proyectos de Wikimedia, todavía se te puede dar acceso a La Biblioteca de Wikipedia. Necesitas comunicarte con el equipo de La Biblioteca de Wikipedia, que revisará tus bloqueos. Si has sido bloqueado por problemas de contenido, principalmente violaciones de copyright, o tienes múltiples bloqueos de largo plazo, puede ser que neguemos tu petición. Adicionalmente, si tu estado de bloqueo cambia después de ser aprobado, necesitarás pedir otra revisión."
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:110
@@ -2432,12 +1921,8 @@ msgstr "Aprobó los editores <i>no deben</i>:"
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:136
-msgid ""
-"Share their account logins or passwords with others, or sell their access to "
-"other parties"
-msgstr ""
-"Compartir su inicio de sesión o contraseñas con otros o vender su acceso a "
-"terceros"
+msgid "Share their account logins or passwords with others, or sell their access to other parties"
+msgstr "Compartir su inicio de sesión o contraseñas con otros o vender su acceso a terceros"
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:140
@@ -2446,30 +1931,18 @@ msgstr "Hacer scraping masivo o descargar masivamente contenido de socios"
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:144
-msgid ""
-"Systematically make printed or electronic copies of multiple extracts of "
-"restricted content available for any purpose"
-msgstr ""
-"Sistemáticamente hacer copias impresas o electrónicas de varios extractos de "
-"contenido restringido disponibles para cualquier propósito"
+msgid "Systematically make printed or electronic copies of multiple extracts of restricted content available for any purpose"
+msgstr "Sistemáticamente hacer copias impresas o electrónicas de varios extractos de contenido restringido disponibles para cualquier propósito"
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/). Stub is a technical term for a short Wikipedia article, use the appropriate Wikipedia term in your language.
 #: TWLight/templates/about.html:148
-msgid ""
-"Datamine metadata without permission, in order, for instance, to use "
-"metadata for auto-created stub articles"
-msgstr ""
-"Hacer minería de datos sin permiso – por ejemplo, para usar los metadatos "
-"para auto-generar plantillas de artículos"
+msgid "Datamine metadata without permission, in order, for instance, to use metadata for auto-created stub articles"
+msgstr "Hacer minería de datos sin permiso – por ejemplo, para usar los metadatos para auto-generar plantillas de artículos"
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:154
-msgid ""
-"Respecting these agreements allows us to continue growing the partnerships "
-"available to the community."
-msgstr ""
-"Respetar estos acuerdos nos permite continuar creciendo las sociedades y "
-"recursos que estas hacen disponibles a la comunidad."
+msgid "Respecting these agreements allows us to continue growing the partnerships available to the community."
+msgstr "Respetar estos acuerdos nos permite continuar creciendo las sociedades y recursos que estas hacen disponibles a la comunidad."
 
 #. Translators: This is the heading for a section on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:160
@@ -2478,65 +1951,23 @@ msgstr "EZProxy"
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:164
-msgid ""
-"EZProxy is a proxy server used to authenticate users for many Wikipedia "
-"Library partners. Users sign into EZProxy via the Library Card platform to "
-"verify that they are authorized users, and then the server accesses "
-"requested resources using its own IP address."
-msgstr ""
-"EZProxy es un servidor proxy usado para autenticar a usuarios para muchos "
-"socios de La Biblioteca de Wikipedia. Los usuarios se registran en EZProxy a "
-"través de La Biblioteca de Wikipedia para verificar que son los usuarios "
-"autorizado y luego el servidor accede a los recursos solicitados usando una "
-"dirección IP propia."
+msgid "EZProxy is a proxy server used to authenticate users for many Wikipedia Library partners. Users sign into EZProxy via the Library Card platform to verify that they are authorized users, and then the server accesses requested resources using its own IP address."
+msgstr "EZProxy es un servidor proxy usado para autenticar a usuarios para muchos socios de La Biblioteca de Wikipedia. Los usuarios se registran en EZProxy a través de La Biblioteca de Wikipedia para verificar que son los usuarios autorizado y luego el servidor accede a los recursos solicitados usando una dirección IP propia."
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:173
-msgid ""
-"You may notice that when accessing resources via EZProxy that URLs are "
-"dynamically rewritten. This is why we recommend logging in via the Library "
-"Card platform rather than going directly to the unproxied partner website. "
-"When in doubt, check the URL for ‘idm.oclc’. If it’s there, then you’re "
-"connected via EZProxy."
-msgstr ""
-"Puedes notar que cuando a accedes a recursos a través de EZProxy las URLs "
-"cambian dinámicamente. Esta es la razón por la que recomendamos iniciar "
-"sesión a través de La Biblioteca de Wikipedia en vez de ir directamente al "
-"sitio web del socio. Si tienes alguna duda si te encuentras en un sitio "
-"proxy, revisa la URL y busca ‘idm.oclc’. Si se encuentra en la URL, entonces "
-"te encuentras conectado al sitio a través de EZProxy."
+msgid "You may notice that when accessing resources via EZProxy that URLs are dynamically rewritten. This is why we recommend logging in via the Library Card platform rather than going directly to the unproxied partner website. When in doubt, check the URL for ‘idm.oclc’. If it’s there, then you’re connected via EZProxy."
+msgstr "Puedes notar que cuando a accedes a recursos a través de EZProxy las URLs cambian dinámicamente. Esta es la razón por la que recomendamos iniciar sesión a través de La Biblioteca de Wikipedia en vez de ir directamente al sitio web del socio. Si tienes alguna duda si te encuentras en un sitio proxy, revisa la URL y busca ‘idm.oclc’. Si se encuentra en la URL, entonces te encuentras conectado al sitio a través de EZProxy."
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:182
-msgid ""
-"Typically once you’ve logged in your session will remain active in your "
-"browser for up to two hours after you’ve finished searching. Note that use "
-"of EZProxy requires you to enable cookies. If you are having problems you "
-"should also try clearing your cache and restarting your browser."
-msgstr ""
-"Típicamente una vez que hayas iniciado sesión, tu sesión permanecerá activa "
-"en tu navegador hasta por dos horas después de haber terminado tu búsqueda. "
-"Nótese que el uso de EZProxy requiere que habilites el uso de cookies. Si "
-"estás teniendo problemas, puedes intentar borrar tu caché y reiniciar tu "
-"navegador."
+msgid "Typically once you’ve logged in your session will remain active in your browser for up to two hours after you’ve finished searching. Note that use of EZProxy requires you to enable cookies. If you are having problems you should also try clearing your cache and restarting your browser."
+msgstr "Típicamente una vez que hayas iniciado sesión, tu sesión permanecerá activa en tu navegador hasta por dos horas después de haber terminado tu búsqueda. Nótese que el uso de EZProxy requiere que habilites el uso de cookies. Si estás teniendo problemas, puedes intentar borrar tu caché y reiniciar tu navegador."
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/)
 #: TWLight/templates/about.html:193
-msgid ""
-"The Library Bundle is a collection of resources for which no application is "
-"required. If you meet the criteria laid out above, you will be authorized "
-"for access automatically upon logging in to the platform. Only some of our "
-"content is currently included in the Library Bundle, however we hope to "
-"expand the collection as more publishers become comfortable with "
-"participating. All Bundle content is accessed via EZProxy."
-msgstr ""
-"El Lote de Biblioteca es una colección de recursos para la cual no se "
-"necesita solicitar. Si cumples los criterios mostrados más arriba se te "
-"autorizará acceso automáticamente cuando inicies sesión en la plataforma. "
-"Actualmente solo una parte de nuestro contenido está incluído en el Lote de "
-"Biblioteca, sin embargo esperamos expandir la colección conforme más "
-"publicadores se sientan cómodos participando. Todo el contenido del Lote es "
-"accedido a través de EZProxy."
+msgid "The Library Bundle is a collection of resources for which no application is required. If you meet the criteria laid out above, you will be authorized for access automatically upon logging in to the platform. Only some of our content is currently included in the Library Bundle, however we hope to expand the collection as more publishers become comfortable with participating. All Bundle content is accessed via EZProxy."
+msgstr "El Lote de Biblioteca es una colección de recursos para la cual no se necesita solicitar. Si cumples los criterios mostrados más arriba se te autorizará acceso automáticamente cuando inicies sesión en la plataforma. Actualmente solo una parte de nuestro contenido está incluído en el Lote de Biblioteca, sin embargo esperamos expandir la colección conforme más publicadores se sientan cómodos participando. Todo el contenido del Lote es accedido a través de EZProxy."
 
 #. Translators: This is the heading for a section on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:202
@@ -2545,19 +1976,8 @@ msgstr "Prácticas de cita"
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:206
-msgid ""
-"Citation practices vary by project and even by article. Generally, we "
-"support editors citing where they found information, in a form that allows "
-"others to check it for themselves. That often means providing both original "
-"source details as well as a link to the partner database in which the source "
-"was found."
-msgstr ""
-"Las prácticas de citación varían por proyecto e incluso por artículo. "
-"Generalmente, apoyamos a los editores que citan donde encontraron "
-"información, en un formulario que le permite a otros revisarlo por ellos "
-"mismos. Eso a menudo significa proporcionar tanto los detalles de la fuente "
-"original como un enlace a la base de datos del socio donde la fuente fue "
-"encontrada."
+msgid "Citation practices vary by project and even by article. Generally, we support editors citing where they found information, in a form that allows others to check it for themselves. That often means providing both original source details as well as a link to the partner database in which the source was found."
+msgstr "Las prácticas de citación varían por proyecto e incluso por artículo. Generalmente, apoyamos a los editores que citan donde encontraron información, en un formulario que le permite a otros revisarlo por ellos mismos. Eso a menudo significa proporcionar tanto los detalles de la fuente original como un enlace a la base de datos del socio donde la fuente fue encontrada."
 
 #. Translators: This is the heading for a section on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #. Translators: This link is at the bottom of every page and can be clicked by users to contact the wikipedia library team.
@@ -2568,13 +1988,8 @@ msgstr "Contáctanos"
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:218
 #, python-format
-msgid ""
-"If you have questions, need help, or want to volunteer to help, please see "
-"our <a class=\"twl-links\" href=\"%(contact_url)s\">contact page</a>."
-msgstr ""
-"Si tienes preguntas, necesitas ayuda o quieres ayudar de forma voluntaria, "
-"favor de ver nuestra <a class=\"twl-links\" href=\"%(contact_url)s\">página "
-"de contacto</a>."
+msgid "If you have questions, need help, or want to volunteer to help, please see our <a class=\"twl-links\" href=\"%(contact_url)s\">contact page</a>."
+msgstr "Si tienes preguntas, necesitas ayuda o quieres ayudar de forma voluntaria, favor de ver nuestra <a class=\"twl-links\" href=\"%(contact_url)s\">página de contacto</a>."
 
 #. Translators: This is the title of the panel box detailing the contact information for the Wikipedia Library team.
 #: TWLight/templates/contact.html:14
@@ -2613,19 +2028,13 @@ msgstr "Página de Twitter de la Biblioteca de Wikipedia"
 #. Translators: This is the text that appears at the bottom of the contact us form directing users to the suggestions form.
 #: TWLight/templates/contact.html:48
 #, python-format
-msgid ""
-"(If you would like to suggest a partner, <a class=\"twl-links\" href="
-"\"%(suggest)s\"><strong>go here</strong></a>.)"
-msgstr ""
-"(Si te gustaría sugerir un socio, <a class=\"twl-links\" href=\"%(suggest)s"
-"\"><strong>navega aquí</strong></a>.)"
+msgid "(If you would like to suggest a partner, <a class=\"twl-links\" href=\"%(suggest)s\"><strong>go here</strong></a>.)"
+msgstr "(Si te gustaría sugerir un socio, <a class=\"twl-links\" href=\"%(suggest)s\"><strong>navega aquí</strong></a>.)"
 
 #. Translators: On a special 'link to search' page, this message is shown if JavaScript is disabled.
 #: TWLight/templates/eds_search_endpoint.html:7
 msgid "JavaScript is disabled; use the button below to continue."
-msgstr ""
-"JavaScript está deshabilitado; favor de usar el botón de abajo para "
-"continuar."
+msgstr "JavaScript está deshabilitado; favor de usar el botón de abajo para continuar."
 
 #. Translators: Alt text for the Wikipedia Library shown in the top left of all pages.
 #: TWLight/templates/header_partial_b4.html:14
@@ -2676,12 +2085,8 @@ msgstr "La Biblioteca de Wikipedia"
 #. Translators: Information about The Wikipedia Library.
 #: TWLight/templates/login_partial.html:53 TWLight/templates/new_base.html:21
 #, python-format
-msgid ""
-"More than 100 of the world's top subscription-only databases, with content "
-"in %(no_of_languages)s languages, free for Wikipedians of all backgrounds"
-msgstr ""
-"Más de 100 de las mejores bases de datos de suscripción, con contenido en "
-"%(no_of_languages)s idiomas, gratis para Wikipedistas de todos los orígenes"
+msgid "More than 100 of the world's top subscription-only databases, with content in %(no_of_languages)s languages, free for Wikipedians of all backgrounds"
+msgstr "Más de 100 de las mejores bases de datos de suscripción, con contenido en %(no_of_languages)s idiomas, gratis para Wikipedistas de todos los orígenes"
 
 #. Translators: Information about The Wikipedia Library.
 #: TWLight/templates/login_partial.html:64
@@ -2689,12 +2094,8 @@ msgid "Meet these criteria for automatic access"
 msgstr "Para tener acceso automático, debes satisfacer estos criterios"
 
 #: TWLight/templates/login_partial.html:69
-msgid ""
-"These criteria grant you access to certain collections but not all. Some "
-"collections are accessible on a per application basis only."
-msgstr ""
-"Estos criterios te dan acceso solamente a algunas colecciones. Algunas "
-"colecciones están disponibles exclusivamente a través de solicitudes."
+msgid "These criteria grant you access to certain collections but not all. Some collections are accessible on a per application basis only."
+msgstr "Estos criterios te dan acceso solamente a algunas colecciones. Algunas colecciones están disponibles exclusivamente a través de solicitudes."
 
 #: TWLight/templates/login_partial.html:89
 msgid "Login via Wikipedia"
@@ -2703,41 +2104,20 @@ msgstr "Iniciar sesión con tu cuenta de Wikipedia"
 #. Translators: Shown if the current user doesn't have a registered email on their account. Don't translate contact_us_url or email_url.
 #: TWLight/templates/message_partial.html:15
 #, python-format
-msgid ""
-"You don't have an email on file. We can't finalize your access to partner "
-"resources, and you won't be able to <a class=\"twl-links\" href="
-"\"%(contact_us_url)s\">contact us</a> without an email. Please <a class="
-"\"twl-links\" href=\"%(email_url)s\">update your email</a>."
-msgstr ""
-"No tienes un correo electrónico agregado. No podemos finalizar to acceso a "
-"los recursos del socio y no podrás  <a class=\"twl-links\" href="
-"\"%(contact_us_url)s\">contactarnos</a> si un correo electrónico. Favor de "
-"<a class=\"twl-links\" href=\"%(email_url)s\">actualizar tu correo "
-"electrónico</a>."
+msgid "You don't have an email on file. We can't finalize your access to partner resources, and you won't be able to <a class=\"twl-links\" href=\"%(contact_us_url)s\">contact us</a> without an email. Please <a class=\"twl-links\" href=\"%(email_url)s\">update your email</a>."
+msgstr "No tienes un correo electrónico agregado. No podemos finalizar to acceso a los recursos del socio y no podrás  <a class=\"twl-links\" href=\"%(contact_us_url)s\">contactarnos</a> si un correo electrónico. Favor de <a class=\"twl-links\" href=\"%(email_url)s\">actualizar tu correo electrónico</a>."
 
 #. Translators: Shown if the current user has requested the processing of their data should be restricted.
 #: TWLight/templates/message_partial.html:26
 #, python-format
-msgid ""
-"You have requested a restriction on the processing of your data. Most site "
-"functionality will not be available to you until you <a class=\"twl-links\" "
-"href=\"%(restrict_url)s\">lift this restriction</a>."
-msgstr ""
-"Has solicitado una restricción al procesamiento de tus datos. La mayor parte "
-"de la funcionalidad del sitio no estará disponible para ti hasta que <a href="
-"\"%(restrict_url)s\">levantes esta restricción</a>."
+msgid "You have requested a restriction on the processing of your data. Most site functionality will not be available to you until you <a class=\"twl-links\" href=\"%(restrict_url)s\">lift this restriction</a>."
+msgstr "Has solicitado una restricción al procesamiento de tus datos. La mayor parte de la funcionalidad del sitio no estará disponible para ti hasta que <a href=\"%(restrict_url)s\">levantes esta restricción</a>."
 
 #. Translators: Shown if the current user has not agreed to the terms of use.
 #: TWLight/templates/message_partial.html:37
 #, python-format
-msgid ""
-"You have not agreed to the <a class=\"twl-links\" href=\"%(terms_url)s"
-"\">terms of use</a> of this site. Your applications will not be processed "
-"and you won't be able to apply or access resources you are approved for."
-msgstr ""
-"No has aceptado las <a class=\"twl-links\" href=\"%(terms_url)s"
-"\">condiciones de uso</a> de este sitio. Tus solicitudes no serán procesadas "
-"y no podrás solicitar acceso o acceder a recursos a los que estás aprobado."
+msgid "You have not agreed to the <a class=\"twl-links\" href=\"%(terms_url)s\">terms of use</a> of this site. Your applications will not be processed and you won't be able to apply or access resources you are approved for."
+msgstr "No has aceptado las <a class=\"twl-links\" href=\"%(terms_url)s\">condiciones de uso</a> de este sitio. Tus solicitudes no serán procesadas y no podrás solicitar acceso o acceder a recursos a los que estás aprobado."
 
 #. Translators: This link is at the bottom of every page and links to the 'About' page (https://wikipedialibrary.wmflabs.org/about/)
 #: TWLight/templates/new_base.html:107
@@ -2783,12 +2163,8 @@ msgstr "Restablecer contraseña"
 
 #. Translators: If a user goes to reset their password, this message asks them to enter their email to do so.
 #: TWLight/templates/registration/password_reset_form.html:13
-msgid ""
-"Forgot your password? Enter your email address below, and we'll email "
-"instructions for setting a new one."
-msgstr ""
-"¿Olvidaste tu contraseña? Introduce tu correo electrónico y te enviaremos "
-"instrucciones para cambiarla."
+msgid "Forgot your password? Enter your email address below, and we'll email instructions for setting a new one."
+msgstr "¿Olvidaste tu contraseña? Introduce tu correo electrónico y te enviaremos instrucciones para cambiarla."
 
 #. Translators: This is the label for a button that users click to update their public information.
 #: TWLight/users/forms.py:36
@@ -2832,22 +2208,13 @@ msgstr "Estoy de acuerdo con las condiciones de uso"
 
 #. Translators: This text explains how to disagree to the site's terms of use and the restrictions that will come into effect when users disagree to the terms of use.
 #: TWLight/users/forms.py:185
-msgid ""
-"By unchecking this box and clicking “Update” you may explore the site, but "
-"you will not be able to apply for access to materials or evaluate "
-"applications unless you agree with the terms of use."
-msgstr ""
-"Al deshabilitar esta casilla de verificación y hacer clic en \"Actualizar\" "
-"puedes explorar el sitio, pero no vas a poder solicitar acceso a materiales "
-"o evaluar solicitudes a menos que aceptes las condiciones de uso."
+msgid "By unchecking this box and clicking “Update” you may explore the site, but you will not be able to apply for access to materials or evaluate applications unless you agree with the terms of use."
+msgstr "Al deshabilitar esta casilla de verificación y hacer clic en \"Actualizar\" puedes explorar el sitio, pero no vas a poder solicitar acceso a materiales o evaluar solicitudes a menos que aceptes las condiciones de uso."
 
 #. Translators: Users click this button to set their website email address to the one linked to their Wikipedia account.
 #: TWLight/users/forms.py:211
-msgid ""
-"Use my Wikipedia email address (will be updated the next time you login)."
-msgstr ""
-"Usar mi correo electrónico de Wikipedia (se actualizará en tu siguiente "
-"inicio de sesión)."
+msgid "Use my Wikipedia email address (will be updated the next time you login)."
+msgstr "Usar mi correo electrónico de Wikipedia (se actualizará en tu siguiente inicio de sesión)."
 
 #. Translators: This labels a button which users click to change their email.
 #: TWLight/users/forms.py:232
@@ -2857,25 +2224,13 @@ msgstr "Actualizar dirección de correo electrónico"
 #. Translators: Shown if the current user tried to 'favorite' a partner they can't access. Do not translate '{partner}'
 #: TWLight/users/models.py:201
 #, python-brace-format
-msgid ""
-"Cannot add partner {partner} to your favorites because you don't have access "
-"to it"
-msgstr ""
-"No puedes agregar al socio {partner} a tus favoritos porque no tienes acceso "
-"a él"
-
-#. Translators: Do not translate.
-#: TWLight/users/models.py:869
-#, fuzzy, python-brace-format
-#| msgid "Username"
-msgid "{wp_username}"
-msgstr "Nombre de usuario"
+msgid "Cannot add partner {partner} to your favorites because you don't have access to it"
+msgstr "No puedes agregar al socio {partner} a tus favoritos porque no tienes acceso a él"
 
 #. Translators: This error message is shown when there's a problem with the authenticated login process.
 #: TWLight/users/oauth.py:243
 msgid "You tried to log in but presented an invalid access token."
-msgstr ""
-"Intentaste iniciar sesión, pero presentaste un token de acceso inválido."
+msgstr "Intentaste iniciar sesión, pero presentaste un token de acceso inválido."
 
 #. Translators: This message is shown when the OAuth login process fails because the request came from the wrong website. Don't translate {domain}.
 #: TWLight/users/oauth.py:298 TWLight/users/oauth.py:444
@@ -2890,12 +2245,8 @@ msgstr "No se inició el handshaker, favor de inciar sesión de nuevo."
 
 #. Translators: this message is displayed to users that don't have accounts and clicked on a proxied link.
 #: TWLight/users/oauth.py:388
-msgid ""
-"To view this link you need to be an eligible library user. Please login to "
-"continue."
-msgstr ""
-"Para ver este enlace, necesitas ser un usuario activo de la biblioteca. Por "
-"favor, inicia sesión para continuar."
+msgid "To view this link you need to be an eligible library user. Please login to continue."
+msgstr "Para ver este enlace, necesitas ser un usuario activo de la biblioteca. Por favor, inicia sesión para continuar."
 
 #. Translators: This warning message is shown to users when the response received from Wikimedia OAuth servers is not a valid one.
 #: TWLight/users/oauth.py:430
@@ -2920,8 +2271,7 @@ msgstr "No hay token de petición."
 #. Translators: This message is shown when the OAuth login process fails.
 #: TWLight/users/oauth.py:498
 msgid "Access token generation failed, please try logging in again."
-msgstr ""
-"Error al generar el token de acceso. Intente iniciar sesión nuevamente."
+msgstr "Error al generar el token de acceso. Intente iniciar sesión nuevamente."
 
 #. Translators: This message is shown when more information is available on another page. Do not translate {issue}
 #: TWLight/users/oauth.py:507
@@ -2931,25 +2281,13 @@ msgstr "Ver {issue} para más información"
 
 #. Translators: If the user tries to log in, but their account does not meet certain requirements, they cannot login.
 #: TWLight/users/oauth.py:528
-msgid ""
-"Your Wikipedia account does not meet the eligibility criteria in the terms "
-"of use, so your Wikipedia Library Card Platform account cannot be activated."
-msgstr ""
-"Tu cuenta de Wikipedia no cumple con los criterios de elegibilidad en la "
-"condiciones de uso, por lo que tu cuenta de La Biblioteca de Wikipedia no "
-"puede ser activada."
+msgid "Your Wikipedia account does not meet the eligibility criteria in the terms of use, so your Wikipedia Library Card Platform account cannot be activated."
+msgstr "Tu cuenta de Wikipedia no cumple con los criterios de elegibilidad en la condiciones de uso, por lo que tu cuenta de La Biblioteca de Wikipedia no puede ser activada."
 
 #. Translators: If the user tries to log in, but their account does not meet certain requirements, they cannot login.
 #: TWLight/users/oauth.py:536
-msgid ""
-"Your Wikipedia account no longer meets the eligibility criteria in the terms "
-"of use, so you cannot be logged in. If you think you should be able to log "
-"in, please email wikipedialibrary@wikimedia.org."
-msgstr ""
-"Tu cuenta de Wikipedia ya no cumple con los criterios de elegibilidad en las "
-"condiciones de uso, por lo que no puedes iniciar sesión. Si piensas que "
-"deberías poder iniciar sesión, favor de mandar un correo a "
-"wikipedialibrary@wikimedia.org."
+msgid "Your Wikipedia account no longer meets the eligibility criteria in the terms of use, so you cannot be logged in. If you think you should be able to log in, please email wikipedialibrary@wikimedia.org."
+msgstr "Tu cuenta de Wikipedia ya no cumple con los criterios de elegibilidad en las condiciones de uso, por lo que no puedes iniciar sesión. Si piensas que deberías poder iniciar sesión, favor de mandar un correo a wikipedialibrary@wikimedia.org."
 
 #. Translators: this message is displayed to users with brand new accounts.
 #: TWLight/users/oauth.py:549
@@ -2959,15 +2297,8 @@ msgstr "¡Bienvenido! Por favor acepta las condiciones de uso."
 #. Translators: This message is displayed on the confirmation page where users can return their access to partner collections.
 #: TWLight/users/templates/users/authorization_confirm_return.html:13
 #, python-format
-msgid ""
-"You will no longer be able to access <b>%(partner)s's</b> resources via the "
-"Library Card platform, but can request access again by clicking 'renew', if "
-"you change your mind. Are you sure you want to return your access?"
-msgstr ""
-"Ya no tendrás acceso a los recursos de  <b>%(partner)s</b> a través de la "
-"Biblioteca de Wikipedia, pero puedes volver a pedir el acceso al hacer clic "
-"en 'renovar' si cambias de opinión. ¿Estás seguro que quieres regresar tu "
-"acceso?"
+msgid "You will no longer be able to access <b>%(partner)s's</b> resources via the Library Card platform, but can request access again by clicking 'renew', if you change your mind. Are you sure you want to return your access?"
+msgstr "Ya no tendrás acceso a los recursos de  <b>%(partner)s</b> a través de la Biblioteca de Wikipedia, pero puedes volver a pedir el acceso al hacer clic en 'renovar' si cambias de opinión. ¿Estás seguro que quieres regresar tu acceso?"
 
 #. Translators: On the MyLibrary page (https://wikipedialibrary.wmflabs.org/users/my_library), this tab shows all favorite collections a user has.
 #: TWLight/users/templates/users/collections_section.html:9
@@ -3036,14 +2367,8 @@ msgstr "Datos del editor"
 
 #. Translators: This is shown on editor profiles, in their profile page or on applications.
 #: TWLight/users/templates/users/editor_detail.html:59
-msgid ""
-"Information with an * was retrieved from Wikipedia directly. Other "
-"information was entered directly by users or site admins, in their preferred "
-"language."
-msgstr ""
-"La información con un * fue recolectada directamente de Wikipedia. La otra "
-"información fue agregada directamente por usuarios o los administradores del "
-"sitio en su idioma de preferencia."
+msgid "Information with an * was retrieved from Wikipedia directly. Other information was entered directly by users or site admins, in their preferred language."
+msgstr "La información con un * fue recolectada directamente de Wikipedia. La otra información fue agregada directamente por usuarios o los administradores del sitio en su idioma de preferencia."
 
 #. Translators: This distinguishes users who have been flagged as account coordinators. Don't translate username.
 #: TWLight/users/templates/users/editor_detail.html:71
@@ -3053,14 +2378,8 @@ msgstr "%(username)s tiene privilegios de coordinador en este sitio."
 
 #. Translators: This is shown on editor profiles, under the heading for Wikipedia editor data.
 #: TWLight/users/templates/users/editor_detail_data.html:5
-msgid ""
-"This information is updated automatically from your Wikimedia account each "
-"time you log in, except for the Contributions field, where you can describe "
-"your Wikimedia editing history."
-msgstr ""
-"Esta información es actualizada automáticamente desde tu cuenta de Wikimedia "
-"cada vez que inicias sesión, exceptuando el campo de Contribuciones, donde "
-"puedes describir tu historial de ediciones en Wikimedia."
+msgid "This information is updated automatically from your Wikimedia account each time you log in, except for the Contributions field, where you can describe your Wikimedia editing history."
+msgstr "Esta información es actualizada automáticamente desde tu cuenta de Wikimedia cada vez que inicias sesión, exceptuando el campo de Contribuciones, donde puedes describir tu historial de ediciones en Wikimedia."
 
 #. Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this labels the user's username.
 #: TWLight/users/templates/users/editor_detail_data.html:17
@@ -3089,22 +2408,14 @@ msgstr "¿Satisface las condiciones de uso?"
 
 #. Translators: when viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this question has a yes or no answer.
 #: TWLight/users/templates/users/editor_detail_data.html:57
-msgid ""
-"at their last login, did this user meet the criteria set forth in the terms "
-"of use?"
-msgstr ""
-"en su último inicio de sesión, ¿el usuario cumple con los criterios de las "
-"condiciones de uso?"
+msgid "at their last login, did this user meet the criteria set forth in the terms of use?"
+msgstr "en su último inicio de sesión, ¿el usuario cumple con los criterios de las condiciones de uso?"
 
 #. Translators: When viewing a user's profile in an application, this message shows if the software doesn't think that the user is eligible for access. Don't translate username.
 #: TWLight/users/templates/users/editor_detail_data.html:72
 #, python-format
-msgid ""
-"%(username)s may still be eligible for access grants at the coordinators' "
-"discretion."
-msgstr ""
-"%(username)s puede ser eligible para permisos de acceso a discreción del "
-"coordinador."
+msgid "%(username)s may still be eligible for access grants at the coordinators' discretion."
+msgstr "%(username)s puede ser eligible para permisos de acceso a discreción del coordinador."
 
 #. Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this is the heading for a Yes/No ToU question.
 #: TWLight/users/templates/users/editor_detail_data.html:83
@@ -3138,14 +2449,8 @@ msgstr "(exención concedida)"
 #. Translators: This message is shown on a user's profile if their Wikimedia account is blocked on one or more projects. They may still be granted access to the Library Bundle, but need to contact Wikipedia Library staff to verify.
 #: TWLight/users/templates/users/editor_detail_data.html:137
 #, python-format
-msgid ""
-"It looks like you have an active block on your account. If you meet the "
-"other criteria you may still be permitted access to the library - please <a "
-"class=\"twl-links\" href=\"%(contact_url)s\">contact us</a>."
-msgstr ""
-"Parece que tienes un bloqueo activo en tu cuenta. Si reúnes los otros "
-"criterios, podrías tener acceso al Paquete de la Biblioteca. Favor de <a "
-"class=\"twl-links\" href=\"%(contact_url)s\">contactarnos</a>."
+msgid "It looks like you have an active block on your account. If you meet the other criteria you may still be permitted access to the library - please <a class=\"twl-links\" href=\"%(contact_url)s\">contact us</a>."
+msgstr "Parece que tienes un bloqueo activo en tu cuenta. Si reúnes los otros criterios, podrías tener acceso al Paquete de la Biblioteca. Favor de <a class=\"twl-links\" href=\"%(contact_url)s\">contactarnos</a>."
 
 #. Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this is the heading for a Yes/No program eligibility question.
 #: TWLight/users/templates/users/editor_detail_data.html:153
@@ -3154,14 +2459,8 @@ msgstr "¿Elegible para Paquete?"
 
 #. Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this question has a Yes or No answer.
 #: TWLight/users/templates/users/editor_detail_data.html:156
-msgid ""
-"At their last login, did this user meet the criteria set forth in the "
-"Library Bundle? Note that satisfying terms of use is a prerequisite to "
-"bundle eligibility."
-msgstr ""
-"¿El usuario reune los requisitos contenidos en el Paquete de Biblioteca en "
-"su último inicio de sesión? Nótese que la aceptación de las condiciones de "
-"uso es un requisito para acceder al paquete."
+msgid "At their last login, did this user meet the criteria set forth in the Library Bundle? Note that satisfying terms of use is a prerequisite to bundle eligibility."
+msgstr "¿El usuario reune los requisitos contenidos en el Paquete de Biblioteca en su último inicio de sesión? Nótese que la aceptación de las condiciones de uso es un requisito para acceder al paquete."
 
 #. Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this is the heading for a Yes/No program eligibility question.
 #: TWLight/users/templates/users/editor_detail_data.html:177
@@ -3205,25 +2504,14 @@ msgstr "Datos personales"
 
 #. Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this text is in the 'Personal data' section. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/users/templates/users/editor_detail_data.html:262
-msgid ""
-"The following information is visible only to you, site administrators, "
-"publishing partners (where required), and volunteer Wikipedia Library "
-"coordinators (who have signed a Non-Disclosure Agreement)."
-msgstr ""
-"La siguiente información es visible solamente a ti, administradores del "
-"sitio, socios publicadores (donde sea requerido) y coordinadores voluntarios "
-"de la Biblioteca de Wikipedia (quienes han firmado un acuerdo de "
-"confidencialidad)."
+msgid "The following information is visible only to you, site administrators, publishing partners (where required), and volunteer Wikipedia Library coordinators (who have signed a Non-Disclosure Agreement)."
+msgstr "La siguiente información es visible solamente a ti, administradores del sitio, socios publicadores (donde sea requerido) y coordinadores voluntarios de la Biblioteca de Wikipedia (quienes han firmado un acuerdo de confidencialidad)."
 
 #. Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this labels a button which users can click to update or remove their personal information. Don't translate update_url.
 #: TWLight/users/templates/users/editor_detail_data.html:272
 #, python-format
-msgid ""
-"You may <a class=\"twl-links\" href=\"%(update_url)s\">update or delete</a> "
-"your data at any time."
-msgstr ""
-"Puedes <a class=\"twl-links\" href=\"%(update_url)s\">actualizar o borrar</"
-"a> tu información en cualquier momento."
+msgid "You may <a class=\"twl-links\" href=\"%(update_url)s\">update or delete</a> your data at any time."
+msgstr "Puedes <a class=\"twl-links\" href=\"%(update_url)s\">actualizar o borrar</a> tu información en cualquier momento."
 
 #. Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this labels the user's email. Don't remove the *.
 #: TWLight/users/templates/users/editor_detail_data.html:283
@@ -3242,30 +2530,19 @@ msgstr "Afiliación institucional"
 
 #. Translators: This message tells users that they are not eligible to access The Wikipedia Library content.
 #: TWLight/users/templates/users/eligibility_modal.html:7
-msgid ""
-"Sorry, your Wikipedia account doesn’t currently qualify to access The "
-"Wikipedia Library."
-msgstr ""
-"Lo sentimos, esta cuenta de Wikipedia de momento no califica para acceso a "
-"La Biblioteca de Wikipedia."
+msgid "Sorry, your Wikipedia account doesn’t currently qualify to access The Wikipedia Library."
+msgstr "Lo sentimos, esta cuenta de Wikipedia de momento no califica para acceso a La Biblioteca de Wikipedia."
 
 #. Translators: This message tells users that they have not agreed to the terms of use, therefore are ineligible to access the content in The Wikipedia Library.
 #: TWLight/users/templates/users/eligibility_modal.html:30
 #, python-format
-msgid ""
-"Agreed with <a href=\"%(terms)s\" class=\"text-danger\"> terms of use </a>"
+msgid "Agreed with <a href=\"%(terms)s\" class=\"text-danger\"> terms of use </a>"
 msgstr "Aceptó las <a href=\"%(terms)s\">condiciones de uso</a> del sitio"
 
 #: TWLight/users/templates/users/eligibility_modal.html:40
 #, python-format
-msgid ""
-"It looks like you have an active block on your account. If you meet the "
-"other criteria you may still be permitted access to the library - please <a "
-"href=\"%(contact_url)s\">contact us</a>."
-msgstr ""
-"Parece que tienes un bloqueo activo en tu cuenta. Si reúnes los otros "
-"criterios, podrías tener acceso al Paquete de la Biblioteca. Favor de <a "
-"class=\"twl-links\" href=\"%(contact_url)s\">contactarnos</a>."
+msgid "It looks like you have an active block on your account. If you meet the other criteria you may still be permitted access to the library - please <a href=\"%(contact_url)s\">contact us</a>."
+msgstr "Parece que tienes un bloqueo activo en tu cuenta. Si reúnes los otros criterios, podrías tener acceso al Paquete de la Biblioteca. Favor de <a class=\"twl-links\" href=\"%(contact_url)s\">contactarnos</a>."
 
 #. Translators: Instructions to refresh a user's data.
 #: TWLight/users/templates/users/eligibility_modal.html:50
@@ -3285,16 +2562,12 @@ msgstr "Clave"
 #. Translators: Text that describes a search icon.
 #: TWLight/users/templates/users/filter_section.html:45
 msgid "Collection is fully searchable via the search bar"
-msgstr ""
-"Se puede buscar todo el contenido de la colección a través de la barra de "
-"búsqueda"
+msgstr "Se puede buscar todo el contenido de la colección a través de la barra de búsqueda"
 
 #. Translators: Text that describes a search icon.
 #: TWLight/users/templates/users/filter_section.html:54
 msgid "Collection is only partially searchable via the search bar"
-msgstr ""
-"Se puede buscar solamente parte del contenido de la colección a través de la "
-"barra de búsqueda"
+msgstr "Se puede buscar solamente parte del contenido de la colección a través de la barra de búsqueda"
 
 #. Translators: Text that explains when there is no search icon.
 #: TWLight/users/templates/users/filter_section.html:58
@@ -3308,14 +2581,8 @@ msgstr "Establecer idioma"
 
 #. Translators: This text on the user page helps users naviage to the TranslateWiki Wikipedia Library Card platform translation page.
 #: TWLight/users/templates/users/language_form.html:31
-msgid ""
-"You can help translate the tool at <a class=\"twl-links\" href=\"https://"
-"translatewiki.net/wiki/Translating:Wikipedia_Library_Card_Platform"
-"\">translatewiki.net</a>."
-msgstr ""
-"Puedes ayudar a traducir la herramienta en <a class=\"twl-links\" href="
-"\"https://translatewiki.net/wiki/Translating:Wikipedia_Library_Card_Platform"
-"\">translatewiki.net</a>."
+msgid "You can help translate the tool at <a class=\"twl-links\" href=\"https://translatewiki.net/wiki/Translating:Wikipedia_Library_Card_Platform\">translatewiki.net</a>."
+msgstr "Puedes ayudar a traducir la herramienta en <a class=\"twl-links\" href=\"https://translatewiki.net/wiki/Translating:Wikipedia_Library_Card_Platform\">translatewiki.net</a>."
 
 #. Translators: When the user starts a new application and submits the application, the user can view the application and withdraw if need be. This changes the label for the Withdraw button.
 #: TWLight/users/templates/users/my_applications.html:65
@@ -3334,12 +2601,8 @@ msgstr "Solicitar renovación"
 
 #. Translators: On the page listing applications, this text explains a user they cannot renew their application since they've already requested a renewal or there aren't any renewals available.
 #: TWLight/users/templates/users/my_applications.html:79
-msgid ""
-"Renewals are either not required, not available right now, or you have "
-"already requested a renewal."
-msgstr ""
-"Las renovaciones no son necesarias, no están disponibles en este momento o "
-"ya has solicitado una renovación."
+msgid "Renewals are either not required, not available right now, or you have already requested a renewal."
+msgstr "Las renovaciones no son necesarias, no están disponibles en este momento o ya has solicitado una renovación."
 
 #. Translators: This text is the heading of a section in a user's profile where they can change their preferences.
 #: TWLight/users/templates/users/preferences.html:6
@@ -3402,28 +2665,13 @@ msgstr "Restringir procesamiento de datos"
 
 #. Translators: This message is displayed on the page where users can request we stop processing their data.
 #: TWLight/users/templates/users/restrict_data.html:15
-msgid ""
-"Checking this box and clicking “Restrict” will pause all processing of the "
-"data you have entered into this website. You will not be able to apply for "
-"access to resources, your applications will not be further processed, and "
-"none of your data will be altered, until you return to this page and uncheck "
-"the box. This is not the same as deleting your data."
-msgstr ""
-"Al habilitar esta casilla de verificación y al hacer clic a \"Restringir\", "
-"se pausará todo el procesamiento de información que has introducido a este "
-"sitio. No podrás solicitar acceso a los recursos, tus solicitudes no serán "
-"procesadas y nada de tu información será alterada hasta que regreses a esta "
-"página y deshabilites esta casilla de verificación. Esto no es lo mismo que "
-"la eliminación de tu información."
+msgid "Checking this box and clicking “Restrict” will pause all processing of the data you have entered into this website. You will not be able to apply for access to resources, your applications will not be further processed, and none of your data will be altered, until you return to this page and uncheck the box. This is not the same as deleting your data."
+msgstr "Al habilitar esta casilla de verificación y al hacer clic a \"Restringir\", se pausará todo el procesamiento de información que has introducido a este sitio. No podrás solicitar acceso a los recursos, tus solicitudes no serán procesadas y nada de tu información será alterada hasta que regreses a esta página y deshabilites esta casilla de verificación. Esto no es lo mismo que la eliminación de tu información."
 
 #. Translators: This warning message is shown to coordinators who view the data restriction page.
 #: TWLight/users/templates/users/restrict_data.html:26
-msgid ""
-"You are a coordinator on this site. If you restrict the processing of your "
-"data, your coordinator flag will be removed."
-msgstr ""
-"Eres un coordinador de este sitio. Si restringes el procesamiento de tu "
-"información, tu estado de coordinador será removido."
+msgid "You are a coordinator on this site. If you restrict the processing of your data, your coordinator flag will be removed."
+msgstr "Eres un coordinador de este sitio. Si restringes el procesamiento de tu información, tu estado de coordinador será removido."
 
 #. Translators: use the date *when you are translating*, in a language-appropriate format.
 #: TWLight/users/templates/users/terms.html:33
@@ -3442,37 +2690,13 @@ msgstr "Condiciones de Uso y Aviso de Privacidad de la Biblioteca de Wikipedia"
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:51
-msgid ""
-"<a class=\"twl-links\" href=\"https://meta.wikimedia.org/wiki/"
-"The_Wikipedia_Library\"> The Wikipedia Library </a> has partnered with "
-"publishers around the world to allow users to access otherwise paywalled "
-"resources. This website allows Wikipedia editors to search and access these "
-"resources."
-msgstr ""
-"<a class=\"twl-links\" href=\"https://meta.wikimedia.org/wiki/"
-"The_Wikipedia_Library\"> La Biblioteca de Wikipedia </a> se ha asociado con "
-"publicaciones de todo el mundo para permitir a los usuarios acceder recursos "
-"no gratuitos. Este sitio permite a editores de Wikipedia buscar y acceder a "
-"estos recursos."
+msgid "<a class=\"twl-links\" href=\"https://meta.wikimedia.org/wiki/The_Wikipedia_Library\"> The Wikipedia Library </a> has partnered with publishers around the world to allow users to access otherwise paywalled resources. This website allows Wikipedia editors to search and access these resources."
+msgstr "<a class=\"twl-links\" href=\"https://meta.wikimedia.org/wiki/The_Wikipedia_Library\"> La Biblioteca de Wikipedia </a> se ha asociado con publicaciones de todo el mundo para permitir a los usuarios acceder recursos no gratuitos. Este sitio permite a editores de Wikipedia buscar y acceder a estos recursos."
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Wikimedia Foundation should not be translated. WMF should not be translated. Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:63
-msgid ""
-"This program is administered by the Wikimedia Foundation (WMF). These terms "
-"of use and privacy notice pertain to your application for access to "
-"resources through the Wikipedia Library, your use of this website, and your "
-"access to and use of those resources. They also describe our handling of the "
-"information you provide to us in order to create and administer your "
-"Wikipedia Library account. If we make material changes to the terms, we will "
-"notify users."
-msgstr ""
-"Este programa es administrado por la Fundación Wikimedia (WMF). Estas "
-"condiciones de uso y aviso de privacidad son pertinentes a tus solicitudes "
-"de acceso a recursos a través de La Biblioteca de Wikipedia, tu uso de este "
-"sitio y tu acceso y uso de dichos recursos. También describen el manejo de "
-"la información proveída a nosotros para crear y administrar tu cuenta de La "
-"Biblioteca de Wikipedia. Si hacemos cualquier cambio material a las "
-"condiciones de uso, notificaremos a los usuarios."
+msgid "This program is administered by the Wikimedia Foundation (WMF). These terms of use and privacy notice pertain to your application for access to resources through the Wikipedia Library, your use of this website, and your access to and use of those resources. They also describe our handling of the information you provide to us in order to create and administer your Wikipedia Library account. If we make material changes to the terms, we will notify users."
+msgstr "Este programa es administrado por la Fundación Wikimedia (WMF). Estas condiciones de uso y aviso de privacidad son pertinentes a tus solicitudes de acceso a recursos a través de La Biblioteca de Wikipedia, tu uso de este sitio y tu acceso y uso de dichos recursos. También describen el manejo de la información proveída a nosotros para crear y administrar tu cuenta de La Biblioteca de Wikipedia. Si hacemos cualquier cambio material a las condiciones de uso, notificaremos a los usuarios."
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:74
@@ -3481,60 +2705,18 @@ msgstr "Requisitos para una cuenta de la Biblioteca de Wikipedia"
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:78
-msgid ""
-"Access to resources via The Wikipedia Library is reserved for community "
-"members who have demonstrated their commitment to the Wikimedia projects, "
-"and who will use their access to these resources to improve project content. "
-"To that end, in order to be eligible for The Wikipedia Library, we require "
-"that you be registered for a user account on the projects, with at least 500 "
-"edits, six (6) months of activity, and 10+ edits in the last month. We ask "
-"that you do not request access to any publishers with a limited number of "
-"available accounts whose resources you can already access for free through "
-"your local library or university, or another institution or organization, in "
-"order to provide that opportunity to others."
-msgstr ""
-"El acceder a recursos a través de La Biblioteca de Wikipedia está reservado "
-"para miembros de la comunidad que han demostrado su compromiso con los "
-"proyectos de Wikimedia, y que usarán su acceso a estos recursos para mejorar "
-"el contenido del proyecto. Para ese fin, en orden para ser elegible para La "
-"Biblioteca de Wikipedia, requerimos que estés registrado con una cuenta de "
-"usuario en los proyectos, con al menos 500 ediciones, seis (6) meses de "
-"actividad, y más de 10 ediciones en el último mes. Le pedimos que no "
-"solicite acceso a ningún publicador con un número limitado de cuentas "
-"disponibles cuyos recursos ya puede acceder de forma gratuita a través de su "
-"biblioteca o universidad local, u otra institución u organización, para "
-"proveerle esa oportunidad a otros."
+msgid "Access to resources via The Wikipedia Library is reserved for community members who have demonstrated their commitment to the Wikimedia projects, and who will use their access to these resources to improve project content. To that end, in order to be eligible for The Wikipedia Library, we require that you be registered for a user account on the projects, with at least 500 edits, six (6) months of activity, and 10+ edits in the last month. We ask that you do not request access to any publishers with a limited number of available accounts whose resources you can already access for free through your local library or university, or another institution or organization, in order to provide that opportunity to others."
+msgstr "El acceder a recursos a través de La Biblioteca de Wikipedia está reservado para miembros de la comunidad que han demostrado su compromiso con los proyectos de Wikimedia, y que usarán su acceso a estos recursos para mejorar el contenido del proyecto. Para ese fin, en orden para ser elegible para La Biblioteca de Wikipedia, requerimos que estés registrado con una cuenta de usuario en los proyectos, con al menos 500 ediciones, seis (6) meses de actividad, y más de 10 ediciones en el último mes. Le pedimos que no solicite acceso a ningún publicador con un número limitado de cuentas disponibles cuyos recursos ya puede acceder de forma gratuita a través de su biblioteca o universidad local, u otra institución u organización, para proveerle esa oportunidad a otros."
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:94
-msgid ""
-"Additionally, if you are currently blocked or banned from a Wikimedia "
-"project, applications to resources may be rejected or restricted. If you "
-"obtain a Wikipedia Library account, but a block or ban is subsequently "
-"instituted against you on one of the projects, you may lose access to your "
-"Wikipedia Library account."
-msgstr ""
-"Adicionalmente, si está actualmente bloqueado de un proyecto de Wikimedia, "
-"sus solicitudes a recursos podrían ser rechazadas o restringidas. Si obtiene "
-"una cuenta de La Biblioteca de Wikipedia, pero un bloqueo es "
-"subsequentemente instituido hacia usted en uno de los proyectos, podría "
-"perder acceso a su cuenta de La Biblioteca de Wikipedia."
+msgid "Additionally, if you are currently blocked or banned from a Wikimedia project, applications to resources may be rejected or restricted. If you obtain a Wikipedia Library account, but a block or ban is subsequently instituted against you on one of the projects, you may lose access to your Wikipedia Library account."
+msgstr "Adicionalmente, si está actualmente bloqueado de un proyecto de Wikimedia, sus solicitudes a recursos podrían ser rechazadas o restringidas. Si obtiene una cuenta de La Biblioteca de Wikipedia, pero un bloqueo es subsequentemente instituido hacia usted en uno de los proyectos, podría perder acceso a su cuenta de La Biblioteca de Wikipedia."
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:104
-msgid ""
-"Your eligibility to access The Wikipedia Library is assessed at each login. "
-"While more than half of the library's content is provided via this automated "
-"eligibility check, access to other publisher's content may be time limited, "
-"typically lapsing after one year, after which you will usually need to apply "
-"for renewal."
-msgstr ""
-"Su elegibilidad para acceder La Biblioteca de Wikipedia es juzgada en cada "
-"sesión. Mientras que más de la mitad del contenido es proporcionado a través "
-"de este revisor de eligibilidad automático, el acceso al contenido de otros "
-"publicadores puede estar limitado temporalmente, generalmente caducando "
-"después de un año, después de lo que normalmente necesitará solicitar una "
-"renovación."
+msgid "Your eligibility to access The Wikipedia Library is assessed at each login. While more than half of the library's content is provided via this automated eligibility check, access to other publisher's content may be time limited, typically lapsing after one year, after which you will usually need to apply for renewal."
+msgstr "Su elegibilidad para acceder La Biblioteca de Wikipedia es juzgada en cada sesión. Mientras que más de la mitad del contenido es proporcionado a través de este revisor de eligibilidad automático, el acceso al contenido de otros publicadores puede estar limitado temporalmente, generalmente caducando después de un año, después de lo que normalmente necesitará solicitar una renovación."
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:114
@@ -3543,71 +2725,28 @@ msgstr "Aplicar por medio de tu cuenta de la Biblioteca de Wikipedia"
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:118
-msgid ""
-"In order to apply for access to a partner resource, you must provide us with "
-"certain information, which we will use to evaluate your application. If your "
-"application is approved, we may transfer the information you have given us "
-"to the publishers whose resources you wish to access. They will either "
-"contact you with the account information directly or we will send access "
-"information to you ourselves."
-msgstr ""
-"Para solicitar acceso al recurso de un socio, debe proporcionarnos con "
-"cierta información, la cual  utilizaremos para evaluar su solicitud. Si su "
-"solicitud es aprobada, podemos transferir la información que nos ha dado a "
-"los editores cuyos recursos desea acceder. Le contactarán con la información "
-"de la cuenta directamente o le enviaremos la informacion de acceso nosotros "
-"mismos."
+msgid "In order to apply for access to a partner resource, you must provide us with certain information, which we will use to evaluate your application. If your application is approved, we may transfer the information you have given us to the publishers whose resources you wish to access. They will either contact you with the account information directly or we will send access information to you ourselves."
+msgstr "Para solicitar acceso al recurso de un socio, debe proporcionarnos con cierta información, la cual  utilizaremos para evaluar su solicitud. Si su solicitud es aprobada, podemos transferir la información que nos ha dado a los editores cuyos recursos desea acceder. Le contactarán con la información de la cuenta directamente o le enviaremos la informacion de acceso nosotros mismos."
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:130
-msgid ""
-"In addition to the basic information you provide to us, our system will "
-"retrieve some information directly from the Wikimedia projects: your "
-"username, email address, edit count, registration date, user ID number, "
-"groups to which you belong, and any special user rights."
-msgstr ""
-"En adición a la información básica que usted nos provea, nuestro sistema "
-"usará alguna información directamente de los proyectos Wikimedia: su nombre "
-"de usuario, dirección de correo electrónico, cantidad de ediciones, fecha de "
-"registro, número de identificación, grupos a los que pertenece y cualquier "
-"permiso especial."
+msgid "In addition to the basic information you provide to us, our system will retrieve some information directly from the Wikimedia projects: your username, email address, edit count, registration date, user ID number, groups to which you belong, and any special user rights."
+msgstr "En adición a la información básica que usted nos provea, nuestro sistema usará alguna información directamente de los proyectos Wikimedia: su nombre de usuario, dirección de correo electrónico, cantidad de ediciones, fecha de registro, número de identificación, grupos a los que pertenece y cualquier permiso especial."
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:140
-msgid ""
-"Each time you log in to the Wikipedia Library Card Platform, this "
-"information will be automatically updated."
-msgstr ""
-"Cada vez que inicias sesión en la Plataforma de Tarjetas de Biblioteca de "
-"Wikipedia (Wikipedia Library Card Platform), esta información se actualizará "
-"automáticamente."
+msgid "Each time you log in to the Wikipedia Library Card Platform, this information will be automatically updated."
+msgstr "Cada vez que inicias sesión en la Plataforma de Tarjetas de Biblioteca de Wikipedia (Wikipedia Library Card Platform), esta información se actualizará automáticamente."
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:148
-msgid ""
-"We will ask you to provide us with some information about your history of "
-"contributions to the Wikimedia projects. Information on contribution history "
-"is optional, but will greatly assist us in evaluating your application."
-msgstr ""
-"Le pediremos que nos provea alguna información sobre su historial de "
-"contribuciones a los proyectos de Wikimedia. La información del historial de "
-"contribuciones es opcional, pero nos ayudará mucho en evaluar su solicitud."
+msgid "We will ask you to provide us with some information about your history of contributions to the Wikimedia projects. Information on contribution history is optional, but will greatly assist us in evaluating your application."
+msgstr "Le pediremos que nos provea alguna información sobre su historial de contribuciones a los proyectos de Wikimedia. La información del historial de contribuciones es opcional, pero nos ayudará mucho en evaluar su solicitud."
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). WMF should not be translated. Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:157
-msgid ""
-"The information you provide when creating your account will be visible to "
-"you while on the site but not to others unless they are approved Wikipedia "
-"Library Coordinators, WMF Staff, or WMF Contractors who need access to this "
-"data in order to carry out their work with the Wikipedia Library, all of "
-"whom are subject to non-disclosure obligations."
-msgstr ""
-"La información que nos provea al crear su cuenta será visible para usted "
-"mientras usted esté en el sitio, pero no para otros a menos que sean "
-"Coordinadores de La Biblioteca de Wikipedia, personal de WMF, o contratistas "
-"de WMF que necesiten acceso a estos datos para llevar a cabo su trabajo con "
-"La Biblioteca de Wikipedia, todos los cuales están sujetos a obligaciones de "
-"no divulgación."
+msgid "The information you provide when creating your account will be visible to you while on the site but not to others unless they are approved Wikipedia Library Coordinators, WMF Staff, or WMF Contractors who need access to this data in order to carry out their work with the Wikipedia Library, all of whom are subject to non-disclosure obligations."
+msgstr "La información que nos provea al crear su cuenta será visible para usted mientras usted esté en el sitio, pero no para otros a menos que sean Coordinadores de La Biblioteca de Wikipedia, personal de WMF, o contratistas de WMF que necesiten acceso a estos datos para llevar a cabo su trabajo con La Biblioteca de Wikipedia, todos los cuales están sujetos a obligaciones de no divulgación."
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:167
@@ -3616,61 +2755,33 @@ msgstr "Tu Uso de Recursos de Publicaciones"
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:171
-msgid ""
-"In order to access an individual publisher’s resources, you must agree to "
-"that publisher’s terms of use and privacy policy. You agree that you will "
-"not violate such terms and policies in connection with your use of the "
-"Wikipedia Library. Additionally, the following activities are prohibited "
-"while accessing publisher resources through the Wikipedia Library."
-msgstr ""
-"Para acceder los recursos de un editor individual, debe aceptar las "
-"condiciones de uso y la política de privacidad de el editor.  Está de "
-"acuerdo que no violará tales plazos y políticas en conexión con su uso de La "
-"Biblioteca de Wikipedia. Además, las siguientes actividades están prohibidas "
-"mientras esté accediendo a recursos de un editor a través de la Biblioteca "
-"de Wikipedia."
+msgid "In order to access an individual publisher’s resources, you must agree to that publisher’s terms of use and privacy policy. You agree that you will not violate such terms and policies in connection with your use of the Wikipedia Library. Additionally, the following activities are prohibited while accessing publisher resources through the Wikipedia Library."
+msgstr "Para acceder los recursos de un editor individual, debe aceptar las condiciones de uso y la política de privacidad de el editor.  Está de acuerdo que no violará tales plazos y políticas en conexión con su uso de La Biblioteca de Wikipedia. Además, las siguientes actividades están prohibidas mientras esté accediendo a recursos de un editor a través de la Biblioteca de Wikipedia."
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:184
-msgid ""
-"Sharing your Wikipedia account, usernames, passwords, or any access codes "
-"for publisher resources with others;"
-msgstr ""
-"Compartir tu cuenta de Wikipedia, tus usuarios, contraseñas o cualquier "
-"código de acceso para recursos de socios con otros;"
+msgid "Sharing your Wikipedia account, usernames, passwords, or any access codes for publisher resources with others;"
+msgstr "Compartir tu cuenta de Wikipedia, tus usuarios, contraseñas o cualquier código de acceso para recursos de socios con otros;"
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:191
-msgid ""
-"Automatically scraping or downloading restricted content from publishers;"
+msgid "Automatically scraping or downloading restricted content from publishers;"
 msgstr "Hacer scraping o descargar contenido restringido de publicaciones;"
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:197
-msgid ""
-"Systematically making printed or electronic copies of multiple extracts of "
-"restricted content available for any purpose;"
-msgstr ""
-"Imprimir o hacer copias electrónicas sistemáticamente de extractos múltiples "
-"de contenido restringido disponible para cualquier propósito;"
+msgid "Systematically making printed or electronic copies of multiple extracts of restricted content available for any purpose;"
+msgstr "Imprimir o hacer copias electrónicas sistemáticamente de extractos múltiples de contenido restringido disponible para cualquier propósito;"
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:204
-msgid ""
-"Data mining metadata without permission—for example, in order to use "
-"metadata for auto-created stub articles;"
-msgstr ""
-"Hacer minería de datos sin permiso – por ejemplo, para usar los metadatos "
-"para auto-generar plantillas de artículos;"
+msgid "Data mining metadata without permission—for example, in order to use metadata for auto-created stub articles;"
+msgstr "Hacer minería de datos sin permiso – por ejemplo, para usar los metadatos para auto-generar plantillas de artículos;"
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:211
-msgid ""
-"Using the access you receive through the Wikipedia Library for profit by "
-"selling access to your account or resources which you have through it."
-msgstr ""
-"Usar el acceso recibido vía la Biblioteca de Wikipedia para beneficio propio "
-"para vender acceso a tu cuenta o los recursos obtenidos a través de ella."
+msgid "Using the access you receive through the Wikipedia Library for profit by selling access to your account or resources which you have through it."
+msgstr "Usar el acceso recibido vía la Biblioteca de Wikipedia para beneficio propio para vender acceso a tu cuenta o los recursos obtenidos a través de ella."
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:220
@@ -3679,26 +2790,13 @@ msgstr "Servicios externos de búsqueda y «proxy»"
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:224
-msgid ""
-"Certain resources may only be accessed using an external search service, "
-"such as the EBSCO Discovery Service, or a proxy service, such as OCLC "
-"EZProxy. If you use such external search and/or proxy services, please "
-"review the applicable terms of use and privacy policies."
-msgstr ""
-"Ciertos recursos sólo pueden ser accedidos utilizando un servicio de "
-"búsqueda externo, como el Servicio de Búsqueda EBSCO, o un servicio de "
-"proxy, como OCLC EZProxy. Si  utiliza tal búsqueda externa y/o servicio de "
-"proxy, por favor revise los términos de uso y las políticas de privacidad "
-"aplicables."
+msgid "Certain resources may only be accessed using an external search service, such as the EBSCO Discovery Service, or a proxy service, such as OCLC EZProxy. If you use such external search and/or proxy services, please review the applicable terms of use and privacy policies."
+msgstr "Ciertos recursos sólo pueden ser accedidos utilizando un servicio de búsqueda externo, como el Servicio de Búsqueda EBSCO, o un servicio de proxy, como OCLC EZProxy. Si  utiliza tal búsqueda externa y/o servicio de proxy, por favor revise los términos de uso y las políticas de privacidad aplicables."
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:234
-msgid ""
-"In addition, if you use OCLC EZProxy, please note that you may not use it "
-"for commercial purposes."
-msgstr ""
-"Adicionalmente, si utilizas OCLC EZProxy, favor de notar que no puede ser "
-"usado para propósitos comerciales."
+msgid "In addition, if you use OCLC EZProxy, please note that you may not use it for commercial purposes."
+msgstr "Adicionalmente, si utilizas OCLC EZProxy, favor de notar que no puede ser usado para propósitos comerciales."
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:241
@@ -3708,202 +2806,51 @@ msgstr "Retención y Manejo de Datos"
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Wikimedia Foundation should not be translated. Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:245
 #, fuzzy
-msgid ""
-"The Wikimedia Foundation and our service providers use your information for "
-"the legitimate purpose of providing Wikipedia Library services in support of "
-"our charitable mission. When you apply for a Wikipedia Library account, or "
-"use your Wikipedia Library account, we may routinely collect the following "
-"information: your username, email address, edit count, registration date, "
-"user ID number, groups to which you belong, and any special user rights; "
-"your name, country of residence, and/or affiliation, if required by a "
-"partner to which you are applying; your narrative description of your "
-"contributions and reasons for applying for access to partner resources; and "
-"the date you agree to these terms of use."
-msgstr ""
-"La Wikimedia Foundation y nuestros proveedores de servicio utilizan su "
-"información para el propósito legítimo de proporcionarle a La Biblioteca de "
-"Wikipedia servicios en soporte de nuestra misión benéfica. Cuándo  solicite "
-"una cuenta de Biblioteca de la Wikipedia, o use su cuenta de La Biblioteca "
-"de Wikipedia, podemos rutinariamente recoger la siguiente información: su "
-"nombre de usuario, dirección de correo electrónico, cantidad de ediciones, "
-"fecha de registro, número de identificación de usuario, grupos a los cuales "
-"pertenece, y cualesquier derechos de usuario especiales; su nombre, país de "
-"residencia, ocupación, y/o afiliación, si lo requiere un socio que esté "
-"solicitando; su descripción narrativa de sus contribuciones y razones para "
-"solicitar acceso a recursos de un socio; y la fecha en la que acepte estos "
-"términos de uso."
+msgid "The Wikimedia Foundation and our service providers use your information for the legitimate purpose of providing Wikipedia Library services in support of our charitable mission. When you apply for a Wikipedia Library account, or use your Wikipedia Library account, we may routinely collect the following information: your username, email address, edit count, registration date, user ID number, groups to which you belong, and any special user rights; your name, country of residence, and/or affiliation, if required by a partner to which you are applying; your narrative description of your contributions and reasons for applying for access to partner resources; and the date you agree to these terms of use."
+msgstr "La Wikimedia Foundation y nuestros proveedores de servicio utilizan su información para el propósito legítimo de proporcionarle a La Biblioteca de Wikipedia servicios en soporte de nuestra misión benéfica. Cuándo  solicite una cuenta de Biblioteca de la Wikipedia, o use su cuenta de La Biblioteca de Wikipedia, podemos rutinariamente recoger la siguiente información: su nombre de usuario, dirección de correo electrónico, cantidad de ediciones, fecha de registro, número de identificación de usuario, grupos a los cuales pertenece, y cualesquier derechos de usuario especiales; su nombre, país de residencia, ocupación, y/o afiliación, si lo requiere un socio que esté solicitando; su descripción narrativa de sus contribuciones y razones para solicitar acceso a recursos de un socio; y la fecha en la que acepte estos términos de uso."
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:262
 #, fuzzy, python-format
-msgid ""
-"Each publisher who is a member of the Wikipedia Library program requires "
-"different specific information in the application. Some publishers may "
-"request only an email address, while others request more detailed data, such "
-"as your name, location, or institutional affiliation. When you complete your "
-"application, you will only be asked to supply information required by the "
-"publishers you have chosen, and each publisher will only receive the "
-"information they require for providing you with access. Please see our <a "
-"class=\"twl-links\" href=\"%(all_partners_url)s\">partner information</a> "
-"pages to learn what information is required by each publisher to gain access "
-"to their resources."
-msgstr ""
-"Cada editor que sea un miembro del programa de La Biblioteca de Wikipedia "
-"requiere diferente  información concreta en la solicitud. Algunos editores "
-"pueden pedir sólo una dirección de correo electrónico, mientras otros piden "
-"datos más detallado, como su nombre, ubicación, ocupación, o afiliación "
-"institucional. Cuándo  complete su aplicación, sólo se le pedirá suministrar "
-"la información requerida por los editores que ha escogido, y cada editor "
-"sólo recibirá la información requerida para proporcionarle acceso. Por favor "
-"vea nuestras páginas de <a class=\"twl-links\" href=\"%(all_partners_url)s"
-"\"></a> información de los socios para aprender que información es requerida "
-"por cada editor para ganar acceso a sus recursos."
+msgid "Each publisher who is a member of the Wikipedia Library program requires different specific information in the application. Some publishers may request only an email address, while others request more detailed data, such as your name, location, or institutional affiliation. When you complete your application, you will only be asked to supply information required by the publishers you have chosen, and each publisher will only receive the information they require for providing you with access. Please see our <a class=\"twl-links\" href=\"%(all_partners_url)s\">partner information</a> pages to learn what information is required by each publisher to gain access to their resources."
+msgstr "Cada editor que sea un miembro del programa de La Biblioteca de Wikipedia requiere diferente  información concreta en la solicitud. Algunos editores pueden pedir sólo una dirección de correo electrónico, mientras otros piden datos más detallado, como su nombre, ubicación, ocupación, o afiliación institucional. Cuándo  complete su aplicación, sólo se le pedirá suministrar la información requerida por los editores que ha escogido, y cada editor sólo recibirá la información requerida para proporcionarle acceso. Por favor vea nuestras páginas de <a class=\"twl-links\" href=\"%(all_partners_url)s\"></a> información de los socios para aprender que información es requerida por cada editor para ganar acceso a sus recursos."
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Wikimedia Foundation should not be translated. Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:277
-msgid ""
-"Some Wikipedia Library pages are visible without logging in, but you will "
-"need to log in to apply or access proprietary partner resources. We use the "
-"data provided by you via OAuth and Wikimedia API calls to assess your "
-"application for access and to process approved requests."
-msgstr ""
-"Algunas páginas de La Biblioteca de Wikipedia son navegables in tener que "
-"iniciar sesión, pero debes iniciar sesión para solicitar acceso o acceder a "
-"recursos que son propiedad de nuestros socios. Usamos los datos "
-"proporcionados por ti por medio de OAuth y de llamadas de la API de "
-"Wikimedia para evaluar tu solicitud de acceso y para procesar las "
-"solicitudes aprobadas."
+msgid "Some Wikipedia Library pages are visible without logging in, but you will need to log in to apply or access proprietary partner resources. We use the data provided by you via OAuth and Wikimedia API calls to assess your application for access and to process approved requests."
+msgstr "Algunas páginas de La Biblioteca de Wikipedia son navegables in tener que iniciar sesión, pero debes iniciar sesión para solicitar acceso o acceder a recursos que son propiedad de nuestros socios. Usamos los datos proporcionados por ti por medio de OAuth y de llamadas de la API de Wikimedia para evaluar tu solicitud de acceso y para procesar las solicitudes aprobadas."
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:288
 #, python-format
-msgid ""
-"In order to administer the Wikipedia Library program, we will retain the "
-"application data we collect from you for three years after your most recent "
-"login, unless you delete your account, as described below. You can log in "
-"and go to <a class=\"twl-links\" href=\"%(profile_url)s\">your profile page</"
-"a> in order to see the information associated with your account, and can "
-"download it in JSON format. You may access, update, restrict, or delete this "
-"information at any time, except for the information that is automatically "
-"retrieved from the projects. If you have any questions or concerns about the "
-"handling of your data, please contact <a class=\"twl-links\" href=\"mailto:"
-"wikipedialibrary@wikimedia.org?Subject=Wikipedia%%20Library%%20Card"
-"%%20account%%20deactivation\"> wikipedialibrary@wikimedia.org </a>."
-msgstr ""
-"Para administrar el programa de la Biblioteca de Wikipedia, conservaremos "
-"los datos de la aplicación que recopilamos de usted durante tres años "
-"después de su inicio de sesión más reciente, a menos que elimine su cuenta, "
-"como se describe a continuación. Puede iniciar sesión e ir a <a class=\"twl-"
-"links\" href=\"%(profile_url)s\">su página de perfil</a> para ver la "
-"información asociada con su cuenta y descargarla en formato JSON. Puede "
-"acceder, actualizar, restringir o eliminar esta información en cualquier "
-"momento, excepto la información que se recupera automáticamente de los "
-"proyectos. Si tiene alguna pregunta o inquietud sobre el manejo de sus "
-"datos, comuníquese con <a class=\"twl-links\" href=\"mailto:"
-"wikipedialibrary@wikimedia.org?Subject=Wikipedia%%20Library%%20Card"
-"%%20account%%20deactivation\"> wikipedialibrary@wikimedia.org</a>."
+msgid "In order to administer the Wikipedia Library program, we will retain the application data we collect from you for three years after your most recent login, unless you delete your account, as described below. You can log in and go to <a class=\"twl-links\" href=\"%(profile_url)s\">your profile page</a> in order to see the information associated with your account, and can download it in JSON format. You may access, update, restrict, or delete this information at any time, except for the information that is automatically retrieved from the projects. If you have any questions or concerns about the handling of your data, please contact <a class=\"twl-links\" href=\"mailto:wikipedialibrary@wikimedia.org?Subject=Wikipedia%%20Library%%20Card%%20account%%20deactivation\"> wikipedialibrary@wikimedia.org </a>."
+msgstr "Para administrar el programa de la Biblioteca de Wikipedia, conservaremos los datos de la aplicación que recopilamos de usted durante tres años después de su inicio de sesión más reciente, a menos que elimine su cuenta, como se describe a continuación. Puede iniciar sesión e ir a <a class=\"twl-links\" href=\"%(profile_url)s\">su página de perfil</a> para ver la información asociada con su cuenta y descargarla en formato JSON. Puede acceder, actualizar, restringir o eliminar esta información en cualquier momento, excepto la información que se recupera automáticamente de los proyectos. Si tiene alguna pregunta o inquietud sobre el manejo de sus datos, comuníquese con <a class=\"twl-links\" href=\"mailto:wikipedialibrary@wikimedia.org?Subject=Wikipedia%%20Library%%20Card%%20account%%20deactivation\"> wikipedialibrary@wikimedia.org</a>."
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:305
 #, fuzzy
-msgid ""
-"If you decide to disable your Wikipedia Library account, you can use the "
-"delete button on your profile to delete certain personal information "
-"associated with your account. We will delete your real name, institutional "
-"affiliation, and country of residence. Please note that the system will "
-"retain a record of your username, the publishers to which you applied or had "
-"access, and the dates of that access. Note that deletion is not reversible. "
-"Deletion of your Wikipedia Library account may also correspond with the "
-"removal of any resource access to which you were eligible or approved. If "
-"you request the deletion of account information and later wish to apply for "
-"a new account, you will need to provide the necessary information again."
-msgstr ""
-"Si decide deshabilitar su cuenta de la Biblioteca de Wikipedia, puede usar "
-"el botón Eliminar en su perfil para eliminar cierta información personal "
-"asociada con su cuenta. Eliminaremos su nombre real, ocupación, afiliación "
-"institucional y país de residencia. Tenga en cuenta que el sistema "
-"conservará un registro de su nombre de usuario, las colecciones a las que "
-"solicitó o tuvo acceso y las fechas de ese acceso. Tenga en cuenta que la "
-"eliminación no es reversible. La eliminación de su cuenta de la Biblioteca "
-"de Wikipedia también puede corresponder con la eliminación de cualquier "
-"acceso a recursos para el cual era elegible o aprobado. Si solicita la "
-"eliminación de la información de la cuenta y luego desea solicitar una nueva "
-"cuenta, deberá proporcionar la información necesaria nuevamente."
+msgid "If you decide to disable your Wikipedia Library account, you can use the delete button on your profile to delete certain personal information associated with your account. We will delete your real name, institutional affiliation, and country of residence. Please note that the system will retain a record of your username, the publishers to which you applied or had access, and the dates of that access. Note that deletion is not reversible. Deletion of your Wikipedia Library account may also correspond with the removal of any resource access to which you were eligible or approved. If you request the deletion of account information and later wish to apply for a new account, you will need to provide the necessary information again."
+msgstr "Si decide deshabilitar su cuenta de la Biblioteca de Wikipedia, puede usar el botón Eliminar en su perfil para eliminar cierta información personal asociada con su cuenta. Eliminaremos su nombre real, ocupación, afiliación institucional y país de residencia. Tenga en cuenta que el sistema conservará un registro de su nombre de usuario, las colecciones a las que solicitó o tuvo acceso y las fechas de ese acceso. Tenga en cuenta que la eliminación no es reversible. La eliminación de su cuenta de la Biblioteca de Wikipedia también puede corresponder con la eliminación de cualquier acceso a recursos para el cual era elegible o aprobado. Si solicita la eliminación de la información de la cuenta y luego desea solicitar una nueva cuenta, deberá proporcionar la información necesaria nuevamente."
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). WMF should not be translated. Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:321
-msgid ""
-"The Wikipedia Library is run by WMF Staff, Contractors, and approved "
-"volunteer Coordinators. The data associated with your account will be shared "
-"with the WMF staff, contractors, service providers, and volunteer "
-"coordinators who need to process the information in connection with their "
-"work for the Wikipedia Library, and who are subject to confidentiality "
-"obligations. We will also use your data for internal Wikipedia Library "
-"purposes such as distributing user surveys and account notifications, and in "
-"a depersonalized or aggregated fashion for statistical analysis and "
-"administration. Finally, we will share your information with the publishers "
-"whom you specifically select in order to provide you with access to "
-"resources. Otherwise, your information will not be shared with third "
-"parties, with the exception of the circumstances described below."
-msgstr ""
-"La biblioteca de Wikipedia está dirigida por personal de WMF, contratistas y "
-"coordinadores voluntarios aprobados. Los datos asociados con su cuenta se "
-"compartirán con el personal de WMF, los contratistas, los proveedores de "
-"servicios y los coordinadores de voluntarios que necesiten procesar la "
-"información en relación con su trabajo para la Biblioteca de Wikipedia y que "
-"están sujetos a obligaciones de confidencialidad. También utilizaremos sus "
-"datos para fines internos de la biblioteca de Wikipedia, como distribuir "
-"encuestas de usuarios y notificaciones de cuentas, y de forma "
-"despersonalizada o agregada para análisis y administración estadísticos. "
-"Finalmente, compartiremos su información con los editores que seleccione "
-"específicamente para brindarle acceso a los recursos. De lo contrario, su "
-"información no será compartida con terceros, con excepción de las "
-"circunstancias que se describen a continuación."
+msgid "The Wikipedia Library is run by WMF Staff, Contractors, and approved volunteer Coordinators. The data associated with your account will be shared with the WMF staff, contractors, service providers, and volunteer coordinators who need to process the information in connection with their work for the Wikipedia Library, and who are subject to confidentiality obligations. We will also use your data for internal Wikipedia Library purposes such as distributing user surveys and account notifications, and in a depersonalized or aggregated fashion for statistical analysis and administration. Finally, we will share your information with the publishers whom you specifically select in order to provide you with access to resources. Otherwise, your information will not be shared with third parties, with the exception of the circumstances described below."
+msgstr "La biblioteca de Wikipedia está dirigida por personal de WMF, contratistas y coordinadores voluntarios aprobados. Los datos asociados con su cuenta se compartirán con el personal de WMF, los contratistas, los proveedores de servicios y los coordinadores de voluntarios que necesiten procesar la información en relación con su trabajo para la Biblioteca de Wikipedia y que están sujetos a obligaciones de confidencialidad. También utilizaremos sus datos para fines internos de la biblioteca de Wikipedia, como distribuir encuestas de usuarios y notificaciones de cuentas, y de forma despersonalizada o agregada para análisis y administración estadísticos. Finalmente, compartiremos su información con los editores que seleccione específicamente para brindarle acceso a los recursos. De lo contrario, su información no será compartida con terceros, con excepción de las circunstancias que se describen a continuación."
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). WMF should not be translated.
 #: TWLight/users/templates/users/terms.html:338
-msgid ""
-"We may disclose any collected information when required by law, when we have "
-"your permission, when needed to protect our rights, privacy, safety, users, "
-"or the general public, and when necessary to enforce these terms, WMF’s "
-"general <a class=\"twl-links\" href=\"https://foundation.wikimedia.org/wiki/"
-"Terms_of_Use\">Terms of Use</a>, or any other WMF policy."
-msgstr ""
-"Podemos divulgar cualquier información recopilada cuando lo exija la ley, "
-"cuando tengamos su permiso, cuando sea necesario para proteger nuestros "
-"derechos, privacidad, seguridad, usuarios o el público en general, y cuando "
-"sea necesario para hacer cumplir estos términos, <a class=\"twl-links\" href="
-"\"https://foundation.wikimedia.org/wiki/Terms_of_Use\">los Términos de uso</"
-"a> generales de WMF, o cualquier otra política de WMF."
+msgid "We may disclose any collected information when required by law, when we have your permission, when needed to protect our rights, privacy, safety, users, or the general public, and when necessary to enforce these terms, WMF’s general <a class=\"twl-links\" href=\"https://foundation.wikimedia.org/wiki/Terms_of_Use\">Terms of Use</a>, or any other WMF policy."
+msgstr "Podemos divulgar cualquier información recopilada cuando lo exija la ley, cuando tengamos su permiso, cuando sea necesario para proteger nuestros derechos, privacidad, seguridad, usuarios o el público en general, y cuando sea necesario para hacer cumplir estos términos, <a class=\"twl-links\" href=\"https://foundation.wikimedia.org/wiki/Terms_of_Use\">los Términos de uso</a> generales de WMF, o cualquier otra política de WMF."
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:349
-msgid ""
-"We take the security of your personal data seriously, and take reasonable "
-"precautions to ensure your data is protected. These precautions include "
-"access controls to limit who has access to your data and security "
-"technologies to protect data stored on the server. However, we cannot "
-"guarantee the safety of your data as it is transmitted and stored."
-msgstr ""
-"Tomamos la seguridad de tus datos personales seriamente y tomamos las "
-"precauciones razonables para asegurar que tus datos estén protegidos. Estas "
-"medidas incluyen control de acceso para limitar quién tiene acceso a tus "
-"datos y tecnologías de seguridad para proteger datos almacenados en el "
-"servidor. Sin embargo, no podemos garantizar la seguridad de tus datos "
-"mientras están siendo transmitidos y almacenados."
+msgid "We take the security of your personal data seriously, and take reasonable precautions to ensure your data is protected. These precautions include access controls to limit who has access to your data and security technologies to protect data stored on the server. However, we cannot guarantee the safety of your data as it is transmitted and stored."
+msgstr "Tomamos la seguridad de tus datos personales seriamente y tomamos las precauciones razonables para asegurar que tus datos estén protegidos. Estas medidas incluyen control de acceso para limitar quién tiene acceso a tus datos y tecnologías de seguridad para proteger datos almacenados en el servidor. Sin embargo, no podemos garantizar la seguridad de tus datos mientras están siendo transmitidos y almacenados."
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:360
-msgid ""
-"Please note that these terms do not control the use and handling of your "
-"data by the publishers and service providers whose resources you access or "
-"apply to access. Please read their individual privacy policies for that "
-"information."
-msgstr ""
-"Tenga en cuenta que estos términos no controlan el uso y manejo de sus datos "
-"por parte de los editores y proveedores de servicios a cuyos recursos accede "
-"o solicita acceder. Lea sus políticas de privacidad individuales para "
-"obtener esa información."
+msgid "Please note that these terms do not control the use and handling of your data by the publishers and service providers whose resources you access or apply to access. Please read their individual privacy policies for that information."
+msgstr "Tenga en cuenta que estos términos no controlan el uso y manejo de sus datos por parte de los editores y proveedores de servicios a cuyos recursos accede o solicita acceder. Lea sus políticas de privacidad individuales para obtener esa información."
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:368
@@ -3912,54 +2859,18 @@ msgstr "Nota importante"
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Wikimedia Foundation should not be translated. Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:373
-msgid ""
-"The Wikimedia Foundation is a nonprofit organization based in San Francisco, "
-"California. The Wikipedia Library program provides access to resources held "
-"by publishers in multiple countries. If you apply for a Wikipedia Library "
-"account (whether you are inside or outside of the United States), you "
-"understand that your personal data will be collected, transferred, stored, "
-"processed, disclosed and otherwise used in the U.S. as described in this "
-"privacy policy. You also understand that your information may be transferred "
-"by us from the U.S. to other countries, which may have different or less "
-"stringent data protection laws than your country, in connection with "
-"providing services to you, including evaluating your application and "
-"securing access to your chosen publishers (locations for each publisher are "
-"outlined on their respective partner information pages)."
-msgstr ""
-"La Fundación Wikimedia es una organización sin fines de lucro con sede en "
-"San Francisco, California. El programa de la Biblioteca de Wikipedia brinda "
-"acceso a recursos de publicaciones en varios países. Si solicita una cuenta "
-"de la Biblioteca de Wikipedia (ya sea que se encuentre dentro o fuera de los "
-"Estados Unidos), comprende que sus datos personales serán recopilados, "
-"transferidos, almacenados, procesados, divulgados y utilizados de otro modo "
-"en los EE. UU. como se describe en esta política de privacidad. . También "
-"comprende que podemos transferir su información desde los EE. UU. a otros "
-"países, que pueden tener leyes de protección de datos diferentes o menos "
-"estrictas que las de su país, en relación con la prestación de servicios, "
-"incluida la evaluación de su solicitud y la seguridad del acceso a su "
-"elección. editores (las ubicaciones de cada editor se describen en sus "
-"respectivas páginas de información de socios)."
+msgid "The Wikimedia Foundation is a nonprofit organization based in San Francisco, California. The Wikipedia Library program provides access to resources held by publishers in multiple countries. If you apply for a Wikipedia Library account (whether you are inside or outside of the United States), you understand that your personal data will be collected, transferred, stored, processed, disclosed and otherwise used in the U.S. as described in this privacy policy. You also understand that your information may be transferred by us from the U.S. to other countries, which may have different or less stringent data protection laws than your country, in connection with providing services to you, including evaluating your application and securing access to your chosen publishers (locations for each publisher are outlined on their respective partner information pages)."
+msgstr "La Fundación Wikimedia es una organización sin fines de lucro con sede en San Francisco, California. El programa de la Biblioteca de Wikipedia brinda acceso a recursos de publicaciones en varios países. Si solicita una cuenta de la Biblioteca de Wikipedia (ya sea que se encuentre dentro o fuera de los Estados Unidos), comprende que sus datos personales serán recopilados, transferidos, almacenados, procesados, divulgados y utilizados de otro modo en los EE. UU. como se describe en esta política de privacidad. . También comprende que podemos transferir su información desde los EE. UU. a otros países, que pueden tener leyes de protección de datos diferentes o menos estrictas que las de su país, en relación con la prestación de servicios, incluida la evaluación de su solicitud y la seguridad del acceso a su elección. editores (las ubicaciones de cada editor se describen en sus respectivas páginas de información de socios)."
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:392
-msgid ""
-"Please note that in the event of any differences in meaning or "
-"interpretation between the original English version of these terms and a "
-"translation, the original English version takes precedence."
-msgstr ""
-"Téngase en cuenta que en caso de diferencias de significado o interpretación "
-"entre la versión original en inglés de esta política y su correspondiente "
-"traducción la versión original en inglés prevalece."
+msgid "Please note that in the event of any differences in meaning or interpretation between the original English version of these terms and a translation, the original English version takes precedence."
+msgstr "Téngase en cuenta que en caso de diferencias de significado o interpretación entre la versión original en inglés de esta política y su correspondiente traducción la versión original en inglés prevalece."
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Wikimedia Foundation should not be translated.
 #: TWLight/users/templates/users/terms.html:403
-msgid ""
-"See also the <a class=\"twl-links\" href=\"https://wikimediafoundation.org/"
-"wiki/Privacy_policy\">Wikimedia Foundation Privacy Policy</a>."
-msgstr ""
-"Véase también la <a class=\"twl-links\" href=\"https://wikimediafoundation."
-"org/wiki/Privacy_policy\">Política de privacidad de la Fundación Wikimedia</"
-"a>."
+msgid "See also the <a class=\"twl-links\" href=\"https://wikimediafoundation.org/wiki/Privacy_policy\">Wikimedia Foundation Privacy Policy</a>."
+msgstr "Véase también la <a class=\"twl-links\" href=\"https://wikimediafoundation.org/wiki/Privacy_policy\">Política de privacidad de la Fundación Wikimedia</a>."
 
 #. Translators: This is the second to last line of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:412
@@ -3978,16 +2889,8 @@ msgstr "Fundación Wikimedia"
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:426
-msgid ""
-"By checking this box and clicking “Submit”, you agree that you have read the "
-"above terms and that you will adhere to the terms of use in your application "
-"to and use of the The Wikipedia Library, and the publishers’ services to "
-"which you gain access through The Wikipedia Library program."
-msgstr ""
-"Al marcar esta casilla y hacer clic en \"Enviar\", acepta que ha leído los "
-"términos anteriores y que cumplirá con los términos de uso en su solicitud y "
-"uso de la Biblioteca de Wikipedia y los servicios de los editores que "
-"obtiene. acceso a través del programa Biblioteca Wikipedia."
+msgid "By checking this box and clicking “Submit”, you agree that you have read the above terms and that you will adhere to the terms of use in your application to and use of the The Wikipedia Library, and the publishers’ services to which you gain access through The Wikipedia Library program."
+msgstr "Al marcar esta casilla y hacer clic en \"Enviar\", acepta que ha leído los términos anteriores y que cumplirá con los términos de uso en su solicitud y uso de la Biblioteca de Wikipedia y los servicios de los editores que obtiene. acceso a través del programa Biblioteca Wikipedia."
 
 #: TWLight/users/templates/users/user_collection_tile.html:32
 msgid "Remove this collection from favorites"
@@ -4039,40 +2942,19 @@ msgstr "Eliminar todos los datos"
 
 #. Translators: This message is displayed on the page where users can request the deletion of their data.
 #: TWLight/users/templates/users/user_confirm_delete.html:17
-msgid ""
-"<b>Warning:</b> Performing this action will delete your Wikipedia Library "
-"Card user account and all associated applications. This process is not "
-"reversible. You may lose any partner accounts you were granted, and will not "
-"be able to renew those accounts or apply for new ones."
-msgstr ""
-"<b>Aviso:</b> Realizando esta acción eliminará su cuenta de usuario de la "
-"Biblioteca de Wikipedia y todas las aplicaciones asociadas. Este proceso es "
-"irreversible. Puedes perder las cuentas de socios que te fueron otorgadas y "
-"no podrás renovar esas cuentas o solicitar nuevos accesos."
+msgid "<b>Warning:</b> Performing this action will delete your Wikipedia Library Card user account and all associated applications. This process is not reversible. You may lose any partner accounts you were granted, and will not be able to renew those accounts or apply for new ones."
+msgstr "<b>Aviso:</b> Realizando esta acción eliminará su cuenta de usuario de la Biblioteca de Wikipedia y todas las aplicaciones asociadas. Este proceso es irreversible. Puedes perder las cuentas de socios que te fueron otorgadas y no podrás renovar esas cuentas o solicitar nuevos accesos."
 
 #. Translators: this should show up for people who log in with a username/password and not OAuth, so we don't know what their Wikipedia identity is.
-#.
 #: TWLight/users/templates/users/user_detail.html:12
 #, python-format
-msgid ""
-"Hi, %(username)s! You don't have a Wikipedia editor profile attached to your "
-"account here, so you are probably a site administrator."
-msgstr ""
-"¡Hola, %(username)s! No tienes un perfil de editor de Wikipedia ligado a "
-"esta cuenta, así que probablemente eres un administrador del sitio."
+msgid "Hi, %(username)s! You don't have a Wikipedia editor profile attached to your account here, so you are probably a site administrator."
+msgstr "¡Hola, %(username)s! No tienes un perfil de editor de Wikipedia ligado a esta cuenta, así que probablemente eres un administrador del sitio."
 
 #. Translators: In the unlikely scenario that someone is able to register an account without using OAuth (thus leaving us without some of the information required for applications), users will see this message, encouraging them to re-register.
 #: TWLight/users/templates/users/user_detail.html:20
-msgid ""
-"If you aren't a site administrator, something weird has happened. You won't "
-"be able to apply for access without a Wikipedia editor profile. You should "
-"log out and create a new account by logging in via OAuth, or contact a site "
-"administrator for help."
-msgstr ""
-"Si no eres un administrador del sitio, algo raro ha pasado. No vas a poder "
-"solicitar acceso sin un perfil de editor de Wikipedia. Debes cerrar sesión y "
-"crear una cuenta nueva iniciando sesión via OAuth o contacta a un "
-"administrador del sitio para que te ayude."
+msgid "If you aren't a site administrator, something weird has happened. You won't be able to apply for access without a Wikipedia editor profile. You should log out and create a new account by logging in via OAuth, or contact a site administrator for help."
+msgstr "Si no eres un administrador del sitio, algo raro ha pasado. No vas a poder solicitar acceso sin un perfil de editor de Wikipedia. Debes cerrar sesión y crear una cuenta nueva iniciando sesión via OAuth o contacta a un administrador del sitio para que te ayude."
 
 #. Translators: Labels a sections where coordinators can select their email preferences.
 #: TWLight/users/templates/users/user_email_preferences.html:15
@@ -4082,23 +2964,13 @@ msgstr "Solo coordinadores"
 #. Translators: This message is shown on user's own profile page, encouraging them to make sure their information is up to date, so that account coordinators can use the information to judge applications.
 #: TWLight/users/views.py:176
 #, python-brace-format
-msgid ""
-"Please <a class='twl-links' href='{url}'>update your contributions</a> to "
-"Wikipedia to help coordinators evaluate your applications."
-msgstr ""
-"Favor de <a class=\"twl-links\" href='{url}'>actualizar tus contribuciones</"
-"a> a Wikipedia para ayudar a coordinadores a evaluar tus solicitudes."
+msgid "Please <a class='twl-links' href='{url}'>update your contributions</a> to Wikipedia to help coordinators evaluate your applications."
+msgstr "Favor de <a class=\"twl-links\" href='{url}'>actualizar tus contribuciones</a> a Wikipedia para ayudar a coordinadores a evaluar tus solicitudes."
 
 #. Translators: Coordinators are shown this message when they unselect all three types of reminder email options under preferences.
 #: TWLight/users/views.py:288
-msgid ""
-"You have chosen not to receive reminder emails. As a coordinator, you should "
-"receive at least one type of reminder emails, so consider changing your "
-"preferences."
-msgstr ""
-"Has escogido no recibir correos de recordatorios. Como coordinador, debes "
-"recibir al menos un tipo de correo de recordatorio, considera cambiar tus "
-"preferencias."
+msgid "You have chosen not to receive reminder emails. As a coordinator, you should receive at least one type of reminder emails, so consider changing your preferences."
+msgstr "Has escogido no recibir correos de recordatorios. Como coordinador, debes recibir al menos un tipo de correo de recordatorio, considera cambiar tus preferencias."
 
 #. Translators: Coordinators are shown this message when they make changes to their reminder email options under preferences.
 #: TWLight/users/views.py:296
@@ -4121,9 +2993,7 @@ msgstr "Su información ha sido actualizada."
 #. Translators: If a user tries to save the 'email change form' without entering one and checking the 'use my Wikipedia email address' checkbox, this message is presented.
 #: TWLight/users/views.py:448
 msgid "Both the values cannot be blank. Either enter a email or check the box."
-msgstr ""
-"Ambos valores no pueden estar vacíos. Registra un correo electrónico o marca "
-"la casilla."
+msgstr "Ambos valores no pueden estar vacíos. Registra un correo electrónico o marca la casilla."
 
 #. Translators: Shown to users when they successfully modify their email. Don't translate {email}.
 #: TWLight/users/views.py:476
@@ -4133,12 +3003,8 @@ msgstr "Tu correo electrónico ha sido cambiado a {email}."
 
 #. Translators: If the user has not filled out their email, they can browse the website but cannot apply for access to resources.
 #: TWLight/users/views.py:487
-msgid ""
-"Your email is blank. You can still explore the site, but you won't be able "
-"to apply for access to partner resources without an email."
-msgstr ""
-"No tienes correo electrónico registrado. Puedes explorar el sitio, pero no "
-"vas a poder solicitar acceso a recursos de socios sin el."
+msgid "Your email is blank. You can still explore the site, but you won't be able to apply for access to partner resources without an email."
+msgstr "No tienes correo electrónico registrado. Puedes explorar el sitio, pero no vas a poder solicitar acceso a recursos de socios sin el."
 
 #. Translators: This message is shown once the access to a partner has successfully been returned.
 #: TWLight/users/views.py:801
@@ -4170,31 +3036,3 @@ msgstr "Ningún bloqueo activo"
 msgid "10+ edits in the last 30 days"
 msgstr "10+ ediciones en los últimos 30 días"
 
-#: tests/shunit/data/bad_i18n_comment_1.py:3
-#: tests/shunit/data/bad_i18n_newline_1.py:5
-msgid "1"
-msgstr ""
-
-#. Translators: Lorem ipsum dolor sit amet, consectetur adipiscing elit. Mauris vitae ipsum ut purus faucibus pretium. Proin tempus neque et aliquet consectetur. Ut egestas sapien in consectetur sagittis. Mauris neque lacus, dapibus non viverra vitae, interdum ut aenean ipsum.
-#. Translators: Lorem ipsum dolor sit amet, consectetur adipiscing elit. Mauris vitae ipsum ut purus faucibus pretium. Proin tempus neque et aliquet consectetur. Ut egestas sapien in consectetur sagittis. Mauris neque lacus, dapibus non.
-#: tests/shunit/data/bad_i18n_comment_2.py:4
-#: tests/shunit/data/bad_i18n_newline_2.py:5 tests/shunit/data/good_i18n_1.py:2
-#: tests/shunit/data/good_i18n_2.py:2
-msgid "2"
-msgstr ""
-
-#: tests/shunit/data/bad_i18n_newline_3.py:5
-msgid "3"
-msgstr ""
-
-#: tests/shunit/data/bad_i18n_newline_4.py:5
-msgid "4"
-msgstr ""
-
-#: tests/shunit/data/bad_i18n_newline_5.py:5
-msgid "5"
-msgstr ""
-
-#: tests/shunit/data/bad_i18n_newline_6.py:5
-msgid "6"
-msgstr ""

--- a/locale/fa/LC_MESSAGES/django.po
+++ b/locale/fa/LC_MESSAGES/django.po
@@ -24,10 +24,11 @@
 # Author: درفش کاویانی
 msgid ""
 msgstr ""
+""
 "Project-Id-Version: Wikipedia Library Card Platform - Website\n"
-"Report-Msgid-Bugs-To: wikipedialibrary@wikimedia.org\n"
+"Report-Msgid-Bugs-To: translatewiki.net\n"
 "POT-Creation-Date: 2024-07-11 20:55+0000\n"
-"PO-Revision-Date: 2024-07-11 12:30:14+0000\n"
+"PO-Revision-Date: 2024-07-15 12:29:14+0000\n"
 "Language: fa\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
@@ -59,12 +60,8 @@ msgstr "دربارۀ شما"
 #. Translators: This note appears in a section of a form where we ask users to enter info (like country of residence) when applying for resource access.
 #: TWLight/applications/forms.py:179
 #, python-brace-format
-msgid ""
-"<p><small><i>Your personal data will be processed according to our <a "
-"class='twl-links' href='{terms_url}'> privacy policy</a>.</i></small></p>"
-msgstr ""
-"<p><small><i>اطلاعات شخصی شما مطابق <a class='twl-links' href="
-"\"{terms_url}\">سیاست محرمانگی ما</a> پردازش خواهد شد.</i></small></p>"
+msgid "<p><small><i>Your personal data will be processed according to our <a class='twl-links' href='{terms_url}'> privacy policy</a>.</i></small></p>"
+msgstr "<p><small><i>اطلاعات شخصی شما مطابق <a class='twl-links' href=\"{terms_url}\">سیاست محرمانگی ما</a> پردازش خواهد شد.</i></small></p>"
 
 #. Translators: This is the title of the application form page, where users enter information required for the application. It lets the user know which partner application they are entering data for. {partner}
 #: TWLight/applications/forms.py:189
@@ -105,12 +102,8 @@ msgstr "ایمیل حساب‌تان در وب‌گاه شریک"
 #. Translators: This labels a choice field where users will have to select the number of months they wish to have their access for as part of the application renewal confirmation.
 #. Translators: When filling out an application, users may be required to enter the length of the account (expiry) they wish to have for proxy partners.
 #: TWLight/applications/forms.py:339 TWLight/applications/helpers.py:100
-msgid ""
-"The number of months you wish to have this access for before renewal is "
-"required"
-msgstr ""
-"تعداد ماه‌هایی که برای داشتن این دسترسی تا پیش از تازه‌سازی مد نظر دارید، "
-"الزامی است"
+msgid "The number of months you wish to have this access for before renewal is required"
+msgstr "تعداد ماه‌هایی که برای داشتن این دسترسی تا پیش از تازه‌سازی مد نظر دارید، الزامی است"
 
 #. Translators: When filling out an application, users may need to specify their name
 #: TWLight/applications/helpers.py:81
@@ -130,10 +123,7 @@ msgstr "وابستگی سازمانی"
 #. Translators: When filling out an application, users must provide an explanation of why these resources would be useful to them
 #: TWLight/applications/helpers.py:89
 msgid "Why do you want access to this resource?"
-msgstr ""
-"توضیح دهید که چرا به این دسترسی نیاز دارید؟ (برای شرکای ایرانی، نورمگز، "
-"سیویلیکا، و ... درخواست‌تان را به فارسی بنویسید و برای دیگر شرکا، به‌زبان "
-"انگلیسی توضیح دهید.)"
+msgstr "توضیح دهید که چرا به این دسترسی نیاز دارید؟ (برای شرکای ایرانی، نورمگز، سیویلیکا، و ... درخواست‌تان را به فارسی بنویسید و برای دیگر شرکا، به‌زبان انگلیسی توضیح دهید.)"
 
 #. Translators: When filling out an application, users may need to specify a particular book they want access to
 #: TWLight/applications/helpers.py:91
@@ -148,9 +138,7 @@ msgstr "توضیحات دیگری که مفید می‌دانید را در ای
 #. Translators: When filling out an application, users may be required to check a box to say they agree with the website's Terms of Use document, which is linked
 #: TWLight/applications/helpers.py:95
 msgid "You must agree with the partner's terms of use"
-msgstr ""
-"شما باید با شرایط استفاده‌ای که از سوی پایگاه مورد نظر مشخص شده است موافقت "
-"کنید."
+msgstr "شما باید با شرایط استفاده‌ای که از سوی پایگاه مورد نظر مشخص شده است موافقت کنید."
 
 #. Translators: When sending application data to partners, this is the text labelling a user's real name
 #. Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this labels the user's real name.
@@ -203,12 +191,8 @@ msgstr "ایمیل"
 
 #. Translators: This comment is added to pending applications when our terms of use change.
 #: TWLight/applications/management/commands/notify_applicants_tou_changes.py:54
-msgid ""
-"Our terms of use have changed. Your applications will not be processed until "
-"you log in and agree to our updated terms."
-msgstr ""
-"شرایط استفادهٔ ما تغییر کرده است. درخواست‌های شما تا زمانی که وارد سیستم نشوید "
-"و با شرایط استفادهٔ بروزشده موافقت نکنید، پردازش نخواهد شد."
+msgid "Our terms of use have changed. Your applications will not be processed until you log in and agree to our updated terms."
+msgstr "شرایط استفادهٔ ما تغییر کرده است. درخواست‌های شما تا زمانی که وارد سیستم نشوید و با شرایط استفادهٔ بروزشده موافقت نکنید، پردازش نخواهد شد."
 
 #. Translators: This is the status of an application that has not yet been reviewed.
 #: TWLight/applications/models.py:54
@@ -274,42 +258,26 @@ msgstr "نشانی دسترسی: {access_url}"
 
 #. Translators: This text goes into account approval emails in the case that we need to send the user's details to a publisher for manual account setup.
 #: TWLight/applications/models.py:331
-msgid ""
-"You can expect to receive access details within a week or two once it has "
-"been processed."
-msgstr ""
-"شما می‌توانید انتظار داشته باشید که پس از بررسی، جزئیات دسترسی را طی یک یا دو "
-"هفته دریافت کنید."
+msgid "You can expect to receive access details within a week or two once it has been processed."
+msgstr "شما می‌توانید انتظار داشته باشید که پس از بررسی، جزئیات دسترسی را طی یک یا دو هفته دریافت کنید."
 
 #. Translators: This comment is added to open applications when a partner joins the Library Bundle, which does not require applications.
 #: TWLight/applications/signals.py:247
-msgid ""
-"This partner joined the Library Bundle, which does not require applications. "
-"This application will be marked as invalid."
-msgstr ""
-"این پایگاه به بستهٔ کتابخانه (Library Bundle) پیوست، که نیازی به درخواست "
-"ندارد. این درخواست به عنوان نامعتبر مشخص خواهد شد."
+msgid "This partner joined the Library Bundle, which does not require applications. This application will be marked as invalid."
+msgstr "این پایگاه به بستهٔ کتابخانه (Library Bundle) پیوست، که نیازی به درخواست ندارد. این درخواست به عنوان نامعتبر مشخص خواهد شد."
 
 #. Translators: This is shown to users if the application is to a partner for which we have run out of available accounts. The application is therefore on a 'waitlist', and will be reviewed when more accounts are available.
 #: TWLight/applications/templates/applications/application_evaluation.html:29
-msgid ""
-"This application is on the waitlist because this partner does not have any "
-"access grants available at this time."
-msgstr ""
-"این درخواست در فهرست انتظار قرار دارد، چرا که موجودی دسترسی‌های اعطا شده از "
-"سوی پایگاه مورد نظر در حال حاضر به پایان رسیده است."
+msgid "This application is on the waitlist because this partner does not have any access grants available at this time."
+msgstr "این درخواست در فهرست انتظار قرار دارد، چرا که موجودی دسترسی‌های اعطا شده از سوی پایگاه مورد نظر در حال حاضر به پایان رسیده است."
 
 #. Translators: This message is shown on pages where coordinators can see personal information about applicants.
 #: TWLight/applications/templates/applications/application_evaluation.html:36
 #: TWLight/applications/templates/applications/application_list_include.html:6
 #: TWLight/applications/templates/applications/send_partner.html:45
 #: TWLight/resources/templates/resources/partner_users.html:18
-msgid ""
-"Coordinators: This page may contain personal information such as real names "
-"and email addresses. Please remember that this information is confidential."
-msgstr ""
-"هماهنگ‌کننده‌ها: این صفحه ممکن است شامل اطلاعات شخصی از جمله نام واقعی و نشانی "
-"رایانامه کاربران باشد. به یاد داشته باشید که این اطلاعات محرمانه‌اند."
+msgid "Coordinators: This page may contain personal information such as real names and email addresses. Please remember that this information is confidential."
+msgstr "هماهنگ‌کننده‌ها: این صفحه ممکن است شامل اطلاعات شخصی از جمله نام واقعی و نشانی رایانامه کاربران باشد. به یاد داشته باشید که این اطلاعات محرمانه‌اند."
 
 #. Translators: This is the title of the application page shown to users who are a coordinator, and are able to accept or reject the application.
 #: TWLight/applications/templates/applications/application_evaluation.html:39
@@ -318,12 +286,8 @@ msgstr "ارزیابی درخواست"
 
 #. Translators: This text is shown to coordinators on application pages if the applicant has restricted processing of their data.
 #: TWLight/applications/templates/applications/application_evaluation.html:42
-msgid ""
-"This user has requested a restriction on the processing of their data, so "
-"you cannot change the status of their application."
-msgstr ""
-"این کاربر درخواست محدود کردن پردازش اطلاعاتش را کرده است، پس نمی‌توانید وضعیت "
-"درخواستش را تغییر دهید."
+msgid "This user has requested a restriction on the processing of their data, so you cannot change the status of their application."
+msgstr "این کاربر درخواست محدود کردن پردازش اطلاعاتش را کرده است، پس نمی‌توانید وضعیت درخواستش را تغییر دهید."
 
 #. Translators: This is the title of the application page shown to users who are not a coordinator.
 #: TWLight/applications/templates/applications/application_evaluation.html:48
@@ -396,12 +360,8 @@ msgstr "نامشخص"
 
 #. Translators: This is the text displayed to coordinators when an applicant has no country of residence in their profile.
 #: TWLight/applications/templates/applications/application_evaluation.html:123
-msgid ""
-"Please request the applicant add their country of residence to their profile "
-"before proceeding further."
-msgstr ""
-"لطفاً از متقاضی درخواست کنید که قبل از پیش‌روی، محل اقامت خود را به پروفایلش "
-"اضافه کند."
+msgid "Please request the applicant add their country of residence to their profile before proceeding further."
+msgstr "لطفاً از متقاضی درخواست کنید که قبل از پیش‌روی، محل اقامت خود را به پروفایلش اضافه کند."
 
 #. Translators: This labels the section of an application showing the total number of accounts available for a partner or their collection.
 #: TWLight/applications/templates/applications/application_evaluation.html:134
@@ -412,12 +372,8 @@ msgstr "موجودی حساب"
 #. Translators: This labels the section of an application showing whether the user had agreed to the terms of use or not.
 #: TWLight/applications/templates/applications/application_evaluation.html:145
 #, python-format
-msgid ""
-"Has agreed to the site's <a class=\"twl-links\" href=\"%(terms_url)s\">terms "
-"of use</a>?"
-msgstr ""
-"با <a class='twl-links' href=\"%(terms_url)s\">شرایط استفادهٔ سایت</a> موافقت "
-"کرده است؟"
+msgid "Has agreed to the site's <a class=\"twl-links\" href=\"%(terms_url)s\">terms of use</a>?"
+msgstr "با <a class='twl-links' href=\"%(terms_url)s\">شرایط استفادهٔ سایت</a> موافقت کرده است؟"
 
 #. Translators: Displayed to coordinators when they've agreed to the terms of use.
 #. Translators: Displayed if the user has agreed to the terms of use.
@@ -452,12 +408,8 @@ msgstr "نه"
 
 #. Translators: This is the text displayed to coordinators when an applicant has not agreed to the terms of use.
 #: TWLight/applications/templates/applications/application_evaluation.html:159
-msgid ""
-"Please request the applicant agree to the site's terms of use before "
-"approving this application."
-msgstr ""
-"لطفاً پیش از تأیید این درخواست، از متقاضی بخواهید تا با شرایط استفادهٔ سایت "
-"موافقت کند."
+msgid "Please request the applicant agree to the site's terms of use before approving this application."
+msgstr "لطفاً پیش از تأیید این درخواست، از متقاضی بخواهید تا با شرایط استفادهٔ سایت موافقت کند."
 
 #. Translators: This labels the section of an application containing the user's motivation for wanting access to this resource.
 #: TWLight/applications/templates/applications/application_evaluation.html:176
@@ -477,8 +429,7 @@ msgstr "آیا درخواست برای تمدید دسترسی است؟"
 #. Translators: This message is shown next to the 'Renewal of existing access grant?' label if the application is a renewal. Don't translate HTML tags or parent_url.
 #: TWLight/applications/templates/applications/application_evaluation.html:195
 #, python-format
-msgid ""
-"Yes (<a class=\"twl-links\" href=\"%(parent_url)s\">previous application</a>)"
+msgid "Yes (<a class=\"twl-links\" href=\"%(parent_url)s\">previous application</a>)"
 msgstr "بله (<a class='twl-links' href=\"%(parent_url)s\">درخواست پیشین</a>)"
 
 #. Translators: This labels the section of the application showing the length of access remaining on the user's previous authorization.
@@ -513,9 +464,7 @@ msgstr "افزودن توضیحات"
 
 #. Translators: On an application page, this text tells users that the comments posted on the application are visible to coordinators and the submitting user only.
 #: TWLight/applications/templates/applications/application_evaluation.html:297
-msgid ""
-"Comments are visible to all coordinators and to the editor who submitted "
-"this application."
+msgid "Comments are visible to all coordinators and to the editor who submitted this application."
 msgstr "توضیحات را همهٔ هماهنگ‌کنندگان و کاربر درخواست‌کننده می‌توانند ببینند."
 
 #. Translators: This is the title of the section of an application page which lists information about the user who submitted the application.
@@ -728,17 +677,8 @@ msgstr "تنظیم وضعیت"
 
 #: TWLight/applications/templates/applications/apply.html:20
 #, python-format
-msgid ""
-"If your application is successful we may share your email address with "
-"%(partner)s. This is required to set up your access to their resources. By "
-"submitting this form you agree to allow your email address to be shared with "
-"%(partner)s if your application is successful, for the purposes of account "
-"setup."
-msgstr ""
-"اگر درخواست شما موفقیت‌آمیز باشد، ممکن است آدرس ایمیل شما را با %(partner)s "
-"به‌اشتراک بگذاریم. این برای تنظیم دسترسی شما به منابع آنها ضروری است. با "
-"ارسال این فرم، موافقت می‌کنید که در صورت موفقیت‌آمیز بودن درخواست، آدرس "
-"ایمیلتان برای اهداف راه‌اندازی حساب با %(partner)s به‌اشتراک گذاشته شود."
+msgid "If your application is successful we may share your email address with %(partner)s. This is required to set up your access to their resources. By submitting this form you agree to allow your email address to be shared with %(partner)s if your application is successful, for the purposes of account setup."
+msgstr "اگر درخواست شما موفقیت‌آمیز باشد، ممکن است آدرس ایمیل شما را با %(partner)s به‌اشتراک بگذاریم. این برای تنظیم دسترسی شما به منابع آنها ضروری است. با ارسال این فرم، موافقت می‌کنید که در صورت موفقیت‌آمیز بودن درخواست، آدرس ایمیلتان برای اهداف راه‌اندازی حساب با %(partner)s به‌اشتراک گذاشته شود."
 
 #. Translators: This message is displayed on the page where users can confirm their renewal. Please do not translate partner.
 #: TWLight/applications/templates/applications/confirm_renewal.html:23
@@ -766,11 +706,8 @@ msgstr "به چه منابعی می‌خواهید دسترسی پیدا کنی�
 
 #. Translators: This text explains that Library Bundle partners are not shown in this list.
 #: TWLight/applications/templates/applications/request_for_application.html:26
-msgid ""
-"Library Bundle partners are not shown as eligibility is determined "
-"automatically."
-msgstr ""
-"شرکای بستهٔ کتابخانه نشان داده نمی‌شوند زیرا صلاحیت به طور خودکار تعیین می‌شود."
+msgid "Library Bundle partners are not shown as eligibility is determined automatically."
+msgstr "شرکای بستهٔ کتابخانه نشان داده نمی‌شوند زیرا صلاحیت به طور خودکار تعیین می‌شود."
 
 #. Translators: On the page where users can apply for multiple partners, this message shows next to the partner name, taking them to the full application page when clicked.
 #: TWLight/applications/templates/applications/request_for_application.html:48
@@ -784,14 +721,8 @@ msgstr "اطلاعاتی برای این پایگاه درج نشده است."
 
 #. Translators: the HTML is so that the word 'waitlisted' will look the same as it does in the page above; please translate 'waitlisted' the same way you did elsewhere in this file.
 #: TWLight/applications/templates/applications/request_for_application.html:74
-msgid ""
-"You can apply to <span class=\"badge badge-warning\">Waitlisted</span> "
-"partners, but they don't have access grants available right now. We will "
-"process those applications when access becomes available."
-msgstr ""
-"شما می‌توانید برای پایگاه مورد نظر در <span class=\"badge badge-warning"
-"\">فهرست انتظار</span> درخواست دهید، ولی در حال حاضر موجودی حساب موجودی برای "
-"آنها وجود ندارد. هر زمان حساب دسترسی موجود بود درخوسا شما بررسی می‌شود."
+msgid "You can apply to <span class=\"badge badge-warning\">Waitlisted</span> partners, but they don't have access grants available right now. We will process those applications when access becomes available."
+msgstr "شما می‌توانید برای پایگاه مورد نظر در <span class=\"badge badge-warning\">فهرست انتظار</span> درخواست دهید، ولی در حال حاضر موجودی حساب موجودی برای آنها وجود ندارد. هر زمان حساب دسترسی موجود بود درخوسا شما بررسی می‌شود."
 
 #. Translators: On the page where coordinators can see approved applications which have not had their details sent to the partner, this message shows when there are applications ready to be processed.
 #: TWLight/applications/templates/applications/send.html:10
@@ -812,19 +743,13 @@ msgstr "تاریخ درخواست برای %(object)s"
 #. Translators: This message is shown when applications exceed the number of accounts available.
 #: TWLight/applications/templates/applications/send_partner.html:54
 #, python-format
-msgid ""
-"Application(s) for %(object)s, if sent, will exceed the total available "
-"accounts for the partner. Please proceed at your own discretion."
-msgstr ""
-"درخواست(ها) برای %(object)s از تعداد کل حساب‌های موجود برای این پایگاه بیش‌تر "
-"است. لطفاً مطمئن شوید که می‌خواهید این ارسال را انجام دهید."
+msgid "Application(s) for %(object)s, if sent, will exceed the total available accounts for the partner. Please proceed at your own discretion."
+msgstr "درخواست(ها) برای %(object)s از تعداد کل حساب‌های موجود برای این پایگاه بیش‌تر است. لطفاً مطمئن شوید که می‌خواهید این ارسال را انجام دهید."
 
 #. Translators: When viewing the list of applications ready to be sent for a particular partner, this is instructions for the coordinator to click the 'mark as sent' button after they have sent the information.
 #: TWLight/applications/templates/applications/send_partner.html:65
 msgid "When you've processed the data below, click the 'mark as sent' button."
-msgstr ""
-"لطفا هنگام پردازش اطلاعات زیر، بر روی دکمهٔ «نشانه‌گذاری به عنوان ارسال‌شده» "
-"کلیک کنید."
+msgstr "لطفا هنگام پردازش اطلاعات زیر، بر روی دکمهٔ «نشانه‌گذاری به عنوان ارسال‌شده» کلیک کنید."
 
 #. Translators: When viewing the list of applications ready to be sent for a particular partner, this is the title of the section containing contact information for the people applications should be sent to.
 #: TWLight/applications/templates/applications/send_partner.html:71
@@ -834,12 +759,8 @@ msgstr[0] "اطلاعات تماس"
 
 #. Translators: When viewing the list of applications ready to be sent for a particular partner, this message shows if there is no information about who the applications should be sent to. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/applications/templates/applications/send_partner.html:89
-msgid ""
-"Whoops, we don't have any listed contacts. Please notify Wikipedia Library "
-"administrators."
-msgstr ""
-"ای وای، اطلاعاتی برای تماس نداریم! لطفاً مدیران کتابخانه ویکی‌پدیا را در جریان "
-"بگذارید."
+msgid "Whoops, we don't have any listed contacts. Please notify Wikipedia Library administrators."
+msgstr "ای وای، اطلاعاتی برای تماس نداریم! لطفاً مدیران کتابخانه ویکی‌پدیا را در جریان بگذارید."
 
 #. Translators: When viewing the list of applications ready to be sent for a particular partner, this is the title of the section containing the information about those applications.
 #: TWLight/applications/templates/applications/send_partner.html:94
@@ -854,12 +775,8 @@ msgstr "علامت‌گذاری به‌عنوان ارسال‌شده"
 
 #. Translators: This text guides coordinators in using the code sending interface for approved applications.
 #: TWLight/applications/templates/applications/send_partner.html:152
-msgid ""
-"Use the dropdown menus to denote which editor will receive each code. Access "
-"codes will be sent to users automatically."
-msgstr ""
-"از منوهای کشویی برای مشخص‌کردن اینکه کدام ویرایشگر کدام کد را دریافت کند "
-"استفاده کنید. کدهای دسترسی به طور خودکار برای کاربران ارسال می‌شوند."
+msgid "Use the dropdown menus to denote which editor will receive each code. Access codes will be sent to users automatically."
+msgstr "از منوهای کشویی برای مشخص‌کردن اینکه کدام ویرایشگر کدام کد را دریافت کند استفاده کنید. کدهای دسترسی به طور خودکار برای کاربران ارسال می‌شوند."
 
 #. Translators: This labels a drop-down selection where staff can assign an access code to a user.
 #: TWLight/applications/templates/applications/send_partner.html:173
@@ -874,24 +791,14 @@ msgstr "هیچ درخواست تأییدشده ولی ارسال‌نشده‌ا
 #. Translators: When a user applies for a set of resources, they receive this message if none are currently available. They are instead placed on a 'waitlist' for later approval.
 #. Translators: When a user renews their resource, they receive this message if none are currently available. They are instead placed on a 'waitlist' for later approval.
 #: TWLight/applications/views.py:140 TWLight/applications/views.py:1282
-msgid ""
-"This partner does not have any access grants available at this time. You may "
-"still apply for access; your application will be reviewed when access grants "
-"become available."
-msgstr ""
-"در حال حاضر حساب دسترسی‌ای برای این پایگاه موجود نیست. بااین حال هنوز "
-"می‌توانید برای دسترسی درخواست دهید تا هر زمان که حساب جدیدی موجود شد "
-"درخواست‌تان بررسی شود."
+msgid "This partner does not have any access grants available at this time. You may still apply for access; your application will be reviewed when access grants become available."
+msgstr "در حال حاضر حساب دسترسی‌ای برای این پایگاه موجود نیست. بااین حال هنوز می‌توانید برای دسترسی درخواست دهید تا هر زمان که حساب جدیدی موجود شد درخواست‌تان بررسی شود."
 
 #. Translators: This message is shown to users once they've successfully submitted their application for review.
 #: TWLight/applications/views.py:163
 #, python-brace-format
-msgid ""
-"Your application has been submitted for review. Head over to <a "
-"href='{applications_url}'>My Applications</a> to view the status."
-msgstr ""
-"درخواست شما برای بررسی ثبت شد. می‌توانید وضعیت درخواست‌تان را در <a "
-"href='{applications_url}'>درخواست‌های من</a> ببینید."
+msgid "Your application has been submitted for review. Head over to <a href='{applications_url}'>My Applications</a> to view the status."
+msgstr "درخواست شما برای بررسی ثبت شد. می‌توانید وضعیت درخواست‌تان را در <a href='{applications_url}'>درخواست‌های من</a> ببینید."
 
 #. Translators: This text is displayed to users when the user has chosen to restrict data and is trying to apply for multiple partners
 #: TWLight/applications/views.py:276
@@ -939,20 +846,13 @@ msgstr "درخواست‌های ارسال‌شده"
 
 #. Translators: After a coordinator has changed the status of an application to APPROVED, if the corresponding partner/collection is waitlisted this message appears.
 #: TWLight/applications/views.py:756
-msgid ""
-"Cannot approve application as partner with proxy authorization method is "
-"waitlisted."
-msgstr ""
-"تأیید درخواست به عنوان پایگاه استفاده از روش مجوز پروکسی در لیست انتظار نیست."
+msgid "Cannot approve application as partner with proxy authorization method is waitlisted."
+msgstr "تأیید درخواست به عنوان پایگاه استفاده از روش مجوز پروکسی در لیست انتظار نیست."
 
 #. Translators: After a coordinator has changed the status of an application to APPROVED, if the corresponding partner/collection has no accounts for distribution, this message appears.
 #: TWLight/applications/views.py:780
-msgid ""
-"Cannot approve application as partner with proxy authorization method is "
-"waitlisted and (or) has zero accounts available for distribution."
-msgstr ""
-"نمی توان درخواست را تأیید کرد زیرا شریک استفاده از روش مجوز پروکسی در لیست "
-"انتظار است و (یا) دارای حساب‌های صفر برای توزیع است."
+msgid "Cannot approve application as partner with proxy authorization method is waitlisted and (or) has zero accounts available for distribution."
+msgstr "نمی توان درخواست را تأیید کرد زیرا شریک استفاده از روش مجوز پروکسی در لیست انتظار است و (یا) دارای حساب‌های صفر برای توزیع است."
 
 #. Translators: This message appears on an "access denied" screen that stops users who attempt to authorize an editor to access a resource during a time period for which they are already authorized.
 #: TWLight/applications/views.py:803
@@ -962,16 +862,8 @@ msgstr "سعی کردید که مجوز تکراری ایجاد کنید."
 #. Translators: This message is shown to users when they access an application page of a now Bundle partner (new applications aren't allowed for Bundle partners and the status of old applications cannot be modified)
 #: TWLight/applications/views.py:857
 #, python-brace-format
-msgid ""
-"This application cannot be modified since this partner is now part of our <a "
-"href='{bundle}'>bundle access</a>. If you are eligible, you can access this "
-"resource from <a href='{library}'>your library</a>. <a "
-"href='{contact}'>Contact us</a> if you have any questions."
-msgstr ""
-"این درخواست را نمی‌توان اصلاح کرد زیرا این شریک اکنون بخشی از <a "
-"href='{bundle}'>دسترسی بستهٔ کتابخانه</a> است. اگر واجد شرایط هستید، می‌توانید "
-"از <a href='{library}'>کتابخانهٔ خودتان</a> به این منبع دسترسی پیدا کنید. در "
-"صورت داشتن هرگونه سوالی، <a href='{contact}'>با ما تماس بگیرید</a>."
+msgid "This application cannot be modified since this partner is now part of our <a href='{bundle}'>bundle access</a>. If you are eligible, you can access this resource from <a href='{library}'>your library</a>. <a href='{contact}'>Contact us</a> if you have any questions."
+msgstr "این درخواست را نمی‌توان اصلاح کرد زیرا این شریک اکنون بخشی از <a href='{bundle}'>دسترسی بستهٔ کتابخانه</a> است. اگر واجد شرایط هستید، می‌توانید از <a href='{library}'>کتابخانهٔ خودتان</a> به این منبع دسترسی پیدا کنید. در صورت داشتن هرگونه سوالی، <a href='{contact}'>با ما تماس بگیرید</a>."
 
 #. Translators: this lets a reviewer set the status of a single application.
 #: TWLight/applications/views.py:873
@@ -980,12 +872,8 @@ msgstr "تنظیم وضعیت درخواست"
 
 #. Translators: This warning is message is shown to applicants when the number of pending applications is greater than the number of accounts available.
 #: TWLight/applications/views.py:891
-msgid ""
-"There are more pending applications than available accounts. Your "
-"application might get waitlisted."
-msgstr ""
-"درخواست‌های معلق بیش‌تری نسبت به حساب‌های موجود وجود دارد. درخواست شما ممکن است "
-"در فهرست انتظار قرار گیرد."
+msgid "There are more pending applications than available accounts. Your application might get waitlisted."
+msgstr "درخواست‌های معلق بیش‌تری نسبت به حساب‌های موجود وجود دارد. درخواست شما ممکن است در فهرست انتظار قرار گیرد."
 
 #. Translators: this message is shown to coordinators who attempt to change an application's Status from INVALID to any other Status.
 #: TWLight/applications/views.py:904
@@ -1004,16 +892,8 @@ msgstr "به‌روزرسانی جمعی درخواست‌ها با موفقیت
 
 #. Translators: After a coordinator has changed the status of a number of applications to APPROVED, if the corresponding partner(s) is/are waitlisted or has no accounts for distribution, this message appears.
 #: TWLight/applications/views.py:1051
-msgid ""
-"Cannot approve application(s) {} as partner(s) with proxy authorization "
-"method is/are waitlisted and (or) has/have not enough accounts available. If "
-"not enough accounts are available, prioritise the applications and then "
-"approve applications equal to the accounts available."
-msgstr ""
-"درخواست(های) {} به عنوان شریک (ها) با روش مجوز پروکسی تأیید نمی‌شود و در لیست "
-"انتظار هستند و (یا) حساب‌های کافی در دسترس ندارند. اگر حساب کافی در دسترس "
-"نیست، درخواست‌ها را اولویت‌بندی کنید و سپس درخواست‌هایی برابر با حساب‌های موجود "
-"را تأیید کنید."
+msgid "Cannot approve application(s) {} as partner(s) with proxy authorization method is/are waitlisted and (or) has/have not enough accounts available. If not enough accounts are available, prioritise the applications and then approve applications equal to the accounts available."
+msgstr "درخواست(های) {} به عنوان شریک (ها) با روش مجوز پروکسی تأیید نمی‌شود و در لیست انتظار هستند و (یا) حساب‌های کافی در دسترس ندارند. اگر حساب کافی در دسترس نیست، درخواست‌ها را اولویت‌بندی کنید و سپس درخواست‌هایی برابر با حساب‌های موجود را تأیید کنید."
 
 #. Translators: This message is shown to coordinators who attempt to assign the same access code to multiple users.
 #: TWLight/applications/views.py:1191
@@ -1027,12 +907,8 @@ msgstr "همهٔ درخواست‌های انتخاب‌شده به عنوان �
 
 #. Translators: When a user tries to renew their resource, they receive this message if the partner is not available.
 #: TWLight/applications/views.py:1272
-msgid ""
-"Cannot renew application at this time as partner is not available. Please "
-"check back later, or contact us for more information."
-msgstr ""
-"در حال حاضر نمی‌توانید درخواست‌تان را تمدید کنید زیرا شریک در دسترس نیست. لطفاً "
-"بعداً دوباره بررسی کنید، یا برای اطلاعات بیش‌تر با ما تماس بگیرید."
+msgid "Cannot renew application at this time as partner is not available. Please check back later, or contact us for more information."
+msgstr "در حال حاضر نمی‌توانید درخواست‌تان را تمدید کنید زیرا شریک در دسترس نیست. لطفاً بعداً دوباره بررسی کنید، یا برای اطلاعات بیش‌تر با ما تماس بگیرید."
 
 #. Translators: This message is displayed when an attempt by a user to renew an application has been denied for some reason.
 #: TWLight/applications/views.py:1308
@@ -1042,20 +918,13 @@ msgstr "تلاش برای تمدید درخواست تأییدنشده #{pk} ر�
 
 #. Translators: If a user requests the renewal of their account, but it wasn't renewed, this message is shown to them.
 #: TWLight/applications/views.py:1385
-msgid ""
-"This object cannot be renewed. (This probably means that you have already "
-"requested that it be renewed.)"
-msgstr ""
-"این شیء را نمی‌توان تمدید کرد. (این معمولا بدین معناست که قبلا درخواست تمدید "
-"داده‌اید.)"
+msgid "This object cannot be renewed. (This probably means that you have already requested that it be renewed.)"
+msgstr "این شیء را نمی‌توان تمدید کرد. (این معمولا بدین معناست که قبلا درخواست تمدید داده‌اید.)"
 
 #. Translators: If a user requests the renewal of their account, this message is shown to them.
 #: TWLight/applications/views.py:1395
-msgid ""
-"Your renewal request has been received. A coordinator will review your "
-"request."
-msgstr ""
-"درخواست تمدید شما دریافت شد. یکی از هماهنگ‌کنندگان آن را بررسی خواهد کرد."
+msgid "Your renewal request has been received. A coordinator will review your request."
+msgstr "درخواست تمدید شما دریافت شد. یکی از هماهنگ‌کنندگان آن را بررسی خواهد کرد."
 
 #. Translators: This labels a textfield where users can enter their email ID.
 #: TWLight/emails/forms.py:18
@@ -1064,12 +933,8 @@ msgstr "ایمیل‌تان"
 
 #. Translators: This is the help text for the email field in the contact us form letting users know the field is updated by value pulled from their respective user profiles.
 #: TWLight/emails/forms.py:21
-msgid ""
-"This field is automatically updated with the email from your <a class='twl-"
-"links' href='{}'>user profile</a>."
-msgstr ""
-"این قسمت به طور خودکار ایمیل شما را از <a class='twl-links' href='{}'>صفحهٔ "
-"کاربری </a> دریافت و بروزرسانی می‌کند."
+msgid "This field is automatically updated with the email from your <a class='twl-links' href='{}'>user profile</a>."
+msgstr "این قسمت به طور خودکار ایمیل شما را از <a class='twl-links' href='{}'>صفحهٔ کاربری </a> دریافت و بروزرسانی می‌کند."
 
 #. Translators: This labels a textfield where users can enter their email message.
 #: TWLight/emails/forms.py:26
@@ -1092,26 +957,14 @@ msgstr "ثبت"
 #. Translators: This email is sent to users with their access code. Don't translate Jinja variables in curly braces like user or partner. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/access_code_email-body-html.html:5
 #, python-format
-msgid ""
-"<p>Your approved application to %(partner)s has now been finalised. Your "
-"access code or login details can be found below:</p> <p><b>%(access_code)s</"
-"b></p> <p>%(user_instructions)s</p>"
-msgstr ""
-"<p>درخواست تأییدشدهٔ شما برای %(partner)s نهایی شده است. کد دسترسی یا جزئیات "
-"ورود به سیستم را می‌توانید در زیر بیابید: :</p> <p><b>%(access_code)s</b></p> "
-"<p>%(user_instructions)s</p>"
+msgid "<p>Your approved application to %(partner)s has now been finalised. Your access code or login details can be found below:</p> <p><b>%(access_code)s</b></p> <p>%(user_instructions)s</p>"
+msgstr "<p>درخواست تأییدشدهٔ شما برای %(partner)s نهایی شده است. کد دسترسی یا جزئیات ورود به سیستم را می‌توانید در زیر بیابید: :</p> <p><b>%(access_code)s</b></p> <p>%(user_instructions)s</p>"
 
 #. Translators: This email is sent to users with their access code. Don't translate Jinja variables in curly braces like user or partner. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/access_code_email-body-text.html:3
 #, python-format
-msgid ""
-"Your approved application to %(partner)s has now been finalised. Your access "
-"code or login details can be found below: %(access_code)s "
-"%(user_instructions)s"
-msgstr ""
-"درخواست تأییدشدهٔ شما برای %(partner)s اکنون نهایی شده است. کد دسترسی یا "
-"جزئیات ورود به سیستم را می‌توانید در زیر پیدا کنید: %(access_code)s "
-"%(user_instructions)s"
+msgid "Your approved application to %(partner)s has now been finalised. Your access code or login details can be found below: %(access_code)s %(user_instructions)s"
+msgstr "درخواست تأییدشدهٔ شما برای %(partner)s اکنون نهایی شده است. کد دسترسی یا جزئیات ورود به سیستم را می‌توانید در زیر پیدا کنید: %(access_code)s %(user_instructions)s"
 
 #. Translators: This is the subject line of an email sent to users with their access code.
 #: TWLight/emails/templates/emails/access_code_email-subject.html:3
@@ -1121,36 +974,14 @@ msgstr "کد دسترسی کتابخانهٔ ویکی‌پدیای شما"
 #. Translators: This email is sent to users when their application is approved. Don't translate Jinja variables in curly braces like user or partner; don't translate html tags either. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/approval_notification-body-html.html:5
 #, python-format
-msgid ""
-"<p>Dear %(user)s,</p> <p>Thank you for applying for access to %(partner)s "
-"resources through The Wikipedia Library. We are happy to inform you that "
-"your application has been approved.</p> <p>%(user_instructions)s</p> <p>You "
-"can view the collections you're authorized to access at My Library: "
-"%(link)s</p> <p>Cheers!</p> <p>The Wikipedia Library</p>"
-msgstr ""
-"<p>%(user)s گرامی،</p> <p>با سپاس از شما برای درخواست دسترسی به منابع "
-"%(partner)s از طریق کتابخانهٔ ویکی‌پدیا. خوشحالیم که به شما اطلاع دهیم که "
-"درخواست‌تان تأیید شده است.</p> <p>%(user_instructions)s</p>\n"
-"<p>می‌توانید مجموعه‌هایی که به آن‌ها دسترسی دارید را از طریق کتابخانهٔ من مشاهده "
-"کنید: %(link)s</p>\n"
-"<p>با احترام،</p> <p>کتابخانهٔ ویکی‌پدیا</p>"
+msgid "<p>Dear %(user)s,</p> <p>Thank you for applying for access to %(partner)s resources through The Wikipedia Library. We are happy to inform you that your application has been approved.</p> <p>%(user_instructions)s</p> <p>You can view the collections you're authorized to access at My Library: %(link)s</p> <p>Cheers!</p> <p>The Wikipedia Library</p>"
+msgstr "<p>%(user)s گرامی،</p> <p>با سپاس از شما برای درخواست دسترسی به منابع %(partner)s از طریق کتابخانهٔ ویکی‌پدیا. خوشحالیم که به شما اطلاع دهیم که درخواست‌تان تأیید شده است.</p> <p>%(user_instructions)s</p>\n<p>می‌توانید مجموعه‌هایی که به آن‌ها دسترسی دارید را از طریق کتابخانهٔ من مشاهده کنید: %(link)s</p>\n<p>با احترام،</p> <p>کتابخانهٔ ویکی‌پدیا</p>"
 
 #. Translators: This email is sent to users when their application is approved. Don't translate Jinja variables in curly braces like user or partner. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/approval_notification-body-text.html:3
 #, python-format
-msgid ""
-"Dear %(user)s, Thank you for applying for access to %(partner)s resources "
-"through The Wikipedia Library. We are happy to inform you that your "
-"application has been approved. %(user_instructions)s You can view the "
-"collections you're authorized to access at My Library: %(link)s Cheers! The "
-"Wikipedia Library"
-msgstr ""
-"%(user)s گرامی، با سپاس از شما برای درخواست دسترسی به منابع\n"
-" %(partner)s از طریق کتابخانهٔ ویکی‌پدیا. خوشحالیم که به شما اطلاع دهیم که "
-"درخواست‌تان تأیید شده است. %(user_instructions)s \n"
-"<p>می‌توانید مجموعه‌هایی که به آن‌ها دسترسی دارید را از طریق کتابخانهٔ من مشاهده "
-"کنید: %(link)s</p>\n"
-"با احترام! کتابخانهٔ ویکی‌پدیا"
+msgid "Dear %(user)s, Thank you for applying for access to %(partner)s resources through The Wikipedia Library. We are happy to inform you that your application has been approved. %(user_instructions)s You can view the collections you're authorized to access at My Library: %(link)s Cheers! The Wikipedia Library"
+msgstr "%(user)s گرامی، با سپاس از شما برای درخواست دسترسی به منابع\n %(partner)s از طریق کتابخانهٔ ویکی‌پدیا. خوشحالیم که به شما اطلاع دهیم که درخواست‌تان تأیید شده است. %(user_instructions)s \n<p>می‌توانید مجموعه‌هایی که به آن‌ها دسترسی دارید را از طریق کتابخانهٔ من مشاهده کنید: %(link)s</p>\nبا احترام! کتابخانهٔ ویکی‌پدیا"
 
 #. Translators: This is the subject of an email which is sent to users when their application has been approved. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/approval_notification-subject.html:4
@@ -1160,26 +991,14 @@ msgstr "درخواست شما در کتابخانهٔ ویکی‌پدیا تأی
 #. Translators: This email is sent to coordinators when a comment is left on an application they are processing. Don't translate Jinja variables in curly braces like user or partner. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/comment_notification_coordinator-body-html.html:5
 #, python-format
-msgid ""
-"<p style=\"color: #500050\">%(submit_date)s - %(commenter)s</p> "
-"<blockquote><p>%(comment)s</p></blockquote> <p>Please reply to these at: <a "
-"href=\"%(app_url)s\">%(app_url)s</a></p> <p>Best,</p> <p>The Wikipedia "
-"Library</p>"
-msgstr ""
-"<p style=\"color: #500050\">%(submit_date)s - %(commenter)s</p> "
-"<blockquote><p>%(comment)s</p></blockquote> <p>لطفاً برای پاسخ از اینجا اقدام "
-"کنید: <a href=\"%(app_url)s\">%(app_url)s</a></p> <p>با احترام،</p> "
-"<p>کتابخانهٔ ویکی‌پدیا</p>"
+msgid "<p style=\"color: #500050\">%(submit_date)s - %(commenter)s</p> <blockquote><p>%(comment)s</p></blockquote> <p>Please reply to these at: <a href=\"%(app_url)s\">%(app_url)s</a></p> <p>Best,</p> <p>The Wikipedia Library</p>"
+msgstr "<p style=\"color: #500050\">%(submit_date)s - %(commenter)s</p> <blockquote><p>%(comment)s</p></blockquote> <p>لطفاً برای پاسخ از اینجا اقدام کنید: <a href=\"%(app_url)s\">%(app_url)s</a></p> <p>با احترام،</p> <p>کتابخانهٔ ویکی‌پدیا</p>"
 
 #. Translators: This email is sent to coordinators when a comment is left on an application they are processing. Don't translate Jinja variables in curly braces like user or partner. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/comment_notification_coordinator-body-text.html:3
 #, python-format
-msgid ""
-"%(submit_date)s - %(commenter)s %(comment)s Please reply to this at: "
-"%(app_url)s Best, The Wikipedia Library"
-msgstr ""
-"%(submit_date)s - %(commenter)s %(comment)s لطفاً برای پاسخ از اینجا اقدام "
-"کنید: %(app_url)s با احترام، کتابخانهٔ ویکی‌پدیا"
+msgid "%(submit_date)s - %(commenter)s %(comment)s Please reply to this at: %(app_url)s Best, The Wikipedia Library"
+msgstr "%(submit_date)s - %(commenter)s %(comment)s لطفاً برای پاسخ از اینجا اقدام کنید: %(app_url)s با احترام، کتابخانهٔ ویکی‌پدیا"
 
 #. Translators: This is the subject line of an email sent to coordinators when a comment is left on an application they processed.
 #: TWLight/emails/templates/emails/comment_notification_coordinator-subject.html:3
@@ -1189,26 +1008,14 @@ msgstr "توضیحی جدید دربارهٔ درخواستی که شما در �
 #. Translators: This email is sent to users when they receive a comment on their application. Don't translate Jinja variables in curly braces like user or partner; don't translate html tags either. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/comment_notification_editors-body-html.html:5
 #, python-format
-msgid ""
-"<p style=\"color: #500050\">%(submit_date)s - %(commenter)s</p> "
-"<blockquote><p>%(comment)s</p></blockquote> <p>Please reply to these at <a "
-"href=\"%(app_url)s\">%(app_url)s</a> so we can evaluate your application.</"
-"p> <p>Best,</p> <p>The Wikipedia Library</p>"
-msgstr ""
-"<p style=\"color: #500050\">%(submit_date)s - %(commenter)s</p> "
-"<blockquote><p>%(comment)s</p></blockquote> <p>لطفاً از اینجا<a href="
-"\"%(app_url)s\">%(app_url)s</a> پاسخ دهید تا بتوانیم درخواست شما را ارزیابی "
-"کنیم.</p> <p>با احترام</p> <p>کتابخانهٔ ویکی‌پدیا</p>"
+msgid "<p style=\"color: #500050\">%(submit_date)s - %(commenter)s</p> <blockquote><p>%(comment)s</p></blockquote> <p>Please reply to these at <a href=\"%(app_url)s\">%(app_url)s</a> so we can evaluate your application.</p> <p>Best,</p> <p>The Wikipedia Library</p>"
+msgstr "<p style=\"color: #500050\">%(submit_date)s - %(commenter)s</p> <blockquote><p>%(comment)s</p></blockquote> <p>لطفاً از اینجا<a href=\"%(app_url)s\">%(app_url)s</a> پاسخ دهید تا بتوانیم درخواست شما را ارزیابی کنیم.</p> <p>با احترام</p> <p>کتابخانهٔ ویکی‌پدیا</p>"
 
 #. Translators: This email is sent to users when they receive a comment on their application. Don't translate Jinja variables in curly braces like user or partner. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/comment_notification_editors-body-text.html:3
 #, python-format
-msgid ""
-"%(submit_date)s - %(commenter)s %(comment)s Please reply to these at: "
-"%(app_url)s so we can evaluate your application. Best, The Wikipedia Library"
-msgstr ""
-"%(submit_date)s - %(commenter)s %(comment)s از اینجا: %(app_url)s پاسخ دهید "
-"تا بتوانیم درخواست شما را ارزیابی کنیم. با احترام، کتابخانهٔ ویکی‌پدیا"
+msgid "%(submit_date)s - %(commenter)s %(comment)s Please reply to these at: %(app_url)s so we can evaluate your application. Best, The Wikipedia Library"
+msgstr "%(submit_date)s - %(commenter)s %(comment)s از اینجا: %(app_url)s پاسخ دهید تا بتوانیم درخواست شما را ارزیابی کنیم. با احترام، کتابخانهٔ ویکی‌پدیا"
 
 #. Translators: This is the subject line of an email sent to users who have a comment added to one of their applications. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/comment_notification_editors-subject.html:3
@@ -1218,25 +1025,14 @@ msgstr "توضیحی جدید دربارهٔ درخواست شما در کتاب
 #. Translators: This email is sent to users when an application they commented on receives another comment. Don't translate Jinja variables in curly braces like app_url; don't translate html tags either. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/comment_notification_others-body-html.html:5
 #, python-format
-msgid ""
-"<p style=\"color: #500050\">%(submit_date)s - %(commenter)s</p> "
-"<blockquote><p>%(comment)s</p></blockquote> See it at <a href=\"%(app_url)s"
-"\">%(app_url)s</a>. Thanks for helping review Wikipedia Library applications!"
-msgstr ""
-"<p style=\"color: #500050\">%(submit_date)s - %(commenter)s</p> "
-"<blockquote><p>%(comment)s</p></blockquote> از اینجا <a href=\"%(app_url)s\">"
-"%(app_url)s</a> مشاهده کنید. با تشکر از شما برای کمک به بررسی درخواست‌های "
-"کتابخانهٔ ویکی‌پدیا!"
+msgid "<p style=\"color: #500050\">%(submit_date)s - %(commenter)s</p> <blockquote><p>%(comment)s</p></blockquote> See it at <a href=\"%(app_url)s\">%(app_url)s</a>. Thanks for helping review Wikipedia Library applications!"
+msgstr "<p style=\"color: #500050\">%(submit_date)s - %(commenter)s</p> <blockquote><p>%(comment)s</p></blockquote> از اینجا <a href=\"%(app_url)s\">%(app_url)s</a> مشاهده کنید. با تشکر از شما برای کمک به بررسی درخواست‌های کتابخانهٔ ویکی‌پدیا!"
 
 #. Translators: This email is sent to users when an application they commented on receives another comment. Don't translate Jinja variables in curly braces like app_url. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/comment_notification_others-body-text.html:3
 #, python-format
-msgid ""
-"%(submit_date)s - %(commenter)s %(comment)s See it at: %(app_url)s Thanks "
-"for helping review Wikipedia Library applications!"
-msgstr ""
-"%(submit_date)s - %(commenter)s %(comment)s از اینجا ببینید: %(app_url)s با "
-"تشکر از شما برای کمک به بررسی درخواست‌های کتابخانهٔ ویکی‌پدیا!"
+msgid "%(submit_date)s - %(commenter)s %(comment)s See it at: %(app_url)s Thanks for helping review Wikipedia Library applications!"
+msgstr "%(submit_date)s - %(commenter)s %(comment)s از اینجا ببینید: %(app_url)s با تشکر از شما برای کمک به بررسی درخواست‌های کتابخانهٔ ویکی‌پدیا!"
 
 #. Translators: This is the subject line of an email sent to users who have a comment added to an application they also commented on. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/comment_notification_others-subject.html:4
@@ -1246,13 +1042,8 @@ msgstr "نظر جدید در مورد درخواستی که شما در مورد
 #. Translators: This text is part of a scheduled reminder email sent to coordinators who have applications requiring action. Don't translate Jinja variables in curly braces like total_apps, or user.
 #: TWLight/emails/templates/emails/coordinator_reminder_notification-body-html.html:5
 #, python-format
-msgid ""
-"<p>Dear %(user)s,</p> <p>Our records indicate that you are the designated "
-"coordinator for partners that have a total of %(total_apps)s applications.</"
-"p>"
-msgstr ""
-"<p>%(user)s عزیز،</p> <p> سوابق ما نشان می‌دهد که شما هماهنگ‌کنندهٔ تعیین‌شده "
-"برای شرکایی هستید که جمعاً %(total_apps)s درخواست دارند.</p>"
+msgid "<p>Dear %(user)s,</p> <p>Our records indicate that you are the designated coordinator for partners that have a total of %(total_apps)s applications.</p>"
+msgstr "<p>%(user)s عزیز،</p> <p> سوابق ما نشان می‌دهد که شما هماهنگ‌کنندهٔ تعیین‌شده برای شرکایی هستید که جمعاً %(total_apps)s درخواست دارند.</p>"
 
 #. Translators: Breakdown as in 'cost breakdown'; analysis.
 #: TWLight/emails/templates/emails/coordinator_reminder_notification-body-html.html:11
@@ -1287,44 +1078,20 @@ msgstr[0] "%(counter)s درخواست تأییدشده"
 #. Translators: This text is part of a scheduled reminder email sent to coordinators who have applications requiring action. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library). Don't translate Jinja variables in curly braces like link; don't translate email addresses or html tags either.
 #: TWLight/emails/templates/emails/coordinator_reminder_notification-body-html.html:39
 #, python-format
-msgid ""
-"<p>This is a gentle reminder that you may review applications at <a href="
-"\"%(link)s\">%(link)s</a>.</p> <p>You can customise your reminders under "
-"'preferences' in your user profile.</p> <p>If you received this message in "
-"error, drop us a line at wikipedialibrary@wikimedia.org.</p> <p>Thanks for "
-"helping review Wikipedia Library applications!</p>"
-msgstr ""
-"<p>این یک یادآوری محترمانه است که می‌توانید درخواست‌ها را در<a href=\"%(link)s"
-"\">%(link)s</a> بررسی کنید.</p> <p>می‌توانید یادآورهایتان را در بخش «ترجیحات» "
-"در نمایهٔ کاربری خود سفارشی کنید.</p> <p>اگر این پیام را به اشتباه دریافت "
-"کردید، به آدرس wikipedialibrary@wikimedia.org گزارش دهید.</p> <p>با تشکر از "
-"شما برای کمک به بررسی درخواست‌های کتابخانهٔ ویکی‌پدیا!</p>"
+msgid "<p>This is a gentle reminder that you may review applications at <a href=\"%(link)s\">%(link)s</a>.</p> <p>You can customise your reminders under 'preferences' in your user profile.</p> <p>If you received this message in error, drop us a line at wikipedialibrary@wikimedia.org.</p> <p>Thanks for helping review Wikipedia Library applications!</p>"
+msgstr "<p>این یک یادآوری محترمانه است که می‌توانید درخواست‌ها را در<a href=\"%(link)s\">%(link)s</a> بررسی کنید.</p> <p>می‌توانید یادآورهایتان را در بخش «ترجیحات» در نمایهٔ کاربری خود سفارشی کنید.</p> <p>اگر این پیام را به اشتباه دریافت کردید، به آدرس wikipedialibrary@wikimedia.org گزارش دهید.</p> <p>با تشکر از شما برای کمک به بررسی درخواست‌های کتابخانهٔ ویکی‌پدیا!</p>"
 
 #. Translators: This text is part of a scheduled reminder email sent to coordinators who have applications requiring action. Don't translate Jinja variables in curly braces like total_apps, or user.
 #: TWLight/emails/templates/emails/coordinator_reminder_notification-body-text.html:3
 #, python-format
-msgid ""
-"Dear %(user)s, Our records indicate that you are the designated coordinator "
-"for partners that have a total of %(total_apps)s applications."
-msgstr ""
-"%(user)s عزیز، سوابق ما نشان می‌دهد که شما هماهنگ‌کنندهٔ طراحی‌شده برای شرکا "
-"هستید که در کل %(total_apps)s درخواست دارند."
+msgid "Dear %(user)s, Our records indicate that you are the designated coordinator for partners that have a total of %(total_apps)s applications."
+msgstr "%(user)s عزیز، سوابق ما نشان می‌دهد که شما هماهنگ‌کنندهٔ طراحی‌شده برای شرکا هستید که در کل %(total_apps)s درخواست دارند."
 
 #. Translators: This text is part of a scheduled reminder email sent to coordinators who have applications requiring action. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library). Don't translate Jinja variables in curly braces like link; don't translate the email address either.
 #: TWLight/emails/templates/emails/coordinator_reminder_notification-body-text.html:38
 #, python-format
-msgid ""
-"This is a gentle reminder that you may review applications at: %(link)s. You "
-"can customise your reminders under 'preferences' in your user profile. If "
-"you received this message in error, drop us a line at: "
-"wikipedialibrary@wikimedia.org Thanks for helping review Wikipedia Library "
-"applications!"
-msgstr ""
-"این یک یادآوری محترمانه است که می‌توانید درخواست‌ها را در %(link)s بررسی کنید. "
-"می‌توانید یادآورهایتان را در بخش «ترجیحات» در نمایهٔ کاربری خود سفارشی کنید. "
-"اگر این پیام را به اشتباه دریافت کردید، به آدرس wikipedialibrary@wikimedia."
-"org گزارش دهید. با تشکر از شما برای کمک به بررسی درخواست‌های کتابخانهٔ "
-"ویکی‌پدیا!"
+msgid "This is a gentle reminder that you may review applications at: %(link)s. You can customise your reminders under 'preferences' in your user profile. If you received this message in error, drop us a line at: wikipedialibrary@wikimedia.org Thanks for helping review Wikipedia Library applications!"
+msgstr "این یک یادآوری محترمانه است که می‌توانید درخواست‌ها را در %(link)s بررسی کنید. می‌توانید یادآورهایتان را در بخش «ترجیحات» در نمایهٔ کاربری خود سفارشی کنید. اگر این پیام را به اشتباه دریافت کردید، به آدرس wikipedialibrary@wikimedia.org گزارش دهید. با تشکر از شما برای کمک به بررسی درخواست‌های کتابخانهٔ ویکی‌پدیا!"
 
 #. Translators: This is the subject line of a scheduled reminder email sent to coordinators who have applications to review. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library). Do not translate items in curly braces.
 #: TWLight/emails/templates/emails/coordinator_reminder_notification-subject.html:4
@@ -1334,32 +1101,14 @@ msgstr "درخواستی‌هایی در کتابخانهٔ ویکی‌پدیا 
 #. Translators: This email is sent to users when their application is rejected. Don't translate Jinja variables in curly braces like user or partner; don't translate html tags either. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/rejection_notification-body-html.html:5
 #, python-format
-msgid ""
-"<p>Dear %(user)s,</p> <p>Thank you for applying for access to %(partner)s "
-"resources through The Wikipedia Library. Unfortunately at this time your "
-"application has not been approved. You can view your application and review "
-"comments at <a href=\"%(app_url)s\">%(app_url)s</a>.</p> <p>Best,</p> <p>The "
-"Wikipedia Library</p>"
-msgstr ""
-"<p>%(user)s عزیز،</p> <p> ممنون از اینکه برای دسترسی به محتوای %(partner)s "
-"از طریق کتابخانهٔ ویکی‌پدیا درخواست دادید. متأسفانه در حال حاضر درخواست شما "
-"تأیید نشد. می‌توانید درخواست‌تان را به همراه نظراتی که بر روی آن داده شده است "
-"را در <a href=\"%(app_url)s\">%(app_url)s</a>ببینید.</p><p>با احترام،</p> "
-"<p>کتابخانهٔ ویکی‌پدیا</p>"
+msgid "<p>Dear %(user)s,</p> <p>Thank you for applying for access to %(partner)s resources through The Wikipedia Library. Unfortunately at this time your application has not been approved. You can view your application and review comments at <a href=\"%(app_url)s\">%(app_url)s</a>.</p> <p>Best,</p> <p>The Wikipedia Library</p>"
+msgstr "<p>%(user)s عزیز،</p> <p> ممنون از اینکه برای دسترسی به محتوای %(partner)s از طریق کتابخانهٔ ویکی‌پدیا درخواست دادید. متأسفانه در حال حاضر درخواست شما تأیید نشد. می‌توانید درخواست‌تان را به همراه نظراتی که بر روی آن داده شده است را در <a href=\"%(app_url)s\">%(app_url)s</a>ببینید.</p><p>با احترام،</p> <p>کتابخانهٔ ویکی‌پدیا</p>"
 
 #. Translators: This email is sent to users when their application is rejected. Don't translate Jinja variables in curly braces like user or partner. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/rejection_notification-body-text.html:3
 #, python-format
-msgid ""
-"Dear %(user)s, Thank you for applying for access to %(partner)s resources "
-"through The Wikipedia Library. Unfortunately at this time your application "
-"has not been approved. You can view your application and review comments at: "
-"%(app_url)s Best, The Wikipedia Library"
-msgstr ""
-"%(user)s گرامی، از اینکه برای دسترسی به %(partner)s از طریق کتابخانهٔ "
-"ویکی‌پدیا درخواست دادید متشکریم. متأسفانه در حال حاضر درخواست شما تأیید نشد. "
-"می‌توانید درخواست‌تان را به‌همراه نظرات داده‌شده بر آن را از %(app_url)s ببینید. "
-"با احترام، کتابخانهٔ ویکی‌پدیا"
+msgid "Dear %(user)s, Thank you for applying for access to %(partner)s resources through The Wikipedia Library. Unfortunately at this time your application has not been approved. You can view your application and review comments at: %(app_url)s Best, The Wikipedia Library"
+msgstr "%(user)s گرامی، از اینکه برای دسترسی به %(partner)s از طریق کتابخانهٔ ویکی‌پدیا درخواست دادید متشکریم. متأسفانه در حال حاضر درخواست شما تأیید نشد. می‌توانید درخواست‌تان را به‌همراه نظرات داده‌شده بر آن را از %(app_url)s ببینید. با احترام، کتابخانهٔ ویکی‌پدیا"
 
 #. Translators: This is the subject of an email which is sent to users when their application has been rejected. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/rejection_notification-subject.html:4
@@ -1369,39 +1118,14 @@ msgstr "درخواست کتابخانهٔ ویکی‌پدیای شما"
 #. Translators: This email is sent to users when they have an account that is soon to expire. Don't translate Jinja variables in curly braces like partner_name or partner_link; don't translate html tags either. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/user_renewal_notice-body-html.html:5
 #, python-format
-msgid ""
-"<p>Dear %(user)s,</p> <p>According to our records, your access to "
-"%(partner_name)s will soon expire and you may lose access. If you want to "
-"continue making use of your free account, you can request renewal of your "
-"account by clicking the 'Renew' or 'Extend' button at %(partner_link)s.</p> "
-"<p>Best,</p> <p>The Wikipedia Library</p> <p>You can disable these emails in "
-"your user page preferences: https://wikipedialibrary.wmflabs.org/users/</p>"
-msgstr ""
-"<p>%(user)s گرامی،</p> <p>طبق سوابق ما، دسترسی شما به %(partner_name)s به "
-"زودی منقضی می‌شود و ممکن است دسترسی خود را از دست بدهید. اگر می‌خواهید به "
-"استفاده از حساب رایگان خود ادامه دهید، می‌توانید با کلیک کردن روی دکمهٔ "
-"'تجدید' یا 'تمدید' در %(partner_link)s درخواست تمدید بدهید.</p> <p>با آرزوی "
-"بهترین‌ها،</p> <p>کتابخانهٔ ویکی‌پدیا</p> شما می‌توانید این ایمیل‌ها را در "
-"ترجیحات صفحهٔ کاربری خود غیرفعال کنید: https://wikipedialibrary.wmflabs.org/"
-"users/"
+msgid "<p>Dear %(user)s,</p> <p>According to our records, your access to %(partner_name)s will soon expire and you may lose access. If you want to continue making use of your free account, you can request renewal of your account by clicking the 'Renew' or 'Extend' button at %(partner_link)s.</p> <p>Best,</p> <p>The Wikipedia Library</p> <p>You can disable these emails in your user page preferences: https://wikipedialibrary.wmflabs.org/users/</p>"
+msgstr "<p>%(user)s گرامی،</p> <p>طبق سوابق ما، دسترسی شما به %(partner_name)s به زودی منقضی می‌شود و ممکن است دسترسی خود را از دست بدهید. اگر می‌خواهید به استفاده از حساب رایگان خود ادامه دهید، می‌توانید با کلیک کردن روی دکمهٔ 'تجدید' یا 'تمدید' در %(partner_link)s درخواست تمدید بدهید.</p> <p>با آرزوی بهترین‌ها،</p> <p>کتابخانهٔ ویکی‌پدیا</p> شما می‌توانید این ایمیل‌ها را در ترجیحات صفحهٔ کاربری خود غیرفعال کنید: https://wikipedialibrary.wmflabs.org/users/"
 
 #. Translators: This email is sent to users when they have an account that is soon to expire. Don't translate Jinja variables in curly braces like partner_name or partner_link; don't translate html tags either. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/user_renewal_notice-body-text.html:3
 #, python-format
-msgid ""
-"Dear %(user)s, According to our records, your access to %(partner_name)s "
-"will soon expire and you may lose access. If you want to continue making use "
-"of your free account, you can request renewal of your account by clicking "
-"the Renew button at %(partner_link)s. Best, The Wikipedia Library You can "
-"disable these emails in your user page preferences: https://wikipedialibrary."
-"wmflabs.org/users/"
-msgstr ""
-"%(user)s گرامی، سوابق ما نشان می‌دهد که دسترسی شما به %(partner_name)s به‌زودی "
-"منقضی می‌شود و ممکن است دسترسی‌تان به این منبع از بین برود. اگر مایلید تا "
-"همچنان به این منبع دسترسی رایگان داشته باشید، کافی‌ست تا با کلیک بر روی "
-"%(partner_link)s درخواست تمدید بدهید. با احترام، کتابخانهٔ ویکی‌پدیا \n"
-"می‌توانید این ایمیل‌ها را در ترجیحات صفحهٔ کاربری خود غیرفعال کنید: https://"
-"wikipedialibrary.wmflabs.org/users"
+msgid "Dear %(user)s, According to our records, your access to %(partner_name)s will soon expire and you may lose access. If you want to continue making use of your free account, you can request renewal of your account by clicking the Renew button at %(partner_link)s. Best, The Wikipedia Library You can disable these emails in your user page preferences: https://wikipedialibrary.wmflabs.org/users/"
+msgstr "%(user)s گرامی، سوابق ما نشان می‌دهد که دسترسی شما به %(partner_name)s به‌زودی منقضی می‌شود و ممکن است دسترسی‌تان به این منبع از بین برود. اگر مایلید تا همچنان به این منبع دسترسی رایگان داشته باشید، کافی‌ست تا با کلیک بر روی %(partner_link)s درخواست تمدید بدهید. با احترام، کتابخانهٔ ویکی‌پدیا \nمی‌توانید این ایمیل‌ها را در ترجیحات صفحهٔ کاربری خود غیرفعال کنید: https://wikipedialibrary.wmflabs.org/users"
 
 #. Translators: This is the subject of an email sent to users when they have an account that is soon to expire. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/user_renewal_notice-subject.html:4
@@ -1411,37 +1135,14 @@ msgstr "عضویت شما در کتابخانهٔ ویکی‌پدیا به‌ز�
 #. Translators: This email is sent to users when their application is waitlisted because there are no more accounts available. Don't translate Jinja variables in curly braces like user or partner; don't translate html tags either. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/waitlist_notification-body-html.html:5
 #, python-format
-msgid ""
-"<p>Dear %(user)s,</p> <p>Thank you for applying for access to %(partner)s "
-"resources through The Wikipedia Library. There are no accounts currently "
-"available so your application has been waitlisted. Your application will be "
-"evaluated if/when more accounts become available. You can see all available "
-"resources at <a href=\"%(link)s\">%(link)s</a>.</p> <p>Best,</p> <p>The "
-"Wikipedia Library</p>"
-msgstr ""
-"<p>%(user)s عزیز،</p> <p> ممنون از اینکه برای دسترسی به %(partner)s از طریق "
-"کتابخانهٔ ویکی‌پدیا درخواست داده‌اید. در حال حاضر هیچ اکانتی برای اعطا به شما "
-"وجود ندارد، در نتیجه، درخواست شما به فهرست انتظار منتقل شد. این درخواست به "
-"محض در دسترس بودن اکانت‌های جدید بررسی خواهد شد. شما می‌توانید همهٔ منابع در "
-"دسترس را از طریق  <a href=\"%(link)s\">%(link)s</a> ببینید.</p> <p>با احترا،"
-"</p> <p>کتابخانهٔ ویکی‌پدیا</p>"
+msgid "<p>Dear %(user)s,</p> <p>Thank you for applying for access to %(partner)s resources through The Wikipedia Library. There are no accounts currently available so your application has been waitlisted. Your application will be evaluated if/when more accounts become available. You can see all available resources at <a href=\"%(link)s\">%(link)s</a>.</p> <p>Best,</p> <p>The Wikipedia Library</p>"
+msgstr "<p>%(user)s عزیز،</p> <p> ممنون از اینکه برای دسترسی به %(partner)s از طریق کتابخانهٔ ویکی‌پدیا درخواست داده‌اید. در حال حاضر هیچ اکانتی برای اعطا به شما وجود ندارد، در نتیجه، درخواست شما به فهرست انتظار منتقل شد. این درخواست به محض در دسترس بودن اکانت‌های جدید بررسی خواهد شد. شما می‌توانید همهٔ منابع در دسترس را از طریق  <a href=\"%(link)s\">%(link)s</a> ببینید.</p> <p>با احترا،</p> <p>کتابخانهٔ ویکی‌پدیا</p>"
 
 #. Translators: This email is sent to users when their application is waitlisted because there are no more accounts available. Don't translate Jinja variables in curly braces like user or partner. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/waitlist_notification-body-text.html:3
 #, python-format
-msgid ""
-"Dear %(user)s, Thank you for applying for access to %(partner)s resources "
-"through The Wikipedia Library. There are no accounts currently available so "
-"your application has been waitlisted. Your application will be evaluated if/"
-"when more accounts become available. You can see all available resources at: "
-"%(link)s Best, The Wikipedia Library"
-msgstr ""
-"<p>%(user)s عزیز،</p> <p> ممنون از اینکه برای دسترسی به %(partner)s از طریق "
-"کتابخانهٔ ویکی‌پدیا درخواست داده‌اید. در حال حاضر هیچ اکانتی برای اعطا به شما "
-"وجود ندارد، در نتیجه، درخواست شما به فهرست انتظار منتقل شد. این درخواست به "
-"محض در دسترس بودن اکانت‌های جدید بررسی خواهد شد. شما می‌توانید همهٔ منابع در "
-"دسترس را از طریق  <a href=\"%(link)s\">%(link)s</a> ببینید.</p> <p>با احترا،"
-"</p> <p>کتابخانهٔ ویکی‌پدیا</p>"
+msgid "Dear %(user)s, Thank you for applying for access to %(partner)s resources through The Wikipedia Library. There are no accounts currently available so your application has been waitlisted. Your application will be evaluated if/when more accounts become available. You can see all available resources at: %(link)s Best, The Wikipedia Library"
+msgstr "<p>%(user)s عزیز،</p> <p> ممنون از اینکه برای دسترسی به %(partner)s از طریق کتابخانهٔ ویکی‌پدیا درخواست داده‌اید. در حال حاضر هیچ اکانتی برای اعطا به شما وجود ندارد، در نتیجه، درخواست شما به فهرست انتظار منتقل شد. این درخواست به محض در دسترس بودن اکانت‌های جدید بررسی خواهد شد. شما می‌توانید همهٔ منابع در دسترس را از طریق  <a href=\"%(link)s\">%(link)s</a> ببینید.</p> <p>با احترا،</p> <p>کتابخانهٔ ویکی‌پدیا</p>"
 
 #. Translators: This is the subject of an email sent to users when their application is waitlisted because there are no more accounts available. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/waitlist_notification-subject.html:4
@@ -1602,19 +1303,14 @@ msgstr "در دسترس نیست"
 #: TWLight/resources/templates/resources/filter_section.html:14
 #: TWLight/templates/about.html:12
 #: TWLight/users/templates/users/filter_section.html:13
-msgid ""
-"The Wikipedia Library allows active editors to access a wide range of "
-"collections of paywalled reliable sources for free!"
-msgstr ""
-"کتابخانهٔ ویکی‌پدیا به ویرایشگران فعال اجازه می‌دهد تا به گسترهٔ وسیعی از "
-"مجموعه‌های معتبر پولی به‌صورت رایگان دسترسی داشته باشند!"
+msgid "The Wikipedia Library allows active editors to access a wide range of collections of paywalled reliable sources for free!"
+msgstr "کتابخانهٔ ویکی‌پدیا به ویرایشگران فعال اجازه می‌دهد تا به گسترهٔ وسیعی از مجموعه‌های معتبر پولی به‌صورت رایگان دسترسی داشته باشند!"
 
 #. Translators: On the Browse Partners page (https://wikipedialibrary.wmflabs.org/partners/), this introduces users to The Wikipedia Library.
 #. Translators: On the MyLibrary page (https://wikipedialibrary.wmflabs.org/users/my_library), this introduces users to The Wikipedia Library.
 #: TWLight/resources/templates/resources/filter_section.html:17
 #: TWLight/users/templates/users/filter_section.html:15
-msgid ""
-"Start with the search bar at the top or browse publisher websites directly."
+msgid "Start with the search bar at the top or browse publisher websites directly."
 msgstr "با نوار جستجوی بالا یا گشتن در وب‌گاه ناشر شروع کنید."
 
 #. Translators: On the Browse Partners page (https://wikipedialibrary.wmflabs.org/partners/), this appears below introductory text and links to the 'About' page (https://wikipedialibrary.wmflabs.org/about/)
@@ -1688,67 +1384,39 @@ msgstr "بازگشت به پایگاه"
 #. Translators: If we have no available accounts for a partner, the coordinator can change the application system to a waiting list.
 #: TWLight/resources/templates/resources/partner_detail.html:36
 #: TWLight/resources/templates/resources/partner_detail_apply.html:17
-msgid ""
-"There are no access grants available for this partner at this time. You can "
-"still apply for access; applications will be processed when access is "
-"available."
-msgstr ""
-"در حال حاضر هیچ مجوز دسترسی‌ای برای این شریک وجود ندارد. هنوز هم می‌توانید "
-"برای دسترسی درخواست دهید. درخواست‌ها هنگامی که امکان دسترسی فراهم باشد پردازش "
-"می‌شوند."
+msgid "There are no access grants available for this partner at this time. You can still apply for access; applications will be processed when access is available."
+msgstr "در حال حاضر هیچ مجوز دسترسی‌ای برای این شریک وجود ندارد. هنوز هم می‌توانید برای دسترسی درخواست دهید. درخواست‌ها هنگامی که امکان دسترسی فراهم باشد پردازش می‌شوند."
 
 #. Translators: This text links to the minimum user requirements and terms of use on the partner page.
 #: TWLight/resources/templates/resources/partner_detail.html:48
 #: TWLight/resources/templates/resources/partner_detail_apply.html:29
 #, python-format
-msgid ""
-"Before applying, please review the <strong><a class=\"twl-links\" href="
-"\"%(about)s#req\">minimum requirements</a></strong> for access and our "
-"<strong><a class=\"twl-links\" href=\"%(terms)s\">terms of use</a></strong>."
-msgstr ""
-"پیش  از اقدام، لطفاً <strong><a class=\"twl-links\" href=\"%(about)s#req"
-"\">حداقل نیازمندی‌ها</a></strong> برای دسترسی و <strong><a class=\"twl-links"
-"\" href=\"%(terms)s\">شرایط استفاده</a></strong> را مرور کنید."
+msgid "Before applying, please review the <strong><a class=\"twl-links\" href=\"%(about)s#req\">minimum requirements</a></strong> for access and our <strong><a class=\"twl-links\" href=\"%(terms)s\">terms of use</a></strong>."
+msgstr "پیش  از اقدام، لطفاً <strong><a class=\"twl-links\" href=\"%(about)s#req\">حداقل نیازمندی‌ها</a></strong> برای دسترسی و <strong><a class=\"twl-links\" href=\"%(terms)s\">شرایط استفاده</a></strong> را مرور کنید."
 
 #. Translators: This text refers to the page containing the content a user is authorized to access.
 #: TWLight/resources/templates/resources/partner_detail.html:69
 #, python-format
-msgid ""
-"View the status of your access in <strong><a class=\"twl-links\" href="
-"\"%(library_url)s\">My Library</a></strong> page."
-msgstr ""
-"وضعیت دسترسی‌تان را در صفحهٔ <strong><a class=\"twl-links\" href="
-"\"%(library_url)s\">کتابخانهٔ من</a></strong> ببینید."
+msgid "View the status of your access in <strong><a class=\"twl-links\" href=\"%(library_url)s\">My Library</a></strong> page."
+msgstr "وضعیت دسترسی‌تان را در صفحهٔ <strong><a class=\"twl-links\" href=\"%(library_url)s\">کتابخانهٔ من</a></strong> ببینید."
 
 #. Translators: This message is shown when a user has open applications, linking to their respective applications page.
 #: TWLight/resources/templates/resources/partner_detail.html:78
 #, python-format
-msgid ""
-"View the status of your application(s) on your <strong><a class=\"twl-links"
-"\" href=\"%(applications_url)s\">My Applications</a></strong> page."
-msgstr ""
-"وضعیت درخواست‌هایتان را می‌توانید در صفحهٔ <strong><a class=\"twl-links\" href="
-"\"%(applications_url)s\">درخواست‌های من</a></strong> ببینید."
+msgid "View the status of your application(s) on your <strong><a class=\"twl-links\" href=\"%(applications_url)s\">My Applications</a></strong> page."
+msgstr "وضعیت درخواست‌هایتان را می‌توانید در صفحهٔ <strong><a class=\"twl-links\" href=\"%(applications_url)s\">درخواست‌های من</a></strong> ببینید."
 
 #. Translators: This message is shown when a user has authorizations, linking to their respective collections page.
 #: TWLight/resources/templates/resources/partner_detail_apply.html:50
 #, python-format
-msgid ""
-"View the status of your access on your <strong><a href=\"%(library_url)s\" "
-"class=\"twl-links\">My Library</a></strong> page."
-msgstr ""
-"وضعیت دسترسی‌تان را می‌توانید در صفحهٔ <strong><a class=\"twl-links\" href="
-"\"%(library_url)s\">کتابخانهٔ من</a></strong> ببینید."
+msgid "View the status of your access on your <strong><a href=\"%(library_url)s\" class=\"twl-links\">My Library</a></strong> page."
+msgstr "وضعیت دسترسی‌تان را می‌توانید در صفحهٔ <strong><a class=\"twl-links\" href=\"%(library_url)s\">کتابخانهٔ من</a></strong> ببینید."
 
 #. Translators: This message is shown when a user has open applications, linking to their respective applications page.
 #: TWLight/resources/templates/resources/partner_detail_apply.html:60
 #, python-format
-msgid ""
-"View the status of your application(s) on your <strong><a href="
-"\"%(applications_url)s\">My Applications</a></strong> page."
-msgstr ""
-"وضعیت درخواست‌هایتان را می‌توانید در صفحهٔ <strong><a href="
-"\"%(applications_url)s\">درخواست‌های من</a></strong> ببینید."
+msgid "View the status of your application(s) on your <strong><a href=\"%(applications_url)s\">My Applications</a></strong> page."
+msgstr "وضعیت درخواست‌هایتان را می‌توانید در صفحهٔ <strong><a href=\"%(applications_url)s\">درخواست‌های من</a></strong> ببینید."
 
 #. Translators: One the partner detail page, this text labels the button which coordinators can click to remove a partner from waitlisted status.
 #: TWLight/resources/templates/resources/partner_detail_apply.html:73
@@ -1763,9 +1431,7 @@ msgstr "قرار دادن در لیست انتظار"
 #: TWLight/resources/templates/resources/partner_detail_apply.html:86
 #, python-format
 msgid "<strong>%(coordinator)s</strong> processes applications to %(partner)s."
-msgstr ""
-"<strong>%(coordinator)s</strong> درخواست‌های مربوط به %(partner)s را بررسی "
-"می‌کند."
+msgstr "<strong>%(coordinator)s</strong> درخواست‌های مربوط به %(partner)s را بررسی می‌کند."
 
 #. Translators: When a coordinator is assigned to a partner, their details are shown on the page. This text labels a link to their Talk page on Wikipedia, and should be translated to the text used for Talk pages in the language you are translating to.
 #: TWLight/resources/templates/resources/partner_detail_apply.html:95
@@ -1779,15 +1445,8 @@ msgstr "صفحهٔ ایمیل به کاربر"
 
 #. Translators: If no account coordinator is assigned to a partner, the Wikipedia Library team will coordinate signups. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/resources/templates/resources/partner_detail_apply.html:112
-msgid ""
-"The Wikipedia Library team will process this application. Want to help? <a "
-"class=\"twl-links\" href=\"https://en.wikipedia.org/wiki/Wikipedia:"
-"The_Wikipedia_Library/Coordinators/Signup\">Sign up as a coordinator.</a>"
-msgstr ""
-"تیم کتابخانهٔ ویکی‌پدیا این درخواست را پردازش می‌کند. می‌خواهید کمک کنید؟ <a "
-"class=\"twl-links\" href=\"https://en.wikipedia.org/wiki/Wikipedia:"
-"The_Wikipedia_Library/Coordinators/Signup\"> به عنوان یک هماهنگ‌کننده ثبت نام "
-"کنید.</a>"
+msgid "The Wikipedia Library team will process this application. Want to help? <a class=\"twl-links\" href=\"https://en.wikipedia.org/wiki/Wikipedia:The_Wikipedia_Library/Coordinators/Signup\">Sign up as a coordinator.</a>"
+msgstr "تیم کتابخانهٔ ویکی‌پدیا این درخواست را پردازش می‌کند. می‌خواهید کمک کنید؟ <a class=\"twl-links\" href=\"https://en.wikipedia.org/wiki/Wikipedia:The_Wikipedia_Library/Coordinators/Signup\"> به عنوان یک هماهنگ‌کننده ثبت نام کنید.</a>"
 
 #. Translators: This text labels a button coordinators can click to view a list of users who have applied for access for a particular partner
 #: TWLight/resources/templates/resources/partner_detail_apply.html:121
@@ -1816,24 +1475,14 @@ msgstr "دسترسی به بستهٔ کتابخانه"
 
 #. Translators: Text shown to authenticated, bundle eligible users when they visit a Bundle partner page.
 #: TWLight/resources/templates/resources/partner_detail_apply.html:138
-msgid ""
-"You are eligible to access Library Bundle partners. Click the button above "
-"to access the collection."
-msgstr ""
-"شما واجد شرایط دسترسی به شرکای بستهٔ کتابخانه هستید. برای دسترسی به مجموعه بر "
-"روی دکمهٔ بالا کلیک کنید."
+msgid "You are eligible to access Library Bundle partners. Click the button above to access the collection."
+msgstr "شما واجد شرایط دسترسی به شرکای بستهٔ کتابخانه هستید. برای دسترسی به مجموعه بر روی دکمهٔ بالا کلیک کنید."
 
 #. Translators: Text shown to authenticated, bundle ineligible users when they visit a Bundle partner page.
 #: TWLight/resources/templates/resources/partner_detail_apply.html:152
 #, python-format
-msgid ""
-"You are not eligible to access Library Bundle partners. Visit the <a class="
-"\"twl-links\" href=\"%(homepage)s\">homepage</a> to check the eligibility "
-"criteria."
-msgstr ""
-"شما واجد شرایط دسترسی به شرکای بستهٔ کتابخانه نیستید. برای بررسی معیارهای "
-"واجد شرایط بودن، از <a class=\"twl-links\" href=\"%(homepage)s\">صفحهٔ اصلی</"
-"a> دیدن کنید."
+msgid "You are not eligible to access Library Bundle partners. Visit the <a class=\"twl-links\" href=\"%(homepage)s\">homepage</a> to check the eligibility criteria."
+msgstr "شما واجد شرایط دسترسی به شرکای بستهٔ کتابخانه نیستید. برای بررسی معیارهای واجد شرایط بودن، از <a class=\"twl-links\" href=\"%(homepage)s\">صفحهٔ اصلی</a> دیدن کنید."
 
 #. Translators: Buttton prompting users to log in.
 #: TWLight/resources/templates/resources/partner_detail_apply.html:160
@@ -1844,14 +1493,8 @@ msgstr "ورود به سامانه"
 #. Translators: Text shown to unauthenticated users when they visit a Bundle partner page.
 #: TWLight/resources/templates/resources/partner_detail_apply.html:168
 #, python-format
-msgid ""
-"This resource is part of our <a class=\"twl-links\" href=\"%(about)s"
-"\">Library Bundle</a>, which you can access if you meet our minimum "
-"eligibility criteria. Log in to find out if you are eligible."
-msgstr ""
-"این منبع بخشی از <a class=\"twl-links\" href=\"%(about)s\">بستهٔ کتابخانه</a> "
-"است، اگر حداقل معیارهای واجد شرایط بودن را داشته باشید می‌توانید به آن دسترسی "
-"پیدا کنید. وارد شوید تا ببینید که آیا واجد شرایط هستید یا نه."
+msgid "This resource is part of our <a class=\"twl-links\" href=\"%(about)s\">Library Bundle</a>, which you can access if you meet our minimum eligibility criteria. Log in to find out if you are eligible."
+msgstr "این منبع بخشی از <a class=\"twl-links\" href=\"%(about)s\">بستهٔ کتابخانه</a> است، اگر حداقل معیارهای واجد شرایط بودن را داشته باشید می‌توانید به آن دسترسی پیدا کنید. وارد شوید تا ببینید که آیا واجد شرایط هستید یا نه."
 
 #. Translators: This is the label for a number which shows the total active accounts for one partner. (e.g. https://wikipedialibrary.wmflabs.org/partners/8/).
 #: TWLight/resources/templates/resources/partner_detail_stats.html:21
@@ -1902,34 +1545,20 @@ msgstr "حداکثر طول نمونه"
 #. Translators: If a partner has specified the excerpt limit both in words and percentage, this message will display the percentage of words and the number of words on the partner page.
 #: TWLight/resources/templates/resources/partner_detail_timeline.html:99
 #, python-format
-msgid ""
-"%(object)s allows a maximum of %(excerpt_limit)s words or "
-"%(excerpt_limit_percentage)s%% of an article be excerpted into a Wikipedia "
-"article."
-msgstr ""
-"%(object)s اجازه می‌دهد که حداکثر تا %(excerpt_limit)s واژه یا "
-"%(excerpt_limit_percentage)s%% از یک مقاله را در یک مدخل ویکی‌پدیا استفاده "
-"کنید."
+msgid "%(object)s allows a maximum of %(excerpt_limit)s words or %(excerpt_limit_percentage)s%% of an article be excerpted into a Wikipedia article."
+msgstr "%(object)s اجازه می‌دهد که حداکثر تا %(excerpt_limit)s واژه یا %(excerpt_limit_percentage)s%% از یک مقاله را در یک مدخل ویکی‌پدیا استفاده کنید."
 
 #. Translators: If a partner has specified the excerpt limit in words, this message will display the number of words on the partner page.
 #: TWLight/resources/templates/resources/partner_detail_timeline.html:106
 #, python-format
-msgid ""
-"%(object)s allows a maximum of %(excerpt_limit)s words be excerpted into a "
-"Wikipedia article."
-msgstr ""
-"%(object)s اجازه می‌دهد که حداکثر تا %(excerpt_limit)s واژه را در یک مدخل "
-"ویکی‌پدیا استفاده کنید."
+msgid "%(object)s allows a maximum of %(excerpt_limit)s words be excerpted into a Wikipedia article."
+msgstr "%(object)s اجازه می‌دهد که حداکثر تا %(excerpt_limit)s واژه را در یک مدخل ویکی‌پدیا استفاده کنید."
 
 #. Translators: If a partner has specified the excerpt limit in percentage, this message will display the percentage of words on the partner page.
 #: TWLight/resources/templates/resources/partner_detail_timeline.html:113
 #, python-format
-msgid ""
-"%(object)s allows a maximum of %(excerpt_limit_percentage)s%% of an article "
-"be excerpted into a Wikipedia article."
-msgstr ""
-"%(object)s اجازه می‌دهد که حداکثر تا %(excerpt_limit_percentage)s%% از یک "
-"مقاله را در یک مدخل ویکی‌پدیا استفاده کنید."
+msgid "%(object)s allows a maximum of %(excerpt_limit_percentage)s%% of an article be excerpted into a Wikipedia article."
+msgstr "%(object)s اجازه می‌دهد که حداکثر تا %(excerpt_limit_percentage)s%% از یک مقاله را در یک مدخل ویکی‌پدیا استفاده کنید."
 
 #. Translators: If a partner has other requirements for access, this text shows as the title for that information field. (e.g. https://wikipedialibrary.wmflabs.org/partners/10/).
 #: TWLight/resources/templates/resources/partner_detail_timeline.html:132
@@ -1939,12 +1568,8 @@ msgstr "شرایط ویژه برای متقاضیان"
 #. Translators: If a user must agree to a Terms of Use document, they see this message, and must enter the name of the resource. Don't translate publisher or url.
 #: TWLight/resources/templates/resources/partner_detail_timeline.html:140
 #, python-format
-msgid ""
-"%(publisher)s requires that you agree with its <a href=\"%(url)s\">terms of "
-"use</a>."
-msgstr ""
-"%(publisher)s نیاز دارد که با <a href=\"%(url)s\">شرایط استفادهٔ آن</a> "
-"موافقت کنید."
+msgid "%(publisher)s requires that you agree with its <a href=\"%(url)s\">terms of use</a>."
+msgstr "%(publisher)s نیاز دارد که با <a href=\"%(url)s\">شرایط استفادهٔ آن</a> موافقت کنید."
 
 #. Translators: If a user must provide their real name to apply to a partner, they see this message, and must enter the name of the resource. Don't translate publisher.
 #: TWLight/resources/templates/resources/partner_detail_timeline.html:150
@@ -1967,22 +1592,14 @@ msgstr "%(publisher)s الزام کرده است که وابستگی سازما�
 #. Translators: If a user must select a specific resource to apply for, they see this message, and must enter the name of the resource. Don't translate publisher.
 #: TWLight/resources/templates/resources/partner_detail_timeline.html:177
 #, python-format
-msgid ""
-"%(publisher)s requires that you specify a particular title that you want to "
-"access."
-msgstr ""
-"برای دسترسی به %(publisher)s حتماً باید عنوان خاصی را که می‌خواهید به آن "
-"دسترسی پیدا کنید مشخص نمایید."
+msgid "%(publisher)s requires that you specify a particular title that you want to access."
+msgstr "برای دسترسی به %(publisher)s حتماً باید عنوان خاصی را که می‌خواهید به آن دسترسی پیدا کنید مشخص نمایید."
 
 #. Translators: If a user must register on the partner website before applying, they see this message. Don't translate partner.
 #: TWLight/resources/templates/resources/partner_detail_timeline.html:187
 #, python-format
-msgid ""
-"%(publisher)s requires that you sign up for an account before applying for "
-"access."
-msgstr ""
-"%(publisher)s الزام کرده است که پیش از درخواست برای دسترسی، برای ایجاد یک "
-"حساب اقدام کنید."
+msgid "%(publisher)s requires that you sign up for an account before applying for access."
+msgstr "%(publisher)s الزام کرده است که پیش از درخواست برای دسترسی، برای ایجاد یک حساب اقدام کنید."
 
 #. Translators: If a partner has their location listed, this message is a label for that location
 #: TWLight/resources/templates/resources/partner_detail_timeline.html:206
@@ -2108,12 +1725,8 @@ msgstr "آیا مطمئنید که می‌خواهید <b>%(object)s</b> را ح
 
 #. Translators: If multiple authorizations where returned for a collection, this message is shown to a user
 #: TWLight/resources/views.py:268
-msgid ""
-"Multiple authorizations were returned – something's wrong. Please contact us "
-"and don't forget to mention this message."
-msgstr ""
-"چندین مجوز برگردانده شد - مشکلی پیش آمده است. لطفاً با ما تماس بگیرید و ذکر "
-"این پیام را فراموش نکنید."
+msgid "Multiple authorizations were returned – something's wrong. Please contact us and don't forget to mention this message."
+msgstr "چندین مجوز برگردانده شد - مشکلی پیش آمده است. لطفاً با ما تماس بگیرید و ذکر این پیام را فراموش نکنید."
 
 #. Translators: This message is shown when user tries to access a NOT_AVAILABLE Partner
 #: TWLight/resources/views.py:316
@@ -2153,30 +1766,14 @@ msgstr "متأسفانه پاسخ درخواستتان معلوم نیست."
 #. Translators: Shown on the website's 400 page, when a user sends a bad request. Don't translate path or Phabricator.
 #: TWLight/templates/400.html:20
 #, python-format
-msgid ""
-"If you think we should know what to do with that, please email us about this "
-"error at <a class=\"twl-links\" href=\"mailto:wikipedialibrary@wikimedia.org?"
-"Subject=Wikipedia%%20Library%%20%(path)s%%20Permission%%20denied"
-"\">wikipedialibrary@wikimedia.org</a> or report it to us on <a class=\"twl-"
-"links\" href=\"https://phabricator.wikimedia.org/maniphest/task/edit/form/1/?"
-"projectPHIDs=Library-Card-Platform&title=Wikipedia%%20Library%%20%(path)s"
-"%%20Bad%%20Request\">Phabricator</a>"
-msgstr ""
-"اگر ایده‌ای برای رفع این مشکل دارید، به ما ایمیل بزنید: <a class=\"twl-links"
-"\" href=\"mailto:wikipedialibrary@wikimedia.org?Subject=Wikipedia%%20Library"
-"%%20%(path)s%%20Permission%%20denied\">wikipedialibrary@wikimedia.org</a> یا "
-"در فبریکیتور به ما <a class=\"twl-links\" href=\"https://phabricator."
-"wikimedia.org/maniphest/task/edit/form/1/?projectPHIDs=Library-Card-"
-"Platform&title=Wikipedia%%20Library%%20%(path)s%%20Bad%%20Request\">گزارش "
-"دهید</a>"
+msgid "If you think we should know what to do with that, please email us about this error at <a class=\"twl-links\" href=\"mailto:wikipedialibrary@wikimedia.org?Subject=Wikipedia%%20Library%%20%(path)s%%20Permission%%20denied\">wikipedialibrary@wikimedia.org</a> or report it to us on <a class=\"twl-links\" href=\"https://phabricator.wikimedia.org/maniphest/task/edit/form/1/?projectPHIDs=Library-Card-Platform&title=Wikipedia%%20Library%%20%(path)s%%20Bad%%20Request\">Phabricator</a>"
+msgstr "اگر ایده‌ای برای رفع این مشکل دارید، به ما ایمیل بزنید: <a class=\"twl-links\" href=\"mailto:wikipedialibrary@wikimedia.org?Subject=Wikipedia%%20Library%%20%(path)s%%20Permission%%20denied\">wikipedialibrary@wikimedia.org</a> یا در فبریکیتور به ما <a class=\"twl-links\" href=\"https://phabricator.wikimedia.org/maniphest/task/edit/form/1/?projectPHIDs=Library-Card-Platform&title=Wikipedia%%20Library%%20%(path)s%%20Bad%%20Request\">گزارش دهید</a>"
 
 #. Translators: Alt text for an image shown on the 400 error page.
 #. Translators: Alt text for an image shown on the 403 error page.
 #: TWLight/templates/400.html:33 TWLight/templates/403.html:33
 msgid "Sad hamster in a cage"
-msgstr ""
-"ز افسار زنبور و شلوار ببر<br />\n"
-"قفس می‌توان ساخت، اما به صبر"
+msgstr "ز افسار زنبور و شلوار ببر<br />\nقفس می‌توان ساخت، اما به صبر"
 
 #. Translators: Shown on the website's 403 page, when a user attempts to navigate to a page they don't have permission to view.
 #: TWLight/templates/403.html:11
@@ -2191,24 +1788,8 @@ msgstr "متأسفانه شما اجازهٔ این اقدام را ندارید
 #. Translators: Shown on the website's 403 page, when a user attempts to navigate to a page they don't have permission to view. Don't translate path or Phabricator.
 #: TWLight/templates/403.html:20
 #, python-format
-msgid ""
-"If you think your account should be able to do that, please email us about "
-"this error at <a class=\"twl-links\" href=\"mailto:"
-"wikipedialibrary@wikimedia.org?Subject=Wikipedia%%20Library%%20%(path)s"
-"%%20Permission%%20denied\">wikipedialibrary@wikimedia.org</a> or report it "
-"to us on <a class=\"twl-links\" href=\"https://phabricator.wikimedia.org/"
-"maniphest/task/edit/form/1/?projectPHIDs=Library-Card-"
-"Platform&title=Wikipedia%%20Library%%20%(path)s%%20Permission%%20denied"
-"\">Phabricator</a>"
-msgstr ""
-"اگر فکر می‌کنید حساب شما باید چنین کاری را انجام دهد، لطفاً در مورد این خطا به "
-"ما ایمیل بزنید: a class=\"twl-links\" href=\"mailto:"
-"wikipedialibrary@wikimedia.org?Subject=Wikipedia%%20Library%%20%(path)s"
-"%%20Permission%%20denied\">wikipedialibrary@wikimedia.org</a> یا در "
-"فبریکیتور به ما <a class=\"twl-links\" href=\"https://phabricator.wikimedia."
-"org/maniphest/task/edit/form/1/?projectPHIDs=Library-Card-"
-"Platform&title=Wikipedia%%20Library%%20%(path)s%%20Permission%%20denied"
-"\">گزارش دهید</a>"
+msgid "If you think your account should be able to do that, please email us about this error at <a class=\"twl-links\" href=\"mailto:wikipedialibrary@wikimedia.org?Subject=Wikipedia%%20Library%%20%(path)s%%20Permission%%20denied\">wikipedialibrary@wikimedia.org</a> or report it to us on <a class=\"twl-links\" href=\"https://phabricator.wikimedia.org/maniphest/task/edit/form/1/?projectPHIDs=Library-Card-Platform&title=Wikipedia%%20Library%%20%(path)s%%20Permission%%20denied\">Phabricator</a>"
+msgstr "اگر فکر می‌کنید حساب شما باید چنین کاری را انجام دهد، لطفاً در مورد این خطا به ما ایمیل بزنید: a class=\"twl-links\" href=\"mailto:wikipedialibrary@wikimedia.org?Subject=Wikipedia%%20Library%%20%(path)s%%20Permission%%20denied\">wikipedialibrary@wikimedia.org</a> یا در فبریکیتور به ما <a class=\"twl-links\" href=\"https://phabricator.wikimedia.org/maniphest/task/edit/form/1/?projectPHIDs=Library-Card-Platform&title=Wikipedia%%20Library%%20%(path)s%%20Permission%%20denied\">گزارش دهید</a>"
 
 #. Translators: Shown on the website's 404 page, when a user attempts to navigate to a page that doesn't exist.
 #: TWLight/templates/404.html:11
@@ -2223,29 +1804,13 @@ msgstr "متأسفانه چیزی یافت نشد."
 #. Translators: Shown on the website's 404 page, when a user attempts to navigate to a page that doesn't exist. Don't translate path or Phabricator.
 #: TWLight/templates/404.html:19
 #, python-format
-msgid ""
-"If you are certain that something should be here, please email us about this "
-"error at <a class=\"twl-links\" href=\"mailto:wikipedialibrary@wikimedia.org?"
-"Subject=Wikipedia%%20Library%%20%(path)s%%20Not%%20found\"> "
-"wikipedialibrary@wikimedia.org</a> or report it to us on <a class=\"twl-links"
-"\" href=\"https://phabricator.wikimedia.org/maniphest/task/edit/form/1/?"
-"projectPHIDs=Library-Card-Platform&title=Wikipedia%%20Library%%20%(path)s"
-"%%20Not%%20found\">Phabricator</a>"
-msgstr ""
-"اگر مطمئن هستید که چیزی باید در اینجا باشد، لطفاً دربارهٔ این خطا به ما ایمیل "
-"بزنید: <a class=\"twl-links\" href=\"mailto:wikipedialibrary@wikimedia.org?"
-"Subject=Wikipedia%%20Library%%20%(path)s%%20Not%%20found\"> "
-"wikipedialibrary@wikimedia.org</a> یا در فبریکیتور به ما  <a class=\"twl-"
-"links\"  href=\"https://phabricator.wikimedia.org/maniphest/task/edit/"
-"form/1/?projectPHIDs=Library-Card-Platform&title=Wikipedia%%20Library"
-"%%20%(path)s%%20Not%%20found\">گزارش دهید.</a>"
+msgid "If you are certain that something should be here, please email us about this error at <a class=\"twl-links\" href=\"mailto:wikipedialibrary@wikimedia.org?Subject=Wikipedia%%20Library%%20%(path)s%%20Not%%20found\"> wikipedialibrary@wikimedia.org</a> or report it to us on <a class=\"twl-links\" href=\"https://phabricator.wikimedia.org/maniphest/task/edit/form/1/?projectPHIDs=Library-Card-Platform&title=Wikipedia%%20Library%%20%(path)s%%20Not%%20found\">Phabricator</a>"
+msgstr "اگر مطمئن هستید که چیزی باید در اینجا باشد، لطفاً دربارهٔ این خطا به ما ایمیل بزنید: <a class=\"twl-links\" href=\"mailto:wikipedialibrary@wikimedia.org?Subject=Wikipedia%%20Library%%20%(path)s%%20Not%%20found\"> wikipedialibrary@wikimedia.org</a> یا در فبریکیتور به ما  <a class=\"twl-links\"  href=\"https://phabricator.wikimedia.org/maniphest/task/edit/form/1/?projectPHIDs=Library-Card-Platform&title=Wikipedia%%20Library%%20%(path)s%%20Not%%20found\">گزارش دهید.</a>"
 
 #. Translators: Alt text for an image shown on the 404 error page.
 #: TWLight/templates/404.html:32
 msgid "A crab on a beach looking towards the camera"
-msgstr ""
-"اگر عاقلی بخیه بر مو مزن<br />\n"
-"بجز پنبه بر نعل آهو مزن"
+msgstr "اگر عاقلی بخیه بر مو مزن<br />\nبجز پنبه بر نعل آهو مزن"
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/). Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/templates/about.html:9
@@ -2254,48 +1819,19 @@ msgstr "دربارهٔ کتابخانهٔ ویکی‌پدیا"
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:20
-msgid ""
-"This platform is our central tool for facilitating access to our available "
-"collections. Here you can see which partnerships are available, search their "
-"contents, and apply for and access the ones you’re interested in."
-msgstr ""
-"این سکو ابزار مرکزی ما برای تسهیل دسترسی به مجموعه‌های موجود ما است. در اینجا "
-"می‌توانید ببینید که کدام پایگاه‌ها در دسترس‌اند، محتوایشان را بکاوید، و برای "
-"پایگاه‌هایی که به آن‌ها علاقه دارید درخواست دسترسی دهید."
+msgid "This platform is our central tool for facilitating access to our available collections. Here you can see which partnerships are available, search their contents, and apply for and access the ones you’re interested in."
+msgstr "این سکو ابزار مرکزی ما برای تسهیل دسترسی به مجموعه‌های موجود ما است. در اینجا می‌توانید ببینید که کدام پایگاه‌ها در دسترس‌اند، محتوایشان را بکاوید، و برای پایگاه‌هایی که به آن‌ها علاقه دارید درخواست دسترسی دهید."
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/). Wikimedia Foundation should not be translated.
 #: TWLight/templates/about.html:29
-msgid ""
-"All users receive immediate access to some collections, which can be browsed "
-"by clicking the 'Access collection' buttons or using the search bar at the "
-"top of the page. Other collections require an application before access is "
-"granted, and may be accessed directly or via an individual login or access "
-"code. Volunteer coordinators, who have signed non-disclosure agreements with "
-"the Wikimedia Foundation, review these applications and work with publishers "
-"to get you your free access."
-msgstr ""
-"همهٔ کاربران دسترسی فوری به برخی از مجموعه‌ها را دریافت می‌کنند که می‌توانند با "
-"کلیک کردن روی دکمه‌های 'دسترسی به مجموعه' یا با استفاده از نوار جستجو در "
-"بالای صفحه مرور شوند. سایر مجموعه‌ها قبل از اعطای دسترسی به یک درخواست نیاز "
-"دارند و ممکن است مستقیماً یا از طریق ورود به سیستم فردی یا کد دسترسی به آنها "
-"دسترسی داشته باشید. هماهنگ‌کنندگان داوطلب، که توافق‌نامه‌های عدم افشای اطلاعات "
-"را با بنیاد ویکی‌مدیا امضا کرده‌اند، این درخواست‌ها را بررسی کرده و با ناشران "
-"همکاری می‌کنند تا دسترسی رایگان شما را بدست آورند."
+msgid "All users receive immediate access to some collections, which can be browsed by clicking the 'Access collection' buttons or using the search bar at the top of the page. Other collections require an application before access is granted, and may be accessed directly or via an individual login or access code. Volunteer coordinators, who have signed non-disclosure agreements with the Wikimedia Foundation, review these applications and work with publishers to get you your free access."
+msgstr "همهٔ کاربران دسترسی فوری به برخی از مجموعه‌ها را دریافت می‌کنند که می‌توانند با کلیک کردن روی دکمه‌های 'دسترسی به مجموعه' یا با استفاده از نوار جستجو در بالای صفحه مرور شوند. سایر مجموعه‌ها قبل از اعطای دسترسی به یک درخواست نیاز دارند و ممکن است مستقیماً یا از طریق ورود به سیستم فردی یا کد دسترسی به آنها دسترسی داشته باشید. هماهنگ‌کنندگان داوطلب، که توافق‌نامه‌های عدم افشای اطلاعات را با بنیاد ویکی‌مدیا امضا کرده‌اند، این درخواست‌ها را بررسی کرده و با ناشران همکاری می‌کنند تا دسترسی رایگان شما را بدست آورند."
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/). Don't translate terms_url.
 #: TWLight/templates/about.html:43
 #, python-format
-msgid ""
-"For more information about how your information is stored and reviewed "
-"please see our <a class=\"twl-links\" href=\"%(terms_url)s\"> terms of use "
-"and privacy policy</a>. Accounts you apply for are also subject to the Terms "
-"of Use provided by each partner’s platform; please review them."
-msgstr ""
-"برای اطلاعات بیش‌تر دربارهٔ اینکه داده‌های شما چگونه دریافت و پردازش می‌شوند، "
-"لطفاً <a class=\"twl-links\" href=\"%(terms_url)s\">شرایط استفاده و حریم "
-"خصوصی</a> را ببینید. حساب‌های کاربری که برای آن درخواست می‌دهید نیز شامل شرایط "
-"استفادهٔ خاص خود است که توسط هر پایگاه به طور مجزا تعیین می‌گردد؛ لطفاً آن را "
-"نیز مطالعه کنید."
+msgid "For more information about how your information is stored and reviewed please see our <a class=\"twl-links\" href=\"%(terms_url)s\"> terms of use and privacy policy</a>. Accounts you apply for are also subject to the Terms of Use provided by each partner’s platform; please review them."
+msgstr "برای اطلاعات بیش‌تر دربارهٔ اینکه داده‌های شما چگونه دریافت و پردازش می‌شوند، لطفاً <a class=\"twl-links\" href=\"%(terms_url)s\">شرایط استفاده و حریم خصوصی</a> را ببینید. حساب‌های کاربری که برای آن درخواست می‌دهید نیز شامل شرایط استفادهٔ خاص خود است که توسط هر پایگاه به طور مجزا تعیین می‌گردد؛ لطفاً آن را نیز مطالعه کنید."
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:51
@@ -2304,25 +1840,13 @@ msgstr "چه کسی می‌تواند دسترسی دریافت کند؟"
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/). Wikimedia Foundation should not be translated.
 #: TWLight/templates/about.html:55
-msgid ""
-"Any active editor in good standing can receive access. For publishers with "
-"limited numbers of accounts, applications are reviewed based on the editor’s "
-"needs and contributions. If you think you could use access to one of our "
-"partner resources and are an active editor in any project supported by the "
-"Wikimedia Foundation, please apply."
-msgstr ""
-"هر ویرایشگر فعالی با وضعیت خوب می‌تواند دسترسی داشته باشد. برای ناشران با "
-"تعداد حساب‌هایی محدود، درخواست‌ها بر اساس نیازها و مشارکت‌های ویرایشگر بررسی "
-"می‌شوند. اگر فکر می‌کنید می‌توانید از دسترسی به یکی از منابع موجود در پایگاه‌ها "
-"ما استفاده کنید و در هر پروژهٔ پشتیبانی‌شده توسط بنیاد ویکی‌مدیا ویرایشگر فعال "
-"هستید، لطفاً درخواست دهید."
+msgid "Any active editor in good standing can receive access. For publishers with limited numbers of accounts, applications are reviewed based on the editor’s needs and contributions. If you think you could use access to one of our partner resources and are an active editor in any project supported by the Wikimedia Foundation, please apply."
+msgstr "هر ویرایشگر فعالی با وضعیت خوب می‌تواند دسترسی داشته باشد. برای ناشران با تعداد حساب‌هایی محدود، درخواست‌ها بر اساس نیازها و مشارکت‌های ویرایشگر بررسی می‌شوند. اگر فکر می‌کنید می‌توانید از دسترسی به یکی از منابع موجود در پایگاه‌ها ما استفاده کنید و در هر پروژهٔ پشتیبانی‌شده توسط بنیاد ویکی‌مدیا ویرایشگر فعال هستید، لطفاً درخواست دهید."
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:65
 msgid "Any editor can use the library if they meet a few basic requirements:"
-msgstr ""
-"هر ویرایشگری که الزامات اصلی را برآورده کند، می‌تواند از کتابخانه استفاده "
-"نماید:"
+msgstr "هر ویرایشگری که الزامات اصلی را برآورده کند، می‌تواند از کتابخانه استفاده نماید:"
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:71
@@ -2342,39 +1866,17 @@ msgstr "در ماه گذشته دست‌کم ۱۰ ویرایش در پروژه�
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:83
 msgid "You are not currently blocked from editing a Wikimedia project"
-msgstr ""
-"در حال حاضر حساب کاربری‌تان در هیچ‌یک از پروژه‌های ویکی‌مدیا بسته نشده باشد"
+msgstr "در حال حاضر حساب کاربری‌تان در هیچ‌یک از پروژه‌های ویکی‌مدیا بسته نشده باشد"
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/)
 #: TWLight/templates/about.html:89
-msgid ""
-"If you are applying for an available collection, please first check that you "
-"don't already have access through another library or institution. If you do, "
-"please consider using that access rather than taking up a seat for this "
-"resource in The Wikipedia Library."
-msgstr ""
-"اگر برای مجموعهٔ موجود درخواست می‌دهید، لطفاً ابتدا بررسی کنید که از طریق "
-"کتابخانه یا مؤسسه دیگری از قبل دسترسی ندارید. اگر این کار را می‌کنید، لطفاً به "
-"جای اینکه در کتابخانهٔ ویکی‌پدیا ظرفیت این منبع را اشغال کنید، از این دسترسی "
-"استفاده کنید."
+msgid "If you are applying for an available collection, please first check that you don't already have access through another library or institution. If you do, please consider using that access rather than taking up a seat for this resource in The Wikipedia Library."
+msgstr "اگر برای مجموعهٔ موجود درخواست می‌دهید، لطفاً ابتدا بررسی کنید که از طریق کتابخانه یا مؤسسه دیگری از قبل دسترسی ندارید. اگر این کار را می‌کنید، لطفاً به جای اینکه در کتابخانهٔ ویکی‌پدیا ظرفیت این منبع را اشغال کنید، از این دسترسی استفاده کنید."
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/)
 #: TWLight/templates/about.html:99
-msgid ""
-"If your account is blocked on one or more Wikimedia projects, you may still "
-"be granted access to The Wikipedia Library. You will need to contact the "
-"Wikipedia Library team, who will review your blocks. If you have been "
-"blocked for content issues, most notably copyright violations, or have "
-"multiple long-term blocks, we may decline your request. Additionally, if "
-"your block status changes after being approved, you will need to request "
-"another review."
-msgstr ""
-"اگر حساب‌تان در یک یا چند پروژهٔ ویکی‌مدیا مسدود شده است، ممکن است همچنان "
-"دسترسی به کتابخانهٔ ویکی‌پدیا اعطا شود. برای این کار باید با تیم کتابخانهٔ "
-"ویکی‌پدیا تماس بگیرید تا قطع دسترسی‌های شما را بررسی کنند. اگر حساب‌تان به علت "
-"مشکلات محتوایی مسدود شده است، به‌ویژه موارد نقض حق تکثیر یا چندین قطع دسترسی "
-"طولانی‌مدت دارید، ممکن است درخواست‌تان را رد کنیم. علاوه بر این، اگر وضعیت قطع "
-"دسترسی‌تان پس از تأیید تغییر کند، باید درخواست بازبینی دیگری را ثبت کنید."
+msgid "If your account is blocked on one or more Wikimedia projects, you may still be granted access to The Wikipedia Library. You will need to contact the Wikipedia Library team, who will review your blocks. If you have been blocked for content issues, most notably copyright violations, or have multiple long-term blocks, we may decline your request. Additionally, if your block status changes after being approved, you will need to request another review."
+msgstr "اگر حساب‌تان در یک یا چند پروژهٔ ویکی‌مدیا مسدود شده است، ممکن است همچنان دسترسی به کتابخانهٔ ویکی‌پدیا اعطا شود. برای این کار باید با تیم کتابخانهٔ ویکی‌پدیا تماس بگیرید تا قطع دسترسی‌های شما را بررسی کنند. اگر حساب‌تان به علت مشکلات محتوایی مسدود شده است، به‌ویژه موارد نقض حق تکثیر یا چندین قطع دسترسی طولانی‌مدت دارید، ممکن است درخواست‌تان را رد کنیم. علاوه بر این، اگر وضعیت قطع دسترسی‌تان پس از تأیید تغییر کند، باید درخواست بازبینی دیگری را ثبت کنید."
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:110
@@ -2408,12 +1910,8 @@ msgstr "حساب‌های تأییدشده <i>نمی‌توانند</i>:"
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:136
-msgid ""
-"Share their account logins or passwords with others, or sell their access to "
-"other parties"
-msgstr ""
-"دسترسی و گذرواژهٔ حسابشان را در اختیار دیگری قرار دهند یا به اشخاص ثالث "
-"بفروشند"
+msgid "Share their account logins or passwords with others, or sell their access to other parties"
+msgstr "دسترسی و گذرواژهٔ حسابشان را در اختیار دیگری قرار دهند یا به اشخاص ثالث بفروشند"
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:140
@@ -2422,30 +1920,18 @@ msgstr "محتوای شرکا را به‌طور انبوه جمع‌آوری ی
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:144
-msgid ""
-"Systematically make printed or electronic copies of multiple extracts of "
-"restricted content available for any purpose"
-msgstr ""
-"چکیده‌های متعدد از محتوای محدودی را که در اختیار دارند به صورت سازماندهی شده "
-"با هر هدفی تکثیر چاپی یا الکترونیکی کنند"
+msgid "Systematically make printed or electronic copies of multiple extracts of restricted content available for any purpose"
+msgstr "چکیده‌های متعدد از محتوای محدودی را که در اختیار دارند به صورت سازماندهی شده با هر هدفی تکثیر چاپی یا الکترونیکی کنند"
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/). Stub is a technical term for a short Wikipedia article, use the appropriate Wikipedia term in your language.
 #: TWLight/templates/about.html:148
-msgid ""
-"Datamine metadata without permission, in order, for instance, to use "
-"metadata for auto-created stub articles"
-msgstr ""
-"بدون مجوز، فراداده‌ها را، به عنوان مثال، برای تولید خودکار مقاله‌های خُرد، "
-"داده‌کاوی کنند"
+msgid "Datamine metadata without permission, in order, for instance, to use metadata for auto-created stub articles"
+msgstr "بدون مجوز، فراداده‌ها را، به عنوان مثال، برای تولید خودکار مقاله‌های خُرد، داده‌کاوی کنند"
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:154
-msgid ""
-"Respecting these agreements allows us to continue growing the partnerships "
-"available to the community."
-msgstr ""
-"رعایت این توافق‌نامه به ما اجازه می‌دهد که به همکاری با پایگاه‌ها ادامه دهیم و "
-"پایگاه‌های جدیدی را به همهٔ اجتماع ویکی‌مدیا بیفزاییم."
+msgid "Respecting these agreements allows us to continue growing the partnerships available to the community."
+msgstr "رعایت این توافق‌نامه به ما اجازه می‌دهد که به همکاری با پایگاه‌ها ادامه دهیم و پایگاه‌های جدیدی را به همهٔ اجتماع ویکی‌مدیا بیفزاییم."
 
 #. Translators: This is the heading for a section on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:160
@@ -2455,61 +1941,23 @@ msgstr "پروکسی"
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:164
-msgid ""
-"EZProxy is a proxy server used to authenticate users for many Wikipedia "
-"Library partners. Users sign into EZProxy via the Library Card platform to "
-"verify that they are authorized users, and then the server accesses "
-"requested resources using its own IP address."
-msgstr ""
-"EZProxy یک سرور پراکسی است که برای تأیید اعتبار کاربران برای بسیاری از "
-"پایگاه‌های کتابخانهٔ ویکی‌پدیا استفاده می‌شود. کاربران از طریق سکوی کارت عضویت "
-"وارد EZProxy می‌شوند تا تأیید کنند که کاربرانی مجاز هستند و سپس سرور با "
-"استفاده از آدرس IP خود به منابع درخواستی دسترسی پیدا می‌کند."
+msgid "EZProxy is a proxy server used to authenticate users for many Wikipedia Library partners. Users sign into EZProxy via the Library Card platform to verify that they are authorized users, and then the server accesses requested resources using its own IP address."
+msgstr "EZProxy یک سرور پراکسی است که برای تأیید اعتبار کاربران برای بسیاری از پایگاه‌های کتابخانهٔ ویکی‌پدیا استفاده می‌شود. کاربران از طریق سکوی کارت عضویت وارد EZProxy می‌شوند تا تأیید کنند که کاربرانی مجاز هستند و سپس سرور با استفاده از آدرس IP خود به منابع درخواستی دسترسی پیدا می‌کند."
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:173
-msgid ""
-"You may notice that when accessing resources via EZProxy that URLs are "
-"dynamically rewritten. This is why we recommend logging in via the Library "
-"Card platform rather than going directly to the unproxied partner website. "
-"When in doubt, check the URL for ‘idm.oclc’. If it’s there, then you’re "
-"connected via EZProxy."
-msgstr ""
-"ممکن است متوجه شده باشید که هنگام دسترسی به منابع از طریق EZProxy آدرس‌ها "
-"(URL) به صورت پویا بازنویسی می‌شوند. به همین دلیل است که ما توصیه می‌کنیم از "
-"طریق سکوی کارت عضویت وارد سیستم شوید نه اینکه مستقیماً به وب‌سایت پایگاه "
-"مراجعه کنید. در صورت تردید، آدرس را برای وجود \"idm.oclc\" بررسی کنید. اگر "
-"آنجا باشد، از طریق EZProxy متصل شده‌اید."
+msgid "You may notice that when accessing resources via EZProxy that URLs are dynamically rewritten. This is why we recommend logging in via the Library Card platform rather than going directly to the unproxied partner website. When in doubt, check the URL for ‘idm.oclc’. If it’s there, then you’re connected via EZProxy."
+msgstr "ممکن است متوجه شده باشید که هنگام دسترسی به منابع از طریق EZProxy آدرس‌ها (URL) به صورت پویا بازنویسی می‌شوند. به همین دلیل است که ما توصیه می‌کنیم از طریق سکوی کارت عضویت وارد سیستم شوید نه اینکه مستقیماً به وب‌سایت پایگاه مراجعه کنید. در صورت تردید، آدرس را برای وجود \"idm.oclc\" بررسی کنید. اگر آنجا باشد، از طریق EZProxy متصل شده‌اید."
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:182
-msgid ""
-"Typically once you’ve logged in your session will remain active in your "
-"browser for up to two hours after you’ve finished searching. Note that use "
-"of EZProxy requires you to enable cookies. If you are having problems you "
-"should also try clearing your cache and restarting your browser."
-msgstr ""
-"معمولاً هنگامی که وارد سیستم می‌شوید، پس از پایان جستجو، تا دو ساعت در مرورگر "
-"شما فعال می‌ماند. توجه داشته باشید که استفاده از EZProxy نیاز به فعال کردن "
-"کوکی‌ها دارد. اگر مشکلی دارید باید سعی کنید حافظهٔ پنهان مرورگر خود را پاک "
-"کرده و مرورگر خود را دوباره راه‌اندازی کنید."
+msgid "Typically once you’ve logged in your session will remain active in your browser for up to two hours after you’ve finished searching. Note that use of EZProxy requires you to enable cookies. If you are having problems you should also try clearing your cache and restarting your browser."
+msgstr "معمولاً هنگامی که وارد سیستم می‌شوید، پس از پایان جستجو، تا دو ساعت در مرورگر شما فعال می‌ماند. توجه داشته باشید که استفاده از EZProxy نیاز به فعال کردن کوکی‌ها دارد. اگر مشکلی دارید باید سعی کنید حافظهٔ پنهان مرورگر خود را پاک کرده و مرورگر خود را دوباره راه‌اندازی کنید."
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/)
 #: TWLight/templates/about.html:193
-msgid ""
-"The Library Bundle is a collection of resources for which no application is "
-"required. If you meet the criteria laid out above, you will be authorized "
-"for access automatically upon logging in to the platform. Only some of our "
-"content is currently included in the Library Bundle, however we hope to "
-"expand the collection as more publishers become comfortable with "
-"participating. All Bundle content is accessed via EZProxy."
-msgstr ""
-"بستهٔ کتابخانه (Library Bundle) مجموعه‌ای از منابع هستند که برای دسترسی به "
-"آن‌ها نیاز به درخواست نیست. اگر از معیارهای تعیین‌شده در بالا برخوردار باشید، "
-"با ورود به سکوی کارت عضویت، به‌طور خودکار اجازهٔ دسترسی خواهید داشت. در حال "
-"حاضر فقط برخی از مطالب ما در بستهٔ کتابخانه موجود است، با این حال امیدواریم "
-"که ناشران بیشتری با شرکت در این زمینه، مجموعه را گسترش دهند. تمام محتوای "
-"بسته از طریق EZProxy قابل دسترسی است."
+msgid "The Library Bundle is a collection of resources for which no application is required. If you meet the criteria laid out above, you will be authorized for access automatically upon logging in to the platform. Only some of our content is currently included in the Library Bundle, however we hope to expand the collection as more publishers become comfortable with participating. All Bundle content is accessed via EZProxy."
+msgstr "بستهٔ کتابخانه (Library Bundle) مجموعه‌ای از منابع هستند که برای دسترسی به آن‌ها نیاز به درخواست نیست. اگر از معیارهای تعیین‌شده در بالا برخوردار باشید، با ورود به سکوی کارت عضویت، به‌طور خودکار اجازهٔ دسترسی خواهید داشت. در حال حاضر فقط برخی از مطالب ما در بستهٔ کتابخانه موجود است، با این حال امیدواریم که ناشران بیشتری با شرکت در این زمینه، مجموعه را گسترش دهند. تمام محتوای بسته از طریق EZProxy قابل دسترسی است."
 
 #. Translators: This is the heading for a section on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:202
@@ -2518,18 +1966,8 @@ msgstr "روش‌های استناد"
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:206
-msgid ""
-"Citation practices vary by project and even by article. Generally, we "
-"support editors citing where they found information, in a form that allows "
-"others to check it for themselves. That often means providing both original "
-"source details as well as a link to the partner database in which the source "
-"was found."
-msgstr ""
-"شیوه‌های استناد و ارجاع، به پروژه و مقاله بستگی دارد. به‌طور کلی، ما از این "
-"روش حمایت می‌کنیم که ویراستاران به مطالبی که از آن استفاده کرده‌اند ارجاع دهند "
-"تا امکان بررسی این مطالب توسط خوانندگان مقدور باشد. این اغلب به معنای ارائهٔ "
-"جزئیات منبع اصلی و همچنین پیوند به پایگاه شریک است که منبع در آن پیدا شده "
-"است."
+msgid "Citation practices vary by project and even by article. Generally, we support editors citing where they found information, in a form that allows others to check it for themselves. That often means providing both original source details as well as a link to the partner database in which the source was found."
+msgstr "شیوه‌های استناد و ارجاع، به پروژه و مقاله بستگی دارد. به‌طور کلی، ما از این روش حمایت می‌کنیم که ویراستاران به مطالبی که از آن استفاده کرده‌اند ارجاع دهند تا امکان بررسی این مطالب توسط خوانندگان مقدور باشد. این اغلب به معنای ارائهٔ جزئیات منبع اصلی و همچنین پیوند به پایگاه شریک است که منبع در آن پیدا شده است."
 
 #. Translators: This is the heading for a section on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #. Translators: This link is at the bottom of every page and can be clicked by users to contact the wikipedia library team.
@@ -2540,13 +1978,8 @@ msgstr "تماس با ما"
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:218
 #, python-format
-msgid ""
-"If you have questions, need help, or want to volunteer to help, please see "
-"our <a class=\"twl-links\" href=\"%(contact_url)s\">contact page</a>."
-msgstr ""
-"اگر سؤالی دارید، کمک می‌خواهید، یا مایلید به‌عنوان داوطلب با ما همکاری کنید، "
-"لطفاً صفحهٔ <a class=\"twl-links\" href=\"%(contact_url)s\">تماس با ما</a> را "
-"ملاحظه کنید."
+msgid "If you have questions, need help, or want to volunteer to help, please see our <a class=\"twl-links\" href=\"%(contact_url)s\">contact page</a>."
+msgstr "اگر سؤالی دارید، کمک می‌خواهید، یا مایلید به‌عنوان داوطلب با ما همکاری کنید، لطفاً صفحهٔ <a class=\"twl-links\" href=\"%(contact_url)s\">تماس با ما</a> را ملاحظه کنید."
 
 #. Translators: This is the title of the panel box detailing the contact information for the Wikipedia Library team.
 #: TWLight/templates/contact.html:14
@@ -2585,12 +2018,8 @@ msgstr "صفحهٔ توییتر کتابخانهٔ ویکی‌پدیا"
 #. Translators: This is the text that appears at the bottom of the contact us form directing users to the suggestions form.
 #: TWLight/templates/contact.html:48
 #, python-format
-msgid ""
-"(If you would like to suggest a partner, <a class=\"twl-links\" href="
-"\"%(suggest)s\"><strong>go here</strong></a>.)"
-msgstr ""
-"(برای پیشنهاد پایگاه‌های همکاری، <a class=\"twl-links\" href=\"%(suggest)s"
-"\"><strong>به اینجا بروید</strong></a>.)"
+msgid "(If you would like to suggest a partner, <a class=\"twl-links\" href=\"%(suggest)s\"><strong>go here</strong></a>.)"
+msgstr "(برای پیشنهاد پایگاه‌های همکاری، <a class=\"twl-links\" href=\"%(suggest)s\"><strong>به اینجا بروید</strong></a>.)"
 
 #. Translators: On a special 'link to search' page, this message is shown if JavaScript is disabled.
 #: TWLight/templates/eds_search_endpoint.html:7
@@ -2646,12 +2075,8 @@ msgstr "کتابخانهٔ ویکی‌پدیا"
 #. Translators: Information about The Wikipedia Library.
 #: TWLight/templates/login_partial.html:53 TWLight/templates/new_base.html:21
 #, python-format
-msgid ""
-"More than 100 of the world's top subscription-only databases, with content "
-"in %(no_of_languages)s languages, free for Wikipedians of all backgrounds"
-msgstr ""
-"بیش از ۱۰۰ پایگاه دانش غیر رایگان برتر جهان، با مطالبی به "
-"%(no_of_languages)s زبان، رایگان برای ویکی‌نویس‌ها"
+msgid "More than 100 of the world's top subscription-only databases, with content in %(no_of_languages)s languages, free for Wikipedians of all backgrounds"
+msgstr "بیش از ۱۰۰ پایگاه دانش غیر رایگان برتر جهان، با مطالبی به %(no_of_languages)s زبان، رایگان برای ویکی‌نویس‌ها"
 
 #. Translators: Information about The Wikipedia Library.
 #: TWLight/templates/login_partial.html:64
@@ -2659,12 +2084,8 @@ msgid "Meet these criteria for automatic access"
 msgstr "برآورده‌کردن این معیار برای دسترسی خودکار"
 
 #: TWLight/templates/login_partial.html:69
-msgid ""
-"These criteria grant you access to certain collections but not all. Some "
-"collections are accessible on a per application basis only."
-msgstr ""
-"این معیارها به شما اجازهٔ دسترسی به مجموعه‌های خاصی را می‌دهد، اما نه همهٔ آن‌ها. "
-"برخی از مجموعه‌ها فقط براساس درخواست قابل دسترسی هستند."
+msgid "These criteria grant you access to certain collections but not all. Some collections are accessible on a per application basis only."
+msgstr "این معیارها به شما اجازهٔ دسترسی به مجموعه‌های خاصی را می‌دهد، اما نه همهٔ آن‌ها. برخی از مجموعه‌ها فقط براساس درخواست قابل دسترسی هستند."
 
 #: TWLight/templates/login_partial.html:89
 msgid "Login via Wikipedia"
@@ -2673,41 +2094,20 @@ msgstr "ورود از طریق ویکی‌پدیا"
 #. Translators: Shown if the current user doesn't have a registered email on their account. Don't translate contact_us_url or email_url.
 #: TWLight/templates/message_partial.html:15
 #, python-format
-msgid ""
-"You don't have an email on file. We can't finalize your access to partner "
-"resources, and you won't be able to <a class=\"twl-links\" href="
-"\"%(contact_us_url)s\">contact us</a> without an email. Please <a class="
-"\"twl-links\" href=\"%(email_url)s\">update your email</a>."
-msgstr ""
-"ایمیلی در پرونده ندارید. نمی‌توانیم دسترسی شما به منابع شریک را نهایی کنیم و "
-"شما نمی‌توانید بدون ایمیل <a class=\"twl-links\" href=\"%(contact_us_url)s"
-"\">با ما تماس بگیرید</a>. لطفاً <a class=\"twl-links\" href=\"%(email_url)s"
-"\">ایمیل‌تان را به‌روزرسانی کنید</a>."
+msgid "You don't have an email on file. We can't finalize your access to partner resources, and you won't be able to <a class=\"twl-links\" href=\"%(contact_us_url)s\">contact us</a> without an email. Please <a class=\"twl-links\" href=\"%(email_url)s\">update your email</a>."
+msgstr "ایمیلی در پرونده ندارید. نمی‌توانیم دسترسی شما به منابع شریک را نهایی کنیم و شما نمی‌توانید بدون ایمیل <a class=\"twl-links\" href=\"%(contact_us_url)s\">با ما تماس بگیرید</a>. لطفاً <a class=\"twl-links\" href=\"%(email_url)s\">ایمیل‌تان را به‌روزرسانی کنید</a>."
 
 #. Translators: Shown if the current user has requested the processing of their data should be restricted.
 #: TWLight/templates/message_partial.html:26
 #, python-format
-msgid ""
-"You have requested a restriction on the processing of your data. Most site "
-"functionality will not be available to you until you <a class=\"twl-links\" "
-"href=\"%(restrict_url)s\">lift this restriction</a>."
-msgstr ""
-"درخواست محدودیت در پردازش داده‌های خود را دارید. تا <a class=\"twl-links\" "
-"href=\"%(restrict_url)s\">این محدودیت را برطرف نکنید</a>، بیش‌تر عملکردهای "
-"سایت در دسترس شما نیست."
+msgid "You have requested a restriction on the processing of your data. Most site functionality will not be available to you until you <a class=\"twl-links\" href=\"%(restrict_url)s\">lift this restriction</a>."
+msgstr "درخواست محدودیت در پردازش داده‌های خود را دارید. تا <a class=\"twl-links\" href=\"%(restrict_url)s\">این محدودیت را برطرف نکنید</a>، بیش‌تر عملکردهای سایت در دسترس شما نیست."
 
 #. Translators: Shown if the current user has not agreed to the terms of use.
 #: TWLight/templates/message_partial.html:37
 #, python-format
-msgid ""
-"You have not agreed to the <a class=\"twl-links\" href=\"%(terms_url)s"
-"\">terms of use</a> of this site. Your applications will not be processed "
-"and you won't be able to apply or access resources you are approved for."
-msgstr ""
-"با <a class=\"twl-links\" href=\"%(terms_url)s\">شرایط استفادهٔ</a> این سایت "
-"موافقت نکرده‌اید. درخواست‌های شما پردازش نمی‌شوند و نمی‌توانید برای منابع جدید "
-"درخواست دهید و یا به منابعی که درخواست‌تان برای آن‌ها تأیید شده است دسترسی "
-"پیدا کنید."
+msgid "You have not agreed to the <a class=\"twl-links\" href=\"%(terms_url)s\">terms of use</a> of this site. Your applications will not be processed and you won't be able to apply or access resources you are approved for."
+msgstr "با <a class=\"twl-links\" href=\"%(terms_url)s\">شرایط استفادهٔ</a> این سایت موافقت نکرده‌اید. درخواست‌های شما پردازش نمی‌شوند و نمی‌توانید برای منابع جدید درخواست دهید و یا به منابعی که درخواست‌تان برای آن‌ها تأیید شده است دسترسی پیدا کنید."
 
 #. Translators: This link is at the bottom of every page and links to the 'About' page (https://wikipedialibrary.wmflabs.org/about/)
 #: TWLight/templates/new_base.html:107
@@ -2753,12 +2153,8 @@ msgstr "تنظیم مجدد رمز عبور"
 
 #. Translators: If a user goes to reset their password, this message asks them to enter their email to do so.
 #: TWLight/templates/registration/password_reset_form.html:13
-msgid ""
-"Forgot your password? Enter your email address below, and we'll email "
-"instructions for setting a new one."
-msgstr ""
-"رمز عبورتان را فراموش کرده‌اید؟ ایمیل‌تان را در کادر زیر بنویسید، سپس برای شما "
-"دستورالمعل دریافت یک رمز عبور جدید ارسال می‌شود."
+msgid "Forgot your password? Enter your email address below, and we'll email instructions for setting a new one."
+msgstr "رمز عبورتان را فراموش کرده‌اید؟ ایمیل‌تان را در کادر زیر بنویسید، سپس برای شما دستورالمعل دریافت یک رمز عبور جدید ارسال می‌شود."
 
 #. Translators: This is the label for a button that users click to update their public information.
 #: TWLight/users/forms.py:36
@@ -2802,21 +2198,13 @@ msgstr "با شرایط استفاده موافقت می‌کنم."
 
 #. Translators: This text explains how to disagree to the site's terms of use and the restrictions that will come into effect when users disagree to the terms of use.
 #: TWLight/users/forms.py:185
-msgid ""
-"By unchecking this box and clicking “Update” you may explore the site, but "
-"you will not be able to apply for access to materials or evaluate "
-"applications unless you agree with the terms of use."
-msgstr ""
-"با علامت نزدن این کادر و کلیک روی «به‌روزرسانی» ممکن است سایت را کاوش کنید، "
-"اما نمی‌توانید درخواست دسترسی به مواد یا ارزیابی درخواست‌ها را بدهید مگر اینکه "
-"با شرایط استفاده موافق باشید."
+msgid "By unchecking this box and clicking “Update” you may explore the site, but you will not be able to apply for access to materials or evaluate applications unless you agree with the terms of use."
+msgstr "با علامت نزدن این کادر و کلیک روی «به‌روزرسانی» ممکن است سایت را کاوش کنید، اما نمی‌توانید درخواست دسترسی به مواد یا ارزیابی درخواست‌ها را بدهید مگر اینکه با شرایط استفاده موافق باشید."
 
 #. Translators: Users click this button to set their website email address to the one linked to their Wikipedia account.
 #: TWLight/users/forms.py:211
-msgid ""
-"Use my Wikipedia email address (will be updated the next time you login)."
-msgstr ""
-"از آدرس ایمیل ویکی‌پدیای من استفاده کنید (بار بعدی که وارد شوید به روز می‌شود)."
+msgid "Use my Wikipedia email address (will be updated the next time you login)."
+msgstr "از آدرس ایمیل ویکی‌پدیای من استفاده کنید (بار بعدی که وارد شوید به روز می‌شود)."
 
 #. Translators: This labels a button which users click to change their email.
 #: TWLight/users/forms.py:232
@@ -2826,19 +2214,8 @@ msgstr "به‌روزرسانی ایمیل"
 #. Translators: Shown if the current user tried to 'favorite' a partner they can't access. Do not translate '{partner}'
 #: TWLight/users/models.py:201
 #, python-brace-format
-msgid ""
-"Cannot add partner {partner} to your favorites because you don't have access "
-"to it"
-msgstr ""
-"شریک {partner} را نمی‌توانید به موارد دلخواه خود اضافه کنید زیرا به آن دسترسی "
-"ندارید"
-
-#. Translators: Do not translate.
-#: TWLight/users/models.py:869
-#, fuzzy, python-brace-format
-#| msgid "Username"
-msgid "{wp_username}"
-msgstr "نام کاربری"
+msgid "Cannot add partner {partner} to your favorites because you don't have access to it"
+msgstr "شریک {partner} را نمی‌توانید به موارد دلخواه خود اضافه کنید زیرا به آن دسترسی ندارید"
 
 #. Translators: This error message is shown when there's a problem with the authenticated login process.
 #: TWLight/users/oauth.py:243
@@ -2858,12 +2235,8 @@ msgstr "Handshaker شروع نشده است، لطفاً دوباره وارد �
 
 #. Translators: this message is displayed to users that don't have accounts and clicked on a proxied link.
 #: TWLight/users/oauth.py:388
-msgid ""
-"To view this link you need to be an eligible library user. Please login to "
-"continue."
-msgstr ""
-"برای مشاهده این پیوند باید یک کاربر واجد شرایط کتابخانه باشید. لطفاً برای "
-"ادامه وارد شوید."
+msgid "To view this link you need to be an eligible library user. Please login to continue."
+msgstr "برای مشاهده این پیوند باید یک کاربر واجد شرایط کتابخانه باشید. لطفاً برای ادامه وارد شوید."
 
 #. Translators: This warning message is shown to users when the response received from Wikimedia OAuth servers is not a valid one.
 #: TWLight/users/oauth.py:430
@@ -2898,23 +2271,13 @@ msgstr "برای اطلاعات بیشتر به {issue} مراجعه کنید"
 
 #. Translators: If the user tries to log in, but their account does not meet certain requirements, they cannot login.
 #: TWLight/users/oauth.py:528
-msgid ""
-"Your Wikipedia account does not meet the eligibility criteria in the terms "
-"of use, so your Wikipedia Library Card Platform account cannot be activated."
-msgstr ""
-"حساب ویکی‌پدیای شما از نظر شرایط استفاده از معیارهای واجد شرایط بودن برخوردار "
-"نیست، بنابراین حساب کارت عضویت کتابخانهٔ ویکی‌پدیای شما نمی‌تواند فعال شود."
+msgid "Your Wikipedia account does not meet the eligibility criteria in the terms of use, so your Wikipedia Library Card Platform account cannot be activated."
+msgstr "حساب ویکی‌پدیای شما از نظر شرایط استفاده از معیارهای واجد شرایط بودن برخوردار نیست، بنابراین حساب کارت عضویت کتابخانهٔ ویکی‌پدیای شما نمی‌تواند فعال شود."
 
 #. Translators: If the user tries to log in, but their account does not meet certain requirements, they cannot login.
 #: TWLight/users/oauth.py:536
-msgid ""
-"Your Wikipedia account no longer meets the eligibility criteria in the terms "
-"of use, so you cannot be logged in. If you think you should be able to log "
-"in, please email wikipedialibrary@wikimedia.org."
-msgstr ""
-"حساب ویکی‌پدیای شما دیگر از نظر شرایط استفاده از معیارهای واجد شرایط بودن "
-"برخوردار نیست، بنابراین نمی‌توانید وارد سیستم شوید. اگر فکر می‌کنید باید "
-"بتوانید وارد شوید، لطفاً به wikipedialibrary@wikimedia.org ایمیل بزنید."
+msgid "Your Wikipedia account no longer meets the eligibility criteria in the terms of use, so you cannot be logged in. If you think you should be able to log in, please email wikipedialibrary@wikimedia.org."
+msgstr "حساب ویکی‌پدیای شما دیگر از نظر شرایط استفاده از معیارهای واجد شرایط بودن برخوردار نیست، بنابراین نمی‌توانید وارد سیستم شوید. اگر فکر می‌کنید باید بتوانید وارد شوید، لطفاً به wikipedialibrary@wikimedia.org ایمیل بزنید."
 
 #. Translators: this message is displayed to users with brand new accounts.
 #: TWLight/users/oauth.py:549
@@ -2924,15 +2287,8 @@ msgstr "خوش آمدید! لطفاً با شرایط استفاده موافق�
 #. Translators: This message is displayed on the confirmation page where users can return their access to partner collections.
 #: TWLight/users/templates/users/authorization_confirm_return.html:13
 #, python-format
-msgid ""
-"You will no longer be able to access <b>%(partner)s's</b> resources via the "
-"Library Card platform, but can request access again by clicking 'renew', if "
-"you change your mind. Are you sure you want to return your access?"
-msgstr ""
-"دیگر نمی‌توانید از طریق کارت عضویت کتابخانهٔ ویکی‌پدیا به منابع <b>"
-"%(partner)s's</b> دسترسی پیدا کنید، اما اگر تصمیم خود را تغییر دهید می‌توانید "
-"با کلیک روی «تمدید» دوباره درخواست دسترسی کنید. آیا مطمئن هستید که می‌خواهید "
-"دسترسی خود را برگردانید؟"
+msgid "You will no longer be able to access <b>%(partner)s's</b> resources via the Library Card platform, but can request access again by clicking 'renew', if you change your mind. Are you sure you want to return your access?"
+msgstr "دیگر نمی‌توانید از طریق کارت عضویت کتابخانهٔ ویکی‌پدیا به منابع <b>%(partner)s's</b> دسترسی پیدا کنید، اما اگر تصمیم خود را تغییر دهید می‌توانید با کلیک روی «تمدید» دوباره درخواست دسترسی کنید. آیا مطمئن هستید که می‌خواهید دسترسی خود را برگردانید؟"
 
 #. Translators: On the MyLibrary page (https://wikipedialibrary.wmflabs.org/users/my_library), this tab shows all favorite collections a user has.
 #: TWLight/users/templates/users/collections_section.html:9
@@ -3001,13 +2357,8 @@ msgstr "داده‌های ویرایشگر"
 
 #. Translators: This is shown on editor profiles, in their profile page or on applications.
 #: TWLight/users/templates/users/editor_detail.html:59
-msgid ""
-"Information with an * was retrieved from Wikipedia directly. Other "
-"information was entered directly by users or site admins, in their preferred "
-"language."
-msgstr ""
-"اطلاعات با * مستقیماً از ویکی‌پدیا اخذ شده‌اند. دیگر اطلاعات توسط کاربران یا "
-"مدیران سایت به‌زبان دلخواه خود وارد شده‌اند."
+msgid "Information with an * was retrieved from Wikipedia directly. Other information was entered directly by users or site admins, in their preferred language."
+msgstr "اطلاعات با * مستقیماً از ویکی‌پدیا اخذ شده‌اند. دیگر اطلاعات توسط کاربران یا مدیران سایت به‌زبان دلخواه خود وارد شده‌اند."
 
 #. Translators: This distinguishes users who have been flagged as account coordinators. Don't translate username.
 #: TWLight/users/templates/users/editor_detail.html:71
@@ -3017,14 +2368,8 @@ msgstr "%(username)s دارای امتیازات هماهنگ‌کننده در 
 
 #. Translators: This is shown on editor profiles, under the heading for Wikipedia editor data.
 #: TWLight/users/templates/users/editor_detail_data.html:5
-msgid ""
-"This information is updated automatically from your Wikimedia account each "
-"time you log in, except for the Contributions field, where you can describe "
-"your Wikimedia editing history."
-msgstr ""
-"این اطلاعات پس از هر بار ورود شما، به‌طور خودکار از حساب ویکی‌مدیای شما "
-"بروزرسانی می‌شوند، به‌جز قسمت مشارکت‌ها، که می‌توانید تاریخچۀ ویرایش ویکی‌مدیایی "
-"خودتان را توصیف کنید."
+msgid "This information is updated automatically from your Wikimedia account each time you log in, except for the Contributions field, where you can describe your Wikimedia editing history."
+msgstr "این اطلاعات پس از هر بار ورود شما، به‌طور خودکار از حساب ویکی‌مدیای شما بروزرسانی می‌شوند، به‌جز قسمت مشارکت‌ها، که می‌توانید تاریخچۀ ویرایش ویکی‌مدیایی خودتان را توصیف کنید."
 
 #. Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this labels the user's username.
 #: TWLight/users/templates/users/editor_detail_data.html:17
@@ -3053,20 +2398,14 @@ msgstr "شرایط استفاده را پذیرفته است؟"
 
 #. Translators: when viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this question has a yes or no answer.
 #: TWLight/users/templates/users/editor_detail_data.html:57
-msgid ""
-"at their last login, did this user meet the criteria set forth in the terms "
-"of use?"
+msgid "at their last login, did this user meet the criteria set forth in the terms of use?"
 msgstr "در آخرین ورود، این کاربر با معیارهای شرایط استفاده مواجه شده است؟"
 
 #. Translators: When viewing a user's profile in an application, this message shows if the software doesn't think that the user is eligible for access. Don't translate username.
 #: TWLight/users/templates/users/editor_detail_data.html:72
 #, python-format
-msgid ""
-"%(username)s may still be eligible for access grants at the coordinators' "
-"discretion."
-msgstr ""
-"%(username)s ممکن است با صلاحدید هماهنگ‌کننده‌ها هنوز واجد شرایط دریافت دسترسی "
-"باشد."
+msgid "%(username)s may still be eligible for access grants at the coordinators' discretion."
+msgstr "%(username)s ممکن است با صلاحدید هماهنگ‌کننده‌ها هنوز واجد شرایط دریافت دسترسی باشد."
 
 #. Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this is the heading for a Yes/No ToU question.
 #: TWLight/users/templates/users/editor_detail_data.html:83
@@ -3100,14 +2439,8 @@ msgstr "(معافیت اعطا شد)"
 #. Translators: This message is shown on a user's profile if their Wikimedia account is blocked on one or more projects. They may still be granted access to the Library Bundle, but need to contact Wikipedia Library staff to verify.
 #: TWLight/users/templates/users/editor_detail_data.html:137
 #, python-format
-msgid ""
-"It looks like you have an active block on your account. If you meet the "
-"other criteria you may still be permitted access to the library - please <a "
-"class=\"twl-links\" href=\"%(contact_url)s\">contact us</a>."
-msgstr ""
-"به‌نظر می‌رسد که دسترسی حساب شما هم‌اکنون بسته است. اگر سایر معیارها را داشته "
-"باشید، ممکن است همچنان اجازهٔ دسترسی به کتابخانه را داشته باشید - لطفاً <a "
-"class=\"twl-links\" href=\"%(contact_url)s\">با ما تماس بگیرید</a>."
+msgid "It looks like you have an active block on your account. If you meet the other criteria you may still be permitted access to the library - please <a class=\"twl-links\" href=\"%(contact_url)s\">contact us</a>."
+msgstr "به‌نظر می‌رسد که دسترسی حساب شما هم‌اکنون بسته است. اگر سایر معیارها را داشته باشید، ممکن است همچنان اجازهٔ دسترسی به کتابخانه را داشته باشید - لطفاً <a class=\"twl-links\" href=\"%(contact_url)s\">با ما تماس بگیرید</a>."
 
 #. Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this is the heading for a Yes/No program eligibility question.
 #: TWLight/users/templates/users/editor_detail_data.html:153
@@ -3116,13 +2449,8 @@ msgstr "واجد شرایط بستهٔ کتابخانه است؟"
 
 #. Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this question has a Yes or No answer.
 #: TWLight/users/templates/users/editor_detail_data.html:156
-msgid ""
-"At their last login, did this user meet the criteria set forth in the "
-"Library Bundle? Note that satisfying terms of use is a prerequisite to "
-"bundle eligibility."
-msgstr ""
-"آیا در آخرین ورود، این کاربر با معیارهای شرایط استفاده مواجه شده است؟ توجه "
-"داشته باشید که رعایت شرایط استفاده، پیش شرط واجد شرایط بودن بسته است"
+msgid "At their last login, did this user meet the criteria set forth in the Library Bundle? Note that satisfying terms of use is a prerequisite to bundle eligibility."
+msgstr "آیا در آخرین ورود، این کاربر با معیارهای شرایط استفاده مواجه شده است؟ توجه داشته باشید که رعایت شرایط استفاده، پیش شرط واجد شرایط بودن بسته است"
 
 #. Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this is the heading for a Yes/No program eligibility question.
 #: TWLight/users/templates/users/editor_detail_data.html:177
@@ -3166,23 +2494,14 @@ msgstr "اطلاعات شخصی"
 
 #. Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this text is in the 'Personal data' section. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/users/templates/users/editor_detail_data.html:262
-msgid ""
-"The following information is visible only to you, site administrators, "
-"publishing partners (where required), and volunteer Wikipedia Library "
-"coordinators (who have signed a Non-Disclosure Agreement)."
-msgstr ""
-"اطلاعات زیر تنها برای شما، مدیران وب‌سایت، انتشارات همکار (در صورت لزوم)، و "
-"هماهنگ‌کنندگان داوطلب کتابخانهٔ ویکی‌پدیا قابل مشاهده است."
+msgid "The following information is visible only to you, site administrators, publishing partners (where required), and volunteer Wikipedia Library coordinators (who have signed a Non-Disclosure Agreement)."
+msgstr "اطلاعات زیر تنها برای شما، مدیران وب‌سایت، انتشارات همکار (در صورت لزوم)، و هماهنگ‌کنندگان داوطلب کتابخانهٔ ویکی‌پدیا قابل مشاهده است."
 
 #. Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this labels a button which users can click to update or remove their personal information. Don't translate update_url.
 #: TWLight/users/templates/users/editor_detail_data.html:272
 #, python-format
-msgid ""
-"You may <a class=\"twl-links\" href=\"%(update_url)s\">update or delete</a> "
-"your data at any time."
-msgstr ""
-"در صورت تمایل می‌توانید اطلاعات‌تان را در هر زمان <a class=\"twl-links\" href="
-"\"%(update_url)s\">به‌روزرسانی یا حذف کنید</a>"
+msgid "You may <a class=\"twl-links\" href=\"%(update_url)s\">update or delete</a> your data at any time."
+msgstr "در صورت تمایل می‌توانید اطلاعات‌تان را در هر زمان <a class=\"twl-links\" href=\"%(update_url)s\">به‌روزرسانی یا حذف کنید</a>"
 
 #. Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this labels the user's email. Don't remove the *.
 #: TWLight/users/templates/users/editor_detail_data.html:283
@@ -3201,32 +2520,19 @@ msgstr "وابستگی سازمانی"
 
 #. Translators: This message tells users that they are not eligible to access The Wikipedia Library content.
 #: TWLight/users/templates/users/eligibility_modal.html:7
-msgid ""
-"Sorry, your Wikipedia account doesn’t currently qualify to access The "
-"Wikipedia Library."
-msgstr ""
-"متأسفانه، حساب ویکی‌پدیای شما در حال حاضر شرایط لازم برای دسترسی به کتابخانهٔ "
-"ویکی‌پدیا را ندارد."
+msgid "Sorry, your Wikipedia account doesn’t currently qualify to access The Wikipedia Library."
+msgstr "متأسفانه، حساب ویکی‌پدیای شما در حال حاضر شرایط لازم برای دسترسی به کتابخانهٔ ویکی‌پدیا را ندارد."
 
 #. Translators: This message tells users that they have not agreed to the terms of use, therefore are ineligible to access the content in The Wikipedia Library.
 #: TWLight/users/templates/users/eligibility_modal.html:30
 #, python-format
-msgid ""
-"Agreed with <a href=\"%(terms)s\" class=\"text-danger\"> terms of use </a>"
-msgstr ""
-"با <a href=\"%(terms)s\" class=\"text-danger\"> شرایط استفاده </a> موافقت "
-"کرده است"
+msgid "Agreed with <a href=\"%(terms)s\" class=\"text-danger\"> terms of use </a>"
+msgstr "با <a href=\"%(terms)s\" class=\"text-danger\"> شرایط استفاده </a> موافقت کرده است"
 
 #: TWLight/users/templates/users/eligibility_modal.html:40
 #, python-format
-msgid ""
-"It looks like you have an active block on your account. If you meet the "
-"other criteria you may still be permitted access to the library - please <a "
-"href=\"%(contact_url)s\">contact us</a>."
-msgstr ""
-"به‌نظر می‌رسد که دسترسی حساب شما هم‌اکنون بسته است. اگر سایر معیارها را داشته "
-"باشید، ممکن است همچنان اجازهٔ دسترسی به کتابخانه را داشته باشید - لطفاً <a "
-"href=\"%(contact_url)s\">با ما تماس بگیرید</a>."
+msgid "It looks like you have an active block on your account. If you meet the other criteria you may still be permitted access to the library - please <a href=\"%(contact_url)s\">contact us</a>."
+msgstr "به‌نظر می‌رسد که دسترسی حساب شما هم‌اکنون بسته است. اگر سایر معیارها را داشته باشید، ممکن است همچنان اجازهٔ دسترسی به کتابخانه را داشته باشید - لطفاً <a href=\"%(contact_url)s\">با ما تماس بگیرید</a>."
 
 #. Translators: Instructions to refresh a user's data.
 #: TWLight/users/templates/users/eligibility_modal.html:50
@@ -3265,14 +2571,8 @@ msgstr "انتخاب زبان"
 
 #. Translators: This text on the user page helps users naviage to the TranslateWiki Wikipedia Library Card platform translation page.
 #: TWLight/users/templates/users/language_form.html:31
-msgid ""
-"You can help translate the tool at <a class=\"twl-links\" href=\"https://"
-"translatewiki.net/wiki/Translating:Wikipedia_Library_Card_Platform"
-"\">translatewiki.net</a>."
-msgstr ""
-"در <a class=\"twl-links\" href=\"https://translatewiki.net/wiki/Translating:"
-"Wikipedia_Library_Card_Platform\">translatewiki.net</a می‌توانید به ترجمهٔ این "
-"پلتفرم کمک کنید."
+msgid "You can help translate the tool at <a class=\"twl-links\" href=\"https://translatewiki.net/wiki/Translating:Wikipedia_Library_Card_Platform\">translatewiki.net</a>."
+msgstr "در <a class=\"twl-links\" href=\"https://translatewiki.net/wiki/Translating:Wikipedia_Library_Card_Platform\">translatewiki.net</a می‌توانید به ترجمهٔ این پلتفرم کمک کنید."
 
 #. Translators: When the user starts a new application and submits the application, the user can view the application and withdraw if need be. This changes the label for the Withdraw button.
 #: TWLight/users/templates/users/my_applications.html:65
@@ -3291,12 +2591,8 @@ msgstr "درخواست تمدید"
 
 #. Translators: On the page listing applications, this text explains a user they cannot renew their application since they've already requested a renewal or there aren't any renewals available.
 #: TWLight/users/templates/users/my_applications.html:79
-msgid ""
-"Renewals are either not required, not available right now, or you have "
-"already requested a renewal."
-msgstr ""
-"یا نیازی به تمدید نیست، یا در حال حاضر امکان تمدید وجود ندارد، و یا قبلا "
-"درخواست تمدید کرده‌اید."
+msgid "Renewals are either not required, not available right now, or you have already requested a renewal."
+msgstr "یا نیازی به تمدید نیست، یا در حال حاضر امکان تمدید وجود ندارد، و یا قبلا درخواست تمدید کرده‌اید."
 
 #. Translators: This text is the heading of a section in a user's profile where they can change their preferences.
 #: TWLight/users/templates/users/preferences.html:6
@@ -3359,27 +2655,13 @@ msgstr "محدودیت پردازش داده"
 
 #. Translators: This message is displayed on the page where users can request we stop processing their data.
 #: TWLight/users/templates/users/restrict_data.html:15
-msgid ""
-"Checking this box and clicking “Restrict” will pause all processing of the "
-"data you have entered into this website. You will not be able to apply for "
-"access to resources, your applications will not be further processed, and "
-"none of your data will be altered, until you return to this page and uncheck "
-"the box. This is not the same as deleting your data."
-msgstr ""
-"با علامت زدن این کادر و کلیک بر روی «محدود کردن»، تمام پردازش داده‌های "
-"واردشده به این وب‌سایت متوقف می‌شود. تا زمانی که به این صفحه برگردید و علامت "
-"کادر را بردارید، نمی‌توانید درخواست دسترسی به منابع را داشته باشید، برنامه‌های "
-"شما دیگر پردازش نمی‌شوند و هیچ‌یک از داده‌های شما تغییر نمی‌کند. این همان حذف "
-"داده‌های شما نیست."
+msgid "Checking this box and clicking “Restrict” will pause all processing of the data you have entered into this website. You will not be able to apply for access to resources, your applications will not be further processed, and none of your data will be altered, until you return to this page and uncheck the box. This is not the same as deleting your data."
+msgstr "با علامت زدن این کادر و کلیک بر روی «محدود کردن»، تمام پردازش داده‌های واردشده به این وب‌سایت متوقف می‌شود. تا زمانی که به این صفحه برگردید و علامت کادر را بردارید، نمی‌توانید درخواست دسترسی به منابع را داشته باشید، برنامه‌های شما دیگر پردازش نمی‌شوند و هیچ‌یک از داده‌های شما تغییر نمی‌کند. این همان حذف داده‌های شما نیست."
 
 #. Translators: This warning message is shown to coordinators who view the data restriction page.
 #: TWLight/users/templates/users/restrict_data.html:26
-msgid ""
-"You are a coordinator on this site. If you restrict the processing of your "
-"data, your coordinator flag will be removed."
-msgstr ""
-"شما یک هماهنگ‌کننده در این سایت هستید. اگر پردازش اطلاعات خود را محدود "
-"می‌کنید، پرچم هماهنگ‌کنندهٔ شما حذف خواهد شد."
+msgid "You are a coordinator on this site. If you restrict the processing of your data, your coordinator flag will be removed."
+msgstr "شما یک هماهنگ‌کننده در این سایت هستید. اگر پردازش اطلاعات خود را محدود می‌کنید، پرچم هماهنگ‌کنندهٔ شما حذف خواهد شد."
 
 #. Translators: use the date *when you are translating*, in a language-appropriate format.
 #: TWLight/users/templates/users/terms.html:33
@@ -3398,36 +2680,13 @@ msgstr "شرایط استفاده و بیاینهٔ حریم خصوصی کارت
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:51
-msgid ""
-"<a class=\"twl-links\" href=\"https://meta.wikimedia.org/wiki/"
-"The_Wikipedia_Library\"> The Wikipedia Library </a> has partnered with "
-"publishers around the world to allow users to access otherwise paywalled "
-"resources. This website allows Wikipedia editors to search and access these "
-"resources."
-msgstr ""
-"<a class=\"twl-links\" href=\"https://meta.wikimedia.org/wiki/"
-"The_Wikipedia_Library\">کتابخانهٔ ویکی‌پدیا</a> با ناشران در سراسر جهان همکاری "
-"کرده است تا به کاربران اجازهٔ دسترسی به منابع پولی و غیررایگان را بدهد. این "
-"وب سایت به کاربران امکان می‌دهد تا همزمان برای دسترسی به چندین ناشر درخواست "
-"دهند و مدیریت و دسترسی به حساب‌های کتابخانهٔ ویکی‌پدیا را آسان و کارآمد می‌کند."
+msgid "<a class=\"twl-links\" href=\"https://meta.wikimedia.org/wiki/The_Wikipedia_Library\"> The Wikipedia Library </a> has partnered with publishers around the world to allow users to access otherwise paywalled resources. This website allows Wikipedia editors to search and access these resources."
+msgstr "<a class=\"twl-links\" href=\"https://meta.wikimedia.org/wiki/The_Wikipedia_Library\">کتابخانهٔ ویکی‌پدیا</a> با ناشران در سراسر جهان همکاری کرده است تا به کاربران اجازهٔ دسترسی به منابع پولی و غیررایگان را بدهد. این وب سایت به کاربران امکان می‌دهد تا همزمان برای دسترسی به چندین ناشر درخواست دهند و مدیریت و دسترسی به حساب‌های کتابخانهٔ ویکی‌پدیا را آسان و کارآمد می‌کند."
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Wikimedia Foundation should not be translated. WMF should not be translated. Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:63
-msgid ""
-"This program is administered by the Wikimedia Foundation (WMF). These terms "
-"of use and privacy notice pertain to your application for access to "
-"resources through the Wikipedia Library, your use of this website, and your "
-"access to and use of those resources. They also describe our handling of the "
-"information you provide to us in order to create and administer your "
-"Wikipedia Library account. If we make material changes to the terms, we will "
-"notify users."
-msgstr ""
-"این برنامه توسط بنیاد ویکی‌مدیا (WMF) اداره می‌شود. این شرایط استفاده و اخطار "
-"حریم خصوصی مربوط به درخواست شما برای دسترسی به منابع از طریق کتابخانهٔ "
-"ویکی‌پدیا، استفادهٔ شما از این وب‌سایت و دسترسی و استفاده از آن منابع است. آنها "
-"همچنین نحوهٔ کار ما با اطلاعاتی را که برای ایجاد و مدیریت حساب کتابخانهٔ "
-"ویکی‌پدیا به ما ارائه می‌دهید، توصیف می‌کنند. اگر تغییرات اساسی در شرایط ایجاد "
-"کنیم، به کاربران اطلاع خواهیم داد."
+msgid "This program is administered by the Wikimedia Foundation (WMF). These terms of use and privacy notice pertain to your application for access to resources through the Wikipedia Library, your use of this website, and your access to and use of those resources. They also describe our handling of the information you provide to us in order to create and administer your Wikipedia Library account. If we make material changes to the terms, we will notify users."
+msgstr "این برنامه توسط بنیاد ویکی‌مدیا (WMF) اداره می‌شود. این شرایط استفاده و اخطار حریم خصوصی مربوط به درخواست شما برای دسترسی به منابع از طریق کتابخانهٔ ویکی‌پدیا، استفادهٔ شما از این وب‌سایت و دسترسی و استفاده از آن منابع است. آنها همچنین نحوهٔ کار ما با اطلاعاتی را که برای ایجاد و مدیریت حساب کتابخانهٔ ویکی‌پدیا به ما ارائه می‌دهید، توصیف می‌کنند. اگر تغییرات اساسی در شرایط ایجاد کنیم، به کاربران اطلاع خواهیم داد."
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:74
@@ -3436,56 +2695,18 @@ msgstr "نیازمندی‌ها برای حساب کارت کتابخانه وی
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:78
-msgid ""
-"Access to resources via The Wikipedia Library is reserved for community "
-"members who have demonstrated their commitment to the Wikimedia projects, "
-"and who will use their access to these resources to improve project content. "
-"To that end, in order to be eligible for The Wikipedia Library, we require "
-"that you be registered for a user account on the projects, with at least 500 "
-"edits, six (6) months of activity, and 10+ edits in the last month. We ask "
-"that you do not request access to any publishers with a limited number of "
-"available accounts whose resources you can already access for free through "
-"your local library or university, or another institution or organization, in "
-"order to provide that opportunity to others."
-msgstr ""
-"دسترسی به منابع از طریق کتابخانهٔ ویکی‌پدیا مختص اعضای جامعه است که تعهد خود "
-"را به پروژه‌های ویکی‌مدیا نشان داده‌اند و از دسترسی خود به این منابع برای بهبود "
-"محتوای پروژه استفاده می‌کنند. برای این منظور، برای واجد شرایط بودن درخواست به "
-"کتابخانهٔ ویکی‌پدیا، لازم است که برای حساب کاربری خود در پروژه‌ها ثبت نام کنید. "
-"ما کاربران با حداقل ۵۰۰ ویرایش، شش (۶) ماه فعالیت، و بیش از ۱۰ ویرایش در یک "
-"ماه اخیر را ترجیح می‌دهیم، اما این موارد سختگیرانه نیستند. ما از شما می‌خواهیم "
-"که به ناشران که از قبل می‌توانید از طریق کتابخانه یا دانشگاه محلی خود، یا یک "
-"مؤسسه یا سازمان دیگر به‌طور رایگان به منابع دسترسی پیدا کنید، دسترسی نداشته "
-"باشید تا این فرصت را در اختیار دیگران قرار دهید."
+msgid "Access to resources via The Wikipedia Library is reserved for community members who have demonstrated their commitment to the Wikimedia projects, and who will use their access to these resources to improve project content. To that end, in order to be eligible for The Wikipedia Library, we require that you be registered for a user account on the projects, with at least 500 edits, six (6) months of activity, and 10+ edits in the last month. We ask that you do not request access to any publishers with a limited number of available accounts whose resources you can already access for free through your local library or university, or another institution or organization, in order to provide that opportunity to others."
+msgstr "دسترسی به منابع از طریق کتابخانهٔ ویکی‌پدیا مختص اعضای جامعه است که تعهد خود را به پروژه‌های ویکی‌مدیا نشان داده‌اند و از دسترسی خود به این منابع برای بهبود محتوای پروژه استفاده می‌کنند. برای این منظور، برای واجد شرایط بودن درخواست به کتابخانهٔ ویکی‌پدیا، لازم است که برای حساب کاربری خود در پروژه‌ها ثبت نام کنید. ما کاربران با حداقل ۵۰۰ ویرایش، شش (۶) ماه فعالیت، و بیش از ۱۰ ویرایش در یک ماه اخیر را ترجیح می‌دهیم، اما این موارد سختگیرانه نیستند. ما از شما می‌خواهیم که به ناشران که از قبل می‌توانید از طریق کتابخانه یا دانشگاه محلی خود، یا یک مؤسسه یا سازمان دیگر به‌طور رایگان به منابع دسترسی پیدا کنید، دسترسی نداشته باشید تا این فرصت را در اختیار دیگران قرار دهید."
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:94
-msgid ""
-"Additionally, if you are currently blocked or banned from a Wikimedia "
-"project, applications to resources may be rejected or restricted. If you "
-"obtain a Wikipedia Library account, but a block or ban is subsequently "
-"instituted against you on one of the projects, you may lose access to your "
-"Wikipedia Library account."
-msgstr ""
-"افزون بر این، اگر در حال حاضر در یک پروژهٔ ویکی‌مدیا قطع دسترسی شده‌اید، ممکن "
-"است درخواست‌های شما برای منابع رد یا محدود شوند. اگر یک حساب کتابخانهٔ "
-"ویکی‌پدیا به دست بیاورید، اما بعداً در یکی از پروژه‌ها قطع دسترسی یا تحریم علیه "
-"شما اعمال شود، ممکن است دسترسی به حساب کتابخانهٔ ویکی‌پدیا را از دست بدهید."
+msgid "Additionally, if you are currently blocked or banned from a Wikimedia project, applications to resources may be rejected or restricted. If you obtain a Wikipedia Library account, but a block or ban is subsequently instituted against you on one of the projects, you may lose access to your Wikipedia Library account."
+msgstr "افزون بر این، اگر در حال حاضر در یک پروژهٔ ویکی‌مدیا قطع دسترسی شده‌اید، ممکن است درخواست‌های شما برای منابع رد یا محدود شوند. اگر یک حساب کتابخانهٔ ویکی‌پدیا به دست بیاورید، اما بعداً در یکی از پروژه‌ها قطع دسترسی یا تحریم علیه شما اعمال شود، ممکن است دسترسی به حساب کتابخانهٔ ویکی‌پدیا را از دست بدهید."
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:104
-msgid ""
-"Your eligibility to access The Wikipedia Library is assessed at each login. "
-"While more than half of the library's content is provided via this automated "
-"eligibility check, access to other publisher's content may be time limited, "
-"typically lapsing after one year, after which you will usually need to apply "
-"for renewal."
-msgstr ""
-"صلاحیت‌تان برای دسترسی به کتابخانهٔ ویکی‌پدیا در هر ورود مورد ارزیابی قرار "
-"می‌گیرد. در حالی که بیش از نیمی از محتوای کتابخانه از طریق این بررسی صلاحیت "
-"خودکار ارائه می‌شود، دسترسی به محتوای ناشران دیگر ممکن است از نظر زمانی محدود "
-"باشد، معمولاً پس از یک سال از بین می‌رود و پس از آن معمولاً باید برای تمدید، "
-"دوباره درخواست دهید."
+msgid "Your eligibility to access The Wikipedia Library is assessed at each login. While more than half of the library's content is provided via this automated eligibility check, access to other publisher's content may be time limited, typically lapsing after one year, after which you will usually need to apply for renewal."
+msgstr "صلاحیت‌تان برای دسترسی به کتابخانهٔ ویکی‌پدیا در هر ورود مورد ارزیابی قرار می‌گیرد. در حالی که بیش از نیمی از محتوای کتابخانه از طریق این بررسی صلاحیت خودکار ارائه می‌شود، دسترسی به محتوای ناشران دیگر ممکن است از نظر زمانی محدود باشد، معمولاً پس از یک سال از بین می‌رود و پس از آن معمولاً باید برای تمدید، دوباره درخواست دهید."
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:114
@@ -3494,68 +2715,28 @@ msgstr "درخواست با حساب کارت کتابخانه ویکی‌پدی
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:118
-msgid ""
-"In order to apply for access to a partner resource, you must provide us with "
-"certain information, which we will use to evaluate your application. If your "
-"application is approved, we may transfer the information you have given us "
-"to the publishers whose resources you wish to access. They will either "
-"contact you with the account information directly or we will send access "
-"information to you ourselves."
-msgstr ""
-"برای درخواست دسترسی به یک منبع شریک، باید اطلاعات خاصی را در اختیار ما قرار "
-"دهید که از آن‌ها برای ارزیابی درخواست شما استفاده خواهیم کرد. در صورت تأیید "
-"درخواست شما، ممکن است اطلاعاتی را که به ما داده‌اید به ناشرانی که مایل به "
-"دسترسی به منابع آن هستید انتقال دهیم. آنها یا مستقیماً با اطلاعات حساب با شما "
-"تماس خواهند گرفت یا ما خودمان اطلاعات دسترسی را برای شما ارسال خواهیم کرد."
+msgid "In order to apply for access to a partner resource, you must provide us with certain information, which we will use to evaluate your application. If your application is approved, we may transfer the information you have given us to the publishers whose resources you wish to access. They will either contact you with the account information directly or we will send access information to you ourselves."
+msgstr "برای درخواست دسترسی به یک منبع شریک، باید اطلاعات خاصی را در اختیار ما قرار دهید که از آن‌ها برای ارزیابی درخواست شما استفاده خواهیم کرد. در صورت تأیید درخواست شما، ممکن است اطلاعاتی را که به ما داده‌اید به ناشرانی که مایل به دسترسی به منابع آن هستید انتقال دهیم. آنها یا مستقیماً با اطلاعات حساب با شما تماس خواهند گرفت یا ما خودمان اطلاعات دسترسی را برای شما ارسال خواهیم کرد."
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:130
-msgid ""
-"In addition to the basic information you provide to us, our system will "
-"retrieve some information directly from the Wikimedia projects: your "
-"username, email address, edit count, registration date, user ID number, "
-"groups to which you belong, and any special user rights."
-msgstr ""
-"علاوه بر اطلاعات اساسی که شما به ما ارائه می‌دهید، سامانۀ ما برخی از اطلاعات "
-"را مستقیماً از پروژه‌های ویکی‌مدیا بازیابی می‌کند: نام کاربری، آدرس ایمیل، تعداد "
-"ویرایش، تاریخ ثبت نام، شمارهٔ شناسه کاربر، گروه‌هایی که به آن‌ها تعلق دارید و "
-"سایر اختیارات کاربری."
+msgid "In addition to the basic information you provide to us, our system will retrieve some information directly from the Wikimedia projects: your username, email address, edit count, registration date, user ID number, groups to which you belong, and any special user rights."
+msgstr "علاوه بر اطلاعات اساسی که شما به ما ارائه می‌دهید، سامانۀ ما برخی از اطلاعات را مستقیماً از پروژه‌های ویکی‌مدیا بازیابی می‌کند: نام کاربری، آدرس ایمیل، تعداد ویرایش، تاریخ ثبت نام، شمارهٔ شناسه کاربر، گروه‌هایی که به آن‌ها تعلق دارید و سایر اختیارات کاربری."
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:140
-msgid ""
-"Each time you log in to the Wikipedia Library Card Platform, this "
-"information will be automatically updated."
-msgstr ""
-"هر بار که وارد سکوی کارت عضویت کتابخانهٔ ویکی‌پدیا می‌شوید، این اطلاعات به‌طور "
-"خودکار به روز می‌شود."
+msgid "Each time you log in to the Wikipedia Library Card Platform, this information will be automatically updated."
+msgstr "هر بار که وارد سکوی کارت عضویت کتابخانهٔ ویکی‌پدیا می‌شوید، این اطلاعات به‌طور خودکار به روز می‌شود."
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:148
-msgid ""
-"We will ask you to provide us with some information about your history of "
-"contributions to the Wikimedia projects. Information on contribution history "
-"is optional, but will greatly assist us in evaluating your application."
-msgstr ""
-"از شما می‌خواهیم برخی از اطلاعات مربوط به سابقهٔ مشارکت در پروژه‌های ویکی‌مدیا "
-"را در اختیار ما قرار دهید. اطلاعات مربوط به سابقهٔ مشارکت اختیاری است، اما در "
-"ارزیابی درخواست شما بسیار به ما کمک می‌کند."
+msgid "We will ask you to provide us with some information about your history of contributions to the Wikimedia projects. Information on contribution history is optional, but will greatly assist us in evaluating your application."
+msgstr "از شما می‌خواهیم برخی از اطلاعات مربوط به سابقهٔ مشارکت در پروژه‌های ویکی‌مدیا را در اختیار ما قرار دهید. اطلاعات مربوط به سابقهٔ مشارکت اختیاری است، اما در ارزیابی درخواست شما بسیار به ما کمک می‌کند."
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). WMF should not be translated. Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:157
-msgid ""
-"The information you provide when creating your account will be visible to "
-"you while on the site but not to others unless they are approved Wikipedia "
-"Library Coordinators, WMF Staff, or WMF Contractors who need access to this "
-"data in order to carry out their work with the Wikipedia Library, all of "
-"whom are subject to non-disclosure obligations."
-msgstr ""
-"اطلاعاتی که هنگام ایجاد حساب کاربری خود ارائه می‌دهید در هنگام حضور در سایت "
-"برای شما قابل مشاهده خواهد بود، اما برای دیگران قابل مشاهده نخواهد بود، مگر "
-"اینکه آنها از هماهنگ‌کنندگان کتابخانهٔ ویکی‌پدیا، کارمندان بنیاد ویکی‌مدیا یا "
-"پیمانکاران بنیاد که برای انجام کار خود به دسترسی به این داده‌ها نیاز دارند، "
-"باشند. کتابخانهٔ ویکی‌پدیا، و دیگرانی که به این اطلاعات دسترسی دارند، تعهد عدم "
-"افشای اطلاعات را امضا کرده‌اند."
+msgid "The information you provide when creating your account will be visible to you while on the site but not to others unless they are approved Wikipedia Library Coordinators, WMF Staff, or WMF Contractors who need access to this data in order to carry out their work with the Wikipedia Library, all of whom are subject to non-disclosure obligations."
+msgstr "اطلاعاتی که هنگام ایجاد حساب کاربری خود ارائه می‌دهید در هنگام حضور در سایت برای شما قابل مشاهده خواهد بود، اما برای دیگران قابل مشاهده نخواهد بود، مگر اینکه آنها از هماهنگ‌کنندگان کتابخانهٔ ویکی‌پدیا، کارمندان بنیاد ویکی‌مدیا یا پیمانکاران بنیاد که برای انجام کار خود به دسترسی به این داده‌ها نیاز دارند، باشند. کتابخانهٔ ویکی‌پدیا، و دیگرانی که به این اطلاعات دسترسی دارند، تعهد عدم افشای اطلاعات را امضا کرده‌اند."
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:167
@@ -3564,61 +2745,35 @@ msgstr "استفادهٔ شما از منابع ناشر"
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:171
-msgid ""
-"In order to access an individual publisher’s resources, you must agree to "
-"that publisher’s terms of use and privacy policy. You agree that you will "
-"not violate such terms and policies in connection with your use of the "
-"Wikipedia Library. Additionally, the following activities are prohibited "
-"while accessing publisher resources through the Wikipedia Library."
-msgstr ""
-"برای دسترسی به منابع ناشری خاص، باید با شرایط استفاده و سیاست حفظ حریم خصوصی "
-"آن ناشر موافقت کنید. شما موافقت می‌کنید که در رابطه با استفادهٔ شما از "
-"کتابخانهٔ ویکی‌پدیا، چنین شرایط و قوانینی را نقض نخواهید کرد. افزون بر این، "
-"فعالیت‌های زیر هنگام دسترسی به منابع ناشر از طریق کتابخانهٔ ویکی‌پدیا ممنوع است."
+msgid "In order to access an individual publisher’s resources, you must agree to that publisher’s terms of use and privacy policy. You agree that you will not violate such terms and policies in connection with your use of the Wikipedia Library. Additionally, the following activities are prohibited while accessing publisher resources through the Wikipedia Library."
+msgstr "برای دسترسی به منابع ناشری خاص، باید با شرایط استفاده و سیاست حفظ حریم خصوصی آن ناشر موافقت کنید. شما موافقت می‌کنید که در رابطه با استفادهٔ شما از کتابخانهٔ ویکی‌پدیا، چنین شرایط و قوانینی را نقض نخواهید کرد. افزون بر این، فعالیت‌های زیر هنگام دسترسی به منابع ناشر از طریق کتابخانهٔ ویکی‌پدیا ممنوع است."
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:184
-msgid ""
-"Sharing your Wikipedia account, usernames, passwords, or any access codes "
-"for publisher resources with others;"
-msgstr ""
-"اشتراک حساب ویکی‌پدیا، نام‌های کاربری، گذرواژه‌ها یا هر کد دسترسی برای منابع "
-"ناشر با دیگران؛"
+msgid "Sharing your Wikipedia account, usernames, passwords, or any access codes for publisher resources with others;"
+msgstr "اشتراک حساب ویکی‌پدیا، نام‌های کاربری، گذرواژه‌ها یا هر کد دسترسی برای منابع ناشر با دیگران؛"
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:191
-msgid ""
-"Automatically scraping or downloading restricted content from publishers;"
+msgid "Automatically scraping or downloading restricted content from publishers;"
 msgstr "به صورت خودکار محتوای محدودشده را از ناشران حذف یا بارگیری کنید."
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:197
 #, fuzzy
-msgid ""
-"Systematically making printed or electronic copies of multiple extracts of "
-"restricted content available for any purpose;"
-msgstr ""
-"چکیده‌های متعدد از محتوای محدودی را که در اختیار دارند به صورت سازماندهی شده "
-"با هر هدفی تکثیر چاپی یا الکترونیکی کنند"
+msgid "Systematically making printed or electronic copies of multiple extracts of restricted content available for any purpose;"
+msgstr "چکیده‌های متعدد از محتوای محدودی را که در اختیار دارند به صورت سازماندهی شده با هر هدفی تکثیر چاپی یا الکترونیکی کنند"
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:204
 #, fuzzy
-msgid ""
-"Data mining metadata without permission—for example, in order to use "
-"metadata for auto-created stub articles;"
-msgstr ""
-"بدون مجوز، فراداده‌ها را، به عنوان مثال، برای تولید خودکار مقاله‌های خُرد، "
-"داده‌کاوی کنند"
+msgid "Data mining metadata without permission—for example, in order to use metadata for auto-created stub articles;"
+msgstr "بدون مجوز، فراداده‌ها را، به عنوان مثال، برای تولید خودکار مقاله‌های خُرد، داده‌کاوی کنند"
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:211
-msgid ""
-"Using the access you receive through the Wikipedia Library for profit by "
-"selling access to your account or resources which you have through it."
-msgstr ""
-"به‌کارگیری دسترسی‌ که از طریق کتابخانهٔ ویکی‌پدیا دریافت می‌کنید برای سودآوری با "
-"فروش دسترسی به حسابتان یا منابعی که از طریق آن دارید."
+msgid "Using the access you receive through the Wikipedia Library for profit by selling access to your account or resources which you have through it."
+msgstr "به‌کارگیری دسترسی‌ که از طریق کتابخانهٔ ویکی‌پدیا دریافت می‌کنید برای سودآوری با فروش دسترسی به حسابتان یا منابعی که از طریق آن دارید."
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:220
@@ -3627,25 +2782,13 @@ msgstr "خدمات جستجوی خارجی و پراکسی"
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:224
-msgid ""
-"Certain resources may only be accessed using an external search service, "
-"such as the EBSCO Discovery Service, or a proxy service, such as OCLC "
-"EZProxy. If you use such external search and/or proxy services, please "
-"review the applicable terms of use and privacy policies."
-msgstr ""
-"منابع خاص فقط با استفاده از یک سرویس جستجوی خارجی، مانند EBSCO Discovery "
-"Service یا یک سرویس پروکسی، مانند OCLC EZProxy، قابل دسترسی است. اگر از چنین "
-"جستجوی خارجی و/یا خدمات پروکسی استفاده می‌کنید، لطفاً شرایط استفاده و سیاست‌های "
-"رازداری قابل اجرا را مرور کنید."
+msgid "Certain resources may only be accessed using an external search service, such as the EBSCO Discovery Service, or a proxy service, such as OCLC EZProxy. If you use such external search and/or proxy services, please review the applicable terms of use and privacy policies."
+msgstr "منابع خاص فقط با استفاده از یک سرویس جستجوی خارجی، مانند EBSCO Discovery Service یا یک سرویس پروکسی، مانند OCLC EZProxy، قابل دسترسی است. اگر از چنین جستجوی خارجی و/یا خدمات پروکسی استفاده می‌کنید، لطفاً شرایط استفاده و سیاست‌های رازداری قابل اجرا را مرور کنید."
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:234
-msgid ""
-"In addition, if you use OCLC EZProxy, please note that you may not use it "
-"for commercial purposes."
-msgstr ""
-"علاوه بر این، اگر از OCLC EZProxy استفاده می‌کنید، لطفاً توجه داشته باشید که "
-"ممکن است از آن برای اهداف تجاری استفاده نکنید."
+msgid "In addition, if you use OCLC EZProxy, please note that you may not use it for commercial purposes."
+msgstr "علاوه بر این، اگر از OCLC EZProxy استفاده می‌کنید، لطفاً توجه داشته باشید که ممکن است از آن برای اهداف تجاری استفاده نکنید."
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:241
@@ -3655,188 +2798,51 @@ msgstr "نگهداری و مدیریت داده‌ها"
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Wikimedia Foundation should not be translated. Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:245
 #, fuzzy
-msgid ""
-"The Wikimedia Foundation and our service providers use your information for "
-"the legitimate purpose of providing Wikipedia Library services in support of "
-"our charitable mission. When you apply for a Wikipedia Library account, or "
-"use your Wikipedia Library account, we may routinely collect the following "
-"information: your username, email address, edit count, registration date, "
-"user ID number, groups to which you belong, and any special user rights; "
-"your name, country of residence, and/or affiliation, if required by a "
-"partner to which you are applying; your narrative description of your "
-"contributions and reasons for applying for access to partner resources; and "
-"the date you agree to these terms of use."
-msgstr ""
-"بنیاد ویکی‌مدیا و ارائه‌دهندگان خدمات ما از اطلاعات شما برای هدف قانونی ارائهٔ "
-"خدمات کتابخانهٔ ویکی‌پدیا در حمایت از مأموریت خیرخواهانهٔ ما استفاده می‌کنند. "
-"هنگامی که برای یک حساب کتابخانهٔ ویکی‌پدیا درخواست می‌کنید، یا از حساب کتابخانهٔ "
-"ویکی‌پدیای خود استفاده می‌کنید، ما می‌توانیم به‌طور معمول اطلاعات زیر را جمع‌آوری "
-"کنیم: نام کاربری، آدرس ایمیل، تعداد ویرایش، تاریخ ثبت نام، شمارهٔ شناسهٔ "
-"کاربر، گروه‌های کاربری که به آن‌ها تعلق دارید و اختیارات کاربری؛ نام، کشور محل "
-"اقامت، شغل و/یا وابستگی سازمانی شما، در صورت نیاز توسط شریکی که از آن "
-"درخواست می‌کنید؛ شرح روایت شما از مشارکت و دلایل درخواست دسترسی به منابع "
-"شریک؛ و تاریخ موافقت شما با این شرایط استفاده."
+msgid "The Wikimedia Foundation and our service providers use your information for the legitimate purpose of providing Wikipedia Library services in support of our charitable mission. When you apply for a Wikipedia Library account, or use your Wikipedia Library account, we may routinely collect the following information: your username, email address, edit count, registration date, user ID number, groups to which you belong, and any special user rights; your name, country of residence, and/or affiliation, if required by a partner to which you are applying; your narrative description of your contributions and reasons for applying for access to partner resources; and the date you agree to these terms of use."
+msgstr "بنیاد ویکی‌مدیا و ارائه‌دهندگان خدمات ما از اطلاعات شما برای هدف قانونی ارائهٔ خدمات کتابخانهٔ ویکی‌پدیا در حمایت از مأموریت خیرخواهانهٔ ما استفاده می‌کنند. هنگامی که برای یک حساب کتابخانهٔ ویکی‌پدیا درخواست می‌کنید، یا از حساب کتابخانهٔ ویکی‌پدیای خود استفاده می‌کنید، ما می‌توانیم به‌طور معمول اطلاعات زیر را جمع‌آوری کنیم: نام کاربری، آدرس ایمیل، تعداد ویرایش، تاریخ ثبت نام، شمارهٔ شناسهٔ کاربر، گروه‌های کاربری که به آن‌ها تعلق دارید و اختیارات کاربری؛ نام، کشور محل اقامت، شغل و/یا وابستگی سازمانی شما، در صورت نیاز توسط شریکی که از آن درخواست می‌کنید؛ شرح روایت شما از مشارکت و دلایل درخواست دسترسی به منابع شریک؛ و تاریخ موافقت شما با این شرایط استفاده."
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:262
 #, fuzzy, python-format
-msgid ""
-"Each publisher who is a member of the Wikipedia Library program requires "
-"different specific information in the application. Some publishers may "
-"request only an email address, while others request more detailed data, such "
-"as your name, location, or institutional affiliation. When you complete your "
-"application, you will only be asked to supply information required by the "
-"publishers you have chosen, and each publisher will only receive the "
-"information they require for providing you with access. Please see our <a "
-"class=\"twl-links\" href=\"%(all_partners_url)s\">partner information</a> "
-"pages to learn what information is required by each publisher to gain access "
-"to their resources."
-msgstr ""
-"هر ناشری که عضو برنامهٔ کتابخانهٔ ویکی‌پدیا باشد، به اطلاعات خاص متفاوت در "
-"درخواست نیاز دارد. برخی از ناشران ممکن است فقط یک آدرس ایمیل درخواست کنند، "
-"در حالی که برخی دیگر اطلاعات دقیق‌تری مانند نام، مکان، شغل یا وابستگی سازمانی "
-"شما را درخواست می‌کنند. هنگامی که درخواست خود را تکمیل می‌کنید، فقط از شما "
-"خواسته می‌شود اطلاعات مورد نیاز ناشران را انتخاب کنید و هر ناشر فقط اطلاعات "
-"مورد نیاز شما را برای دسترسی شما دریافت می‌کند. لطفاً از صفحات <a class=\"twl-"
-"links\" href=\"%(all_partners_url)s\">اطلاعات پایگاه</a> ما دیدن کنید تا "
-"بدانید هر ناشر برای دسترسی به منابع خود چه اطلاعاتی را لازم دارد."
+msgid "Each publisher who is a member of the Wikipedia Library program requires different specific information in the application. Some publishers may request only an email address, while others request more detailed data, such as your name, location, or institutional affiliation. When you complete your application, you will only be asked to supply information required by the publishers you have chosen, and each publisher will only receive the information they require for providing you with access. Please see our <a class=\"twl-links\" href=\"%(all_partners_url)s\">partner information</a> pages to learn what information is required by each publisher to gain access to their resources."
+msgstr "هر ناشری که عضو برنامهٔ کتابخانهٔ ویکی‌پدیا باشد، به اطلاعات خاص متفاوت در درخواست نیاز دارد. برخی از ناشران ممکن است فقط یک آدرس ایمیل درخواست کنند، در حالی که برخی دیگر اطلاعات دقیق‌تری مانند نام، مکان، شغل یا وابستگی سازمانی شما را درخواست می‌کنند. هنگامی که درخواست خود را تکمیل می‌کنید، فقط از شما خواسته می‌شود اطلاعات مورد نیاز ناشران را انتخاب کنید و هر ناشر فقط اطلاعات مورد نیاز شما را برای دسترسی شما دریافت می‌کند. لطفاً از صفحات <a class=\"twl-links\" href=\"%(all_partners_url)s\">اطلاعات پایگاه</a> ما دیدن کنید تا بدانید هر ناشر برای دسترسی به منابع خود چه اطلاعاتی را لازم دارد."
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Wikimedia Foundation should not be translated. Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:277
-msgid ""
-"Some Wikipedia Library pages are visible without logging in, but you will "
-"need to log in to apply or access proprietary partner resources. We use the "
-"data provided by you via OAuth and Wikimedia API calls to assess your "
-"application for access and to process approved requests."
-msgstr ""
-"بدون ورود به سیستم می‌توانید برخی از صفحات سایت کتابخانهٔ ویکی‌‌پدیا را مرور "
-"کنید، اما برای اعمال یا دسترسی به منابع شریک اختصاصی باید وارد سیستم شوید. "
-"ما از داده‌های ارائه‌شده توسط شما از طریق تماس‌های OAuth و Wikimedia API برای "
-"ارزیابی درخواست شما برای دسترسی و پردازش درخواست‌های تأییدشده استفاده می‌کنیم."
+msgid "Some Wikipedia Library pages are visible without logging in, but you will need to log in to apply or access proprietary partner resources. We use the data provided by you via OAuth and Wikimedia API calls to assess your application for access and to process approved requests."
+msgstr "بدون ورود به سیستم می‌توانید برخی از صفحات سایت کتابخانهٔ ویکی‌‌پدیا را مرور کنید، اما برای اعمال یا دسترسی به منابع شریک اختصاصی باید وارد سیستم شوید. ما از داده‌های ارائه‌شده توسط شما از طریق تماس‌های OAuth و Wikimedia API برای ارزیابی درخواست شما برای دسترسی و پردازش درخواست‌های تأییدشده استفاده می‌کنیم."
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:288
 #, python-format
-msgid ""
-"In order to administer the Wikipedia Library program, we will retain the "
-"application data we collect from you for three years after your most recent "
-"login, unless you delete your account, as described below. You can log in "
-"and go to <a class=\"twl-links\" href=\"%(profile_url)s\">your profile page</"
-"a> in order to see the information associated with your account, and can "
-"download it in JSON format. You may access, update, restrict, or delete this "
-"information at any time, except for the information that is automatically "
-"retrieved from the projects. If you have any questions or concerns about the "
-"handling of your data, please contact <a class=\"twl-links\" href=\"mailto:"
-"wikipedialibrary@wikimedia.org?Subject=Wikipedia%%20Library%%20Card"
-"%%20account%%20deactivation\"> wikipedialibrary@wikimedia.org </a>."
-msgstr ""
-"به منظور اجرای برنامهٔ کتابخانهٔ ویکی‌پدیا، ما داده‌های درخواست را که از شما "
-"جمع‌آوری می‌کنیم به مدت سه سال پس از ورود به سیستم اخیر حفظ خواهیم کرد، مگر "
-"اینکه حساب خود را حذف کنید، همان‌طور که در زیر توضیح داده شده است برای دیدن "
-"اطلاعات مرتبط با حساب خود، می‌توانید وارد شوید و به <a class=\"twl-links\" "
-"href=\"%(profile_url)s\">صفحهٔ نمایه‌تان</a> بروید و می‌توانید آن را در قالب "
-"JSON بارگیری کنید. شما می‌توانید در هر زمان به این اطلاعات دسترسی پیدا کنید، "
-"آن‌ها را به‌روزرسانی کنید، محدود کنید یا حذف کنید، به جز اطلاعاتی که به‌طور "
-"خودکار از پروژه‌ها بازیابی می‌شوند. اگر در مورد کار با داده‌های خود پرسش یا "
-"نگرانی دارید، لطفاً با <a class=\"twl-links\" href=\"mailto:"
-"wikipedialibrary@wikimedia.org?Subject=Wikipedia%%20Library%%20Card"
-"%%20account%%20deactivation\">wikipedialibrary@wikimedia.org</a> تماس بگیرید."
+msgid "In order to administer the Wikipedia Library program, we will retain the application data we collect from you for three years after your most recent login, unless you delete your account, as described below. You can log in and go to <a class=\"twl-links\" href=\"%(profile_url)s\">your profile page</a> in order to see the information associated with your account, and can download it in JSON format. You may access, update, restrict, or delete this information at any time, except for the information that is automatically retrieved from the projects. If you have any questions or concerns about the handling of your data, please contact <a class=\"twl-links\" href=\"mailto:wikipedialibrary@wikimedia.org?Subject=Wikipedia%%20Library%%20Card%%20account%%20deactivation\"> wikipedialibrary@wikimedia.org </a>."
+msgstr "به منظور اجرای برنامهٔ کتابخانهٔ ویکی‌پدیا، ما داده‌های درخواست را که از شما جمع‌آوری می‌کنیم به مدت سه سال پس از ورود به سیستم اخیر حفظ خواهیم کرد، مگر اینکه حساب خود را حذف کنید، همان‌طور که در زیر توضیح داده شده است برای دیدن اطلاعات مرتبط با حساب خود، می‌توانید وارد شوید و به <a class=\"twl-links\" href=\"%(profile_url)s\">صفحهٔ نمایه‌تان</a> بروید و می‌توانید آن را در قالب JSON بارگیری کنید. شما می‌توانید در هر زمان به این اطلاعات دسترسی پیدا کنید، آن‌ها را به‌روزرسانی کنید، محدود کنید یا حذف کنید، به جز اطلاعاتی که به‌طور خودکار از پروژه‌ها بازیابی می‌شوند. اگر در مورد کار با داده‌های خود پرسش یا نگرانی دارید، لطفاً با <a class=\"twl-links\" href=\"mailto:wikipedialibrary@wikimedia.org?Subject=Wikipedia%%20Library%%20Card%%20account%%20deactivation\">wikipedialibrary@wikimedia.org</a> تماس بگیرید."
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:305
 #, fuzzy
-msgid ""
-"If you decide to disable your Wikipedia Library account, you can use the "
-"delete button on your profile to delete certain personal information "
-"associated with your account. We will delete your real name, institutional "
-"affiliation, and country of residence. Please note that the system will "
-"retain a record of your username, the publishers to which you applied or had "
-"access, and the dates of that access. Note that deletion is not reversible. "
-"Deletion of your Wikipedia Library account may also correspond with the "
-"removal of any resource access to which you were eligible or approved. If "
-"you request the deletion of account information and later wish to apply for "
-"a new account, you will need to provide the necessary information again."
-msgstr ""
-"اگر تصمیم دارید حساب کتابخانهٔ ویکی‌پدیای خود را غیرفعال کنید، می‌توانید با "
-"استفاده از دکمهٔ حذف نمایهٔ خود، اطلاعات شخصی مرتبط با حساب خود را حذف کنید. "
-"ما نام واقعی، شغل، وابستگی نهادی و کشور محل اقامت شما را حذف خواهیم کرد. "
-"لطفاً توجه داشته باشید که این سامانۀ سابقهٔ نام کاربری شما، ناشرانی را که به "
-"آن‌ها درخواست کرده‌اید یا به آن‌ها دسترسی داشته‌اید، و تاریخ‌های دسترسی را در خود "
-"حفظ می‌کند. توجه داشته باشید که حذف قابل برگشت نیست. حذف حساب کتابخانهٔ "
-"ویکی‌پدیا ممکن است با حذف هرگونه دسترسی به منابعی که شما مجاز یا تأیید "
-"شده‌اید، مطابقت داشته باشد. اگر درخواست حذف اطلاعات حساب را دارید و بعداً "
-"می‌خواهید برای یک حساب جدید درخواست دهید، باید اطلاعات لازم را دوباره ارائه "
-"دهید."
+msgid "If you decide to disable your Wikipedia Library account, you can use the delete button on your profile to delete certain personal information associated with your account. We will delete your real name, institutional affiliation, and country of residence. Please note that the system will retain a record of your username, the publishers to which you applied or had access, and the dates of that access. Note that deletion is not reversible. Deletion of your Wikipedia Library account may also correspond with the removal of any resource access to which you were eligible or approved. If you request the deletion of account information and later wish to apply for a new account, you will need to provide the necessary information again."
+msgstr "اگر تصمیم دارید حساب کتابخانهٔ ویکی‌پدیای خود را غیرفعال کنید، می‌توانید با استفاده از دکمهٔ حذف نمایهٔ خود، اطلاعات شخصی مرتبط با حساب خود را حذف کنید. ما نام واقعی، شغل، وابستگی نهادی و کشور محل اقامت شما را حذف خواهیم کرد. لطفاً توجه داشته باشید که این سامانۀ سابقهٔ نام کاربری شما، ناشرانی را که به آن‌ها درخواست کرده‌اید یا به آن‌ها دسترسی داشته‌اید، و تاریخ‌های دسترسی را در خود حفظ می‌کند. توجه داشته باشید که حذف قابل برگشت نیست. حذف حساب کتابخانهٔ ویکی‌پدیا ممکن است با حذف هرگونه دسترسی به منابعی که شما مجاز یا تأیید شده‌اید، مطابقت داشته باشد. اگر درخواست حذف اطلاعات حساب را دارید و بعداً می‌خواهید برای یک حساب جدید درخواست دهید، باید اطلاعات لازم را دوباره ارائه دهید."
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). WMF should not be translated. Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:321
-msgid ""
-"The Wikipedia Library is run by WMF Staff, Contractors, and approved "
-"volunteer Coordinators. The data associated with your account will be shared "
-"with the WMF staff, contractors, service providers, and volunteer "
-"coordinators who need to process the information in connection with their "
-"work for the Wikipedia Library, and who are subject to confidentiality "
-"obligations. We will also use your data for internal Wikipedia Library "
-"purposes such as distributing user surveys and account notifications, and in "
-"a depersonalized or aggregated fashion for statistical analysis and "
-"administration. Finally, we will share your information with the publishers "
-"whom you specifically select in order to provide you with access to "
-"resources. Otherwise, your information will not be shared with third "
-"parties, with the exception of the circumstances described below."
-msgstr ""
-"کتابخانهٔ ویکی‌پدیا توسط کارمندان بنیاد ویکی‌مدیا، پیمانکاران و هماهنگ‌کنندگان "
-"داوطلب مورد تأیید اداره می‌شود. داده‌های مرتبط با حساب شما با کارمندان بنیاد "
-"ویکی‌مدیا، پیمانکاران، ارائه‌دهندگان خدمات و هماهنگ‌کننده‌های داوطلب که نیاز به "
-"پردازش اطلاعات در ارتباط با کار خود برای کتابخانهٔ ویکی‌پدیا دارند و مشمول "
-"تعهدات محرمانه هستند، به اشتراک گذاشته می‌شود. ما همچنین از داده‌های شما برای "
-"اهداف داخلی کتابخانهٔ ویکی‌پدیا مانند توزیع نظرسنجی‌های کاربر و آگاه‌سازی‌های "
-"حساب و به صورت شخصی یا جمع‌شده برای تجزیه و تحلیل آماری و مدیریت استفاده "
-"خواهیم کرد. در آخر، ما اطلاعات شما را با ناشرانی که به‌طور خاص انتخاب می‌کنید "
-"به اشتراک می‌گذاریم تا دسترسی شما به منابع را فراهم کنیم. در غیر این صورت، به "
-"استثنای شرایط شرح داده‌شده، اطلاعات شما با اشخاص ثالث به اشتراک گذاشته نمی‌شود."
+msgid "The Wikipedia Library is run by WMF Staff, Contractors, and approved volunteer Coordinators. The data associated with your account will be shared with the WMF staff, contractors, service providers, and volunteer coordinators who need to process the information in connection with their work for the Wikipedia Library, and who are subject to confidentiality obligations. We will also use your data for internal Wikipedia Library purposes such as distributing user surveys and account notifications, and in a depersonalized or aggregated fashion for statistical analysis and administration. Finally, we will share your information with the publishers whom you specifically select in order to provide you with access to resources. Otherwise, your information will not be shared with third parties, with the exception of the circumstances described below."
+msgstr "کتابخانهٔ ویکی‌پدیا توسط کارمندان بنیاد ویکی‌مدیا، پیمانکاران و هماهنگ‌کنندگان داوطلب مورد تأیید اداره می‌شود. داده‌های مرتبط با حساب شما با کارمندان بنیاد ویکی‌مدیا، پیمانکاران، ارائه‌دهندگان خدمات و هماهنگ‌کننده‌های داوطلب که نیاز به پردازش اطلاعات در ارتباط با کار خود برای کتابخانهٔ ویکی‌پدیا دارند و مشمول تعهدات محرمانه هستند، به اشتراک گذاشته می‌شود. ما همچنین از داده‌های شما برای اهداف داخلی کتابخانهٔ ویکی‌پدیا مانند توزیع نظرسنجی‌های کاربر و آگاه‌سازی‌های حساب و به صورت شخصی یا جمع‌شده برای تجزیه و تحلیل آماری و مدیریت استفاده خواهیم کرد. در آخر، ما اطلاعات شما را با ناشرانی که به‌طور خاص انتخاب می‌کنید به اشتراک می‌گذاریم تا دسترسی شما به منابع را فراهم کنیم. در غیر این صورت، به استثنای شرایط شرح داده‌شده، اطلاعات شما با اشخاص ثالث به اشتراک گذاشته نمی‌شود."
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). WMF should not be translated.
 #: TWLight/users/templates/users/terms.html:338
-msgid ""
-"We may disclose any collected information when required by law, when we have "
-"your permission, when needed to protect our rights, privacy, safety, users, "
-"or the general public, and when necessary to enforce these terms, WMF’s "
-"general <a class=\"twl-links\" href=\"https://foundation.wikimedia.org/wiki/"
-"Terms_of_Use\">Terms of Use</a>, or any other WMF policy."
-msgstr ""
-"ممکن است هرگونه اطلاعات جمع‌آوری‌شده را در صورت الزام قانون، در صورت داشتن "
-"اجازهٔ شما، در صورت نیاز برای محافظت از حقوق، حریم خصوصی، ایمنی کاربران یا "
-"عموم مردم، و در صورت لزوم برای اجرای <a class=\"twl-links\" href=\"https://"
-"foundation.wikimedia.org/wiki/Terms_of_Use\">این شرایط</a> یا دیگر سیاست‌های "
-"بنیاد ویکی‌مدیا افشا کنیم."
+msgid "We may disclose any collected information when required by law, when we have your permission, when needed to protect our rights, privacy, safety, users, or the general public, and when necessary to enforce these terms, WMF’s general <a class=\"twl-links\" href=\"https://foundation.wikimedia.org/wiki/Terms_of_Use\">Terms of Use</a>, or any other WMF policy."
+msgstr "ممکن است هرگونه اطلاعات جمع‌آوری‌شده را در صورت الزام قانون، در صورت داشتن اجازهٔ شما، در صورت نیاز برای محافظت از حقوق، حریم خصوصی، ایمنی کاربران یا عموم مردم، و در صورت لزوم برای اجرای <a class=\"twl-links\" href=\"https://foundation.wikimedia.org/wiki/Terms_of_Use\">این شرایط</a> یا دیگر سیاست‌های بنیاد ویکی‌مدیا افشا کنیم."
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:349
-msgid ""
-"We take the security of your personal data seriously, and take reasonable "
-"precautions to ensure your data is protected. These precautions include "
-"access controls to limit who has access to your data and security "
-"technologies to protect data stored on the server. However, we cannot "
-"guarantee the safety of your data as it is transmitted and stored."
-msgstr ""
-"ما امنیت داده‌های شخصی شما را جدی می‌گیریم و اقدامات احتیاطی منطقی را برای "
-"اطمینان از محافظت از داده‌های شما انجام می‌دهیم. این اقدامات احتیاطی شامل "
-"کنترل دسترسی برای محدود کردن دسترسی به داده‌ها و فناوری‌های امنیتی شما برای "
-"محافظت از داده‌های ذخیره‌شده در سرور است. با این حال، ما نمی‌توانیم ایمنی "
-"داده‌های شما را هنگام انتقال و ذخیره تضمین کنیم."
+msgid "We take the security of your personal data seriously, and take reasonable precautions to ensure your data is protected. These precautions include access controls to limit who has access to your data and security technologies to protect data stored on the server. However, we cannot guarantee the safety of your data as it is transmitted and stored."
+msgstr "ما امنیت داده‌های شخصی شما را جدی می‌گیریم و اقدامات احتیاطی منطقی را برای اطمینان از محافظت از داده‌های شما انجام می‌دهیم. این اقدامات احتیاطی شامل کنترل دسترسی برای محدود کردن دسترسی به داده‌ها و فناوری‌های امنیتی شما برای محافظت از داده‌های ذخیره‌شده در سرور است. با این حال، ما نمی‌توانیم ایمنی داده‌های شما را هنگام انتقال و ذخیره تضمین کنیم."
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:360
-msgid ""
-"Please note that these terms do not control the use and handling of your "
-"data by the publishers and service providers whose resources you access or "
-"apply to access. Please read their individual privacy policies for that "
-"information."
-msgstr ""
-"لطفاً توجه داشته باشید که این شرایط کنترل و استفاده از داده‌های شما توسط "
-"ناشران و ارائه‌دهندگان خدمات را که به منابع آن‌ها دسترسی یا درخواست دسترسی "
-"دارید کنترل نمی‌کند. لطفاً برای این اطلاعات سیاست‌های خصوصی حریم خصوصی آن‌ها را "
-"بخوانید."
+msgid "Please note that these terms do not control the use and handling of your data by the publishers and service providers whose resources you access or apply to access. Please read their individual privacy policies for that information."
+msgstr "لطفاً توجه داشته باشید که این شرایط کنترل و استفاده از داده‌های شما توسط ناشران و ارائه‌دهندگان خدمات را که به منابع آن‌ها دسترسی یا درخواست دسترسی دارید کنترل نمی‌کند. لطفاً برای این اطلاعات سیاست‌های خصوصی حریم خصوصی آن‌ها را بخوانید."
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:368
@@ -3846,49 +2852,18 @@ msgstr "وارد شده"
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Wikimedia Foundation should not be translated. Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:373
-msgid ""
-"The Wikimedia Foundation is a nonprofit organization based in San Francisco, "
-"California. The Wikipedia Library program provides access to resources held "
-"by publishers in multiple countries. If you apply for a Wikipedia Library "
-"account (whether you are inside or outside of the United States), you "
-"understand that your personal data will be collected, transferred, stored, "
-"processed, disclosed and otherwise used in the U.S. as described in this "
-"privacy policy. You also understand that your information may be transferred "
-"by us from the U.S. to other countries, which may have different or less "
-"stringent data protection laws than your country, in connection with "
-"providing services to you, including evaluating your application and "
-"securing access to your chosen publishers (locations for each publisher are "
-"outlined on their respective partner information pages)."
-msgstr ""
-"بنیاد ویکی‌مدیا یک سازمان غیرانتفاعی است که در سانفرانسیسکو، کالیفرنیا مستقر "
-"است. برنامهٔ کتابخانهٔ ویکی‌پدیا دسترسی به منابعی را که ناشران در چندین کشور در "
-"اختیار دارند فراهم می‌کند. اگر برای یک حساب کتابخانهٔ ویکی‌پدیا اقدام کنید "
-"(خواه در داخل یا خارج از ایالات متحدهٔ آمریکا باشید)، می‌دانید که اطلاعات شخصی "
-"شما جمع‌آوری، انتقال، ذخیره، پردازش، و افشا می‌شود و در غیر این صورت در ایالات "
-"متحده استفاده می‌شود، همان‌طور که در این سیاست حفظ حریم خصوصی شرح داده شده "
-"است. شما همچنین می‌فهمید که ممکن است اطلاعات شما توسط ایالات متحده به سایر "
-"کشورها، که ممکن است قوانین محافظت از داده‌های متفاوت یا کمتر سختگیرانه‌تری "
-"نسبت به کشور شما داشته باشند، در ارتباط با ارائهٔ خدمات به شما، از جمله "
-"ارزیابی درخواست شما و اطمینان از دسترسی به انتخاب شما، توسط ما منتقل شود."
+msgid "The Wikimedia Foundation is a nonprofit organization based in San Francisco, California. The Wikipedia Library program provides access to resources held by publishers in multiple countries. If you apply for a Wikipedia Library account (whether you are inside or outside of the United States), you understand that your personal data will be collected, transferred, stored, processed, disclosed and otherwise used in the U.S. as described in this privacy policy. You also understand that your information may be transferred by us from the U.S. to other countries, which may have different or less stringent data protection laws than your country, in connection with providing services to you, including evaluating your application and securing access to your chosen publishers (locations for each publisher are outlined on their respective partner information pages)."
+msgstr "بنیاد ویکی‌مدیا یک سازمان غیرانتفاعی است که در سانفرانسیسکو، کالیفرنیا مستقر است. برنامهٔ کتابخانهٔ ویکی‌پدیا دسترسی به منابعی را که ناشران در چندین کشور در اختیار دارند فراهم می‌کند. اگر برای یک حساب کتابخانهٔ ویکی‌پدیا اقدام کنید (خواه در داخل یا خارج از ایالات متحدهٔ آمریکا باشید)، می‌دانید که اطلاعات شخصی شما جمع‌آوری، انتقال، ذخیره، پردازش، و افشا می‌شود و در غیر این صورت در ایالات متحده استفاده می‌شود، همان‌طور که در این سیاست حفظ حریم خصوصی شرح داده شده است. شما همچنین می‌فهمید که ممکن است اطلاعات شما توسط ایالات متحده به سایر کشورها، که ممکن است قوانین محافظت از داده‌های متفاوت یا کمتر سختگیرانه‌تری نسبت به کشور شما داشته باشند، در ارتباط با ارائهٔ خدمات به شما، از جمله ارزیابی درخواست شما و اطمینان از دسترسی به انتخاب شما، توسط ما منتقل شود."
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:392
-msgid ""
-"Please note that in the event of any differences in meaning or "
-"interpretation between the original English version of these terms and a "
-"translation, the original English version takes precedence."
-msgstr ""
-"لطفاً توجه داشته باشید که در صورت تفاوت در معنی و تفسیر بین نسخهٔ اصلی انگلیسی "
-"و این ترجمه، نسخهٔ اصلی انگلیسی اولویت دارد."
+msgid "Please note that in the event of any differences in meaning or interpretation between the original English version of these terms and a translation, the original English version takes precedence."
+msgstr "لطفاً توجه داشته باشید که در صورت تفاوت در معنی و تفسیر بین نسخهٔ اصلی انگلیسی و این ترجمه، نسخهٔ اصلی انگلیسی اولویت دارد."
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Wikimedia Foundation should not be translated.
 #: TWLight/users/templates/users/terms.html:403
-msgid ""
-"See also the <a class=\"twl-links\" href=\"https://wikimediafoundation.org/"
-"wiki/Privacy_policy\">Wikimedia Foundation Privacy Policy</a>."
-msgstr ""
-"همچنین به  <a class=\"twl-links\" href=\"https://wikimediafoundation.org/"
-"wiki/Privacy_policy\">خط مشی رازداری بنیاد ویکی‌مدیا</a>. نگاه کنید."
+msgid "See also the <a class=\"twl-links\" href=\"https://wikimediafoundation.org/wiki/Privacy_policy\">Wikimedia Foundation Privacy Policy</a>."
+msgstr "همچنین به  <a class=\"twl-links\" href=\"https://wikimediafoundation.org/wiki/Privacy_policy\">خط مشی رازداری بنیاد ویکی‌مدیا</a>. نگاه کنید."
 
 #. Translators: This is the second to last line of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:412
@@ -3908,15 +2883,8 @@ msgstr "سیاست محرمانگی بنیاد ویکی‌مدیا"
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:426
-msgid ""
-"By checking this box and clicking “Submit”, you agree that you have read the "
-"above terms and that you will adhere to the terms of use in your application "
-"to and use of the The Wikipedia Library, and the publishers’ services to "
-"which you gain access through The Wikipedia Library program."
-msgstr ""
-"با علامت زدن این کادر و کلیک روی «ارسال»، شما موافقت می‌کنید که اصطلاحات فوق "
-"را خوانده‌اید و به شرایط استفاده در درخواست خود و استفاده از کتابخانهٔ "
-"ویکی‌پدیا و خدمات ناشران که به آنها دست می‌یابید پایبند خواهید بود."
+msgid "By checking this box and clicking “Submit”, you agree that you have read the above terms and that you will adhere to the terms of use in your application to and use of the The Wikipedia Library, and the publishers’ services to which you gain access through The Wikipedia Library program."
+msgstr "با علامت زدن این کادر و کلیک روی «ارسال»، شما موافقت می‌کنید که اصطلاحات فوق را خوانده‌اید و به شرایط استفاده در درخواست خود و استفاده از کتابخانهٔ ویکی‌پدیا و خدمات ناشران که به آنها دست می‌یابید پایبند خواهید بود."
 
 #: TWLight/users/templates/users/user_collection_tile.html:32
 msgid "Remove this collection from favorites"
@@ -3968,39 +2936,19 @@ msgstr "حذف همهٔ داده‌ها"
 
 #. Translators: This message is displayed on the page where users can request the deletion of their data.
 #: TWLight/users/templates/users/user_confirm_delete.html:17
-msgid ""
-"<b>Warning:</b> Performing this action will delete your Wikipedia Library "
-"Card user account and all associated applications. This process is not "
-"reversible. You may lose any partner accounts you were granted, and will not "
-"be able to renew those accounts or apply for new ones."
-msgstr ""
-"<b>هشدار:</b> انجام این عمل حساب کتابخانهٔ ویکی‌پدیا شما و همهٔ درخواست‌های "
-"مرتبط‌تان را حذف می‌کند. این روند برگشت‌پذیر نیست. ممکن است هر حساب شریکی را که "
-"به شما اعطا شده از دست دهید و دیگر نمی‌توانید آن حساب را تمدید کنید یا برای "
-"حساب جدید درخواست کنید"
+msgid "<b>Warning:</b> Performing this action will delete your Wikipedia Library Card user account and all associated applications. This process is not reversible. You may lose any partner accounts you were granted, and will not be able to renew those accounts or apply for new ones."
+msgstr "<b>هشدار:</b> انجام این عمل حساب کتابخانهٔ ویکی‌پدیا شما و همهٔ درخواست‌های مرتبط‌تان را حذف می‌کند. این روند برگشت‌پذیر نیست. ممکن است هر حساب شریکی را که به شما اعطا شده از دست دهید و دیگر نمی‌توانید آن حساب را تمدید کنید یا برای حساب جدید درخواست کنید"
 
 #. Translators: this should show up for people who log in with a username/password and not OAuth, so we don't know what their Wikipedia identity is.
-#.
 #: TWLight/users/templates/users/user_detail.html:12
 #, python-format
-msgid ""
-"Hi, %(username)s! You don't have a Wikipedia editor profile attached to your "
-"account here, so you are probably a site administrator."
-msgstr ""
-"سلام %(username)s! شما در اینجا یک نمایۀ ویرایشگر ویکی‌پدیا متصل به یک "
-"حسابتان را ندارید، بنابراین احتمالاً یک مدیر سایت هستید."
+msgid "Hi, %(username)s! You don't have a Wikipedia editor profile attached to your account here, so you are probably a site administrator."
+msgstr "سلام %(username)s! شما در اینجا یک نمایۀ ویرایشگر ویکی‌پدیا متصل به یک حسابتان را ندارید، بنابراین احتمالاً یک مدیر سایت هستید."
 
 #. Translators: In the unlikely scenario that someone is able to register an account without using OAuth (thus leaving us without some of the information required for applications), users will see this message, encouraging them to re-register.
 #: TWLight/users/templates/users/user_detail.html:20
-msgid ""
-"If you aren't a site administrator, something weird has happened. You won't "
-"be able to apply for access without a Wikipedia editor profile. You should "
-"log out and create a new account by logging in via OAuth, or contact a site "
-"administrator for help."
-msgstr ""
-"اگر مدیر سایت نیستید، اتفاق عجیبی رخ داده است. بدون نمایه ویرایشگر ویکی‌پدیا "
-"نمی‌توانید درخواست دسترسی دهید. باید از سیستم خارج شوید و با ورود به سیستم از "
-"طریق OAuth حساب جدیدی ایجاد کنید یا برای راهنمایی با مدیر سایت تماس بگیرید."
+msgid "If you aren't a site administrator, something weird has happened. You won't be able to apply for access without a Wikipedia editor profile. You should log out and create a new account by logging in via OAuth, or contact a site administrator for help."
+msgstr "اگر مدیر سایت نیستید، اتفاق عجیبی رخ داده است. بدون نمایه ویرایشگر ویکی‌پدیا نمی‌توانید درخواست دسترسی دهید. باید از سیستم خارج شوید و با ورود به سیستم از طریق OAuth حساب جدیدی ایجاد کنید یا برای راهنمایی با مدیر سایت تماس بگیرید."
 
 #. Translators: Labels a sections where coordinators can select their email preferences.
 #: TWLight/users/templates/users/user_email_preferences.html:15
@@ -4010,23 +2958,13 @@ msgstr "فقط هماهنگ‌کنندگان"
 #. Translators: This message is shown on user's own profile page, encouraging them to make sure their information is up to date, so that account coordinators can use the information to judge applications.
 #: TWLight/users/views.py:176
 #, python-brace-format
-msgid ""
-"Please <a class='twl-links' href='{url}'>update your contributions</a> to "
-"Wikipedia to help coordinators evaluate your applications."
-msgstr ""
-"لطفاً <a class='twl-links' href='{url}'>مشارکت‌هایتان را به‌روزرسانی کنید</a> "
-"تا هماهنگ‌کنندگان کتابخانهٔ ویکی‌پدیا بتوانند درخواست‌های شما را ارزیابی کنند."
+msgid "Please <a class='twl-links' href='{url}'>update your contributions</a> to Wikipedia to help coordinators evaluate your applications."
+msgstr "لطفاً <a class='twl-links' href='{url}'>مشارکت‌هایتان را به‌روزرسانی کنید</a> تا هماهنگ‌کنندگان کتابخانهٔ ویکی‌پدیا بتوانند درخواست‌های شما را ارزیابی کنند."
 
 #. Translators: Coordinators are shown this message when they unselect all three types of reminder email options under preferences.
 #: TWLight/users/views.py:288
-msgid ""
-"You have chosen not to receive reminder emails. As a coordinator, you should "
-"receive at least one type of reminder emails, so consider changing your "
-"preferences."
-msgstr ""
-"انتخاب کرده‌اید که ایمیل‌های یادآوری را دریافت نکنید. به‌عنوان یک هماهنگ‌کننده، "
-"باید حداقل یک نوع ایمیل یادآوری دریافت کنید، بنابراین تنظیمات خود را تغییر "
-"دهید."
+msgid "You have chosen not to receive reminder emails. As a coordinator, you should receive at least one type of reminder emails, so consider changing your preferences."
+msgstr "انتخاب کرده‌اید که ایمیل‌های یادآوری را دریافت نکنید. به‌عنوان یک هماهنگ‌کننده، باید حداقل یک نوع ایمیل یادآوری دریافت کنید، بنابراین تنظیمات خود را تغییر دهید."
 
 #. Translators: Coordinators are shown this message when they make changes to their reminder email options under preferences.
 #: TWLight/users/views.py:296
@@ -4049,8 +2987,7 @@ msgstr "اطلاعات‌تان بروزرسانی شد."
 #. Translators: If a user tries to save the 'email change form' without entering one and checking the 'use my Wikipedia email address' checkbox, this message is presented.
 #: TWLight/users/views.py:448
 msgid "Both the values cannot be blank. Either enter a email or check the box."
-msgstr ""
-"هر دو مقدار نمی‌تواند خالی باشد. یا یک ایمیل وارد کنید یا باکس را تیک بزنید."
+msgstr "هر دو مقدار نمی‌تواند خالی باشد. یا یک ایمیل وارد کنید یا باکس را تیک بزنید."
 
 #. Translators: Shown to users when they successfully modify their email. Don't translate {email}.
 #: TWLight/users/views.py:476
@@ -4060,12 +2997,8 @@ msgstr "ایمیل شما به {email} تغییر یافت."
 
 #. Translators: If the user has not filled out their email, they can browse the website but cannot apply for access to resources.
 #: TWLight/users/views.py:487
-msgid ""
-"Your email is blank. You can still explore the site, but you won't be able "
-"to apply for access to partner resources without an email."
-msgstr ""
-"ایمیل شما خالی است. همچنان می‌توانید در سایت بگردید، اما بدون ایمیل نمی‌توانید "
-"برای دسترسی به منابع درخواست دهید."
+msgid "Your email is blank. You can still explore the site, but you won't be able to apply for access to partner resources without an email."
+msgstr "ایمیل شما خالی است. همچنان می‌توانید در سایت بگردید، اما بدون ایمیل نمی‌توانید برای دسترسی به منابع درخواست دهید."
 
 #. Translators: This message is shown once the access to a partner has successfully been returned.
 #: TWLight/users/views.py:801
@@ -4098,31 +3031,3 @@ msgstr "در حال حاضر حساب‌تان قطع دسترسی نشده با
 msgid "10+ edits in the last 30 days"
 msgstr "بیش از ۱۰ ویرایش در ۳۰ روز گذشته"
 
-#: tests/shunit/data/bad_i18n_comment_1.py:3
-#: tests/shunit/data/bad_i18n_newline_1.py:5
-msgid "1"
-msgstr ""
-
-#. Translators: Lorem ipsum dolor sit amet, consectetur adipiscing elit. Mauris vitae ipsum ut purus faucibus pretium. Proin tempus neque et aliquet consectetur. Ut egestas sapien in consectetur sagittis. Mauris neque lacus, dapibus non viverra vitae, interdum ut aenean ipsum.
-#. Translators: Lorem ipsum dolor sit amet, consectetur adipiscing elit. Mauris vitae ipsum ut purus faucibus pretium. Proin tempus neque et aliquet consectetur. Ut egestas sapien in consectetur sagittis. Mauris neque lacus, dapibus non.
-#: tests/shunit/data/bad_i18n_comment_2.py:4
-#: tests/shunit/data/bad_i18n_newline_2.py:5 tests/shunit/data/good_i18n_1.py:2
-#: tests/shunit/data/good_i18n_2.py:2
-msgid "2"
-msgstr ""
-
-#: tests/shunit/data/bad_i18n_newline_3.py:5
-msgid "3"
-msgstr ""
-
-#: tests/shunit/data/bad_i18n_newline_4.py:5
-msgid "4"
-msgstr ""
-
-#: tests/shunit/data/bad_i18n_newline_5.py:5
-msgid "5"
-msgstr ""
-
-#: tests/shunit/data/bad_i18n_newline_6.py:5
-msgid "6"
-msgstr ""

--- a/locale/fi/LC_MESSAGES/django.po
+++ b/locale/fi/LC_MESSAGES/django.po
@@ -17,10 +17,11 @@
 # Author: Yupik
 msgid ""
 msgstr ""
+""
 "Project-Id-Version: Wikipedia Library Card Platform - Website\n"
-"Report-Msgid-Bugs-To: wikipedialibrary@wikimedia.org\n"
+"Report-Msgid-Bugs-To: translatewiki.net\n"
 "POT-Creation-Date: 2024-07-11 20:54+0000\n"
-"PO-Revision-Date: 2024-07-11 12:30:14+0000\n"
+"PO-Revision-Date: 2024-07-15 12:29:15+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
 "Language: fi\n"
@@ -55,12 +56,8 @@ msgstr "Tietoja sinusta"
 #. Translators: This note appears in a section of a form where we ask users to enter info (like country of residence) when applying for resource access.
 #: TWLight/applications/forms.py:179
 #, python-brace-format
-msgid ""
-"<p><small><i>Your personal data will be processed according to our <a "
-"class='twl-links' href='{terms_url}'> privacy policy</a>.</i></small></p>"
-msgstr ""
-"<p><small><i>Henkilötietojasi käsitellään <a class='twl-links' "
-"href='{terms_url}'> tietosuojakäytäntömme</a> mukaisesti.</i></small> </p>"
+msgid "<p><small><i>Your personal data will be processed according to our <a class='twl-links' href='{terms_url}'> privacy policy</a>.</i></small></p>"
+msgstr "<p><small><i>Henkilötietojasi käsitellään <a class='twl-links' href='{terms_url}'> tietosuojakäytäntömme</a> mukaisesti.</i></small> </p>"
 
 #. Translators: This is the title of the application form page, where users enter information required for the application. It lets the user know which partner application they are entering data for. {partner}
 #: TWLight/applications/forms.py:189
@@ -101,12 +98,8 @@ msgstr "Yhteistyökumppanin verkkosivustolla olevan tilisi sähköpostiosoite"
 #. Translators: This labels a choice field where users will have to select the number of months they wish to have their access for as part of the application renewal confirmation.
 #. Translators: When filling out an application, users may be required to enter the length of the account (expiry) they wish to have for proxy partners.
 #: TWLight/applications/forms.py:339 TWLight/applications/helpers.py:100
-msgid ""
-"The number of months you wish to have this access for before renewal is "
-"required"
-msgstr ""
-"Kuinka monta kuukautta haluat käyttää tätä käyttöoikeutta, ennen kuin "
-"uusiminen vaaditaan"
+msgid "The number of months you wish to have this access for before renewal is required"
+msgstr "Kuinka monta kuukautta haluat käyttää tätä käyttöoikeutta, ennen kuin uusiminen vaaditaan"
 
 #. Translators: When filling out an application, users may need to specify their name
 #: TWLight/applications/helpers.py:81
@@ -141,9 +134,7 @@ msgstr "Onko sinulla jotain muuta sanottavaa?"
 #. Translators: When filling out an application, users may be required to check a box to say they agree with the website's Terms of Use document, which is linked
 #: TWLight/applications/helpers.py:95
 msgid "You must agree with the partner's terms of use"
-msgstr ""
-"Sinun täytyy hyväksyä yhteistyökumppanin käyttöehdot saadaksesi "
-"käyttöoikeuden aineistoon"
+msgstr "Sinun täytyy hyväksyä yhteistyökumppanin käyttöehdot saadaksesi käyttöoikeuden aineistoon"
 
 #. Translators: When sending application data to partners, this is the text labelling a user's real name
 #. Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this labels the user's real name.
@@ -196,12 +187,8 @@ msgstr "Sähköposti"
 
 #. Translators: This comment is added to pending applications when our terms of use change.
 #: TWLight/applications/management/commands/notify_applicants_tou_changes.py:54
-msgid ""
-"Our terms of use have changed. Your applications will not be processed until "
-"you log in and agree to our updated terms."
-msgstr ""
-"Käyttöehtomme ovat muuttuneet. Hakemuksiasi ei käsitellä ennen kuin "
-"kirjaudut sisään ja hyväksyt päivitetyt ehdot."
+msgid "Our terms of use have changed. Your applications will not be processed until you log in and agree to our updated terms."
+msgstr "Käyttöehtomme ovat muuttuneet. Hakemuksiasi ei käsitellä ennen kuin kirjaudut sisään ja hyväksyt päivitetyt ehdot."
 
 #. Translators: This is the status of an application that has not yet been reviewed.
 #: TWLight/applications/models.py:54
@@ -267,23 +254,17 @@ msgstr ""
 
 #. Translators: This text goes into account approval emails in the case that we need to send the user's details to a publisher for manual account setup.
 #: TWLight/applications/models.py:331
-msgid ""
-"You can expect to receive access details within a week or two once it has "
-"been processed."
+msgid "You can expect to receive access details within a week or two once it has been processed."
 msgstr ""
 
 #. Translators: This comment is added to open applications when a partner joins the Library Bundle, which does not require applications.
 #: TWLight/applications/signals.py:247
-msgid ""
-"This partner joined the Library Bundle, which does not require applications. "
-"This application will be marked as invalid."
+msgid "This partner joined the Library Bundle, which does not require applications. This application will be marked as invalid."
 msgstr ""
 
 #. Translators: This is shown to users if the application is to a partner for which we have run out of available accounts. The application is therefore on a 'waitlist', and will be reviewed when more accounts are available.
 #: TWLight/applications/templates/applications/application_evaluation.html:29
-msgid ""
-"This application is on the waitlist because this partner does not have any "
-"access grants available at this time."
+msgid "This application is on the waitlist because this partner does not have any access grants available at this time."
 msgstr ""
 
 #. Translators: This message is shown on pages where coordinators can see personal information about applicants.
@@ -291,9 +272,7 @@ msgstr ""
 #: TWLight/applications/templates/applications/application_list_include.html:6
 #: TWLight/applications/templates/applications/send_partner.html:45
 #: TWLight/resources/templates/resources/partner_users.html:18
-msgid ""
-"Coordinators: This page may contain personal information such as real names "
-"and email addresses. Please remember that this information is confidential."
+msgid "Coordinators: This page may contain personal information such as real names and email addresses. Please remember that this information is confidential."
 msgstr ""
 
 #. Translators: This is the title of the application page shown to users who are a coordinator, and are able to accept or reject the application.
@@ -303,9 +282,7 @@ msgstr "Arvioi hakemus"
 
 #. Translators: This text is shown to coordinators on application pages if the applicant has restricted processing of their data.
 #: TWLight/applications/templates/applications/application_evaluation.html:42
-msgid ""
-"This user has requested a restriction on the processing of their data, so "
-"you cannot change the status of their application."
+msgid "This user has requested a restriction on the processing of their data, so you cannot change the status of their application."
 msgstr ""
 
 #. Translators: This is the title of the application page shown to users who are not a coordinator.
@@ -379,9 +356,7 @@ msgstr "Tuntematon"
 
 #. Translators: This is the text displayed to coordinators when an applicant has no country of residence in their profile.
 #: TWLight/applications/templates/applications/application_evaluation.html:123
-msgid ""
-"Please request the applicant add their country of residence to their profile "
-"before proceeding further."
+msgid "Please request the applicant add their country of residence to their profile before proceeding further."
 msgstr "Pyydä hakijaa lisäämään asuinmaansa profiiliinsa ennen jatkamista."
 
 #. Translators: This labels the section of an application showing the total number of accounts available for a partner or their collection.
@@ -392,12 +367,8 @@ msgstr "Tunnuksia saatavilla"
 #. Translators: This labels the section of an application showing whether the user had agreed to the terms of use or not.
 #: TWLight/applications/templates/applications/application_evaluation.html:145
 #, python-format
-msgid ""
-"Has agreed to the site's <a class=\"twl-links\" href=\"%(terms_url)s\">terms "
-"of use</a>?"
-msgstr ""
-"On hyväksynyt sivuston <a class='twl-links' href=\"%(terms_url)s"
-"\">käyttöehdot</a>?"
+msgid "Has agreed to the site's <a class=\"twl-links\" href=\"%(terms_url)s\">terms of use</a>?"
+msgstr "On hyväksynyt sivuston <a class='twl-links' href=\"%(terms_url)s\">käyttöehdot</a>?"
 
 #. Translators: Displayed to coordinators when they've agreed to the terms of use.
 #. Translators: Displayed if the user has agreed to the terms of use.
@@ -432,12 +403,8 @@ msgstr "Ei"
 
 #. Translators: This is the text displayed to coordinators when an applicant has not agreed to the terms of use.
 #: TWLight/applications/templates/applications/application_evaluation.html:159
-msgid ""
-"Please request the applicant agree to the site's terms of use before "
-"approving this application."
-msgstr ""
-"Pyydä hakijaa hyväksymään sivuston käyttöehdot ennen tämän hakemuksen "
-"hyväksymistä."
+msgid "Please request the applicant agree to the site's terms of use before approving this application."
+msgstr "Pyydä hakijaa hyväksymään sivuston käyttöehdot ennen tämän hakemuksen hyväksymistä."
 
 #. Translators: This labels the section of an application containing the user's motivation for wanting access to this resource.
 #: TWLight/applications/templates/applications/application_evaluation.html:176
@@ -457,10 +424,8 @@ msgstr "Onko olemassaolevan pääsyluvan uusintahakemus?"
 #. Translators: This message is shown next to the 'Renewal of existing access grant?' label if the application is a renewal. Don't translate HTML tags or parent_url.
 #: TWLight/applications/templates/applications/application_evaluation.html:195
 #, python-format
-msgid ""
-"Yes (<a class=\"twl-links\" href=\"%(parent_url)s\">previous application</a>)"
-msgstr ""
-"Kyllä (<a class=\"twl-links\" href=\"%(parent_url)s\">edellinen hakemus</a>)"
+msgid "Yes (<a class=\"twl-links\" href=\"%(parent_url)s\">previous application</a>)"
+msgstr "Kyllä (<a class=\"twl-links\" href=\"%(parent_url)s\">edellinen hakemus</a>)"
 
 #. Translators: This labels the section of the application showing the length of access remaining on the user's previous authorization.
 #: TWLight/applications/templates/applications/application_evaluation.html:208
@@ -494,12 +459,8 @@ msgstr "Lisää kommentti"
 
 #. Translators: On an application page, this text tells users that the comments posted on the application are visible to coordinators and the submitting user only.
 #: TWLight/applications/templates/applications/application_evaluation.html:297
-msgid ""
-"Comments are visible to all coordinators and to the editor who submitted "
-"this application."
-msgstr ""
-"Tämä sivu ja sen sisältämät kommentit ovat nähtävinä kaikille Wikipedian "
-"Lähdekirjaston koordinaattoreille"
+msgid "Comments are visible to all coordinators and to the editor who submitted this application."
+msgstr "Tämä sivu ja sen sisältämät kommentit ovat nähtävinä kaikille Wikipedian Lähdekirjaston koordinaattoreille"
 
 #. Translators: This is the title of the section of an application page which lists information about the user who submitted the application.
 #. Translators: On the page where coordinators can view data on applications to a partner they coordinate, this is a table column heading for the username.
@@ -712,12 +673,7 @@ msgstr "Aseta tila"
 
 #: TWLight/applications/templates/applications/apply.html:20
 #, python-format
-msgid ""
-"If your application is successful we may share your email address with "
-"%(partner)s. This is required to set up your access to their resources. By "
-"submitting this form you agree to allow your email address to be shared with "
-"%(partner)s if your application is successful, for the purposes of account "
-"setup."
+msgid "If your application is successful we may share your email address with %(partner)s. This is required to set up your access to their resources. By submitting this form you agree to allow your email address to be shared with %(partner)s if your application is successful, for the purposes of account setup."
 msgstr ""
 
 #. Translators: This message is displayed on the page where users can confirm their renewal. Please do not translate partner.
@@ -746,9 +702,7 @@ msgstr "Kenen aineistoon haluat käyttöoikeuden?"
 
 #. Translators: This text explains that Library Bundle partners are not shown in this list.
 #: TWLight/applications/templates/applications/request_for_application.html:26
-msgid ""
-"Library Bundle partners are not shown as eligibility is determined "
-"automatically."
+msgid "Library Bundle partners are not shown as eligibility is determined automatically."
 msgstr ""
 
 #. Translators: On the page where users can apply for multiple partners, this message shows next to the partner name, taking them to the full application page when clicked.
@@ -763,24 +717,18 @@ msgstr "Yhteistyökumppanin tietoja ei ole lisätty vielä tietokantaan."
 
 #. Translators: the HTML is so that the word 'waitlisted' will look the same as it does in the page above; please translate 'waitlisted' the same way you did elsewhere in this file.
 #: TWLight/applications/templates/applications/request_for_application.html:74
-msgid ""
-"You can apply to <span class=\"badge badge-warning\">Waitlisted</span> "
-"partners, but they don't have access grants available right now. We will "
-"process those applications when access becomes available."
+msgid "You can apply to <span class=\"badge badge-warning\">Waitlisted</span> partners, but they don't have access grants available right now. We will process those applications when access becomes available."
 msgstr ""
 
 #. Translators: On the page where coordinators can see approved applications which have not had their details sent to the partner, this message shows when there are applications ready to be processed.
 #: TWLight/applications/templates/applications/send.html:10
 msgid "Partners with approved, unsent applications"
-msgstr ""
-"Yhteistyökumppanit, joilla on hyväksyttyjä mutta lähettämättömiä hakemuksia."
+msgstr "Yhteistyökumppanit, joilla on hyväksyttyjä mutta lähettämättömiä hakemuksia."
 
 #. Translators: On the page where coordinators can see approved applications which have not had their details sent to the partner, this message shows when no such applications exist or all have already been sent.
 #: TWLight/applications/templates/applications/send.html:23
 msgid "There are no partners with applications ready to send."
-msgstr ""
-"Tällä hetkellä ei ole yhtään valmista hakemusta lähetettäväksi "
-"yhteistyökumppaneille."
+msgstr "Tällä hetkellä ei ole yhtään valmista hakemusta lähetettäväksi yhteistyökumppaneille."
 
 #. Translators: When viewing the list of applications ready to be sent for a particular partner, this is the title of the page, where object will be the name of the partner. Don't translate object.
 #: TWLight/applications/templates/applications/send_partner.html:40
@@ -791,9 +739,7 @@ msgstr "Hakemustiedot kohteelle %(object)s"
 #. Translators: This message is shown when applications exceed the number of accounts available.
 #: TWLight/applications/templates/applications/send_partner.html:54
 #, python-format
-msgid ""
-"Application(s) for %(object)s, if sent, will exceed the total available "
-"accounts for the partner. Please proceed at your own discretion."
+msgid "Application(s) for %(object)s, if sent, will exceed the total available accounts for the partner. Please proceed at your own discretion."
 msgstr ""
 
 #. Translators: When viewing the list of applications ready to be sent for a particular partner, this is instructions for the coordinator to click the 'mark as sent' button after they have sent the information.
@@ -810,12 +756,8 @@ msgstr[1] "Yrityksen edustajat"
 
 #. Translators: When viewing the list of applications ready to be sent for a particular partner, this message shows if there is no information about who the applications should be sent to. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/applications/templates/applications/send_partner.html:89
-msgid ""
-"Whoops, we don't have any listed contacts. Please notify Wikipedia Library "
-"administrators."
-msgstr ""
-"Meillä ei ole yhteyshenkilöitä tähän yritykseen. Ole hyvä ja kerroasiasta "
-"Wikipedian Lähdekirjaston ylläpitäjille."
+msgid "Whoops, we don't have any listed contacts. Please notify Wikipedia Library administrators."
+msgstr "Meillä ei ole yhteyshenkilöitä tähän yritykseen. Ole hyvä ja kerroasiasta Wikipedian Lähdekirjaston ylläpitäjille."
 
 #. Translators: When viewing the list of applications ready to be sent for a particular partner, this is the title of the section containing the information about those applications.
 #: TWLight/applications/templates/applications/send_partner.html:94
@@ -830,9 +772,7 @@ msgstr "Merkitse lähetetyksi"
 
 #. Translators: This text guides coordinators in using the code sending interface for approved applications.
 #: TWLight/applications/templates/applications/send_partner.html:152
-msgid ""
-"Use the dropdown menus to denote which editor will receive each code. Access "
-"codes will be sent to users automatically."
+msgid "Use the dropdown menus to denote which editor will receive each code. Access codes will be sent to users automatically."
 msgstr ""
 
 #. Translators: This labels a drop-down selection where staff can assign an access code to a user.
@@ -848,21 +788,14 @@ msgstr "Tällä hetkellä ei ole lähettämättömiä hyväksyttyjä hakemuksia.
 #. Translators: When a user applies for a set of resources, they receive this message if none are currently available. They are instead placed on a 'waitlist' for later approval.
 #. Translators: When a user renews their resource, they receive this message if none are currently available. They are instead placed on a 'waitlist' for later approval.
 #: TWLight/applications/views.py:140 TWLight/applications/views.py:1282
-msgid ""
-"This partner does not have any access grants available at this time. You may "
-"still apply for access; your application will be reviewed when access grants "
-"become available."
+msgid "This partner does not have any access grants available at this time. You may still apply for access; your application will be reviewed when access grants become available."
 msgstr ""
 
 #. Translators: This message is shown to users once they've successfully submitted their application for review.
 #: TWLight/applications/views.py:163
 #, python-brace-format
-msgid ""
-"Your application has been submitted for review. Head over to <a "
-"href='{applications_url}'>My Applications</a> to view the status."
-msgstr ""
-"Hakemuksesi on lähetetty. Mene sivulle <a href='{applications_url}'>Omat "
-"hakemukset</a> tarkistaaksesi hakemuksesi tilan."
+msgid "Your application has been submitted for review. Head over to <a href='{applications_url}'>My Applications</a> to view the status."
+msgstr "Hakemuksesi on lähetetty. Mene sivulle <a href='{applications_url}'>Omat hakemukset</a> tarkistaaksesi hakemuksesi tilan."
 
 #. Translators: This text is displayed to users when the user has chosen to restrict data and is trying to apply for multiple partners
 #: TWLight/applications/views.py:276
@@ -910,16 +843,12 @@ msgstr "Lähetetyt hakemukset"
 
 #. Translators: After a coordinator has changed the status of an application to APPROVED, if the corresponding partner/collection is waitlisted this message appears.
 #: TWLight/applications/views.py:756
-msgid ""
-"Cannot approve application as partner with proxy authorization method is "
-"waitlisted."
+msgid "Cannot approve application as partner with proxy authorization method is waitlisted."
 msgstr ""
 
 #. Translators: After a coordinator has changed the status of an application to APPROVED, if the corresponding partner/collection has no accounts for distribution, this message appears.
 #: TWLight/applications/views.py:780
-msgid ""
-"Cannot approve application as partner with proxy authorization method is "
-"waitlisted and (or) has zero accounts available for distribution."
+msgid "Cannot approve application as partner with proxy authorization method is waitlisted and (or) has zero accounts available for distribution."
 msgstr ""
 
 #. Translators: This message appears on an "access denied" screen that stops users who attempt to authorize an editor to access a resource during a time period for which they are already authorized.
@@ -930,11 +859,7 @@ msgstr ""
 #. Translators: This message is shown to users when they access an application page of a now Bundle partner (new applications aren't allowed for Bundle partners and the status of old applications cannot be modified)
 #: TWLight/applications/views.py:857
 #, python-brace-format
-msgid ""
-"This application cannot be modified since this partner is now part of our <a "
-"href='{bundle}'>bundle access</a>. If you are eligible, you can access this "
-"resource from <a href='{library}'>your library</a>. <a "
-"href='{contact}'>Contact us</a> if you have any questions."
+msgid "This application cannot be modified since this partner is now part of our <a href='{bundle}'>bundle access</a>. If you are eligible, you can access this resource from <a href='{library}'>your library</a>. <a href='{contact}'>Contact us</a> if you have any questions."
 msgstr ""
 
 #. Translators: this lets a reviewer set the status of a single application.
@@ -944,12 +869,8 @@ msgstr "Aseta hakemuksen tila"
 
 #. Translators: This warning is message is shown to applicants when the number of pending applications is greater than the number of accounts available.
 #: TWLight/applications/views.py:891
-msgid ""
-"There are more pending applications than available accounts. Your "
-"application might get waitlisted."
-msgstr ""
-"Odottavien hakemusten määrä ylittää saatavilla olevien lupien määrän. "
-"Hakemuksesi saattaa joutua odotuslistalle."
+msgid "There are more pending applications than available accounts. Your application might get waitlisted."
+msgstr "Odottavien hakemusten määrä ylittää saatavilla olevien lupien määrän. Hakemuksesi saattaa joutua odotuslistalle."
 
 #. Translators: this message is shown to coordinators who attempt to change an application's Status from INVALID to any other Status.
 #: TWLight/applications/views.py:904
@@ -969,11 +890,7 @@ msgstr "Joukkopäivitys onnistui. Kiitos tämänpäiväisistä arvioinneistasi."
 
 #. Translators: After a coordinator has changed the status of a number of applications to APPROVED, if the corresponding partner(s) is/are waitlisted or has no accounts for distribution, this message appears.
 #: TWLight/applications/views.py:1051
-msgid ""
-"Cannot approve application(s) {} as partner(s) with proxy authorization "
-"method is/are waitlisted and (or) has/have not enough accounts available. If "
-"not enough accounts are available, prioritise the applications and then "
-"approve applications equal to the accounts available."
+msgid "Cannot approve application(s) {} as partner(s) with proxy authorization method is/are waitlisted and (or) has/have not enough accounts available. If not enough accounts are available, prioritise the applications and then approve applications equal to the accounts available."
 msgstr ""
 
 #. Translators: This message is shown to coordinators who attempt to assign the same access code to multiple users.
@@ -988,9 +905,7 @@ msgstr "Kaikki valitut hakemukset on merkitty lähetetyiksi."
 
 #. Translators: When a user tries to renew their resource, they receive this message if the partner is not available.
 #: TWLight/applications/views.py:1272
-msgid ""
-"Cannot renew application at this time as partner is not available. Please "
-"check back later, or contact us for more information."
+msgid "Cannot renew application at this time as partner is not available. Please check back later, or contact us for more information."
 msgstr ""
 
 #. Translators: This message is displayed when an attempt by a user to renew an application has been denied for some reason.
@@ -1001,16 +916,12 @@ msgstr ""
 
 #. Translators: If a user requests the renewal of their account, but it wasn't renewed, this message is shown to them.
 #: TWLight/applications/views.py:1385
-msgid ""
-"This object cannot be renewed. (This probably means that you have already "
-"requested that it be renewed.)"
+msgid "This object cannot be renewed. (This probably means that you have already requested that it be renewed.)"
 msgstr ""
 
 #. Translators: If a user requests the renewal of their account, this message is shown to them.
 #: TWLight/applications/views.py:1395
-msgid ""
-"Your renewal request has been received. A coordinator will review your "
-"request."
+msgid "Your renewal request has been received. A coordinator will review your request."
 msgstr ""
 
 #. Translators: This labels a textfield where users can enter their email ID.
@@ -1020,12 +931,8 @@ msgstr "Sähköpostiosoitteesi"
 
 #. Translators: This is the help text for the email field in the contact us form letting users know the field is updated by value pulled from their respective user profiles.
 #: TWLight/emails/forms.py:21
-msgid ""
-"This field is automatically updated with the email from your <a class='twl-"
-"links' href='{}'>user profile</a>."
-msgstr ""
-"Tämä kenttä täytetään automaattisesti <a class='twl-links' "
-"href='{}'>käyttäjäprofiilistasi</a> otetulla sähköpostiosoitteellasi."
+msgid "This field is automatically updated with the email from your <a class='twl-links' href='{}'>user profile</a>."
+msgstr "Tämä kenttä täytetään automaattisesti <a class='twl-links' href='{}'>käyttäjäprofiilistasi</a> otetulla sähköpostiosoitteellasi."
 
 #. Translators: This labels a textfield where users can enter their email message.
 #: TWLight/emails/forms.py:26
@@ -1048,19 +955,13 @@ msgstr "Lähetä"
 #. Translators: This email is sent to users with their access code. Don't translate Jinja variables in curly braces like user or partner. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/access_code_email-body-html.html:5
 #, python-format
-msgid ""
-"<p>Your approved application to %(partner)s has now been finalised. Your "
-"access code or login details can be found below:</p> <p><b>%(access_code)s</"
-"b></p> <p>%(user_instructions)s</p>"
+msgid "<p>Your approved application to %(partner)s has now been finalised. Your access code or login details can be found below:</p> <p><b>%(access_code)s</b></p> <p>%(user_instructions)s</p>"
 msgstr ""
 
 #. Translators: This email is sent to users with their access code. Don't translate Jinja variables in curly braces like user or partner. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/access_code_email-body-text.html:3
 #, python-format
-msgid ""
-"Your approved application to %(partner)s has now been finalised. Your access "
-"code or login details can be found below: %(access_code)s "
-"%(user_instructions)s"
+msgid "Your approved application to %(partner)s has now been finalised. Your access code or login details can be found below: %(access_code)s %(user_instructions)s"
 msgstr ""
 
 #. Translators: This is the subject line of an email sent to users with their access code.
@@ -1071,23 +972,13 @@ msgstr "Wikipedian Lähdekirjaston pääsykoodi"
 #. Translators: This email is sent to users when their application is approved. Don't translate Jinja variables in curly braces like user or partner; don't translate html tags either. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/approval_notification-body-html.html:5
 #, python-format
-msgid ""
-"<p>Dear %(user)s,</p> <p>Thank you for applying for access to %(partner)s "
-"resources through The Wikipedia Library. We are happy to inform you that "
-"your application has been approved.</p> <p>%(user_instructions)s</p> <p>You "
-"can view the collections you're authorized to access at My Library: "
-"%(link)s</p> <p>Cheers!</p> <p>The Wikipedia Library</p>"
+msgid "<p>Dear %(user)s,</p> <p>Thank you for applying for access to %(partner)s resources through The Wikipedia Library. We are happy to inform you that your application has been approved.</p> <p>%(user_instructions)s</p> <p>You can view the collections you're authorized to access at My Library: %(link)s</p> <p>Cheers!</p> <p>The Wikipedia Library</p>"
 msgstr ""
 
 #. Translators: This email is sent to users when their application is approved. Don't translate Jinja variables in curly braces like user or partner. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/approval_notification-body-text.html:3
 #, python-format
-msgid ""
-"Dear %(user)s, Thank you for applying for access to %(partner)s resources "
-"through The Wikipedia Library. We are happy to inform you that your "
-"application has been approved. %(user_instructions)s You can view the "
-"collections you're authorized to access at My Library: %(link)s Cheers! The "
-"Wikipedia Library"
+msgid "Dear %(user)s, Thank you for applying for access to %(partner)s resources through The Wikipedia Library. We are happy to inform you that your application has been approved. %(user_instructions)s You can view the collections you're authorized to access at My Library: %(link)s Cheers! The Wikipedia Library"
 msgstr ""
 
 #. Translators: This is the subject of an email which is sent to users when their application has been approved. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
@@ -1098,19 +989,13 @@ msgstr "Wikipedian Lähdekirjaston hakemuksesi on hyväksytty"
 #. Translators: This email is sent to coordinators when a comment is left on an application they are processing. Don't translate Jinja variables in curly braces like user or partner. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/comment_notification_coordinator-body-html.html:5
 #, python-format
-msgid ""
-"<p style=\"color: #500050\">%(submit_date)s - %(commenter)s</p> "
-"<blockquote><p>%(comment)s</p></blockquote> <p>Please reply to these at: <a "
-"href=\"%(app_url)s\">%(app_url)s</a></p> <p>Best,</p> <p>The Wikipedia "
-"Library</p>"
+msgid "<p style=\"color: #500050\">%(submit_date)s - %(commenter)s</p> <blockquote><p>%(comment)s</p></blockquote> <p>Please reply to these at: <a href=\"%(app_url)s\">%(app_url)s</a></p> <p>Best,</p> <p>The Wikipedia Library</p>"
 msgstr ""
 
 #. Translators: This email is sent to coordinators when a comment is left on an application they are processing. Don't translate Jinja variables in curly braces like user or partner. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/comment_notification_coordinator-body-text.html:3
 #, python-format
-msgid ""
-"%(submit_date)s - %(commenter)s %(comment)s Please reply to this at: "
-"%(app_url)s Best, The Wikipedia Library"
+msgid "%(submit_date)s - %(commenter)s %(comment)s Please reply to this at: %(app_url)s Best, The Wikipedia Library"
 msgstr ""
 
 #. Translators: This is the subject line of an email sent to coordinators when a comment is left on an application they processed.
@@ -1121,19 +1006,13 @@ msgstr "Uusi kommentti käsittelemässäsi Wikipedian Lähdekirjaston hakemukses
 #. Translators: This email is sent to users when they receive a comment on their application. Don't translate Jinja variables in curly braces like user or partner; don't translate html tags either. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/comment_notification_editors-body-html.html:5
 #, python-format
-msgid ""
-"<p style=\"color: #500050\">%(submit_date)s - %(commenter)s</p> "
-"<blockquote><p>%(comment)s</p></blockquote> <p>Please reply to these at <a "
-"href=\"%(app_url)s\">%(app_url)s</a> so we can evaluate your application.</"
-"p> <p>Best,</p> <p>The Wikipedia Library</p>"
+msgid "<p style=\"color: #500050\">%(submit_date)s - %(commenter)s</p> <blockquote><p>%(comment)s</p></blockquote> <p>Please reply to these at <a href=\"%(app_url)s\">%(app_url)s</a> so we can evaluate your application.</p> <p>Best,</p> <p>The Wikipedia Library</p>"
 msgstr ""
 
 #. Translators: This email is sent to users when they receive a comment on their application. Don't translate Jinja variables in curly braces like user or partner. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/comment_notification_editors-body-text.html:3
 #, python-format
-msgid ""
-"%(submit_date)s - %(commenter)s %(comment)s Please reply to these at: "
-"%(app_url)s so we can evaluate your application. Best, The Wikipedia Library"
+msgid "%(submit_date)s - %(commenter)s %(comment)s Please reply to these at: %(app_url)s so we can evaluate your application. Best, The Wikipedia Library"
 msgstr ""
 
 #. Translators: This is the subject line of an email sent to users who have a comment added to one of their applications. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
@@ -1144,41 +1023,24 @@ msgstr "Wikipedian Lähdekirjaston hakemukseesi on jätetty uusi kommentti"
 #. Translators: This email is sent to users when an application they commented on receives another comment. Don't translate Jinja variables in curly braces like app_url; don't translate html tags either. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/comment_notification_others-body-html.html:5
 #, python-format
-msgid ""
-"<p style=\"color: #500050\">%(submit_date)s - %(commenter)s</p> "
-"<blockquote><p>%(comment)s</p></blockquote> See it at <a href=\"%(app_url)s"
-"\">%(app_url)s</a>. Thanks for helping review Wikipedia Library applications!"
-msgstr ""
-"<p style=\"color: #500050\">%(submit_date)s - %(commenter)s</p> "
-"<blockquote><p>%(comment)s</p></blockquote> Voit lukea kommentin osoitteessa "
-"<a href=\"%(app_url)s\">%(app_url)s</a>. Kiitos avustasi Wikipedian "
-"Lähdekirjaston hakemuksien käsittelyssä!"
+msgid "<p style=\"color: #500050\">%(submit_date)s - %(commenter)s</p> <blockquote><p>%(comment)s</p></blockquote> See it at <a href=\"%(app_url)s\">%(app_url)s</a>. Thanks for helping review Wikipedia Library applications!"
+msgstr "<p style=\"color: #500050\">%(submit_date)s - %(commenter)s</p> <blockquote><p>%(comment)s</p></blockquote> Voit lukea kommentin osoitteessa <a href=\"%(app_url)s\">%(app_url)s</a>. Kiitos avustasi Wikipedian Lähdekirjaston hakemuksien käsittelyssä!"
 
 #. Translators: This email is sent to users when an application they commented on receives another comment. Don't translate Jinja variables in curly braces like app_url. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/comment_notification_others-body-text.html:3
 #, python-format
-msgid ""
-"%(submit_date)s - %(commenter)s %(comment)s See it at: %(app_url)s Thanks "
-"for helping review Wikipedia Library applications!"
-msgstr ""
-"%(submit_date)s - %(commenter)s %(comment)s Voit lukea kommentin "
-"osoitteessa: %(app_url)s Kiitos avustasi Wikipedian Lähdekirjaston "
-"hakemusten käsittelyssä!"
+msgid "%(submit_date)s - %(commenter)s %(comment)s See it at: %(app_url)s Thanks for helping review Wikipedia Library applications!"
+msgstr "%(submit_date)s - %(commenter)s %(comment)s Voit lukea kommentin osoitteessa: %(app_url)s Kiitos avustasi Wikipedian Lähdekirjaston hakemusten käsittelyssä!"
 
 #. Translators: This is the subject line of an email sent to users who have a comment added to an application they also commented on. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/comment_notification_others-subject.html:4
 msgid "New comment on a Wikipedia Library application you commented on"
-msgstr ""
-"Uusi kommentti Wikipedian Lähdekirjaston hakemuksessa, jota olet "
-"kommentoinut."
+msgstr "Uusi kommentti Wikipedian Lähdekirjaston hakemuksessa, jota olet kommentoinut."
 
 #. Translators: This text is part of a scheduled reminder email sent to coordinators who have applications requiring action. Don't translate Jinja variables in curly braces like total_apps, or user.
 #: TWLight/emails/templates/emails/coordinator_reminder_notification-body-html.html:5
 #, python-format
-msgid ""
-"<p>Dear %(user)s,</p> <p>Our records indicate that you are the designated "
-"coordinator for partners that have a total of %(total_apps)s applications.</"
-"p>"
+msgid "<p>Dear %(user)s,</p> <p>Our records indicate that you are the designated coordinator for partners that have a total of %(total_apps)s applications.</p>"
 msgstr ""
 
 #. Translators: Breakdown as in 'cost breakdown'; analysis.
@@ -1217,31 +1079,19 @@ msgstr[1] "%(counter)s hyväksyttyä hakemusta."
 #. Translators: This text is part of a scheduled reminder email sent to coordinators who have applications requiring action. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library). Don't translate Jinja variables in curly braces like link; don't translate email addresses or html tags either.
 #: TWLight/emails/templates/emails/coordinator_reminder_notification-body-html.html:39
 #, python-format
-msgid ""
-"<p>This is a gentle reminder that you may review applications at <a href="
-"\"%(link)s\">%(link)s</a>.</p> <p>You can customise your reminders under "
-"'preferences' in your user profile.</p> <p>If you received this message in "
-"error, drop us a line at wikipedialibrary@wikimedia.org.</p> <p>Thanks for "
-"helping review Wikipedia Library applications!</p>"
+msgid "<p>This is a gentle reminder that you may review applications at <a href=\"%(link)s\">%(link)s</a>.</p> <p>You can customise your reminders under 'preferences' in your user profile.</p> <p>If you received this message in error, drop us a line at wikipedialibrary@wikimedia.org.</p> <p>Thanks for helping review Wikipedia Library applications!</p>"
 msgstr ""
 
 #. Translators: This text is part of a scheduled reminder email sent to coordinators who have applications requiring action. Don't translate Jinja variables in curly braces like total_apps, or user.
 #: TWLight/emails/templates/emails/coordinator_reminder_notification-body-text.html:3
 #, python-format
-msgid ""
-"Dear %(user)s, Our records indicate that you are the designated coordinator "
-"for partners that have a total of %(total_apps)s applications."
+msgid "Dear %(user)s, Our records indicate that you are the designated coordinator for partners that have a total of %(total_apps)s applications."
 msgstr ""
 
 #. Translators: This text is part of a scheduled reminder email sent to coordinators who have applications requiring action. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library). Don't translate Jinja variables in curly braces like link; don't translate the email address either.
 #: TWLight/emails/templates/emails/coordinator_reminder_notification-body-text.html:38
 #, python-format
-msgid ""
-"This is a gentle reminder that you may review applications at: %(link)s. You "
-"can customise your reminders under 'preferences' in your user profile. If "
-"you received this message in error, drop us a line at: "
-"wikipedialibrary@wikimedia.org Thanks for helping review Wikipedia Library "
-"applications!"
+msgid "This is a gentle reminder that you may review applications at: %(link)s. You can customise your reminders under 'preferences' in your user profile. If you received this message in error, drop us a line at: wikipedialibrary@wikimedia.org Thanks for helping review Wikipedia Library applications!"
 msgstr ""
 
 #. Translators: This is the subject line of a scheduled reminder email sent to coordinators who have applications to review. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library). Do not translate items in curly braces.
@@ -1252,22 +1102,13 @@ msgstr "Wikipedian Lähdekirjaston hakemuksia odottaa käsittelyäsi"
 #. Translators: This email is sent to users when their application is rejected. Don't translate Jinja variables in curly braces like user or partner; don't translate html tags either. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/rejection_notification-body-html.html:5
 #, python-format
-msgid ""
-"<p>Dear %(user)s,</p> <p>Thank you for applying for access to %(partner)s "
-"resources through The Wikipedia Library. Unfortunately at this time your "
-"application has not been approved. You can view your application and review "
-"comments at <a href=\"%(app_url)s\">%(app_url)s</a>.</p> <p>Best,</p> <p>The "
-"Wikipedia Library</p>"
+msgid "<p>Dear %(user)s,</p> <p>Thank you for applying for access to %(partner)s resources through The Wikipedia Library. Unfortunately at this time your application has not been approved. You can view your application and review comments at <a href=\"%(app_url)s\">%(app_url)s</a>.</p> <p>Best,</p> <p>The Wikipedia Library</p>"
 msgstr ""
 
 #. Translators: This email is sent to users when their application is rejected. Don't translate Jinja variables in curly braces like user or partner. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/rejection_notification-body-text.html:3
 #, python-format
-msgid ""
-"Dear %(user)s, Thank you for applying for access to %(partner)s resources "
-"through The Wikipedia Library. Unfortunately at this time your application "
-"has not been approved. You can view your application and review comments at: "
-"%(app_url)s Best, The Wikipedia Library"
+msgid "Dear %(user)s, Thank you for applying for access to %(partner)s resources through The Wikipedia Library. Unfortunately at this time your application has not been approved. You can view your application and review comments at: %(app_url)s Best, The Wikipedia Library"
 msgstr ""
 
 #. Translators: This is the subject of an email which is sent to users when their application has been rejected. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
@@ -1278,25 +1119,13 @@ msgstr "Wikipedian Lähdekirjaston hakemuksesi"
 #. Translators: This email is sent to users when they have an account that is soon to expire. Don't translate Jinja variables in curly braces like partner_name or partner_link; don't translate html tags either. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/user_renewal_notice-body-html.html:5
 #, python-format
-msgid ""
-"<p>Dear %(user)s,</p> <p>According to our records, your access to "
-"%(partner_name)s will soon expire and you may lose access. If you want to "
-"continue making use of your free account, you can request renewal of your "
-"account by clicking the 'Renew' or 'Extend' button at %(partner_link)s.</p> "
-"<p>Best,</p> <p>The Wikipedia Library</p> <p>You can disable these emails in "
-"your user page preferences: https://wikipedialibrary.wmflabs.org/users/</p>"
+msgid "<p>Dear %(user)s,</p> <p>According to our records, your access to %(partner_name)s will soon expire and you may lose access. If you want to continue making use of your free account, you can request renewal of your account by clicking the 'Renew' or 'Extend' button at %(partner_link)s.</p> <p>Best,</p> <p>The Wikipedia Library</p> <p>You can disable these emails in your user page preferences: https://wikipedialibrary.wmflabs.org/users/</p>"
 msgstr ""
 
 #. Translators: This email is sent to users when they have an account that is soon to expire. Don't translate Jinja variables in curly braces like partner_name or partner_link; don't translate html tags either. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/user_renewal_notice-body-text.html:3
 #, python-format
-msgid ""
-"Dear %(user)s, According to our records, your access to %(partner_name)s "
-"will soon expire and you may lose access. If you want to continue making use "
-"of your free account, you can request renewal of your account by clicking "
-"the Renew button at %(partner_link)s. Best, The Wikipedia Library You can "
-"disable these emails in your user page preferences: https://wikipedialibrary."
-"wmflabs.org/users/"
+msgid "Dear %(user)s, According to our records, your access to %(partner_name)s will soon expire and you may lose access. If you want to continue making use of your free account, you can request renewal of your account by clicking the Renew button at %(partner_link)s. Best, The Wikipedia Library You can disable these emails in your user page preferences: https://wikipedialibrary.wmflabs.org/users/"
 msgstr ""
 
 #. Translators: This is the subject of an email sent to users when they have an account that is soon to expire. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
@@ -1307,24 +1136,13 @@ msgstr "Pääsysi Wikipedian Lähdekirjastoon saattaa erääntyä pian"
 #. Translators: This email is sent to users when their application is waitlisted because there are no more accounts available. Don't translate Jinja variables in curly braces like user or partner; don't translate html tags either. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/waitlist_notification-body-html.html:5
 #, python-format
-msgid ""
-"<p>Dear %(user)s,</p> <p>Thank you for applying for access to %(partner)s "
-"resources through The Wikipedia Library. There are no accounts currently "
-"available so your application has been waitlisted. Your application will be "
-"evaluated if/when more accounts become available. You can see all available "
-"resources at <a href=\"%(link)s\">%(link)s</a>.</p> <p>Best,</p> <p>The "
-"Wikipedia Library</p>"
+msgid "<p>Dear %(user)s,</p> <p>Thank you for applying for access to %(partner)s resources through The Wikipedia Library. There are no accounts currently available so your application has been waitlisted. Your application will be evaluated if/when more accounts become available. You can see all available resources at <a href=\"%(link)s\">%(link)s</a>.</p> <p>Best,</p> <p>The Wikipedia Library</p>"
 msgstr ""
 
 #. Translators: This email is sent to users when their application is waitlisted because there are no more accounts available. Don't translate Jinja variables in curly braces like user or partner. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/waitlist_notification-body-text.html:3
 #, python-format
-msgid ""
-"Dear %(user)s, Thank you for applying for access to %(partner)s resources "
-"through The Wikipedia Library. There are no accounts currently available so "
-"your application has been waitlisted. Your application will be evaluated if/"
-"when more accounts become available. You can see all available resources at: "
-"%(link)s Best, The Wikipedia Library"
+msgid "Dear %(user)s, Thank you for applying for access to %(partner)s resources through The Wikipedia Library. There are no accounts currently available so your application has been waitlisted. Your application will be evaluated if/when more accounts become available. You can see all available resources at: %(link)s Best, The Wikipedia Library"
 msgstr ""
 
 #. Translators: This is the subject of an email sent to users when their application is waitlisted because there are no more accounts available. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
@@ -1486,20 +1304,14 @@ msgstr "Ei saatavilla"
 #: TWLight/resources/templates/resources/filter_section.html:14
 #: TWLight/templates/about.html:12
 #: TWLight/users/templates/users/filter_section.html:13
-msgid ""
-"The Wikipedia Library allows active editors to access a wide range of "
-"collections of paywalled reliable sources for free!"
-msgstr ""
-"Wikipedian Lähdekirjasto tarjoaa aktiivisille muokkaajille ilmaisen pääsyn "
-"lukuisiin muuten maksumuurin takana oleviin luotettavien lähteiden "
-"kokoelmiin!"
+msgid "The Wikipedia Library allows active editors to access a wide range of collections of paywalled reliable sources for free!"
+msgstr "Wikipedian Lähdekirjasto tarjoaa aktiivisille muokkaajille ilmaisen pääsyn lukuisiin muuten maksumuurin takana oleviin luotettavien lähteiden kokoelmiin!"
 
 #. Translators: On the Browse Partners page (https://wikipedialibrary.wmflabs.org/partners/), this introduces users to The Wikipedia Library.
 #. Translators: On the MyLibrary page (https://wikipedialibrary.wmflabs.org/users/my_library), this introduces users to The Wikipedia Library.
 #: TWLight/resources/templates/resources/filter_section.html:17
 #: TWLight/users/templates/users/filter_section.html:15
-msgid ""
-"Start with the search bar at the top or browse publisher websites directly."
+msgid "Start with the search bar at the top or browse publisher websites directly."
 msgstr ""
 
 #. Translators: On the Browse Partners page (https://wikipedialibrary.wmflabs.org/partners/), this appears below introductory text and links to the 'About' page (https://wikipedialibrary.wmflabs.org/about/)
@@ -1573,62 +1385,39 @@ msgstr "Takaisin yhteistyökumppaneihin"
 #. Translators: If we have no available accounts for a partner, the coordinator can change the application system to a waiting list.
 #: TWLight/resources/templates/resources/partner_detail.html:36
 #: TWLight/resources/templates/resources/partner_detail_apply.html:17
-msgid ""
-"There are no access grants available for this partner at this time. You can "
-"still apply for access; applications will be processed when access is "
-"available."
+msgid "There are no access grants available for this partner at this time. You can still apply for access; applications will be processed when access is available."
 msgstr ""
 
 #. Translators: This text links to the minimum user requirements and terms of use on the partner page.
 #: TWLight/resources/templates/resources/partner_detail.html:48
 #: TWLight/resources/templates/resources/partner_detail_apply.html:29
 #, python-format
-msgid ""
-"Before applying, please review the <strong><a class=\"twl-links\" href="
-"\"%(about)s#req\">minimum requirements</a></strong> for access and our "
-"<strong><a class=\"twl-links\" href=\"%(terms)s\">terms of use</a></strong>."
-msgstr ""
-"Ennen hakemuksen täyttämistä, tutustu <strong><a class=\"twl-links\" href="
-"\"%(terms)s\">käyttöehtoihimme</a></strong> ja <strong><a class=\"twl-links"
-"\" href=\"%(about)s#req\">vähimmäisvaatimuksiin</a></strong> pääsyä varten."
+msgid "Before applying, please review the <strong><a class=\"twl-links\" href=\"%(about)s#req\">minimum requirements</a></strong> for access and our <strong><a class=\"twl-links\" href=\"%(terms)s\">terms of use</a></strong>."
+msgstr "Ennen hakemuksen täyttämistä, tutustu <strong><a class=\"twl-links\" href=\"%(terms)s\">käyttöehtoihimme</a></strong> ja <strong><a class=\"twl-links\" href=\"%(about)s#req\">vähimmäisvaatimuksiin</a></strong> pääsyä varten."
 
 #. Translators: This text refers to the page containing the content a user is authorized to access.
 #: TWLight/resources/templates/resources/partner_detail.html:69
 #, python-format
-msgid ""
-"View the status of your access in <strong><a class=\"twl-links\" href="
-"\"%(library_url)s\">My Library</a></strong> page."
+msgid "View the status of your access in <strong><a class=\"twl-links\" href=\"%(library_url)s\">My Library</a></strong> page."
 msgstr ""
 
 #. Translators: This message is shown when a user has open applications, linking to their respective applications page.
 #: TWLight/resources/templates/resources/partner_detail.html:78
 #, python-format
-msgid ""
-"View the status of your application(s) on your <strong><a class=\"twl-links"
-"\" href=\"%(applications_url)s\">My Applications</a></strong> page."
-msgstr ""
-"Näet hakemustesi tilanteen <strong><a class=\"twl-links\" href="
-"\"%(applications_url)s\">Omat hakemukset</a></strong> -sivulta."
+msgid "View the status of your application(s) on your <strong><a class=\"twl-links\" href=\"%(applications_url)s\">My Applications</a></strong> page."
+msgstr "Näet hakemustesi tilanteen <strong><a class=\"twl-links\" href=\"%(applications_url)s\">Omat hakemukset</a></strong> -sivulta."
 
 #. Translators: This message is shown when a user has authorizations, linking to their respective collections page.
 #: TWLight/resources/templates/resources/partner_detail_apply.html:50
 #, python-format
-msgid ""
-"View the status of your access on your <strong><a href=\"%(library_url)s\" "
-"class=\"twl-links\">My Library</a></strong> page."
-msgstr ""
-"Katso pääsyoikeuksiesi tila <strong><a href=\"%(library_url)s\" class=\"twl-"
-"links\">Oma kirjasto</a></strong>-sivulta."
+msgid "View the status of your access on your <strong><a href=\"%(library_url)s\" class=\"twl-links\">My Library</a></strong> page."
+msgstr "Katso pääsyoikeuksiesi tila <strong><a href=\"%(library_url)s\" class=\"twl-links\">Oma kirjasto</a></strong>-sivulta."
 
 #. Translators: This message is shown when a user has open applications, linking to their respective applications page.
 #: TWLight/resources/templates/resources/partner_detail_apply.html:60
 #, python-format
-msgid ""
-"View the status of your application(s) on your <strong><a href="
-"\"%(applications_url)s\">My Applications</a></strong> page."
-msgstr ""
-"Näet hakemustesi tilanteen <strong><a class=\"twl-links\" href="
-"\"%(applications_url)s\">Omat hakemukset</a></strong> -sivulta."
+msgid "View the status of your application(s) on your <strong><a href=\"%(applications_url)s\">My Applications</a></strong> page."
+msgstr "Näet hakemustesi tilanteen <strong><a class=\"twl-links\" href=\"%(applications_url)s\">Omat hakemukset</a></strong> -sivulta."
 
 #. Translators: One the partner detail page, this text labels the button which coordinators can click to remove a partner from waitlisted status.
 #: TWLight/resources/templates/resources/partner_detail_apply.html:73
@@ -1643,9 +1432,7 @@ msgstr ""
 #: TWLight/resources/templates/resources/partner_detail_apply.html:86
 #, python-format
 msgid "<strong>%(coordinator)s</strong> processes applications to %(partner)s."
-msgstr ""
-"<strong>%(coordinator)s</strong> käsittelee hakemuksia kumppanille "
-"%(partner)s."
+msgstr "<strong>%(coordinator)s</strong> käsittelee hakemuksia kumppanille %(partner)s."
 
 #. Translators: When a coordinator is assigned to a partner, their details are shown on the page. This text labels a link to their Talk page on Wikipedia, and should be translated to the text used for Talk pages in the language you are translating to.
 #: TWLight/resources/templates/resources/partner_detail_apply.html:95
@@ -1659,15 +1446,8 @@ msgstr ""
 
 #. Translators: If no account coordinator is assigned to a partner, the Wikipedia Library team will coordinate signups. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/resources/templates/resources/partner_detail_apply.html:112
-msgid ""
-"The Wikipedia Library team will process this application. Want to help? <a "
-"class=\"twl-links\" href=\"https://en.wikipedia.org/wiki/Wikipedia:"
-"The_Wikipedia_Library/Coordinators/Signup\">Sign up as a coordinator.</a>"
-msgstr ""
-"Wikipedian Lähdekirjasto -tiimi käsittelee tätä hakemusta. Haluatko auttaa? "
-"<a class=\"twl-links\" href=\"https://en.wikipedia.org/wiki/Wikipedia:"
-"The_Wikipedia_Library/Coordinators/Signup\">Ilmoittaudu koordinaattoriksi.</"
-"a>"
+msgid "The Wikipedia Library team will process this application. Want to help? <a class=\"twl-links\" href=\"https://en.wikipedia.org/wiki/Wikipedia:The_Wikipedia_Library/Coordinators/Signup\">Sign up as a coordinator.</a>"
+msgstr "Wikipedian Lähdekirjasto -tiimi käsittelee tätä hakemusta. Haluatko auttaa? <a class=\"twl-links\" href=\"https://en.wikipedia.org/wiki/Wikipedia:The_Wikipedia_Library/Coordinators/Signup\">Ilmoittaudu koordinaattoriksi.</a>"
 
 #. Translators: This text labels a button coordinators can click to view a list of users who have applied for access for a particular partner
 #: TWLight/resources/templates/resources/partner_detail_apply.html:121
@@ -1696,18 +1476,13 @@ msgstr ""
 
 #. Translators: Text shown to authenticated, bundle eligible users when they visit a Bundle partner page.
 #: TWLight/resources/templates/resources/partner_detail_apply.html:138
-msgid ""
-"You are eligible to access Library Bundle partners. Click the button above "
-"to access the collection."
+msgid "You are eligible to access Library Bundle partners. Click the button above to access the collection."
 msgstr ""
 
 #. Translators: Text shown to authenticated, bundle ineligible users when they visit a Bundle partner page.
 #: TWLight/resources/templates/resources/partner_detail_apply.html:152
 #, python-format
-msgid ""
-"You are not eligible to access Library Bundle partners. Visit the <a class="
-"\"twl-links\" href=\"%(homepage)s\">homepage</a> to check the eligibility "
-"criteria."
+msgid "You are not eligible to access Library Bundle partners. Visit the <a class=\"twl-links\" href=\"%(homepage)s\">homepage</a> to check the eligibility criteria."
 msgstr ""
 
 #. Translators: Buttton prompting users to log in.
@@ -1719,10 +1494,7 @@ msgstr "Kirjaudu sisään/luo tunnus"
 #. Translators: Text shown to unauthenticated users when they visit a Bundle partner page.
 #: TWLight/resources/templates/resources/partner_detail_apply.html:168
 #, python-format
-msgid ""
-"This resource is part of our <a class=\"twl-links\" href=\"%(about)s"
-"\">Library Bundle</a>, which you can access if you meet our minimum "
-"eligibility criteria. Log in to find out if you are eligible."
+msgid "This resource is part of our <a class=\"twl-links\" href=\"%(about)s\">Library Bundle</a>, which you can access if you meet our minimum eligibility criteria. Log in to find out if you are eligible."
 msgstr ""
 
 #. Translators: This is the label for a number which shows the total active accounts for one partner. (e.g. https://wikipedialibrary.wmflabs.org/partners/8/).
@@ -1773,26 +1545,19 @@ msgstr ""
 #. Translators: If a partner has specified the excerpt limit both in words and percentage, this message will display the percentage of words and the number of words on the partner page.
 #: TWLight/resources/templates/resources/partner_detail_timeline.html:99
 #, python-format
-msgid ""
-"%(object)s allows a maximum of %(excerpt_limit)s words or "
-"%(excerpt_limit_percentage)s%% of an article be excerpted into a Wikipedia "
-"article."
+msgid "%(object)s allows a maximum of %(excerpt_limit)s words or %(excerpt_limit_percentage)s%% of an article be excerpted into a Wikipedia article."
 msgstr ""
 
 #. Translators: If a partner has specified the excerpt limit in words, this message will display the number of words on the partner page.
 #: TWLight/resources/templates/resources/partner_detail_timeline.html:106
 #, python-format
-msgid ""
-"%(object)s allows a maximum of %(excerpt_limit)s words be excerpted into a "
-"Wikipedia article."
+msgid "%(object)s allows a maximum of %(excerpt_limit)s words be excerpted into a Wikipedia article."
 msgstr ""
 
 #. Translators: If a partner has specified the excerpt limit in percentage, this message will display the percentage of words on the partner page.
 #: TWLight/resources/templates/resources/partner_detail_timeline.html:113
 #, python-format
-msgid ""
-"%(object)s allows a maximum of %(excerpt_limit_percentage)s%% of an article "
-"be excerpted into a Wikipedia article."
+msgid "%(object)s allows a maximum of %(excerpt_limit_percentage)s%% of an article be excerpted into a Wikipedia article."
 msgstr ""
 
 #. Translators: If a partner has other requirements for access, this text shows as the title for that information field. (e.g. https://wikipedialibrary.wmflabs.org/partners/10/).
@@ -1803,12 +1568,8 @@ msgstr "Erityisvaatimukset hakijoille"
 #. Translators: If a user must agree to a Terms of Use document, they see this message, and must enter the name of the resource. Don't translate publisher or url.
 #: TWLight/resources/templates/resources/partner_detail_timeline.html:140
 #, python-format
-msgid ""
-"%(publisher)s requires that you agree with its <a href=\"%(url)s\">terms of "
-"use</a>."
-msgstr ""
-"%(publisher)s vaatii, että hyväksyt heidän <a href=\"%(url)s"
-"\">käyttöehtonsa</a>."
+msgid "%(publisher)s requires that you agree with its <a href=\"%(url)s\">terms of use</a>."
+msgstr "%(publisher)s vaatii, että hyväksyt heidän <a href=\"%(url)s\">käyttöehtonsa</a>."
 
 #. Translators: If a user must provide their real name to apply to a partner, they see this message, and must enter the name of the resource. Don't translate publisher.
 #: TWLight/resources/templates/resources/partner_detail_timeline.html:150
@@ -1831,19 +1592,13 @@ msgstr "%(publisher)s vaatii, että nimeät instituution johon olet sidoksissa."
 #. Translators: If a user must select a specific resource to apply for, they see this message, and must enter the name of the resource. Don't translate publisher.
 #: TWLight/resources/templates/resources/partner_detail_timeline.html:177
 #, python-format
-msgid ""
-"%(publisher)s requires that you specify a particular title that you want to "
-"access."
-msgstr ""
-"%(publisher)s vaatii, että määrittelet nimikkeen, johon haluat "
-"käyttöoikeuden."
+msgid "%(publisher)s requires that you specify a particular title that you want to access."
+msgstr "%(publisher)s vaatii, että määrittelet nimikkeen, johon haluat käyttöoikeuden."
 
 #. Translators: If a user must register on the partner website before applying, they see this message. Don't translate partner.
 #: TWLight/resources/templates/resources/partner_detail_timeline.html:187
 #, python-format
-msgid ""
-"%(publisher)s requires that you sign up for an account before applying for "
-"access."
+msgid "%(publisher)s requires that you sign up for an account before applying for access."
 msgstr "%(publisher)s vaatii, että luot tilin ennen käyttöoikeuden hakemista."
 
 #. Translators: If a partner has their location listed, this message is a label for that location
@@ -1970,9 +1725,7 @@ msgstr ""
 
 #. Translators: If multiple authorizations where returned for a collection, this message is shown to a user
 #: TWLight/resources/views.py:268
-msgid ""
-"Multiple authorizations were returned – something's wrong. Please contact us "
-"and don't forget to mention this message."
+msgid "Multiple authorizations were returned – something's wrong. Please contact us and don't forget to mention this message."
 msgstr ""
 
 #. Translators: This message is shown when user tries to access a NOT_AVAILABLE Partner
@@ -2013,14 +1766,7 @@ msgstr ""
 #. Translators: Shown on the website's 400 page, when a user sends a bad request. Don't translate path or Phabricator.
 #: TWLight/templates/400.html:20
 #, python-format
-msgid ""
-"If you think we should know what to do with that, please email us about this "
-"error at <a class=\"twl-links\" href=\"mailto:wikipedialibrary@wikimedia.org?"
-"Subject=Wikipedia%%20Library%%20%(path)s%%20Permission%%20denied"
-"\">wikipedialibrary@wikimedia.org</a> or report it to us on <a class=\"twl-"
-"links\" href=\"https://phabricator.wikimedia.org/maniphest/task/edit/form/1/?"
-"projectPHIDs=Library-Card-Platform&title=Wikipedia%%20Library%%20%(path)s"
-"%%20Bad%%20Request\">Phabricator</a>"
+msgid "If you think we should know what to do with that, please email us about this error at <a class=\"twl-links\" href=\"mailto:wikipedialibrary@wikimedia.org?Subject=Wikipedia%%20Library%%20%(path)s%%20Permission%%20denied\">wikipedialibrary@wikimedia.org</a> or report it to us on <a class=\"twl-links\" href=\"https://phabricator.wikimedia.org/maniphest/task/edit/form/1/?projectPHIDs=Library-Card-Platform&title=Wikipedia%%20Library%%20%(path)s%%20Bad%%20Request\">Phabricator</a>"
 msgstr ""
 
 #. Translators: Alt text for an image shown on the 400 error page.
@@ -2042,15 +1788,7 @@ msgstr ""
 #. Translators: Shown on the website's 403 page, when a user attempts to navigate to a page they don't have permission to view. Don't translate path or Phabricator.
 #: TWLight/templates/403.html:20
 #, python-format
-msgid ""
-"If you think your account should be able to do that, please email us about "
-"this error at <a class=\"twl-links\" href=\"mailto:"
-"wikipedialibrary@wikimedia.org?Subject=Wikipedia%%20Library%%20%(path)s"
-"%%20Permission%%20denied\">wikipedialibrary@wikimedia.org</a> or report it "
-"to us on <a class=\"twl-links\" href=\"https://phabricator.wikimedia.org/"
-"maniphest/task/edit/form/1/?projectPHIDs=Library-Card-"
-"Platform&title=Wikipedia%%20Library%%20%(path)s%%20Permission%%20denied"
-"\">Phabricator</a>"
+msgid "If you think your account should be able to do that, please email us about this error at <a class=\"twl-links\" href=\"mailto:wikipedialibrary@wikimedia.org?Subject=Wikipedia%%20Library%%20%(path)s%%20Permission%%20denied\">wikipedialibrary@wikimedia.org</a> or report it to us on <a class=\"twl-links\" href=\"https://phabricator.wikimedia.org/maniphest/task/edit/form/1/?projectPHIDs=Library-Card-Platform&title=Wikipedia%%20Library%%20%(path)s%%20Permission%%20denied\">Phabricator</a>"
 msgstr ""
 
 #. Translators: Shown on the website's 404 page, when a user attempts to navigate to a page that doesn't exist.
@@ -2066,14 +1804,7 @@ msgstr ""
 #. Translators: Shown on the website's 404 page, when a user attempts to navigate to a page that doesn't exist. Don't translate path or Phabricator.
 #: TWLight/templates/404.html:19
 #, python-format
-msgid ""
-"If you are certain that something should be here, please email us about this "
-"error at <a class=\"twl-links\" href=\"mailto:wikipedialibrary@wikimedia.org?"
-"Subject=Wikipedia%%20Library%%20%(path)s%%20Not%%20found\"> "
-"wikipedialibrary@wikimedia.org</a> or report it to us on <a class=\"twl-links"
-"\" href=\"https://phabricator.wikimedia.org/maniphest/task/edit/form/1/?"
-"projectPHIDs=Library-Card-Platform&title=Wikipedia%%20Library%%20%(path)s"
-"%%20Not%%20found\">Phabricator</a>"
+msgid "If you are certain that something should be here, please email us about this error at <a class=\"twl-links\" href=\"mailto:wikipedialibrary@wikimedia.org?Subject=Wikipedia%%20Library%%20%(path)s%%20Not%%20found\"> wikipedialibrary@wikimedia.org</a> or report it to us on <a class=\"twl-links\" href=\"https://phabricator.wikimedia.org/maniphest/task/edit/form/1/?projectPHIDs=Library-Card-Platform&title=Wikipedia%%20Library%%20%(path)s%%20Not%%20found\">Phabricator</a>"
 msgstr ""
 
 #. Translators: Alt text for an image shown on the 404 error page.
@@ -2088,44 +1819,18 @@ msgstr "Tietoja Wikipedian Lähdekirjastosta"
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:20
-msgid ""
-"This platform is our central tool for facilitating access to our available "
-"collections. Here you can see which partnerships are available, search their "
-"contents, and apply for and access the ones you’re interested in."
-msgstr ""
-"Tämä alusta on keskitetty välineemme aineistokokoelmien käyttöoikeuksien "
-"hallintaan. Täällä voit tarkastella käytettävissä olevia "
-"yhteistyökumppaneita, millaisia aineistoja kukin tarjoaa ja hakea "
-"käyttöoikeutta niihin joista olet kiinnostunut."
+msgid "This platform is our central tool for facilitating access to our available collections. Here you can see which partnerships are available, search their contents, and apply for and access the ones you’re interested in."
+msgstr "Tämä alusta on keskitetty välineemme aineistokokoelmien käyttöoikeuksien hallintaan. Täällä voit tarkastella käytettävissä olevia yhteistyökumppaneita, millaisia aineistoja kukin tarjoaa ja hakea käyttöoikeutta niihin joista olet kiinnostunut."
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/). Wikimedia Foundation should not be translated.
 #: TWLight/templates/about.html:29
-msgid ""
-"All users receive immediate access to some collections, which can be browsed "
-"by clicking the 'Access collection' buttons or using the search bar at the "
-"top of the page. Other collections require an application before access is "
-"granted, and may be accessed directly or via an individual login or access "
-"code. Volunteer coordinators, who have signed non-disclosure agreements with "
-"the Wikimedia Foundation, review these applications and work with publishers "
-"to get you your free access."
-msgstr ""
-"Kaikilla käyttäjillä on käyttöoikeus tiettyihin kokoelmiin, joita voi selata "
-"painamalla \"Selaa kokoelmaa\"-nappeja tai käyttämällä sivun yläosan "
-"hakupalkkia. Muut kokoelmat vaativat hakemuksen täyttämistä ennen kuin "
-"käyttöoikeus myönnetään, minkä jälkeen niitä voi selata joko suoraan tältä "
-"sivustolta, henkilökohtaisilla tunnuksilla tai pääsykoodilla. Vapaaehtoiset "
-"koordinaattorit, jotka ovat allekirjoittaneet salassapitosopimuksen "
-"Wikimedia Foundationin kanssa, käsittelevät hakemuksia ja työskentelevät "
-"julkaisijan kanssa käyttöoikeutesi saamiseksi."
+msgid "All users receive immediate access to some collections, which can be browsed by clicking the 'Access collection' buttons or using the search bar at the top of the page. Other collections require an application before access is granted, and may be accessed directly or via an individual login or access code. Volunteer coordinators, who have signed non-disclosure agreements with the Wikimedia Foundation, review these applications and work with publishers to get you your free access."
+msgstr "Kaikilla käyttäjillä on käyttöoikeus tiettyihin kokoelmiin, joita voi selata painamalla \"Selaa kokoelmaa\"-nappeja tai käyttämällä sivun yläosan hakupalkkia. Muut kokoelmat vaativat hakemuksen täyttämistä ennen kuin käyttöoikeus myönnetään, minkä jälkeen niitä voi selata joko suoraan tältä sivustolta, henkilökohtaisilla tunnuksilla tai pääsykoodilla. Vapaaehtoiset koordinaattorit, jotka ovat allekirjoittaneet salassapitosopimuksen Wikimedia Foundationin kanssa, käsittelevät hakemuksia ja työskentelevät julkaisijan kanssa käyttöoikeutesi saamiseksi."
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/). Don't translate terms_url.
 #: TWLight/templates/about.html:43
 #, python-format
-msgid ""
-"For more information about how your information is stored and reviewed "
-"please see our <a class=\"twl-links\" href=\"%(terms_url)s\"> terms of use "
-"and privacy policy</a>. Accounts you apply for are also subject to the Terms "
-"of Use provided by each partner’s platform; please review them."
+msgid "For more information about how your information is stored and reviewed please see our <a class=\"twl-links\" href=\"%(terms_url)s\"> terms of use and privacy policy</a>. Accounts you apply for are also subject to the Terms of Use provided by each partner’s platform; please review them."
 msgstr ""
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
@@ -2135,19 +1840,8 @@ msgstr "Kuka voi saada käyttöoikeuden?"
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/). Wikimedia Foundation should not be translated.
 #: TWLight/templates/about.html:55
-msgid ""
-"Any active editor in good standing can receive access. For publishers with "
-"limited numbers of accounts, applications are reviewed based on the editor’s "
-"needs and contributions. If you think you could use access to one of our "
-"partner resources and are an active editor in any project supported by the "
-"Wikimedia Foundation, please apply."
-msgstr ""
-"Kuka tahansa aktiivinen ja hyvämaineinen muokkaaja voi saada käyttöoikeuden. "
-"Niiden julkaisijoiden kohdalla joilla on rajoitettu määrä käyttöoikeuksia, "
-"hakemukset arvioidaan muokkaajan tarpeen ja yleisten Wikimedia-muokkausten "
-"perusteella. Jos koet tarvitsevasi käyttöoikeutta johonkin "
-"yhteistyökumppanimme aineistoon ja olet aktiivinen muokkaaja missä tahansa "
-"Wikimedia-säätiön projektissa, voit hakea käyttöoikeuksia."
+msgid "Any active editor in good standing can receive access. For publishers with limited numbers of accounts, applications are reviewed based on the editor’s needs and contributions. If you think you could use access to one of our partner resources and are an active editor in any project supported by the Wikimedia Foundation, please apply."
+msgstr "Kuka tahansa aktiivinen ja hyvämaineinen muokkaaja voi saada käyttöoikeuden. Niiden julkaisijoiden kohdalla joilla on rajoitettu määrä käyttöoikeuksia, hakemukset arvioidaan muokkaajan tarpeen ja yleisten Wikimedia-muokkausten perusteella. Jos koet tarvitsevasi käyttöoikeutta johonkin yhteistyökumppanimme aineistoon ja olet aktiivinen muokkaaja missä tahansa Wikimedia-säätiön projektissa, voit hakea käyttöoikeuksia."
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:65
@@ -2176,23 +1870,12 @@ msgstr "Et ole tällä hetkellä estetty muokkaamasta Wikimedia-hanketta"
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/)
 #: TWLight/templates/about.html:89
-msgid ""
-"If you are applying for an available collection, please first check that you "
-"don't already have access through another library or institution. If you do, "
-"please consider using that access rather than taking up a seat for this "
-"resource in The Wikipedia Library."
+msgid "If you are applying for an available collection, please first check that you don't already have access through another library or institution. If you do, please consider using that access rather than taking up a seat for this resource in The Wikipedia Library."
 msgstr ""
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/)
 #: TWLight/templates/about.html:99
-msgid ""
-"If your account is blocked on one or more Wikimedia projects, you may still "
-"be granted access to The Wikipedia Library. You will need to contact the "
-"Wikipedia Library team, who will review your blocks. If you have been "
-"blocked for content issues, most notably copyright violations, or have "
-"multiple long-term blocks, we may decline your request. Additionally, if "
-"your block status changes after being approved, you will need to request "
-"another review."
+msgid "If your account is blocked on one or more Wikimedia projects, you may still be granted access to The Wikipedia Library. You will need to contact the Wikipedia Library team, who will review your blocks. If you have been blocked for content issues, most notably copyright violations, or have multiple long-term blocks, we may decline your request. Additionally, if your block status changes after being approved, you will need to request another review."
 msgstr ""
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
@@ -2208,9 +1891,7 @@ msgstr "Hyväksytyt muokkaajat <i>saavat</i> käyttää käyttöoikeuttaan:"
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:118
 msgid "Search, view, retrieve, and display partner content"
-msgstr ""
-"etsiäkseen, näyttääkseen, tallentaakseen ja esittääkseen osia rajoitetusta "
-"sisällöstä"
+msgstr "etsiäkseen, näyttääkseen, tallentaakseen ja esittääkseen osia rajoitetusta sisällöstä"
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:122
@@ -2229,12 +1910,8 @@ msgstr "Hyväksytyt muokkaajat <i>eivät saa</i>:"
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:136
-msgid ""
-"Share their account logins or passwords with others, or sell their access to "
-"other parties"
-msgstr ""
-"Jakaa tunnuksiaan tai salasanojaan muiden kanssa tai myydä "
-"niitäulkopuolisille tahoille"
+msgid "Share their account logins or passwords with others, or sell their access to other parties"
+msgstr "Jakaa tunnuksiaan tai salasanojaan muiden kanssa tai myydä niitäulkopuolisille tahoille"
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:140
@@ -2243,30 +1920,18 @@ msgstr "Massaladata yhteistyökumppanin sisältöjä"
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:144
-msgid ""
-"Systematically make printed or electronic copies of multiple extracts of "
-"restricted content available for any purpose"
-msgstr ""
-"Järjestelmällisesti tehdä tulostettuja ja sähköisiä kopioita lukuisista "
-"rajoitetuista sisällöistä, oli tarkoitus mikä tahansa"
+msgid "Systematically make printed or electronic copies of multiple extracts of restricted content available for any purpose"
+msgstr "Järjestelmällisesti tehdä tulostettuja ja sähköisiä kopioita lukuisista rajoitetuista sisällöistä, oli tarkoitus mikä tahansa"
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/). Stub is a technical term for a short Wikipedia article, use the appropriate Wikipedia term in your language.
 #: TWLight/templates/about.html:148
-msgid ""
-"Datamine metadata without permission, in order, for instance, to use "
-"metadata for auto-created stub articles"
-msgstr ""
-"Louhia metadataa ilman lupaa esimerkiksi automaattisesti luotavia "
-"tynkäartikkeleita varten."
+msgid "Datamine metadata without permission, in order, for instance, to use metadata for auto-created stub articles"
+msgstr "Louhia metadataa ilman lupaa esimerkiksi automaattisesti luotavia tynkäartikkeleita varten."
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:154
-msgid ""
-"Respecting these agreements allows us to continue growing the partnerships "
-"available to the community."
-msgstr ""
-"Sopimusten noudattaminen mahdollistaa uusien yhteistyökumppanien hankkimisen "
-"yhteisöllemme."
+msgid "Respecting these agreements allows us to continue growing the partnerships available to the community."
+msgstr "Sopimusten noudattaminen mahdollistaa uusien yhteistyökumppanien hankkimisen yhteisöllemme."
 
 #. Translators: This is the heading for a section on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:160
@@ -2275,41 +1940,22 @@ msgstr ""
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:164
-msgid ""
-"EZProxy is a proxy server used to authenticate users for many Wikipedia "
-"Library partners. Users sign into EZProxy via the Library Card platform to "
-"verify that they are authorized users, and then the server accesses "
-"requested resources using its own IP address."
+msgid "EZProxy is a proxy server used to authenticate users for many Wikipedia Library partners. Users sign into EZProxy via the Library Card platform to verify that they are authorized users, and then the server accesses requested resources using its own IP address."
 msgstr ""
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:173
-msgid ""
-"You may notice that when accessing resources via EZProxy that URLs are "
-"dynamically rewritten. This is why we recommend logging in via the Library "
-"Card platform rather than going directly to the unproxied partner website. "
-"When in doubt, check the URL for ‘idm.oclc’. If it’s there, then you’re "
-"connected via EZProxy."
+msgid "You may notice that when accessing resources via EZProxy that URLs are dynamically rewritten. This is why we recommend logging in via the Library Card platform rather than going directly to the unproxied partner website. When in doubt, check the URL for ‘idm.oclc’. If it’s there, then you’re connected via EZProxy."
 msgstr ""
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:182
-msgid ""
-"Typically once you’ve logged in your session will remain active in your "
-"browser for up to two hours after you’ve finished searching. Note that use "
-"of EZProxy requires you to enable cookies. If you are having problems you "
-"should also try clearing your cache and restarting your browser."
+msgid "Typically once you’ve logged in your session will remain active in your browser for up to two hours after you’ve finished searching. Note that use of EZProxy requires you to enable cookies. If you are having problems you should also try clearing your cache and restarting your browser."
 msgstr ""
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/)
 #: TWLight/templates/about.html:193
-msgid ""
-"The Library Bundle is a collection of resources for which no application is "
-"required. If you meet the criteria laid out above, you will be authorized "
-"for access automatically upon logging in to the platform. Only some of our "
-"content is currently included in the Library Bundle, however we hope to "
-"expand the collection as more publishers become comfortable with "
-"participating. All Bundle content is accessed via EZProxy."
+msgid "The Library Bundle is a collection of resources for which no application is required. If you meet the criteria laid out above, you will be authorized for access automatically upon logging in to the platform. Only some of our content is currently included in the Library Bundle, however we hope to expand the collection as more publishers become comfortable with participating. All Bundle content is accessed via EZProxy."
 msgstr ""
 
 #. Translators: This is the heading for a section on the About page (https://wikipedialibrary.wmflabs.org/about/).
@@ -2320,18 +1966,8 @@ msgstr ""
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:206
 #, fuzzy
-msgid ""
-"Citation practices vary by project and even by article. Generally, we "
-"support editors citing where they found information, in a form that allows "
-"others to check it for themselves. That often means providing both original "
-"source details as well as a link to the partner database in which the source "
-"was found."
-msgstr ""
-"Viittauskäytännöt vaihtelevat projekteittain ja jopa artikkeleittain. "
-"Yleisesti ottaen suosittelemme muokkaajia viittaamaan lähteeseen, josta he "
-"löysivät tiedon, muodossa joka sallii muiden tarkistaa tiedon itse "
-"haluamallaan tavalla.  Se tarkoittaa alkuperäisen lähteen tietojen "
-"merkitsemistä ja linkittämistä yhteistyökumppanin tietokantaan. "
+msgid "Citation practices vary by project and even by article. Generally, we support editors citing where they found information, in a form that allows others to check it for themselves. That often means providing both original source details as well as a link to the partner database in which the source was found."
+msgstr "Viittauskäytännöt vaihtelevat projekteittain ja jopa artikkeleittain. Yleisesti ottaen suosittelemme muokkaajia viittaamaan lähteeseen, josta he löysivät tiedon, muodossa joka sallii muiden tarkistaa tiedon itse haluamallaan tavalla.  Se tarkoittaa alkuperäisen lähteen tietojen merkitsemistä ja linkittämistä yhteistyökumppanin tietokantaan. "
 
 #. Translators: This is the heading for a section on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #. Translators: This link is at the bottom of every page and can be clicked by users to contact the wikipedia library team.
@@ -2342,9 +1978,7 @@ msgstr "Ota yhteyttä"
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:218
 #, python-format
-msgid ""
-"If you have questions, need help, or want to volunteer to help, please see "
-"our <a class=\"twl-links\" href=\"%(contact_url)s\">contact page</a>."
+msgid "If you have questions, need help, or want to volunteer to help, please see our <a class=\"twl-links\" href=\"%(contact_url)s\">contact page</a>."
 msgstr ""
 
 #. Translators: This is the title of the panel box detailing the contact information for the Wikipedia Library team.
@@ -2384,9 +2018,7 @@ msgstr "Wikipedian Lähdekirjaston Twitter-sivu"
 #. Translators: This is the text that appears at the bottom of the contact us form directing users to the suggestions form.
 #: TWLight/templates/contact.html:48
 #, python-format
-msgid ""
-"(If you would like to suggest a partner, <a class=\"twl-links\" href="
-"\"%(suggest)s\"><strong>go here</strong></a>.)"
+msgid "(If you would like to suggest a partner, <a class=\"twl-links\" href=\"%(suggest)s\"><strong>go here</strong></a>.)"
 msgstr ""
 
 #. Translators: On a special 'link to search' page, this message is shown if JavaScript is disabled.
@@ -2444,12 +2076,8 @@ msgstr "Wikipedian Lähdekirjasto"
 #. Translators: Information about The Wikipedia Library.
 #: TWLight/templates/login_partial.html:53 TWLight/templates/new_base.html:21
 #, fuzzy, python-format
-msgid ""
-"More than 100 of the world's top subscription-only databases, with content "
-"in %(no_of_languages)s languages, free for Wikipedians of all backgrounds"
-msgstr ""
-"Yli 90 suosittua vain tilaajille tarkoitettua tietokantaa maailmalta, "
-"vapaasti kaikille wikipedisteille"
+msgid "More than 100 of the world's top subscription-only databases, with content in %(no_of_languages)s languages, free for Wikipedians of all backgrounds"
+msgstr "Yli 90 suosittua vain tilaajille tarkoitettua tietokantaa maailmalta, vapaasti kaikille wikipedisteille"
 
 #. Translators: Information about The Wikipedia Library.
 #: TWLight/templates/login_partial.html:64
@@ -2457,9 +2085,7 @@ msgid "Meet these criteria for automatic access"
 msgstr "Saat pääsyn automaattisesti täyttämällä nämä ehdot"
 
 #: TWLight/templates/login_partial.html:69
-msgid ""
-"These criteria grant you access to certain collections but not all. Some "
-"collections are accessible on a per application basis only."
+msgid "These criteria grant you access to certain collections but not all. Some collections are accessible on a per application basis only."
 msgstr ""
 
 #: TWLight/templates/login_partial.html:89
@@ -2469,29 +2095,19 @@ msgstr "Kirjaudu sisään Wikipedian kautta"
 #. Translators: Shown if the current user doesn't have a registered email on their account. Don't translate contact_us_url or email_url.
 #: TWLight/templates/message_partial.html:15
 #, python-format
-msgid ""
-"You don't have an email on file. We can't finalize your access to partner "
-"resources, and you won't be able to <a class=\"twl-links\" href="
-"\"%(contact_us_url)s\">contact us</a> without an email. Please <a class="
-"\"twl-links\" href=\"%(email_url)s\">update your email</a>."
+msgid "You don't have an email on file. We can't finalize your access to partner resources, and you won't be able to <a class=\"twl-links\" href=\"%(contact_us_url)s\">contact us</a> without an email. Please <a class=\"twl-links\" href=\"%(email_url)s\">update your email</a>."
 msgstr ""
 
 #. Translators: Shown if the current user has requested the processing of their data should be restricted.
 #: TWLight/templates/message_partial.html:26
 #, python-format
-msgid ""
-"You have requested a restriction on the processing of your data. Most site "
-"functionality will not be available to you until you <a class=\"twl-links\" "
-"href=\"%(restrict_url)s\">lift this restriction</a>."
+msgid "You have requested a restriction on the processing of your data. Most site functionality will not be available to you until you <a class=\"twl-links\" href=\"%(restrict_url)s\">lift this restriction</a>."
 msgstr ""
 
 #. Translators: Shown if the current user has not agreed to the terms of use.
 #: TWLight/templates/message_partial.html:37
 #, python-format
-msgid ""
-"You have not agreed to the <a class=\"twl-links\" href=\"%(terms_url)s"
-"\">terms of use</a> of this site. Your applications will not be processed "
-"and you won't be able to apply or access resources you are approved for."
+msgid "You have not agreed to the <a class=\"twl-links\" href=\"%(terms_url)s\">terms of use</a> of this site. Your applications will not be processed and you won't be able to apply or access resources you are approved for."
 msgstr ""
 
 #. Translators: This link is at the bottom of every page and links to the 'About' page (https://wikipedialibrary.wmflabs.org/about/)
@@ -2538,12 +2154,8 @@ msgstr "Nollaa salasana"
 
 #. Translators: If a user goes to reset their password, this message asks them to enter their email to do so.
 #: TWLight/templates/registration/password_reset_form.html:13
-msgid ""
-"Forgot your password? Enter your email address below, and we'll email "
-"instructions for setting a new one."
-msgstr ""
-"Unohditko salasanasi? Anna sähköpostiosoitteesi, niin lähetämme sinulle "
-"ohjeet uuden salasanan luomiseksi."
+msgid "Forgot your password? Enter your email address below, and we'll email instructions for setting a new one."
+msgstr "Unohditko salasanasi? Anna sähköpostiosoitteesi, niin lähetämme sinulle ohjeet uuden salasanan luomiseksi."
 
 #. Translators: This is the label for a button that users click to update their public information.
 #: TWLight/users/forms.py:36
@@ -2587,19 +2199,12 @@ msgstr "Hyväksyn käyttöehdot"
 
 #. Translators: This text explains how to disagree to the site's terms of use and the restrictions that will come into effect when users disagree to the terms of use.
 #: TWLight/users/forms.py:185
-msgid ""
-"By unchecking this box and clicking “Update” you may explore the site, but "
-"you will not be able to apply for access to materials or evaluate "
-"applications unless you agree with the terms of use."
-msgstr ""
-"Poistamalla rastin tästä ruudusta ja painamalla \"Päivitä\" voit selata "
-"sivua, mutta et voi hakea käyttöoikeutta aineistoon tai arvioida hakemuksia "
-"ennen kuin olet hyväksynyt käyttöehdot."
+msgid "By unchecking this box and clicking “Update” you may explore the site, but you will not be able to apply for access to materials or evaluate applications unless you agree with the terms of use."
+msgstr "Poistamalla rastin tästä ruudusta ja painamalla \"Päivitä\" voit selata sivua, mutta et voi hakea käyttöoikeutta aineistoon tai arvioida hakemuksia ennen kuin olet hyväksynyt käyttöehdot."
 
 #. Translators: Users click this button to set their website email address to the one linked to their Wikipedia account.
 #: TWLight/users/forms.py:211
-msgid ""
-"Use my Wikipedia email address (will be updated the next time you login)."
+msgid "Use my Wikipedia email address (will be updated the next time you login)."
 msgstr ""
 
 #. Translators: This labels a button which users click to change their email.
@@ -2610,17 +2215,8 @@ msgstr "Päivitä sähköposti"
 #. Translators: Shown if the current user tried to 'favorite' a partner they can't access. Do not translate '{partner}'
 #: TWLight/users/models.py:201
 #, python-brace-format
-msgid ""
-"Cannot add partner {partner} to your favorites because you don't have access "
-"to it"
+msgid "Cannot add partner {partner} to your favorites because you don't have access to it"
 msgstr ""
-
-#. Translators: Do not translate.
-#: TWLight/users/models.py:869
-#, fuzzy, python-brace-format
-#| msgid "Username"
-msgid "{wp_username}"
-msgstr "Käyttäjänimi"
 
 #. Translators: This error message is shown when there's a problem with the authenticated login process.
 #: TWLight/users/oauth.py:243
@@ -2640,9 +2236,7 @@ msgstr ""
 
 #. Translators: this message is displayed to users that don't have accounts and clicked on a proxied link.
 #: TWLight/users/oauth.py:388
-msgid ""
-"To view this link you need to be an eligible library user. Please login to "
-"continue."
+msgid "To view this link you need to be an eligible library user. Please login to continue."
 msgstr ""
 
 #. Translators: This warning message is shown to users when the response received from Wikimedia OAuth servers is not a valid one.
@@ -2678,24 +2272,13 @@ msgstr "Katso lisätietoja kohdasta {issue}"
 
 #. Translators: If the user tries to log in, but their account does not meet certain requirements, they cannot login.
 #: TWLight/users/oauth.py:528
-msgid ""
-"Your Wikipedia account does not meet the eligibility criteria in the terms "
-"of use, so your Wikipedia Library Card Platform account cannot be activated."
-msgstr ""
-"Wikipedia-käyttäjätunnuksesi ei täytä kelpoisuusehtoja, jotka on esitetty "
-"käyttöehdoissa, joten Käyttöoikeustoimiston tunnustasi ei voida aktivoida."
+msgid "Your Wikipedia account does not meet the eligibility criteria in the terms of use, so your Wikipedia Library Card Platform account cannot be activated."
+msgstr "Wikipedia-käyttäjätunnuksesi ei täytä kelpoisuusehtoja, jotka on esitetty käyttöehdoissa, joten Käyttöoikeustoimiston tunnustasi ei voida aktivoida."
 
 #. Translators: If the user tries to log in, but their account does not meet certain requirements, they cannot login.
 #: TWLight/users/oauth.py:536
-msgid ""
-"Your Wikipedia account no longer meets the eligibility criteria in the terms "
-"of use, so you cannot be logged in. If you think you should be able to log "
-"in, please email wikipedialibrary@wikimedia.org."
-msgstr ""
-"Wikipedia-tilisi ei enää täytä käyttöehdoissa määriteltyjä kelpoisuusehtoja, "
-"joten et voi kirjautua sisään. Mikäli sinun tulisi mielestäsi pystyä "
-"kirjautumaan sisään, lähetä sähköpostia osoitteeseen "
-"wikipedialibrary@wikimedia.org."
+msgid "Your Wikipedia account no longer meets the eligibility criteria in the terms of use, so you cannot be logged in. If you think you should be able to log in, please email wikipedialibrary@wikimedia.org."
+msgstr "Wikipedia-tilisi ei enää täytä käyttöehdoissa määriteltyjä kelpoisuusehtoja, joten et voi kirjautua sisään. Mikäli sinun tulisi mielestäsi pystyä kirjautumaan sisään, lähetä sähköpostia osoitteeseen wikipedialibrary@wikimedia.org."
 
 #. Translators: this message is displayed to users with brand new accounts.
 #: TWLight/users/oauth.py:549
@@ -2705,10 +2288,7 @@ msgstr "Tervetuloa! Hyväksythän käyttöehdot."
 #. Translators: This message is displayed on the confirmation page where users can return their access to partner collections.
 #: TWLight/users/templates/users/authorization_confirm_return.html:13
 #, python-format
-msgid ""
-"You will no longer be able to access <b>%(partner)s's</b> resources via the "
-"Library Card platform, but can request access again by clicking 'renew', if "
-"you change your mind. Are you sure you want to return your access?"
+msgid "You will no longer be able to access <b>%(partner)s's</b> resources via the Library Card platform, but can request access again by clicking 'renew', if you change your mind. Are you sure you want to return your access?"
 msgstr ""
 
 #. Translators: On the MyLibrary page (https://wikipedialibrary.wmflabs.org/users/my_library), this tab shows all favorite collections a user has.
@@ -2778,13 +2358,8 @@ msgstr "Muokkaajan tiedot"
 
 #. Translators: This is shown on editor profiles, in their profile page or on applications.
 #: TWLight/users/templates/users/editor_detail.html:59
-msgid ""
-"Information with an * was retrieved from Wikipedia directly. Other "
-"information was entered directly by users or site admins, in their preferred "
-"language."
-msgstr ""
-"Tiedot, jotka on merkitty *, on haettu suoraan Wikipediasta. Muut tiedot "
-"ovat käyttäjän tai ylläpitäjien määrittelemiä, valitsemallaan kielellä."
+msgid "Information with an * was retrieved from Wikipedia directly. Other information was entered directly by users or site admins, in their preferred language."
+msgstr "Tiedot, jotka on merkitty *, on haettu suoraan Wikipediasta. Muut tiedot ovat käyttäjän tai ylläpitäjien määrittelemiä, valitsemallaan kielellä."
 
 #. Translators: This distinguishes users who have been flagged as account coordinators. Don't translate username.
 #: TWLight/users/templates/users/editor_detail.html:71
@@ -2794,10 +2369,7 @@ msgstr "Käyttäjällä %(username)s on koordinaattorin oikeudet tällä sivusto
 
 #. Translators: This is shown on editor profiles, under the heading for Wikipedia editor data.
 #: TWLight/users/templates/users/editor_detail_data.html:5
-msgid ""
-"This information is updated automatically from your Wikimedia account each "
-"time you log in, except for the Contributions field, where you can describe "
-"your Wikimedia editing history."
+msgid "This information is updated automatically from your Wikimedia account each time you log in, except for the Contributions field, where you can describe your Wikimedia editing history."
 msgstr ""
 
 #. Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this labels the user's username.
@@ -2827,21 +2399,14 @@ msgstr "Vastaa käyttöehtoja?"
 
 #. Translators: when viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this question has a yes or no answer.
 #: TWLight/users/templates/users/editor_detail_data.html:57
-msgid ""
-"at their last login, did this user meet the criteria set forth in the terms "
-"of use?"
-msgstr ""
-"Täyttikö käyttäjä käyttöehdoissa mainitut kriteerit kirjautuessaan viimeksi?"
+msgid "at their last login, did this user meet the criteria set forth in the terms of use?"
+msgstr "Täyttikö käyttäjä käyttöehdoissa mainitut kriteerit kirjautuessaan viimeksi?"
 
 #. Translators: When viewing a user's profile in an application, this message shows if the software doesn't think that the user is eligible for access. Don't translate username.
 #: TWLight/users/templates/users/editor_detail_data.html:72
 #, python-format
-msgid ""
-"%(username)s may still be eligible for access grants at the coordinators' "
-"discretion."
-msgstr ""
-"%(username)s voi silti olla kelpoinen käyttöoikeuteen koordinaattorien "
-"harkinnan mukaisesti."
+msgid "%(username)s may still be eligible for access grants at the coordinators' discretion."
+msgstr "%(username)s voi silti olla kelpoinen käyttöoikeuteen koordinaattorien harkinnan mukaisesti."
 
 #. Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this is the heading for a Yes/No ToU question.
 #: TWLight/users/templates/users/editor_detail_data.html:83
@@ -2875,10 +2440,7 @@ msgstr ""
 #. Translators: This message is shown on a user's profile if their Wikimedia account is blocked on one or more projects. They may still be granted access to the Library Bundle, but need to contact Wikipedia Library staff to verify.
 #: TWLight/users/templates/users/editor_detail_data.html:137
 #, python-format
-msgid ""
-"It looks like you have an active block on your account. If you meet the "
-"other criteria you may still be permitted access to the library - please <a "
-"class=\"twl-links\" href=\"%(contact_url)s\">contact us</a>."
+msgid "It looks like you have an active block on your account. If you meet the other criteria you may still be permitted access to the library - please <a class=\"twl-links\" href=\"%(contact_url)s\">contact us</a>."
 msgstr ""
 
 #. Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this is the heading for a Yes/No program eligibility question.
@@ -2888,14 +2450,8 @@ msgstr ""
 
 #. Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this question has a Yes or No answer.
 #: TWLight/users/templates/users/editor_detail_data.html:156
-msgid ""
-"At their last login, did this user meet the criteria set forth in the "
-"Library Bundle? Note that satisfying terms of use is a prerequisite to "
-"bundle eligibility."
-msgstr ""
-"Täyttikö tämä käyttäjä Library Bundlessa asetetut ehdot viimeisellä "
-"kirjautumisella? Huomaa, että käyttöehtojen täyttäminen on Bundlen "
-"kelpoisuuden edellytys."
+msgid "At their last login, did this user meet the criteria set forth in the Library Bundle? Note that satisfying terms of use is a prerequisite to bundle eligibility."
+msgstr "Täyttikö tämä käyttäjä Library Bundlessa asetetut ehdot viimeisellä kirjautumisella? Huomaa, että käyttöehtojen täyttäminen on Bundlen kelpoisuuden edellytys."
 
 #. Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this is the heading for a Yes/No program eligibility question.
 #: TWLight/users/templates/users/editor_detail_data.html:177
@@ -2927,8 +2483,7 @@ msgstr "Ei tiedossa (kunnes 30 päivää kulunut ensimmäisestä kirjautumisesta
 #. Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this labels the date the user registered their Meta-wiki account or the date their account was merged by the SUL merge process. Don't remove the *
 #: TWLight/users/templates/users/editor_detail_data.html:232
 msgid "Meta-Wiki registration or SUL merge date *"
-msgstr ""
-"Meta-Wikiin rekisteröitymispäivä tai yhdistetyn tunnuksen yhdistämispäivä *"
+msgstr "Meta-Wikiin rekisteröitymispäivä tai yhdistetyn tunnuksen yhdistämispäivä *"
 
 #. Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this labels the user's Wikipedia User ID. Don't remove the *
 #: TWLight/users/templates/users/editor_detail_data.html:244
@@ -2943,24 +2498,14 @@ msgstr "Henkilökohtaiset tiedot"
 #. Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this text is in the 'Personal data' section. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/users/templates/users/editor_detail_data.html:262
 #, fuzzy
-msgid ""
-"The following information is visible only to you, site administrators, "
-"publishing partners (where required), and volunteer Wikipedia Library "
-"coordinators (who have signed a Non-Disclosure Agreement)."
-msgstr ""
-"Seuraavat tiedot ovat näkyvissä vain sinulle, sivuston ylläpitäjille, ja "
-"(tarvittaessa) yhteistyökumppaneille. Sitä ei näytetä vapaaehtoisille "
-"Wikipedian Lähdekirjaston koordinaattoreille."
+msgid "The following information is visible only to you, site administrators, publishing partners (where required), and volunteer Wikipedia Library coordinators (who have signed a Non-Disclosure Agreement)."
+msgstr "Seuraavat tiedot ovat näkyvissä vain sinulle, sivuston ylläpitäjille, ja (tarvittaessa) yhteistyökumppaneille. Sitä ei näytetä vapaaehtoisille Wikipedian Lähdekirjaston koordinaattoreille."
 
 #. Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this labels a button which users can click to update or remove their personal information. Don't translate update_url.
 #: TWLight/users/templates/users/editor_detail_data.html:272
 #, python-format
-msgid ""
-"You may <a class=\"twl-links\" href=\"%(update_url)s\">update or delete</a> "
-"your data at any time."
-msgstr ""
-"Voit <a class=\"twl-links\" href=\"%(update_url)s\">päivittää tai poistaa</"
-"a> tietojasi milloin tahansa."
+msgid "You may <a class=\"twl-links\" href=\"%(update_url)s\">update or delete</a> your data at any time."
+msgstr "Voit <a class=\"twl-links\" href=\"%(update_url)s\">päivittää tai poistaa</a> tietojasi milloin tahansa."
 
 #. Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this labels the user's email. Don't remove the *.
 #: TWLight/users/templates/users/editor_detail_data.html:283
@@ -2979,26 +2524,18 @@ msgstr "Instituutio"
 
 #. Translators: This message tells users that they are not eligible to access The Wikipedia Library content.
 #: TWLight/users/templates/users/eligibility_modal.html:7
-msgid ""
-"Sorry, your Wikipedia account doesn’t currently qualify to access The "
-"Wikipedia Library."
+msgid "Sorry, your Wikipedia account doesn’t currently qualify to access The Wikipedia Library."
 msgstr ""
 
 #. Translators: This message tells users that they have not agreed to the terms of use, therefore are ineligible to access the content in The Wikipedia Library.
 #: TWLight/users/templates/users/eligibility_modal.html:30
 #, python-format
-msgid ""
-"Agreed with <a href=\"%(terms)s\" class=\"text-danger\"> terms of use </a>"
-msgstr ""
-"On hyväksynyt sivuston <a href=\"%(terms)s\" class=\"text-danger"
-"\">käyttöehdot</a>?"
+msgid "Agreed with <a href=\"%(terms)s\" class=\"text-danger\"> terms of use </a>"
+msgstr "On hyväksynyt sivuston <a href=\"%(terms)s\" class=\"text-danger\">käyttöehdot</a>?"
 
 #: TWLight/users/templates/users/eligibility_modal.html:40
 #, python-format
-msgid ""
-"It looks like you have an active block on your account. If you meet the "
-"other criteria you may still be permitted access to the library - please <a "
-"href=\"%(contact_url)s\">contact us</a>."
+msgid "It looks like you have an active block on your account. If you meet the other criteria you may still be permitted access to the library - please <a href=\"%(contact_url)s\">contact us</a>."
 msgstr ""
 
 #. Translators: Instructions to refresh a user's data.
@@ -3038,14 +2575,8 @@ msgstr "Aseta kieli"
 
 #. Translators: This text on the user page helps users naviage to the TranslateWiki Wikipedia Library Card platform translation page.
 #: TWLight/users/templates/users/language_form.html:31
-msgid ""
-"You can help translate the tool at <a class=\"twl-links\" href=\"https://"
-"translatewiki.net/wiki/Translating:Wikipedia_Library_Card_Platform"
-"\">translatewiki.net</a>."
-msgstr ""
-"Voit auttaa kääntämään työkalua <a class=\"twl-links\" href=\"https://"
-"translatewiki.net/wiki/Translating:Wikipedia_Library_Card_Platform"
-"\">translatewiki.netissä</a>."
+msgid "You can help translate the tool at <a class=\"twl-links\" href=\"https://translatewiki.net/wiki/Translating:Wikipedia_Library_Card_Platform\">translatewiki.net</a>."
+msgstr "Voit auttaa kääntämään työkalua <a class=\"twl-links\" href=\"https://translatewiki.net/wiki/Translating:Wikipedia_Library_Card_Platform\">translatewiki.netissä</a>."
 
 #. Translators: When the user starts a new application and submits the application, the user can view the application and withdraw if need be. This changes the label for the Withdraw button.
 #: TWLight/users/templates/users/my_applications.html:65
@@ -3064,9 +2595,7 @@ msgstr ""
 
 #. Translators: On the page listing applications, this text explains a user they cannot renew their application since they've already requested a renewal or there aren't any renewals available.
 #: TWLight/users/templates/users/my_applications.html:79
-msgid ""
-"Renewals are either not required, not available right now, or you have "
-"already requested a renewal."
+msgid "Renewals are either not required, not available right now, or you have already requested a renewal."
 msgstr ""
 
 #. Translators: This text is the heading of a section in a user's profile where they can change their preferences.
@@ -3130,19 +2659,12 @@ msgstr ""
 
 #. Translators: This message is displayed on the page where users can request we stop processing their data.
 #: TWLight/users/templates/users/restrict_data.html:15
-msgid ""
-"Checking this box and clicking “Restrict” will pause all processing of the "
-"data you have entered into this website. You will not be able to apply for "
-"access to resources, your applications will not be further processed, and "
-"none of your data will be altered, until you return to this page and uncheck "
-"the box. This is not the same as deleting your data."
+msgid "Checking this box and clicking “Restrict” will pause all processing of the data you have entered into this website. You will not be able to apply for access to resources, your applications will not be further processed, and none of your data will be altered, until you return to this page and uncheck the box. This is not the same as deleting your data."
 msgstr ""
 
 #. Translators: This warning message is shown to coordinators who view the data restriction page.
 #: TWLight/users/templates/users/restrict_data.html:26
-msgid ""
-"You are a coordinator on this site. If you restrict the processing of your "
-"data, your coordinator flag will be removed."
+msgid "You are a coordinator on this site. If you restrict the processing of your data, your coordinator flag will be removed."
 msgstr ""
 
 #. Translators: use the date *when you are translating*, in a language-appropriate format.
@@ -3158,47 +2680,18 @@ msgstr "Wikimedia Foundationin tietosuojakäytäntö"
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:41
 msgid "Wikipedia Library Card Terms of Use and Privacy Statement"
-msgstr ""
-"Tervetuloa Wikipedian Lähdekirjaston käyttöoikeustoimiston käyttöehtoihin ja "
-"yksityisyydensuojakäytäntöön!"
+msgstr "Tervetuloa Wikipedian Lähdekirjaston käyttöoikeustoimiston käyttöehtoihin ja yksityisyydensuojakäytäntöön!"
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:51
-msgid ""
-"<a class=\"twl-links\" href=\"https://meta.wikimedia.org/wiki/"
-"The_Wikipedia_Library\"> The Wikipedia Library </a> has partnered with "
-"publishers around the world to allow users to access otherwise paywalled "
-"resources. This website allows Wikipedia editors to search and access these "
-"resources."
-msgstr ""
-"<a class=\"twl-links\" href=\"https://meta.wikimedia.org/wiki/"
-"The_Wikipedia_Library/fi\">Wikipedian Lähdekirjasto</a> on avoin "
-"tutkimuskeskus, jonka kautta aktiivisetWikipedia muokkaajat voivat saada "
-"käyttöoikeuksia elintärkeisiin luotettaviin lähteisiin, joita he käyttävät "
-"tietosanakirjan kehittämiseen. Teemme yhteistyötä julkaisijoiden kanssa "
-"ympäri maailman tarjotaksemme muokkaajillemme vapaan pääsyn "
-"maksumuurillisiin sisältöihin."
+msgid "<a class=\"twl-links\" href=\"https://meta.wikimedia.org/wiki/The_Wikipedia_Library\"> The Wikipedia Library </a> has partnered with publishers around the world to allow users to access otherwise paywalled resources. This website allows Wikipedia editors to search and access these resources."
+msgstr "<a class=\"twl-links\" href=\"https://meta.wikimedia.org/wiki/The_Wikipedia_Library/fi\">Wikipedian Lähdekirjasto</a> on avoin tutkimuskeskus, jonka kautta aktiivisetWikipedia muokkaajat voivat saada käyttöoikeuksia elintärkeisiin luotettaviin lähteisiin, joita he käyttävät tietosanakirjan kehittämiseen. Teemme yhteistyötä julkaisijoiden kanssa ympäri maailman tarjotaksemme muokkaajillemme vapaan pääsyn maksumuurillisiin sisältöihin."
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Wikimedia Foundation should not be translated. WMF should not be translated. Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:63
 #, fuzzy
-msgid ""
-"This program is administered by the Wikimedia Foundation (WMF). These terms "
-"of use and privacy notice pertain to your application for access to "
-"resources through the Wikipedia Library, your use of this website, and your "
-"access to and use of those resources. They also describe our handling of the "
-"information you provide to us in order to create and administer your "
-"Wikipedia Library account. If we make material changes to the terms, we will "
-"notify users."
-msgstr ""
-"Nämä ehdot koskevat hakemustasi käyttöoikeuden saamiseksi Wikipedian "
-"Lähdekirjaston resursseihin, ja niiden käyttöä. Ehdot myös kuvaavat kuinka "
-"käsittelemme antamiasi tietoja, joita tarvitaan Wikipedian Lähdekirjaston "
-"tunnuksen luomiseksi. Wikipedian Lähdekirjasto on kehittyvä järjestelmä, ja "
-"ajan kuluessa saatamme päivittää näitä ehtoja teknologisten muutosten "
-"vuoksi. Suosittelemme, että tarkistat ehdot aika ajoin. Jos teemme "
-"merkittäviä muutoksia ehtoihin, lähetämme ilmoituksen sähköpostitse "
-"Wikipedian Lähdekirjaston käyttäjille."
+msgid "This program is administered by the Wikimedia Foundation (WMF). These terms of use and privacy notice pertain to your application for access to resources through the Wikipedia Library, your use of this website, and your access to and use of those resources. They also describe our handling of the information you provide to us in order to create and administer your Wikipedia Library account. If we make material changes to the terms, we will notify users."
+msgstr "Nämä ehdot koskevat hakemustasi käyttöoikeuden saamiseksi Wikipedian Lähdekirjaston resursseihin, ja niiden käyttöä. Ehdot myös kuvaavat kuinka käsittelemme antamiasi tietoja, joita tarvitaan Wikipedian Lähdekirjaston tunnuksen luomiseksi. Wikipedian Lähdekirjasto on kehittyvä järjestelmä, ja ajan kuluessa saatamme päivittää näitä ehtoja teknologisten muutosten vuoksi. Suosittelemme, että tarkistat ehdot aika ajoin. Jos teemme merkittäviä muutoksia ehtoihin, lähetämme ilmoituksen sähköpostitse Wikipedian Lähdekirjaston käyttäjille."
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:74
@@ -3208,53 +2701,18 @@ msgstr "Vaatimukset Wikipedian Lähdekirjaston tunnukselle"
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:78
 #, fuzzy
-msgid ""
-"Access to resources via The Wikipedia Library is reserved for community "
-"members who have demonstrated their commitment to the Wikimedia projects, "
-"and who will use their access to these resources to improve project content. "
-"To that end, in order to be eligible for The Wikipedia Library, we require "
-"that you be registered for a user account on the projects, with at least 500 "
-"edits, six (6) months of activity, and 10+ edits in the last month. We ask "
-"that you do not request access to any publishers with a limited number of "
-"available accounts whose resources you can already access for free through "
-"your local library or university, or another institution or organization, in "
-"order to provide that opportunity to others."
-msgstr ""
-"Wikipedian Lähdekirjaston tunnukset on varattu yhteisön jäsenille, jotka "
-"ovat osoittaneet sitoutumisensa Wikimedia-projekteihin ja jotka käyttävät "
-"käyttöoikeuttaan aineistoihin projektien sisältöjen parantamiseen. Ollaksesi "
-"oikeutettu Wikipedian Lähdekirjaston ohjelmaan, edellyttämme että olet "
-"rekisteröinyt käyttäjätunnuksen Wikimedian projekteihin. Yleensä etusijalle "
-"laitetaan käyttäjät, joilla on vähintään 500 muokkausta ja kuusi (6) "
-"kuukautta muokkaushistoriaa, mutta nämä eivät ole ehdottomia vaatimuksia. "
-"Sinulla täytyy olla asetuksissasi Toiminnot:Lähetä sähköpostia käytössä "
-"ainakin yhdessä Wikipedian kieliversiossa ja nimettynä oma \"koti\" wiki, "
-"kun luot tunnuksen. Pyydämme, että et hakisi käyttöoikeutta aineistoon, "
-"johon sinulla on jo käyttöoikeus jotain toista kautta, jotta käyttöoikeus "
-"jäisi jonkun sitä enemmän tarvitsevan saataville."
+msgid "Access to resources via The Wikipedia Library is reserved for community members who have demonstrated their commitment to the Wikimedia projects, and who will use their access to these resources to improve project content. To that end, in order to be eligible for The Wikipedia Library, we require that you be registered for a user account on the projects, with at least 500 edits, six (6) months of activity, and 10+ edits in the last month. We ask that you do not request access to any publishers with a limited number of available accounts whose resources you can already access for free through your local library or university, or another institution or organization, in order to provide that opportunity to others."
+msgstr "Wikipedian Lähdekirjaston tunnukset on varattu yhteisön jäsenille, jotka ovat osoittaneet sitoutumisensa Wikimedia-projekteihin ja jotka käyttävät käyttöoikeuttaan aineistoihin projektien sisältöjen parantamiseen. Ollaksesi oikeutettu Wikipedian Lähdekirjaston ohjelmaan, edellyttämme että olet rekisteröinyt käyttäjätunnuksen Wikimedian projekteihin. Yleensä etusijalle laitetaan käyttäjät, joilla on vähintään 500 muokkausta ja kuusi (6) kuukautta muokkaushistoriaa, mutta nämä eivät ole ehdottomia vaatimuksia. Sinulla täytyy olla asetuksissasi Toiminnot:Lähetä sähköpostia käytössä ainakin yhdessä Wikipedian kieliversiossa ja nimettynä oma \"koti\" wiki, kun luot tunnuksen. Pyydämme, että et hakisi käyttöoikeutta aineistoon, johon sinulla on jo käyttöoikeus jotain toista kautta, jotta käyttöoikeus jäisi jonkun sitä enemmän tarvitsevan saataville."
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:94
 #, fuzzy
-msgid ""
-"Additionally, if you are currently blocked or banned from a Wikimedia "
-"project, applications to resources may be rejected or restricted. If you "
-"obtain a Wikipedia Library account, but a block or ban is subsequently "
-"instituted against you on one of the projects, you may lose access to your "
-"Wikipedia Library account."
-msgstr ""
-"Lisäksi, jos olet tällä hetkellä estettynä Wikimedia-projektissa , hakemus "
-"voidaan hylätä. Tunnuksesi voidaan myös poistaa käytöstä, mikäli saat eston "
-"jossain Wikimedia-projektissa."
+msgid "Additionally, if you are currently blocked or banned from a Wikimedia project, applications to resources may be rejected or restricted. If you obtain a Wikipedia Library account, but a block or ban is subsequently instituted against you on one of the projects, you may lose access to your Wikipedia Library account."
+msgstr "Lisäksi, jos olet tällä hetkellä estettynä Wikimedia-projektissa , hakemus voidaan hylätä. Tunnuksesi voidaan myös poistaa käytöstä, mikäli saat eston jossain Wikimedia-projektissa."
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:104
-msgid ""
-"Your eligibility to access The Wikipedia Library is assessed at each login. "
-"While more than half of the library's content is provided via this automated "
-"eligibility check, access to other publisher's content may be time limited, "
-"typically lapsing after one year, after which you will usually need to apply "
-"for renewal."
+msgid "Your eligibility to access The Wikipedia Library is assessed at each login. While more than half of the library's content is provided via this automated eligibility check, access to other publisher's content may be time limited, typically lapsing after one year, after which you will usually need to apply for renewal."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
@@ -3266,69 +2724,29 @@ msgstr "Wikipedian Lähdekirjaston käyttöoikeustoimiston tunnuksen hakeminen"
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:118
 #, fuzzy
-msgid ""
-"In order to apply for access to a partner resource, you must provide us with "
-"certain information, which we will use to evaluate your application. If your "
-"application is approved, we may transfer the information you have given us "
-"to the publishers whose resources you wish to access. They will either "
-"contact you with the account information directly or we will send access "
-"information to you ourselves."
-msgstr ""
-"Jotta Wikipedian Lähdekirjaston käyttöoikeustoimiston tunnusta voi hakea, "
-"sinun täytyy antaa meille tiettyjä tietoja, joita käytämme hakemuksen "
-"arvioimiseen. Jos hakemus hyväksytään, voimme siirtää antamasi tiedot "
-"suoraan julkaisijalle, jonka aineistoon olet käyttöoikeutta pyytänyt. Sen "
-"jälkeen julkaisija luo sinulle ilmaisen tunnuksen palveluunsa. Useimmissa "
-"tapauksissa julkaisijat ottavat sinuun suoraan yhteyttä, mutta toisinaan me "
-"lähetämme tiedot itse."
+msgid "In order to apply for access to a partner resource, you must provide us with certain information, which we will use to evaluate your application. If your application is approved, we may transfer the information you have given us to the publishers whose resources you wish to access. They will either contact you with the account information directly or we will send access information to you ourselves."
+msgstr "Jotta Wikipedian Lähdekirjaston käyttöoikeustoimiston tunnusta voi hakea, sinun täytyy antaa meille tiettyjä tietoja, joita käytämme hakemuksen arvioimiseen. Jos hakemus hyväksytään, voimme siirtää antamasi tiedot suoraan julkaisijalle, jonka aineistoon olet käyttöoikeutta pyytänyt. Sen jälkeen julkaisija luo sinulle ilmaisen tunnuksen palveluunsa. Useimmissa tapauksissa julkaisijat ottavat sinuun suoraan yhteyttä, mutta toisinaan me lähetämme tiedot itse."
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:130
-msgid ""
-"In addition to the basic information you provide to us, our system will "
-"retrieve some information directly from the Wikimedia projects: your "
-"username, email address, edit count, registration date, user ID number, "
-"groups to which you belong, and any special user rights."
-msgstr ""
-"Meille antamiesi perustietojen lisäksi järjestelmä noutaa joitakin tietoja "
-"suoraan Wikimedia-projekteista: käyttäjänimesi, sähköpostiosoitteesi, "
-"muokkausmääräsi, käyttäjän tunnistenumeron, sekä käyttäjäryhmät ja -oikeudet."
+msgid "In addition to the basic information you provide to us, our system will retrieve some information directly from the Wikimedia projects: your username, email address, edit count, registration date, user ID number, groups to which you belong, and any special user rights."
+msgstr "Meille antamiesi perustietojen lisäksi järjestelmä noutaa joitakin tietoja suoraan Wikimedia-projekteista: käyttäjänimesi, sähköpostiosoitteesi, muokkausmääräsi, käyttäjän tunnistenumeron, sekä käyttäjäryhmät ja -oikeudet."
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:140
-msgid ""
-"Each time you log in to the Wikipedia Library Card Platform, this "
-"information will be automatically updated."
+msgid "Each time you log in to the Wikipedia Library Card Platform, this information will be automatically updated."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:148
 #, fuzzy
-msgid ""
-"We will ask you to provide us with some information about your history of "
-"contributions to the Wikimedia projects. Information on contribution history "
-"is optional, but will greatly assist us in evaluating your application."
-msgstr ""
-"Pyydämme sinua nimeämään kotiwikisi (tai minkä tahansa Wikipedian "
-"kieliversion, jossa olet asettanut sähköpostin lähettämisen ja "
-"vastaanottamisen päälle asetuksistasi) sekä antamaan joitain tietoja "
-"historiastasi ja muokkauksistasi Wikimedia-projekteissa. Muokkaushistoriasta "
-"kertominen on vapaaehtoisia, mutta se helpotaa hakemusten arviointia."
+msgid "We will ask you to provide us with some information about your history of contributions to the Wikimedia projects. Information on contribution history is optional, but will greatly assist us in evaluating your application."
+msgstr "Pyydämme sinua nimeämään kotiwikisi (tai minkä tahansa Wikipedian kieliversion, jossa olet asettanut sähköpostin lähettämisen ja vastaanottamisen päälle asetuksistasi) sekä antamaan joitain tietoja historiastasi ja muokkauksistasi Wikimedia-projekteissa. Muokkaushistoriasta kertominen on vapaaehtoisia, mutta se helpotaa hakemusten arviointia."
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). WMF should not be translated. Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:157
-msgid ""
-"The information you provide when creating your account will be visible to "
-"you while on the site but not to others unless they are approved Wikipedia "
-"Library Coordinators, WMF Staff, or WMF Contractors who need access to this "
-"data in order to carry out their work with the Wikipedia Library, all of "
-"whom are subject to non-disclosure obligations."
-msgstr ""
-"Tiedot joita annat tunnuksen luomisen yhteydessä ovat näkyvillä sinulle "
-"kunolet sivustolla, mutta ei muille käyttäjille, elleivät he ole "
-"hyväksyttyjä koordinaattoreita, Wikimedia-säätiön työntekijöitä tai "
-"sopimustyöntekijöitä, joita kaikkia velvoittaa salassapitosopimus ja jotka "
-"työskentelevät Wikipedian lähdekirjastolle."
+msgid "The information you provide when creating your account will be visible to you while on the site but not to others unless they are approved Wikipedia Library Coordinators, WMF Staff, or WMF Contractors who need access to this data in order to carry out their work with the Wikipedia Library, all of whom are subject to non-disclosure obligations."
+msgstr "Tiedot joita annat tunnuksen luomisen yhteydessä ovat näkyvillä sinulle kunolet sivustolla, mutta ei muille käyttäjille, elleivät he ole hyväksyttyjä koordinaattoreita, Wikimedia-säätiön työntekijöitä tai sopimustyöntekijöitä, joita kaikkia velvoittaa salassapitosopimus ja jotka työskentelevät Wikipedian lähdekirjastolle."
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:167
@@ -3338,59 +2756,35 @@ msgstr "Julkaisijan aineiston käyttö"
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:171
 #, fuzzy
-msgid ""
-"In order to access an individual publisher’s resources, you must agree to "
-"that publisher’s terms of use and privacy policy. You agree that you will "
-"not violate such terms and policies in connection with your use of the "
-"Wikipedia Library. Additionally, the following activities are prohibited "
-"while accessing publisher resources through the Wikipedia Library."
-msgstr ""
-"Huomaa, että voidakseen käyttää yksittäisen julkaisijan resursseja, "
-"sinuntäytyy hyväksyä julkaisijan käyttöehdot ja yksityisyydensuojakäytäntö. "
-"Lisäksikäyttöoikeuteesi julkaisijan aineistoon Wikipedia Lähdekirjaston "
-"kautta liittyvät seuraavat ehdot."
+msgid "In order to access an individual publisher’s resources, you must agree to that publisher’s terms of use and privacy policy. You agree that you will not violate such terms and policies in connection with your use of the Wikipedia Library. Additionally, the following activities are prohibited while accessing publisher resources through the Wikipedia Library."
+msgstr "Huomaa, että voidakseen käyttää yksittäisen julkaisijan resursseja, sinuntäytyy hyväksyä julkaisijan käyttöehdot ja yksityisyydensuojakäytäntö. Lisäksikäyttöoikeuteesi julkaisijan aineistoon Wikipedia Lähdekirjaston kautta liittyvät seuraavat ehdot."
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:184
 #, fuzzy
-msgid ""
-"Sharing your Wikipedia account, usernames, passwords, or any access codes "
-"for publisher resources with others;"
-msgstr ""
-"Et saa jakaa muille käyttäjätunnustasi ja salasanaasi yhteistyökumppanin "
-"aineistoon."
+msgid "Sharing your Wikipedia account, usernames, passwords, or any access codes for publisher resources with others;"
+msgstr "Et saa jakaa muille käyttäjätunnustasi ja salasanaasi yhteistyökumppanin aineistoon."
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:191
-msgid ""
-"Automatically scraping or downloading restricted content from publishers;"
+msgid "Automatically scraping or downloading restricted content from publishers;"
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:197
 #, fuzzy
-msgid ""
-"Systematically making printed or electronic copies of multiple extracts of "
-"restricted content available for any purpose;"
-msgstr ""
-"Järjestelmällisesti tehdä tulostettuja ja sähköisiä kopioita lukuisista "
-"rajoitetuista sisällöistä, oli tarkoitus mikä tahansa"
+msgid "Systematically making printed or electronic copies of multiple extracts of restricted content available for any purpose;"
+msgstr "Järjestelmällisesti tehdä tulostettuja ja sähköisiä kopioita lukuisista rajoitetuista sisällöistä, oli tarkoitus mikä tahansa"
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:204
 #, fuzzy
-msgid ""
-"Data mining metadata without permission—for example, in order to use "
-"metadata for auto-created stub articles;"
-msgstr ""
-"Louhia metadataa ilman lupaa esimerkiksi automaattisesti luotavia "
-"tynkäartikkeleita varten."
+msgid "Data mining metadata without permission—for example, in order to use metadata for auto-created stub articles;"
+msgstr "Louhia metadataa ilman lupaa esimerkiksi automaattisesti luotavia tynkäartikkeleita varten."
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:211
-msgid ""
-"Using the access you receive through the Wikipedia Library for profit by "
-"selling access to your account or resources which you have through it."
+msgid "Using the access you receive through the Wikipedia Library for profit by selling access to your account or resources which you have through it."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
@@ -3400,18 +2794,12 @@ msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:224
-msgid ""
-"Certain resources may only be accessed using an external search service, "
-"such as the EBSCO Discovery Service, or a proxy service, such as OCLC "
-"EZProxy. If you use such external search and/or proxy services, please "
-"review the applicable terms of use and privacy policies."
+msgid "Certain resources may only be accessed using an external search service, such as the EBSCO Discovery Service, or a proxy service, such as OCLC EZProxy. If you use such external search and/or proxy services, please review the applicable terms of use and privacy policies."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:234
-msgid ""
-"In addition, if you use OCLC EZProxy, please note that you may not use it "
-"for commercial purposes."
+msgid "In addition, if you use OCLC EZProxy, please note that you may not use it for commercial purposes."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
@@ -3421,166 +2809,54 @@ msgstr "Tietojen säilytys ja käsittely"
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Wikimedia Foundation should not be translated. Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:245
-msgid ""
-"The Wikimedia Foundation and our service providers use your information for "
-"the legitimate purpose of providing Wikipedia Library services in support of "
-"our charitable mission. When you apply for a Wikipedia Library account, or "
-"use your Wikipedia Library account, we may routinely collect the following "
-"information: your username, email address, edit count, registration date, "
-"user ID number, groups to which you belong, and any special user rights; "
-"your name, country of residence, and/or affiliation, if required by a "
-"partner to which you are applying; your narrative description of your "
-"contributions and reasons for applying for access to partner resources; and "
-"the date you agree to these terms of use."
+msgid "The Wikimedia Foundation and our service providers use your information for the legitimate purpose of providing Wikipedia Library services in support of our charitable mission. When you apply for a Wikipedia Library account, or use your Wikipedia Library account, we may routinely collect the following information: your username, email address, edit count, registration date, user ID number, groups to which you belong, and any special user rights; your name, country of residence, and/or affiliation, if required by a partner to which you are applying; your narrative description of your contributions and reasons for applying for access to partner resources; and the date you agree to these terms of use."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:262
 #, fuzzy, python-format
-msgid ""
-"Each publisher who is a member of the Wikipedia Library program requires "
-"different specific information in the application. Some publishers may "
-"request only an email address, while others request more detailed data, such "
-"as your name, location, or institutional affiliation. When you complete your "
-"application, you will only be asked to supply information required by the "
-"publishers you have chosen, and each publisher will only receive the "
-"information they require for providing you with access. Please see our <a "
-"class=\"twl-links\" href=\"%(all_partners_url)s\">partner information</a> "
-"pages to learn what information is required by each publisher to gain access "
-"to their resources."
-msgstr ""
-"Jokainen julkaisija, joka on jäsenenä Wikipedian Lähdekirjastossa, vaatii "
-"erilaisia konkreettisia tietoja hakemusta varten. Jotkut julkaisijat voivat "
-"vaatia vain sähköpostiosoitteen, kun taas toiset voivat vaatia "
-"yksityiskohtaisempaa tietoa, kuten nimesi, asuinpaikkasi, ammattisi ja "
-"sidoksesi instituutioihin. Kun täytät hakemustasi, sinua pyydetään antamaan "
-"vain tietoja joita julkaisija on vaatinut, ja jokainen julkaisija saa vain "
-"vaatimansa tiedot. Tutustu <a class=\"twl-links\" href=\"%(all_partners_url)s"
-"\">yhteistyökumppanit-sivuun</a> saadaksesi lisää tietoa siitä, mitä tietoja "
-"julkaisijat vaativat käyttöoikeuden myöntämiseksi."
+msgid "Each publisher who is a member of the Wikipedia Library program requires different specific information in the application. Some publishers may request only an email address, while others request more detailed data, such as your name, location, or institutional affiliation. When you complete your application, you will only be asked to supply information required by the publishers you have chosen, and each publisher will only receive the information they require for providing you with access. Please see our <a class=\"twl-links\" href=\"%(all_partners_url)s\">partner information</a> pages to learn what information is required by each publisher to gain access to their resources."
+msgstr "Jokainen julkaisija, joka on jäsenenä Wikipedian Lähdekirjastossa, vaatii erilaisia konkreettisia tietoja hakemusta varten. Jotkut julkaisijat voivat vaatia vain sähköpostiosoitteen, kun taas toiset voivat vaatia yksityiskohtaisempaa tietoa, kuten nimesi, asuinpaikkasi, ammattisi ja sidoksesi instituutioihin. Kun täytät hakemustasi, sinua pyydetään antamaan vain tietoja joita julkaisija on vaatinut, ja jokainen julkaisija saa vain vaatimansa tiedot. Tutustu <a class=\"twl-links\" href=\"%(all_partners_url)s\">yhteistyökumppanit-sivuun</a> saadaksesi lisää tietoa siitä, mitä tietoja julkaisijat vaativat käyttöoikeuden myöntämiseksi."
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Wikimedia Foundation should not be translated. Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:277
-msgid ""
-"Some Wikipedia Library pages are visible without logging in, but you will "
-"need to log in to apply or access proprietary partner resources. We use the "
-"data provided by you via OAuth and Wikimedia API calls to assess your "
-"application for access and to process approved requests."
+msgid "Some Wikipedia Library pages are visible without logging in, but you will need to log in to apply or access proprietary partner resources. We use the data provided by you via OAuth and Wikimedia API calls to assess your application for access and to process approved requests."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:288
 #, fuzzy, python-format
-msgid ""
-"In order to administer the Wikipedia Library program, we will retain the "
-"application data we collect from you for three years after your most recent "
-"login, unless you delete your account, as described below. You can log in "
-"and go to <a class=\"twl-links\" href=\"%(profile_url)s\">your profile page</"
-"a> in order to see the information associated with your account, and can "
-"download it in JSON format. You may access, update, restrict, or delete this "
-"information at any time, except for the information that is automatically "
-"retrieved from the projects. If you have any questions or concerns about the "
-"handling of your data, please contact <a class=\"twl-links\" href=\"mailto:"
-"wikipedialibrary@wikimedia.org?Subject=Wikipedia%%20Library%%20Card"
-"%%20account%%20deactivation\"> wikipedialibrary@wikimedia.org </a>."
-msgstr ""
-"Jotta voisimme hallinnoida Wikipedian Lähdekirjastoa, me säilytämme "
-"keräämämme tiedot ikuisesti, ellet poista tiliäsi kuten alla on kuvattu. "
-"Voit kirjautua sisään ja mennä <a href=\"%(user_home_url)s\"> profiilin </a> "
-"nähdäksesi tunnukseen liittyvät tiedot. Voit päivittää näitä tietoja milloin "
-"tahansa, lukuun ottamatta tietoja, jotka noudetaan automaattisesti "
-"projekteista."
+msgid "In order to administer the Wikipedia Library program, we will retain the application data we collect from you for three years after your most recent login, unless you delete your account, as described below. You can log in and go to <a class=\"twl-links\" href=\"%(profile_url)s\">your profile page</a> in order to see the information associated with your account, and can download it in JSON format. You may access, update, restrict, or delete this information at any time, except for the information that is automatically retrieved from the projects. If you have any questions or concerns about the handling of your data, please contact <a class=\"twl-links\" href=\"mailto:wikipedialibrary@wikimedia.org?Subject=Wikipedia%%20Library%%20Card%%20account%%20deactivation\"> wikipedialibrary@wikimedia.org </a>."
+msgstr "Jotta voisimme hallinnoida Wikipedian Lähdekirjastoa, me säilytämme keräämämme tiedot ikuisesti, ellet poista tiliäsi kuten alla on kuvattu. Voit kirjautua sisään ja mennä <a href=\"%(user_home_url)s\"> profiilin </a> nähdäksesi tunnukseen liittyvät tiedot. Voit päivittää näitä tietoja milloin tahansa, lukuun ottamatta tietoja, jotka noudetaan automaattisesti projekteista."
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:305
 #, fuzzy
-msgid ""
-"If you decide to disable your Wikipedia Library account, you can use the "
-"delete button on your profile to delete certain personal information "
-"associated with your account. We will delete your real name, institutional "
-"affiliation, and country of residence. Please note that the system will "
-"retain a record of your username, the publishers to which you applied or had "
-"access, and the dates of that access. Note that deletion is not reversible. "
-"Deletion of your Wikipedia Library account may also correspond with the "
-"removal of any resource access to which you were eligible or approved. If "
-"you request the deletion of account information and later wish to apply for "
-"a new account, you will need to provide the necessary information again."
-msgstr ""
-"Jos päätät poistaa käytöstä Wikipedian Lähdekirjaston tunnuksen, voit "
-"lähettää sähköpostia osoitteeseen <A href = \" mailto: "
-"wikipedialibrary@wikimedia.org? Subject = Wikipedia %% 20Library %% 20Card %"
-"% 20account %% 20deactivation \"> wikipedialibrary@wikimedia.org </a> ja "
-"pyytää poistamaan joitakin tunnukseesi liittyviä henkilökohtaisia tietojasi. "
-"Poistamme oikean nimesi, ammattisi, instituutio-sidoksesi sekä asuinmaasi. "
-"Huomaa, että järjestelmä säilyttää merkinnän käyttäjätunnuksestasi ja "
-"julkaisijoista, joiden aineistoihin hait käyttöoikeutta tai sait "
-"käyttöoikeuden, sekä pääsyn päivämäärät. Jos pyydät tietojen poistamista, ja "
-"haluat myöhemmin luoda uuden tunnuksen, joudut täyttämään tarvittavat tiedot "
-"uudestaan."
+msgid "If you decide to disable your Wikipedia Library account, you can use the delete button on your profile to delete certain personal information associated with your account. We will delete your real name, institutional affiliation, and country of residence. Please note that the system will retain a record of your username, the publishers to which you applied or had access, and the dates of that access. Note that deletion is not reversible. Deletion of your Wikipedia Library account may also correspond with the removal of any resource access to which you were eligible or approved. If you request the deletion of account information and later wish to apply for a new account, you will need to provide the necessary information again."
+msgstr "Jos päätät poistaa käytöstä Wikipedian Lähdekirjaston tunnuksen, voit lähettää sähköpostia osoitteeseen <A href = \" mailto: wikipedialibrary@wikimedia.org? Subject = Wikipedia %% 20Library %% 20Card %% 20account %% 20deactivation \"> wikipedialibrary@wikimedia.org </a> ja pyytää poistamaan joitakin tunnukseesi liittyviä henkilökohtaisia tietojasi. Poistamme oikean nimesi, ammattisi, instituutio-sidoksesi sekä asuinmaasi. Huomaa, että järjestelmä säilyttää merkinnän käyttäjätunnuksestasi ja julkaisijoista, joiden aineistoihin hait käyttöoikeutta tai sait käyttöoikeuden, sekä pääsyn päivämäärät. Jos pyydät tietojen poistamista, ja haluat myöhemmin luoda uuden tunnuksen, joudut täyttämään tarvittavat tiedot uudestaan."
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). WMF should not be translated. Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:321
 #, fuzzy
-msgid ""
-"The Wikipedia Library is run by WMF Staff, Contractors, and approved "
-"volunteer Coordinators. The data associated with your account will be shared "
-"with the WMF staff, contractors, service providers, and volunteer "
-"coordinators who need to process the information in connection with their "
-"work for the Wikipedia Library, and who are subject to confidentiality "
-"obligations. We will also use your data for internal Wikipedia Library "
-"purposes such as distributing user surveys and account notifications, and in "
-"a depersonalized or aggregated fashion for statistical analysis and "
-"administration. Finally, we will share your information with the publishers "
-"whom you specifically select in order to provide you with access to "
-"resources. Otherwise, your information will not be shared with third "
-"parties, with the exception of the circumstances described below."
-msgstr ""
-"Wikipedian Lähdekirjastoa ylläpitää Wikimedia-säätiön työntekijät, "
-"sopimustyöntekijät ja hyväksytyt vapaaehtoiskoordinaattorit, joilla on pääsy "
-"tietoihisi. Tunnukseesi liittyvät tiedot jaetaan niitä käsittelevien "
-"Wikimedian työntekijöiden, sopimustyöntekijöiden, palveluntarjoajien ja "
-"vapaaehtoiskoordinaattorien kanssa, joita velvoittaa salassapitosopimus. "
-"Muussa tapauksessa Wikimedia-säätiö jakaa tietojasi vain valitsemasi "
-"julkaisijan kanssa, lukuun ottamatta alla esiteltäviä poikkeustapauksia."
+msgid "The Wikipedia Library is run by WMF Staff, Contractors, and approved volunteer Coordinators. The data associated with your account will be shared with the WMF staff, contractors, service providers, and volunteer coordinators who need to process the information in connection with their work for the Wikipedia Library, and who are subject to confidentiality obligations. We will also use your data for internal Wikipedia Library purposes such as distributing user surveys and account notifications, and in a depersonalized or aggregated fashion for statistical analysis and administration. Finally, we will share your information with the publishers whom you specifically select in order to provide you with access to resources. Otherwise, your information will not be shared with third parties, with the exception of the circumstances described below."
+msgstr "Wikipedian Lähdekirjastoa ylläpitää Wikimedia-säätiön työntekijät, sopimustyöntekijät ja hyväksytyt vapaaehtoiskoordinaattorit, joilla on pääsy tietoihisi. Tunnukseesi liittyvät tiedot jaetaan niitä käsittelevien Wikimedian työntekijöiden, sopimustyöntekijöiden, palveluntarjoajien ja vapaaehtoiskoordinaattorien kanssa, joita velvoittaa salassapitosopimus. Muussa tapauksessa Wikimedia-säätiö jakaa tietojasi vain valitsemasi julkaisijan kanssa, lukuun ottamatta alla esiteltäviä poikkeustapauksia."
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). WMF should not be translated.
 #: TWLight/users/templates/users/terms.html:338
 #, fuzzy
-msgid ""
-"We may disclose any collected information when required by law, when we have "
-"your permission, when needed to protect our rights, privacy, safety, users, "
-"or the general public, and when necessary to enforce these terms, WMF’s "
-"general <a class=\"twl-links\" href=\"https://foundation.wikimedia.org/wiki/"
-"Terms_of_Use\">Terms of Use</a>, or any other WMF policy."
-msgstr ""
-"Voimme esittää mitä tahansa kerättyjä tietoja lain niin vaatiessa, kun "
-"meillä on lupaasi, kun tarvisemme sitä oikeuksiemme, yksityisyytemme, "
-"turvallisuutemme, käyttäjiemme tai yleisömme suojelemiseksi, ja kun on "
-"tarpeellista valvoa palvelun käyttöehtojen, yleisten käyttöehtojemme tai "
-"jonkin muun Wikimedia-käytännön noudattamista."
+msgid "We may disclose any collected information when required by law, when we have your permission, when needed to protect our rights, privacy, safety, users, or the general public, and when necessary to enforce these terms, WMF’s general <a class=\"twl-links\" href=\"https://foundation.wikimedia.org/wiki/Terms_of_Use\">Terms of Use</a>, or any other WMF policy."
+msgstr "Voimme esittää mitä tahansa kerättyjä tietoja lain niin vaatiessa, kun meillä on lupaasi, kun tarvisemme sitä oikeuksiemme, yksityisyytemme, turvallisuutemme, käyttäjiemme tai yleisömme suojelemiseksi, ja kun on tarpeellista valvoa palvelun käyttöehtojen, yleisten käyttöehtojemme tai jonkin muun Wikimedia-käytännön noudattamista."
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:349
-msgid ""
-"We take the security of your personal data seriously, and take reasonable "
-"precautions to ensure your data is protected. These precautions include "
-"access controls to limit who has access to your data and security "
-"technologies to protect data stored on the server. However, we cannot "
-"guarantee the safety of your data as it is transmitted and stored."
+msgid "We take the security of your personal data seriously, and take reasonable precautions to ensure your data is protected. These precautions include access controls to limit who has access to your data and security technologies to protect data stored on the server. However, we cannot guarantee the safety of your data as it is transmitted and stored."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:360
 #, fuzzy
-msgid ""
-"Please note that these terms do not control the use and handling of your "
-"data by the publishers and service providers whose resources you access or "
-"apply to access. Please read their individual privacy policies for that "
-"information."
-msgstr ""
-"Huomaa, että nämä käyttöehdot eivät valvo sitä, kuinka julkaisijat käyttävät "
-"tietojasi. Lue yksittäisten julkaisijoiden yksityisyydensuojakäytännöt "
-"erikseen."
+msgid "Please note that these terms do not control the use and handling of your data by the publishers and service providers whose resources you access or apply to access. Please read their individual privacy policies for that information."
+msgstr "Huomaa, että nämä käyttöehdot eivät valvo sitä, kuinka julkaisijat käyttävät tietojasi. Lue yksittäisten julkaisijoiden yksityisyydensuojakäytännöt erikseen."
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:368
@@ -3590,50 +2866,17 @@ msgstr ""
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Wikimedia Foundation should not be translated. Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:373
 #, fuzzy
-msgid ""
-"The Wikimedia Foundation is a nonprofit organization based in San Francisco, "
-"California. The Wikipedia Library program provides access to resources held "
-"by publishers in multiple countries. If you apply for a Wikipedia Library "
-"account (whether you are inside or outside of the United States), you "
-"understand that your personal data will be collected, transferred, stored, "
-"processed, disclosed and otherwise used in the U.S. as described in this "
-"privacy policy. You also understand that your information may be transferred "
-"by us from the U.S. to other countries, which may have different or less "
-"stringent data protection laws than your country, in connection with "
-"providing services to you, including evaluating your application and "
-"securing access to your chosen publishers (locations for each publisher are "
-"outlined on their respective partner information pages)."
-msgstr ""
-"Wikimedia Foundation on voittoa tavoittelematon järjestö, jonka päämaja on "
-"San Franciscossa, Kaliforniassa, Yhdysvalloissa. Wikipedian Lähdekirjasto "
-"tarjoaa käyttöoikeuksia aineistoihin julkaisijoilta useasta eri maasta. "
-"Hakemalla käyttöoikeutta Wikipedian Lähdekirjastolta (olit sitten "
-"Yhdysvalloissa tai sen ulkopuolella), hyväksyt tietojen keräämisen, "
-"tallentamisen, siirron, esittämisen ja muun käytön Yhdysvalloissa ja muualla "
-"siinä laajuudessa kuin on tarpeellista yllä olevien tarkoitusperien ja "
-"tavoitteiden saavuttamiseksi. Sallit myös tietojesi siirtämisen "
-"Yhdysvalloista muihin maihin, joissa voi olla erilaisia tietosuojalakeja "
-"kuin omassa maassasi, liittyen sinulle tarjottuihin palveluihin kuten "
-"hakemuksesi arvioiminen ja käyttöoikeuden hankkiminen valitsemasi "
-"yhteistyökumppanin aineistoon."
+msgid "The Wikimedia Foundation is a nonprofit organization based in San Francisco, California. The Wikipedia Library program provides access to resources held by publishers in multiple countries. If you apply for a Wikipedia Library account (whether you are inside or outside of the United States), you understand that your personal data will be collected, transferred, stored, processed, disclosed and otherwise used in the U.S. as described in this privacy policy. You also understand that your information may be transferred by us from the U.S. to other countries, which may have different or less stringent data protection laws than your country, in connection with providing services to you, including evaluating your application and securing access to your chosen publishers (locations for each publisher are outlined on their respective partner information pages)."
+msgstr "Wikimedia Foundation on voittoa tavoittelematon järjestö, jonka päämaja on San Franciscossa, Kaliforniassa, Yhdysvalloissa. Wikipedian Lähdekirjasto tarjoaa käyttöoikeuksia aineistoihin julkaisijoilta useasta eri maasta. Hakemalla käyttöoikeutta Wikipedian Lähdekirjastolta (olit sitten Yhdysvalloissa tai sen ulkopuolella), hyväksyt tietojen keräämisen, tallentamisen, siirron, esittämisen ja muun käytön Yhdysvalloissa ja muualla siinä laajuudessa kuin on tarpeellista yllä olevien tarkoitusperien ja tavoitteiden saavuttamiseksi. Sallit myös tietojesi siirtämisen Yhdysvalloista muihin maihin, joissa voi olla erilaisia tietosuojalakeja kuin omassa maassasi, liittyen sinulle tarjottuihin palveluihin kuten hakemuksesi arvioiminen ja käyttöoikeuden hankkiminen valitsemasi yhteistyökumppanin aineistoon."
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:392
-msgid ""
-"Please note that in the event of any differences in meaning or "
-"interpretation between the original English version of these terms and a "
-"translation, the original English version takes precedence."
-msgstr ""
-"Huomioithan että tilanteessa, jossa ilmenee mahdollisia eroavaisuuksia "
-"tarkoituksesta tai tulkinnasta alkuperäisten englanninkielisten ja "
-"käännettyjen käyttöehtojen välillä, englanninkieliset käyttöehdot ovat "
-"ensisijaiset."
+msgid "Please note that in the event of any differences in meaning or interpretation between the original English version of these terms and a translation, the original English version takes precedence."
+msgstr "Huomioithan että tilanteessa, jossa ilmenee mahdollisia eroavaisuuksia tarkoituksesta tai tulkinnasta alkuperäisten englanninkielisten ja käännettyjen käyttöehtojen välillä, englanninkieliset käyttöehdot ovat ensisijaiset."
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Wikimedia Foundation should not be translated.
 #: TWLight/users/templates/users/terms.html:403
-msgid ""
-"See also the <a class=\"twl-links\" href=\"https://wikimediafoundation.org/"
-"wiki/Privacy_policy\">Wikimedia Foundation Privacy Policy</a>."
+msgid "See also the <a class=\"twl-links\" href=\"https://wikimediafoundation.org/wiki/Privacy_policy\">Wikimedia Foundation Privacy Policy</a>."
 msgstr ""
 
 #. Translators: This is the second to last line of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
@@ -3654,16 +2897,8 @@ msgstr "Wikimedia Foundationin tietosuojakäytäntö"
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:426
-msgid ""
-"By checking this box and clicking “Submit”, you agree that you have read the "
-"above terms and that you will adhere to the terms of use in your application "
-"to and use of the The Wikipedia Library, and the publishers’ services to "
-"which you gain access through The Wikipedia Library program."
-msgstr ""
-"Rastimalla tämän laatikon ja klikkaamalla “Hyväksyn”, hyväksyt ylläolevan "
-"yksityisyydensuojakäytännön ja käyttöehdot, ja sitoudut noudattamaan niitä "
-"hakemuksessasi ja Wikipedian Lähdekirjastoa käyttäessäsi sekä Lähdekirjaston "
-"kautta saamaasi yhteistyökumppanin aineistoa käyttäessäsi."
+msgid "By checking this box and clicking “Submit”, you agree that you have read the above terms and that you will adhere to the terms of use in your application to and use of the The Wikipedia Library, and the publishers’ services to which you gain access through The Wikipedia Library program."
+msgstr "Rastimalla tämän laatikon ja klikkaamalla “Hyväksyn”, hyväksyt ylläolevan yksityisyydensuojakäytännön ja käyttöehdot, ja sitoudut noudattamaan niitä hakemuksessasi ja Wikipedian Lähdekirjastoa käyttäessäsi sekä Lähdekirjaston kautta saamaasi yhteistyökumppanin aineistoa käyttäessäsi."
 
 #: TWLight/users/templates/users/user_collection_tile.html:32
 msgid "Remove this collection from favorites"
@@ -3715,38 +2950,19 @@ msgstr "Poista kaikki tiedot"
 
 #. Translators: This message is displayed on the page where users can request the deletion of their data.
 #: TWLight/users/templates/users/user_confirm_delete.html:17
-msgid ""
-"<b>Warning:</b> Performing this action will delete your Wikipedia Library "
-"Card user account and all associated applications. This process is not "
-"reversible. You may lose any partner accounts you were granted, and will not "
-"be able to renew those accounts or apply for new ones."
+msgid "<b>Warning:</b> Performing this action will delete your Wikipedia Library Card user account and all associated applications. This process is not reversible. You may lose any partner accounts you were granted, and will not be able to renew those accounts or apply for new ones."
 msgstr ""
 
 #. Translators: this should show up for people who log in with a username/password and not OAuth, so we don't know what their Wikipedia identity is.
-#.
 #: TWLight/users/templates/users/user_detail.html:12
 #, python-format
-msgid ""
-"Hi, %(username)s! You don't have a Wikipedia editor profile attached to your "
-"account here, so you are probably a site administrator."
-msgstr ""
-"Terve, %(username)s! Tunnukseesi ei ole liitetty Wikipedian "
-"käyttäjätunnusta, joten olet luultavasti sivuston ylläpitäjä."
+msgid "Hi, %(username)s! You don't have a Wikipedia editor profile attached to your account here, so you are probably a site administrator."
+msgstr "Terve, %(username)s! Tunnukseesi ei ole liitetty Wikipedian käyttäjätunnusta, joten olet luultavasti sivuston ylläpitäjä."
 
 #. Translators: In the unlikely scenario that someone is able to register an account without using OAuth (thus leaving us without some of the information required for applications), users will see this message, encouraging them to re-register.
 #: TWLight/users/templates/users/user_detail.html:20
-msgid ""
-"If you aren't a site administrator, something weird has happened. You won't "
-"be able to apply for access without a Wikipedia editor profile. You should "
-"log out and create a new account by logging in via OAuth, or contact a site "
-"administrator for help."
-msgstr ""
-"Jos et ole sivuston ylläpitäjä, jotain outoa tapahtui. Sinä et voi hakea "
-"käyttöoikeutta suojattuihin aineistoihin ilman Wikipedian käyttäjätunnusta. "
-"Jos sinulla ei ole syytä sille, miksi tunnukseesi ei ole liitetty Wikipedian "
-"käyttäjätunnusta (esim. olet sivuston ylläpitäjä), sinun tulisi kirjautua "
-"ulos ja luoda uusi tunnus kirjautumalla sisään OAuthin kautta, tai ottaa "
-"yhteyttä ylläpitäjään."
+msgid "If you aren't a site administrator, something weird has happened. You won't be able to apply for access without a Wikipedia editor profile. You should log out and create a new account by logging in via OAuth, or contact a site administrator for help."
+msgstr "Jos et ole sivuston ylläpitäjä, jotain outoa tapahtui. Sinä et voi hakea käyttöoikeutta suojattuihin aineistoihin ilman Wikipedian käyttäjätunnusta. Jos sinulla ei ole syytä sille, miksi tunnukseesi ei ole liitetty Wikipedian käyttäjätunnusta (esim. olet sivuston ylläpitäjä), sinun tulisi kirjautua ulos ja luoda uusi tunnus kirjautumalla sisään OAuthin kautta, tai ottaa yhteyttä ylläpitäjään."
 
 #. Translators: Labels a sections where coordinators can select their email preferences.
 #: TWLight/users/templates/users/user_email_preferences.html:15
@@ -3756,19 +2972,12 @@ msgstr ""
 #. Translators: This message is shown on user's own profile page, encouraging them to make sure their information is up to date, so that account coordinators can use the information to judge applications.
 #: TWLight/users/views.py:176
 #, fuzzy, python-brace-format
-msgid ""
-"Please <a class='twl-links' href='{url}'>update your contributions</a> to "
-"Wikipedia to help coordinators evaluate your applications."
-msgstr ""
-"Täydennäthän alle tiedot Wikipedia-muokkauksistasi, jotta koordinaattorit "
-"voivat arvioida hakemuksesi."
+msgid "Please <a class='twl-links' href='{url}'>update your contributions</a> to Wikipedia to help coordinators evaluate your applications."
+msgstr "Täydennäthän alle tiedot Wikipedia-muokkauksistasi, jotta koordinaattorit voivat arvioida hakemuksesi."
 
 #. Translators: Coordinators are shown this message when they unselect all three types of reminder email options under preferences.
 #: TWLight/users/views.py:288
-msgid ""
-"You have chosen not to receive reminder emails. As a coordinator, you should "
-"receive at least one type of reminder emails, so consider changing your "
-"preferences."
+msgid "You have chosen not to receive reminder emails. As a coordinator, you should receive at least one type of reminder emails, so consider changing your preferences."
 msgstr ""
 
 #. Translators: Coordinators are shown this message when they make changes to their reminder email options under preferences.
@@ -3802,12 +3011,8 @@ msgstr "Sähköpostiksesi on vaihdettu {email}."
 
 #. Translators: If the user has not filled out their email, they can browse the website but cannot apply for access to resources.
 #: TWLight/users/views.py:487
-msgid ""
-"Your email is blank. You can still explore the site, but you won't be able "
-"to apply for access to partner resources without an email."
-msgstr ""
-"Sähköpostiosoitteesi on tyhjä. Voit silti tutkia sivustoa, mutta et voi "
-"hakea käyttöoikeutta aineistoon ilman sähköpostiosoitetta."
+msgid "Your email is blank. You can still explore the site, but you won't be able to apply for access to partner resources without an email."
+msgstr "Sähköpostiosoitteesi on tyhjä. Voit silti tutkia sivustoa, mutta et voi hakea käyttöoikeutta aineistoon ilman sähköpostiosoitetta."
 
 #. Translators: This message is shown once the access to a partner has successfully been returned.
 #: TWLight/users/views.py:801
@@ -3840,31 +3045,3 @@ msgstr "Ei aktiivisia estoja"
 msgid "10+ edits in the last 30 days"
 msgstr "Yli 10 muokkausta viimeisen 30 päivän aikana"
 
-#: tests/shunit/data/bad_i18n_comment_1.py:3
-#: tests/shunit/data/bad_i18n_newline_1.py:5
-msgid "1"
-msgstr ""
-
-#. Translators: Lorem ipsum dolor sit amet, consectetur adipiscing elit. Mauris vitae ipsum ut purus faucibus pretium. Proin tempus neque et aliquet consectetur. Ut egestas sapien in consectetur sagittis. Mauris neque lacus, dapibus non viverra vitae, interdum ut aenean ipsum.
-#. Translators: Lorem ipsum dolor sit amet, consectetur adipiscing elit. Mauris vitae ipsum ut purus faucibus pretium. Proin tempus neque et aliquet consectetur. Ut egestas sapien in consectetur sagittis. Mauris neque lacus, dapibus non.
-#: tests/shunit/data/bad_i18n_comment_2.py:4
-#: tests/shunit/data/bad_i18n_newline_2.py:5 tests/shunit/data/good_i18n_1.py:2
-#: tests/shunit/data/good_i18n_2.py:2
-msgid "2"
-msgstr ""
-
-#: tests/shunit/data/bad_i18n_newline_3.py:5
-msgid "3"
-msgstr ""
-
-#: tests/shunit/data/bad_i18n_newline_4.py:5
-msgid "4"
-msgstr ""
-
-#: tests/shunit/data/bad_i18n_newline_5.py:5
-msgid "5"
-msgstr ""
-
-#: tests/shunit/data/bad_i18n_newline_6.py:5
-msgid "6"
-msgstr ""

--- a/locale/fr/LC_MESSAGES/django.po
+++ b/locale/fr/LC_MESSAGES/django.po
@@ -19,10 +19,11 @@
 # Author: Zarisi
 msgid ""
 msgstr ""
+""
 "Project-Id-Version: Wikipedia Library Card Platform - Website\n"
-"Report-Msgid-Bugs-To: wikipedialibrary@wikimedia.org\n"
+"Report-Msgid-Bugs-To: translatewiki.net\n"
 "POT-Creation-Date: 2024-07-11 20:54+0000\n"
-"PO-Revision-Date: 2024-07-11 12:30:15+0000\n"
+"PO-Revision-Date: 2024-07-15 12:29:15+0000\n"
 "Last-Translator: FULL NAME\n"
 "Language-Team: LANGUAGE\n"
 "Language: fr\n"
@@ -57,13 +58,8 @@ msgstr "À propos de vous"
 #. Translators: This note appears in a section of a form where we ask users to enter info (like country of residence) when applying for resource access.
 #: TWLight/applications/forms.py:179
 #, python-brace-format
-msgid ""
-"<p><small><i>Your personal data will be processed according to our <a "
-"class='twl-links' href='{terms_url}'> privacy policy</a>.</i></small></p>"
-msgstr ""
-"<p><small><i>Vos données personnelles seront traitées conformément à notre "
-"<a  class=\"twl-links\" href=\"{terms_url}\">politique de confidentialité</"
-"a>.</i></small></p>"
+msgid "<p><small><i>Your personal data will be processed according to our <a class='twl-links' href='{terms_url}'> privacy policy</a>.</i></small></p>"
+msgstr "<p><small><i>Vos données personnelles seront traitées conformément à notre <a  class=\"twl-links\" href=\"{terms_url}\">politique de confidentialité</a>.</i></small></p>"
 
 #. Translators: This is the title of the application form page, where users enter information required for the application. It lets the user know which partner application they are entering data for. {partner}
 #: TWLight/applications/forms.py:189
@@ -104,12 +100,8 @@ msgstr "Le courriel de votre compte sur le site web du partenaire"
 #. Translators: This labels a choice field where users will have to select the number of months they wish to have their access for as part of the application renewal confirmation.
 #. Translators: When filling out an application, users may be required to enter the length of the account (expiry) they wish to have for proxy partners.
 #: TWLight/applications/forms.py:339 TWLight/applications/helpers.py:100
-msgid ""
-"The number of months you wish to have this access for before renewal is "
-"required"
-msgstr ""
-"Le nombre de mois pendant lesquels vous désirez avoir cet accès avant qu’un "
-"renouvellement soit nécessaire"
+msgid "The number of months you wish to have this access for before renewal is required"
+msgstr "Le nombre de mois pendant lesquels vous désirez avoir cet accès avant qu’un renouvellement soit nécessaire"
 
 #. Translators: When filling out an application, users may need to specify their name
 #: TWLight/applications/helpers.py:81
@@ -197,13 +189,8 @@ msgstr "Courriel"
 
 #. Translators: This comment is added to pending applications when our terms of use change.
 #: TWLight/applications/management/commands/notify_applicants_tou_changes.py:54
-msgid ""
-"Our terms of use have changed. Your applications will not be processed until "
-"you log in and agree to our updated terms."
-msgstr ""
-"Nos conditions d’utilisation ont changé. Vos candidatures ne seront pas "
-"traitées avant que vous vous connectiez et que vous acceptiez nos conditions "
-"mises à jour."
+msgid "Our terms of use have changed. Your applications will not be processed until you log in and agree to our updated terms."
+msgstr "Nos conditions d’utilisation ont changé. Vos candidatures ne seront pas traitées avant que vous vous connectiez et que vous acceptiez nos conditions mises à jour."
 
 #. Translators: This is the status of an application that has not yet been reviewed.
 #: TWLight/applications/models.py:54
@@ -269,43 +256,26 @@ msgstr "URL d’accès : {access_url}"
 
 #. Translators: This text goes into account approval emails in the case that we need to send the user's details to a publisher for manual account setup.
 #: TWLight/applications/models.py:331
-msgid ""
-"You can expect to receive access details within a week or two once it has "
-"been processed."
-msgstr ""
-"Vous pouvez vous attendre à recevoir les détails d’accès sous une semaine ou "
-"deux, une fois votre candidature traitée."
+msgid "You can expect to receive access details within a week or two once it has been processed."
+msgstr "Vous pouvez vous attendre à recevoir les détails d’accès sous une semaine ou deux, une fois votre candidature traitée."
 
 #. Translators: This comment is added to open applications when a partner joins the Library Bundle, which does not require applications.
 #: TWLight/applications/signals.py:247
-msgid ""
-"This partner joined the Library Bundle, which does not require applications. "
-"This application will be marked as invalid."
-msgstr ""
-"Ce partenaire a rejoint le Bouquet de la bibliothèque, qui ne nécessite "
-"aucune candidature. Cette candidature va donc être marquée comme non valide."
+msgid "This partner joined the Library Bundle, which does not require applications. This application will be marked as invalid."
+msgstr "Ce partenaire a rejoint le Bouquet de la bibliothèque, qui ne nécessite aucune candidature. Cette candidature va donc être marquée comme non valide."
 
 #. Translators: This is shown to users if the application is to a partner for which we have run out of available accounts. The application is therefore on a 'waitlist', and will be reviewed when more accounts are available.
 #: TWLight/applications/templates/applications/application_evaluation.html:29
-msgid ""
-"This application is on the waitlist because this partner does not have any "
-"access grants available at this time."
-msgstr ""
-"Cette candidature est en liste d’attente car ce partenaire n’a aucun accès "
-"autorisé disponible pour le moment."
+msgid "This application is on the waitlist because this partner does not have any access grants available at this time."
+msgstr "Cette candidature est en liste d’attente car ce partenaire n’a aucun accès autorisé disponible pour le moment."
 
 #. Translators: This message is shown on pages where coordinators can see personal information about applicants.
 #: TWLight/applications/templates/applications/application_evaluation.html:36
 #: TWLight/applications/templates/applications/application_list_include.html:6
 #: TWLight/applications/templates/applications/send_partner.html:45
 #: TWLight/resources/templates/resources/partner_users.html:18
-msgid ""
-"Coordinators: This page may contain personal information such as real names "
-"and email addresses. Please remember that this information is confidential."
-msgstr ""
-"Coordinateurs : cette page peut contenir des informations personnelles "
-"telles que les noms réels et les adresses de courriel. Veuillez vous "
-"rappeler que ces informations sont confidentielles."
+msgid "Coordinators: This page may contain personal information such as real names and email addresses. Please remember that this information is confidential."
+msgstr "Coordinateurs : cette page peut contenir des informations personnelles telles que les noms réels et les adresses de courriel. Veuillez vous rappeler que ces informations sont confidentielles."
 
 #. Translators: This is the title of the application page shown to users who are a coordinator, and are able to accept or reject the application.
 #: TWLight/applications/templates/applications/application_evaluation.html:39
@@ -314,12 +284,8 @@ msgstr "Évaluer la candidature"
 
 #. Translators: This text is shown to coordinators on application pages if the applicant has restricted processing of their data.
 #: TWLight/applications/templates/applications/application_evaluation.html:42
-msgid ""
-"This user has requested a restriction on the processing of their data, so "
-"you cannot change the status of their application."
-msgstr ""
-"Cet utilisateur a demandé une restriction concernant le traitement de ses "
-"données, vous ne pouvez donc pas modifier l’état de sa candidature."
+msgid "This user has requested a restriction on the processing of their data, so you cannot change the status of their application."
+msgstr "Cet utilisateur a demandé une restriction concernant le traitement de ses données, vous ne pouvez donc pas modifier l’état de sa candidature."
 
 #. Translators: This is the title of the application page shown to users who are not a coordinator.
 #: TWLight/applications/templates/applications/application_evaluation.html:48
@@ -392,12 +358,8 @@ msgstr "Inconnu"
 
 #. Translators: This is the text displayed to coordinators when an applicant has no country of residence in their profile.
 #: TWLight/applications/templates/applications/application_evaluation.html:123
-msgid ""
-"Please request the applicant add their country of residence to their profile "
-"before proceeding further."
-msgstr ""
-"Veuillez demander au candidat d’ajouter son pays de résidence dans son "
-"profil avant d’aller plus loin."
+msgid "Please request the applicant add their country of residence to their profile before proceeding further."
+msgstr "Veuillez demander au candidat d’ajouter son pays de résidence dans son profil avant d’aller plus loin."
 
 #. Translators: This labels the section of an application showing the total number of accounts available for a partner or their collection.
 #: TWLight/applications/templates/applications/application_evaluation.html:134
@@ -407,12 +369,8 @@ msgstr "Comptes disponibles"
 #. Translators: This labels the section of an application showing whether the user had agreed to the terms of use or not.
 #: TWLight/applications/templates/applications/application_evaluation.html:145
 #, python-format
-msgid ""
-"Has agreed to the site's <a class=\"twl-links\" href=\"%(terms_url)s\">terms "
-"of use</a>?"
-msgstr ""
-"A accepté les <a class=\"twl-links\" href=\"%(terms_url)s\">conditions "
-"d’utilisation</a> du site ?"
+msgid "Has agreed to the site's <a class=\"twl-links\" href=\"%(terms_url)s\">terms of use</a>?"
+msgstr "A accepté les <a class=\"twl-links\" href=\"%(terms_url)s\">conditions d’utilisation</a> du site ?"
 
 #. Translators: Displayed to coordinators when they've agreed to the terms of use.
 #. Translators: Displayed if the user has agreed to the terms of use.
@@ -447,12 +405,8 @@ msgstr "Non"
 
 #. Translators: This is the text displayed to coordinators when an applicant has not agreed to the terms of use.
 #: TWLight/applications/templates/applications/application_evaluation.html:159
-msgid ""
-"Please request the applicant agree to the site's terms of use before "
-"approving this application."
-msgstr ""
-"Veuillez demander au candidat d’accepter les conditions d’utilisation du "
-"site avant d’approuver sa candidature."
+msgid "Please request the applicant agree to the site's terms of use before approving this application."
+msgstr "Veuillez demander au candidat d’accepter les conditions d’utilisation du site avant d’approuver sa candidature."
 
 #. Translators: This labels the section of an application containing the user's motivation for wanting access to this resource.
 #: TWLight/applications/templates/applications/application_evaluation.html:176
@@ -472,11 +426,8 @@ msgstr "Renouveler les droits d’accès existants ?"
 #. Translators: This message is shown next to the 'Renewal of existing access grant?' label if the application is a renewal. Don't translate HTML tags or parent_url.
 #: TWLight/applications/templates/applications/application_evaluation.html:195
 #, python-format
-msgid ""
-"Yes (<a class=\"twl-links\" href=\"%(parent_url)s\">previous application</a>)"
-msgstr ""
-"Oui (<a class=\"twl-links\" href=\"%(parent_url)s\">candidature précédente</"
-"a>)"
+msgid "Yes (<a class=\"twl-links\" href=\"%(parent_url)s\">previous application</a>)"
+msgstr "Oui (<a class=\"twl-links\" href=\"%(parent_url)s\">candidature précédente</a>)"
 
 #. Translators: This labels the section of the application showing the length of access remaining on the user's previous authorization.
 #: TWLight/applications/templates/applications/application_evaluation.html:208
@@ -496,8 +447,7 @@ msgstr "Candidatures récentes (90 derniers jours)"
 #. Translators: This text is shown to Coordinators when applicant has not made any application in the last 90 days.
 #: TWLight/applications/templates/applications/application_evaluation.html:264
 msgid "No applications were made in last 90 days by the applicant"
-msgstr ""
-"Aucune candidature n’a été faite les 90 derniers jours par le candidat."
+msgstr "Aucune candidature n’a été faite les 90 derniers jours par le candidat."
 
 #. Translators: This is the title of the section of an application page which contains the comment thread between the user and account coordinator.
 #: TWLight/applications/templates/applications/application_evaluation.html:268
@@ -511,12 +461,8 @@ msgstr "Ajouter un commentaire"
 
 #. Translators: On an application page, this text tells users that the comments posted on the application are visible to coordinators and the submitting user only.
 #: TWLight/applications/templates/applications/application_evaluation.html:297
-msgid ""
-"Comments are visible to all coordinators and to the editor who submitted "
-"this application."
-msgstr ""
-"Les commentaires sont visibles par tous les coordinateurs et par le "
-"contributeur qui a soumis cette candidature."
+msgid "Comments are visible to all coordinators and to the editor who submitted this application."
+msgstr "Les commentaires sont visibles par tous les coordinateurs et par le contributeur qui a soumis cette candidature."
 
 #. Translators: This is the title of the section of an application page which lists information about the user who submitted the application.
 #. Translators: On the page where coordinators can view data on applications to a partner they coordinate, this is a table column heading for the username.
@@ -727,26 +673,14 @@ msgstr "Définir l’état"
 
 #: TWLight/applications/templates/applications/apply.html:20
 #, python-format
-msgid ""
-"If your application is successful we may share your email address with "
-"%(partner)s. This is required to set up your access to their resources. By "
-"submitting this form you agree to allow your email address to be shared with "
-"%(partner)s if your application is successful, for the purposes of account "
-"setup."
-msgstr ""
-"Si vous candidature est acceptée, nous pourrions partager votre adresse de "
-"courriel avec %(partner)s. Ceci est nécessaire pour régler votre accès à "
-"leurs ressources. En soumettant ce formulaire, vous acceptez que votre "
-"adresse de courriel sera partagée avec %(partner)s si votre candidature est "
-"acceptée, pour les objectifs liés à l’installation de votre compte."
+msgid "If your application is successful we may share your email address with %(partner)s. This is required to set up your access to their resources. By submitting this form you agree to allow your email address to be shared with %(partner)s if your application is successful, for the purposes of account setup."
+msgstr "Si vous candidature est acceptée, nous pourrions partager votre adresse de courriel avec %(partner)s. Ceci est nécessaire pour régler votre accès à leurs ressources. En soumettant ce formulaire, vous acceptez que votre adresse de courriel sera partagée avec %(partner)s si votre candidature est acceptée, pour les objectifs liés à l’installation de votre compte."
 
 #. Translators: This message is displayed on the page where users can confirm their renewal. Please do not translate partner.
 #: TWLight/applications/templates/applications/confirm_renewal.html:23
 #, python-format
 msgid "Click 'confirm' to renew your application for %(partner)s"
-msgstr ""
-"Cliquez sur « Confirmer » pour renouveler votre candidature auprès de "
-"%(partner)s"
+msgstr "Cliquez sur « Confirmer » pour renouveler votre candidature auprès de %(partner)s"
 
 #. Translators: Labels the submit button requesting confirmation of application renewal.
 #. Translators: This is the button coordinators click to confirm deletion of a suggestion.
@@ -768,12 +702,8 @@ msgstr "À quelles ressources voulez-vous accéder ?"
 
 #. Translators: This text explains that Library Bundle partners are not shown in this list.
 #: TWLight/applications/templates/applications/request_for_application.html:26
-msgid ""
-"Library Bundle partners are not shown as eligibility is determined "
-"automatically."
-msgstr ""
-"Les partenaires du Bouquet de la bibliothèque ne sont pas affichés car "
-"l’éligibilité est déterminée automatiquement."
+msgid "Library Bundle partners are not shown as eligibility is determined automatically."
+msgstr "Les partenaires du Bouquet de la bibliothèque ne sont pas affichés car l’éligibilité est déterminée automatiquement."
 
 #. Translators: On the page where users can apply for multiple partners, this message shows next to the partner name, taking them to the full application page when clicked.
 #: TWLight/applications/templates/applications/request_for_application.html:48
@@ -787,15 +717,8 @@ msgstr "Aucune donnée de partenaire n’a encore été ajoutée."
 
 #. Translators: the HTML is so that the word 'waitlisted' will look the same as it does in the page above; please translate 'waitlisted' the same way you did elsewhere in this file.
 #: TWLight/applications/templates/applications/request_for_application.html:74
-msgid ""
-"You can apply to <span class=\"badge badge-warning\">Waitlisted</span> "
-"partners, but they don't have access grants available right now. We will "
-"process those applications when access becomes available."
-msgstr ""
-"Vous pouvez faire une candidature auprès de partenaires <span class=\"badge "
-"badge-warning\">en liste d’attente</span>, mais il n’ont actuellement aucun "
-"accès autorisé disponible. Nous traiterons ces candidatures lorsque des "
-"accès seront disponibles."
+msgid "You can apply to <span class=\"badge badge-warning\">Waitlisted</span> partners, but they don't have access grants available right now. We will process those applications when access becomes available."
+msgstr "Vous pouvez faire une candidature auprès de partenaires <span class=\"badge badge-warning\">en liste d’attente</span>, mais il n’ont actuellement aucun accès autorisé disponible. Nous traiterons ces candidatures lorsque des accès seront disponibles."
 
 #. Translators: On the page where coordinators can see approved applications which have not had their details sent to the partner, this message shows when there are applications ready to be processed.
 #: TWLight/applications/templates/applications/send.html:10
@@ -816,20 +739,13 @@ msgstr "Données de candidature pour %(object)s"
 #. Translators: This message is shown when applications exceed the number of accounts available.
 #: TWLight/applications/templates/applications/send_partner.html:54
 #, python-format
-msgid ""
-"Application(s) for %(object)s, if sent, will exceed the total available "
-"accounts for the partner. Please proceed at your own discretion."
-msgstr ""
-"Les candidatures pour %(object)s, si elles sont envoyées, dépasseront le "
-"total des comptes disponibles pour le partenaire. Veuillez procéder selon "
-"votre appréciation."
+msgid "Application(s) for %(object)s, if sent, will exceed the total available accounts for the partner. Please proceed at your own discretion."
+msgstr "Les candidatures pour %(object)s, si elles sont envoyées, dépasseront le total des comptes disponibles pour le partenaire. Veuillez procéder selon votre appréciation."
 
 #. Translators: When viewing the list of applications ready to be sent for a particular partner, this is instructions for the coordinator to click the 'mark as sent' button after they have sent the information.
 #: TWLight/applications/templates/applications/send_partner.html:65
 msgid "When you've processed the data below, click the 'mark as sent' button."
-msgstr ""
-"Lorsque vous avez traité les données ci-dessous, cliquez sur le bouton "
-"« Marquer comme envoyé »."
+msgstr "Lorsque vous avez traité les données ci-dessous, cliquez sur le bouton « Marquer comme envoyé »."
 
 #. Translators: When viewing the list of applications ready to be sent for a particular partner, this is the title of the section containing contact information for the people applications should be sent to.
 #: TWLight/applications/templates/applications/send_partner.html:71
@@ -840,12 +756,8 @@ msgstr[1] "Contacts"
 
 #. Translators: When viewing the list of applications ready to be sent for a particular partner, this message shows if there is no information about who the applications should be sent to. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/applications/templates/applications/send_partner.html:89
-msgid ""
-"Whoops, we don't have any listed contacts. Please notify Wikipedia Library "
-"administrators."
-msgstr ""
-"Malheureusement, nous n’avons aucun contact répertorié. Veuillez aviser les "
-"administrateurs de La Bibliothèque Wikipédia."
+msgid "Whoops, we don't have any listed contacts. Please notify Wikipedia Library administrators."
+msgstr "Malheureusement, nous n’avons aucun contact répertorié. Veuillez aviser les administrateurs de La Bibliothèque Wikipédia."
 
 #. Translators: When viewing the list of applications ready to be sent for a particular partner, this is the title of the section containing the information about those applications.
 #: TWLight/applications/templates/applications/send_partner.html:94
@@ -860,12 +772,8 @@ msgstr "Marquer comme envoyé"
 
 #. Translators: This text guides coordinators in using the code sending interface for approved applications.
 #: TWLight/applications/templates/applications/send_partner.html:152
-msgid ""
-"Use the dropdown menus to denote which editor will receive each code. Access "
-"codes will be sent to users automatically."
-msgstr ""
-"Utilisez les menus déroulants pour indiquer quel éditeur va recevoir chaque "
-"code. Les codes d’accès seront envoyés automatiquement aux utilisateurs."
+msgid "Use the dropdown menus to denote which editor will receive each code. Access codes will be sent to users automatically."
+msgstr "Utilisez les menus déroulants pour indiquer quel éditeur va recevoir chaque code. Les codes d’accès seront envoyés automatiquement aux utilisateurs."
 
 #. Translators: This labels a drop-down selection where staff can assign an access code to a user.
 #: TWLight/applications/templates/applications/send_partner.html:173
@@ -880,24 +788,14 @@ msgstr "Il n’y a aucune candidature approuvée mais pas encore envoyée."
 #. Translators: When a user applies for a set of resources, they receive this message if none are currently available. They are instead placed on a 'waitlist' for later approval.
 #. Translators: When a user renews their resource, they receive this message if none are currently available. They are instead placed on a 'waitlist' for later approval.
 #: TWLight/applications/views.py:140 TWLight/applications/views.py:1282
-msgid ""
-"This partner does not have any access grants available at this time. You may "
-"still apply for access; your application will be reviewed when access grants "
-"become available."
-msgstr ""
-"Il n’y a actuellement aucun compte disponible pour ce partenaire. Vous "
-"pouvez cependant postuler pour l’accès ; nous traiterons votre candidature "
-"lorsque les droits d’accès seront disponibles."
+msgid "This partner does not have any access grants available at this time. You may still apply for access; your application will be reviewed when access grants become available."
+msgstr "Il n’y a actuellement aucun compte disponible pour ce partenaire. Vous pouvez cependant postuler pour l’accès ; nous traiterons votre candidature lorsque les droits d’accès seront disponibles."
 
 #. Translators: This message is shown to users once they've successfully submitted their application for review.
 #: TWLight/applications/views.py:163
 #, python-brace-format
-msgid ""
-"Your application has been submitted for review. Head over to <a "
-"href='{applications_url}'>My Applications</a> to view the status."
-msgstr ""
-"Votre candidature a été soumise pour être prise en compte. Allez sur <a href="
-"\"{applications_url}\">Mes candidatures</a> pour en consulter l’état."
+msgid "Your application has been submitted for review. Head over to <a href='{applications_url}'>My Applications</a> to view the status."
+msgstr "Votre candidature a été soumise pour être prise en compte. Allez sur <a href=\"{applications_url}\">Mes candidatures</a> pour en consulter l’état."
 
 #. Translators: This text is displayed to users when the user has chosen to restrict data and is trying to apply for multiple partners
 #: TWLight/applications/views.py:276
@@ -945,22 +843,13 @@ msgstr "Candidatures envoyées"
 
 #. Translators: After a coordinator has changed the status of an application to APPROVED, if the corresponding partner/collection is waitlisted this message appears.
 #: TWLight/applications/views.py:756
-msgid ""
-"Cannot approve application as partner with proxy authorization method is "
-"waitlisted."
-msgstr ""
-"Impossible d’approuver la candidature car le partenaire avec méthode "
-"d’autorisation par mandataire est en liste d’attente."
+msgid "Cannot approve application as partner with proxy authorization method is waitlisted."
+msgstr "Impossible d’approuver la candidature car le partenaire avec méthode d’autorisation par mandataire est en liste d’attente."
 
 #. Translators: After a coordinator has changed the status of an application to APPROVED, if the corresponding partner/collection has no accounts for distribution, this message appears.
 #: TWLight/applications/views.py:780
-msgid ""
-"Cannot approve application as partner with proxy authorization method is "
-"waitlisted and (or) has zero accounts available for distribution."
-msgstr ""
-"Impossible d’approuver la candidature car le partenaire avec méthode "
-"d’autorisation par mandataire est en liste d’attente ou n’a aucun compte "
-"disponible à distribuer."
+msgid "Cannot approve application as partner with proxy authorization method is waitlisted and (or) has zero accounts available for distribution."
+msgstr "Impossible d’approuver la candidature car le partenaire avec méthode d’autorisation par mandataire est en liste d’attente ou n’a aucun compte disponible à distribuer."
 
 #. Translators: This message appears on an "access denied" screen that stops users who attempt to authorize an editor to access a resource during a time period for which they are already authorized.
 #: TWLight/applications/views.py:803
@@ -970,17 +859,8 @@ msgstr "Vous avez essayé de créer une autorisation en doublon."
 #. Translators: This message is shown to users when they access an application page of a now Bundle partner (new applications aren't allowed for Bundle partners and the status of old applications cannot be modified)
 #: TWLight/applications/views.py:857
 #, python-brace-format
-msgid ""
-"This application cannot be modified since this partner is now part of our <a "
-"href='{bundle}'>bundle access</a>. If you are eligible, you can access this "
-"resource from <a href='{library}'>your library</a>. <a "
-"href='{contact}'>Contact us</a> if you have any questions."
-msgstr ""
-"Cette candidature ne peut pas être modifiée car le partenaire fait "
-"maintenant partie de notre <a href=\"{bundle}\">accès groupé</a>. Si vous en "
-"avez le droit, vous pouvez accéder à cette ressource depuis <a href="
-"\"{library}\">Votre bibliothèque</a>. <a href=\"{contact}\">Contactez-nous</"
-"a> pour toute question."
+msgid "This application cannot be modified since this partner is now part of our <a href='{bundle}'>bundle access</a>. If you are eligible, you can access this resource from <a href='{library}'>your library</a>. <a href='{contact}'>Contact us</a> if you have any questions."
+msgstr "Cette candidature ne peut pas être modifiée car le partenaire fait maintenant partie de notre <a href=\"{bundle}\">accès groupé</a>. Si vous en avez le droit, vous pouvez accéder à cette ressource depuis <a href=\"{library}\">Votre bibliothèque</a>. <a href=\"{contact}\">Contactez-nous</a> pour toute question."
 
 #. Translators: this lets a reviewer set the status of a single application.
 #: TWLight/applications/views.py:873
@@ -989,12 +869,8 @@ msgstr "Définir l’état de la candidature"
 
 #. Translators: This warning is message is shown to applicants when the number of pending applications is greater than the number of accounts available.
 #: TWLight/applications/views.py:891
-msgid ""
-"There are more pending applications than available accounts. Your "
-"application might get waitlisted."
-msgstr ""
-"Il y a plus de candidatures en cours que de comptes disponibles. Il se peut "
-"que votre candidature soit placée en liste d’attente."
+msgid "There are more pending applications than available accounts. Your application might get waitlisted."
+msgstr "Il y a plus de candidatures en cours que de comptes disponibles. Il se peut que votre candidature soit placée en liste d’attente."
 
 #. Translators: this message is shown to coordinators who attempt to change an application's Status from INVALID to any other Status.
 #: TWLight/applications/views.py:904
@@ -1013,17 +889,8 @@ msgstr "Mise à jour par lot réussie des candidatures {}."
 
 #. Translators: After a coordinator has changed the status of a number of applications to APPROVED, if the corresponding partner(s) is/are waitlisted or has no accounts for distribution, this message appears.
 #: TWLight/applications/views.py:1051
-msgid ""
-"Cannot approve application(s) {} as partner(s) with proxy authorization "
-"method is/are waitlisted and (or) has/have not enough accounts available. If "
-"not enough accounts are available, prioritise the applications and then "
-"approve applications equal to the accounts available."
-msgstr ""
-"Impossible d’approuver la(les) candidature(s) {} car le(s) partenaire(s) "
-"avec méthode d’autorisation par mandataire est(sont) en liste d’attente ou "
-"n’a(ont) pas assez de comptes disponibles. Si insuffisamment de comptes sont "
-"disponibles, définissez  un ordre de priorité pour les candidatures et "
-"approuvez autant de candidatures que de comptes disponibles."
+msgid "Cannot approve application(s) {} as partner(s) with proxy authorization method is/are waitlisted and (or) has/have not enough accounts available. If not enough accounts are available, prioritise the applications and then approve applications equal to the accounts available."
+msgstr "Impossible d’approuver la(les) candidature(s) {} car le(s) partenaire(s) avec méthode d’autorisation par mandataire est(sont) en liste d’attente ou n’a(ont) pas assez de comptes disponibles. Si insuffisamment de comptes sont disponibles, définissez  un ordre de priorité pour les candidatures et approuvez autant de candidatures que de comptes disponibles."
 
 #. Translators: This message is shown to coordinators who attempt to assign the same access code to multiple users.
 #: TWLight/applications/views.py:1191
@@ -1037,39 +904,24 @@ msgstr "Toutes les candidatures sélectionnées ont été marquées comme envoy�
 
 #. Translators: When a user tries to renew their resource, they receive this message if the partner is not available.
 #: TWLight/applications/views.py:1272
-msgid ""
-"Cannot renew application at this time as partner is not available. Please "
-"check back later, or contact us for more information."
-msgstr ""
-"Impossible de renouveler la candidature pour le moment car le partenaire "
-"n’est pas disponible. Veuillez vérifier à nouveau plus tard, ou nous "
-"contacter pour plus d’informations."
+msgid "Cannot renew application at this time as partner is not available. Please check back later, or contact us for more information."
+msgstr "Impossible de renouveler la candidature pour le moment car le partenaire n’est pas disponible. Veuillez vérifier à nouveau plus tard, ou nous contacter pour plus d’informations."
 
 #. Translators: This message is displayed when an attempt by a user to renew an application has been denied for some reason.
 #: TWLight/applications/views.py:1308
 #, python-brace-format
 msgid "Attempt to renew unapproved application #{pk} has been denied"
-msgstr ""
-"La tentative de renouvellement de candidature non approuvée nº {pk} a été "
-"rejetée."
+msgstr "La tentative de renouvellement de candidature non approuvée nº {pk} a été rejetée."
 
 #. Translators: If a user requests the renewal of their account, but it wasn't renewed, this message is shown to them.
 #: TWLight/applications/views.py:1385
-msgid ""
-"This object cannot be renewed. (This probably means that you have already "
-"requested that it be renewed.)"
-msgstr ""
-"Cet objet ne peut pas être renouvelé (cela signifie probablement que vous "
-"avez déjà demandé son renouvellement)."
+msgid "This object cannot be renewed. (This probably means that you have already requested that it be renewed.)"
+msgstr "Cet objet ne peut pas être renouvelé (cela signifie probablement que vous avez déjà demandé son renouvellement)."
 
 #. Translators: If a user requests the renewal of their account, this message is shown to them.
 #: TWLight/applications/views.py:1395
-msgid ""
-"Your renewal request has been received. A coordinator will review your "
-"request."
-msgstr ""
-"Votre demande de renouvellement a été reçue. Un coordinateur examinera votre "
-"demande."
+msgid "Your renewal request has been received. A coordinator will review your request."
+msgstr "Votre demande de renouvellement a été reçue. Un coordinateur examinera votre demande."
 
 #. Translators: This labels a textfield where users can enter their email ID.
 #: TWLight/emails/forms.py:18
@@ -1078,12 +930,8 @@ msgstr "Votre adresse de courriel"
 
 #. Translators: This is the help text for the email field in the contact us form letting users know the field is updated by value pulled from their respective user profiles.
 #: TWLight/emails/forms.py:21
-msgid ""
-"This field is automatically updated with the email from your <a class='twl-"
-"links' href='{}'>user profile</a>."
-msgstr ""
-"Ce champ est automatiquement mis à jour avec l’adresse de courriel de votre "
-"<a class=\"twl-links\" href=\"{}\">profil utilisateur</a>."
+msgid "This field is automatically updated with the email from your <a class='twl-links' href='{}'>user profile</a>."
+msgstr "Ce champ est automatiquement mis à jour avec l’adresse de courriel de votre <a class=\"twl-links\" href=\"{}\">profil utilisateur</a>."
 
 #. Translators: This labels a textfield where users can enter their email message.
 #: TWLight/emails/forms.py:26
@@ -1106,26 +954,14 @@ msgstr "Soumettre"
 #. Translators: This email is sent to users with their access code. Don't translate Jinja variables in curly braces like user or partner. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/access_code_email-body-html.html:5
 #, python-format
-msgid ""
-"<p>Your approved application to %(partner)s has now been finalised. Your "
-"access code or login details can be found below:</p> <p><b>%(access_code)s</"
-"b></p> <p>%(user_instructions)s</p>"
-msgstr ""
-"<p>Votre candidature approuvée à %(partner)s a maintenant été finalisée. "
-"Votre code d’accès ou les détails de connexion peuvent être trouvés ci-"
-"dessous :</p><p><b>%(access_code)s</b></p><p>%(user_instructions)s</p>"
+msgid "<p>Your approved application to %(partner)s has now been finalised. Your access code or login details can be found below:</p> <p><b>%(access_code)s</b></p> <p>%(user_instructions)s</p>"
+msgstr "<p>Votre candidature approuvée à %(partner)s a maintenant été finalisée. Votre code d’accès ou les détails de connexion peuvent être trouvés ci-dessous :</p><p><b>%(access_code)s</b></p><p>%(user_instructions)s</p>"
 
 #. Translators: This email is sent to users with their access code. Don't translate Jinja variables in curly braces like user or partner. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/access_code_email-body-text.html:3
 #, python-format
-msgid ""
-"Your approved application to %(partner)s has now been finalised. Your access "
-"code or login details can be found below: %(access_code)s "
-"%(user_instructions)s"
-msgstr ""
-"Votre candidature approuvée à %(partner)s a maintenant été finalisée. Votre "
-"code d’accès ou vos détails de connexion peuvent être trouvés ci-dessous : "
-"%(access_code)s %(user_instructions)s"
+msgid "Your approved application to %(partner)s has now been finalised. Your access code or login details can be found below: %(access_code)s %(user_instructions)s"
+msgstr "Votre candidature approuvée à %(partner)s a maintenant été finalisée. Votre code d’accès ou vos détails de connexion peuvent être trouvés ci-dessous : %(access_code)s %(user_instructions)s"
 
 #. Translators: This is the subject line of an email sent to users with their access code.
 #: TWLight/emails/templates/emails/access_code_email-subject.html:3
@@ -1135,38 +971,14 @@ msgstr "Votre code d’accès à La Bibliothèque Wikipédia"
 #. Translators: This email is sent to users when their application is approved. Don't translate Jinja variables in curly braces like user or partner; don't translate html tags either. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/approval_notification-body-html.html:5
 #, python-format
-msgid ""
-"<p>Dear %(user)s,</p> <p>Thank you for applying for access to %(partner)s "
-"resources through The Wikipedia Library. We are happy to inform you that "
-"your application has been approved.</p> <p>%(user_instructions)s</p> <p>You "
-"can view the collections you're authorized to access at My Library: "
-"%(link)s</p> <p>Cheers!</p> <p>The Wikipedia Library</p>"
-msgstr ""
-"<p>Cher/chère %(user)s,</p><p>Merci pour votre candidature d’accès aux "
-"ressources de %(partner)s via La Bibliothèque Wikipédia. Nous sommes heureux "
-"de vous informer que votre candidature a été approuvée.</p><p>"
-"%(user_instructions)s</p><p>Vous pouvez voir les collections auxquelles vous "
-"avez accès dans Ma bibliothèque : %(link)s</p><p>Cordialement,</p><p>La "
-"Bibliothèque Wikipédia.</p>"
+msgid "<p>Dear %(user)s,</p> <p>Thank you for applying for access to %(partner)s resources through The Wikipedia Library. We are happy to inform you that your application has been approved.</p> <p>%(user_instructions)s</p> <p>You can view the collections you're authorized to access at My Library: %(link)s</p> <p>Cheers!</p> <p>The Wikipedia Library</p>"
+msgstr "<p>Cher/chère %(user)s,</p><p>Merci pour votre candidature d’accès aux ressources de %(partner)s via La Bibliothèque Wikipédia. Nous sommes heureux de vous informer que votre candidature a été approuvée.</p><p>%(user_instructions)s</p><p>Vous pouvez voir les collections auxquelles vous avez accès dans Ma bibliothèque : %(link)s</p><p>Cordialement,</p><p>La Bibliothèque Wikipédia.</p>"
 
 #. Translators: This email is sent to users when their application is approved. Don't translate Jinja variables in curly braces like user or partner. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/approval_notification-body-text.html:3
 #, python-format
-msgid ""
-"Dear %(user)s, Thank you for applying for access to %(partner)s resources "
-"through The Wikipedia Library. We are happy to inform you that your "
-"application has been approved. %(user_instructions)s You can view the "
-"collections you're authorized to access at My Library: %(link)s Cheers! The "
-"Wikipedia Library"
-msgstr ""
-"Cher/chère %(user)s,\n"
-"Merci pour votre candidature d’accès aux ressources de %(partner)s via La "
-"Bibliothèque Wikipédia. Nous sommes heureux de vous informer que votre "
-"candidature a été approuvée.\n"
-"%(user_instructions)s\n"
-"Vous pouvez voir les collections auxquelles vous avez accès dans Ma "
-"bibliothèque : %(link)s\n"
-"Cordialement, La Bibliothèque Wikipédia."
+msgid "Dear %(user)s, Thank you for applying for access to %(partner)s resources through The Wikipedia Library. We are happy to inform you that your application has been approved. %(user_instructions)s You can view the collections you're authorized to access at My Library: %(link)s Cheers! The Wikipedia Library"
+msgstr "Cher/chère %(user)s,\nMerci pour votre candidature d’accès aux ressources de %(partner)s via La Bibliothèque Wikipédia. Nous sommes heureux de vous informer que votre candidature a été approuvée.\n%(user_instructions)s\nVous pouvez voir les collections auxquelles vous avez accès dans Ma bibliothèque : %(link)s\nCordialement, La Bibliothèque Wikipédia."
 
 #. Translators: This is the subject of an email which is sent to users when their application has been approved. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/approval_notification-subject.html:4
@@ -1176,62 +988,31 @@ msgstr "Votre candidature à La Bibliothèque Wikipédia a été approuvée"
 #. Translators: This email is sent to coordinators when a comment is left on an application they are processing. Don't translate Jinja variables in curly braces like user or partner. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/comment_notification_coordinator-body-html.html:5
 #, python-format
-msgid ""
-"<p style=\"color: #500050\">%(submit_date)s - %(commenter)s</p> "
-"<blockquote><p>%(comment)s</p></blockquote> <p>Please reply to these at: <a "
-"href=\"%(app_url)s\">%(app_url)s</a></p> <p>Best,</p> <p>The Wikipedia "
-"Library</p>"
-msgstr ""
-"<p style=\"color:#500050\">%(submit_date)s – %(commenter)s</p><blockquote><p>"
-"%(comment)s</p></blockquote> <p>Veuillez répondre à ceci sur : <a href="
-"\"%(app_url)s\">%(app_url)s</a></p><p>Cordialement,</p><p>La Bibliothèque "
-"Wikipédia.</p>"
+msgid "<p style=\"color: #500050\">%(submit_date)s - %(commenter)s</p> <blockquote><p>%(comment)s</p></blockquote> <p>Please reply to these at: <a href=\"%(app_url)s\">%(app_url)s</a></p> <p>Best,</p> <p>The Wikipedia Library</p>"
+msgstr "<p style=\"color:#500050\">%(submit_date)s – %(commenter)s</p><blockquote><p>%(comment)s</p></blockquote> <p>Veuillez répondre à ceci sur : <a href=\"%(app_url)s\">%(app_url)s</a></p><p>Cordialement,</p><p>La Bibliothèque Wikipédia.</p>"
 
 #. Translators: This email is sent to coordinators when a comment is left on an application they are processing. Don't translate Jinja variables in curly braces like user or partner. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/comment_notification_coordinator-body-text.html:3
 #, python-format
-msgid ""
-"%(submit_date)s - %(commenter)s %(comment)s Please reply to this at: "
-"%(app_url)s Best, The Wikipedia Library"
-msgstr ""
-"%(submit_date)s – %(commenter)s\n"
-"%(comment)s\n"
-"Veuillez répondre à ceci sur : %(app_url)s\n"
-"Cordialement, La Bibliothèque Wikipédia."
+msgid "%(submit_date)s - %(commenter)s %(comment)s Please reply to this at: %(app_url)s Best, The Wikipedia Library"
+msgstr "%(submit_date)s – %(commenter)s\n%(comment)s\nVeuillez répondre à ceci sur : %(app_url)s\nCordialement, La Bibliothèque Wikipédia."
 
 #. Translators: This is the subject line of an email sent to coordinators when a comment is left on an application they processed.
 #: TWLight/emails/templates/emails/comment_notification_coordinator-subject.html:3
 msgid "New comment on a Wikipedia Library application you processed"
-msgstr ""
-"Nouveau commentaire sur une candidature que vous avez traitée concernant La "
-"Bibliothèque Wikipédia"
+msgstr "Nouveau commentaire sur une candidature que vous avez traitée concernant La Bibliothèque Wikipédia"
 
 #. Translators: This email is sent to users when they receive a comment on their application. Don't translate Jinja variables in curly braces like user or partner; don't translate html tags either. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/comment_notification_editors-body-html.html:5
 #, python-format
-msgid ""
-"<p style=\"color: #500050\">%(submit_date)s - %(commenter)s</p> "
-"<blockquote><p>%(comment)s</p></blockquote> <p>Please reply to these at <a "
-"href=\"%(app_url)s\">%(app_url)s</a> so we can evaluate your application.</"
-"p> <p>Best,</p> <p>The Wikipedia Library</p>"
-msgstr ""
-"<p style=\"color:#500050\">%(submit_date)s – %(commenter)s</p><blockquote><p>"
-"%(comment)s</p></blockquote> <p>Veuillez répondre à ceux-ci sur <a href="
-"\"%(app_url)s\">%(app_url)s</a> afin que nous puissions évaluer votre "
-"candidature.</p><p>Cordialement,</p><p>La Bibliothèque Wikipédia.</p>"
+msgid "<p style=\"color: #500050\">%(submit_date)s - %(commenter)s</p> <blockquote><p>%(comment)s</p></blockquote> <p>Please reply to these at <a href=\"%(app_url)s\">%(app_url)s</a> so we can evaluate your application.</p> <p>Best,</p> <p>The Wikipedia Library</p>"
+msgstr "<p style=\"color:#500050\">%(submit_date)s – %(commenter)s</p><blockquote><p>%(comment)s</p></blockquote> <p>Veuillez répondre à ceux-ci sur <a href=\"%(app_url)s\">%(app_url)s</a> afin que nous puissions évaluer votre candidature.</p><p>Cordialement,</p><p>La Bibliothèque Wikipédia.</p>"
 
 #. Translators: This email is sent to users when they receive a comment on their application. Don't translate Jinja variables in curly braces like user or partner. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/comment_notification_editors-body-text.html:3
 #, python-format
-msgid ""
-"%(submit_date)s - %(commenter)s %(comment)s Please reply to these at: "
-"%(app_url)s so we can evaluate your application. Best, The Wikipedia Library"
-msgstr ""
-"%(submit_date)s – %(commenter)s\n"
-"%(comment)s\n"
-"Veuillez répondre à ceci sur : %(app_url)s afin que nous puissions évaluer "
-"votre candidature.\n"
-"Cordialement, La Bibliothèque Wikipédia."
+msgid "%(submit_date)s - %(commenter)s %(comment)s Please reply to these at: %(app_url)s so we can evaluate your application. Best, The Wikipedia Library"
+msgstr "%(submit_date)s – %(commenter)s\n%(comment)s\nVeuillez répondre à ceci sur : %(app_url)s afin que nous puissions évaluer votre candidature.\nCordialement, La Bibliothèque Wikipédia."
 
 #. Translators: This is the subject line of an email sent to users who have a comment added to one of their applications. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/comment_notification_editors-subject.html:3
@@ -1241,46 +1022,25 @@ msgstr "Nouveau commentaire sur votre candidature à La Bibliothèque Wikipédia
 #. Translators: This email is sent to users when an application they commented on receives another comment. Don't translate Jinja variables in curly braces like app_url; don't translate html tags either. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/comment_notification_others-body-html.html:5
 #, python-format
-msgid ""
-"<p style=\"color: #500050\">%(submit_date)s - %(commenter)s</p> "
-"<blockquote><p>%(comment)s</p></blockquote> See it at <a href=\"%(app_url)s"
-"\">%(app_url)s</a>. Thanks for helping review Wikipedia Library applications!"
-msgstr ""
-"<p style=\"color:#500050\">%(submit_date)s – %(commenter)s</p><blockquote><p>"
-"%(comment)s</p></blockquote> Voyez-le sur <a href=\"%(app_url)s\">"
-"%(app_url)s</a>.\n"
-"Merci d’aider à vérifier les candidatures à La Bibliothèque Wikipédia !"
+msgid "<p style=\"color: #500050\">%(submit_date)s - %(commenter)s</p> <blockquote><p>%(comment)s</p></blockquote> See it at <a href=\"%(app_url)s\">%(app_url)s</a>. Thanks for helping review Wikipedia Library applications!"
+msgstr "<p style=\"color:#500050\">%(submit_date)s – %(commenter)s</p><blockquote><p>%(comment)s</p></blockquote> Voyez-le sur <a href=\"%(app_url)s\">%(app_url)s</a>.\nMerci d’aider à vérifier les candidatures à La Bibliothèque Wikipédia !"
 
 #. Translators: This email is sent to users when an application they commented on receives another comment. Don't translate Jinja variables in curly braces like app_url. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/comment_notification_others-body-text.html:3
 #, python-format
-msgid ""
-"%(submit_date)s - %(commenter)s %(comment)s See it at: %(app_url)s Thanks "
-"for helping review Wikipedia Library applications!"
-msgstr ""
-"%(submit_date)s – %(commenter)s\n"
-"%(comment)s\n"
-"Voyez-le sur : %(app_url)s\n"
-"Merci d’aider à vérifier les candidatures à La Bibliothèque Wikipédia !"
+msgid "%(submit_date)s - %(commenter)s %(comment)s See it at: %(app_url)s Thanks for helping review Wikipedia Library applications!"
+msgstr "%(submit_date)s – %(commenter)s\n%(comment)s\nVoyez-le sur : %(app_url)s\nMerci d’aider à vérifier les candidatures à La Bibliothèque Wikipédia !"
 
 #. Translators: This is the subject line of an email sent to users who have a comment added to an application they also commented on. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/comment_notification_others-subject.html:4
 msgid "New comment on a Wikipedia Library application you commented on"
-msgstr ""
-"Nouveau commentaire sur une candidature à la Bibliothèque Wikipédia que vous "
-"avez commentée"
+msgstr "Nouveau commentaire sur une candidature à la Bibliothèque Wikipédia que vous avez commentée"
 
 #. Translators: This text is part of a scheduled reminder email sent to coordinators who have applications requiring action. Don't translate Jinja variables in curly braces like total_apps, or user.
 #: TWLight/emails/templates/emails/coordinator_reminder_notification-body-html.html:5
 #, python-format
-msgid ""
-"<p>Dear %(user)s,</p> <p>Our records indicate that you are the designated "
-"coordinator for partners that have a total of %(total_apps)s applications.</"
-"p>"
-msgstr ""
-"<p>Cher/chère %(user)s,</p><p>Nos enregistrements indiquent que vous êtes le "
-"coordinateur désigné ou la coordinatrice désignée pour des partenaires qui "
-"ont un total de %(total_apps)s candidatures.</p>"
+msgid "<p>Dear %(user)s,</p> <p>Our records indicate that you are the designated coordinator for partners that have a total of %(total_apps)s applications.</p>"
+msgstr "<p>Cher/chère %(user)s,</p><p>Nos enregistrements indiquent que vous êtes le coordinateur désigné ou la coordinatrice désignée pour des partenaires qui ont un total de %(total_apps)s candidatures.</p>"
 
 #. Translators: Breakdown as in 'cost breakdown'; analysis.
 #: TWLight/emails/templates/emails/coordinator_reminder_notification-body-html.html:11
@@ -1318,86 +1078,37 @@ msgstr[1] "%(counter)s candidatures approuvées."
 #. Translators: This text is part of a scheduled reminder email sent to coordinators who have applications requiring action. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library). Don't translate Jinja variables in curly braces like link; don't translate email addresses or html tags either.
 #: TWLight/emails/templates/emails/coordinator_reminder_notification-body-html.html:39
 #, python-format
-msgid ""
-"<p>This is a gentle reminder that you may review applications at <a href="
-"\"%(link)s\">%(link)s</a>.</p> <p>You can customise your reminders under "
-"'preferences' in your user profile.</p> <p>If you received this message in "
-"error, drop us a line at wikipedialibrary@wikimedia.org.</p> <p>Thanks for "
-"helping review Wikipedia Library applications!</p>"
-msgstr ""
-"<p>Ceci est un petit rappel que vous pouvez examiner les candidatures "
-"d’accès sur <a href=\"%(link)s\">%(link)s</a>.</p><p>Vous pouvez "
-"personnaliser vos rappels sous « préférences » dans votre profil utilisateur."
-"</p><p>Si vous avez reçu ce message par erreur, envoyez-nous un petit mot à "
-"wikipedialibrary@wikimedia.org.</p><p>Merci pour votre aide dans l’examen "
-"des candidatures d’accès à La Bibliothèque Wikipédia !</p>"
+msgid "<p>This is a gentle reminder that you may review applications at <a href=\"%(link)s\">%(link)s</a>.</p> <p>You can customise your reminders under 'preferences' in your user profile.</p> <p>If you received this message in error, drop us a line at wikipedialibrary@wikimedia.org.</p> <p>Thanks for helping review Wikipedia Library applications!</p>"
+msgstr "<p>Ceci est un petit rappel que vous pouvez examiner les candidatures d’accès sur <a href=\"%(link)s\">%(link)s</a>.</p><p>Vous pouvez personnaliser vos rappels sous « préférences » dans votre profil utilisateur.</p><p>Si vous avez reçu ce message par erreur, envoyez-nous un petit mot à wikipedialibrary@wikimedia.org.</p><p>Merci pour votre aide dans l’examen des candidatures d’accès à La Bibliothèque Wikipédia !</p>"
 
 #. Translators: This text is part of a scheduled reminder email sent to coordinators who have applications requiring action. Don't translate Jinja variables in curly braces like total_apps, or user.
 #: TWLight/emails/templates/emails/coordinator_reminder_notification-body-text.html:3
 #, python-format
-msgid ""
-"Dear %(user)s, Our records indicate that you are the designated coordinator "
-"for partners that have a total of %(total_apps)s applications."
-msgstr ""
-"<p>Cher/chère %(user)s,</p><p>Nos enregistrements indiquent que vous êtes le "
-"coordinateur désigné ou la coordinatrice désignée pour les partenaires qui "
-"ont un total de %(total_apps)s candidatures.</p>"
+msgid "Dear %(user)s, Our records indicate that you are the designated coordinator for partners that have a total of %(total_apps)s applications."
+msgstr "<p>Cher/chère %(user)s,</p><p>Nos enregistrements indiquent que vous êtes le coordinateur désigné ou la coordinatrice désignée pour les partenaires qui ont un total de %(total_apps)s candidatures.</p>"
 
 #. Translators: This text is part of a scheduled reminder email sent to coordinators who have applications requiring action. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library). Don't translate Jinja variables in curly braces like link; don't translate the email address either.
 #: TWLight/emails/templates/emails/coordinator_reminder_notification-body-text.html:38
 #, python-format
-msgid ""
-"This is a gentle reminder that you may review applications at: %(link)s. You "
-"can customise your reminders under 'preferences' in your user profile. If "
-"you received this message in error, drop us a line at: "
-"wikipedialibrary@wikimedia.org Thanks for helping review Wikipedia Library "
-"applications!"
-msgstr ""
-"Ceci est un petit rappel que vous pouvez examiner les candidatures  d’accès "
-"à %(link)s. Vous pouvez personnaliser vos rappels sous « préférences » dans "
-"votre profil utilisateur. Si vous avez reçu ce message par erreur, envoyez-"
-"nous un petit mot wikipedialibrary@wikimedia.org.\n"
-"Merci pour votre aide dans l’examen des candidatures d’accès à La "
-"Bibliothèque Wikipédia !"
+msgid "This is a gentle reminder that you may review applications at: %(link)s. You can customise your reminders under 'preferences' in your user profile. If you received this message in error, drop us a line at: wikipedialibrary@wikimedia.org Thanks for helping review Wikipedia Library applications!"
+msgstr "Ceci est un petit rappel que vous pouvez examiner les candidatures  d’accès à %(link)s. Vous pouvez personnaliser vos rappels sous « préférences » dans votre profil utilisateur. Si vous avez reçu ce message par erreur, envoyez-nous un petit mot wikipedialibrary@wikimedia.org.\nMerci pour votre aide dans l’examen des candidatures d’accès à La Bibliothèque Wikipédia !"
 
 #. Translators: This is the subject line of a scheduled reminder email sent to coordinators who have applications to review. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library). Do not translate items in curly braces.
 #: TWLight/emails/templates/emails/coordinator_reminder_notification-subject.html:4
 msgid "Wikipedia Library applications await your review"
-msgstr ""
-"Des candidatures pour La Bibliothèque Wikipédia sont en attente de votre "
-"examen"
+msgstr "Des candidatures pour La Bibliothèque Wikipédia sont en attente de votre examen"
 
 #. Translators: This email is sent to users when their application is rejected. Don't translate Jinja variables in curly braces like user or partner; don't translate html tags either. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/rejection_notification-body-html.html:5
 #, python-format
-msgid ""
-"<p>Dear %(user)s,</p> <p>Thank you for applying for access to %(partner)s "
-"resources through The Wikipedia Library. Unfortunately at this time your "
-"application has not been approved. You can view your application and review "
-"comments at <a href=\"%(app_url)s\">%(app_url)s</a>.</p> <p>Best,</p> <p>The "
-"Wikipedia Library</p>"
-msgstr ""
-"<p>Cher/chère %(user)s,</p><p>Merci pour votre candidature pour l’accès aux "
-"ressources de %(partner)s via la Bibliothèque Wikipédia. Malheureusement, "
-"votre candidature n’a pas encore été approuvée. Vous pouvez consulter votre "
-"candidature et les commentaires de son examen sur <a href=\"%(app_url)s\">"
-"%(app_url)s</a>.</p><p>Cordialement,</p><p>La Bibliothèque Wikipédia.</p>"
+msgid "<p>Dear %(user)s,</p> <p>Thank you for applying for access to %(partner)s resources through The Wikipedia Library. Unfortunately at this time your application has not been approved. You can view your application and review comments at <a href=\"%(app_url)s\">%(app_url)s</a>.</p> <p>Best,</p> <p>The Wikipedia Library</p>"
+msgstr "<p>Cher/chère %(user)s,</p><p>Merci pour votre candidature pour l’accès aux ressources de %(partner)s via la Bibliothèque Wikipédia. Malheureusement, votre candidature n’a pas encore été approuvée. Vous pouvez consulter votre candidature et les commentaires de son examen sur <a href=\"%(app_url)s\">%(app_url)s</a>.</p><p>Cordialement,</p><p>La Bibliothèque Wikipédia.</p>"
 
 #. Translators: This email is sent to users when their application is rejected. Don't translate Jinja variables in curly braces like user or partner. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/rejection_notification-body-text.html:3
 #, python-format
-msgid ""
-"Dear %(user)s, Thank you for applying for access to %(partner)s resources "
-"through The Wikipedia Library. Unfortunately at this time your application "
-"has not been approved. You can view your application and review comments at: "
-"%(app_url)s Best, The Wikipedia Library"
-msgstr ""
-"Cher/chère %(user)s,\n"
-"Merci pour votre candidature pour l’accès aux ressources de %(partner)s via "
-"La Bibliothèque Wikipédia. Malheureusement, votre candidature n’a pas encore "
-"été approuvée. Vous pouvez voir votre candidature et les commentaires de son "
-"examen sur : %(app_url)s.\n"
-"Cordialement, La Bibliothèque Wikipédia."
+msgid "Dear %(user)s, Thank you for applying for access to %(partner)s resources through The Wikipedia Library. Unfortunately at this time your application has not been approved. You can view your application and review comments at: %(app_url)s Best, The Wikipedia Library"
+msgstr "Cher/chère %(user)s,\nMerci pour votre candidature pour l’accès aux ressources de %(partner)s via La Bibliothèque Wikipédia. Malheureusement, votre candidature n’a pas encore été approuvée. Vous pouvez voir votre candidature et les commentaires de son examen sur : %(app_url)s.\nCordialement, La Bibliothèque Wikipédia."
 
 #. Translators: This is the subject of an email which is sent to users when their application has been rejected. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/rejection_notification-subject.html:4
@@ -1407,42 +1118,14 @@ msgstr "Votre candidature pour La Bibliothèque Wikipédia"
 #. Translators: This email is sent to users when they have an account that is soon to expire. Don't translate Jinja variables in curly braces like partner_name or partner_link; don't translate html tags either. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/user_renewal_notice-body-html.html:5
 #, python-format
-msgid ""
-"<p>Dear %(user)s,</p> <p>According to our records, your access to "
-"%(partner_name)s will soon expire and you may lose access. If you want to "
-"continue making use of your free account, you can request renewal of your "
-"account by clicking the 'Renew' or 'Extend' button at %(partner_link)s.</p> "
-"<p>Best,</p> <p>The Wikipedia Library</p> <p>You can disable these emails in "
-"your user page preferences: https://wikipedialibrary.wmflabs.org/users/</p>"
-msgstr ""
-"<p>Cher/chère %(user)s,</p><p>Selon nos informations, votre accès à "
-"%(partner_name)s expirera bientôt et vous pourriez en perdre l’accès. Si "
-"vous voulez continuer à utiliser votre compte gratuit, vous pouvez en "
-"demander le renouvellement en cliquant sur le bouton « Renouveler » ou "
-"« Étendre » sur %(partner_link)s.</p><p>Sincères salutations,</p><p>La "
-"Bibliothèque Wikipédia.</p><p>Vous pouvez désactiver ces courriels dans "
-"votre page de préférences utilisateur : https://wikipedialibrary.wmflabs.org/"
-"users/</p>"
+msgid "<p>Dear %(user)s,</p> <p>According to our records, your access to %(partner_name)s will soon expire and you may lose access. If you want to continue making use of your free account, you can request renewal of your account by clicking the 'Renew' or 'Extend' button at %(partner_link)s.</p> <p>Best,</p> <p>The Wikipedia Library</p> <p>You can disable these emails in your user page preferences: https://wikipedialibrary.wmflabs.org/users/</p>"
+msgstr "<p>Cher/chère %(user)s,</p><p>Selon nos informations, votre accès à %(partner_name)s expirera bientôt et vous pourriez en perdre l’accès. Si vous voulez continuer à utiliser votre compte gratuit, vous pouvez en demander le renouvellement en cliquant sur le bouton « Renouveler » ou « Étendre » sur %(partner_link)s.</p><p>Sincères salutations,</p><p>La Bibliothèque Wikipédia.</p><p>Vous pouvez désactiver ces courriels dans votre page de préférences utilisateur : https://wikipedialibrary.wmflabs.org/users/</p>"
 
 #. Translators: This email is sent to users when they have an account that is soon to expire. Don't translate Jinja variables in curly braces like partner_name or partner_link; don't translate html tags either. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/user_renewal_notice-body-text.html:3
 #, python-format
-msgid ""
-"Dear %(user)s, According to our records, your access to %(partner_name)s "
-"will soon expire and you may lose access. If you want to continue making use "
-"of your free account, you can request renewal of your account by clicking "
-"the Renew button at %(partner_link)s. Best, The Wikipedia Library You can "
-"disable these emails in your user page preferences: https://wikipedialibrary."
-"wmflabs.org/users/"
-msgstr ""
-"Cher/chère %(user)s, \n"
-"Selon nos informations, votre accès à %(partner_name)s expirera bientôt et "
-"vous pourriez en perdre l’accès. Si vous voulez continuer à utiliser votre "
-"compte gratuit, vous pouvez demander son renouvellement en cliquant sur le "
-"bouton « Renouveler » sur %(partner_link)s.\n"
-"Cordialement, La Bibliothèque Wikipédia.\n"
-"Vous pouvez désactiver ces courriels dans votre page de préférences "
-"utilisateur : https://wikipedialibrary.wmflabs.org/users/"
+msgid "Dear %(user)s, According to our records, your access to %(partner_name)s will soon expire and you may lose access. If you want to continue making use of your free account, you can request renewal of your account by clicking the Renew button at %(partner_link)s. Best, The Wikipedia Library You can disable these emails in your user page preferences: https://wikipedialibrary.wmflabs.org/users/"
+msgstr "Cher/chère %(user)s, \nSelon nos informations, votre accès à %(partner_name)s expirera bientôt et vous pourriez en perdre l’accès. Si vous voulez continuer à utiliser votre compte gratuit, vous pouvez demander son renouvellement en cliquant sur le bouton « Renouveler » sur %(partner_link)s.\nCordialement, La Bibliothèque Wikipédia.\nVous pouvez désactiver ces courriels dans votre page de préférences utilisateur : https://wikipedialibrary.wmflabs.org/users/"
 
 #. Translators: This is the subject of an email sent to users when they have an account that is soon to expire. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/user_renewal_notice-subject.html:4
@@ -1452,39 +1135,14 @@ msgstr "Votre accès à la Bibliothèque Wikipédia va bientôt expirer"
 #. Translators: This email is sent to users when their application is waitlisted because there are no more accounts available. Don't translate Jinja variables in curly braces like user or partner; don't translate html tags either. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/waitlist_notification-body-html.html:5
 #, python-format
-msgid ""
-"<p>Dear %(user)s,</p> <p>Thank you for applying for access to %(partner)s "
-"resources through The Wikipedia Library. There are no accounts currently "
-"available so your application has been waitlisted. Your application will be "
-"evaluated if/when more accounts become available. You can see all available "
-"resources at <a href=\"%(link)s\">%(link)s</a>.</p> <p>Best,</p> <p>The "
-"Wikipedia Library</p>"
-msgstr ""
-"<p>Cher/chère %(user)s,</p><p>Merci pour votre candidature pour l’accès aux "
-"ressources de %(partner)s via La Bibliothèque Wikipédia. Il n’y a "
-"actuellement aucun compte disponible, votre demande a donc été mise en liste "
-"d’attente. Votre candidature sera évaluée lorsque,  le cas échéant, d’autres "
-"comptes deviendront disponibles. Vous pouvez voir toutes les ressources "
-"disponibles sur <a href=\"%(link)s\">%(link)s</a>.</p><p>Amicalement,</"
-"p><p>La Bibliothèque Wikipédia.</p>"
+msgid "<p>Dear %(user)s,</p> <p>Thank you for applying for access to %(partner)s resources through The Wikipedia Library. There are no accounts currently available so your application has been waitlisted. Your application will be evaluated if/when more accounts become available. You can see all available resources at <a href=\"%(link)s\">%(link)s</a>.</p> <p>Best,</p> <p>The Wikipedia Library</p>"
+msgstr "<p>Cher/chère %(user)s,</p><p>Merci pour votre candidature pour l’accès aux ressources de %(partner)s via La Bibliothèque Wikipédia. Il n’y a actuellement aucun compte disponible, votre demande a donc été mise en liste d’attente. Votre candidature sera évaluée lorsque,  le cas échéant, d’autres comptes deviendront disponibles. Vous pouvez voir toutes les ressources disponibles sur <a href=\"%(link)s\">%(link)s</a>.</p><p>Amicalement,</p><p>La Bibliothèque Wikipédia.</p>"
 
 #. Translators: This email is sent to users when their application is waitlisted because there are no more accounts available. Don't translate Jinja variables in curly braces like user or partner. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/waitlist_notification-body-text.html:3
 #, python-format
-msgid ""
-"Dear %(user)s, Thank you for applying for access to %(partner)s resources "
-"through The Wikipedia Library. There are no accounts currently available so "
-"your application has been waitlisted. Your application will be evaluated if/"
-"when more accounts become available. You can see all available resources at: "
-"%(link)s Best, The Wikipedia Library"
-msgstr ""
-"Cher/chère %(user)s,\n"
-"Merci pour votre candidature pour l’accès aux ressources de %(partner)s via "
-"La Bibliothèque Wikipédia. Il n’y a actuellement aucun compte disponible, "
-"votre demande a donc été mise en liste d’attente. Votre candidature sera "
-"évaluée lorsque, le cas échéant, d’autres comptes deviendront disponibles. "
-"Vous pouvez voir toutes les ressources disponibles sur : %(link)s\n"
-"Cordialement, La Bibliothèque Wikipédia."
+msgid "Dear %(user)s, Thank you for applying for access to %(partner)s resources through The Wikipedia Library. There are no accounts currently available so your application has been waitlisted. Your application will be evaluated if/when more accounts become available. You can see all available resources at: %(link)s Best, The Wikipedia Library"
+msgstr "Cher/chère %(user)s,\nMerci pour votre candidature pour l’accès aux ressources de %(partner)s via La Bibliothèque Wikipédia. Il n’y a actuellement aucun compte disponible, votre demande a donc été mise en liste d’attente. Votre candidature sera évaluée lorsque, le cas échéant, d’autres comptes deviendront disponibles. Vous pouvez voir toutes les ressources disponibles sur : %(link)s\nCordialement, La Bibliothèque Wikipédia."
 
 #. Translators: This is the subject of an email sent to users when their application is waitlisted because there are no more accounts available. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/waitlist_notification-subject.html:4
@@ -1645,22 +1303,15 @@ msgstr "Indisponible"
 #: TWLight/resources/templates/resources/filter_section.html:14
 #: TWLight/templates/about.html:12
 #: TWLight/users/templates/users/filter_section.html:13
-msgid ""
-"The Wikipedia Library allows active editors to access a wide range of "
-"collections of paywalled reliable sources for free!"
-msgstr ""
-"La Bibliothèque Wikipédia permet aux éditeurs actifs d’accéder gratuitement "
-"à une vaste collection de sources fiables payantes !"
+msgid "The Wikipedia Library allows active editors to access a wide range of collections of paywalled reliable sources for free!"
+msgstr "La Bibliothèque Wikipédia permet aux éditeurs actifs d’accéder gratuitement à une vaste collection de sources fiables payantes !"
 
 #. Translators: On the Browse Partners page (https://wikipedialibrary.wmflabs.org/partners/), this introduces users to The Wikipedia Library.
 #. Translators: On the MyLibrary page (https://wikipedialibrary.wmflabs.org/users/my_library), this introduces users to The Wikipedia Library.
 #: TWLight/resources/templates/resources/filter_section.html:17
 #: TWLight/users/templates/users/filter_section.html:15
-msgid ""
-"Start with the search bar at the top or browse publisher websites directly."
-msgstr ""
-"Commencez avec la barre de recherche en haut ou naviguez directement sur les "
-"sites web de l’éditeur."
+msgid "Start with the search bar at the top or browse publisher websites directly."
+msgstr "Commencez avec la barre de recherche en haut ou naviguez directement sur les sites web de l’éditeur."
 
 #. Translators: On the Browse Partners page (https://wikipedialibrary.wmflabs.org/partners/), this appears below introductory text and links to the 'About' page (https://wikipedialibrary.wmflabs.org/about/)
 #. Translators: On the MyLibrary page (https://wikipedialibrary.wmflabs.org/users/my_library), this appears below introductory text and links to the 'About' page (https://wikipedialibrary.wmflabs.org/about/)
@@ -1733,68 +1384,39 @@ msgstr "Retour aux partenaires"
 #. Translators: If we have no available accounts for a partner, the coordinator can change the application system to a waiting list.
 #: TWLight/resources/templates/resources/partner_detail.html:36
 #: TWLight/resources/templates/resources/partner_detail_apply.html:17
-msgid ""
-"There are no access grants available for this partner at this time. You can "
-"still apply for access; applications will be processed when access is "
-"available."
-msgstr ""
-"Il n’y a aucun accès disponible pour ce partenaire en ce moment. Vous pouvez "
-"quand même postuler pour l’accès ; les candidatures seront traitées lorsque "
-"des accès seront disponibles."
+msgid "There are no access grants available for this partner at this time. You can still apply for access; applications will be processed when access is available."
+msgstr "Il n’y a aucun accès disponible pour ce partenaire en ce moment. Vous pouvez quand même postuler pour l’accès ; les candidatures seront traitées lorsque des accès seront disponibles."
 
 #. Translators: This text links to the minimum user requirements and terms of use on the partner page.
 #: TWLight/resources/templates/resources/partner_detail.html:48
 #: TWLight/resources/templates/resources/partner_detail_apply.html:29
 #, python-format
-msgid ""
-"Before applying, please review the <strong><a class=\"twl-links\" href="
-"\"%(about)s#req\">minimum requirements</a></strong> for access and our "
-"<strong><a class=\"twl-links\" href=\"%(terms)s\">terms of use</a></strong>."
-msgstr ""
-"Avant de soumettre votre candidature, veuillez relire les <strong><a class="
-"\"twl-links\" href=\"%(about)s#req\">exigences minimales</a></strong> pour "
-"l’accès et nos <strong><a class=\"twl-links\" href=\"%(terms)s\">conditions "
-"d’utilisation</a></strong>."
+msgid "Before applying, please review the <strong><a class=\"twl-links\" href=\"%(about)s#req\">minimum requirements</a></strong> for access and our <strong><a class=\"twl-links\" href=\"%(terms)s\">terms of use</a></strong>."
+msgstr "Avant de soumettre votre candidature, veuillez relire les <strong><a class=\"twl-links\" href=\"%(about)s#req\">exigences minimales</a></strong> pour l’accès et nos <strong><a class=\"twl-links\" href=\"%(terms)s\">conditions d’utilisation</a></strong>."
 
 #. Translators: This text refers to the page containing the content a user is authorized to access.
 #: TWLight/resources/templates/resources/partner_detail.html:69
 #, python-format
-msgid ""
-"View the status of your access in <strong><a class=\"twl-links\" href="
-"\"%(library_url)s\">My Library</a></strong> page."
-msgstr ""
-"Afficher l’état de vos accès sur la page <strong><a class=\"twl-links\" href="
-"\"%(library_url)s\">Ma bibliothèque</a></strong>."
+msgid "View the status of your access in <strong><a class=\"twl-links\" href=\"%(library_url)s\">My Library</a></strong> page."
+msgstr "Afficher l’état de vos accès sur la page <strong><a class=\"twl-links\" href=\"%(library_url)s\">Ma bibliothèque</a></strong>."
 
 #. Translators: This message is shown when a user has open applications, linking to their respective applications page.
 #: TWLight/resources/templates/resources/partner_detail.html:78
 #, python-format
-msgid ""
-"View the status of your application(s) on your <strong><a class=\"twl-links"
-"\" href=\"%(applications_url)s\">My Applications</a></strong> page."
-msgstr ""
-"Voir l’état de vos candidatures sur la page <strong><a class=\"twl-links\" "
-"href=\"%(applications_url)s\">Mes candidatures</a></strong>."
+msgid "View the status of your application(s) on your <strong><a class=\"twl-links\" href=\"%(applications_url)s\">My Applications</a></strong> page."
+msgstr "Voir l’état de vos candidatures sur la page <strong><a class=\"twl-links\" href=\"%(applications_url)s\">Mes candidatures</a></strong>."
 
 #. Translators: This message is shown when a user has authorizations, linking to their respective collections page.
 #: TWLight/resources/templates/resources/partner_detail_apply.html:50
 #, python-format
-msgid ""
-"View the status of your access on your <strong><a href=\"%(library_url)s\" "
-"class=\"twl-links\">My Library</a></strong> page."
-msgstr ""
-"Afficher l’état de vos accès sur votre page <strong><a href=\"%(library_url)s"
-"\" class=\"twl-links\">Ma bibliothèque</a></strong>."
+msgid "View the status of your access on your <strong><a href=\"%(library_url)s\" class=\"twl-links\">My Library</a></strong> page."
+msgstr "Afficher l’état de vos accès sur votre page <strong><a href=\"%(library_url)s\" class=\"twl-links\">Ma bibliothèque</a></strong>."
 
 #. Translators: This message is shown when a user has open applications, linking to their respective applications page.
 #: TWLight/resources/templates/resources/partner_detail_apply.html:60
 #, python-format
-msgid ""
-"View the status of your application(s) on your <strong><a href="
-"\"%(applications_url)s\">My Applications</a></strong> page."
-msgstr ""
-"Voir l’état de vos candidatures sur la page <strong><a href="
-"\"%(applications_url)s\">Mes candidatures</a></strong>."
+msgid "View the status of your application(s) on your <strong><a href=\"%(applications_url)s\">My Applications</a></strong> page."
+msgstr "Voir l’état de vos candidatures sur la page <strong><a href=\"%(applications_url)s\">Mes candidatures</a></strong>."
 
 #. Translators: One the partner detail page, this text labels the button which coordinators can click to remove a partner from waitlisted status.
 #: TWLight/resources/templates/resources/partner_detail_apply.html:73
@@ -1809,8 +1431,7 @@ msgstr "Mettre en liste d’attente"
 #: TWLight/resources/templates/resources/partner_detail_apply.html:86
 #, python-format
 msgid "<strong>%(coordinator)s</strong> processes applications to %(partner)s."
-msgstr ""
-"<strong>%(coordinator)s</strong> traite les applications de %(partner)s."
+msgstr "<strong>%(coordinator)s</strong> traite les applications de %(partner)s."
 
 #. Translators: When a coordinator is assigned to a partner, their details are shown on the page. This text labels a link to their Talk page on Wikipedia, and should be translated to the text used for Talk pages in the language you are translating to.
 #: TWLight/resources/templates/resources/partner_detail_apply.html:95
@@ -1824,15 +1445,8 @@ msgstr "Page Special:EmailUser"
 
 #. Translators: If no account coordinator is assigned to a partner, the Wikipedia Library team will coordinate signups. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/resources/templates/resources/partner_detail_apply.html:112
-msgid ""
-"The Wikipedia Library team will process this application. Want to help? <a "
-"class=\"twl-links\" href=\"https://en.wikipedia.org/wiki/Wikipedia:"
-"The_Wikipedia_Library/Coordinators/Signup\">Sign up as a coordinator.</a>"
-msgstr ""
-"L’équipe de La Bibliothèque Wikipédia va traiter cette candidature. Voulez-"
-"vous l’aider ? <a class=\"twl-links\" href=\"https://en.wikipedia.org/wiki/"
-"Wikipedia:The_Wikipedia_Library/Coordinators/Signup\">Inscrivez-vous en tant "
-"que coordinateur.</a>"
+msgid "The Wikipedia Library team will process this application. Want to help? <a class=\"twl-links\" href=\"https://en.wikipedia.org/wiki/Wikipedia:The_Wikipedia_Library/Coordinators/Signup\">Sign up as a coordinator.</a>"
+msgstr "L’équipe de La Bibliothèque Wikipédia va traiter cette candidature. Voulez-vous l’aider ? <a class=\"twl-links\" href=\"https://en.wikipedia.org/wiki/Wikipedia:The_Wikipedia_Library/Coordinators/Signup\">Inscrivez-vous en tant que coordinateur.</a>"
 
 #. Translators: This text labels a button coordinators can click to view a list of users who have applied for access for a particular partner
 #: TWLight/resources/templates/resources/partner_detail_apply.html:121
@@ -1861,24 +1475,14 @@ msgstr "Accès au Bouquet de la bibliothèque"
 
 #. Translators: Text shown to authenticated, bundle eligible users when they visit a Bundle partner page.
 #: TWLight/resources/templates/resources/partner_detail_apply.html:138
-msgid ""
-"You are eligible to access Library Bundle partners. Click the button above "
-"to access the collection."
-msgstr ""
-"Vous avez accès aux partenaires du Bouquet de la bibliothèque. Cliquez sur "
-"le bouton ci-dessus pour accéder aux collections."
+msgid "You are eligible to access Library Bundle partners. Click the button above to access the collection."
+msgstr "Vous avez accès aux partenaires du Bouquet de la bibliothèque. Cliquez sur le bouton ci-dessus pour accéder aux collections."
 
 #. Translators: Text shown to authenticated, bundle ineligible users when they visit a Bundle partner page.
 #: TWLight/resources/templates/resources/partner_detail_apply.html:152
 #, python-format
-msgid ""
-"You are not eligible to access Library Bundle partners. Visit the <a class="
-"\"twl-links\" href=\"%(homepage)s\">homepage</a> to check the eligibility "
-"criteria."
-msgstr ""
-"Vous ne répondez aux critères pour accéder aux partenaires du Bouquet de la "
-"bibliothèque. Visitez la <a class=\"twl-links\" href=\"%(homepage)s\">page "
-"d’accueil</a> pour consulter les critères d’admissibilité."
+msgid "You are not eligible to access Library Bundle partners. Visit the <a class=\"twl-links\" href=\"%(homepage)s\">homepage</a> to check the eligibility criteria."
+msgstr "Vous ne répondez aux critères pour accéder aux partenaires du Bouquet de la bibliothèque. Visitez la <a class=\"twl-links\" href=\"%(homepage)s\">page d’accueil</a> pour consulter les critères d’admissibilité."
 
 #. Translators: Buttton prompting users to log in.
 #: TWLight/resources/templates/resources/partner_detail_apply.html:160
@@ -1889,15 +1493,8 @@ msgstr "Se connecter"
 #. Translators: Text shown to unauthenticated users when they visit a Bundle partner page.
 #: TWLight/resources/templates/resources/partner_detail_apply.html:168
 #, python-format
-msgid ""
-"This resource is part of our <a class=\"twl-links\" href=\"%(about)s"
-"\">Library Bundle</a>, which you can access if you meet our minimum "
-"eligibility criteria. Log in to find out if you are eligible."
-msgstr ""
-"Cette ressource fait partie de notre accès au <a class=\"twl-links\" href="
-"\"%(about)s\">Bouquet de la bibliothèque</a>, auquel vous pouvez accéder si "
-"vous répondez aux critères. Connectez-vous pour vérifier si vous y avez "
-"accès."
+msgid "This resource is part of our <a class=\"twl-links\" href=\"%(about)s\">Library Bundle</a>, which you can access if you meet our minimum eligibility criteria. Log in to find out if you are eligible."
+msgstr "Cette ressource fait partie de notre accès au <a class=\"twl-links\" href=\"%(about)s\">Bouquet de la bibliothèque</a>, auquel vous pouvez accéder si vous répondez aux critères. Connectez-vous pour vérifier si vous y avez accès."
 
 #. Translators: This is the label for a number which shows the total active accounts for one partner. (e.g. https://wikipedialibrary.wmflabs.org/partners/8/).
 #: TWLight/resources/templates/resources/partner_detail_stats.html:21
@@ -1947,34 +1544,20 @@ msgstr "Limite des extraits"
 #. Translators: If a partner has specified the excerpt limit both in words and percentage, this message will display the percentage of words and the number of words on the partner page.
 #: TWLight/resources/templates/resources/partner_detail_timeline.html:99
 #, python-format
-msgid ""
-"%(object)s allows a maximum of %(excerpt_limit)s words or "
-"%(excerpt_limit_percentage)s%% of an article be excerpted into a Wikipedia "
-"article."
-msgstr ""
-"%(object)s permet qu’un maximum de %(excerpt_limit)s mots ou "
-"%(excerpt_limit_percentage)s %% d’un article soient extraits dans un article "
-"de Wikipédia."
+msgid "%(object)s allows a maximum of %(excerpt_limit)s words or %(excerpt_limit_percentage)s%% of an article be excerpted into a Wikipedia article."
+msgstr "%(object)s permet qu’un maximum de %(excerpt_limit)s mots ou %(excerpt_limit_percentage)s %% d’un article soient extraits dans un article de Wikipédia."
 
 #. Translators: If a partner has specified the excerpt limit in words, this message will display the number of words on the partner page.
 #: TWLight/resources/templates/resources/partner_detail_timeline.html:106
 #, python-format
-msgid ""
-"%(object)s allows a maximum of %(excerpt_limit)s words be excerpted into a "
-"Wikipedia article."
-msgstr ""
-"%(object)s permet qu’un maximum de %(excerpt_limit)s mots soient extraits "
-"dans un article Wikipédia."
+msgid "%(object)s allows a maximum of %(excerpt_limit)s words be excerpted into a Wikipedia article."
+msgstr "%(object)s permet qu’un maximum de %(excerpt_limit)s mots soient extraits dans un article Wikipédia."
 
 #. Translators: If a partner has specified the excerpt limit in percentage, this message will display the percentage of words on the partner page.
 #: TWLight/resources/templates/resources/partner_detail_timeline.html:113
 #, python-format
-msgid ""
-"%(object)s allows a maximum of %(excerpt_limit_percentage)s%% of an article "
-"be excerpted into a Wikipedia article."
-msgstr ""
-"%(object)s autorise qu’au plus %(excerpt_limit_percentage)s %% d’un article "
-"soit extrait vers un article de Wikipédia."
+msgid "%(object)s allows a maximum of %(excerpt_limit_percentage)s%% of an article be excerpted into a Wikipedia article."
+msgstr "%(object)s autorise qu’au plus %(excerpt_limit_percentage)s %% d’un article soit extrait vers un article de Wikipédia."
 
 #. Translators: If a partner has other requirements for access, this text shows as the title for that information field. (e.g. https://wikipedialibrary.wmflabs.org/partners/10/).
 #: TWLight/resources/templates/resources/partner_detail_timeline.html:132
@@ -1984,12 +1567,8 @@ msgstr "Exigences particulières pour les candidats"
 #. Translators: If a user must agree to a Terms of Use document, they see this message, and must enter the name of the resource. Don't translate publisher or url.
 #: TWLight/resources/templates/resources/partner_detail_timeline.html:140
 #, python-format
-msgid ""
-"%(publisher)s requires that you agree with its <a href=\"%(url)s\">terms of "
-"use</a>."
-msgstr ""
-"%(publisher)s exige que vous acceptiez ses <a href=\"%(url)s\">conditions "
-"d’utilisation</a>."
+msgid "%(publisher)s requires that you agree with its <a href=\"%(url)s\">terms of use</a>."
+msgstr "%(publisher)s exige que vous acceptiez ses <a href=\"%(url)s\">conditions d’utilisation</a>."
 
 #. Translators: If a user must provide their real name to apply to a partner, they see this message, and must enter the name of the resource. Don't translate publisher.
 #: TWLight/resources/templates/resources/partner_detail_timeline.html:150
@@ -2007,28 +1586,19 @@ msgstr "%(publisher)s exige que vous spécifiez votre pays de résidence."
 #: TWLight/resources/templates/resources/partner_detail_timeline.html:168
 #, python-format
 msgid "%(publisher)s requires that you provide your institutional affiliation."
-msgstr ""
-"%(publisher)s exige que vous fournissiez votre affiliation institutionnelle."
+msgstr "%(publisher)s exige que vous fournissiez votre affiliation institutionnelle."
 
 #. Translators: If a user must select a specific resource to apply for, they see this message, and must enter the name of the resource. Don't translate publisher.
 #: TWLight/resources/templates/resources/partner_detail_timeline.html:177
 #, python-format
-msgid ""
-"%(publisher)s requires that you specify a particular title that you want to "
-"access."
-msgstr ""
-"%(publisher)s exige que vous spécifiez un titre particulier auquel vous "
-"souhaitez accéder."
+msgid "%(publisher)s requires that you specify a particular title that you want to access."
+msgstr "%(publisher)s exige que vous spécifiez un titre particulier auquel vous souhaitez accéder."
 
 #. Translators: If a user must register on the partner website before applying, they see this message. Don't translate partner.
 #: TWLight/resources/templates/resources/partner_detail_timeline.html:187
 #, python-format
-msgid ""
-"%(publisher)s requires that you sign up for an account before applying for "
-"access."
-msgstr ""
-"%(publisher)s exige que vous vous inscriviez avec un compte avant de "
-"postuler pour l’accès."
+msgid "%(publisher)s requires that you sign up for an account before applying for access."
+msgstr "%(publisher)s exige que vous vous inscriviez avec un compte avant de postuler pour l’accès."
 
 #. Translators: If a partner has their location listed, this message is a label for that location
 #: TWLight/resources/templates/resources/partner_detail_timeline.html:206
@@ -2154,18 +1724,13 @@ msgstr "Êtes-vous sûr de vouloir supprimer <b>%(object)s</b> ?"
 
 #. Translators: If multiple authorizations where returned for a collection, this message is shown to a user
 #: TWLight/resources/views.py:268
-msgid ""
-"Multiple authorizations were returned – something's wrong. Please contact us "
-"and don't forget to mention this message."
-msgstr ""
-"Plusieurs autorisations ont été renvoyées : quelque chose ne fonctionne pas. "
-"Veuillez nous contacter sans omettre ce message."
+msgid "Multiple authorizations were returned – something's wrong. Please contact us and don't forget to mention this message."
+msgstr "Plusieurs autorisations ont été renvoyées : quelque chose ne fonctionne pas. Veuillez nous contacter sans omettre ce message."
 
 #. Translators: This message is shown when user tries to access a NOT_AVAILABLE Partner
 #: TWLight/resources/views.py:316
 msgid "This partner is currently not open for applications"
-msgstr ""
-"Ce partenaire n’est pour le moment pas disponible pour les candidatures"
+msgstr "Ce partenaire n’est pour le moment pas disponible pour les candidatures"
 
 #. Translators: When an account coordinator changes a partner from being open to applications to having a 'waitlist', they are shown this message.
 #: TWLight/resources/views.py:408
@@ -2200,22 +1765,8 @@ msgstr "Désolé ; nous ne savons pas quoi faire de cela."
 #. Translators: Shown on the website's 400 page, when a user sends a bad request. Don't translate path or Phabricator.
 #: TWLight/templates/400.html:20
 #, python-format
-msgid ""
-"If you think we should know what to do with that, please email us about this "
-"error at <a class=\"twl-links\" href=\"mailto:wikipedialibrary@wikimedia.org?"
-"Subject=Wikipedia%%20Library%%20%(path)s%%20Permission%%20denied"
-"\">wikipedialibrary@wikimedia.org</a> or report it to us on <a class=\"twl-"
-"links\" href=\"https://phabricator.wikimedia.org/maniphest/task/edit/form/1/?"
-"projectPHIDs=Library-Card-Platform&title=Wikipedia%%20Library%%20%(path)s"
-"%%20Bad%%20Request\">Phabricator</a>"
-msgstr ""
-"Si vous pensez que votre compte devrait pouvoir le faire, veuillez nous "
-"contacter à <a class=\"twl-links\" href=\"mailto:wikipedialibrary@wikimedia."
-"org?Subject=Wikipedia%%20Library%%20%(path)s%%20Permission%%20denied"
-"\">wikipedialibrary@wikimedia.org</a> ou nous le signaler sur <a class=\"twl-"
-"links\" href=\"https://phabricator.wikimedia.org/maniphest/task/edit/form/1/?"
-"projectPHIDs=Library-Card-Platform&title=Wikipedia%%20Library%%20%(path)s"
-"%%20Permission%%20denied\">Phabricator</a>"
+msgid "If you think we should know what to do with that, please email us about this error at <a class=\"twl-links\" href=\"mailto:wikipedialibrary@wikimedia.org?Subject=Wikipedia%%20Library%%20%(path)s%%20Permission%%20denied\">wikipedialibrary@wikimedia.org</a> or report it to us on <a class=\"twl-links\" href=\"https://phabricator.wikimedia.org/maniphest/task/edit/form/1/?projectPHIDs=Library-Card-Platform&title=Wikipedia%%20Library%%20%(path)s%%20Bad%%20Request\">Phabricator</a>"
+msgstr "Si vous pensez que votre compte devrait pouvoir le faire, veuillez nous contacter à <a class=\"twl-links\" href=\"mailto:wikipedialibrary@wikimedia.org?Subject=Wikipedia%%20Library%%20%(path)s%%20Permission%%20denied\">wikipedialibrary@wikimedia.org</a> ou nous le signaler sur <a class=\"twl-links\" href=\"https://phabricator.wikimedia.org/maniphest/task/edit/form/1/?projectPHIDs=Library-Card-Platform&title=Wikipedia%%20Library%%20%(path)s%%20Permission%%20denied\">Phabricator</a>"
 
 #. Translators: Alt text for an image shown on the 400 error page.
 #. Translators: Alt text for an image shown on the 403 error page.
@@ -2236,23 +1787,8 @@ msgstr "Désolé, vous n’êtes pas autorisé à faire cela."
 #. Translators: Shown on the website's 403 page, when a user attempts to navigate to a page they don't have permission to view. Don't translate path or Phabricator.
 #: TWLight/templates/403.html:20
 #, python-format
-msgid ""
-"If you think your account should be able to do that, please email us about "
-"this error at <a class=\"twl-links\" href=\"mailto:"
-"wikipedialibrary@wikimedia.org?Subject=Wikipedia%%20Library%%20%(path)s"
-"%%20Permission%%20denied\">wikipedialibrary@wikimedia.org</a> or report it "
-"to us on <a class=\"twl-links\" href=\"https://phabricator.wikimedia.org/"
-"maniphest/task/edit/form/1/?projectPHIDs=Library-Card-"
-"Platform&title=Wikipedia%%20Library%%20%(path)s%%20Permission%%20denied"
-"\">Phabricator</a>"
-msgstr ""
-"Si vous pensez que votre compte devrait pouvoir le faire, veuillez nous "
-"contacter à <a class=\"twl-links\" href=\"mailto:wikipedialibrary@wikimedia."
-"org?Subject=Wikipedia%%20Library%%20%(path)s%%20Permission%%20denied"
-"\">wikipedialibrary@wikimedia.org</a> ou nous le signaler sur <a class=\"twl-"
-"links\" href=\"https://phabricator.wikimedia.org/maniphest/task/edit/form/1/?"
-"projectPHIDs=Library-Card-Platform&title=Wikipedia%%20Library%%20%(path)s"
-"%%20Permission%%20denied\">Phabricator</a>"
+msgid "If you think your account should be able to do that, please email us about this error at <a class=\"twl-links\" href=\"mailto:wikipedialibrary@wikimedia.org?Subject=Wikipedia%%20Library%%20%(path)s%%20Permission%%20denied\">wikipedialibrary@wikimedia.org</a> or report it to us on <a class=\"twl-links\" href=\"https://phabricator.wikimedia.org/maniphest/task/edit/form/1/?projectPHIDs=Library-Card-Platform&title=Wikipedia%%20Library%%20%(path)s%%20Permission%%20denied\">Phabricator</a>"
+msgstr "Si vous pensez que votre compte devrait pouvoir le faire, veuillez nous contacter à <a class=\"twl-links\" href=\"mailto:wikipedialibrary@wikimedia.org?Subject=Wikipedia%%20Library%%20%(path)s%%20Permission%%20denied\">wikipedialibrary@wikimedia.org</a> ou nous le signaler sur <a class=\"twl-links\" href=\"https://phabricator.wikimedia.org/maniphest/task/edit/form/1/?projectPHIDs=Library-Card-Platform&title=Wikipedia%%20Library%%20%(path)s%%20Permission%%20denied\">Phabricator</a>"
 
 #. Translators: Shown on the website's 404 page, when a user attempts to navigate to a page that doesn't exist.
 #: TWLight/templates/404.html:11
@@ -2267,22 +1803,8 @@ msgstr "Désolé, nous ne pouvons pas le trouver."
 #. Translators: Shown on the website's 404 page, when a user attempts to navigate to a page that doesn't exist. Don't translate path or Phabricator.
 #: TWLight/templates/404.html:19
 #, python-format
-msgid ""
-"If you are certain that something should be here, please email us about this "
-"error at <a class=\"twl-links\" href=\"mailto:wikipedialibrary@wikimedia.org?"
-"Subject=Wikipedia%%20Library%%20%(path)s%%20Not%%20found\"> "
-"wikipedialibrary@wikimedia.org</a> or report it to us on <a class=\"twl-links"
-"\" href=\"https://phabricator.wikimedia.org/maniphest/task/edit/form/1/?"
-"projectPHIDs=Library-Card-Platform&title=Wikipedia%%20Library%%20%(path)s"
-"%%20Not%%20found\">Phabricator</a>"
-msgstr ""
-"Si vous êtes certain que quelque chose devrait être ici, veuillez nous "
-"contacter à <a class=\"twl-links\" href=\"mailto:wikipedialibrary@wikimedia."
-"org?Subject=Wikipedia%%20Library%%20%(path)s%%20Permission%%20denied"
-"\">wikipedialibrary@wikimedia.org</a> ou nous le signaler sur <a class=\"twl-"
-"links\" href=\"https://phabricator.wikimedia.org/maniphest/task/edit/form/1/?"
-"projectPHIDs=Library-Card-Platform&title=Wikipedia%%20Library%%20%(path)s"
-"%%20Permission%%20denied\">Phabricator</a>"
+msgid "If you are certain that something should be here, please email us about this error at <a class=\"twl-links\" href=\"mailto:wikipedialibrary@wikimedia.org?Subject=Wikipedia%%20Library%%20%(path)s%%20Not%%20found\"> wikipedialibrary@wikimedia.org</a> or report it to us on <a class=\"twl-links\" href=\"https://phabricator.wikimedia.org/maniphest/task/edit/form/1/?projectPHIDs=Library-Card-Platform&title=Wikipedia%%20Library%%20%(path)s%%20Not%%20found\">Phabricator</a>"
+msgstr "Si vous êtes certain que quelque chose devrait être ici, veuillez nous contacter à <a class=\"twl-links\" href=\"mailto:wikipedialibrary@wikimedia.org?Subject=Wikipedia%%20Library%%20%(path)s%%20Permission%%20denied\">wikipedialibrary@wikimedia.org</a> ou nous le signaler sur <a class=\"twl-links\" href=\"https://phabricator.wikimedia.org/maniphest/task/edit/form/1/?projectPHIDs=Library-Card-Platform&title=Wikipedia%%20Library%%20%(path)s%%20Permission%%20denied\">Phabricator</a>"
 
 #. Translators: Alt text for an image shown on the 404 error page.
 #: TWLight/templates/404.html:32
@@ -2296,51 +1818,19 @@ msgstr "À propos de la Bibliothèque Wikipédia"
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:20
-msgid ""
-"This platform is our central tool for facilitating access to our available "
-"collections. Here you can see which partnerships are available, search their "
-"contents, and apply for and access the ones you’re interested in."
-msgstr ""
-"Cette plateforme est notre outil central pour faciliter l’accès à nos "
-"collections disponibles. Ici vous pouvez voir quels partenariats sont "
-"disponibles, rechercher dans leurs contenus et demander l’accès aux "
-"ressources qui vous intéressent."
+msgid "This platform is our central tool for facilitating access to our available collections. Here you can see which partnerships are available, search their contents, and apply for and access the ones you’re interested in."
+msgstr "Cette plateforme est notre outil central pour faciliter l’accès à nos collections disponibles. Ici vous pouvez voir quels partenariats sont disponibles, rechercher dans leurs contenus et demander l’accès aux ressources qui vous intéressent."
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/). Wikimedia Foundation should not be translated.
 #: TWLight/templates/about.html:29
-msgid ""
-"All users receive immediate access to some collections, which can be browsed "
-"by clicking the 'Access collection' buttons or using the search bar at the "
-"top of the page. Other collections require an application before access is "
-"granted, and may be accessed directly or via an individual login or access "
-"code. Volunteer coordinators, who have signed non-disclosure agreements with "
-"the Wikimedia Foundation, review these applications and work with publishers "
-"to get you your free access."
-msgstr ""
-"Tous les utilisateurs reçoivent un accès immédiat à certaines collections, "
-"dans lesquelles ils peuvent naviguer en cliquant sur les boutons « Accéder à "
-"la collection » ou en utilisant la barre de recherche en haut de la page. "
-"D’autres collections nécessitent une candidature avant que l’accès soit "
-"accordé et peuvent être accédées directement ou via une connexion ou un code "
-"d’accès individuel. Des coordinateurs bénévoles, qui ont signé des accords "
-"de confidentialité avec la Fondation Wikimedia, traitent ces candidatures et "
-"travaillent avec les éditeurs pour vous donner un libre accès."
+msgid "All users receive immediate access to some collections, which can be browsed by clicking the 'Access collection' buttons or using the search bar at the top of the page. Other collections require an application before access is granted, and may be accessed directly or via an individual login or access code. Volunteer coordinators, who have signed non-disclosure agreements with the Wikimedia Foundation, review these applications and work with publishers to get you your free access."
+msgstr "Tous les utilisateurs reçoivent un accès immédiat à certaines collections, dans lesquelles ils peuvent naviguer en cliquant sur les boutons « Accéder à la collection » ou en utilisant la barre de recherche en haut de la page. D’autres collections nécessitent une candidature avant que l’accès soit accordé et peuvent être accédées directement ou via une connexion ou un code d’accès individuel. Des coordinateurs bénévoles, qui ont signé des accords de confidentialité avec la Fondation Wikimedia, traitent ces candidatures et travaillent avec les éditeurs pour vous donner un libre accès."
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/). Don't translate terms_url.
 #: TWLight/templates/about.html:43
 #, python-format
-msgid ""
-"For more information about how your information is stored and reviewed "
-"please see our <a class=\"twl-links\" href=\"%(terms_url)s\"> terms of use "
-"and privacy policy</a>. Accounts you apply for are also subject to the Terms "
-"of Use provided by each partner’s platform; please review them."
-msgstr ""
-"Pour plus d’informations sur la manière dont vos informations sont stockées "
-"et évaluées, veuillez voir nos <a class=\"twl-links\" href=\"%(terms_url)s"
-"\">conditions d’utilisation et politiques de confidentialité</a>. Les "
-"comptes que vous demandez sont également soumis aux conditions d’utilisation "
-"dictées par les plateformes de chaque partenaire ; veuillez les examiner "
-"attentivement."
+msgid "For more information about how your information is stored and reviewed please see our <a class=\"twl-links\" href=\"%(terms_url)s\"> terms of use and privacy policy</a>. Accounts you apply for are also subject to the Terms of Use provided by each partner’s platform; please review them."
+msgstr "Pour plus d’informations sur la manière dont vos informations sont stockées et évaluées, veuillez voir nos <a class=\"twl-links\" href=\"%(terms_url)s\">conditions d’utilisation et politiques de confidentialité</a>. Les comptes que vous demandez sont également soumis aux conditions d’utilisation dictées par les plateformes de chaque partenaire ; veuillez les examiner attentivement."
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:51
@@ -2349,26 +1839,13 @@ msgstr "Qui peut obtenir l’accès ?"
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/). Wikimedia Foundation should not be translated.
 #: TWLight/templates/about.html:55
-msgid ""
-"Any active editor in good standing can receive access. For publishers with "
-"limited numbers of accounts, applications are reviewed based on the editor’s "
-"needs and contributions. If you think you could use access to one of our "
-"partner resources and are an active editor in any project supported by the "
-"Wikimedia Foundation, please apply."
-msgstr ""
-"Tout utilisateur actif et en règle peut avoir accès. Pour les éditeurs de "
-"contenus ayant un nombre limité de comptes, les candidatures sont évaluées "
-"en fonction des besoins de l’utilisateur et de ses contributions. Si vous "
-"pensez que vous pouvez utiliser l’accès à l’une des ressources de nos "
-"partenaires et que vous êtes un utilisateur actif dans un projet soutenu par "
-"la Wikimedia Foundation, vous êtes invité à soumettre une demande."
+msgid "Any active editor in good standing can receive access. For publishers with limited numbers of accounts, applications are reviewed based on the editor’s needs and contributions. If you think you could use access to one of our partner resources and are an active editor in any project supported by the Wikimedia Foundation, please apply."
+msgstr "Tout utilisateur actif et en règle peut avoir accès. Pour les éditeurs de contenus ayant un nombre limité de comptes, les candidatures sont évaluées en fonction des besoins de l’utilisateur et de ses contributions. Si vous pensez que vous pouvez utiliser l’accès à l’une des ressources de nos partenaires et que vous êtes un utilisateur actif dans un projet soutenu par la Wikimedia Foundation, vous êtes invité à soumettre une demande."
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:65
 msgid "Any editor can use the library if they meet a few basic requirements:"
-msgstr ""
-"Tous les contributeurs peuvent utiliser la bibliothèque, vous devez "
-"seulement remplir ces critères basiques :"
+msgstr "Tous les contributeurs peuvent utiliser la bibliothèque, vous devez seulement remplir ces critères basiques :"
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:71
@@ -2383,48 +1860,22 @@ msgstr "Vous avez réalisé au moins 500 contributions aux projets de Wikimedia
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:79
 msgid "You have made at least 10 edits to Wikimedia projects in the last month"
-msgstr ""
-"Vous avez fait au moins 10 modifications aux projets Wikimedia au cours du "
-"dernier mois"
+msgstr "Vous avez fait au moins 10 modifications aux projets Wikimedia au cours du dernier mois"
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:83
 msgid "You are not currently blocked from editing a Wikimedia project"
-msgstr ""
-"vous n’êtes actuellement pas bloqué en écriture sur un projet de Wikimedia ;"
+msgstr "vous n’êtes actuellement pas bloqué en écriture sur un projet de Wikimedia ;"
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/)
 #: TWLight/templates/about.html:89
-msgid ""
-"If you are applying for an available collection, please first check that you "
-"don't already have access through another library or institution. If you do, "
-"please consider using that access rather than taking up a seat for this "
-"resource in The Wikipedia Library."
-msgstr ""
-"Si vous êtes candidat pour accéder à une collection disponible, veuillez "
-"d’abord vérifier que vous n’y avez pas déjà accès par une autre bibliothèque "
-"ou institution. Si c’est le cas, veuillez songer à utiliser cet accès plutôt "
-"que de prendre une place dans le quota d'accès accordé à la Bibliothèque "
-"Wikipédia."
+msgid "If you are applying for an available collection, please first check that you don't already have access through another library or institution. If you do, please consider using that access rather than taking up a seat for this resource in The Wikipedia Library."
+msgstr "Si vous êtes candidat pour accéder à une collection disponible, veuillez d’abord vérifier que vous n’y avez pas déjà accès par une autre bibliothèque ou institution. Si c’est le cas, veuillez songer à utiliser cet accès plutôt que de prendre une place dans le quota d'accès accordé à la Bibliothèque Wikipédia."
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/)
 #: TWLight/templates/about.html:99
-msgid ""
-"If your account is blocked on one or more Wikimedia projects, you may still "
-"be granted access to The Wikipedia Library. You will need to contact the "
-"Wikipedia Library team, who will review your blocks. If you have been "
-"blocked for content issues, most notably copyright violations, or have "
-"multiple long-term blocks, we may decline your request. Additionally, if "
-"your block status changes after being approved, you will need to request "
-"another review."
-msgstr ""
-"Si votre compte est bloqué sur au moins un projet Wikimedia, il vous est "
-"toujours possible d’avoir accès à la Bibliothèque de Wikipédia. Vous devez "
-"contacter l’équipe de la Bibliothèque Wikipédia qui examinera vos blocages. "
-"Si vous avez été bloqué pour des problèmes de contenu et notamment pour des "
-"violations de droit d’auteur ou si vous avez été bloqué longtemps plusieurs "
-"fois, nous pourrons refuser votre demande. De plus, si vous êtes bloqué "
-"après avoir été approuvé, vous devrez demander un nouvel examen."
+msgid "If your account is blocked on one or more Wikimedia projects, you may still be granted access to The Wikipedia Library. You will need to contact the Wikipedia Library team, who will review your blocks. If you have been blocked for content issues, most notably copyright violations, or have multiple long-term blocks, we may decline your request. Additionally, if your block status changes after being approved, you will need to request another review."
+msgstr "Si votre compte est bloqué sur au moins un projet Wikimedia, il vous est toujours possible d’avoir accès à la Bibliothèque de Wikipédia. Vous devez contacter l’équipe de la Bibliothèque Wikipédia qui examinera vos blocages. Si vous avez été bloqué pour des problèmes de contenu et notamment pour des violations de droit d’auteur ou si vous avez été bloqué longtemps plusieurs fois, nous pourrons refuser votre demande. De plus, si vous êtes bloqué après avoir été approuvé, vous devrez demander un nouvel examen."
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:110
@@ -2458,12 +1909,8 @@ msgstr "Les contributeurs approuvés <i>ne peuvent pas</i> :"
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:136
-msgid ""
-"Share their account logins or passwords with others, or sell their access to "
-"other parties"
-msgstr ""
-"partager ses identifiants de connexion ou mots de passe avec d’autres, "
-"vendre ou céder ses accès à des tiers ;"
+msgid "Share their account logins or passwords with others, or sell their access to other parties"
+msgstr "partager ses identifiants de connexion ou mots de passe avec d’autres, vendre ou céder ses accès à des tiers ;"
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:140
@@ -2472,30 +1919,18 @@ msgstr "soutirer ou télécharger en masse des contenus des partenaires ;"
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:144
-msgid ""
-"Systematically make printed or electronic copies of multiple extracts of "
-"restricted content available for any purpose"
-msgstr ""
-"faire systématiquement des copies imprimées ou électroniques de nombreux "
-"extraits de contenu restreint dans un but quelconque ;"
+msgid "Systematically make printed or electronic copies of multiple extracts of restricted content available for any purpose"
+msgstr "faire systématiquement des copies imprimées ou électroniques de nombreux extraits de contenu restreint dans un but quelconque ;"
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/). Stub is a technical term for a short Wikipedia article, use the appropriate Wikipedia term in your language.
 #: TWLight/templates/about.html:148
-msgid ""
-"Datamine metadata without permission, in order, for instance, to use "
-"metadata for auto-created stub articles"
-msgstr ""
-"fouiller des métadonnées sans permission, par exemple pour la création "
-"automatique d’ébauches d’articles."
+msgid "Datamine metadata without permission, in order, for instance, to use metadata for auto-created stub articles"
+msgstr "fouiller des métadonnées sans permission, par exemple pour la création automatique d’ébauches d’articles."
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:154
-msgid ""
-"Respecting these agreements allows us to continue growing the partnerships "
-"available to the community."
-msgstr ""
-"Le respect de ces accords nous permet de continuer à augmenter le nombre de "
-"partenariats à la disposition de la communauté."
+msgid "Respecting these agreements allows us to continue growing the partnerships available to the community."
+msgstr "Le respect de ces accords nous permet de continuer à augmenter le nombre de partenariats à la disposition de la communauté."
 
 #. Translators: This is the heading for a section on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:160
@@ -2504,67 +1939,23 @@ msgstr "EZProxy"
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:164
-msgid ""
-"EZProxy is a proxy server used to authenticate users for many Wikipedia "
-"Library partners. Users sign into EZProxy via the Library Card platform to "
-"verify that they are authorized users, and then the server accesses "
-"requested resources using its own IP address."
-msgstr ""
-"EZProxy est un logiciel de type proxy utilisé pour authentifier les "
-"utilisateurs pour de nombreux partenaires de La Bibliothèque Wikipédia. Les "
-"utilisateurs s’inscrivent dans EZProxy via la plateforme de Carte de "
-"Bibliothèque afin de vérifier qu’ils sont des utilisateurs autorisés, puis "
-"le serveur mandataire accède aux ressources demandées en utilisant sa propre "
-"adresse IP."
+msgid "EZProxy is a proxy server used to authenticate users for many Wikipedia Library partners. Users sign into EZProxy via the Library Card platform to verify that they are authorized users, and then the server accesses requested resources using its own IP address."
+msgstr "EZProxy est un logiciel de type proxy utilisé pour authentifier les utilisateurs pour de nombreux partenaires de La Bibliothèque Wikipédia. Les utilisateurs s’inscrivent dans EZProxy via la plateforme de Carte de Bibliothèque afin de vérifier qu’ils sont des utilisateurs autorisés, puis le serveur mandataire accède aux ressources demandées en utilisant sa propre adresse IP."
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:173
-msgid ""
-"You may notice that when accessing resources via EZProxy that URLs are "
-"dynamically rewritten. This is why we recommend logging in via the Library "
-"Card platform rather than going directly to the unproxied partner website. "
-"When in doubt, check the URL for ‘idm.oclc’. If it’s there, then you’re "
-"connected via EZProxy."
-msgstr ""
-"Vous pouvez remarquer que lors de l’accès aux ressources via EZProxy, les "
-"URL sont réécrites dynamiquement. C’est pourquoi nous vous recommandons de "
-"vous connecter via la plateforme de Carte de Bibliothèque plutôt que "
-"directement sur le site web non mandaté du partenaire. En cas de doute, "
-"vérifiez la présence du paramètre « idm.oclc » dans l’URL : s’il est "
-"présent, alors vous êtes connecté via EZProxy."
+msgid "You may notice that when accessing resources via EZProxy that URLs are dynamically rewritten. This is why we recommend logging in via the Library Card platform rather than going directly to the unproxied partner website. When in doubt, check the URL for ‘idm.oclc’. If it’s there, then you’re connected via EZProxy."
+msgstr "Vous pouvez remarquer que lors de l’accès aux ressources via EZProxy, les URL sont réécrites dynamiquement. C’est pourquoi nous vous recommandons de vous connecter via la plateforme de Carte de Bibliothèque plutôt que directement sur le site web non mandaté du partenaire. En cas de doute, vérifiez la présence du paramètre « idm.oclc » dans l’URL : s’il est présent, alors vous êtes connecté via EZProxy."
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:182
-msgid ""
-"Typically once you’ve logged in your session will remain active in your "
-"browser for up to two hours after you’ve finished searching. Note that use "
-"of EZProxy requires you to enable cookies. If you are having problems you "
-"should also try clearing your cache and restarting your browser."
-msgstr ""
-"Typiquement, une fois que vous êtes connecté, votre session restera active "
-"dans votre navigateur pour une durée allant jusqu’à deux heures après la fin "
-"de votre recherche. Notez que l’utilisation d’EZProxy requière que vous "
-"activiez les témoins (cookies) de session dans votre navigateur. Si vous "
-"avez des problèmes à garder vos sessions autorisées, vous devriez également "
-"essayer d’effacer votre cache et de redémarrer votre navigateur."
+msgid "Typically once you’ve logged in your session will remain active in your browser for up to two hours after you’ve finished searching. Note that use of EZProxy requires you to enable cookies. If you are having problems you should also try clearing your cache and restarting your browser."
+msgstr "Typiquement, une fois que vous êtes connecté, votre session restera active dans votre navigateur pour une durée allant jusqu’à deux heures après la fin de votre recherche. Notez que l’utilisation d’EZProxy requière que vous activiez les témoins (cookies) de session dans votre navigateur. Si vous avez des problèmes à garder vos sessions autorisées, vous devriez également essayer d’effacer votre cache et de redémarrer votre navigateur."
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/)
 #: TWLight/templates/about.html:193
-msgid ""
-"The Library Bundle is a collection of resources for which no application is "
-"required. If you meet the criteria laid out above, you will be authorized "
-"for access automatically upon logging in to the platform. Only some of our "
-"content is currently included in the Library Bundle, however we hope to "
-"expand the collection as more publishers become comfortable with "
-"participating. All Bundle content is accessed via EZProxy."
-msgstr ""
-"La Bouquet de la bibliothèque est une collection de ressources pour "
-"lesquelles aucune candidature n’est nécessaire. Si vous répondez aux "
-"critères expliqués plus haut, vous y aurez automatiquement accès dès lors "
-"que vous êtes connecté(e) sur la plateforme. Seule une partie de notre "
-"contenu est actuellement inclus dans le Bouquet de la bibliothèque, "
-"cependant nous espérons étendre la collection quand d’autres éditeurs "
-"accepteront de participer. L’ensemble du Bouquet est accessible via EZProxy."
+msgid "The Library Bundle is a collection of resources for which no application is required. If you meet the criteria laid out above, you will be authorized for access automatically upon logging in to the platform. Only some of our content is currently included in the Library Bundle, however we hope to expand the collection as more publishers become comfortable with participating. All Bundle content is accessed via EZProxy."
+msgstr "La Bouquet de la bibliothèque est une collection de ressources pour lesquelles aucune candidature n’est nécessaire. Si vous répondez aux critères expliqués plus haut, vous y aurez automatiquement accès dès lors que vous êtes connecté(e) sur la plateforme. Seule une partie de notre contenu est actuellement inclus dans le Bouquet de la bibliothèque, cependant nous espérons étendre la collection quand d’autres éditeurs accepteront de participer. L’ensemble du Bouquet est accessible via EZProxy."
 
 #. Translators: This is the heading for a section on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:202
@@ -2573,19 +1964,8 @@ msgstr "Usage des citations en référence"
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:206
-msgid ""
-"Citation practices vary by project and even by article. Generally, we "
-"support editors citing where they found information, in a form that allows "
-"others to check it for themselves. That often means providing both original "
-"source details as well as a link to the partner database in which the source "
-"was found."
-msgstr ""
-"Les usages concernant les citations de référence varient selon le projet, "
-"voire selon l’article. En règle générale, nous encourageons les "
-"contributeurs à citer leurs sources sous une forme qui permet aux autres de "
-"vérifier les informations par eux-mêmes. Cela implique souvent de fournir "
-"les informations détaillées sur la source d’origine ainsi qu’un lien vers la "
-"base de données du partenaire dans laquelle la source a été trouvée."
+msgid "Citation practices vary by project and even by article. Generally, we support editors citing where they found information, in a form that allows others to check it for themselves. That often means providing both original source details as well as a link to the partner database in which the source was found."
+msgstr "Les usages concernant les citations de référence varient selon le projet, voire selon l’article. En règle générale, nous encourageons les contributeurs à citer leurs sources sous une forme qui permet aux autres de vérifier les informations par eux-mêmes. Cela implique souvent de fournir les informations détaillées sur la source d’origine ainsi qu’un lien vers la base de données du partenaire dans laquelle la source a été trouvée."
 
 #. Translators: This is the heading for a section on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #. Translators: This link is at the bottom of every page and can be clicked by users to contact the wikipedia library team.
@@ -2596,13 +1976,8 @@ msgstr "Nous contacter"
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:218
 #, python-format
-msgid ""
-"If you have questions, need help, or want to volunteer to help, please see "
-"our <a class=\"twl-links\" href=\"%(contact_url)s\">contact page</a>."
-msgstr ""
-"Si vous avez des questions, si avez besoin d’aide ou si vous désirez nous "
-"aider en tant que bénévole, veuillez consulter notre <a class=\"twl-links\" "
-"href=\"%(contact_url)s\">page de contact</t>."
+msgid "If you have questions, need help, or want to volunteer to help, please see our <a class=\"twl-links\" href=\"%(contact_url)s\">contact page</a>."
+msgstr "Si vous avez des questions, si avez besoin d’aide ou si vous désirez nous aider en tant que bénévole, veuillez consulter notre <a class=\"twl-links\" href=\"%(contact_url)s\">page de contact</t>."
 
 #. Translators: This is the title of the panel box detailing the contact information for the Wikipedia Library team.
 #: TWLight/templates/contact.html:14
@@ -2641,18 +2016,13 @@ msgstr "Page Twitter de La Bibliothèque Wikipédia"
 #. Translators: This is the text that appears at the bottom of the contact us form directing users to the suggestions form.
 #: TWLight/templates/contact.html:48
 #, python-format
-msgid ""
-"(If you would like to suggest a partner, <a class=\"twl-links\" href="
-"\"%(suggest)s\"><strong>go here</strong></a>.)"
-msgstr ""
-"(Si vous aimeriez suggérer un partenaire, <a class=\"twl-links\" href="
-"\"%(suggest)s\"><strong>suivez ce lien</strong></a>.)"
+msgid "(If you would like to suggest a partner, <a class=\"twl-links\" href=\"%(suggest)s\"><strong>go here</strong></a>.)"
+msgstr "(Si vous aimeriez suggérer un partenaire, <a class=\"twl-links\" href=\"%(suggest)s\"><strong>suivez ce lien</strong></a>.)"
 
 #. Translators: On a special 'link to search' page, this message is shown if JavaScript is disabled.
 #: TWLight/templates/eds_search_endpoint.html:7
 msgid "JavaScript is disabled; use the button below to continue."
-msgstr ""
-"JavaScript est désactivé ; utiliser le bouton ci-dessous pour continuer."
+msgstr "JavaScript est désactivé ; utiliser le bouton ci-dessous pour continuer."
 
 #. Translators: Alt text for the Wikipedia Library shown in the top left of all pages.
 #: TWLight/templates/header_partial_b4.html:14
@@ -2703,13 +2073,8 @@ msgstr "La Bibliothèque Wikipédia"
 #. Translators: Information about The Wikipedia Library.
 #: TWLight/templates/login_partial.html:53 TWLight/templates/new_base.html:21
 #, python-format
-msgid ""
-"More than 100 of the world's top subscription-only databases, with content "
-"in %(no_of_languages)s languages, free for Wikipedians of all backgrounds"
-msgstr ""
-"Plus de 100 des meilleures bases de données sur abonnement au monde, avec "
-"des contenus dans %(no_of_languages)s langues, disponibles gratuitement pour "
-"tous les Wikipédiens"
+msgid "More than 100 of the world's top subscription-only databases, with content in %(no_of_languages)s languages, free for Wikipedians of all backgrounds"
+msgstr "Plus de 100 des meilleures bases de données sur abonnement au monde, avec des contenus dans %(no_of_languages)s langues, disponibles gratuitement pour tous les Wikipédiens"
 
 #. Translators: Information about The Wikipedia Library.
 #: TWLight/templates/login_partial.html:64
@@ -2717,12 +2082,8 @@ msgid "Meet these criteria for automatic access"
 msgstr "Répondre à ces critères pour un accès automatique"
 
 #: TWLight/templates/login_partial.html:69
-msgid ""
-"These criteria grant you access to certain collections but not all. Some "
-"collections are accessible on a per application basis only."
-msgstr ""
-"Ces critères vous donnent accès à certaines collections, mais pas toutes. "
-"Certaines collections sont accessibles uniquement par candidature."
+msgid "These criteria grant you access to certain collections but not all. Some collections are accessible on a per application basis only."
+msgstr "Ces critères vous donnent accès à certaines collections, mais pas toutes. Certaines collections sont accessibles uniquement par candidature."
 
 #: TWLight/templates/login_partial.html:89
 msgid "Login via Wikipedia"
@@ -2731,43 +2092,20 @@ msgstr "Connexion via Wikipédia"
 #. Translators: Shown if the current user doesn't have a registered email on their account. Don't translate contact_us_url or email_url.
 #: TWLight/templates/message_partial.html:15
 #, python-format
-msgid ""
-"You don't have an email on file. We can't finalize your access to partner "
-"resources, and you won't be able to <a class=\"twl-links\" href="
-"\"%(contact_us_url)s\">contact us</a> without an email. Please <a class="
-"\"twl-links\" href=\"%(email_url)s\">update your email</a>."
-msgstr ""
-"Vous n’avez pas d’adresse courriel enregistrée. Nous ne pouvons pas "
-"finaliser votre accès aux ressources du partenaire et vous ne pourrez pas <a "
-"href=\"%(contact_us_url)s\">nous contacter</a> si vous n’en possédez pas "
-"une. Veuillez <a class=\"twl-links\" href=\"%(email_url)s\">mettre à jour "
-"votre adresse courriel</a>."
+msgid "You don't have an email on file. We can't finalize your access to partner resources, and you won't be able to <a class=\"twl-links\" href=\"%(contact_us_url)s\">contact us</a> without an email. Please <a class=\"twl-links\" href=\"%(email_url)s\">update your email</a>."
+msgstr "Vous n’avez pas d’adresse courriel enregistrée. Nous ne pouvons pas finaliser votre accès aux ressources du partenaire et vous ne pourrez pas <a href=\"%(contact_us_url)s\">nous contacter</a> si vous n’en possédez pas une. Veuillez <a class=\"twl-links\" href=\"%(email_url)s\">mettre à jour votre adresse courriel</a>."
 
 #. Translators: Shown if the current user has requested the processing of their data should be restricted.
 #: TWLight/templates/message_partial.html:26
 #, python-format
-msgid ""
-"You have requested a restriction on the processing of your data. Most site "
-"functionality will not be available to you until you <a class=\"twl-links\" "
-"href=\"%(restrict_url)s\">lift this restriction</a>."
-msgstr ""
-"Vous avez demandé une restriction sur le traitement de vos données. La "
-"plupart des fonctions du site ne vous seront plus accessibles tant que vous "
-"ne <a class=\"twl-links\" href=\"%(restrict_url)s\">lèverez pas cette "
-"restriction</a>."
+msgid "You have requested a restriction on the processing of your data. Most site functionality will not be available to you until you <a class=\"twl-links\" href=\"%(restrict_url)s\">lift this restriction</a>."
+msgstr "Vous avez demandé une restriction sur le traitement de vos données. La plupart des fonctions du site ne vous seront plus accessibles tant que vous ne <a class=\"twl-links\" href=\"%(restrict_url)s\">lèverez pas cette restriction</a>."
 
 #. Translators: Shown if the current user has not agreed to the terms of use.
 #: TWLight/templates/message_partial.html:37
 #, python-format
-msgid ""
-"You have not agreed to the <a class=\"twl-links\" href=\"%(terms_url)s"
-"\">terms of use</a> of this site. Your applications will not be processed "
-"and you won't be able to apply or access resources you are approved for."
-msgstr ""
-"Vous n’avez pas accepté les <a class=\"twl-links\" href=\"%(terms_url)s"
-"\">conditions d’utilisation</a> de ce site. Vos candidatures ne seront pas "
-"traitées et vous ne pourrez pas vous accéder aux ressources pour lesquelles "
-"vous êtes approuvé, ni même y postuler."
+msgid "You have not agreed to the <a class=\"twl-links\" href=\"%(terms_url)s\">terms of use</a> of this site. Your applications will not be processed and you won't be able to apply or access resources you are approved for."
+msgstr "Vous n’avez pas accepté les <a class=\"twl-links\" href=\"%(terms_url)s\">conditions d’utilisation</a> de ce site. Vos candidatures ne seront pas traitées et vous ne pourrez pas vous accéder aux ressources pour lesquelles vous êtes approuvé, ni même y postuler."
 
 #. Translators: This link is at the bottom of every page and links to the 'About' page (https://wikipedialibrary.wmflabs.org/about/)
 #: TWLight/templates/new_base.html:107
@@ -2813,12 +2151,8 @@ msgstr "Réinitialiser votre mot de passe"
 
 #. Translators: If a user goes to reset their password, this message asks them to enter their email to do so.
 #: TWLight/templates/registration/password_reset_form.html:13
-msgid ""
-"Forgot your password? Enter your email address below, and we'll email "
-"instructions for setting a new one."
-msgstr ""
-"Mot de passe oublié ? Entrez votre courriel ci-dessous et nous vous "
-"enverrons les instructions pour en définir un nouveau."
+msgid "Forgot your password? Enter your email address below, and we'll email instructions for setting a new one."
+msgstr "Mot de passe oublié ? Entrez votre courriel ci-dessous et nous vous enverrons les instructions pour en définir un nouveau."
 
 #. Translators: This is the label for a button that users click to update their public information.
 #: TWLight/users/forms.py:36
@@ -2828,9 +2162,7 @@ msgstr "Mettre à jour le profil"
 #. Translators: This labels a field where users can describe their activity on Wikipedia in a small biography.
 #: TWLight/users/forms.py:45
 msgid "Describe your contributions to Wikipedia: topics edited, et cetera."
-msgstr ""
-"Décrivez vos contributions à Wikipédia : sujets auxquels vous participez, "
-"etc."
+msgstr "Décrivez vos contributions à Wikipédia : sujets auxquels vous participez, etc."
 
 #. Translators: In the preferences section (Emails) of a user profile, this text labels the checkbox users can (un)click to change if they wish to receive account renewal notices or not.
 #: TWLight/users/forms.py:98
@@ -2864,22 +2196,13 @@ msgstr "J’accepte les conditions d’utilisation"
 
 #. Translators: This text explains how to disagree to the site's terms of use and the restrictions that will come into effect when users disagree to the terms of use.
 #: TWLight/users/forms.py:185
-msgid ""
-"By unchecking this box and clicking “Update” you may explore the site, but "
-"you will not be able to apply for access to materials or evaluate "
-"applications unless you agree with the terms of use."
-msgstr ""
-"En décochant cette case et en cliquant sur « Mettre à jour », vous pouvez "
-"explorer le site, mais vous ne pourrez pas demander l’accès aux ressources "
-"ou évaluer les demandes sans avoir accepté les conditions d’utilisation."
+msgid "By unchecking this box and clicking “Update” you may explore the site, but you will not be able to apply for access to materials or evaluate applications unless you agree with the terms of use."
+msgstr "En décochant cette case et en cliquant sur « Mettre à jour », vous pouvez explorer le site, mais vous ne pourrez pas demander l’accès aux ressources ou évaluer les demandes sans avoir accepté les conditions d’utilisation."
 
 #. Translators: Users click this button to set their website email address to the one linked to their Wikipedia account.
 #: TWLight/users/forms.py:211
-msgid ""
-"Use my Wikipedia email address (will be updated the next time you login)."
-msgstr ""
-"Utiliser mon adresse de messagerie enregistrée sur Wikipédia (sera mise à "
-"jour la prochaine fois que vous vous connectez)."
+msgid "Use my Wikipedia email address (will be updated the next time you login)."
+msgstr "Utiliser mon adresse de messagerie enregistrée sur Wikipédia (sera mise à jour la prochaine fois que vous vous connectez)."
 
 #. Translators: This labels a button which users click to change their email.
 #: TWLight/users/forms.py:232
@@ -2889,26 +2212,13 @@ msgstr "Mettre à jour votre courriel"
 #. Translators: Shown if the current user tried to 'favorite' a partner they can't access. Do not translate '{partner}'
 #: TWLight/users/models.py:201
 #, python-brace-format
-msgid ""
-"Cannot add partner {partner} to your favorites because you don't have access "
-"to it"
-msgstr ""
-"Impossible d’ajouter le partenaire {partner} à vos favoris, parce que vous "
-"n’y avez pas accès."
-
-#. Translators: Do not translate.
-#: TWLight/users/models.py:869
-#, fuzzy, python-brace-format
-#| msgid "Username"
-msgid "{wp_username}"
-msgstr "Nom d’utilisateur"
+msgid "Cannot add partner {partner} to your favorites because you don't have access to it"
+msgstr "Impossible d’ajouter le partenaire {partner} à vos favoris, parce que vous n’y avez pas accès."
 
 #. Translators: This error message is shown when there's a problem with the authenticated login process.
 #: TWLight/users/oauth.py:243
 msgid "You tried to log in but presented an invalid access token."
-msgstr ""
-"Vous avez essayé de vous connecter mais en présentant un jeton d’accès non "
-"valide."
+msgstr "Vous avez essayé de vous connecter mais en présentant un jeton d’accès non valide."
 
 #. Translators: This message is shown when the OAuth login process fails because the request came from the wrong website. Don't translate {domain}.
 #: TWLight/users/oauth.py:298 TWLight/users/oauth.py:444
@@ -2923,12 +2233,8 @@ msgstr "Poignée de main non initialisée, veuillez essayer de vous reconnecter.
 
 #. Translators: this message is displayed to users that don't have accounts and clicked on a proxied link.
 #: TWLight/users/oauth.py:388
-msgid ""
-"To view this link you need to be an eligible library user. Please login to "
-"continue."
-msgstr ""
-"Pour voir ce lien, vous devez être un utilisateur éligible à la "
-"bibliothèque. Veuillez vous connecter pour continuer."
+msgid "To view this link you need to be an eligible library user. Please login to continue."
+msgstr "Pour voir ce lien, vous devez être un utilisateur éligible à la bibliothèque. Veuillez vous connecter pour continuer."
 
 #. Translators: This warning message is shown to users when the response received from Wikimedia OAuth servers is not a valid one.
 #: TWLight/users/oauth.py:430
@@ -2953,9 +2259,7 @@ msgstr "Aucun jeton de demande."
 #. Translators: This message is shown when the OAuth login process fails.
 #: TWLight/users/oauth.py:498
 msgid "Access token generation failed, please try logging in again."
-msgstr ""
-"La génération du jeton d’accès a échoué, veuillez essayer de vous connecter "
-"à nouveau."
+msgstr "La génération du jeton d’accès a échoué, veuillez essayer de vous connecter à nouveau."
 
 #. Translators: This message is shown when more information is available on another page. Do not translate {issue}
 #: TWLight/users/oauth.py:507
@@ -2965,25 +2269,13 @@ msgstr "Voir {issue} pour plus d’informations"
 
 #. Translators: If the user tries to log in, but their account does not meet certain requirements, they cannot login.
 #: TWLight/users/oauth.py:528
-msgid ""
-"Your Wikipedia account does not meet the eligibility criteria in the terms "
-"of use, so your Wikipedia Library Card Platform account cannot be activated."
-msgstr ""
-"Votre compte Wikipédia ne répond pas aux critères d’admissibilité des "
-"conditions d’utilisation, par conséquent votre compte sur la plateforme de "
-"Carte de Bibliothèque Wikipédia ne peut pas être activé."
+msgid "Your Wikipedia account does not meet the eligibility criteria in the terms of use, so your Wikipedia Library Card Platform account cannot be activated."
+msgstr "Votre compte Wikipédia ne répond pas aux critères d’admissibilité des conditions d’utilisation, par conséquent votre compte sur la plateforme de Carte de Bibliothèque Wikipédia ne peut pas être activé."
 
 #. Translators: If the user tries to log in, but their account does not meet certain requirements, they cannot login.
 #: TWLight/users/oauth.py:536
-msgid ""
-"Your Wikipedia account no longer meets the eligibility criteria in the terms "
-"of use, so you cannot be logged in. If you think you should be able to log "
-"in, please email wikipedialibrary@wikimedia.org."
-msgstr ""
-"Votre compte Wikipédia ne répond plus aux critères d’admissibilité dans les "
-"conditions d’utilisation, de sorte que vous ne pouvez pas vous connecter. Si "
-"vous pensez avoir l’autorisation de vous connecter, veuillez envoyer un "
-"courriel à wikipedialibrary@wikimedia.org."
+msgid "Your Wikipedia account no longer meets the eligibility criteria in the terms of use, so you cannot be logged in. If you think you should be able to log in, please email wikipedialibrary@wikimedia.org."
+msgstr "Votre compte Wikipédia ne répond plus aux critères d’admissibilité dans les conditions d’utilisation, de sorte que vous ne pouvez pas vous connecter. Si vous pensez avoir l’autorisation de vous connecter, veuillez envoyer un courriel à wikipedialibrary@wikimedia.org."
 
 #. Translators: this message is displayed to users with brand new accounts.
 #: TWLight/users/oauth.py:549
@@ -2993,15 +2285,8 @@ msgstr "Bienvenue ! Veuillez accepter les conditions d’utilisation."
 #. Translators: This message is displayed on the confirmation page where users can return their access to partner collections.
 #: TWLight/users/templates/users/authorization_confirm_return.html:13
 #, python-format
-msgid ""
-"You will no longer be able to access <b>%(partner)s's</b> resources via the "
-"Library Card platform, but can request access again by clicking 'renew', if "
-"you change your mind. Are you sure you want to return your access?"
-msgstr ""
-"Vous ne serez plus en mesure d’accéder aux ressources de <b>%(partner)s</b> "
-"par la plateforme Carte de Bibliothèque, mais pourrez demander à nouveau un "
-"accès en cliquant « renouveler », si vous changez d’avis. Êtes-vous sûr de "
-"vouloir retourner votre accès ?"
+msgid "You will no longer be able to access <b>%(partner)s's</b> resources via the Library Card platform, but can request access again by clicking 'renew', if you change your mind. Are you sure you want to return your access?"
+msgstr "Vous ne serez plus en mesure d’accéder aux ressources de <b>%(partner)s</b> par la plateforme Carte de Bibliothèque, mais pourrez demander à nouveau un accès en cliquant « renouveler », si vous changez d’avis. Êtes-vous sûr de vouloir retourner votre accès ?"
 
 #. Translators: On the MyLibrary page (https://wikipedialibrary.wmflabs.org/users/my_library), this tab shows all favorite collections a user has.
 #: TWLight/users/templates/users/collections_section.html:9
@@ -3044,8 +2329,7 @@ msgstr "Ma bibliothèque"
 #. Translators: Line two of two, explaining the purpose of the page in a button on users' profile page which when clicked takes users to a page with their available collections.
 #: TWLight/users/templates/users/editor_detail.html:28
 msgid "A collective list of collections you are authorized to access"
-msgstr ""
-"Une liste commune de collections auxquelles vous avez le droit d’accéder"
+msgstr "Une liste commune de collections auxquelles vous avez le droit d’accéder"
 
 #. Translators: Line one of two in a button on users' profile page which when clicked takes users to their applications page.
 #. Translators: Heading of the applications page where users can view all of their applications listed with other relevant info.
@@ -3071,15 +2355,8 @@ msgstr "Données d’utilisateur"
 
 #. Translators: This is shown on editor profiles, in their profile page or on applications.
 #: TWLight/users/templates/users/editor_detail.html:59
-msgid ""
-"Information with an * was retrieved from Wikipedia directly. Other "
-"information was entered directly by users or site admins, in their preferred "
-"language."
-msgstr ""
-"Les informations marquées avec une « * » ont été récupérées directement à "
-"partir de Wikipédia. Les autres informations ont été ajoutées directement "
-"par les utilisateurs ou les administrateurs du site, dans leur langue "
-"préférée."
+msgid "Information with an * was retrieved from Wikipedia directly. Other information was entered directly by users or site admins, in their preferred language."
+msgstr "Les informations marquées avec une « * » ont été récupérées directement à partir de Wikipédia. Les autres informations ont été ajoutées directement par les utilisateurs ou les administrateurs du site, dans leur langue préférée."
 
 #. Translators: This distinguishes users who have been flagged as account coordinators. Don't translate username.
 #: TWLight/users/templates/users/editor_detail.html:71
@@ -3089,15 +2366,8 @@ msgstr "%(username)s a des privilèges de coordinateur sur ce site."
 
 #. Translators: This is shown on editor profiles, under the heading for Wikipedia editor data.
 #: TWLight/users/templates/users/editor_detail_data.html:5
-msgid ""
-"This information is updated automatically from your Wikimedia account each "
-"time you log in, except for the Contributions field, where you can describe "
-"your Wikimedia editing history."
-msgstr ""
-"Ces informations sont mises à jour automatiquement à partir de votre compte "
-"Wikimedia à chaque fois que vous vous connectez, à l’exception du champ des "
-"contributions, dans lequel vous pouvez décrire l’historique de vos "
-"modifications sur Wikimedia."
+msgid "This information is updated automatically from your Wikimedia account each time you log in, except for the Contributions field, where you can describe your Wikimedia editing history."
+msgstr "Ces informations sont mises à jour automatiquement à partir de votre compte Wikimedia à chaque fois que vous vous connectez, à l’exception du champ des contributions, dans lequel vous pouvez décrire l’historique de vos modifications sur Wikimedia."
 
 #. Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this labels the user's username.
 #: TWLight/users/templates/users/editor_detail_data.html:17
@@ -3126,22 +2396,14 @@ msgstr "Répond aux conditions d’utilisation ?"
 
 #. Translators: when viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this question has a yes or no answer.
 #: TWLight/users/templates/users/editor_detail_data.html:57
-msgid ""
-"at their last login, did this user meet the criteria set forth in the terms "
-"of use?"
-msgstr ""
-"lors de sa dernière connexion, est-ce que cet utilisateur répondait aux "
-"critères énoncés dans les conditions d’utilisation ?"
+msgid "at their last login, did this user meet the criteria set forth in the terms of use?"
+msgstr "lors de sa dernière connexion, est-ce que cet utilisateur répondait aux critères énoncés dans les conditions d’utilisation ?"
 
 #. Translators: When viewing a user's profile in an application, this message shows if the software doesn't think that the user is eligible for access. Don't translate username.
 #: TWLight/users/templates/users/editor_detail_data.html:72
 #, python-format
-msgid ""
-"%(username)s may still be eligible for access grants at the coordinators' "
-"discretion."
-msgstr ""
-"%(username)s peut encore être admissible à l’accès à la discrétion des "
-"coordinateurs."
+msgid "%(username)s may still be eligible for access grants at the coordinators' discretion."
+msgstr "%(username)s peut encore être admissible à l’accès à la discrétion des coordinateurs."
 
 #. Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this is the heading for a Yes/No ToU question.
 #: TWLight/users/templates/users/editor_detail_data.html:83
@@ -3175,15 +2437,8 @@ msgstr "(exemption accordée)"
 #. Translators: This message is shown on a user's profile if their Wikimedia account is blocked on one or more projects. They may still be granted access to the Library Bundle, but need to contact Wikipedia Library staff to verify.
 #: TWLight/users/templates/users/editor_detail_data.html:137
 #, python-format
-msgid ""
-"It looks like you have an active block on your account. If you meet the "
-"other criteria you may still be permitted access to the library - please <a "
-"class=\"twl-links\" href=\"%(contact_url)s\">contact us</a>."
-msgstr ""
-"Il semblerait que vous ayez un blocage actif sur votre compte. Si vous "
-"répondez aux autres critères, vous pouvez encore être autorisé à accéder à "
-"la bibliothèque — veuillez <a class=\"twl-links\" href=\"%(contact_url)s"
-"\">nous contacter</a>."
+msgid "It looks like you have an active block on your account. If you meet the other criteria you may still be permitted access to the library - please <a class=\"twl-links\" href=\"%(contact_url)s\">contact us</a>."
+msgstr "Il semblerait que vous ayez un blocage actif sur votre compte. Si vous répondez aux autres critères, vous pouvez encore être autorisé à accéder à la bibliothèque — veuillez <a class=\"twl-links\" href=\"%(contact_url)s\">nous contacter</a>."
 
 #. Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this is the heading for a Yes/No program eligibility question.
 #: TWLight/users/templates/users/editor_detail_data.html:153
@@ -3192,15 +2447,8 @@ msgstr "Éligible pour l’accès au Bouquet ?"
 
 #. Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this question has a Yes or No answer.
 #: TWLight/users/templates/users/editor_detail_data.html:156
-msgid ""
-"At their last login, did this user meet the criteria set forth in the "
-"Library Bundle? Note that satisfying terms of use is a prerequisite to "
-"bundle eligibility."
-msgstr ""
-"Lors de sa dernière connexion, est-ce que cet utilisateur répondait aux "
-"critères énoncés dans les conditions d’utilisation ? Sachez que répondre aux "
-"conditions d’utilisations est un prérequis pour disposer de l’accès au "
-"bouquet."
+msgid "At their last login, did this user meet the criteria set forth in the Library Bundle? Note that satisfying terms of use is a prerequisite to bundle eligibility."
+msgstr "Lors de sa dernière connexion, est-ce que cet utilisateur répondait aux critères énoncés dans les conditions d’utilisation ? Sachez que répondre aux conditions d’utilisations est un prérequis pour disposer de l’accès au bouquet."
 
 #. Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this is the heading for a Yes/No program eligibility question.
 #: TWLight/users/templates/users/editor_detail_data.html:177
@@ -3225,8 +2473,7 @@ msgstr "Dernière valeur du compteur global de modifications *"
 #. Translators: This text is shown next to a user's recent global edit count if less than 30 days has passed since they first logged in to the Library Card. In this case, we don't yet know if they're eligible.
 #: TWLight/users/templates/users/editor_detail_data.html:220
 msgid "Unknown (requires 30 days from initial user login)"
-msgstr ""
-"Inconnu (nécessite 30 jours depuis la première connexion de l’utilisateur)"
+msgstr "Inconnu (nécessite 30 jours depuis la première connexion de l’utilisateur)"
 
 #. Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this labels the date the user registered their Meta-wiki account or the date their account was merged by the SUL merge process. Don't remove the *
 #: TWLight/users/templates/users/editor_detail_data.html:232
@@ -3245,25 +2492,14 @@ msgstr "Données personnelles"
 
 #. Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this text is in the 'Personal data' section. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/users/templates/users/editor_detail_data.html:262
-msgid ""
-"The following information is visible only to you, site administrators, "
-"publishing partners (where required), and volunteer Wikipedia Library "
-"coordinators (who have signed a Non-Disclosure Agreement)."
-msgstr ""
-"Cette information est visible seulement par vous, par les administrateurs du "
-"site, les partenaires de publication (quand cela est nécessaire) et par les "
-"coordinateurs bénévoles de la Bibliothèque Wikipédia (qui ont signé un "
-"accord de confidentialité)."
+msgid "The following information is visible only to you, site administrators, publishing partners (where required), and volunteer Wikipedia Library coordinators (who have signed a Non-Disclosure Agreement)."
+msgstr "Cette information est visible seulement par vous, par les administrateurs du site, les partenaires de publication (quand cela est nécessaire) et par les coordinateurs bénévoles de la Bibliothèque Wikipédia (qui ont signé un accord de confidentialité)."
 
 #. Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this labels a button which users can click to update or remove their personal information. Don't translate update_url.
 #: TWLight/users/templates/users/editor_detail_data.html:272
 #, python-format
-msgid ""
-"You may <a class=\"twl-links\" href=\"%(update_url)s\">update or delete</a> "
-"your data at any time."
-msgstr ""
-"Vous pouvez <a class=\"twl-links\" href=\"%(update_url)s\">mettre à jour ou "
-"supprimer</a> vos données à tout moment."
+msgid "You may <a class=\"twl-links\" href=\"%(update_url)s\">update or delete</a> your data at any time."
+msgstr "Vous pouvez <a class=\"twl-links\" href=\"%(update_url)s\">mettre à jour ou supprimer</a> vos données à tout moment."
 
 #. Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this labels the user's email. Don't remove the *.
 #: TWLight/users/templates/users/editor_detail_data.html:283
@@ -3282,32 +2518,19 @@ msgstr "Affiliation institutionnelle"
 
 #. Translators: This message tells users that they are not eligible to access The Wikipedia Library content.
 #: TWLight/users/templates/users/eligibility_modal.html:7
-msgid ""
-"Sorry, your Wikipedia account doesn’t currently qualify to access The "
-"Wikipedia Library."
-msgstr ""
-"Désolé, votre compte Wikipédia ne remplit pas les critères pour accéder à La "
-"Bibliothèque Wikipédia."
+msgid "Sorry, your Wikipedia account doesn’t currently qualify to access The Wikipedia Library."
+msgstr "Désolé, votre compte Wikipédia ne remplit pas les critères pour accéder à La Bibliothèque Wikipédia."
 
 #. Translators: This message tells users that they have not agreed to the terms of use, therefore are ineligible to access the content in The Wikipedia Library.
 #: TWLight/users/templates/users/eligibility_modal.html:30
 #, python-format
-msgid ""
-"Agreed with <a href=\"%(terms)s\" class=\"text-danger\"> terms of use </a>"
-msgstr ""
-"A accepté les <a href=\"%(terms)s\" class=\"text-danger\">conditions "
-"d’utilisation</a> du site"
+msgid "Agreed with <a href=\"%(terms)s\" class=\"text-danger\"> terms of use </a>"
+msgstr "A accepté les <a href=\"%(terms)s\" class=\"text-danger\">conditions d’utilisation</a> du site"
 
 #: TWLight/users/templates/users/eligibility_modal.html:40
 #, python-format
-msgid ""
-"It looks like you have an active block on your account. If you meet the "
-"other criteria you may still be permitted access to the library - please <a "
-"href=\"%(contact_url)s\">contact us</a>."
-msgstr ""
-"Il semblerait que vous ayez un blocage actif sur votre compte. Si vous "
-"répondez aux autres critères, vous pouvez encore être autorisé à accéder à "
-"la bibliothèque — veuillez <a href=\"%(contact_url)s\">nous contacter</a>."
+msgid "It looks like you have an active block on your account. If you meet the other criteria you may still be permitted access to the library - please <a href=\"%(contact_url)s\">contact us</a>."
+msgstr "Il semblerait que vous ayez un blocage actif sur votre compte. Si vous répondez aux autres critères, vous pouvez encore être autorisé à accéder à la bibliothèque — veuillez <a href=\"%(contact_url)s\">nous contacter</a>."
 
 #. Translators: Instructions to refresh a user's data.
 #: TWLight/users/templates/users/eligibility_modal.html:50
@@ -3332,8 +2555,7 @@ msgstr "La collection est entièrement consultable via la barre de recherche"
 #. Translators: Text that describes a search icon.
 #: TWLight/users/templates/users/filter_section.html:54
 msgid "Collection is only partially searchable via the search bar"
-msgstr ""
-"La collection n'est que partiellement consultable via la barre de recherche."
+msgstr "La collection n'est que partiellement consultable via la barre de recherche."
 
 #. Translators: Text that explains when there is no search icon.
 #: TWLight/users/templates/users/filter_section.html:58
@@ -3347,14 +2569,8 @@ msgstr "Définir la langue"
 
 #. Translators: This text on the user page helps users naviage to the TranslateWiki Wikipedia Library Card platform translation page.
 #: TWLight/users/templates/users/language_form.html:31
-msgid ""
-"You can help translate the tool at <a class=\"twl-links\" href=\"https://"
-"translatewiki.net/wiki/Translating:Wikipedia_Library_Card_Platform"
-"\">translatewiki.net</a>."
-msgstr ""
-"Vous pouvez aider à traduire l’outil sur <a class=\"twl-links\" href="
-"\"https://translatewiki.net/wiki/Translating:Wikipedia_Library_Card_Platform"
-"\">translatewiki.net</a>."
+msgid "You can help translate the tool at <a class=\"twl-links\" href=\"https://translatewiki.net/wiki/Translating:Wikipedia_Library_Card_Platform\">translatewiki.net</a>."
+msgstr "Vous pouvez aider à traduire l’outil sur <a class=\"twl-links\" href=\"https://translatewiki.net/wiki/Translating:Wikipedia_Library_Card_Platform\">translatewiki.net</a>."
 
 #. Translators: When the user starts a new application and submits the application, the user can view the application and withdraw if need be. This changes the label for the Withdraw button.
 #: TWLight/users/templates/users/my_applications.html:65
@@ -3373,12 +2589,8 @@ msgstr "Demander un renouvellement"
 
 #. Translators: On the page listing applications, this text explains a user they cannot renew their application since they've already requested a renewal or there aren't any renewals available.
 #: TWLight/users/templates/users/my_applications.html:79
-msgid ""
-"Renewals are either not required, not available right now, or you have "
-"already requested a renewal."
-msgstr ""
-"Les renouvellements ne sont pas nécessaires,ou sont indisponibles pour le "
-"moment, ou sont impossibles car vous avez déjà demandé un renouvellement."
+msgid "Renewals are either not required, not available right now, or you have already requested a renewal."
+msgstr "Les renouvellements ne sont pas nécessaires,ou sont indisponibles pour le moment, ou sont impossibles car vous avez déjà demandé un renouvellement."
 
 #. Translators: This text is the heading of a section in a user's profile where they can change their preferences.
 #: TWLight/users/templates/users/preferences.html:6
@@ -3441,27 +2653,13 @@ msgstr "Restreindre le traitement des données"
 
 #. Translators: This message is displayed on the page where users can request we stop processing their data.
 #: TWLight/users/templates/users/restrict_data.html:15
-msgid ""
-"Checking this box and clicking “Restrict” will pause all processing of the "
-"data you have entered into this website. You will not be able to apply for "
-"access to resources, your applications will not be further processed, and "
-"none of your data will be altered, until you return to this page and uncheck "
-"the box. This is not the same as deleting your data."
-msgstr ""
-"Cochez cette case et cliquez sur « Restreindre » suspendra tout traitement "
-"des données que vous avez entrées sur ce site. Vous ne pourrez pas demander "
-"d’accès aux ressources, vos candidatures ne seront plus traitées et aucune "
-"de vos données ne sera modifiée avant que vous reveniez à cette page et "
-"décochiez la case. Ce n’est pas la même chose que supprimer vos données."
+msgid "Checking this box and clicking “Restrict” will pause all processing of the data you have entered into this website. You will not be able to apply for access to resources, your applications will not be further processed, and none of your data will be altered, until you return to this page and uncheck the box. This is not the same as deleting your data."
+msgstr "Cochez cette case et cliquez sur « Restreindre » suspendra tout traitement des données que vous avez entrées sur ce site. Vous ne pourrez pas demander d’accès aux ressources, vos candidatures ne seront plus traitées et aucune de vos données ne sera modifiée avant que vous reveniez à cette page et décochiez la case. Ce n’est pas la même chose que supprimer vos données."
 
 #. Translators: This warning message is shown to coordinators who view the data restriction page.
 #: TWLight/users/templates/users/restrict_data.html:26
-msgid ""
-"You are a coordinator on this site. If you restrict the processing of your "
-"data, your coordinator flag will be removed."
-msgstr ""
-"Vous êtes un coordinateur de ce site. Si vous limitez le traitement de vos "
-"données, votre statut de coordinateur vous sera retiré."
+msgid "You are a coordinator on this site. If you restrict the processing of your data, your coordinator flag will be removed."
+msgstr "Vous êtes un coordinateur de ce site. Si vous limitez le traitement de vos données, votre statut de coordinateur vous sera retiré."
 
 #. Translators: use the date *when you are translating*, in a language-appropriate format.
 #: TWLight/users/templates/users/terms.html:33
@@ -3476,108 +2674,37 @@ msgstr "Politique de confidentialité de la Wikimedia Foundation"
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:41
 msgid "Wikipedia Library Card Terms of Use and Privacy Statement"
-msgstr ""
-"Conditions d’utilisation et politique de confidentialité pour la Carte de "
-"Bibliothèque Wikipédia"
+msgstr "Conditions d’utilisation et politique de confidentialité pour la Carte de Bibliothèque Wikipédia"
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:51
-msgid ""
-"<a class=\"twl-links\" href=\"https://meta.wikimedia.org/wiki/"
-"The_Wikipedia_Library\"> The Wikipedia Library </a> has partnered with "
-"publishers around the world to allow users to access otherwise paywalled "
-"resources. This website allows Wikipedia editors to search and access these "
-"resources."
-msgstr ""
-"<a class=\"twl-links\"href=\"https://meta.wikimedia.org/wiki/"
-"The_Wikipedia_Library/fr\"> La Bibliothèque Wikipédia </a> a établi un "
-"partenariat avec des organisations du monde entier pour permettre aux "
-"utilisateurs d’accéder gratuitement à des ressources normalement payantes. "
-"Ce site web permet aux contributeurs de Wikipédia de rechercher et d’accéder "
-"à ces ressources."
+msgid "<a class=\"twl-links\" href=\"https://meta.wikimedia.org/wiki/The_Wikipedia_Library\"> The Wikipedia Library </a> has partnered with publishers around the world to allow users to access otherwise paywalled resources. This website allows Wikipedia editors to search and access these resources."
+msgstr "<a class=\"twl-links\"href=\"https://meta.wikimedia.org/wiki/The_Wikipedia_Library/fr\"> La Bibliothèque Wikipédia </a> a établi un partenariat avec des organisations du monde entier pour permettre aux utilisateurs d’accéder gratuitement à des ressources normalement payantes. Ce site web permet aux contributeurs de Wikipédia de rechercher et d’accéder à ces ressources."
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Wikimedia Foundation should not be translated. WMF should not be translated. Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:63
-msgid ""
-"This program is administered by the Wikimedia Foundation (WMF). These terms "
-"of use and privacy notice pertain to your application for access to "
-"resources through the Wikipedia Library, your use of this website, and your "
-"access to and use of those resources. They also describe our handling of the "
-"information you provide to us in order to create and administer your "
-"Wikipedia Library account. If we make material changes to the terms, we will "
-"notify users."
-msgstr ""
-"Ce programme est géré par la Fondation Wikimedia (WMF). Ces conditions "
-"d’utilisation et avis de confidentialité se rapportent à votre demande "
-"d’accès aux ressources disponibles à travers La Bibliothèque Wikipédia, à "
-"votre utilisation de ce site web et à votre accès et utilisation de ces "
-"ressources. Ils décrivent également notre gestion des informations que vous "
-"nous fournissez afin de créer et de gérer votre compte sur La Bibliothèque "
-"Wikipédia. Si nous apportons des modifications substantielles à ces "
-"conditions, nous notifierons les utilisateurs."
+msgid "This program is administered by the Wikimedia Foundation (WMF). These terms of use and privacy notice pertain to your application for access to resources through the Wikipedia Library, your use of this website, and your access to and use of those resources. They also describe our handling of the information you provide to us in order to create and administer your Wikipedia Library account. If we make material changes to the terms, we will notify users."
+msgstr "Ce programme est géré par la Fondation Wikimedia (WMF). Ces conditions d’utilisation et avis de confidentialité se rapportent à votre demande d’accès aux ressources disponibles à travers La Bibliothèque Wikipédia, à votre utilisation de ce site web et à votre accès et utilisation de ces ressources. Ils décrivent également notre gestion des informations que vous nous fournissez afin de créer et de gérer votre compte sur La Bibliothèque Wikipédia. Si nous apportons des modifications substantielles à ces conditions, nous notifierons les utilisateurs."
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:74
 msgid "Requirements for a Wikipedia Library Card Account"
-msgstr ""
-"Conditions pour obtenir un compte pour la Carte de Bibliothèque Wikipédia"
+msgstr "Conditions pour obtenir un compte pour la Carte de Bibliothèque Wikipédia"
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:78
-msgid ""
-"Access to resources via The Wikipedia Library is reserved for community "
-"members who have demonstrated their commitment to the Wikimedia projects, "
-"and who will use their access to these resources to improve project content. "
-"To that end, in order to be eligible for The Wikipedia Library, we require "
-"that you be registered for a user account on the projects, with at least 500 "
-"edits, six (6) months of activity, and 10+ edits in the last month. We ask "
-"that you do not request access to any publishers with a limited number of "
-"available accounts whose resources you can already access for free through "
-"your local library or university, or another institution or organization, in "
-"order to provide that opportunity to others."
-msgstr ""
-"L’accès aux ressources de La Bibliothèque Wikipédia est réservé aux membres "
-"de la communauté qui ont démontré leur engagement envers les projets "
-"Wikimedia et qui utiliseront leur accès à ces ressources pour améliorer le "
-"contenu des projets. Ainsi, pour avoir accès La Bibliothèque Wikipédia, nous "
-"demandons à ce que vous ayez un compte utilisateur enregistré sur les "
-"projets, avec au moins 500 modifications, six (6) mois d’activité et plus de "
-"10 modifications durant le dernier mois. Nous vous demandons de ne pas "
-"demander l’accès à un éditeur dont l’accès est limité à un certain nombre de "
-"comptes, s’il vous est déjà accessible gratuitement depuis votre "
-"bibliothèque ou université locale ou toute autre institution ou "
-"organisation, afin d’offrir cette possibilité à d’autres."
+msgid "Access to resources via The Wikipedia Library is reserved for community members who have demonstrated their commitment to the Wikimedia projects, and who will use their access to these resources to improve project content. To that end, in order to be eligible for The Wikipedia Library, we require that you be registered for a user account on the projects, with at least 500 edits, six (6) months of activity, and 10+ edits in the last month. We ask that you do not request access to any publishers with a limited number of available accounts whose resources you can already access for free through your local library or university, or another institution or organization, in order to provide that opportunity to others."
+msgstr "L’accès aux ressources de La Bibliothèque Wikipédia est réservé aux membres de la communauté qui ont démontré leur engagement envers les projets Wikimedia et qui utiliseront leur accès à ces ressources pour améliorer le contenu des projets. Ainsi, pour avoir accès La Bibliothèque Wikipédia, nous demandons à ce que vous ayez un compte utilisateur enregistré sur les projets, avec au moins 500 modifications, six (6) mois d’activité et plus de 10 modifications durant le dernier mois. Nous vous demandons de ne pas demander l’accès à un éditeur dont l’accès est limité à un certain nombre de comptes, s’il vous est déjà accessible gratuitement depuis votre bibliothèque ou université locale ou toute autre institution ou organisation, afin d’offrir cette possibilité à d’autres."
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:94
-msgid ""
-"Additionally, if you are currently blocked or banned from a Wikimedia "
-"project, applications to resources may be rejected or restricted. If you "
-"obtain a Wikipedia Library account, but a block or ban is subsequently "
-"instituted against you on one of the projects, you may lose access to your "
-"Wikipedia Library account."
-msgstr ""
-"En outre, si vous êtes actuellement bloqué(e) ou banni(e) d’un projet "
-"Wikimedia, vos candidatures pour l’accès aux ressources peuvent être "
-"rejetées ou restreintes. Si vous obtenez un compte sur La Bibliothèque "
-"Wikipédia mais qu’un blocage ou un bannissement est ensuite intenté contre "
-"vous sur l’un des projets, vous risquez de perdre l’accès à votre compte sur "
-"La Bibliothèque Wikipédia."
+msgid "Additionally, if you are currently blocked or banned from a Wikimedia project, applications to resources may be rejected or restricted. If you obtain a Wikipedia Library account, but a block or ban is subsequently instituted against you on one of the projects, you may lose access to your Wikipedia Library account."
+msgstr "En outre, si vous êtes actuellement bloqué(e) ou banni(e) d’un projet Wikimedia, vos candidatures pour l’accès aux ressources peuvent être rejetées ou restreintes. Si vous obtenez un compte sur La Bibliothèque Wikipédia mais qu’un blocage ou un bannissement est ensuite intenté contre vous sur l’un des projets, vous risquez de perdre l’accès à votre compte sur La Bibliothèque Wikipédia."
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:104
-msgid ""
-"Your eligibility to access The Wikipedia Library is assessed at each login. "
-"While more than half of the library's content is provided via this automated "
-"eligibility check, access to other publisher's content may be time limited, "
-"typically lapsing after one year, after which you will usually need to apply "
-"for renewal."
-msgstr ""
-"Votre droit à accéder à La Bibliothèque Wikipédia est réévalué à chaque "
-"connexion. Même si plus de la moitié des ressources de la bibliothèque est "
-"fournie grâce à cette vérification automatique, l’accès à d’autres "
-"ressources peut être limité dans le temps, typiquement un an, après quoi "
-"vous devrez généralement demander un renouvèlement."
+msgid "Your eligibility to access The Wikipedia Library is assessed at each login. While more than half of the library's content is provided via this automated eligibility check, access to other publisher's content may be time limited, typically lapsing after one year, after which you will usually need to apply for renewal."
+msgstr "Votre droit à accéder à La Bibliothèque Wikipédia est réévalué à chaque connexion. Même si plus de la moitié des ressources de la bibliothèque est fournie grâce à cette vérification automatique, l’accès à d’autres ressources peut être limité dans le temps, typiquement un an, après quoi vous devrez généralement demander un renouvèlement."
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:114
@@ -3586,72 +2713,28 @@ msgstr "Faire une demande via votre compte de Carte de Bibliothèque Wikipédia"
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:118
-msgid ""
-"In order to apply for access to a partner resource, you must provide us with "
-"certain information, which we will use to evaluate your application. If your "
-"application is approved, we may transfer the information you have given us "
-"to the publishers whose resources you wish to access. They will either "
-"contact you with the account information directly or we will send access "
-"information to you ourselves."
-msgstr ""
-"Pour demander l’accès à une ressource d’un partenaire, vous devez nous "
-"fournir certaines informations, que nous allons utiliser pour évaluer votre "
-"demande. Si votre demande est approuvée, nous pouvons transférer les "
-"informations que vous avez données aux organisations dont vous souhaitez "
-"accéder aux ressources. Ils vous contacteront directement avec les "
-"informations du compte ou nous vous enverrons les informations d’accès nous-"
-"mêmes."
+msgid "In order to apply for access to a partner resource, you must provide us with certain information, which we will use to evaluate your application. If your application is approved, we may transfer the information you have given us to the publishers whose resources you wish to access. They will either contact you with the account information directly or we will send access information to you ourselves."
+msgstr "Pour demander l’accès à une ressource d’un partenaire, vous devez nous fournir certaines informations, que nous allons utiliser pour évaluer votre demande. Si votre demande est approuvée, nous pouvons transférer les informations que vous avez données aux organisations dont vous souhaitez accéder aux ressources. Ils vous contacteront directement avec les informations du compte ou nous vous enverrons les informations d’accès nous-mêmes."
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:130
-msgid ""
-"In addition to the basic information you provide to us, our system will "
-"retrieve some information directly from the Wikimedia projects: your "
-"username, email address, edit count, registration date, user ID number, "
-"groups to which you belong, and any special user rights."
-msgstr ""
-"Outre les informations de base que vous nous fournissez, notre système "
-"permet de récupérer des informations directement des projets Wikimedia : "
-"votre nom d’utilisateur, courriel, nombre de modifications, la date "
-"d’enregistrement, le numéro ID d'utilisateur, les groupes auxquels vous "
-"appartenez et tous vos droits d’utilisateur."
+msgid "In addition to the basic information you provide to us, our system will retrieve some information directly from the Wikimedia projects: your username, email address, edit count, registration date, user ID number, groups to which you belong, and any special user rights."
+msgstr "Outre les informations de base que vous nous fournissez, notre système permet de récupérer des informations directement des projets Wikimedia : votre nom d’utilisateur, courriel, nombre de modifications, la date d’enregistrement, le numéro ID d'utilisateur, les groupes auxquels vous appartenez et tous vos droits d’utilisateur."
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:140
-msgid ""
-"Each time you log in to the Wikipedia Library Card Platform, this "
-"information will be automatically updated."
-msgstr ""
-"Chaque fois que vous vous connectez au système, ces informations seront "
-"automatiquement mises à jour."
+msgid "Each time you log in to the Wikipedia Library Card Platform, this information will be automatically updated."
+msgstr "Chaque fois que vous vous connectez au système, ces informations seront automatiquement mises à jour."
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:148
-msgid ""
-"We will ask you to provide us with some information about your history of "
-"contributions to the Wikimedia projects. Information on contribution history "
-"is optional, but will greatly assist us in evaluating your application."
-msgstr ""
-"Nous vous demanderons de nous fournir des informations au sujet de vos "
-"contributions aux projets Wikimedia. Ce dernier est facultatif, mais nous "
-"aidera grandement dans l’évaluation de votre demande."
+msgid "We will ask you to provide us with some information about your history of contributions to the Wikimedia projects. Information on contribution history is optional, but will greatly assist us in evaluating your application."
+msgstr "Nous vous demanderons de nous fournir des informations au sujet de vos contributions aux projets Wikimedia. Ce dernier est facultatif, mais nous aidera grandement dans l’évaluation de votre demande."
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). WMF should not be translated. Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:157
-msgid ""
-"The information you provide when creating your account will be visible to "
-"you while on the site but not to others unless they are approved Wikipedia "
-"Library Coordinators, WMF Staff, or WMF Contractors who need access to this "
-"data in order to carry out their work with the Wikipedia Library, all of "
-"whom are subject to non-disclosure obligations."
-msgstr ""
-"Les informations que vous fournissez lors de la création de votre compte "
-"seront visibles pour vous depuis le site, mais pas pour les autres, à moins "
-"qu’ils soient des coordinateurs agréés de La Bibliothèque Wikipédia, des "
-"membres du personnel de la WMF ou des personnes sous contrat avec la WMF qui "
-"ont besoin d’accéder à ces données afin de faire leur travail sur La "
-"Bibliothèque Wikipédia ; tous sont soumis à une obligation de "
-"confidentialité."
+msgid "The information you provide when creating your account will be visible to you while on the site but not to others unless they are approved Wikipedia Library Coordinators, WMF Staff, or WMF Contractors who need access to this data in order to carry out their work with the Wikipedia Library, all of whom are subject to non-disclosure obligations."
+msgstr "Les informations que vous fournissez lors de la création de votre compte seront visibles pour vous depuis le site, mais pas pour les autres, à moins qu’ils soient des coordinateurs agréés de La Bibliothèque Wikipédia, des membres du personnel de la WMF ou des personnes sous contrat avec la WMF qui ont besoin d’accéder à ces données afin de faire leur travail sur La Bibliothèque Wikipédia ; tous sont soumis à une obligation de confidentialité."
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:167
@@ -3660,64 +2743,33 @@ msgstr "Votre utilisation des ressources des partenaires"
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:171
-msgid ""
-"In order to access an individual publisher’s resources, you must agree to "
-"that publisher’s terms of use and privacy policy. You agree that you will "
-"not violate such terms and policies in connection with your use of the "
-"Wikipedia Library. Additionally, the following activities are prohibited "
-"while accessing publisher resources through the Wikipedia Library."
-msgstr ""
-"Pour accéder aux ressources d’un partenaire particulier, vous devez accepter "
-"les conditions d’utilisation de ce partenaire ainsi que sa politique de "
-"confidentialité. Vous acceptez de ne pas violer ces conditions et politiques "
-"lors de votre utilisation de la Bibliothèque Wikipédia. En outre, les "
-"activités suivantes sont interdites lorsque vous accédez aux ressources via "
-"la Bibliothèque Wikipédia."
+msgid "In order to access an individual publisher’s resources, you must agree to that publisher’s terms of use and privacy policy. You agree that you will not violate such terms and policies in connection with your use of the Wikipedia Library. Additionally, the following activities are prohibited while accessing publisher resources through the Wikipedia Library."
+msgstr "Pour accéder aux ressources d’un partenaire particulier, vous devez accepter les conditions d’utilisation de ce partenaire ainsi que sa politique de confidentialité. Vous acceptez de ne pas violer ces conditions et politiques lors de votre utilisation de la Bibliothèque Wikipédia. En outre, les activités suivantes sont interdites lorsque vous accédez aux ressources via la Bibliothèque Wikipédia."
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:184
-msgid ""
-"Sharing your Wikipedia account, usernames, passwords, or any access codes "
-"for publisher resources with others;"
-msgstr ""
-"partager avec d’autres personnes votre compte Wikipédia, vos noms "
-"d’utilisateur, mots de passe ou n’importe quel code d’accès aux ressources "
-"des éditeurs ;"
+msgid "Sharing your Wikipedia account, usernames, passwords, or any access codes for publisher resources with others;"
+msgstr "partager avec d’autres personnes votre compte Wikipédia, vos noms d’utilisateur, mots de passe ou n’importe quel code d’accès aux ressources des éditeurs ;"
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:191
-msgid ""
-"Automatically scraping or downloading restricted content from publishers;"
-msgstr ""
-"extraire ou télécharger automatiquement du contenu restreint des éditeurs ;"
+msgid "Automatically scraping or downloading restricted content from publishers;"
+msgstr "extraire ou télécharger automatiquement du contenu restreint des éditeurs ;"
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:197
-msgid ""
-"Systematically making printed or electronic copies of multiple extracts of "
-"restricted content available for any purpose;"
-msgstr ""
-"faire systématiquement des copies imprimées ou électroniques de plusieurs "
-"extraits de contenu restreint dans un but quelconque ;"
+msgid "Systematically making printed or electronic copies of multiple extracts of restricted content available for any purpose;"
+msgstr "faire systématiquement des copies imprimées ou électroniques de plusieurs extraits de contenu restreint dans un but quelconque ;"
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:204
-msgid ""
-"Data mining metadata without permission—for example, in order to use "
-"metadata for auto-created stub articles;"
-msgstr ""
-"fouiller des métadonnées sans permission, par exemple pour la création "
-"automatique d’ébauches d’articles ;"
+msgid "Data mining metadata without permission—for example, in order to use metadata for auto-created stub articles;"
+msgstr "fouiller des métadonnées sans permission, par exemple pour la création automatique d’ébauches d’articles ;"
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:211
-msgid ""
-"Using the access you receive through the Wikipedia Library for profit by "
-"selling access to your account or resources which you have through it."
-msgstr ""
-"Utiliser l’accès que vous avez reçu grâce à la Bibliothèque Wikipédia pour "
-"en tirer un profit en vendant un accès à votre compte ou des ressources que "
-"vous avez récupérées grâce à votre compte."
+msgid "Using the access you receive through the Wikipedia Library for profit by selling access to your account or resources which you have through it."
+msgstr "Utiliser l’accès que vous avez reçu grâce à la Bibliothèque Wikipédia pour en tirer un profit en vendant un accès à votre compte ou des ressources que vous avez récupérées grâce à votre compte."
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:220
@@ -3726,27 +2778,13 @@ msgstr "Services externes de recherche et de mandataire"
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:224
-msgid ""
-"Certain resources may only be accessed using an external search service, "
-"such as the EBSCO Discovery Service, or a proxy service, such as OCLC "
-"EZProxy. If you use such external search and/or proxy services, please "
-"review the applicable terms of use and privacy policies."
-msgstr ""
-"Il n’est possible d’accéder à certaines ressources qu’en utilisant un "
-"service de recherche externe (tel que le Service de découverte EBSCO) ou un "
-"service de serveur mandataire (tel que EZProxy d’OCLC). Si vous utilisez un "
-"tel service de recherche externe ou de serveur mandataire, lisez "
-"attentivement leurs conditions d’utilisation et politiques de "
-"confidentialité applicables."
+msgid "Certain resources may only be accessed using an external search service, such as the EBSCO Discovery Service, or a proxy service, such as OCLC EZProxy. If you use such external search and/or proxy services, please review the applicable terms of use and privacy policies."
+msgstr "Il n’est possible d’accéder à certaines ressources qu’en utilisant un service de recherche externe (tel que le Service de découverte EBSCO) ou un service de serveur mandataire (tel que EZProxy d’OCLC). Si vous utilisez un tel service de recherche externe ou de serveur mandataire, lisez attentivement leurs conditions d’utilisation et politiques de confidentialité applicables."
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:234
-msgid ""
-"In addition, if you use OCLC EZProxy, please note that you may not use it "
-"for commercial purposes."
-msgstr ""
-"De plus, si vous utilisez ''EZProxy de OCLC'', prenez note que vous ne "
-"pouvez pas l’utiliser à des fins commerciales."
+msgid "In addition, if you use OCLC EZProxy, please note that you may not use it for commercial purposes."
+msgstr "De plus, si vous utilisez ''EZProxy de OCLC'', prenez note que vous ne pouvez pas l’utiliser à des fins commerciales."
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:241
@@ -3755,209 +2793,51 @@ msgstr "Conservation et traitement de l’information"
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Wikimedia Foundation should not be translated. Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:245
-msgid ""
-"The Wikimedia Foundation and our service providers use your information for "
-"the legitimate purpose of providing Wikipedia Library services in support of "
-"our charitable mission. When you apply for a Wikipedia Library account, or "
-"use your Wikipedia Library account, we may routinely collect the following "
-"information: your username, email address, edit count, registration date, "
-"user ID number, groups to which you belong, and any special user rights; "
-"your name, country of residence, and/or affiliation, if required by a "
-"partner to which you are applying; your narrative description of your "
-"contributions and reasons for applying for access to partner resources; and "
-"the date you agree to these terms of use."
-msgstr ""
-"La Fondation Wikimedia et nos fournisseurs de services utilisent vos "
-"informations dans des buts légitimes pour fournir les services de la "
-"Bibliothèque Wikipédia dans le cadre de notre mission d’utilité publique. "
-"Lorsque vous demandez un compte sur la Bibliothèque Wikipédia ou vous "
-"utilisez votre compte de Bibliothèque Wikipédia, nous pouvons couramment "
-"récupérer les informations suivantes : votre nom d’utilisateur, votre "
-"adresse de courriel, votre nombre de modifications, votre date "
-"d’inscription, votre numéro d’identifiant utilisateur, les groupes auxquels "
-"vous appartenez et tous vos droits d’utilisateur spéciaux ; votre nom, votre "
-"pays de résidence et (ou) votre affiliation, si requis par un partenaire "
-"auquel vous faite la demande ; la description de vos contributions et les "
-"raisons de votre demande d’accès aux ressources du partenaire ; enfin la "
-"date à laquelle vous avez acceptez ces conditions d’utilisation."
+msgid "The Wikimedia Foundation and our service providers use your information for the legitimate purpose of providing Wikipedia Library services in support of our charitable mission. When you apply for a Wikipedia Library account, or use your Wikipedia Library account, we may routinely collect the following information: your username, email address, edit count, registration date, user ID number, groups to which you belong, and any special user rights; your name, country of residence, and/or affiliation, if required by a partner to which you are applying; your narrative description of your contributions and reasons for applying for access to partner resources; and the date you agree to these terms of use."
+msgstr "La Fondation Wikimedia et nos fournisseurs de services utilisent vos informations dans des buts légitimes pour fournir les services de la Bibliothèque Wikipédia dans le cadre de notre mission d’utilité publique. Lorsque vous demandez un compte sur la Bibliothèque Wikipédia ou vous utilisez votre compte de Bibliothèque Wikipédia, nous pouvons couramment récupérer les informations suivantes : votre nom d’utilisateur, votre adresse de courriel, votre nombre de modifications, votre date d’inscription, votre numéro d’identifiant utilisateur, les groupes auxquels vous appartenez et tous vos droits d’utilisateur spéciaux ; votre nom, votre pays de résidence et (ou) votre affiliation, si requis par un partenaire auquel vous faite la demande ; la description de vos contributions et les raisons de votre demande d’accès aux ressources du partenaire ; enfin la date à laquelle vous avez acceptez ces conditions d’utilisation."
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:262
 #, python-format
-msgid ""
-"Each publisher who is a member of the Wikipedia Library program requires "
-"different specific information in the application. Some publishers may "
-"request only an email address, while others request more detailed data, such "
-"as your name, location, or institutional affiliation. When you complete your "
-"application, you will only be asked to supply information required by the "
-"publishers you have chosen, and each publisher will only receive the "
-"information they require for providing you with access. Please see our <a "
-"class=\"twl-links\" href=\"%(all_partners_url)s\">partner information</a> "
-"pages to learn what information is required by each publisher to gain access "
-"to their resources."
-msgstr ""
-"Chaque éditeur de publication partenaire, membre du programme de La "
-"Bibliothèque Wikipédia, a besoin d’informations différentes dans les actes "
-"de candidatures. Certains éditeurs peuvent ne demander qu’une adresse de "
-"courriel, tandis que d’autres demandent des données plus détaillées telles "
-"que votre nom, votre pays de résidence, ou votre affiliation "
-"institutionnelle. Lorsque vous remplissez votre candidature, vous serez "
-"invité(e) à ne fournir que les informations requises par les partenaires que "
-"vous avez choisis et chaque partenaire ne recevra que les informations dont "
-"il a besoin pour vous fournir l’accès. Vous pouvez consulter les pages d’<a "
-"class=\"twl-links\" href=\"%(all_partners_url)s\">information sur nos "
-"partenaires</a> pour connaître les informations requises par chaque éditeur "
-"de publication afin d'obtenir l'accès à ses ressources."
+msgid "Each publisher who is a member of the Wikipedia Library program requires different specific information in the application. Some publishers may request only an email address, while others request more detailed data, such as your name, location, or institutional affiliation. When you complete your application, you will only be asked to supply information required by the publishers you have chosen, and each publisher will only receive the information they require for providing you with access. Please see our <a class=\"twl-links\" href=\"%(all_partners_url)s\">partner information</a> pages to learn what information is required by each publisher to gain access to their resources."
+msgstr "Chaque éditeur de publication partenaire, membre du programme de La Bibliothèque Wikipédia, a besoin d’informations différentes dans les actes de candidatures. Certains éditeurs peuvent ne demander qu’une adresse de courriel, tandis que d’autres demandent des données plus détaillées telles que votre nom, votre pays de résidence, ou votre affiliation institutionnelle. Lorsque vous remplissez votre candidature, vous serez invité(e) à ne fournir que les informations requises par les partenaires que vous avez choisis et chaque partenaire ne recevra que les informations dont il a besoin pour vous fournir l’accès. Vous pouvez consulter les pages d’<a class=\"twl-links\" href=\"%(all_partners_url)s\">information sur nos partenaires</a> pour connaître les informations requises par chaque éditeur de publication afin d'obtenir l'accès à ses ressources."
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Wikimedia Foundation should not be translated. Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:277
-msgid ""
-"Some Wikipedia Library pages are visible without logging in, but you will "
-"need to log in to apply or access proprietary partner resources. We use the "
-"data provided by you via OAuth and Wikimedia API calls to assess your "
-"application for access and to process approved requests."
-msgstr ""
-"Certaines pages de La Bibliothèque Wikipédia sont visibles sans se "
-"connecter, mais la connexion est requise pour accéder à des ressources "
-"appartenant aux partenaires ou les demander par un acte de candidature. Nous "
-"utilisons les données fournies par vous via OAuth et l’API Wikimedia afin "
-"d’évaluer votre candidature pour l’accès et de traiter les demandes "
-"approuvées."
+msgid "Some Wikipedia Library pages are visible without logging in, but you will need to log in to apply or access proprietary partner resources. We use the data provided by you via OAuth and Wikimedia API calls to assess your application for access and to process approved requests."
+msgstr "Certaines pages de La Bibliothèque Wikipédia sont visibles sans se connecter, mais la connexion est requise pour accéder à des ressources appartenant aux partenaires ou les demander par un acte de candidature. Nous utilisons les données fournies par vous via OAuth et l’API Wikimedia afin d’évaluer votre candidature pour l’accès et de traiter les demandes approuvées."
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:288
 #, python-format
-msgid ""
-"In order to administer the Wikipedia Library program, we will retain the "
-"application data we collect from you for three years after your most recent "
-"login, unless you delete your account, as described below. You can log in "
-"and go to <a class=\"twl-links\" href=\"%(profile_url)s\">your profile page</"
-"a> in order to see the information associated with your account, and can "
-"download it in JSON format. You may access, update, restrict, or delete this "
-"information at any time, except for the information that is automatically "
-"retrieved from the projects. If you have any questions or concerns about the "
-"handling of your data, please contact <a class=\"twl-links\" href=\"mailto:"
-"wikipedialibrary@wikimedia.org?Subject=Wikipedia%%20Library%%20Card"
-"%%20account%%20deactivation\"> wikipedialibrary@wikimedia.org </a>."
-msgstr ""
-"Afin d’administrer le programme de la Bibliothèque Wikipédia, nous "
-"conserverons les données de la demande d’accès que nous recueillons à "
-"travers vous pendant trois ans après votre dernière connexion, sauf si vous "
-"supprimez votre compte, tel que décrit ci-dessous. Vous pouvez vous "
-"connecter et accéder à <a class=\"twl-links\" href=\"%(profile_url)s\">votre "
-"page de profil</a> afin de voir les informations associées à votre compte, "
-"et de pouvoir les télécharger au format JSON. Vous pouvez accéder, mettre à "
-"jour, restreindre ou supprimer ces informations à tout moment, sauf pour les "
-"informations qui sont automatiquement extraites des projets. Si vous avez "
-"une quelconque question ou préoccupation sur la gestion de vos données, vous "
-"pouvez contacter <a class=\"twl-links\" href=\"mailto:"
-"wikipedialibrary@wikimedia.org?Subject=Wikipedia%%20Library%%20Card"
-"%%20account%%20deactivation\">wikipedialibrary@wikimedia.org</a>."
+msgid "In order to administer the Wikipedia Library program, we will retain the application data we collect from you for three years after your most recent login, unless you delete your account, as described below. You can log in and go to <a class=\"twl-links\" href=\"%(profile_url)s\">your profile page</a> in order to see the information associated with your account, and can download it in JSON format. You may access, update, restrict, or delete this information at any time, except for the information that is automatically retrieved from the projects. If you have any questions or concerns about the handling of your data, please contact <a class=\"twl-links\" href=\"mailto:wikipedialibrary@wikimedia.org?Subject=Wikipedia%%20Library%%20Card%%20account%%20deactivation\"> wikipedialibrary@wikimedia.org </a>."
+msgstr "Afin d’administrer le programme de la Bibliothèque Wikipédia, nous conserverons les données de la demande d’accès que nous recueillons à travers vous pendant trois ans après votre dernière connexion, sauf si vous supprimez votre compte, tel que décrit ci-dessous. Vous pouvez vous connecter et accéder à <a class=\"twl-links\" href=\"%(profile_url)s\">votre page de profil</a> afin de voir les informations associées à votre compte, et de pouvoir les télécharger au format JSON. Vous pouvez accéder, mettre à jour, restreindre ou supprimer ces informations à tout moment, sauf pour les informations qui sont automatiquement extraites des projets. Si vous avez une quelconque question ou préoccupation sur la gestion de vos données, vous pouvez contacter <a class=\"twl-links\" href=\"mailto:wikipedialibrary@wikimedia.org?Subject=Wikipedia%%20Library%%20Card%%20account%%20deactivation\">wikipedialibrary@wikimedia.org</a>."
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:305
 #, fuzzy
-msgid ""
-"If you decide to disable your Wikipedia Library account, you can use the "
-"delete button on your profile to delete certain personal information "
-"associated with your account. We will delete your real name, institutional "
-"affiliation, and country of residence. Please note that the system will "
-"retain a record of your username, the publishers to which you applied or had "
-"access, and the dates of that access. Note that deletion is not reversible. "
-"Deletion of your Wikipedia Library account may also correspond with the "
-"removal of any resource access to which you were eligible or approved. If "
-"you request the deletion of account information and later wish to apply for "
-"a new account, you will need to provide the necessary information again."
-msgstr ""
-"Si vous décidez de désactiver votre compte, vous pouvez nous envoyer un "
-"courriel à <a href=\"mailto:wikipedialibrary@wikimedia.org?Subject=Wikipedia%"
-"%20Library%%20Card%%20account%%20deactivation\">wikipedialibrary@wikimedia."
-"org</a> afin de demander la suppression de certaines informations "
-"personnelles associées à votre compte. Nous supprimerons vos nom, "
-"profession, affiliation institutionnelle et pays de résidence. Notez que le "
-"système conservera un enregistrement de votre nom d’utilisateur, des "
-"ressources que vous avez demandées ou auxquelles vous avez eu accès et les "
-"dates de cet accès. Si vous demandez la suppression des informations de "
-"votre compte et plus tard souhaitez un nouveau compte, vous devrez fournir à "
-"nouveau les informations nécessaires."
+msgid "If you decide to disable your Wikipedia Library account, you can use the delete button on your profile to delete certain personal information associated with your account. We will delete your real name, institutional affiliation, and country of residence. Please note that the system will retain a record of your username, the publishers to which you applied or had access, and the dates of that access. Note that deletion is not reversible. Deletion of your Wikipedia Library account may also correspond with the removal of any resource access to which you were eligible or approved. If you request the deletion of account information and later wish to apply for a new account, you will need to provide the necessary information again."
+msgstr "Si vous décidez de désactiver votre compte, vous pouvez nous envoyer un courriel à <a href=\"mailto:wikipedialibrary@wikimedia.org?Subject=Wikipedia%%20Library%%20Card%%20account%%20deactivation\">wikipedialibrary@wikimedia.org</a> afin de demander la suppression de certaines informations personnelles associées à votre compte. Nous supprimerons vos nom, profession, affiliation institutionnelle et pays de résidence. Notez que le système conservera un enregistrement de votre nom d’utilisateur, des ressources que vous avez demandées ou auxquelles vous avez eu accès et les dates de cet accès. Si vous demandez la suppression des informations de votre compte et plus tard souhaitez un nouveau compte, vous devrez fournir à nouveau les informations nécessaires."
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). WMF should not be translated. Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:321
-msgid ""
-"The Wikipedia Library is run by WMF Staff, Contractors, and approved "
-"volunteer Coordinators. The data associated with your account will be shared "
-"with the WMF staff, contractors, service providers, and volunteer "
-"coordinators who need to process the information in connection with their "
-"work for the Wikipedia Library, and who are subject to confidentiality "
-"obligations. We will also use your data for internal Wikipedia Library "
-"purposes such as distributing user surveys and account notifications, and in "
-"a depersonalized or aggregated fashion for statistical analysis and "
-"administration. Finally, we will share your information with the publishers "
-"whom you specifically select in order to provide you with access to "
-"resources. Otherwise, your information will not be shared with third "
-"parties, with the exception of the circumstances described below."
-msgstr ""
-"La Bibliothèque Wikipédia est gérée par le personnel de la WMF, par des "
-"personnes sous contrat avec elle et par des coordinateurs bénévoles. Les "
-"données liées à votre compte seront partagées avec le personnel de la WMF, "
-"les prestataires, les fournisseurs de services et les coordinateurs "
-"bénévoles qui ont besoin de traiter les informations dans le cadre de leur "
-"travail pour la Bibliothèque Wikipedia et qui sont soumis à l’obligation de "
-"confidentialité. Nous utiliserons aussi vos données à des fins internes à la "
-"Bibliothèque Wikipedia comme la distribution des enquêtes utilisateur et des "
-"notifications et, de manière anonymisée ou agrégée, pour la réalisation "
-"d’analyse et d’administration statistiques. Pour finir, nous partagerons vos "
-"informations avec les éditeurs que vous sélectionnez spécifiquement afin "
-"qu’ils vous fournissent un accès à leurs ressources. Autrement, vos "
-"informations ne seront pas partagées à des tiers, sauf dans les "
-"circonstances décrites ci-dessous."
+msgid "The Wikipedia Library is run by WMF Staff, Contractors, and approved volunteer Coordinators. The data associated with your account will be shared with the WMF staff, contractors, service providers, and volunteer coordinators who need to process the information in connection with their work for the Wikipedia Library, and who are subject to confidentiality obligations. We will also use your data for internal Wikipedia Library purposes such as distributing user surveys and account notifications, and in a depersonalized or aggregated fashion for statistical analysis and administration. Finally, we will share your information with the publishers whom you specifically select in order to provide you with access to resources. Otherwise, your information will not be shared with third parties, with the exception of the circumstances described below."
+msgstr "La Bibliothèque Wikipédia est gérée par le personnel de la WMF, par des personnes sous contrat avec elle et par des coordinateurs bénévoles. Les données liées à votre compte seront partagées avec le personnel de la WMF, les prestataires, les fournisseurs de services et les coordinateurs bénévoles qui ont besoin de traiter les informations dans le cadre de leur travail pour la Bibliothèque Wikipedia et qui sont soumis à l’obligation de confidentialité. Nous utiliserons aussi vos données à des fins internes à la Bibliothèque Wikipedia comme la distribution des enquêtes utilisateur et des notifications et, de manière anonymisée ou agrégée, pour la réalisation d’analyse et d’administration statistiques. Pour finir, nous partagerons vos informations avec les éditeurs que vous sélectionnez spécifiquement afin qu’ils vous fournissent un accès à leurs ressources. Autrement, vos informations ne seront pas partagées à des tiers, sauf dans les circonstances décrites ci-dessous."
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). WMF should not be translated.
 #: TWLight/users/templates/users/terms.html:338
-msgid ""
-"We may disclose any collected information when required by law, when we have "
-"your permission, when needed to protect our rights, privacy, safety, users, "
-"or the general public, and when necessary to enforce these terms, WMF’s "
-"general <a class=\"twl-links\" href=\"https://foundation.wikimedia.org/wiki/"
-"Terms_of_Use\">Terms of Use</a>, or any other WMF policy."
-msgstr ""
-"Nous pouvons divulguer vos informations lorsque c’est requis pour obéir à la "
-"loi, lorsque vous nous l’autorisez, lorsque c’est nécessaire pour renforcer "
-"nos droits, protéger la vie privée, la sécurité, les utilisateurs ou le "
-"grand public et lorsque c’est nécessaire pour renforcer ces conditions, <a "
-"class=\"twl-links\" href=\"https://foundation.wikimedia.org/wiki/Terms_of_Use"
-"\">les Conditions générales d’utilisation</a> de la WMF ou toute autre "
-"politique de la WMF."
+msgid "We may disclose any collected information when required by law, when we have your permission, when needed to protect our rights, privacy, safety, users, or the general public, and when necessary to enforce these terms, WMF’s general <a class=\"twl-links\" href=\"https://foundation.wikimedia.org/wiki/Terms_of_Use\">Terms of Use</a>, or any other WMF policy."
+msgstr "Nous pouvons divulguer vos informations lorsque c’est requis pour obéir à la loi, lorsque vous nous l’autorisez, lorsque c’est nécessaire pour renforcer nos droits, protéger la vie privée, la sécurité, les utilisateurs ou le grand public et lorsque c’est nécessaire pour renforcer ces conditions, <a class=\"twl-links\" href=\"https://foundation.wikimedia.org/wiki/Terms_of_Use\">les Conditions générales d’utilisation</a> de la WMF ou toute autre politique de la WMF."
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:349
-msgid ""
-"We take the security of your personal data seriously, and take reasonable "
-"precautions to ensure your data is protected. These precautions include "
-"access controls to limit who has access to your data and security "
-"technologies to protect data stored on the server. However, we cannot "
-"guarantee the safety of your data as it is transmitted and stored."
-msgstr ""
-"Nous prenons en compte avec sérieux la sécurité de vos données personnelles "
-"et prenons des précautions appropriées pour nous assurer que vos données "
-"sont protégées. Parmi ces précautions : des contrôles d’accès pour limiter "
-"le nombre de personnes ayant accès à vos données et des technologies de "
-"sécurité pour protéger les données stockées sur le serveur. Cependant, nous "
-"ne pouvons pas garantir la sûreté complète de vos données puisqu’elles sont "
-"transmises et stockées."
+msgid "We take the security of your personal data seriously, and take reasonable precautions to ensure your data is protected. These precautions include access controls to limit who has access to your data and security technologies to protect data stored on the server. However, we cannot guarantee the safety of your data as it is transmitted and stored."
+msgstr "Nous prenons en compte avec sérieux la sécurité de vos données personnelles et prenons des précautions appropriées pour nous assurer que vos données sont protégées. Parmi ces précautions : des contrôles d’accès pour limiter le nombre de personnes ayant accès à vos données et des technologies de sécurité pour protéger les données stockées sur le serveur. Cependant, nous ne pouvons pas garantir la sûreté complète de vos données puisqu’elles sont transmises et stockées."
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:360
-msgid ""
-"Please note that these terms do not control the use and handling of your "
-"data by the publishers and service providers whose resources you access or "
-"apply to access. Please read their individual privacy policies for that "
-"information."
-msgstr ""
-"Remarquez que ces modalités ne contrôlent pas l’utilisation et la gestion de "
-"vos données par les éditeurs et les fournisseurs de services auxquelles "
-"appartiennent les ressources auxquelles vous accédez ou demandez l’accès. "
-"Veuillez lire leur politique respective de confidentialité à ce sujet."
+msgid "Please note that these terms do not control the use and handling of your data by the publishers and service providers whose resources you access or apply to access. Please read their individual privacy policies for that information."
+msgstr "Remarquez que ces modalités ne contrôlent pas l’utilisation et la gestion de vos données par les éditeurs et les fournisseurs de services auxquelles appartiennent les ressources auxquelles vous accédez ou demandez l’accès. Veuillez lire leur politique respective de confidentialité à ce sujet."
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:368
@@ -3966,56 +2846,18 @@ msgstr "Remarque importante :"
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Wikimedia Foundation should not be translated. Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:373
-msgid ""
-"The Wikimedia Foundation is a nonprofit organization based in San Francisco, "
-"California. The Wikipedia Library program provides access to resources held "
-"by publishers in multiple countries. If you apply for a Wikipedia Library "
-"account (whether you are inside or outside of the United States), you "
-"understand that your personal data will be collected, transferred, stored, "
-"processed, disclosed and otherwise used in the U.S. as described in this "
-"privacy policy. You also understand that your information may be transferred "
-"by us from the U.S. to other countries, which may have different or less "
-"stringent data protection laws than your country, in connection with "
-"providing services to you, including evaluating your application and "
-"securing access to your chosen publishers (locations for each publisher are "
-"outlined on their respective partner information pages)."
-msgstr ""
-"La Fondation est une association à but non lucratif située à San Francisco, "
-"en Californie, États-Unis. La Bibliothèque Wikipédia donne accès aux "
-"ressources détenues par des organisations dans plusieurs pays. Si vous "
-"demandez un compte pour la Bibliothèque Wikipédia (que vous soyez à "
-"l’intérieur ou à l’extérieur des États-Unis), vous comprenez que vos données "
-"personnelles seront collectées, transférées, stockées, traitées, "
-"communiquées et utilisées autrement aux États-Unis tel que décrit dans cette "
-"politique de confidentialité. Vous comprenez également que vos informations "
-"peuvent être transférées par nous des États-Unis vers d’autres pays qui "
-"peuvent avoir des lois de protection des données différentes ou moins "
-"strictes que votre pays, dans le cadre de la fourniture de services pour "
-"vous, y compris pour l’évaluation de votre demande et pour la sécurisation "
-"des accès aux éditeurs que vous avez choisis (les endroits pour chaque "
-"éditeur sont énoncés sur les pages d’information respectives de ces "
-"partenaires)."
+msgid "The Wikimedia Foundation is a nonprofit organization based in San Francisco, California. The Wikipedia Library program provides access to resources held by publishers in multiple countries. If you apply for a Wikipedia Library account (whether you are inside or outside of the United States), you understand that your personal data will be collected, transferred, stored, processed, disclosed and otherwise used in the U.S. as described in this privacy policy. You also understand that your information may be transferred by us from the U.S. to other countries, which may have different or less stringent data protection laws than your country, in connection with providing services to you, including evaluating your application and securing access to your chosen publishers (locations for each publisher are outlined on their respective partner information pages)."
+msgstr "La Fondation est une association à but non lucratif située à San Francisco, en Californie, États-Unis. La Bibliothèque Wikipédia donne accès aux ressources détenues par des organisations dans plusieurs pays. Si vous demandez un compte pour la Bibliothèque Wikipédia (que vous soyez à l’intérieur ou à l’extérieur des États-Unis), vous comprenez que vos données personnelles seront collectées, transférées, stockées, traitées, communiquées et utilisées autrement aux États-Unis tel que décrit dans cette politique de confidentialité. Vous comprenez également que vos informations peuvent être transférées par nous des États-Unis vers d’autres pays qui peuvent avoir des lois de protection des données différentes ou moins strictes que votre pays, dans le cadre de la fourniture de services pour vous, y compris pour l’évaluation de votre demande et pour la sécurisation des accès aux éditeurs que vous avez choisis (les endroits pour chaque éditeur sont énoncés sur les pages d’information respectives de ces partenaires)."
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:392
-msgid ""
-"Please note that in the event of any differences in meaning or "
-"interpretation between the original English version of these terms and a "
-"translation, the original English version takes precedence."
-msgstr ""
-"Veuillez noter, qu’au cas où il y aurait des différences éventuelles entre "
-"la signification ou l’interprétation de la version originale en anglais de "
-"ces conditions et une traduction, la version originale en anglais prévaut."
+msgid "Please note that in the event of any differences in meaning or interpretation between the original English version of these terms and a translation, the original English version takes precedence."
+msgstr "Veuillez noter, qu’au cas où il y aurait des différences éventuelles entre la signification ou l’interprétation de la version originale en anglais de ces conditions et une traduction, la version originale en anglais prévaut."
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Wikimedia Foundation should not be translated.
 #: TWLight/users/templates/users/terms.html:403
-msgid ""
-"See also the <a class=\"twl-links\" href=\"https://wikimediafoundation.org/"
-"wiki/Privacy_policy\">Wikimedia Foundation Privacy Policy</a>."
-msgstr ""
-"Lisez aussi la <a class=\"twl-links\" href=\"https://wikimediafoundation.org/"
-"wiki/Privacy_policy\">Politique de la Wikimedia Foundation concernant la vie "
-"privée</a>."
+msgid "See also the <a class=\"twl-links\" href=\"https://wikimediafoundation.org/wiki/Privacy_policy\">Wikimedia Foundation Privacy Policy</a>."
+msgstr "Lisez aussi la <a class=\"twl-links\" href=\"https://wikimediafoundation.org/wiki/Privacy_policy\">Politique de la Wikimedia Foundation concernant la vie privée</a>."
 
 #. Translators: This is the second to last line of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:412
@@ -4034,17 +2876,8 @@ msgstr "Wikimedia Foundation"
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:426
-msgid ""
-"By checking this box and clicking “Submit”, you agree that you have read the "
-"above terms and that you will adhere to the terms of use in your application "
-"to and use of the The Wikipedia Library, and the publishers’ services to "
-"which you gain access through The Wikipedia Library program."
-msgstr ""
-"En cochant cette case et cliquant sur « Soumettre », vous confirmez que vous "
-"avez lu les conditions ci-dessus et que vous respecterez les conditions "
-"d’utilisation dans votre demande d’accès à La Bibliothèque Wikipédia et dans "
-"son utilisation, ainsi que pour les services des éditeurs auxquels vous avez "
-"accès par le biais du programme de La Bibliothèque Wikipédia."
+msgid "By checking this box and clicking “Submit”, you agree that you have read the above terms and that you will adhere to the terms of use in your application to and use of the The Wikipedia Library, and the publishers’ services to which you gain access through The Wikipedia Library program."
+msgstr "En cochant cette case et cliquant sur « Soumettre », vous confirmez que vous avez lu les conditions ci-dessus et que vous respecterez les conditions d’utilisation dans votre demande d’accès à La Bibliothèque Wikipédia et dans son utilisation, ainsi que pour les services des éditeurs auxquels vous avez accès par le biais du programme de La Bibliothèque Wikipédia."
 
 #: TWLight/users/templates/users/user_collection_tile.html:32
 msgid "Remove this collection from favorites"
@@ -4096,43 +2929,19 @@ msgstr "Supprimer toutes les données"
 
 #. Translators: This message is displayed on the page where users can request the deletion of their data.
 #: TWLight/users/templates/users/user_confirm_delete.html:17
-msgid ""
-"<b>Warning:</b> Performing this action will delete your Wikipedia Library "
-"Card user account and all associated applications. This process is not "
-"reversible. You may lose any partner accounts you were granted, and will not "
-"be able to renew those accounts or apply for new ones."
-msgstr ""
-"<b>Attention :</b> effectuer cette action supprimera votre compte "
-"utilisateur pour la Carte de Bibliothèque Wikipédia ainsi que toutes les "
-"applications associées. Ce processus est irréversible. Vous risquez de "
-"perdre les comptes des partenaires auxquels vous aviez accès et vous ne "
-"pourrez pas renouveler ces comptes ni en demander de nouveaux."
+msgid "<b>Warning:</b> Performing this action will delete your Wikipedia Library Card user account and all associated applications. This process is not reversible. You may lose any partner accounts you were granted, and will not be able to renew those accounts or apply for new ones."
+msgstr "<b>Attention :</b> effectuer cette action supprimera votre compte utilisateur pour la Carte de Bibliothèque Wikipédia ainsi que toutes les applications associées. Ce processus est irréversible. Vous risquez de perdre les comptes des partenaires auxquels vous aviez accès et vous ne pourrez pas renouveler ces comptes ni en demander de nouveaux."
 
 #. Translators: this should show up for people who log in with a username/password and not OAuth, so we don't know what their Wikipedia identity is.
-#.
 #: TWLight/users/templates/users/user_detail.html:12
 #, python-format
-msgid ""
-"Hi, %(username)s! You don't have a Wikipedia editor profile attached to your "
-"account here, so you are probably a site administrator."
-msgstr ""
-"Bonjour, %(username)s ! Vous n’avez pas de profil contributeur Wikipédia "
-"attaché à votre compte ici, donc vous êtes probablement un administrateur du "
-"site."
+msgid "Hi, %(username)s! You don't have a Wikipedia editor profile attached to your account here, so you are probably a site administrator."
+msgstr "Bonjour, %(username)s ! Vous n’avez pas de profil contributeur Wikipédia attaché à votre compte ici, donc vous êtes probablement un administrateur du site."
 
 #. Translators: In the unlikely scenario that someone is able to register an account without using OAuth (thus leaving us without some of the information required for applications), users will see this message, encouraging them to re-register.
 #: TWLight/users/templates/users/user_detail.html:20
-msgid ""
-"If you aren't a site administrator, something weird has happened. You won't "
-"be able to apply for access without a Wikipedia editor profile. You should "
-"log out and create a new account by logging in via OAuth, or contact a site "
-"administrator for help."
-msgstr ""
-"Si vous n’êtes pas un administrateur du site, quelque chose de bizarre a eu "
-"lieu. Vous ne serez pas en mesure de demander un accès sans un profil "
-"d'utilisateur de Wikipédia. Vous devez vous déconnecter et créer un nouveau "
-"compte en vous connectant via <em>OAuth</em> ou contacter un administrateur "
-"du site pour demander de l’aide."
+msgid "If you aren't a site administrator, something weird has happened. You won't be able to apply for access without a Wikipedia editor profile. You should log out and create a new account by logging in via OAuth, or contact a site administrator for help."
+msgstr "Si vous n’êtes pas un administrateur du site, quelque chose de bizarre a eu lieu. Vous ne serez pas en mesure de demander un accès sans un profil d'utilisateur de Wikipédia. Vous devez vous déconnecter et créer un nouveau compte en vous connectant via <em>OAuth</em> ou contacter un administrateur du site pour demander de l’aide."
 
 #. Translators: Labels a sections where coordinators can select their email preferences.
 #: TWLight/users/templates/users/user_email_preferences.html:15
@@ -4142,24 +2951,13 @@ msgstr "Coordinateurs uniquement"
 #. Translators: This message is shown on user's own profile page, encouraging them to make sure their information is up to date, so that account coordinators can use the information to judge applications.
 #: TWLight/users/views.py:176
 #, python-brace-format
-msgid ""
-"Please <a class='twl-links' href='{url}'>update your contributions</a> to "
-"Wikipedia to help coordinators evaluate your applications."
-msgstr ""
-"Veuillez <a class=\"twl-links\" href=\"{url}\">mettre à jour vos "
-"contributions</a> sur Wikipédia pour aider les coordinateurs à évaluer vos "
-"demandes."
+msgid "Please <a class='twl-links' href='{url}'>update your contributions</a> to Wikipedia to help coordinators evaluate your applications."
+msgstr "Veuillez <a class=\"twl-links\" href=\"{url}\">mettre à jour vos contributions</a> sur Wikipédia pour aider les coordinateurs à évaluer vos demandes."
 
 #. Translators: Coordinators are shown this message when they unselect all three types of reminder email options under preferences.
 #: TWLight/users/views.py:288
-msgid ""
-"You have chosen not to receive reminder emails. As a coordinator, you should "
-"receive at least one type of reminder emails, so consider changing your "
-"preferences."
-msgstr ""
-"Vous avez choisi de ne pas recevoir les courriels de rappel. En tant que "
-"coordinateur, vous devez recevoir au moins un type des courriels de rappel, "
-"veuillez donc revoir vos préférences."
+msgid "You have chosen not to receive reminder emails. As a coordinator, you should receive at least one type of reminder emails, so consider changing your preferences."
+msgstr "Vous avez choisi de ne pas recevoir les courriels de rappel. En tant que coordinateur, vous devez recevoir au moins un type des courriels de rappel, veuillez donc revoir vos préférences."
 
 #. Translators: Coordinators are shown this message when they make changes to their reminder email options under preferences.
 #: TWLight/users/views.py:296
@@ -4182,9 +2980,7 @@ msgstr "Vos informations ont été mises à jour."
 #. Translators: If a user tries to save the 'email change form' without entering one and checking the 'use my Wikipedia email address' checkbox, this message is presented.
 #: TWLight/users/views.py:448
 msgid "Both the values cannot be blank. Either enter a email or check the box."
-msgstr ""
-"Les deux valeurs ne peuvent pas être vides. Saisissez une adresse de "
-"messagerie ou bien cochez la case."
+msgstr "Les deux valeurs ne peuvent pas être vides. Saisissez une adresse de messagerie ou bien cochez la case."
 
 #. Translators: Shown to users when they successfully modify their email. Don't translate {email}.
 #: TWLight/users/views.py:476
@@ -4194,13 +2990,8 @@ msgstr "Votre courriel a été changé en {email}."
 
 #. Translators: If the user has not filled out their email, they can browse the website but cannot apply for access to resources.
 #: TWLight/users/views.py:487
-msgid ""
-"Your email is blank. You can still explore the site, but you won't be able "
-"to apply for access to partner resources without an email."
-msgstr ""
-"Votre adresse de messagerie n'est pas définie. Vous pouvez toujours "
-"parcourir le site, mais vous ne pourrez pas demander l’accès aux ressources "
-"des partenaires sans adresse courriel."
+msgid "Your email is blank. You can still explore the site, but you won't be able to apply for access to partner resources without an email."
+msgstr "Votre adresse de messagerie n'est pas définie. Vous pouvez toujours parcourir le site, mais vous ne pourrez pas demander l’accès aux ressources des partenaires sans adresse courriel."
 
 #. Translators: This message is shown once the access to a partner has successfully been returned.
 #: TWLight/users/views.py:801
@@ -4232,31 +3023,3 @@ msgstr "Aucun blocage en cours"
 msgid "10+ edits in the last 30 days"
 msgstr "Plus de 10 modifications ces 30 derniers jours"
 
-#: tests/shunit/data/bad_i18n_comment_1.py:3
-#: tests/shunit/data/bad_i18n_newline_1.py:5
-msgid "1"
-msgstr ""
-
-#. Translators: Lorem ipsum dolor sit amet, consectetur adipiscing elit. Mauris vitae ipsum ut purus faucibus pretium. Proin tempus neque et aliquet consectetur. Ut egestas sapien in consectetur sagittis. Mauris neque lacus, dapibus non viverra vitae, interdum ut aenean ipsum.
-#. Translators: Lorem ipsum dolor sit amet, consectetur adipiscing elit. Mauris vitae ipsum ut purus faucibus pretium. Proin tempus neque et aliquet consectetur. Ut egestas sapien in consectetur sagittis. Mauris neque lacus, dapibus non.
-#: tests/shunit/data/bad_i18n_comment_2.py:4
-#: tests/shunit/data/bad_i18n_newline_2.py:5 tests/shunit/data/good_i18n_1.py:2
-#: tests/shunit/data/good_i18n_2.py:2
-msgid "2"
-msgstr ""
-
-#: tests/shunit/data/bad_i18n_newline_3.py:5
-msgid "3"
-msgstr ""
-
-#: tests/shunit/data/bad_i18n_newline_4.py:5
-msgid "4"
-msgstr ""
-
-#: tests/shunit/data/bad_i18n_newline_5.py:5
-msgid "5"
-msgstr ""
-
-#: tests/shunit/data/bad_i18n_newline_6.py:5
-msgid "6"
-msgstr ""

--- a/locale/he/LC_MESSAGES/django.po
+++ b/locale/he/LC_MESSAGES/django.po
@@ -14,10 +14,11 @@
 # Author: ישראל קלר
 msgid ""
 msgstr ""
+""
 "Project-Id-Version: Wikipedia Library Card Platform - Website\n"
-"Report-Msgid-Bugs-To: wikipedialibrary@wikimedia.org\n"
+"Report-Msgid-Bugs-To: translatewiki.net\n"
 "POT-Creation-Date: 2024-07-11 20:54+0000\n"
-"PO-Revision-Date: 2024-07-11 12:30:15+0000\n"
+"PO-Revision-Date: 2024-07-15 12:29:15+0000\n"
 "Language: he\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
@@ -49,12 +50,8 @@ msgstr "מידע עליך"
 #. Translators: This note appears in a section of a form where we ask users to enter info (like country of residence) when applying for resource access.
 #: TWLight/applications/forms.py:179
 #, python-brace-format
-msgid ""
-"<p><small><i>Your personal data will be processed according to our <a "
-"class='twl-links' href='{terms_url}'> privacy policy</a>.</i></small></p>"
-msgstr ""
-"<p><small><i>הנתונים האישיים שלך יעובדו בהתאם ל<a class=\"twl-links\" "
-"href='{terms_url}'> מדיניות הפרטיות</a> שלנו.</i></small></p>"
+msgid "<p><small><i>Your personal data will be processed according to our <a class='twl-links' href='{terms_url}'> privacy policy</a>.</i></small></p>"
+msgstr "<p><small><i>הנתונים האישיים שלך יעובדו בהתאם ל<a class=\"twl-links\" href='{terms_url}'> מדיניות הפרטיות</a> שלנו.</i></small></p>"
 
 #. Translators: This is the title of the application form page, where users enter information required for the application. It lets the user know which partner application they are entering data for. {partner}
 #: TWLight/applications/forms.py:189
@@ -95,9 +92,7 @@ msgstr "כתובת הדוא״ל לחשבון שלך באתר של השותף"
 #. Translators: This labels a choice field where users will have to select the number of months they wish to have their access for as part of the application renewal confirmation.
 #. Translators: When filling out an application, users may be required to enter the length of the account (expiry) they wish to have for proxy partners.
 #: TWLight/applications/forms.py:339 TWLight/applications/helpers.py:100
-msgid ""
-"The number of months you wish to have this access for before renewal is "
-"required"
+msgid "The number of months you wish to have this access for before renewal is required"
 msgstr "לכמה חודשים תרצה לקבל את הגישה הזאת לפני שיידרש חידוש"
 
 #. Translators: When filling out an application, users may need to specify their name
@@ -186,12 +181,8 @@ msgstr "דואר אלקטרוני"
 
 #. Translators: This comment is added to pending applications when our terms of use change.
 #: TWLight/applications/management/commands/notify_applicants_tou_changes.py:54
-msgid ""
-"Our terms of use have changed. Your applications will not be processed until "
-"you log in and agree to our updated terms."
-msgstr ""
-"תנאי השימוש שלנו השתנו. הבקשות שלך לא תטופלנה עד שלא תיכנס ותסכים לתנאי "
-"השימוש המעודכנים שלנו."
+msgid "Our terms of use have changed. Your applications will not be processed until you log in and agree to our updated terms."
+msgstr "תנאי השימוש שלנו השתנו. הבקשות שלך לא תטופלנה עד שלא תיכנס ותסכים לתנאי השימוש המעודכנים שלנו."
 
 #. Translators: This is the status of an application that has not yet been reviewed.
 #: TWLight/applications/models.py:54
@@ -257,25 +248,17 @@ msgstr "כתובת גישה: {access_url}"
 
 #. Translators: This text goes into account approval emails in the case that we need to send the user's details to a publisher for manual account setup.
 #: TWLight/applications/models.py:331
-msgid ""
-"You can expect to receive access details within a week or two once it has "
-"been processed."
+msgid "You can expect to receive access details within a week or two once it has been processed."
 msgstr "אפשר לצפות לקבל פרטי גישה בתוך שבוע–שבועיים אחרי הטיפול."
 
 #. Translators: This comment is added to open applications when a partner joins the Library Bundle, which does not require applications.
 #: TWLight/applications/signals.py:247
-msgid ""
-"This partner joined the Library Bundle, which does not require applications. "
-"This application will be marked as invalid."
-msgstr ""
-"השותף הזה הצטרף לחבילת הספרייה, שאינה דורשת הגשת בקשות. הבקשה הזאת תסומן "
-"כבלתי־תקינה."
+msgid "This partner joined the Library Bundle, which does not require applications. This application will be marked as invalid."
+msgstr "השותף הזה הצטרף לחבילת הספרייה, שאינה דורשת הגשת בקשות. הבקשה הזאת תסומן כבלתי־תקינה."
 
 #. Translators: This is shown to users if the application is to a partner for which we have run out of available accounts. The application is therefore on a 'waitlist', and will be reviewed when more accounts are available.
 #: TWLight/applications/templates/applications/application_evaluation.html:29
-msgid ""
-"This application is on the waitlist because this partner does not have any "
-"access grants available at this time."
+msgid "This application is on the waitlist because this partner does not have any access grants available at this time."
 msgstr "הבקשה הזאת ברשימת המתנה כי לשותף הזה הזה אין זיכיונות גישה זמינים כעת."
 
 #. Translators: This message is shown on pages where coordinators can see personal information about applicants.
@@ -283,12 +266,8 @@ msgstr "הבקשה הזאת ברשימת המתנה כי לשותף הזה הז�
 #: TWLight/applications/templates/applications/application_list_include.html:6
 #: TWLight/applications/templates/applications/send_partner.html:45
 #: TWLight/resources/templates/resources/partner_users.html:18
-msgid ""
-"Coordinators: This page may contain personal information such as real names "
-"and email addresses. Please remember that this information is confidential."
-msgstr ""
-"מתאמים: הדף הזה יכול להכיל מידע אישי כגון שמות אמיתיים וכתובות דוא״ל. נא "
-"לזכור שהמידע הזה חסוי."
+msgid "Coordinators: This page may contain personal information such as real names and email addresses. Please remember that this information is confidential."
+msgstr "מתאמים: הדף הזה יכול להכיל מידע אישי כגון שמות אמיתיים וכתובות דוא״ל. נא לזכור שהמידע הזה חסוי."
 
 #. Translators: This is the title of the application page shown to users who are a coordinator, and are able to accept or reject the application.
 #: TWLight/applications/templates/applications/application_evaluation.html:39
@@ -297,11 +276,8 @@ msgstr "הערכת הבקשה"
 
 #. Translators: This text is shown to coordinators on application pages if the applicant has restricted processing of their data.
 #: TWLight/applications/templates/applications/application_evaluation.html:42
-msgid ""
-"This user has requested a restriction on the processing of their data, so "
-"you cannot change the status of their application."
-msgstr ""
-"המשתמש הזה ביקש להגביל את עיבוד הנתונים שלו, אז לא ניתן לשנות מצב הבקשה."
+msgid "This user has requested a restriction on the processing of their data, so you cannot change the status of their application."
+msgstr "המשתמש הזה ביקש להגביל את עיבוד הנתונים שלו, אז לא ניתן לשנות מצב הבקשה."
 
 #. Translators: This is the title of the application page shown to users who are not a coordinator.
 #: TWLight/applications/templates/applications/application_evaluation.html:48
@@ -374,9 +350,7 @@ msgstr "אינו יודע"
 
 #. Translators: This is the text displayed to coordinators when an applicant has no country of residence in their profile.
 #: TWLight/applications/templates/applications/application_evaluation.html:123
-msgid ""
-"Please request the applicant add their country of residence to their profile "
-"before proceeding further."
+msgid "Please request the applicant add their country of residence to their profile before proceeding further."
 msgstr "נא לבקש ממגיש הבקשה להוסיף את ארץ המגורים שלו לפרופיל שלו לפני המשך."
 
 #. Translators: This labels the section of an application showing the total number of accounts available for a partner or their collection.
@@ -387,11 +361,8 @@ msgstr "חשבונות זמינים"
 #. Translators: This labels the section of an application showing whether the user had agreed to the terms of use or not.
 #: TWLight/applications/templates/applications/application_evaluation.html:145
 #, python-format
-msgid ""
-"Has agreed to the site's <a class=\"twl-links\" href=\"%(terms_url)s\">terms "
-"of use</a>?"
-msgstr ""
-"הסכים ל<a class=\"twl-links\" href=\"%(terms_url)s\">תנאי השימוש</a> של האתר?"
+msgid "Has agreed to the site's <a class=\"twl-links\" href=\"%(terms_url)s\">terms of use</a>?"
+msgstr "הסכים ל<a class=\"twl-links\" href=\"%(terms_url)s\">תנאי השימוש</a> של האתר?"
 
 #. Translators: Displayed to coordinators when they've agreed to the terms of use.
 #. Translators: Displayed if the user has agreed to the terms of use.
@@ -426,9 +397,7 @@ msgstr "לא"
 
 #. Translators: This is the text displayed to coordinators when an applicant has not agreed to the terms of use.
 #: TWLight/applications/templates/applications/application_evaluation.html:159
-msgid ""
-"Please request the applicant agree to the site's terms of use before "
-"approving this application."
+msgid "Please request the applicant agree to the site's terms of use before approving this application."
 msgstr "נא לבקש ממגיש הבקשה להסכים לתנאי השימוש של האתר לפני אישור הבקשה הזאת."
 
 #. Translators: This labels the section of an application containing the user's motivation for wanting access to this resource.
@@ -449,8 +418,7 @@ msgstr "חידוש של זיכיון גישה קיים?"
 #. Translators: This message is shown next to the 'Renewal of existing access grant?' label if the application is a renewal. Don't translate HTML tags or parent_url.
 #: TWLight/applications/templates/applications/application_evaluation.html:195
 #, python-format
-msgid ""
-"Yes (<a class=\"twl-links\" href=\"%(parent_url)s\">previous application</a>)"
+msgid "Yes (<a class=\"twl-links\" href=\"%(parent_url)s\">previous application</a>)"
 msgstr "כן (<a class=\"twl-links\" href=\"%(parent_url)s\">בקשה קודמת</a>)"
 
 #. Translators: This labels the section of the application showing the length of access remaining on the user's previous authorization.
@@ -485,9 +453,7 @@ msgstr "הוספת הערה"
 
 #. Translators: On an application page, this text tells users that the comments posted on the application are visible to coordinators and the submitting user only.
 #: TWLight/applications/templates/applications/application_evaluation.html:297
-msgid ""
-"Comments are visible to all coordinators and to the editor who submitted "
-"this application."
+msgid "Comments are visible to all coordinators and to the editor who submitted this application."
 msgstr "ההערות מוצגות לכל המתאמים ולעורך שהגיש את הבקשה הזאת."
 
 #. Translators: This is the title of the section of an application page which lists information about the user who submitted the application.
@@ -699,17 +665,8 @@ msgstr "הגדרת מצב"
 
 #: TWLight/applications/templates/applications/apply.html:20
 #, python-format
-msgid ""
-"If your application is successful we may share your email address with "
-"%(partner)s. This is required to set up your access to their resources. By "
-"submitting this form you agree to allow your email address to be shared with "
-"%(partner)s if your application is successful, for the purposes of account "
-"setup."
-msgstr ""
-"אם הבקשה שלך מאושרת, ייתכן שנשתף את כתובת הדוא\"ל שלך עם %(partner)s. זה "
-"נדרש כדי להגדיר את הגישה שלך למשאבים שלהם. שליחת הטופס הזה מהווה את הסכמתך "
-"לשיתוף הדואר האלקטרוני שלך עם %(partner)s אם הבקשה שלך מאושרת, לצורך הגדרת "
-"החשבון."
+msgid "If your application is successful we may share your email address with %(partner)s. This is required to set up your access to their resources. By submitting this form you agree to allow your email address to be shared with %(partner)s if your application is successful, for the purposes of account setup."
+msgstr "אם הבקשה שלך מאושרת, ייתכן שנשתף את כתובת הדוא\"ל שלך עם %(partner)s. זה נדרש כדי להגדיר את הגישה שלך למשאבים שלהם. שליחת הטופס הזה מהווה את הסכמתך לשיתוף הדואר האלקטרוני שלך עם %(partner)s אם הבקשה שלך מאושרת, לצורך הגדרת החשבון."
 
 #. Translators: This message is displayed on the page where users can confirm their renewal. Please do not translate partner.
 #: TWLight/applications/templates/applications/confirm_renewal.html:23
@@ -737,9 +694,7 @@ msgstr "לאילו משאבים אתה רוצה לגשת?"
 
 #. Translators: This text explains that Library Bundle partners are not shown in this list.
 #: TWLight/applications/templates/applications/request_for_application.html:26
-msgid ""
-"Library Bundle partners are not shown as eligibility is determined "
-"automatically."
+msgid "Library Bundle partners are not shown as eligibility is determined automatically."
 msgstr "שותפי חבילת הספרייה אינם מוצגים כי הזכאות נקבעת אוטומטית."
 
 #. Translators: On the page where users can apply for multiple partners, this message shows next to the partner name, taking them to the full application page when clicked.
@@ -754,14 +709,8 @@ msgstr "עדיין לא נוספו נתוני שותף."
 
 #. Translators: the HTML is so that the word 'waitlisted' will look the same as it does in the page above; please translate 'waitlisted' the same way you did elsewhere in this file.
 #: TWLight/applications/templates/applications/request_for_application.html:74
-msgid ""
-"You can apply to <span class=\"badge badge-warning\">Waitlisted</span> "
-"partners, but they don't have access grants available right now. We will "
-"process those applications when access becomes available."
-msgstr ""
-"באפשרותך להגיש בקשה לשותפים <span class=\"badge badge-warning\">ברשימת "
-"ההמתנה</span>, אבל אין להם זיכיונות גישה עכשיו. נטפל בבקשות האלו כשהגישה "
-"תהיה זמינה."
+msgid "You can apply to <span class=\"badge badge-warning\">Waitlisted</span> partners, but they don't have access grants available right now. We will process those applications when access becomes available."
+msgstr "באפשרותך להגיש בקשה לשותפים <span class=\"badge badge-warning\">ברשימת ההמתנה</span>, אבל אין להם זיכיונות גישה עכשיו. נטפל בבקשות האלו כשהגישה תהיה זמינה."
 
 #. Translators: On the page where coordinators can see approved applications which have not had their details sent to the partner, this message shows when there are applications ready to be processed.
 #: TWLight/applications/templates/applications/send.html:10
@@ -782,12 +731,8 @@ msgstr "נתוני בקשות עבור %(object)s"
 #. Translators: This message is shown when applications exceed the number of accounts available.
 #: TWLight/applications/templates/applications/send_partner.html:54
 #, python-format
-msgid ""
-"Application(s) for %(object)s, if sent, will exceed the total available "
-"accounts for the partner. Please proceed at your own discretion."
-msgstr ""
-"בקשות עבור %(object)s, אם תישלחנה, תעבורנה את מספר החשבונות הזמינים עבור "
-"השותף. נא להמשיך על אחריותך."
+msgid "Application(s) for %(object)s, if sent, will exceed the total available accounts for the partner. Please proceed at your own discretion."
+msgstr "בקשות עבור %(object)s, אם תישלחנה, תעבורנה את מספר החשבונות הזמינים עבור השותף. נא להמשיך על אחריותך."
 
 #. Translators: When viewing the list of applications ready to be sent for a particular partner, this is instructions for the coordinator to click the 'mark as sent' button after they have sent the information.
 #: TWLight/applications/templates/applications/send_partner.html:65
@@ -803,9 +748,7 @@ msgstr[1] "אנשי קשר"
 
 #. Translators: When viewing the list of applications ready to be sent for a particular partner, this message shows if there is no information about who the applications should be sent to. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/applications/templates/applications/send_partner.html:89
-msgid ""
-"Whoops, we don't have any listed contacts. Please notify Wikipedia Library "
-"administrators."
+msgid "Whoops, we don't have any listed contacts. Please notify Wikipedia Library administrators."
 msgstr "אוי, אין לנו שום אנשי קשר רשומים. נא להודיע למנהלי ספריית ויקיפדיה."
 
 #. Translators: When viewing the list of applications ready to be sent for a particular partner, this is the title of the section containing the information about those applications.
@@ -821,12 +764,8 @@ msgstr "לסמן בתור בקשות שנשלחו"
 
 #. Translators: This text guides coordinators in using the code sending interface for approved applications.
 #: TWLight/applications/templates/applications/send_partner.html:152
-msgid ""
-"Use the dropdown menus to denote which editor will receive each code. Access "
-"codes will be sent to users automatically."
-msgstr ""
-"יש להשתמש בתפריטים נפתחים כדי לציין איזה עורך יקבל איזה קוד. קודי גישה "
-"יישלחו למשתמשים אוטומטית."
+msgid "Use the dropdown menus to denote which editor will receive each code. Access codes will be sent to users automatically."
+msgstr "יש להשתמש בתפריטים נפתחים כדי לציין איזה עורך יקבל איזה קוד. קודי גישה יישלחו למשתמשים אוטומטית."
 
 #. Translators: This labels a drop-down selection where staff can assign an access code to a user.
 #: TWLight/applications/templates/applications/send_partner.html:173
@@ -841,23 +780,14 @@ msgstr "אין בקשות שאושרו ולא נשלחו."
 #. Translators: When a user applies for a set of resources, they receive this message if none are currently available. They are instead placed on a 'waitlist' for later approval.
 #. Translators: When a user renews their resource, they receive this message if none are currently available. They are instead placed on a 'waitlist' for later approval.
 #: TWLight/applications/views.py:140 TWLight/applications/views.py:1282
-msgid ""
-"This partner does not have any access grants available at this time. You may "
-"still apply for access; your application will be reviewed when access grants "
-"become available."
-msgstr ""
-"לשותף הזה אין זיכיונות גישה זמינים כעת. עדיין אפשר לשלוח בקשת גישה; הבקשה "
-"שלך תיסקר כשזיכיונות גישה יהיו זמינים."
+msgid "This partner does not have any access grants available at this time. You may still apply for access; your application will be reviewed when access grants become available."
+msgstr "לשותף הזה אין זיכיונות גישה זמינים כעת. עדיין אפשר לשלוח בקשת גישה; הבקשה שלך תיסקר כשזיכיונות גישה יהיו זמינים."
 
 #. Translators: This message is shown to users once they've successfully submitted their application for review.
 #: TWLight/applications/views.py:163
 #, python-brace-format
-msgid ""
-"Your application has been submitted for review. Head over to <a "
-"href='{applications_url}'>My Applications</a> to view the status."
-msgstr ""
-"הבקשה שלך נשלחה לסקירה. נא לעבור לדף <a href='{applications_url}'>הבקשות "
-"שלי</a> כדי לצפות במצב."
+msgid "Your application has been submitted for review. Head over to <a href='{applications_url}'>My Applications</a> to view the status."
+msgstr "הבקשה שלך נשלחה לסקירה. נא לעבור לדף <a href='{applications_url}'>הבקשות שלי</a> כדי לצפות במצב."
 
 #. Translators: This text is displayed to users when the user has chosen to restrict data and is trying to apply for multiple partners
 #: TWLight/applications/views.py:276
@@ -905,20 +835,13 @@ msgstr "בקשות שנשלחו"
 
 #. Translators: After a coordinator has changed the status of an application to APPROVED, if the corresponding partner/collection is waitlisted this message appears.
 #: TWLight/applications/views.py:756
-msgid ""
-"Cannot approve application as partner with proxy authorization method is "
-"waitlisted."
-msgstr ""
-"לא ניתן לאשר את הבקשה כי שותף עם שיטת האישור המתוּוכת נמצא ברשימת המתנה."
+msgid "Cannot approve application as partner with proxy authorization method is waitlisted."
+msgstr "לא ניתן לאשר את הבקשה כי שותף עם שיטת האישור המתוּוכת נמצא ברשימת המתנה."
 
 #. Translators: After a coordinator has changed the status of an application to APPROVED, if the corresponding partner/collection has no accounts for distribution, this message appears.
 #: TWLight/applications/views.py:780
-msgid ""
-"Cannot approve application as partner with proxy authorization method is "
-"waitlisted and (or) has zero accounts available for distribution."
-msgstr ""
-"לא ניתן לאשר את הבקשה כי שותף עם שיטת האישור המתוּוכת נמצא ברשימת המתנה (או) "
-"שיש לו אפס חשבונות זמינים להפצה."
+msgid "Cannot approve application as partner with proxy authorization method is waitlisted and (or) has zero accounts available for distribution."
+msgstr "לא ניתן לאשר את הבקשה כי שותף עם שיטת האישור המתוּוכת נמצא ברשימת המתנה (או) שיש לו אפס חשבונות זמינים להפצה."
 
 #. Translators: This message appears on an "access denied" screen that stops users who attempt to authorize an editor to access a resource during a time period for which they are already authorized.
 #: TWLight/applications/views.py:803
@@ -928,16 +851,8 @@ msgstr "ניסיתי ליצור אישור כפול."
 #. Translators: This message is shown to users when they access an application page of a now Bundle partner (new applications aren't allowed for Bundle partners and the status of old applications cannot be modified)
 #: TWLight/applications/views.py:857
 #, python-brace-format
-msgid ""
-"This application cannot be modified since this partner is now part of our <a "
-"href='{bundle}'>bundle access</a>. If you are eligible, you can access this "
-"resource from <a href='{library}'>your library</a>. <a "
-"href='{contact}'>Contact us</a> if you have any questions."
-msgstr ""
-"לא ניתן לשנות את הבקשה הזאת כי השותף הזה הוא עכשיו חלק מ<a "
-"href='{bundle}'>גישת החבילה</a> שלנו. אם אתה זכאי, ניתן לגשת למשאב הזה מ<a "
-"href='{library}'>הספרייה שלך</a>. אפשר <a href='{contact}'>ליצור איתנו קשר</"
-"a> אם יש לך שאלות כלשהו."
+msgid "This application cannot be modified since this partner is now part of our <a href='{bundle}'>bundle access</a>. If you are eligible, you can access this resource from <a href='{library}'>your library</a>. <a href='{contact}'>Contact us</a> if you have any questions."
+msgstr "לא ניתן לשנות את הבקשה הזאת כי השותף הזה הוא עכשיו חלק מ<a href='{bundle}'>גישת החבילה</a> שלנו. אם אתה זכאי, ניתן לגשת למשאב הזה מ<a href='{library}'>הספרייה שלך</a>. אפשר <a href='{contact}'>ליצור איתנו קשר</a> אם יש לך שאלות כלשהו."
 
 #. Translators: this lets a reviewer set the status of a single application.
 #: TWLight/applications/views.py:873
@@ -946,11 +861,8 @@ msgstr "הגדרת מצב הבקשה"
 
 #. Translators: This warning is message is shown to applicants when the number of pending applications is greater than the number of accounts available.
 #: TWLight/applications/views.py:891
-msgid ""
-"There are more pending applications than available accounts. Your "
-"application might get waitlisted."
-msgstr ""
-"יש יותר בקשות ממתינות מחשבונות זמינים. ייתכן שהבקשה שלך תיכנס לרשימת המתנה."
+msgid "There are more pending applications than available accounts. Your application might get waitlisted."
+msgstr "יש יותר בקשות ממתינות מחשבונות זמינים. ייתכן שהבקשה שלך תיכנס לרשימת המתנה."
 
 #. Translators: this message is shown to coordinators who attempt to change an application's Status from INVALID to any other Status.
 #: TWLight/applications/views.py:904
@@ -969,15 +881,8 @@ msgstr "עדכון אצווה של בקשות {} הצליח."
 
 #. Translators: After a coordinator has changed the status of a number of applications to APPROVED, if the corresponding partner(s) is/are waitlisted or has no accounts for distribution, this message appears.
 #: TWLight/applications/views.py:1051
-msgid ""
-"Cannot approve application(s) {} as partner(s) with proxy authorization "
-"method is/are waitlisted and (or) has/have not enough accounts available. If "
-"not enough accounts are available, prioritise the applications and then "
-"approve applications equal to the accounts available."
-msgstr ""
-"לא ניתן לאשר בקשות {} כי שותפים עם שיטת האישור המתוּוכת נמצאים ברשימת המתנה "
-"או שאין להם מספיק חשבונות זמינים. אם אין מספיק חשבונות זמינים, נא לתעדף את "
-"הבקשות ואז לאשר בקשות לפי מספר החשבונות הזמינים."
+msgid "Cannot approve application(s) {} as partner(s) with proxy authorization method is/are waitlisted and (or) has/have not enough accounts available. If not enough accounts are available, prioritise the applications and then approve applications equal to the accounts available."
+msgstr "לא ניתן לאשר בקשות {} כי שותפים עם שיטת האישור המתוּוכת נמצאים ברשימת המתנה או שאין להם מספיק חשבונות זמינים. אם אין מספיק חשבונות זמינים, נא לתעדף את הבקשות ואז לאשר בקשות לפי מספר החשבונות הזמינים."
 
 #. Translators: This message is shown to coordinators who attempt to assign the same access code to multiple users.
 #: TWLight/applications/views.py:1191
@@ -991,12 +896,8 @@ msgstr "כל הבקשות שנבחרו סומנו בתור בקשות שנשלח
 
 #. Translators: When a user tries to renew their resource, they receive this message if the partner is not available.
 #: TWLight/applications/views.py:1272
-msgid ""
-"Cannot renew application at this time as partner is not available. Please "
-"check back later, or contact us for more information."
-msgstr ""
-"לא ניתן לחדש בקשות עכשיו כי השותף אינו זמין. נא לבדוק מאוחר יותר או ליצור "
-"איתנו קשר למידע נוסף."
+msgid "Cannot renew application at this time as partner is not available. Please check back later, or contact us for more information."
+msgstr "לא ניתן לחדש בקשות עכשיו כי השותף אינו זמין. נא לבדוק מאוחר יותר או ליצור איתנו קשר למידע נוסף."
 
 #. Translators: This message is displayed when an attempt by a user to renew an application has been denied for some reason.
 #: TWLight/applications/views.py:1308
@@ -1006,16 +907,12 @@ msgstr "הניסיון לחדש את הבקשה הלא־מאושרת #{pk} נד�
 
 #. Translators: If a user requests the renewal of their account, but it wasn't renewed, this message is shown to them.
 #: TWLight/applications/views.py:1385
-msgid ""
-"This object cannot be renewed. (This probably means that you have already "
-"requested that it be renewed.)"
+msgid "This object cannot be renewed. (This probably means that you have already requested that it be renewed.)"
 msgstr "לא ניתן לחדש את העצם הזה. (זה כנראה אומר שכבר ביקשת שהוא יחודש.)"
 
 #. Translators: If a user requests the renewal of their account, this message is shown to them.
 #: TWLight/applications/views.py:1395
-msgid ""
-"Your renewal request has been received. A coordinator will review your "
-"request."
+msgid "Your renewal request has been received. A coordinator will review your request."
 msgstr "בקשת החידוש שלך התקבלה. מתאם יסקור את הבקשה שלך."
 
 #. Translators: This labels a textfield where users can enter their email ID.
@@ -1025,12 +922,8 @@ msgstr "כתובת הדוא״ל שלך"
 
 #. Translators: This is the help text for the email field in the contact us form letting users know the field is updated by value pulled from their respective user profiles.
 #: TWLight/emails/forms.py:21
-msgid ""
-"This field is automatically updated with the email from your <a class='twl-"
-"links' href='{}'>user profile</a>."
-msgstr ""
-"השדה הזה מתעדכן אוטומטית עם הדוא״ל מ<a class='twl-links' href='{}'>פרופיל "
-"המשתמש</a> שלך."
+msgid "This field is automatically updated with the email from your <a class='twl-links' href='{}'>user profile</a>."
+msgstr "השדה הזה מתעדכן אוטומטית עם הדוא״ל מ<a class='twl-links' href='{}'>פרופיל המשתמש</a> שלך."
 
 #. Translators: This labels a textfield where users can enter their email message.
 #: TWLight/emails/forms.py:26
@@ -1053,26 +946,14 @@ msgstr "שליחה"
 #. Translators: This email is sent to users with their access code. Don't translate Jinja variables in curly braces like user or partner. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/access_code_email-body-html.html:5
 #, python-format
-msgid ""
-"<p>Your approved application to %(partner)s has now been finalised. Your "
-"access code or login details can be found below:</p> <p><b>%(access_code)s</"
-"b></p> <p>%(user_instructions)s</p>"
-msgstr ""
-"<p>הטיפול בבקשה המאושרת שלך עבור %(partner)s הסתיים עכשיו. אפשר למצוא את קוד "
-"הגישה או את פרטי הכניסה לחשבון שלך להלן:</p> <p><b>%(access_code)s</b></p> "
-"<p>%(user_instructions)s</p>"
+msgid "<p>Your approved application to %(partner)s has now been finalised. Your access code or login details can be found below:</p> <p><b>%(access_code)s</b></p> <p>%(user_instructions)s</p>"
+msgstr "<p>הטיפול בבקשה המאושרת שלך עבור %(partner)s הסתיים עכשיו. אפשר למצוא את קוד הגישה או את פרטי הכניסה לחשבון שלך להלן:</p> <p><b>%(access_code)s</b></p> <p>%(user_instructions)s</p>"
 
 #. Translators: This email is sent to users with their access code. Don't translate Jinja variables in curly braces like user or partner. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/access_code_email-body-text.html:3
 #, python-format
-msgid ""
-"Your approved application to %(partner)s has now been finalised. Your access "
-"code or login details can be found below: %(access_code)s "
-"%(user_instructions)s"
-msgstr ""
-"הטיפול בבקשה המאושרת שלך עבור %(partner)s הסתיים עכשיו. אפשר למצוא את קוד "
-"הגישה או את פרטי הכניסה לחשבון שלך להלן: %(access_code)s "
-"%(user_instructions)s"
+msgid "Your approved application to %(partner)s has now been finalised. Your access code or login details can be found below: %(access_code)s %(user_instructions)s"
+msgstr "הטיפול בבקשה המאושרת שלך עבור %(partner)s הסתיים עכשיו. אפשר למצוא את קוד הגישה או את פרטי הכניסה לחשבון שלך להלן: %(access_code)s %(user_instructions)s"
 
 #. Translators: This is the subject line of an email sent to users with their access code.
 #: TWLight/emails/templates/emails/access_code_email-subject.html:3
@@ -1082,32 +963,14 @@ msgstr "קוד הגישה שלך לספריית ויקיפדיה"
 #. Translators: This email is sent to users when their application is approved. Don't translate Jinja variables in curly braces like user or partner; don't translate html tags either. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/approval_notification-body-html.html:5
 #, python-format
-msgid ""
-"<p>Dear %(user)s,</p> <p>Thank you for applying for access to %(partner)s "
-"resources through The Wikipedia Library. We are happy to inform you that "
-"your application has been approved.</p> <p>%(user_instructions)s</p> <p>You "
-"can view the collections you're authorized to access at My Library: "
-"%(link)s</p> <p>Cheers!</p> <p>The Wikipedia Library</p>"
-msgstr ""
-"<p>%(user)s היקר,</p> <p>תודה על שליחת בקשת גישה למשאבי %(partner)s דרך "
-"ספריית ויקיפדיה. אנחנו שמחים להודיע לך שהבקשה שלך אושרה.</p> <p>"
-"%(user_instructions)s</p> <p>באפשרותך לצפות באוספים שקיבלת אישור לגשת אליהם "
-"באזור \"הספרייה שלי\": %(link)s</p> <p>ברכות!</p> <p>ספריית ויקיפדיה</p>"
+msgid "<p>Dear %(user)s,</p> <p>Thank you for applying for access to %(partner)s resources through The Wikipedia Library. We are happy to inform you that your application has been approved.</p> <p>%(user_instructions)s</p> <p>You can view the collections you're authorized to access at My Library: %(link)s</p> <p>Cheers!</p> <p>The Wikipedia Library</p>"
+msgstr "<p>%(user)s היקר,</p> <p>תודה על שליחת בקשת גישה למשאבי %(partner)s דרך ספריית ויקיפדיה. אנחנו שמחים להודיע לך שהבקשה שלך אושרה.</p> <p>%(user_instructions)s</p> <p>באפשרותך לצפות באוספים שקיבלת אישור לגשת אליהם באזור \"הספרייה שלי\": %(link)s</p> <p>ברכות!</p> <p>ספריית ויקיפדיה</p>"
 
 #. Translators: This email is sent to users when their application is approved. Don't translate Jinja variables in curly braces like user or partner. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/approval_notification-body-text.html:3
 #, python-format
-msgid ""
-"Dear %(user)s, Thank you for applying for access to %(partner)s resources "
-"through The Wikipedia Library. We are happy to inform you that your "
-"application has been approved. %(user_instructions)s You can view the "
-"collections you're authorized to access at My Library: %(link)s Cheers! The "
-"Wikipedia Library"
-msgstr ""
-"%(user)s היקר, תודה על שליחת בקשת גישה למשאבי %(partner)s דרך ספריית "
-"ויקיפדיה. אנחנו שמחים להודיע לך שהבקשה שלך אושרה. %(user_instructions)s "
-"באפשרותך לצפות באוספים שקיבלת אישור לגשת אליהם באזור \"הספרייה שלי\": "
-"%(link)s ברכות! ספריית ויקיפדיה"
+msgid "Dear %(user)s, Thank you for applying for access to %(partner)s resources through The Wikipedia Library. We are happy to inform you that your application has been approved. %(user_instructions)s You can view the collections you're authorized to access at My Library: %(link)s Cheers! The Wikipedia Library"
+msgstr "%(user)s היקר, תודה על שליחת בקשת גישה למשאבי %(partner)s דרך ספריית ויקיפדיה. אנחנו שמחים להודיע לך שהבקשה שלך אושרה. %(user_instructions)s באפשרותך לצפות באוספים שקיבלת אישור לגשת אליהם באזור \"הספרייה שלי\": %(link)s ברכות! ספריית ויקיפדיה"
 
 #. Translators: This is the subject of an email which is sent to users when their application has been approved. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/approval_notification-subject.html:4
@@ -1117,25 +980,14 @@ msgstr "הבקשה שלך לספריית ויקיפדיה אושרה"
 #. Translators: This email is sent to coordinators when a comment is left on an application they are processing. Don't translate Jinja variables in curly braces like user or partner. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/comment_notification_coordinator-body-html.html:5
 #, python-format
-msgid ""
-"<p style=\"color: #500050\">%(submit_date)s - %(commenter)s</p> "
-"<blockquote><p>%(comment)s</p></blockquote> <p>Please reply to these at: <a "
-"href=\"%(app_url)s\">%(app_url)s</a></p> <p>Best,</p> <p>The Wikipedia "
-"Library</p>"
-msgstr ""
-"<p style=\"color: #500050\">%(submit_date)s - %(commenter)s</p> "
-"<blockquote><p>%(comment)s</p></blockquote> <p>נא להשיב לאלה בכתובת: <a href="
-"\"%(app_url)s\">%(app_url)s</a></p> <p>בברכה,</p> <p>ספריית ויקיפדיה</p>"
+msgid "<p style=\"color: #500050\">%(submit_date)s - %(commenter)s</p> <blockquote><p>%(comment)s</p></blockquote> <p>Please reply to these at: <a href=\"%(app_url)s\">%(app_url)s</a></p> <p>Best,</p> <p>The Wikipedia Library</p>"
+msgstr "<p style=\"color: #500050\">%(submit_date)s - %(commenter)s</p> <blockquote><p>%(comment)s</p></blockquote> <p>נא להשיב לאלה בכתובת: <a href=\"%(app_url)s\">%(app_url)s</a></p> <p>בברכה,</p> <p>ספריית ויקיפדיה</p>"
 
 #. Translators: This email is sent to coordinators when a comment is left on an application they are processing. Don't translate Jinja variables in curly braces like user or partner. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/comment_notification_coordinator-body-text.html:3
 #, python-format
-msgid ""
-"%(submit_date)s - %(commenter)s %(comment)s Please reply to this at: "
-"%(app_url)s Best, The Wikipedia Library"
-msgstr ""
-"%(submit_date)s - %(commenter)s %(comment)s נא להשיב לאלה בכתובת: "
-"%(app_url)s בברכה, ספריית ויקיפדיה"
+msgid "%(submit_date)s - %(commenter)s %(comment)s Please reply to this at: %(app_url)s Best, The Wikipedia Library"
+msgstr "%(submit_date)s - %(commenter)s %(comment)s נא להשיב לאלה בכתובת: %(app_url)s בברכה, ספריית ויקיפדיה"
 
 #. Translators: This is the subject line of an email sent to coordinators when a comment is left on an application they processed.
 #: TWLight/emails/templates/emails/comment_notification_coordinator-subject.html:3
@@ -1145,26 +997,14 @@ msgstr "הערה חדשה בבקשת ספריית ויקיפדיה שטיפלת 
 #. Translators: This email is sent to users when they receive a comment on their application. Don't translate Jinja variables in curly braces like user or partner; don't translate html tags either. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/comment_notification_editors-body-html.html:5
 #, python-format
-msgid ""
-"<p style=\"color: #500050\">%(submit_date)s - %(commenter)s</p> "
-"<blockquote><p>%(comment)s</p></blockquote> <p>Please reply to these at <a "
-"href=\"%(app_url)s\">%(app_url)s</a> so we can evaluate your application.</"
-"p> <p>Best,</p> <p>The Wikipedia Library</p>"
-msgstr ""
-"<p style=\"color: #500050\">%(submit_date)s - %(commenter)s</p> "
-"<blockquote><p>%(comment)s</p></blockquote> <p>נא להשיב לאלה בכתובת <a href="
-"\"%(app_url)s\">%(app_url)s</a> כדי שנוכל להעריך את הבקשה שלך.</p> <p>בברכה,"
-"</p> <p>ספריית ויקיפדיה</p>"
+msgid "<p style=\"color: #500050\">%(submit_date)s - %(commenter)s</p> <blockquote><p>%(comment)s</p></blockquote> <p>Please reply to these at <a href=\"%(app_url)s\">%(app_url)s</a> so we can evaluate your application.</p> <p>Best,</p> <p>The Wikipedia Library</p>"
+msgstr "<p style=\"color: #500050\">%(submit_date)s - %(commenter)s</p> <blockquote><p>%(comment)s</p></blockquote> <p>נא להשיב לאלה בכתובת <a href=\"%(app_url)s\">%(app_url)s</a> כדי שנוכל להעריך את הבקשה שלך.</p> <p>בברכה,</p> <p>ספריית ויקיפדיה</p>"
 
 #. Translators: This email is sent to users when they receive a comment on their application. Don't translate Jinja variables in curly braces like user or partner. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/comment_notification_editors-body-text.html:3
 #, python-format
-msgid ""
-"%(submit_date)s - %(commenter)s %(comment)s Please reply to these at: "
-"%(app_url)s so we can evaluate your application. Best, The Wikipedia Library"
-msgstr ""
-"%(submit_date)s - %(commenter)s %(comment)s נא להשיב לאלה בכתובת %(app_url)s "
-"כדי שנוכל להעריך את הבקשה שלך. בברכה, ספריית ויקיפדיה"
+msgid "%(submit_date)s - %(commenter)s %(comment)s Please reply to these at: %(app_url)s so we can evaluate your application. Best, The Wikipedia Library"
+msgstr "%(submit_date)s - %(commenter)s %(comment)s נא להשיב לאלה בכתובת %(app_url)s כדי שנוכל להעריך את הבקשה שלך. בברכה, ספריית ויקיפדיה"
 
 #. Translators: This is the subject line of an email sent to users who have a comment added to one of their applications. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/comment_notification_editors-subject.html:3
@@ -1174,24 +1014,14 @@ msgstr "הערה חדשה בבקשת ספריית ויקיפדיה שלך"
 #. Translators: This email is sent to users when an application they commented on receives another comment. Don't translate Jinja variables in curly braces like app_url; don't translate html tags either. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/comment_notification_others-body-html.html:5
 #, python-format
-msgid ""
-"<p style=\"color: #500050\">%(submit_date)s - %(commenter)s</p> "
-"<blockquote><p>%(comment)s</p></blockquote> See it at <a href=\"%(app_url)s"
-"\">%(app_url)s</a>. Thanks for helping review Wikipedia Library applications!"
-msgstr ""
-"<p style=\"color: #500050\">%(submit_date)s - %(commenter)s</p> "
-"<blockquote><p>%(comment)s</p></blockquote> ר׳ אותה בכתובת <a href="
-"\"%(app_url)s\">%(app_url)s</a>. תודה על העזרה בסקירת בקשות ספריית ויקיפדיה!"
+msgid "<p style=\"color: #500050\">%(submit_date)s - %(commenter)s</p> <blockquote><p>%(comment)s</p></blockquote> See it at <a href=\"%(app_url)s\">%(app_url)s</a>. Thanks for helping review Wikipedia Library applications!"
+msgstr "<p style=\"color: #500050\">%(submit_date)s - %(commenter)s</p> <blockquote><p>%(comment)s</p></blockquote> ר׳ אותה בכתובת <a href=\"%(app_url)s\">%(app_url)s</a>. תודה על העזרה בסקירת בקשות ספריית ויקיפדיה!"
 
 #. Translators: This email is sent to users when an application they commented on receives another comment. Don't translate Jinja variables in curly braces like app_url. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/comment_notification_others-body-text.html:3
 #, python-format
-msgid ""
-"%(submit_date)s - %(commenter)s %(comment)s See it at: %(app_url)s Thanks "
-"for helping review Wikipedia Library applications!"
-msgstr ""
-"%(submit_date)s - %(commenter)s %(comment)s ר׳ אותה בכתובת %(app_url)s תודה "
-"על העזרה בסקירת בקשות ספריית ויקיפדיה!"
+msgid "%(submit_date)s - %(commenter)s %(comment)s See it at: %(app_url)s Thanks for helping review Wikipedia Library applications!"
+msgstr "%(submit_date)s - %(commenter)s %(comment)s ר׳ אותה בכתובת %(app_url)s תודה על העזרה בסקירת בקשות ספריית ויקיפדיה!"
 
 #. Translators: This is the subject line of an email sent to users who have a comment added to an application they also commented on. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/comment_notification_others-subject.html:4
@@ -1201,13 +1031,8 @@ msgstr "הערה חדשה בבקשת ספריית ויקיפדיה שהערת ע
 #. Translators: This text is part of a scheduled reminder email sent to coordinators who have applications requiring action. Don't translate Jinja variables in curly braces like total_apps, or user.
 #: TWLight/emails/templates/emails/coordinator_reminder_notification-body-html.html:5
 #, python-format
-msgid ""
-"<p>Dear %(user)s,</p> <p>Our records indicate that you are the designated "
-"coordinator for partners that have a total of %(total_apps)s applications.</"
-"p>"
-msgstr ""
-"<p>%(user)s היקר,</p> <p>לפי הרישומים שלנו, אתה המתאם המוגדר לשותפים שיש להם "
-"%(total_apps)s בקשות.</p>"
+msgid "<p>Dear %(user)s,</p> <p>Our records indicate that you are the designated coordinator for partners that have a total of %(total_apps)s applications.</p>"
+msgstr "<p>%(user)s היקר,</p> <p>לפי הרישומים שלנו, אתה המתאם המוגדר לשותפים שיש להם %(total_apps)s בקשות.</p>"
 
 #. Translators: Breakdown as in 'cost breakdown'; analysis.
 #: TWLight/emails/templates/emails/coordinator_reminder_notification-body-html.html:11
@@ -1245,43 +1070,20 @@ msgstr[1] "%(counter)s יישומים מאושרים."
 #. Translators: This text is part of a scheduled reminder email sent to coordinators who have applications requiring action. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library). Don't translate Jinja variables in curly braces like link; don't translate email addresses or html tags either.
 #: TWLight/emails/templates/emails/coordinator_reminder_notification-body-html.html:39
 #, python-format
-msgid ""
-"<p>This is a gentle reminder that you may review applications at <a href="
-"\"%(link)s\">%(link)s</a>.</p> <p>You can customise your reminders under "
-"'preferences' in your user profile.</p> <p>If you received this message in "
-"error, drop us a line at wikipedialibrary@wikimedia.org.</p> <p>Thanks for "
-"helping review Wikipedia Library applications!</p>"
-msgstr ""
-"<p>זאת תזכורת ידידותית שבאפשרותך לסקור בקשות בקישור <a href=\"%(link)s\">"
-"%(link)s</a>.</p> <p>באפשרותך לעשות התאמה אישית של התזכורות שלך בהעדפות "
-"בפרופיל המשתמש שלך.</p> <p>אם קיבלת את ההודעה הזאת בטעות, כתוב לנו לדוא״ל "
-"wikipedialibrary@wikimedia.org.</p> <p>תודה על העזרה בסקירת בקשות ספריית "
-"ויקיפדיה!</p>"
+msgid "<p>This is a gentle reminder that you may review applications at <a href=\"%(link)s\">%(link)s</a>.</p> <p>You can customise your reminders under 'preferences' in your user profile.</p> <p>If you received this message in error, drop us a line at wikipedialibrary@wikimedia.org.</p> <p>Thanks for helping review Wikipedia Library applications!</p>"
+msgstr "<p>זאת תזכורת ידידותית שבאפשרותך לסקור בקשות בקישור <a href=\"%(link)s\">%(link)s</a>.</p> <p>באפשרותך לעשות התאמה אישית של התזכורות שלך בהעדפות בפרופיל המשתמש שלך.</p> <p>אם קיבלת את ההודעה הזאת בטעות, כתוב לנו לדוא״ל wikipedialibrary@wikimedia.org.</p> <p>תודה על העזרה בסקירת בקשות ספריית ויקיפדיה!</p>"
 
 #. Translators: This text is part of a scheduled reminder email sent to coordinators who have applications requiring action. Don't translate Jinja variables in curly braces like total_apps, or user.
 #: TWLight/emails/templates/emails/coordinator_reminder_notification-body-text.html:3
 #, python-format
-msgid ""
-"Dear %(user)s, Our records indicate that you are the designated coordinator "
-"for partners that have a total of %(total_apps)s applications."
-msgstr ""
-"%(user)s היקר, לפי הרישומים שלנו, אתה המתאם המוגדר לשותפים שיש להם "
-"%(total_apps)s בקשות."
+msgid "Dear %(user)s, Our records indicate that you are the designated coordinator for partners that have a total of %(total_apps)s applications."
+msgstr "%(user)s היקר, לפי הרישומים שלנו, אתה המתאם המוגדר לשותפים שיש להם %(total_apps)s בקשות."
 
 #. Translators: This text is part of a scheduled reminder email sent to coordinators who have applications requiring action. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library). Don't translate Jinja variables in curly braces like link; don't translate the email address either.
 #: TWLight/emails/templates/emails/coordinator_reminder_notification-body-text.html:38
 #, python-format
-msgid ""
-"This is a gentle reminder that you may review applications at: %(link)s. You "
-"can customise your reminders under 'preferences' in your user profile. If "
-"you received this message in error, drop us a line at: "
-"wikipedialibrary@wikimedia.org Thanks for helping review Wikipedia Library "
-"applications!"
-msgstr ""
-"זאת תזכורת ידידותית שבאפשרותך לסקור בקשות בקישור <a href=\"%(link)s\">"
-"%(link)s</a>. באפשרותך לעשות התאמה אישית של התזכורות שלך בהעדפות בפרופיל "
-"המשתמש שלך. אם קיבלת את ההודעה הזאת בטעות, כתוב לנו לדוא״ל "
-"wikipedialibrary@wikimedia.org. תודה על העזרה בסקירת בקשות ספריית ויקיפדיה!"
+msgid "This is a gentle reminder that you may review applications at: %(link)s. You can customise your reminders under 'preferences' in your user profile. If you received this message in error, drop us a line at: wikipedialibrary@wikimedia.org Thanks for helping review Wikipedia Library applications!"
+msgstr "זאת תזכורת ידידותית שבאפשרותך לסקור בקשות בקישור <a href=\"%(link)s\">%(link)s</a>. באפשרותך לעשות התאמה אישית של התזכורות שלך בהעדפות בפרופיל המשתמש שלך. אם קיבלת את ההודעה הזאת בטעות, כתוב לנו לדוא״ל wikipedialibrary@wikimedia.org. תודה על העזרה בסקירת בקשות ספריית ויקיפדיה!"
 
 #. Translators: This is the subject line of a scheduled reminder email sent to coordinators who have applications to review. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library). Do not translate items in curly braces.
 #: TWLight/emails/templates/emails/coordinator_reminder_notification-subject.html:4
@@ -1291,29 +1093,14 @@ msgstr "בקשות ספריית ויקיפדיה ממתינות לסקירה ש�
 #. Translators: This email is sent to users when their application is rejected. Don't translate Jinja variables in curly braces like user or partner; don't translate html tags either. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/rejection_notification-body-html.html:5
 #, python-format
-msgid ""
-"<p>Dear %(user)s,</p> <p>Thank you for applying for access to %(partner)s "
-"resources through The Wikipedia Library. Unfortunately at this time your "
-"application has not been approved. You can view your application and review "
-"comments at <a href=\"%(app_url)s\">%(app_url)s</a>.</p> <p>Best,</p> <p>The "
-"Wikipedia Library</p>"
-msgstr ""
-"<p>%(user)s היקר,</p> <p>תודה על בקשת גישה למשאבים של %(partner)s דרך ספריית "
-"ויקיפדיה. לצערנו, נכון לעכשיו הבקשה שלך לא אושרה. אפשר לצפות בבקשה שלך "
-"ולבדוק את ההערות בכתובת %(app_url)s.</p> <p>בברכה, ספריית ויקיפדיה</p>"
+msgid "<p>Dear %(user)s,</p> <p>Thank you for applying for access to %(partner)s resources through The Wikipedia Library. Unfortunately at this time your application has not been approved. You can view your application and review comments at <a href=\"%(app_url)s\">%(app_url)s</a>.</p> <p>Best,</p> <p>The Wikipedia Library</p>"
+msgstr "<p>%(user)s היקר,</p> <p>תודה על בקשת גישה למשאבים של %(partner)s דרך ספריית ויקיפדיה. לצערנו, נכון לעכשיו הבקשה שלך לא אושרה. אפשר לצפות בבקשה שלך ולבדוק את ההערות בכתובת %(app_url)s.</p> <p>בברכה, ספריית ויקיפדיה</p>"
 
 #. Translators: This email is sent to users when their application is rejected. Don't translate Jinja variables in curly braces like user or partner. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/rejection_notification-body-text.html:3
 #, python-format
-msgid ""
-"Dear %(user)s, Thank you for applying for access to %(partner)s resources "
-"through The Wikipedia Library. Unfortunately at this time your application "
-"has not been approved. You can view your application and review comments at: "
-"%(app_url)s Best, The Wikipedia Library"
-msgstr ""
-"%(user)s היקר, תודה על בקשת גישה למשאבים של %(partner)s דרך ספריית ויקיפדיה. "
-"לצערנו, נכון לעכשיו הבקשה שלך לא אושרה. אפשר לצפות בבקשה שלך ולבדוק את "
-"ההערות בכתובת %(app_url)s. בברכה, ספריית ויקיפדיה"
+msgid "Dear %(user)s, Thank you for applying for access to %(partner)s resources through The Wikipedia Library. Unfortunately at this time your application has not been approved. You can view your application and review comments at: %(app_url)s Best, The Wikipedia Library"
+msgstr "%(user)s היקר, תודה על בקשת גישה למשאבים של %(partner)s דרך ספריית ויקיפדיה. לצערנו, נכון לעכשיו הבקשה שלך לא אושרה. אפשר לצפות בבקשה שלך ולבדוק את ההערות בכתובת %(app_url)s. בברכה, ספריית ויקיפדיה"
 
 #. Translators: This is the subject of an email which is sent to users when their application has been rejected. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/rejection_notification-subject.html:4
@@ -1323,37 +1110,14 @@ msgstr "בקשת ספריית ויקיפדיה שלך"
 #. Translators: This email is sent to users when they have an account that is soon to expire. Don't translate Jinja variables in curly braces like partner_name or partner_link; don't translate html tags either. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/user_renewal_notice-body-html.html:5
 #, python-format
-msgid ""
-"<p>Dear %(user)s,</p> <p>According to our records, your access to "
-"%(partner_name)s will soon expire and you may lose access. If you want to "
-"continue making use of your free account, you can request renewal of your "
-"account by clicking the 'Renew' or 'Extend' button at %(partner_link)s.</p> "
-"<p>Best,</p> <p>The Wikipedia Library</p> <p>You can disable these emails in "
-"your user page preferences: https://wikipedialibrary.wmflabs.org/users/</p>"
-msgstr ""
-"<p>%(user)s היקר,</p> <p>לפי הרישומים שלנו, הגישה שלך למאגרים של "
-"%(partner_name)s תפוג בקרוב ותאבד אותה. אם אתה רוצה להמשיך להשתמש בחשבון, "
-"אתה יכול לבקש את חידוש החשבון שלך באמצעות לחיצה על חשבון \"חידוש\" או \"הרחבה"
-"\" בדף %(partner_link)s.</p> <p>בברכה,</p> <p>ספריית ויקיפדיה</p> <p>אתה "
-"יכול לכבות את שליחת המכתבים האלה בהעדפות בדף המשתמש שלך: https://"
-"wikipedialibrary.wmflabs.org/users/</p>"
+msgid "<p>Dear %(user)s,</p> <p>According to our records, your access to %(partner_name)s will soon expire and you may lose access. If you want to continue making use of your free account, you can request renewal of your account by clicking the 'Renew' or 'Extend' button at %(partner_link)s.</p> <p>Best,</p> <p>The Wikipedia Library</p> <p>You can disable these emails in your user page preferences: https://wikipedialibrary.wmflabs.org/users/</p>"
+msgstr "<p>%(user)s היקר,</p> <p>לפי הרישומים שלנו, הגישה שלך למאגרים של %(partner_name)s תפוג בקרוב ותאבד אותה. אם אתה רוצה להמשיך להשתמש בחשבון, אתה יכול לבקש את חידוש החשבון שלך באמצעות לחיצה על חשבון \"חידוש\" או \"הרחבה\" בדף %(partner_link)s.</p> <p>בברכה,</p> <p>ספריית ויקיפדיה</p> <p>אתה יכול לכבות את שליחת המכתבים האלה בהעדפות בדף המשתמש שלך: https://wikipedialibrary.wmflabs.org/users/</p>"
 
 #. Translators: This email is sent to users when they have an account that is soon to expire. Don't translate Jinja variables in curly braces like partner_name or partner_link; don't translate html tags either. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/user_renewal_notice-body-text.html:3
 #, python-format
-msgid ""
-"Dear %(user)s, According to our records, your access to %(partner_name)s "
-"will soon expire and you may lose access. If you want to continue making use "
-"of your free account, you can request renewal of your account by clicking "
-"the Renew button at %(partner_link)s. Best, The Wikipedia Library You can "
-"disable these emails in your user page preferences: https://wikipedialibrary."
-"wmflabs.org/users/"
-msgstr ""
-"%(user)s היקר, לפי הרישומים שלנו, הגישה שלך למאגרים של %(partner_name)s תפוג "
-"בקרוב ותאבד אותה. אם אתה רוצה להמשיך להשתמש בחשבון, אתה יכול לבקש את חידוש "
-"החשבון שלך באמצעות לחיצה על חשבון חידוש בדף %(partner_link)s. בברכה, ספריית "
-"ויקיפדיה אתה יכול לכבות את שליחת המכתבים האלה בהעדפות בדף המשתמש שלך: "
-"https://wikipedialibrary.wmflabs.org/users/"
+msgid "Dear %(user)s, According to our records, your access to %(partner_name)s will soon expire and you may lose access. If you want to continue making use of your free account, you can request renewal of your account by clicking the Renew button at %(partner_link)s. Best, The Wikipedia Library You can disable these emails in your user page preferences: https://wikipedialibrary.wmflabs.org/users/"
+msgstr "%(user)s היקר, לפי הרישומים שלנו, הגישה שלך למאגרים של %(partner_name)s תפוג בקרוב ותאבד אותה. אם אתה רוצה להמשיך להשתמש בחשבון, אתה יכול לבקש את חידוש החשבון שלך באמצעות לחיצה על חשבון חידוש בדף %(partner_link)s. בברכה, ספריית ויקיפדיה אתה יכול לכבות את שליחת המכתבים האלה בהעדפות בדף המשתמש שלך: https://wikipedialibrary.wmflabs.org/users/"
 
 #. Translators: This is the subject of an email sent to users when they have an account that is soon to expire. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/user_renewal_notice-subject.html:4
@@ -1363,34 +1127,14 @@ msgstr "הגישה שלך לספריית ויקיפדיה יכולה לפוג ב
 #. Translators: This email is sent to users when their application is waitlisted because there are no more accounts available. Don't translate Jinja variables in curly braces like user or partner; don't translate html tags either. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/waitlist_notification-body-html.html:5
 #, python-format
-msgid ""
-"<p>Dear %(user)s,</p> <p>Thank you for applying for access to %(partner)s "
-"resources through The Wikipedia Library. There are no accounts currently "
-"available so your application has been waitlisted. Your application will be "
-"evaluated if/when more accounts become available. You can see all available "
-"resources at <a href=\"%(link)s\">%(link)s</a>.</p> <p>Best,</p> <p>The "
-"Wikipedia Library</p>"
-msgstr ""
-"<p>%(user)s היקר,</p> <p>תודה על שליחת הבקשה לגשת למשאבים של %(partner)s דרך "
-"ספריית ויקיפדיה. אין חשבונות שזמינים עכשיו, אז הבקשה שלך הוכנסה לרשימת "
-"המעקב. הבקשה שלך תיבדק אם וכאשר יהיו יותר חשבונות זמינים. אפשר לראות את כל "
-"המשאבים הזמינים בדף <a href=\"%(link)s\">%(link)s</a>.</p> <p>בברכה,</p> "
-"<p>ספריית ויקיפדיה</p>"
+msgid "<p>Dear %(user)s,</p> <p>Thank you for applying for access to %(partner)s resources through The Wikipedia Library. There are no accounts currently available so your application has been waitlisted. Your application will be evaluated if/when more accounts become available. You can see all available resources at <a href=\"%(link)s\">%(link)s</a>.</p> <p>Best,</p> <p>The Wikipedia Library</p>"
+msgstr "<p>%(user)s היקר,</p> <p>תודה על שליחת הבקשה לגשת למשאבים של %(partner)s דרך ספריית ויקיפדיה. אין חשבונות שזמינים עכשיו, אז הבקשה שלך הוכנסה לרשימת המעקב. הבקשה שלך תיבדק אם וכאשר יהיו יותר חשבונות זמינים. אפשר לראות את כל המשאבים הזמינים בדף <a href=\"%(link)s\">%(link)s</a>.</p> <p>בברכה,</p> <p>ספריית ויקיפדיה</p>"
 
 #. Translators: This email is sent to users when their application is waitlisted because there are no more accounts available. Don't translate Jinja variables in curly braces like user or partner. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/waitlist_notification-body-text.html:3
 #, python-format
-msgid ""
-"Dear %(user)s, Thank you for applying for access to %(partner)s resources "
-"through The Wikipedia Library. There are no accounts currently available so "
-"your application has been waitlisted. Your application will be evaluated if/"
-"when more accounts become available. You can see all available resources at: "
-"%(link)s Best, The Wikipedia Library"
-msgstr ""
-"%(user)s היקר, תודה על שליחת הבקשה לגשת למשאבים של %(partner)s דרך ספריית "
-"ויקיפדיה. אין חשבונות שזמינים עכשיו, אז הבקשה שלך הוכנסה לרשימת המעקב. הבקשה "
-"שלך תיבדק אם וכאשר יהיו יותר חשבונות זמינים. אפשר לראות את כל המשאבים "
-"הזמינים בדף <a href=\"%(link)s\">%(link)s</a>. בברכה, ספריית ויקיפדיה"
+msgid "Dear %(user)s, Thank you for applying for access to %(partner)s resources through The Wikipedia Library. There are no accounts currently available so your application has been waitlisted. Your application will be evaluated if/when more accounts become available. You can see all available resources at: %(link)s Best, The Wikipedia Library"
+msgstr "%(user)s היקר, תודה על שליחת הבקשה לגשת למשאבים של %(partner)s דרך ספריית ויקיפדיה. אין חשבונות שזמינים עכשיו, אז הבקשה שלך הוכנסה לרשימת המעקב. הבקשה שלך תיבדק אם וכאשר יהיו יותר חשבונות זמינים. אפשר לראות את כל המשאבים הזמינים בדף <a href=\"%(link)s\">%(link)s</a>. בברכה, ספריית ויקיפדיה"
 
 #. Translators: This is the subject of an email sent to users when their application is waitlisted because there are no more accounts available. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/waitlist_notification-subject.html:4
@@ -1551,19 +1295,14 @@ msgstr "אינו זמין"
 #: TWLight/resources/templates/resources/filter_section.html:14
 #: TWLight/templates/about.html:12
 #: TWLight/users/templates/users/filter_section.html:13
-msgid ""
-"The Wikipedia Library allows active editors to access a wide range of "
-"collections of paywalled reliable sources for free!"
-msgstr ""
-"ספריית ויקיפדיה מאפשרת לעורכים פעילים לגשת למגוון רחב של אוספים מקורות "
-"מהימנים מאחורי חומת תשלום בחינם!"
+msgid "The Wikipedia Library allows active editors to access a wide range of collections of paywalled reliable sources for free!"
+msgstr "ספריית ויקיפדיה מאפשרת לעורכים פעילים לגשת למגוון רחב של אוספים מקורות מהימנים מאחורי חומת תשלום בחינם!"
 
 #. Translators: On the Browse Partners page (https://wikipedialibrary.wmflabs.org/partners/), this introduces users to The Wikipedia Library.
 #. Translators: On the MyLibrary page (https://wikipedialibrary.wmflabs.org/users/my_library), this introduces users to The Wikipedia Library.
 #: TWLight/resources/templates/resources/filter_section.html:17
 #: TWLight/users/templates/users/filter_section.html:15
-msgid ""
-"Start with the search bar at the top or browse publisher websites directly."
+msgid "Start with the search bar at the top or browse publisher websites directly."
 msgstr "נא להתחיל מסרגל החיפוש למעלה או לעיין באתרי המוציאים לאור ישירות."
 
 #. Translators: On the Browse Partners page (https://wikipedialibrary.wmflabs.org/partners/), this appears below introductory text and links to the 'About' page (https://wikipedialibrary.wmflabs.org/about/)
@@ -1637,66 +1376,39 @@ msgstr "חזרה לשותפים"
 #. Translators: If we have no available accounts for a partner, the coordinator can change the application system to a waiting list.
 #: TWLight/resources/templates/resources/partner_detail.html:36
 #: TWLight/resources/templates/resources/partner_detail_apply.html:17
-msgid ""
-"There are no access grants available for this partner at this time. You can "
-"still apply for access; applications will be processed when access is "
-"available."
-msgstr ""
-"אין זיכיונות גישה זמינים לשותף הזה בזמן הזה. באפשרותך בכל־זאת לבקש גישה; "
-"בקשות תטופלנה כשתהיה גישה."
+msgid "There are no access grants available for this partner at this time. You can still apply for access; applications will be processed when access is available."
+msgstr "אין זיכיונות גישה זמינים לשותף הזה בזמן הזה. באפשרותך בכל־זאת לבקש גישה; בקשות תטופלנה כשתהיה גישה."
 
 #. Translators: This text links to the minimum user requirements and terms of use on the partner page.
 #: TWLight/resources/templates/resources/partner_detail.html:48
 #: TWLight/resources/templates/resources/partner_detail_apply.html:29
 #, python-format
-msgid ""
-"Before applying, please review the <strong><a class=\"twl-links\" href="
-"\"%(about)s#req\">minimum requirements</a></strong> for access and our "
-"<strong><a class=\"twl-links\" href=\"%(terms)s\">terms of use</a></strong>."
-msgstr ""
-"לפני הגשת בקשה, נא לסקור את <strong><a class=\"twl-links\" href="
-"\"%(about)s#req\">הדרישות</a></strong> לגישה ואת <strong><a class=\"twl-links"
-"\" href=\"%(terms)s\">תנאי השימוש</a></strong> שלנו."
+msgid "Before applying, please review the <strong><a class=\"twl-links\" href=\"%(about)s#req\">minimum requirements</a></strong> for access and our <strong><a class=\"twl-links\" href=\"%(terms)s\">terms of use</a></strong>."
+msgstr "לפני הגשת בקשה, נא לסקור את <strong><a class=\"twl-links\" href=\"%(about)s#req\">הדרישות</a></strong> לגישה ואת <strong><a class=\"twl-links\" href=\"%(terms)s\">תנאי השימוש</a></strong> שלנו."
 
 #. Translators: This text refers to the page containing the content a user is authorized to access.
 #: TWLight/resources/templates/resources/partner_detail.html:69
 #, python-format
-msgid ""
-"View the status of your access in <strong><a class=\"twl-links\" href="
-"\"%(library_url)s\">My Library</a></strong> page."
-msgstr ""
-"צפייה במצב הבקשות שלך בדף <strong><a class=\"twl-links\" href="
-"\"%(library_url)s\">הספרייה שלי</a></strong>."
+msgid "View the status of your access in <strong><a class=\"twl-links\" href=\"%(library_url)s\">My Library</a></strong> page."
+msgstr "צפייה במצב הבקשות שלך בדף <strong><a class=\"twl-links\" href=\"%(library_url)s\">הספרייה שלי</a></strong>."
 
 #. Translators: This message is shown when a user has open applications, linking to their respective applications page.
 #: TWLight/resources/templates/resources/partner_detail.html:78
 #, python-format
-msgid ""
-"View the status of your application(s) on your <strong><a class=\"twl-links"
-"\" href=\"%(applications_url)s\">My Applications</a></strong> page."
-msgstr ""
-"צפייה במצב הבקשות שלך בדף <strong><a class=\"twl-links\" href="
-"\"%(applications_url)s\">הבקשות שלי</a></strong> שלך."
+msgid "View the status of your application(s) on your <strong><a class=\"twl-links\" href=\"%(applications_url)s\">My Applications</a></strong> page."
+msgstr "צפייה במצב הבקשות שלך בדף <strong><a class=\"twl-links\" href=\"%(applications_url)s\">הבקשות שלי</a></strong> שלך."
 
 #. Translators: This message is shown when a user has authorizations, linking to their respective collections page.
 #: TWLight/resources/templates/resources/partner_detail_apply.html:50
 #, python-format
-msgid ""
-"View the status of your access on your <strong><a href=\"%(library_url)s\" "
-"class=\"twl-links\">My Library</a></strong> page."
-msgstr ""
-"צפייה במצב הבקשות שלך בדף <strong><a href=\"%(library_url)s\"  class=\"twl-"
-"links\">הספרייה שלי</a></strong>."
+msgid "View the status of your access on your <strong><a href=\"%(library_url)s\" class=\"twl-links\">My Library</a></strong> page."
+msgstr "צפייה במצב הבקשות שלך בדף <strong><a href=\"%(library_url)s\"  class=\"twl-links\">הספרייה שלי</a></strong>."
 
 #. Translators: This message is shown when a user has open applications, linking to their respective applications page.
 #: TWLight/resources/templates/resources/partner_detail_apply.html:60
 #, python-format
-msgid ""
-"View the status of your application(s) on your <strong><a href="
-"\"%(applications_url)s\">My Applications</a></strong> page."
-msgstr ""
-"צפייה במצב הבקשות שלך בדף <strong><a href=\"%(applications_url)s\">הבקשות "
-"שלי</a></strong> שלך."
+msgid "View the status of your application(s) on your <strong><a href=\"%(applications_url)s\">My Applications</a></strong> page."
+msgstr "צפייה במצב הבקשות שלך בדף <strong><a href=\"%(applications_url)s\">הבקשות שלי</a></strong> שלך."
 
 #. Translators: One the partner detail page, this text labels the button which coordinators can click to remove a partner from waitlisted status.
 #: TWLight/resources/templates/resources/partner_detail_apply.html:73
@@ -1725,14 +1437,8 @@ msgstr "מיוחד:שליחת דואר למשתמש"
 
 #. Translators: If no account coordinator is assigned to a partner, the Wikipedia Library team will coordinate signups. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/resources/templates/resources/partner_detail_apply.html:112
-msgid ""
-"The Wikipedia Library team will process this application. Want to help? <a "
-"class=\"twl-links\" href=\"https://en.wikipedia.org/wiki/Wikipedia:"
-"The_Wikipedia_Library/Coordinators/Signup\">Sign up as a coordinator.</a>"
-msgstr ""
-"צוות ספריית ויקיפדיה יטפל בבקשה הזאת. רוצה לעזור? <a class=\"twl-links\" "
-"href=\"https://en.wikipedia.org/wiki/Wikipedia:The_Wikipedia_Library/"
-"Coordinators/Signup\">הירשם כמתאם.</a>"
+msgid "The Wikipedia Library team will process this application. Want to help? <a class=\"twl-links\" href=\"https://en.wikipedia.org/wiki/Wikipedia:The_Wikipedia_Library/Coordinators/Signup\">Sign up as a coordinator.</a>"
+msgstr "צוות ספריית ויקיפדיה יטפל בבקשה הזאת. רוצה לעזור? <a class=\"twl-links\" href=\"https://en.wikipedia.org/wiki/Wikipedia:The_Wikipedia_Library/Coordinators/Signup\">הירשם כמתאם.</a>"
 
 #. Translators: This text labels a button coordinators can click to view a list of users who have applied for access for a particular partner
 #: TWLight/resources/templates/resources/partner_detail_apply.html:121
@@ -1761,22 +1467,14 @@ msgstr "גישת לחבילת הספרייה"
 
 #. Translators: Text shown to authenticated, bundle eligible users when they visit a Bundle partner page.
 #: TWLight/resources/templates/resources/partner_detail_apply.html:138
-msgid ""
-"You are eligible to access Library Bundle partners. Click the button above "
-"to access the collection."
-msgstr ""
-"אתה זכאי לגשת לשותפי חבילת הספרייה. נא ללחוץ על הכפתור לעיל כדי לגשת לאוסף."
+msgid "You are eligible to access Library Bundle partners. Click the button above to access the collection."
+msgstr "אתה זכאי לגשת לשותפי חבילת הספרייה. נא ללחוץ על הכפתור לעיל כדי לגשת לאוסף."
 
 #. Translators: Text shown to authenticated, bundle ineligible users when they visit a Bundle partner page.
 #: TWLight/resources/templates/resources/partner_detail_apply.html:152
 #, python-format
-msgid ""
-"You are not eligible to access Library Bundle partners. Visit the <a class="
-"\"twl-links\" href=\"%(homepage)s\">homepage</a> to check the eligibility "
-"criteria."
-msgstr ""
-"אינך זכאי לגשת לשותפי חבילת הספרייה. נא לבקר ב<a class=\"twl-links\" href="
-"\"%(homepage)s\">דף הבית</a> כדי לבדוק את התנאים לזכאות."
+msgid "You are not eligible to access Library Bundle partners. Visit the <a class=\"twl-links\" href=\"%(homepage)s\">homepage</a> to check the eligibility criteria."
+msgstr "אינך זכאי לגשת לשותפי חבילת הספרייה. נא לבקר ב<a class=\"twl-links\" href=\"%(homepage)s\">דף הבית</a> כדי לבדוק את התנאים לזכאות."
 
 #. Translators: Buttton prompting users to log in.
 #: TWLight/resources/templates/resources/partner_detail_apply.html:160
@@ -1787,14 +1485,8 @@ msgstr "כניסה"
 #. Translators: Text shown to unauthenticated users when they visit a Bundle partner page.
 #: TWLight/resources/templates/resources/partner_detail_apply.html:168
 #, python-format
-msgid ""
-"This resource is part of our <a class=\"twl-links\" href=\"%(about)s"
-"\">Library Bundle</a>, which you can access if you meet our minimum "
-"eligibility criteria. Log in to find out if you are eligible."
-msgstr ""
-"המשאב הזה הוא חלק מהגישה שלנו ל<a class=\"twl-links\" href=\"%(about)s"
-"\">חבילת הספרייה</a>, שיש לך זכות לגשת אליה אם עמדת בתנאי הזכאות המזעריים "
-"שלנו. יש להיכנס לחשבון כדי לבדוק זכאות."
+msgid "This resource is part of our <a class=\"twl-links\" href=\"%(about)s\">Library Bundle</a>, which you can access if you meet our minimum eligibility criteria. Log in to find out if you are eligible."
+msgstr "המשאב הזה הוא חלק מהגישה שלנו ל<a class=\"twl-links\" href=\"%(about)s\">חבילת הספרייה</a>, שיש לך זכות לגשת אליה אם עמדת בתנאי הזכאות המזעריים שלנו. יש להיכנס לחשבון כדי לבדוק זכאות."
 
 #. Translators: This is the label for a number which shows the total active accounts for one partner. (e.g. https://wikipedialibrary.wmflabs.org/partners/8/).
 #: TWLight/resources/templates/resources/partner_detail_stats.html:21
@@ -1844,32 +1536,20 @@ msgstr "מגבלת מובאות"
 #. Translators: If a partner has specified the excerpt limit both in words and percentage, this message will display the percentage of words and the number of words on the partner page.
 #: TWLight/resources/templates/resources/partner_detail_timeline.html:99
 #, python-format
-msgid ""
-"%(object)s allows a maximum of %(excerpt_limit)s words or "
-"%(excerpt_limit_percentage)s%% of an article be excerpted into a Wikipedia "
-"article."
-msgstr ""
-"%(object)s מאפשר להביא %(excerpt_limit)s מילים או "
-"%(excerpt_limit_percentage)s%% מתוך מאמר לכל היותר לתוך ערך בוויקיפדיה."
+msgid "%(object)s allows a maximum of %(excerpt_limit)s words or %(excerpt_limit_percentage)s%% of an article be excerpted into a Wikipedia article."
+msgstr "%(object)s מאפשר להביא %(excerpt_limit)s מילים או %(excerpt_limit_percentage)s%% מתוך מאמר לכל היותר לתוך ערך בוויקיפדיה."
 
 #. Translators: If a partner has specified the excerpt limit in words, this message will display the number of words on the partner page.
 #: TWLight/resources/templates/resources/partner_detail_timeline.html:106
 #, python-format
-msgid ""
-"%(object)s allows a maximum of %(excerpt_limit)s words be excerpted into a "
-"Wikipedia article."
-msgstr ""
-"%(object)s מאפשר להביא %(excerpt_limit)s מילים לכל היותר לתוך ערך בוויקיפדיה."
+msgid "%(object)s allows a maximum of %(excerpt_limit)s words be excerpted into a Wikipedia article."
+msgstr "%(object)s מאפשר להביא %(excerpt_limit)s מילים לכל היותר לתוך ערך בוויקיפדיה."
 
 #. Translators: If a partner has specified the excerpt limit in percentage, this message will display the percentage of words on the partner page.
 #: TWLight/resources/templates/resources/partner_detail_timeline.html:113
 #, python-format
-msgid ""
-"%(object)s allows a maximum of %(excerpt_limit_percentage)s%% of an article "
-"be excerpted into a Wikipedia article."
-msgstr ""
-"%(object)s מאפשר להביא %(excerpt_limit_percentage)s%% מתוך מאמר לכל היותר "
-"לתוך ערך בוויקיפדיה."
+msgid "%(object)s allows a maximum of %(excerpt_limit_percentage)s%% of an article be excerpted into a Wikipedia article."
+msgstr "%(object)s מאפשר להביא %(excerpt_limit_percentage)s%% מתוך מאמר לכל היותר לתוך ערך בוויקיפדיה."
 
 #. Translators: If a partner has other requirements for access, this text shows as the title for that information field. (e.g. https://wikipedialibrary.wmflabs.org/partners/10/).
 #: TWLight/resources/templates/resources/partner_detail_timeline.html:132
@@ -1879,11 +1559,8 @@ msgstr "דרישות מיוחדת ממגישי בקשות"
 #. Translators: If a user must agree to a Terms of Use document, they see this message, and must enter the name of the resource. Don't translate publisher or url.
 #: TWLight/resources/templates/resources/partner_detail_timeline.html:140
 #, python-format
-msgid ""
-"%(publisher)s requires that you agree with its <a href=\"%(url)s\">terms of "
-"use</a>."
-msgstr ""
-"המו״ל %(publisher)s דורש ממך להסכים ל<a href=\"%(url)s\">תנאי השימוש</a> שלו."
+msgid "%(publisher)s requires that you agree with its <a href=\"%(url)s\">terms of use</a>."
+msgstr "המו״ל %(publisher)s דורש ממך להסכים ל<a href=\"%(url)s\">תנאי השימוש</a> שלו."
 
 #. Translators: If a user must provide their real name to apply to a partner, they see this message, and must enter the name of the resource. Don't translate publisher.
 #: TWLight/resources/templates/resources/partner_detail_timeline.html:150
@@ -1906,18 +1583,13 @@ msgstr "המו״ל %(publisher)s דורש ממך לספק את ההשתייכו�
 #. Translators: If a user must select a specific resource to apply for, they see this message, and must enter the name of the resource. Don't translate publisher.
 #: TWLight/resources/templates/resources/partner_detail_timeline.html:177
 #, python-format
-msgid ""
-"%(publisher)s requires that you specify a particular title that you want to "
-"access."
-msgstr ""
-"המו״ל %(publisher)s דורש ממך לספק כותרת של יצירה מסוימת שברצונך לגשת אליה."
+msgid "%(publisher)s requires that you specify a particular title that you want to access."
+msgstr "המו״ל %(publisher)s דורש ממך לספק כותרת של יצירה מסוימת שברצונך לגשת אליה."
 
 #. Translators: If a user must register on the partner website before applying, they see this message. Don't translate partner.
 #: TWLight/resources/templates/resources/partner_detail_timeline.html:187
 #, python-format
-msgid ""
-"%(publisher)s requires that you sign up for an account before applying for "
-"access."
+msgid "%(publisher)s requires that you sign up for an account before applying for access."
 msgstr "המו״ל %(publisher)s דורש ממך להירשם לחשבון לפני שליחת בקשת גישה."
 
 #. Translators: If a partner has their location listed, this message is a label for that location
@@ -2044,12 +1716,8 @@ msgstr "האם ברצונך באמת למחוק את <b>%(object)s</b>?"
 
 #. Translators: If multiple authorizations where returned for a collection, this message is shown to a user
 #: TWLight/resources/views.py:268
-msgid ""
-"Multiple authorizations were returned – something's wrong. Please contact us "
-"and don't forget to mention this message."
-msgstr ""
-"הוחזרו כמה אישורים – משהו אינו תקין. נא ליצור איתנו קשר ולא לשכוח להזכיר את "
-"ההודעה הזאת."
+msgid "Multiple authorizations were returned – something's wrong. Please contact us and don't forget to mention this message."
+msgstr "הוחזרו כמה אישורים – משהו אינו תקין. נא ליצור איתנו קשר ולא לשכוח להזכיר את ההודעה הזאת."
 
 #. Translators: This message is shown when user tries to access a NOT_AVAILABLE Partner
 #: TWLight/resources/views.py:316
@@ -2089,22 +1757,8 @@ msgstr "סליחה; אנחנו לא יודעים מה לעשות את זה."
 #. Translators: Shown on the website's 400 page, when a user sends a bad request. Don't translate path or Phabricator.
 #: TWLight/templates/400.html:20
 #, python-format
-msgid ""
-"If you think we should know what to do with that, please email us about this "
-"error at <a class=\"twl-links\" href=\"mailto:wikipedialibrary@wikimedia.org?"
-"Subject=Wikipedia%%20Library%%20%(path)s%%20Permission%%20denied"
-"\">wikipedialibrary@wikimedia.org</a> or report it to us on <a class=\"twl-"
-"links\" href=\"https://phabricator.wikimedia.org/maniphest/task/edit/form/1/?"
-"projectPHIDs=Library-Card-Platform&title=Wikipedia%%20Library%%20%(path)s"
-"%%20Bad%%20Request\">Phabricator</a>"
-msgstr ""
-"אם נראה לך שאנחנו אמורים לדעת מה לעשות עם זה, נא לשלוח לנו מכתב על השגיאה "
-"הזאת לכתובת <a class=\"twl-links\" href=\"mailto:wikipedialibrary@wikimedia."
-"org?Subject=Wikipedia%%20Library%%20%(path)s%%20Permission%%20denied"
-"\">wikipedialibrary@wikimedia.org</a> או לדווח את זה לנו ב<a class=\"twl-"
-"links\" href=\"https://phabricator.wikimedia.org/maniphest/task/edit/form/1/?"
-"projectPHIDs=Library-Card-Platform&title=Wikipedia%%20Library%%20%(path)s"
-"%%20Bad%%20Request\">פבריקטור</a>"
+msgid "If you think we should know what to do with that, please email us about this error at <a class=\"twl-links\" href=\"mailto:wikipedialibrary@wikimedia.org?Subject=Wikipedia%%20Library%%20%(path)s%%20Permission%%20denied\">wikipedialibrary@wikimedia.org</a> or report it to us on <a class=\"twl-links\" href=\"https://phabricator.wikimedia.org/maniphest/task/edit/form/1/?projectPHIDs=Library-Card-Platform&title=Wikipedia%%20Library%%20%(path)s%%20Bad%%20Request\">Phabricator</a>"
+msgstr "אם נראה לך שאנחנו אמורים לדעת מה לעשות עם זה, נא לשלוח לנו מכתב על השגיאה הזאת לכתובת <a class=\"twl-links\" href=\"mailto:wikipedialibrary@wikimedia.org?Subject=Wikipedia%%20Library%%20%(path)s%%20Permission%%20denied\">wikipedialibrary@wikimedia.org</a> או לדווח את זה לנו ב<a class=\"twl-links\" href=\"https://phabricator.wikimedia.org/maniphest/task/edit/form/1/?projectPHIDs=Library-Card-Platform&title=Wikipedia%%20Library%%20%(path)s%%20Bad%%20Request\">פבריקטור</a>"
 
 #. Translators: Alt text for an image shown on the 400 error page.
 #. Translators: Alt text for an image shown on the 403 error page.
@@ -2125,23 +1779,8 @@ msgstr "סליחה; אין לך הרשאה לעשות את זה."
 #. Translators: Shown on the website's 403 page, when a user attempts to navigate to a page they don't have permission to view. Don't translate path or Phabricator.
 #: TWLight/templates/403.html:20
 #, python-format
-msgid ""
-"If you think your account should be able to do that, please email us about "
-"this error at <a class=\"twl-links\" href=\"mailto:"
-"wikipedialibrary@wikimedia.org?Subject=Wikipedia%%20Library%%20%(path)s"
-"%%20Permission%%20denied\">wikipedialibrary@wikimedia.org</a> or report it "
-"to us on <a class=\"twl-links\" href=\"https://phabricator.wikimedia.org/"
-"maniphest/task/edit/form/1/?projectPHIDs=Library-Card-"
-"Platform&title=Wikipedia%%20Library%%20%(path)s%%20Permission%%20denied"
-"\">Phabricator</a>"
-msgstr ""
-"אם נראה לך שהחשבון שלך אמור להיות מסוגל לעשות את זה, נא לשלוח לנו מכתב על זה "
-"לכתובת <a class=\"twl-links\" href=\"mailto:wikipedialibrary@wikimedia.org?"
-"Subject=Wikipedia%%20Library%%20%(path)s%%20Permission%%20denied"
-"\">wikipedialibrary@wikimedia.org</a> או לדווח את זה לנו ב<a class=\"twl-"
-"links\" href=\"https://phabricator.wikimedia.org/maniphest/task/edit/form/1/?"
-"projectPHIDs=Library-Card-Platform&title=Wikipedia%%20Library%%20%(path)s"
-"%%20Permission%%20denied\">פבריקטור</a>"
+msgid "If you think your account should be able to do that, please email us about this error at <a class=\"twl-links\" href=\"mailto:wikipedialibrary@wikimedia.org?Subject=Wikipedia%%20Library%%20%(path)s%%20Permission%%20denied\">wikipedialibrary@wikimedia.org</a> or report it to us on <a class=\"twl-links\" href=\"https://phabricator.wikimedia.org/maniphest/task/edit/form/1/?projectPHIDs=Library-Card-Platform&title=Wikipedia%%20Library%%20%(path)s%%20Permission%%20denied\">Phabricator</a>"
+msgstr "אם נראה לך שהחשבון שלך אמור להיות מסוגל לעשות את זה, נא לשלוח לנו מכתב על זה לכתובת <a class=\"twl-links\" href=\"mailto:wikipedialibrary@wikimedia.org?Subject=Wikipedia%%20Library%%20%(path)s%%20Permission%%20denied\">wikipedialibrary@wikimedia.org</a> או לדווח את זה לנו ב<a class=\"twl-links\" href=\"https://phabricator.wikimedia.org/maniphest/task/edit/form/1/?projectPHIDs=Library-Card-Platform&title=Wikipedia%%20Library%%20%(path)s%%20Permission%%20denied\">פבריקטור</a>"
 
 #. Translators: Shown on the website's 404 page, when a user attempts to navigate to a page that doesn't exist.
 #: TWLight/templates/404.html:11
@@ -2156,22 +1795,8 @@ msgstr "סליחה; אנחנו לא יכולים למצוא את זה."
 #. Translators: Shown on the website's 404 page, when a user attempts to navigate to a page that doesn't exist. Don't translate path or Phabricator.
 #: TWLight/templates/404.html:19
 #, python-format
-msgid ""
-"If you are certain that something should be here, please email us about this "
-"error at <a class=\"twl-links\" href=\"mailto:wikipedialibrary@wikimedia.org?"
-"Subject=Wikipedia%%20Library%%20%(path)s%%20Not%%20found\"> "
-"wikipedialibrary@wikimedia.org</a> or report it to us on <a class=\"twl-links"
-"\" href=\"https://phabricator.wikimedia.org/maniphest/task/edit/form/1/?"
-"projectPHIDs=Library-Card-Platform&title=Wikipedia%%20Library%%20%(path)s"
-"%%20Not%%20found\">Phabricator</a>"
-msgstr ""
-"אם אתה בטוח שמשהו צריך להיות כאן, נא לשלוח לנו מכתב על זה לכתובת <a class="
-"\"twl-links\" href=\"mailto:wikipedialibrary@wikimedia.org?Subject=Wikipedia"
-"%%20Library%%20%(path)s%%20Not%%20found\"> wikipedialibrary@wikimedia.org</"
-"a> או לדווח את זה לנו ב<a class=\"twl-links\" href=\"https://phabricator."
-"wikimedia.org/maniphest/task/edit/form/1/?projectPHIDs=Library-Card-"
-"Platform&title=Wikipedia%%20Library%%20%(path)s%%20Not%%20found\">פבריקטור</"
-"a>"
+msgid "If you are certain that something should be here, please email us about this error at <a class=\"twl-links\" href=\"mailto:wikipedialibrary@wikimedia.org?Subject=Wikipedia%%20Library%%20%(path)s%%20Not%%20found\"> wikipedialibrary@wikimedia.org</a> or report it to us on <a class=\"twl-links\" href=\"https://phabricator.wikimedia.org/maniphest/task/edit/form/1/?projectPHIDs=Library-Card-Platform&title=Wikipedia%%20Library%%20%(path)s%%20Not%%20found\">Phabricator</a>"
+msgstr "אם אתה בטוח שמשהו צריך להיות כאן, נא לשלוח לנו מכתב על זה לכתובת <a class=\"twl-links\" href=\"mailto:wikipedialibrary@wikimedia.org?Subject=Wikipedia%%20Library%%20%(path)s%%20Not%%20found\"> wikipedialibrary@wikimedia.org</a> או לדווח את זה לנו ב<a class=\"twl-links\" href=\"https://phabricator.wikimedia.org/maniphest/task/edit/form/1/?projectPHIDs=Library-Card-Platform&title=Wikipedia%%20Library%%20%(path)s%%20Not%%20found\">פבריקטור</a>"
 
 #. Translators: Alt text for an image shown on the 404 error page.
 #: TWLight/templates/404.html:32
@@ -2185,44 +1810,19 @@ msgstr "אודות ספריית ויקיפדיה"
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:20
-msgid ""
-"This platform is our central tool for facilitating access to our available "
-"collections. Here you can see which partnerships are available, search their "
-"contents, and apply for and access the ones you’re interested in."
-msgstr ""
-"הפלטפורמה הזאת היא הכלי המרכזי שלנו להקלת הגישה לאוספים הזמינים שלנו. כאן "
-"אפשר לראות אלו שותפויות זמינות, לחפש בתוכן שלהן, ולבקש גישה לאלו שאתה "
-"מעוניין בהן ולגשת אליהן."
+msgid "This platform is our central tool for facilitating access to our available collections. Here you can see which partnerships are available, search their contents, and apply for and access the ones you’re interested in."
+msgstr "הפלטפורמה הזאת היא הכלי המרכזי שלנו להקלת הגישה לאוספים הזמינים שלנו. כאן אפשר לראות אלו שותפויות זמינות, לחפש בתוכן שלהן, ולבקש גישה לאלו שאתה מעוניין בהן ולגשת אליהן."
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/). Wikimedia Foundation should not be translated.
 #: TWLight/templates/about.html:29
-msgid ""
-"All users receive immediate access to some collections, which can be browsed "
-"by clicking the 'Access collection' buttons or using the search bar at the "
-"top of the page. Other collections require an application before access is "
-"granted, and may be accessed directly or via an individual login or access "
-"code. Volunteer coordinators, who have signed non-disclosure agreements with "
-"the Wikimedia Foundation, review these applications and work with publishers "
-"to get you your free access."
-msgstr ""
-"כל המשתמשים מקבלים גישה מיידית לחלק מהאוספים, שאפשר לעיין בהם באמצעות לחיצה "
-"על כפתורי \"לגשת לאוסף\" או שימוש בסרגל החיפוש בראש הדף. אוספים אחרים דורשים "
-"הגשת בקשה לפני שהגישה מוענקת, ואפשר לגשת אליהם ישירות או דרך קוד גישה פרטי. "
-"מתאמים מתנדבים, שחתמו על הסכם סודיות עם קרן ויקימדיה, סוקרים את הבקשות "
-"ועובדים עם מוציאים לאור כדי לתת לך גישה חופשית."
+msgid "All users receive immediate access to some collections, which can be browsed by clicking the 'Access collection' buttons or using the search bar at the top of the page. Other collections require an application before access is granted, and may be accessed directly or via an individual login or access code. Volunteer coordinators, who have signed non-disclosure agreements with the Wikimedia Foundation, review these applications and work with publishers to get you your free access."
+msgstr "כל המשתמשים מקבלים גישה מיידית לחלק מהאוספים, שאפשר לעיין בהם באמצעות לחיצה על כפתורי \"לגשת לאוסף\" או שימוש בסרגל החיפוש בראש הדף. אוספים אחרים דורשים הגשת בקשה לפני שהגישה מוענקת, ואפשר לגשת אליהם ישירות או דרך קוד גישה פרטי. מתאמים מתנדבים, שחתמו על הסכם סודיות עם קרן ויקימדיה, סוקרים את הבקשות ועובדים עם מוציאים לאור כדי לתת לך גישה חופשית."
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/). Don't translate terms_url.
 #: TWLight/templates/about.html:43
 #, python-format
-msgid ""
-"For more information about how your information is stored and reviewed "
-"please see our <a class=\"twl-links\" href=\"%(terms_url)s\"> terms of use "
-"and privacy policy</a>. Accounts you apply for are also subject to the Terms "
-"of Use provided by each partner’s platform; please review them."
-msgstr ""
-"למידע נוסף על איך המידע שלך מאוחסן ונסקר, ר' את <a class=\"twl-links\" href="
-"\"%(terms_url)s\">תנאי השימוש ואת מדיניות הפרטיות</a> שלנו. חשבונות שאתם "
-"מבקשות פועלים גם בהתאם לתנאי השימוש של כל פלטפורמת שותף; נא לסקור אותם."
+msgid "For more information about how your information is stored and reviewed please see our <a class=\"twl-links\" href=\"%(terms_url)s\"> terms of use and privacy policy</a>. Accounts you apply for are also subject to the Terms of Use provided by each partner’s platform; please review them."
+msgstr "למידע נוסף על איך המידע שלך מאוחסן ונסקר, ר' את <a class=\"twl-links\" href=\"%(terms_url)s\">תנאי השימוש ואת מדיניות הפרטיות</a> שלנו. חשבונות שאתם מבקשות פועלים גם בהתאם לתנאי השימוש של כל פלטפורמת שותף; נא לסקור אותם."
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:51
@@ -2231,17 +1831,8 @@ msgstr "מי יכול לקבל גישה?"
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/). Wikimedia Foundation should not be translated.
 #: TWLight/templates/about.html:55
-msgid ""
-"Any active editor in good standing can receive access. For publishers with "
-"limited numbers of accounts, applications are reviewed based on the editor’s "
-"needs and contributions. If you think you could use access to one of our "
-"partner resources and are an active editor in any project supported by the "
-"Wikimedia Foundation, please apply."
-msgstr ""
-"כל עורך פעיל בהתאם למדיניות יכול לקבל גישה. עבור מוציאים לאור עם מספר מוגבל "
-"של חשבונות, בקשות גישה נסקרות בהתאם לצרכים ולתרומה של העורך. אם נראה לך "
-"שגישה לאחד ממשאבי השותפים שלנו ואתה עורך פעיל באחד מהמיזמים שנתמכים על־ידי "
-"קרן ויקימדיה, נא להגיש בקשה."
+msgid "Any active editor in good standing can receive access. For publishers with limited numbers of accounts, applications are reviewed based on the editor’s needs and contributions. If you think you could use access to one of our partner resources and are an active editor in any project supported by the Wikimedia Foundation, please apply."
+msgstr "כל עורך פעיל בהתאם למדיניות יכול לקבל גישה. עבור מוציאים לאור עם מספר מוגבל של חשבונות, בקשות גישה נסקרות בהתאם לצרכים ולתרומה של העורך. אם נראה לך שגישה לאחד ממשאבי השותפים שלנו ואתה עורך פעיל באחד מהמיזמים שנתמכים על־ידי קרן ויקימדיה, נא להגיש בקשה."
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:65
@@ -2270,31 +1861,13 @@ msgstr "החשבון שלך אינו חסום מעריכה בשום מיזם ו�
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/)
 #: TWLight/templates/about.html:89
-msgid ""
-"If you are applying for an available collection, please first check that you "
-"don't already have access through another library or institution. If you do, "
-"please consider using that access rather than taking up a seat for this "
-"resource in The Wikipedia Library."
-msgstr ""
-"אם זאת בקשה של אוסף זמין, נא לבדוק קודם אם יש לך כבר גישה דרך ספרייה או מוסד "
-"אחר. אם יש לך, נא לשקול להשתמש בגישה ההיא במקום לתפוס מקום בספריית ויקיפדיה."
+msgid "If you are applying for an available collection, please first check that you don't already have access through another library or institution. If you do, please consider using that access rather than taking up a seat for this resource in The Wikipedia Library."
+msgstr "אם זאת בקשה של אוסף זמין, נא לבדוק קודם אם יש לך כבר גישה דרך ספרייה או מוסד אחר. אם יש לך, נא לשקול להשתמש בגישה ההיא במקום לתפוס מקום בספריית ויקיפדיה."
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/)
 #: TWLight/templates/about.html:99
-msgid ""
-"If your account is blocked on one or more Wikimedia projects, you may still "
-"be granted access to The Wikipedia Library. You will need to contact the "
-"Wikipedia Library team, who will review your blocks. If you have been "
-"blocked for content issues, most notably copyright violations, or have "
-"multiple long-term blocks, we may decline your request. Additionally, if "
-"your block status changes after being approved, you will need to request "
-"another review."
-msgstr ""
-"אם החשבון שלך חסום במיזם ויקימדיה אחד או יותר, עדיין ייתכן שתינתן לך גישה "
-"לספריית ויקיפדיה. תצטרך ליצור קשר עם צוות ספריית ויקיפדיה, שיבדוק את החסומות "
-"שלך. אם נחסמת בעבור ענייני תוכן, במיוחד הפרות זכויות יוצרים, או שיש לך "
-"חסימות ארוכות רבות, ייתכן שנדחה את בקשתך. בנוסף, אם מצב החסימה שלך משתנה "
-"אחרי שאושרת, תצטרך לבקש עוד בדיקה."
+msgid "If your account is blocked on one or more Wikimedia projects, you may still be granted access to The Wikipedia Library. You will need to contact the Wikipedia Library team, who will review your blocks. If you have been blocked for content issues, most notably copyright violations, or have multiple long-term blocks, we may decline your request. Additionally, if your block status changes after being approved, you will need to request another review."
+msgstr "אם החשבון שלך חסום במיזם ויקימדיה אחד או יותר, עדיין ייתכן שתינתן לך גישה לספריית ויקיפדיה. תצטרך ליצור קשר עם צוות ספריית ויקיפדיה, שיבדוק את החסומות שלך. אם נחסמת בעבור ענייני תוכן, במיוחד הפרות זכויות יוצרים, או שיש לך חסימות ארוכות רבות, ייתכן שנדחה את בקשתך. בנוסף, אם מצב החסימה שלך משתנה אחרי שאושרת, תצטרך לבקש עוד בדיקה."
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:110
@@ -2328,12 +1901,8 @@ msgstr "עורכים מאושרים <i>לא אמורים</i>:"
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:136
-msgid ""
-"Share their account logins or passwords with others, or sell their access to "
-"other parties"
-msgstr ""
-"לשתף את נתוני הכניסה שלהם או את הסיסמאות שלהם עם אחרים, או למכור את הגישה "
-"שלהם לאחרים"
+msgid "Share their account logins or passwords with others, or sell their access to other parties"
+msgstr "לשתף את נתוני הכניסה שלהם או את הסיסמאות שלהם עם אחרים, או למכור את הגישה שלהם לאחרים"
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:140
@@ -2342,27 +1911,18 @@ msgstr "לגרד (scrape) או לעשות הורדה המונית של תוכן 
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:144
-msgid ""
-"Systematically make printed or electronic copies of multiple extracts of "
-"restricted content available for any purpose"
-msgstr ""
-"לעשות באופן שיטתי עותקים מודפסים או אלקטרוניים של מובאות מרובות של תוכן "
-"מוגבל ולהפוך אותם לזמינים לכל מטרה"
+msgid "Systematically make printed or electronic copies of multiple extracts of restricted content available for any purpose"
+msgstr "לעשות באופן שיטתי עותקים מודפסים או אלקטרוניים של מובאות מרובות של תוכן מוגבל ולהפוך אותם לזמינים לכל מטרה"
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/). Stub is a technical term for a short Wikipedia article, use the appropriate Wikipedia term in your language.
 #: TWLight/templates/about.html:148
-msgid ""
-"Datamine metadata without permission, in order, for instance, to use "
-"metadata for auto-created stub articles"
+msgid "Datamine metadata without permission, in order, for instance, to use metadata for auto-created stub articles"
 msgstr "לכרות נתונים ללא רשות, כדי, למשל, להשתמש במטא־נתונים ליצירת קצרמרים"
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:154
-msgid ""
-"Respecting these agreements allows us to continue growing the partnerships "
-"available to the community."
-msgstr ""
-"כיבוד ההסכמים האלה מאפשר לנו להמשיך להצמיח את השותפויות הזמינות לקהילה."
+msgid "Respecting these agreements allows us to continue growing the partnerships available to the community."
+msgstr "כיבוד ההסכמים האלה מאפשר לנו להמשיך להצמיח את השותפויות הזמינות לקהילה."
 
 #. Translators: This is the heading for a section on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:160
@@ -2371,57 +1931,23 @@ msgstr "איזיפרוקסי"
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:164
-msgid ""
-"EZProxy is a proxy server used to authenticate users for many Wikipedia "
-"Library partners. Users sign into EZProxy via the Library Card platform to "
-"verify that they are authorized users, and then the server accesses "
-"requested resources using its own IP address."
-msgstr ""
-"איזיפרוקסי (EZProxy) הוא שרת מתווך שמשמש לזיהוי משתמשים עבור שותפים רבים של "
-"ספריית ויקיפדיה. משתמשים נרשמים לאיזיפרוקסי דרך פלטפורמת כרטיס ספרייה כדי "
-"לאמת שהם משתמשים מאושרים, ואז השרת ניגש למשאבים מבוקשים באמצעות כתובת ה־IP "
-"שלו עצמו."
+msgid "EZProxy is a proxy server used to authenticate users for many Wikipedia Library partners. Users sign into EZProxy via the Library Card platform to verify that they are authorized users, and then the server accesses requested resources using its own IP address."
+msgstr "איזיפרוקסי (EZProxy) הוא שרת מתווך שמשמש לזיהוי משתמשים עבור שותפים רבים של ספריית ויקיפדיה. משתמשים נרשמים לאיזיפרוקסי דרך פלטפורמת כרטיס ספרייה כדי לאמת שהם משתמשים מאושרים, ואז השרת ניגש למשאבים מבוקשים באמצעות כתובת ה־IP שלו עצמו."
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:173
-msgid ""
-"You may notice that when accessing resources via EZProxy that URLs are "
-"dynamically rewritten. This is why we recommend logging in via the Library "
-"Card platform rather than going directly to the unproxied partner website. "
-"When in doubt, check the URL for ‘idm.oclc’. If it’s there, then you’re "
-"connected via EZProxy."
-msgstr ""
-"ייתכן שתשים לב לכך שכשאתה ניגש דרך איזיפרוקסי, כתובות ה־URL משוכתבות באופן "
-"דינמי. בגלל זה אנחנו ממליצים להיכנס דרך פלטפורמת כרטיס הספרייה ולא ללכת ישר "
-"לאתר של השותף ללא התיווך. כשיש ספק, יש לבדוק אם ב־URL כתוב \"idm.oclc\". אם "
-"זה שם, התחברת דרך איזיפרוקסי."
+msgid "You may notice that when accessing resources via EZProxy that URLs are dynamically rewritten. This is why we recommend logging in via the Library Card platform rather than going directly to the unproxied partner website. When in doubt, check the URL for ‘idm.oclc’. If it’s there, then you’re connected via EZProxy."
+msgstr "ייתכן שתשים לב לכך שכשאתה ניגש דרך איזיפרוקסי, כתובות ה־URL משוכתבות באופן דינמי. בגלל זה אנחנו ממליצים להיכנס דרך פלטפורמת כרטיס הספרייה ולא ללכת ישר לאתר של השותף ללא התיווך. כשיש ספק, יש לבדוק אם ב־URL כתוב \"idm.oclc\". אם זה שם, התחברת דרך איזיפרוקסי."
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:182
-msgid ""
-"Typically once you’ve logged in your session will remain active in your "
-"browser for up to two hours after you’ve finished searching. Note that use "
-"of EZProxy requires you to enable cookies. If you are having problems you "
-"should also try clearing your cache and restarting your browser."
-msgstr ""
-"בדרך־כלל, אחרי שנכנסת, ההתחברות שלך תישאר פעילה בדפדפן שלך עד שעתיים אחרי "
-"שסיימת לחפש. נא לשים לב לכך שאיזיפרוקסי דורשת הפעלת עוגיות. אם יש לך בעיות, "
-"כדאי לנסות לנקות את המטמון ולהפעיל מחדש את הדפדפן."
+msgid "Typically once you’ve logged in your session will remain active in your browser for up to two hours after you’ve finished searching. Note that use of EZProxy requires you to enable cookies. If you are having problems you should also try clearing your cache and restarting your browser."
+msgstr "בדרך־כלל, אחרי שנכנסת, ההתחברות שלך תישאר פעילה בדפדפן שלך עד שעתיים אחרי שסיימת לחפש. נא לשים לב לכך שאיזיפרוקסי דורשת הפעלת עוגיות. אם יש לך בעיות, כדאי לנסות לנקות את המטמון ולהפעיל מחדש את הדפדפן."
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/)
 #: TWLight/templates/about.html:193
-msgid ""
-"The Library Bundle is a collection of resources for which no application is "
-"required. If you meet the criteria laid out above, you will be authorized "
-"for access automatically upon logging in to the platform. Only some of our "
-"content is currently included in the Library Bundle, however we hope to "
-"expand the collection as more publishers become comfortable with "
-"participating. All Bundle content is accessed via EZProxy."
-msgstr ""
-"חבילת הספרייה היא אוסף משאבים שאפשר לגשת אליהם בלי לבקש. אם עמדת בתנאים "
-"המפורטים לעיל, יהיה לך אישור גישה אוטומטי עם כניסה לפלטפורמה. רק חלק מהתוכן "
-"שלנו כלול כעת בחבילת הספרייה, אבל אנחנו מקווים להרחיב את האוסף כשליותר "
-"מוציאים לאור יהיה נוח להשתתף. לכל תוכן חבילת הספרייה ניגשים דרך איזיפרוקסי."
+msgid "The Library Bundle is a collection of resources for which no application is required. If you meet the criteria laid out above, you will be authorized for access automatically upon logging in to the platform. Only some of our content is currently included in the Library Bundle, however we hope to expand the collection as more publishers become comfortable with participating. All Bundle content is accessed via EZProxy."
+msgstr "חבילת הספרייה היא אוסף משאבים שאפשר לגשת אליהם בלי לבקש. אם עמדת בתנאים המפורטים לעיל, יהיה לך אישור גישה אוטומטי עם כניסה לפלטפורמה. רק חלק מהתוכן שלנו כלול כעת בחבילת הספרייה, אבל אנחנו מקווים להרחיב את האוסף כשליותר מוציאים לאור יהיה נוח להשתתף. לכל תוכן חבילת הספרייה ניגשים דרך איזיפרוקסי."
 
 #. Translators: This is the heading for a section on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:202
@@ -2430,17 +1956,8 @@ msgstr "שיטות ציטוט מקורות"
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:206
-msgid ""
-"Citation practices vary by project and even by article. Generally, we "
-"support editors citing where they found information, in a form that allows "
-"others to check it for themselves. That often means providing both original "
-"source details as well as a link to the partner database in which the source "
-"was found."
-msgstr ""
-"שיטות ציטוט המקורות משתנות ממיזם למיזם ואפילו מערך לערך. באופן כללי, אנו "
-"תומכים בכך שעורכים יצטטו איפה הם מצאו את המידע, בצורה שתאפשר לאחרים לבדוק "
-"אותו בעצמם. לעיתים קרובות זה אומר להביא גם את פרטי המקור עצמו וגם קישור למסד "
-"הנתונים של השותף שבו המקור נמצא."
+msgid "Citation practices vary by project and even by article. Generally, we support editors citing where they found information, in a form that allows others to check it for themselves. That often means providing both original source details as well as a link to the partner database in which the source was found."
+msgstr "שיטות ציטוט המקורות משתנות ממיזם למיזם ואפילו מערך לערך. באופן כללי, אנו תומכים בכך שעורכים יצטטו איפה הם מצאו את המידע, בצורה שתאפשר לאחרים לבדוק אותו בעצמם. לעיתים קרובות זה אומר להביא גם את פרטי המקור עצמו וגם קישור למסד הנתונים של השותף שבו המקור נמצא."
 
 #. Translators: This is the heading for a section on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #. Translators: This link is at the bottom of every page and can be clicked by users to contact the wikipedia library team.
@@ -2451,12 +1968,8 @@ msgstr "ליצור איתנו קשר"
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:218
 #, python-format
-msgid ""
-"If you have questions, need help, or want to volunteer to help, please see "
-"our <a class=\"twl-links\" href=\"%(contact_url)s\">contact page</a>."
-msgstr ""
-"אם יש לך שאלות, אם אתה זקוק לעזרה, או רוצה להתנדב לעזור, ר' את <a class="
-"\"twl-links\" href=\"%(contact_url)s\">דף יצירת הקשר שלנו</a>."
+msgid "If you have questions, need help, or want to volunteer to help, please see our <a class=\"twl-links\" href=\"%(contact_url)s\">contact page</a>."
+msgstr "אם יש לך שאלות, אם אתה זקוק לעזרה, או רוצה להתנדב לעזור, ר' את <a class=\"twl-links\" href=\"%(contact_url)s\">דף יצירת הקשר שלנו</a>."
 
 #. Translators: This is the title of the panel box detailing the contact information for the Wikipedia Library team.
 #: TWLight/templates/contact.html:14
@@ -2495,12 +2008,8 @@ msgstr "דף הטוויטר של ספריית ויקיפדיה"
 #. Translators: This is the text that appears at the bottom of the contact us form directing users to the suggestions form.
 #: TWLight/templates/contact.html:48
 #, python-format
-msgid ""
-"(If you would like to suggest a partner, <a class=\"twl-links\" href="
-"\"%(suggest)s\"><strong>go here</strong></a>.)"
-msgstr ""
-"(אם אתה רוצה להציע שותף <a class=\"twl-links\" href=\"%(suggest)s"
-"\"><strong>אפשר לעשות את זה כאן</strong></a>.)"
+msgid "(If you would like to suggest a partner, <a class=\"twl-links\" href=\"%(suggest)s\"><strong>go here</strong></a>.)"
+msgstr "(אם אתה רוצה להציע שותף <a class=\"twl-links\" href=\"%(suggest)s\"><strong>אפשר לעשות את זה כאן</strong></a>.)"
 
 #. Translators: On a special 'link to search' page, this message is shown if JavaScript is disabled.
 #: TWLight/templates/eds_search_endpoint.html:7
@@ -2556,12 +2065,8 @@ msgstr "ספריית ויקיפדיה"
 #. Translators: Information about The Wikipedia Library.
 #: TWLight/templates/login_partial.html:53 TWLight/templates/new_base.html:21
 #, python-format
-msgid ""
-"More than 100 of the world's top subscription-only databases, with content "
-"in %(no_of_languages)s languages, free for Wikipedians of all backgrounds"
-msgstr ""
-"יותר מ־100 מסדי נתונים מהמובילים בעולם שדורשים מינוי, עם תוכן ביותר מ־"
-"%(no_of_languages)s שפות, חופשיים לוויקיפדים מכל הרקעים"
+msgid "More than 100 of the world's top subscription-only databases, with content in %(no_of_languages)s languages, free for Wikipedians of all backgrounds"
+msgstr "יותר מ־100 מסדי נתונים מהמובילים בעולם שדורשים מינוי, עם תוכן ביותר מ־%(no_of_languages)s שפות, חופשיים לוויקיפדים מכל הרקעים"
 
 #. Translators: Information about The Wikipedia Library.
 #: TWLight/templates/login_partial.html:64
@@ -2569,12 +2074,8 @@ msgid "Meet these criteria for automatic access"
 msgstr "חובה לעמוד בתנאי הזכאות לקבלת גישה אוטומטית"
 
 #: TWLight/templates/login_partial.html:69
-msgid ""
-"These criteria grant you access to certain collections but not all. Some "
-"collections are accessible on a per application basis only."
-msgstr ""
-"התנאים האלה נותנים לך גישה לאוספים מסוימים, אבל לא לכולם. אוספים מסוימים "
-"יכולים להיות נגישים רק על בסיס בקשה."
+msgid "These criteria grant you access to certain collections but not all. Some collections are accessible on a per application basis only."
+msgstr "התנאים האלה נותנים לך גישה לאוספים מסוימים, אבל לא לכולם. אוספים מסוימים יכולים להיות נגישים רק על בסיס בקשה."
 
 #: TWLight/templates/login_partial.html:89
 msgid "Login via Wikipedia"
@@ -2583,39 +2084,20 @@ msgstr "כניסה דרך ויקיפדיה"
 #. Translators: Shown if the current user doesn't have a registered email on their account. Don't translate contact_us_url or email_url.
 #: TWLight/templates/message_partial.html:15
 #, python-format
-msgid ""
-"You don't have an email on file. We can't finalize your access to partner "
-"resources, and you won't be able to <a class=\"twl-links\" href="
-"\"%(contact_us_url)s\">contact us</a> without an email. Please <a class="
-"\"twl-links\" href=\"%(email_url)s\">update your email</a>."
-msgstr ""
-"הדואר האלקטרוני שלך אינו רשום. איננו יכולים לסיים את הטיפול בגישתך למשאבי "
-"השותף, ולא תוכל <a class=\"twl-links\" href=\"%(contact_us_url)s\">ליצור "
-"איתנו קשר</a>  ללא דוא״ל. נא <a class=\"twl-links\" href=\"%(email_url)s"
-"\">לעדכן את הדוא״ל שלך</a>."
+msgid "You don't have an email on file. We can't finalize your access to partner resources, and you won't be able to <a class=\"twl-links\" href=\"%(contact_us_url)s\">contact us</a> without an email. Please <a class=\"twl-links\" href=\"%(email_url)s\">update your email</a>."
+msgstr "הדואר האלקטרוני שלך אינו רשום. איננו יכולים לסיים את הטיפול בגישתך למשאבי השותף, ולא תוכל <a class=\"twl-links\" href=\"%(contact_us_url)s\">ליצור איתנו קשר</a>  ללא דוא״ל. נא <a class=\"twl-links\" href=\"%(email_url)s\">לעדכן את הדוא״ל שלך</a>."
 
 #. Translators: Shown if the current user has requested the processing of their data should be restricted.
 #: TWLight/templates/message_partial.html:26
 #, python-format
-msgid ""
-"You have requested a restriction on the processing of your data. Most site "
-"functionality will not be available to you until you <a class=\"twl-links\" "
-"href=\"%(restrict_url)s\">lift this restriction</a>."
-msgstr ""
-"ביקשת להגביל את הטיפול בנתונים שלך. רוב האפשרויות באתר לא יהיו זמינות לך עד "
-"<a class=\"twl-links\" href=\"%(restrict_url)s\">ביטול ההגבלה הזאת</a>."
+msgid "You have requested a restriction on the processing of your data. Most site functionality will not be available to you until you <a class=\"twl-links\" href=\"%(restrict_url)s\">lift this restriction</a>."
+msgstr "ביקשת להגביל את הטיפול בנתונים שלך. רוב האפשרויות באתר לא יהיו זמינות לך עד <a class=\"twl-links\" href=\"%(restrict_url)s\">ביטול ההגבלה הזאת</a>."
 
 #. Translators: Shown if the current user has not agreed to the terms of use.
 #: TWLight/templates/message_partial.html:37
 #, python-format
-msgid ""
-"You have not agreed to the <a class=\"twl-links\" href=\"%(terms_url)s"
-"\">terms of use</a> of this site. Your applications will not be processed "
-"and you won't be able to apply or access resources you are approved for."
-msgstr ""
-"לא הסכמת ל<a class=\"twl-links\" href=\"%(terms_url)s\">תנאי השימוש</a> של "
-"האתר הזה. הבקשות שלך לא תטופלנה ולא תוכל לשלוח בקשות או לגשת למשאבים שאושרו "
-"בשבילך."
+msgid "You have not agreed to the <a class=\"twl-links\" href=\"%(terms_url)s\">terms of use</a> of this site. Your applications will not be processed and you won't be able to apply or access resources you are approved for."
+msgstr "לא הסכמת ל<a class=\"twl-links\" href=\"%(terms_url)s\">תנאי השימוש</a> של האתר הזה. הבקשות שלך לא תטופלנה ולא תוכל לשלוח בקשות או לגשת למשאבים שאושרו בשבילך."
 
 #. Translators: This link is at the bottom of every page and links to the 'About' page (https://wikipedialibrary.wmflabs.org/about/)
 #: TWLight/templates/new_base.html:107
@@ -2661,12 +2143,8 @@ msgstr "איפוס סיסמה"
 
 #. Translators: If a user goes to reset their password, this message asks them to enter their email to do so.
 #: TWLight/templates/registration/password_reset_form.html:13
-msgid ""
-"Forgot your password? Enter your email address below, and we'll email "
-"instructions for setting a new one."
-msgstr ""
-"שכחתך את סיסמתך? נא להזין את כתובת הדוא״ל שלך להלן ונשלח לך הוראות להגדרת "
-"סיסמה חדשה."
+msgid "Forgot your password? Enter your email address below, and we'll email instructions for setting a new one."
+msgstr "שכחתך את סיסמתך? נא להזין את כתובת הדוא״ל שלך להלן ונשלח לך הוראות להגדרת סיסמה חדשה."
 
 #. Translators: This is the label for a button that users click to update their public information.
 #: TWLight/users/forms.py:36
@@ -2710,20 +2188,13 @@ msgstr "אני מסכים לתנאי השימוש"
 
 #. Translators: This text explains how to disagree to the site's terms of use and the restrictions that will come into effect when users disagree to the terms of use.
 #: TWLight/users/forms.py:185
-msgid ""
-"By unchecking this box and clicking “Update” you may explore the site, but "
-"you will not be able to apply for access to materials or evaluate "
-"applications unless you agree with the terms of use."
-msgstr ""
-"ביטול סימון התיבה הזאת ולחיצה על \"עדכון\" תגרום לכך שתוכל לעיין באתר, אבל "
-"לא תוכל לשלוח בקשות לגשת לחומרים או להעריך בקשות אלא אם תסכים לתנאי השימוש."
+msgid "By unchecking this box and clicking “Update” you may explore the site, but you will not be able to apply for access to materials or evaluate applications unless you agree with the terms of use."
+msgstr "ביטול סימון התיבה הזאת ולחיצה על \"עדכון\" תגרום לכך שתוכל לעיין באתר, אבל לא תוכל לשלוח בקשות לגשת לחומרים או להעריך בקשות אלא אם תסכים לתנאי השימוש."
 
 #. Translators: Users click this button to set their website email address to the one linked to their Wikipedia account.
 #: TWLight/users/forms.py:211
-msgid ""
-"Use my Wikipedia email address (will be updated the next time you login)."
-msgstr ""
-"להשתמש בכתובת הדוא״ל שלי מוויקיפדיה (זה יעודכן בפעם הבאה שתיכנס לחשבון)"
+msgid "Use my Wikipedia email address (will be updated the next time you login)."
+msgstr "להשתמש בכתובת הדוא״ל שלי מוויקיפדיה (זה יעודכן בפעם הבאה שתיכנס לחשבון)"
 
 #. Translators: This labels a button which users click to change their email.
 #: TWLight/users/forms.py:232
@@ -2733,17 +2204,8 @@ msgstr "עדכון דוא״ל"
 #. Translators: Shown if the current user tried to 'favorite' a partner they can't access. Do not translate '{partner}'
 #: TWLight/users/models.py:201
 #, python-brace-format
-msgid ""
-"Cannot add partner {partner} to your favorites because you don't have access "
-"to it"
+msgid "Cannot add partner {partner} to your favorites because you don't have access to it"
 msgstr "לא ניתן להוסיף את השותף {partner} למועדפים שלך כי אין לך גישה אליו"
-
-#. Translators: Do not translate.
-#: TWLight/users/models.py:869
-#, fuzzy, python-brace-format
-#| msgid "Username"
-msgid "{wp_username}"
-msgstr "שם משתמש"
 
 #. Translators: This error message is shown when there's a problem with the authenticated login process.
 #: TWLight/users/oauth.py:243
@@ -2763,12 +2225,8 @@ msgstr "לחיצת היד לא אותחלה, נא לנסות להיכנס מחד
 
 #. Translators: this message is displayed to users that don't have accounts and clicked on a proxied link.
 #: TWLight/users/oauth.py:388
-msgid ""
-"To view this link you need to be an eligible library user. Please login to "
-"continue."
-msgstr ""
-"כדי לצפור בקישור הזה חובה להיות משתמש ספרייה זכאי. נא להיכנס לחשבון כדי "
-"להמשיך."
+msgid "To view this link you need to be an eligible library user. Please login to continue."
+msgstr "כדי לצפור בקישור הזה חובה להיות משתמש ספרייה זכאי. נא להיכנס לחשבון כדי להמשיך."
 
 #. Translators: This warning message is shown to users when the response received from Wikimedia OAuth servers is not a valid one.
 #: TWLight/users/oauth.py:430
@@ -2803,23 +2261,13 @@ msgstr "ר' {issue} למידע נוסף"
 
 #. Translators: If the user tries to log in, but their account does not meet certain requirements, they cannot login.
 #: TWLight/users/oauth.py:528
-msgid ""
-"Your Wikipedia account does not meet the eligibility criteria in the terms "
-"of use, so your Wikipedia Library Card Platform account cannot be activated."
-msgstr ""
-"חשבון הוויקיפדיה שלך לא עומד בדרישות לזכאות בתנאי השימוש, ולכן החשבון שלך "
-"בפלטפורמת ספריית ויקיפדיה אינו יכול להיות מופעל."
+msgid "Your Wikipedia account does not meet the eligibility criteria in the terms of use, so your Wikipedia Library Card Platform account cannot be activated."
+msgstr "חשבון הוויקיפדיה שלך לא עומד בדרישות לזכאות בתנאי השימוש, ולכן החשבון שלך בפלטפורמת ספריית ויקיפדיה אינו יכול להיות מופעל."
 
 #. Translators: If the user tries to log in, but their account does not meet certain requirements, they cannot login.
 #: TWLight/users/oauth.py:536
-msgid ""
-"Your Wikipedia account no longer meets the eligibility criteria in the terms "
-"of use, so you cannot be logged in. If you think you should be able to log "
-"in, please email wikipedialibrary@wikimedia.org."
-msgstr ""
-"חשבון הוויקיפדיה שלך כבר לא עונה על דרישות הזכאות בתנאי השימוש, ולכן אי־אפשר "
-"להכניס אותך לחשבון. אם נראה לך שאמורה להיות האפשרות להיכנס, נא לשלוח מכתב "
-"לכתובת wikipedialibrary@wikimedia.org."
+msgid "Your Wikipedia account no longer meets the eligibility criteria in the terms of use, so you cannot be logged in. If you think you should be able to log in, please email wikipedialibrary@wikimedia.org."
+msgstr "חשבון הוויקיפדיה שלך כבר לא עונה על דרישות הזכאות בתנאי השימוש, ולכן אי־אפשר להכניס אותך לחשבון. אם נראה לך שאמורה להיות האפשרות להיכנס, נא לשלוח מכתב לכתובת wikipedialibrary@wikimedia.org."
 
 #. Translators: this message is displayed to users with brand new accounts.
 #: TWLight/users/oauth.py:549
@@ -2829,14 +2277,8 @@ msgstr "שלום! נא להסכים לתנאי השימוש."
 #. Translators: This message is displayed on the confirmation page where users can return their access to partner collections.
 #: TWLight/users/templates/users/authorization_confirm_return.html:13
 #, python-format
-msgid ""
-"You will no longer be able to access <b>%(partner)s's</b> resources via the "
-"Library Card platform, but can request access again by clicking 'renew', if "
-"you change your mind. Are you sure you want to return your access?"
-msgstr ""
-"לא תוכל עוד לגשת למשאבים של <b>%(partner)s's</b> דרך פלטפורמת כרטיס הספרייה, "
-"אבל תוכל לבקש גישה מחדש באמצעות לחיצה על \"חידוש\", אם תשנה את דעתך.האם "
-"ברצונך באמת להזדכות על הגישה שלה?"
+msgid "You will no longer be able to access <b>%(partner)s's</b> resources via the Library Card platform, but can request access again by clicking 'renew', if you change your mind. Are you sure you want to return your access?"
+msgstr "לא תוכל עוד לגשת למשאבים של <b>%(partner)s's</b> דרך פלטפורמת כרטיס הספרייה, אבל תוכל לבקש גישה מחדש באמצעות לחיצה על \"חידוש\", אם תשנה את דעתך.האם ברצונך באמת להזדכות על הגישה שלה?"
 
 #. Translators: On the MyLibrary page (https://wikipedialibrary.wmflabs.org/users/my_library), this tab shows all favorite collections a user has.
 #: TWLight/users/templates/users/collections_section.html:9
@@ -2905,13 +2347,8 @@ msgstr "נתוני עורך"
 
 #. Translators: This is shown on editor profiles, in their profile page or on applications.
 #: TWLight/users/templates/users/editor_detail.html:59
-msgid ""
-"Information with an * was retrieved from Wikipedia directly. Other "
-"information was entered directly by users or site admins, in their preferred "
-"language."
-msgstr ""
-"מידע עם * אוחזר מוויקיפדיה לאחרונה. מידע אחר הוזן ישירות על־ידי משתמשים או "
-"מנהלי אתר, בשפה המועדפת עליהם."
+msgid "Information with an * was retrieved from Wikipedia directly. Other information was entered directly by users or site admins, in their preferred language."
+msgstr "מידע עם * אוחזר מוויקיפדיה לאחרונה. מידע אחר הוזן ישירות על־ידי משתמשים או מנהלי אתר, בשפה המועדפת עליהם."
 
 #. Translators: This distinguishes users who have been flagged as account coordinators. Don't translate username.
 #: TWLight/users/templates/users/editor_detail.html:71
@@ -2921,13 +2358,8 @@ msgstr "למשתמש %(username)s יש הרשאות מתאם באתר הזה."
 
 #. Translators: This is shown on editor profiles, under the heading for Wikipedia editor data.
 #: TWLight/users/templates/users/editor_detail_data.html:5
-msgid ""
-"This information is updated automatically from your Wikimedia account each "
-"time you log in, except for the Contributions field, where you can describe "
-"your Wikimedia editing history."
-msgstr ""
-"המידע הזה מעודכן אוטומטית מחשבון ויקימדיה שלך בכל כניסה לחשבון, למעט שדה "
-"תרומות, שבו אפשר לתאר את היסטוריית העריכה שלך בוויקימדיה."
+msgid "This information is updated automatically from your Wikimedia account each time you log in, except for the Contributions field, where you can describe your Wikimedia editing history."
+msgstr "המידע הזה מעודכן אוטומטית מחשבון ויקימדיה שלך בכל כניסה לחשבון, למעט שדה תרומות, שבו אפשר לתאר את היסטוריית העריכה שלך בוויקימדיה."
 
 #. Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this labels the user's username.
 #: TWLight/users/templates/users/editor_detail_data.html:17
@@ -2956,17 +2388,13 @@ msgstr "מקיים את תנאי השימוש?"
 
 #. Translators: when viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this question has a yes or no answer.
 #: TWLight/users/templates/users/editor_detail_data.html:57
-msgid ""
-"at their last login, did this user meet the criteria set forth in the terms "
-"of use?"
+msgid "at their last login, did this user meet the criteria set forth in the terms of use?"
 msgstr "בכניסה האחרונה, האם המשתמש הזה עמד בדרישות המופיעות בתנאי השימוש?"
 
 #. Translators: When viewing a user's profile in an application, this message shows if the software doesn't think that the user is eligible for access. Don't translate username.
 #: TWLight/users/templates/users/editor_detail_data.html:72
 #, python-format
-msgid ""
-"%(username)s may still be eligible for access grants at the coordinators' "
-"discretion."
+msgid "%(username)s may still be eligible for access grants at the coordinators' discretion."
 msgstr "ייתכן שמשתמש %(username)s זכאי לגישה בהתאם לשיקול דעת המתאמים."
 
 #. Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this is the heading for a Yes/No ToU question.
@@ -3001,14 +2429,8 @@ msgstr "(הוענקה חסינות)"
 #. Translators: This message is shown on a user's profile if their Wikimedia account is blocked on one or more projects. They may still be granted access to the Library Bundle, but need to contact Wikipedia Library staff to verify.
 #: TWLight/users/templates/users/editor_detail_data.html:137
 #, python-format
-msgid ""
-"It looks like you have an active block on your account. If you meet the "
-"other criteria you may still be permitted access to the library - please <a "
-"class=\"twl-links\" href=\"%(contact_url)s\">contact us</a>."
-msgstr ""
-"נראה שיש לך חסימה פעילה בחשבון שלך. אם אתה עומד בתנאים האחרים, אולי עדיין "
-"תוכל לקבל גישה לחבילת הספרייה – נא <a class=\"twl-links\" href="
-"\"%(contact_url)s\">ליצור איתנו קשר</a>."
+msgid "It looks like you have an active block on your account. If you meet the other criteria you may still be permitted access to the library - please <a class=\"twl-links\" href=\"%(contact_url)s\">contact us</a>."
+msgstr "נראה שיש לך חסימה פעילה בחשבון שלך. אם אתה עומד בתנאים האחרים, אולי עדיין תוכל לקבל גישה לחבילת הספרייה – נא <a class=\"twl-links\" href=\"%(contact_url)s\">ליצור איתנו קשר</a>."
 
 #. Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this is the heading for a Yes/No program eligibility question.
 #: TWLight/users/templates/users/editor_detail_data.html:153
@@ -3017,13 +2439,8 @@ msgstr "זכאי לחבילה?"
 
 #. Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this question has a Yes or No answer.
 #: TWLight/users/templates/users/editor_detail_data.html:156
-msgid ""
-"At their last login, did this user meet the criteria set forth in the "
-"Library Bundle? Note that satisfying terms of use is a prerequisite to "
-"bundle eligibility."
-msgstr ""
-"בכניסה האחרונה לחשבון, האם המשתמש הזה עמד בתנאים המוגדרים עבור חבילת "
-"הספרייה? נא לשים לב לכך שעמידה בתנאים האלה היא חובה לקבלת זכאות לחבילה."
+msgid "At their last login, did this user meet the criteria set forth in the Library Bundle? Note that satisfying terms of use is a prerequisite to bundle eligibility."
+msgstr "בכניסה האחרונה לחשבון, האם המשתמש הזה עמד בתנאים המוגדרים עבור חבילת הספרייה? נא לשים לב לכך שעמידה בתנאים האלה היא חובה לקבלת זכאות לחבילה."
 
 #. Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this is the heading for a Yes/No program eligibility question.
 #: TWLight/users/templates/users/editor_detail_data.html:177
@@ -3067,23 +2484,14 @@ msgstr "נתונים אישיים"
 
 #. Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this text is in the 'Personal data' section. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/users/templates/users/editor_detail_data.html:262
-msgid ""
-"The following information is visible only to you, site administrators, "
-"publishing partners (where required), and volunteer Wikipedia Library "
-"coordinators (who have signed a Non-Disclosure Agreement)."
-msgstr ""
-"המידע הבא מוצג רק לך, למנהלי האתר, לשותפי ההוצאה לאור (איפה שדרוש), ומתאמים "
-"מתנדבים של ספריית ויקיפדיה (שחתמו על הסכם סודיות)."
+msgid "The following information is visible only to you, site administrators, publishing partners (where required), and volunteer Wikipedia Library coordinators (who have signed a Non-Disclosure Agreement)."
+msgstr "המידע הבא מוצג רק לך, למנהלי האתר, לשותפי ההוצאה לאור (איפה שדרוש), ומתאמים מתנדבים של ספריית ויקיפדיה (שחתמו על הסכם סודיות)."
 
 #. Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this labels a button which users can click to update or remove their personal information. Don't translate update_url.
 #: TWLight/users/templates/users/editor_detail_data.html:272
 #, python-format
-msgid ""
-"You may <a class=\"twl-links\" href=\"%(update_url)s\">update or delete</a> "
-"your data at any time."
-msgstr ""
-"באפשרותך <a class=\"twl-links\" href=\"%(update_url)s\">לעדכן או למחוק</a> "
-"את הנתונים שלך בכל זמן."
+msgid "You may <a class=\"twl-links\" href=\"%(update_url)s\">update or delete</a> your data at any time."
+msgstr "באפשרותך <a class=\"twl-links\" href=\"%(update_url)s\">לעדכן או למחוק</a> את הנתונים שלך בכל זמן."
 
 #. Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this labels the user's email. Don't remove the *.
 #: TWLight/users/templates/users/editor_detail_data.html:283
@@ -3102,29 +2510,19 @@ msgstr "השתייכות מוסדית"
 
 #. Translators: This message tells users that they are not eligible to access The Wikipedia Library content.
 #: TWLight/users/templates/users/eligibility_modal.html:7
-msgid ""
-"Sorry, your Wikipedia account doesn’t currently qualify to access The "
-"Wikipedia Library."
+msgid "Sorry, your Wikipedia account doesn’t currently qualify to access The Wikipedia Library."
 msgstr "סליחה, החשבון שלך אינו זכאי לגישה לספריית ויקיפדיה."
 
 #. Translators: This message tells users that they have not agreed to the terms of use, therefore are ineligible to access the content in The Wikipedia Library.
 #: TWLight/users/templates/users/eligibility_modal.html:30
 #, python-format
-msgid ""
-"Agreed with <a href=\"%(terms)s\" class=\"text-danger\"> terms of use </a>"
-msgstr ""
-"הסכים ל<a href=\"%(terms)s\" class=\"text-danger\">תנאי השימוש</a> של האתר"
+msgid "Agreed with <a href=\"%(terms)s\" class=\"text-danger\"> terms of use </a>"
+msgstr "הסכים ל<a href=\"%(terms)s\" class=\"text-danger\">תנאי השימוש</a> של האתר"
 
 #: TWLight/users/templates/users/eligibility_modal.html:40
 #, python-format
-msgid ""
-"It looks like you have an active block on your account. If you meet the "
-"other criteria you may still be permitted access to the library - please <a "
-"href=\"%(contact_url)s\">contact us</a>."
-msgstr ""
-"נראה שיש לך חסימה פעילה בחשבון שלך. אם אתה עומד בתנאים האחרים, אולי עדיין "
-"תוכל לקבל גישה לחבילת הספרייה – נא <a href=\"%(contact_url)s\">ליצור איתנו "
-"קשר</a>."
+msgid "It looks like you have an active block on your account. If you meet the other criteria you may still be permitted access to the library - please <a href=\"%(contact_url)s\">contact us</a>."
+msgstr "נראה שיש לך חסימה פעילה בחשבון שלך. אם אתה עומד בתנאים האחרים, אולי עדיין תוכל לקבל גישה לחבילת הספרייה – נא <a href=\"%(contact_url)s\">ליצור איתנו קשר</a>."
 
 #. Translators: Instructions to refresh a user's data.
 #: TWLight/users/templates/users/eligibility_modal.html:50
@@ -3163,14 +2561,8 @@ msgstr "הגדרת שפה"
 
 #. Translators: This text on the user page helps users naviage to the TranslateWiki Wikipedia Library Card platform translation page.
 #: TWLight/users/templates/users/language_form.html:31
-msgid ""
-"You can help translate the tool at <a class=\"twl-links\" href=\"https://"
-"translatewiki.net/wiki/Translating:Wikipedia_Library_Card_Platform"
-"\">translatewiki.net</a>."
-msgstr ""
-"באפשרותך לעזור לתרגם את הכלי באתר <a class=\"twl-links\" href=\"https://"
-"translatewiki.net/wiki/Translating:Wikipedia_Library_Card_Platform"
-"\">translatewiki.net</a>."
+msgid "You can help translate the tool at <a class=\"twl-links\" href=\"https://translatewiki.net/wiki/Translating:Wikipedia_Library_Card_Platform\">translatewiki.net</a>."
+msgstr "באפשרותך לעזור לתרגם את הכלי באתר <a class=\"twl-links\" href=\"https://translatewiki.net/wiki/Translating:Wikipedia_Library_Card_Platform\">translatewiki.net</a>."
 
 #. Translators: When the user starts a new application and submits the application, the user can view the application and withdraw if need be. This changes the label for the Withdraw button.
 #: TWLight/users/templates/users/my_applications.html:65
@@ -3189,9 +2581,7 @@ msgstr "בקשת חידוש"
 
 #. Translators: On the page listing applications, this text explains a user they cannot renew their application since they've already requested a renewal or there aren't any renewals available.
 #: TWLight/users/templates/users/my_applications.html:79
-msgid ""
-"Renewals are either not required, not available right now, or you have "
-"already requested a renewal."
+msgid "Renewals are either not required, not available right now, or you have already requested a renewal."
 msgstr "חידושים אינם דרושים או אינם זמינים כעת, או שכבר ביקשת חידוש."
 
 #. Translators: This text is the heading of a section in a user's profile where they can change their preferences.
@@ -3255,25 +2645,13 @@ msgstr "להגביל את הטיפול בנתונים"
 
 #. Translators: This message is displayed on the page where users can request we stop processing their data.
 #: TWLight/users/templates/users/restrict_data.html:15
-msgid ""
-"Checking this box and clicking “Restrict” will pause all processing of the "
-"data you have entered into this website. You will not be able to apply for "
-"access to resources, your applications will not be further processed, and "
-"none of your data will be altered, until you return to this page and uncheck "
-"the box. This is not the same as deleting your data."
-msgstr ""
-"סימון התיבה הזאת ולחיצה על \"הגבלה\" יעצור את הטיפול בנתונים שהזנת לאתר הזה. "
-"לא תוכל לשלוח בקשת גישה למשאבים, הבקשות שלך לא תטופלנה עוד, ושום דבר "
-"מהנתונים שלך לא ישונה, עד שתחזור לדף הזה ותסיר את הסימון מהתיבה הזאת. זה לא "
-"זהה למחיקת הנתונים שלך."
+msgid "Checking this box and clicking “Restrict” will pause all processing of the data you have entered into this website. You will not be able to apply for access to resources, your applications will not be further processed, and none of your data will be altered, until you return to this page and uncheck the box. This is not the same as deleting your data."
+msgstr "סימון התיבה הזאת ולחיצה על \"הגבלה\" יעצור את הטיפול בנתונים שהזנת לאתר הזה. לא תוכל לשלוח בקשת גישה למשאבים, הבקשות שלך לא תטופלנה עוד, ושום דבר מהנתונים שלך לא ישונה, עד שתחזור לדף הזה ותסיר את הסימון מהתיבה הזאת. זה לא זהה למחיקת הנתונים שלך."
 
 #. Translators: This warning message is shown to coordinators who view the data restriction page.
 #: TWLight/users/templates/users/restrict_data.html:26
-msgid ""
-"You are a coordinator on this site. If you restrict the processing of your "
-"data, your coordinator flag will be removed."
-msgstr ""
-"אתה המתאם עבור האתר הזה. אם תגביל את הטיפול בנתונים, הרשאת המתאם שלך תוסר."
+msgid "You are a coordinator on this site. If you restrict the processing of your data, your coordinator flag will be removed."
+msgstr "אתה המתאם עבור האתר הזה. אם תגביל את הטיפול בנתונים, הרשאת המתאם שלך תוסר."
 
 #. Translators: use the date *when you are translating*, in a language-appropriate format.
 #: TWLight/users/templates/users/terms.html:33
@@ -3292,35 +2670,13 @@ msgstr "תנאי שימוש והצהרת פרטיות של ספריית ויקי
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:51
-msgid ""
-"<a class=\"twl-links\" href=\"https://meta.wikimedia.org/wiki/"
-"The_Wikipedia_Library\"> The Wikipedia Library </a> has partnered with "
-"publishers around the world to allow users to access otherwise paywalled "
-"resources. This website allows Wikipedia editors to search and access these "
-"resources."
-msgstr ""
-"<a class=\"twl-links\" href=\"https://meta.wikimedia.org/wiki/"
-"The_Wikipedia_Library\">ספריית ויקיפדיה</a> הסכימה על שותפות עם מוציאים לאור "
-"מסביב לעולם כדי לאפשר למשתמשים לגשת למשאבים שבדרך־כלל נמצאים מאחורי חומת "
-"תשלום. האתר הזה מאפשר לעורכי ויקיפדיה לחפש את המשאבים האלה ולגשת אליהם."
+msgid "<a class=\"twl-links\" href=\"https://meta.wikimedia.org/wiki/The_Wikipedia_Library\"> The Wikipedia Library </a> has partnered with publishers around the world to allow users to access otherwise paywalled resources. This website allows Wikipedia editors to search and access these resources."
+msgstr "<a class=\"twl-links\" href=\"https://meta.wikimedia.org/wiki/The_Wikipedia_Library\">ספריית ויקיפדיה</a> הסכימה על שותפות עם מוציאים לאור מסביב לעולם כדי לאפשר למשתמשים לגשת למשאבים שבדרך־כלל נמצאים מאחורי חומת תשלום. האתר הזה מאפשר לעורכי ויקיפדיה לחפש את המשאבים האלה ולגשת אליהם."
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Wikimedia Foundation should not be translated. WMF should not be translated. Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:63
-msgid ""
-"This program is administered by the Wikimedia Foundation (WMF). These terms "
-"of use and privacy notice pertain to your application for access to "
-"resources through the Wikipedia Library, your use of this website, and your "
-"access to and use of those resources. They also describe our handling of the "
-"information you provide to us in order to create and administer your "
-"Wikipedia Library account. If we make material changes to the terms, we will "
-"notify users."
-msgstr ""
-"התוכנית הזאת מנוהלת על־ידי קרן ויקימדיה (Wikimedia Foundation או בקיצור "
-"WMF). תנאי השימוש האלה ומדיניות הפרטיות הזאת מתייחסים לבקשה שלך לגשת למשאבים "
-"דרך ספריית ויקיפדיה, לשימוש שלך באתר הזה, ולגישה ולשימוש שלך במשאבים האלה. "
-"הם גם מתארים את הטיפול שלנו במידע שתספק לנו כדי ליצור ולנהל את חשבון ספריית "
-"הוויקיפדיה שלך. אם אנחנו עושים שינויים משמעותיים בתנאים האלה, אנחנו נודיע "
-"למשתמשים."
+msgid "This program is administered by the Wikimedia Foundation (WMF). These terms of use and privacy notice pertain to your application for access to resources through the Wikipedia Library, your use of this website, and your access to and use of those resources. They also describe our handling of the information you provide to us in order to create and administer your Wikipedia Library account. If we make material changes to the terms, we will notify users."
+msgstr "התוכנית הזאת מנוהלת על־ידי קרן ויקימדיה (Wikimedia Foundation או בקיצור WMF). תנאי השימוש האלה ומדיניות הפרטיות הזאת מתייחסים לבקשה שלך לגשת למשאבים דרך ספריית ויקיפדיה, לשימוש שלך באתר הזה, ולגישה ולשימוש שלך במשאבים האלה. הם גם מתארים את הטיפול שלנו במידע שתספק לנו כדי ליצור ולנהל את חשבון ספריית הוויקיפדיה שלך. אם אנחנו עושים שינויים משמעותיים בתנאים האלה, אנחנו נודיע למשתמשים."
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:74
@@ -3329,52 +2685,18 @@ msgstr "דרישות לחשבון כרטיס ספריית ויקיפדיה"
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:78
-msgid ""
-"Access to resources via The Wikipedia Library is reserved for community "
-"members who have demonstrated their commitment to the Wikimedia projects, "
-"and who will use their access to these resources to improve project content. "
-"To that end, in order to be eligible for The Wikipedia Library, we require "
-"that you be registered for a user account on the projects, with at least 500 "
-"edits, six (6) months of activity, and 10+ edits in the last month. We ask "
-"that you do not request access to any publishers with a limited number of "
-"available accounts whose resources you can already access for free through "
-"your local library or university, or another institution or organization, in "
-"order to provide that opportunity to others."
-msgstr ""
-"גישה למשאבים דרך ספריית ויקיפדיה שמורה לחברי קהילה שהפגינו את המחויבות שלהם "
-"למיזמי ויקימדיה, ושישתמשו בגישה שלהם למשאבים האלה כדי לשפר את תוכן המיזמים. "
-"למטרה הזאת, כדי לזכות להשתמש בתוכנית ספריית ויקיפדיה, אנחנו דורשים שתהיה "
-"רשום לחשבון משתמש במיזמים, עם לפחות 500 עריכות ושישה (6) חודשים של פעילות, "
-"ולפחות 10 עריכות בחודש האחרון. אנחנו מבקשים ממך לא לבקש גישה לשום מוציא לאור "
-"שכבר יש לך אפשרות לגשת למשאבים שלו בחינם דרך הספרייה או האוניברסיטה שלך, או "
-"דרך מוסד או ארגון אחר, כדי לתת הזדמנות לאחרים."
+msgid "Access to resources via The Wikipedia Library is reserved for community members who have demonstrated their commitment to the Wikimedia projects, and who will use their access to these resources to improve project content. To that end, in order to be eligible for The Wikipedia Library, we require that you be registered for a user account on the projects, with at least 500 edits, six (6) months of activity, and 10+ edits in the last month. We ask that you do not request access to any publishers with a limited number of available accounts whose resources you can already access for free through your local library or university, or another institution or organization, in order to provide that opportunity to others."
+msgstr "גישה למשאבים דרך ספריית ויקיפדיה שמורה לחברי קהילה שהפגינו את המחויבות שלהם למיזמי ויקימדיה, ושישתמשו בגישה שלהם למשאבים האלה כדי לשפר את תוכן המיזמים. למטרה הזאת, כדי לזכות להשתמש בתוכנית ספריית ויקיפדיה, אנחנו דורשים שתהיה רשום לחשבון משתמש במיזמים, עם לפחות 500 עריכות ושישה (6) חודשים של פעילות, ולפחות 10 עריכות בחודש האחרון. אנחנו מבקשים ממך לא לבקש גישה לשום מוציא לאור שכבר יש לך אפשרות לגשת למשאבים שלו בחינם דרך הספרייה או האוניברסיטה שלך, או דרך מוסד או ארגון אחר, כדי לתת הזדמנות לאחרים."
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:94
-msgid ""
-"Additionally, if you are currently blocked or banned from a Wikimedia "
-"project, applications to resources may be rejected or restricted. If you "
-"obtain a Wikipedia Library account, but a block or ban is subsequently "
-"instituted against you on one of the projects, you may lose access to your "
-"Wikipedia Library account."
-msgstr ""
-"בנוסף, אם חשבונך חסום או מוחרם במיזם ויקימדיה, בקשות גישה למשאבים יכולות "
-"להידחות או להיות מוגבלות. אם אתה מקבל חשבון ספריית ויקיפדיה, ולאחר מכן "
-"חשבונך נחסם באחד מהמיזמים, אתה עשוי לאבד את הגישה לחשבון ספריית ויקיפדיה שלך."
+msgid "Additionally, if you are currently blocked or banned from a Wikimedia project, applications to resources may be rejected or restricted. If you obtain a Wikipedia Library account, but a block or ban is subsequently instituted against you on one of the projects, you may lose access to your Wikipedia Library account."
+msgstr "בנוסף, אם חשבונך חסום או מוחרם במיזם ויקימדיה, בקשות גישה למשאבים יכולות להידחות או להיות מוגבלות. אם אתה מקבל חשבון ספריית ויקיפדיה, ולאחר מכן חשבונך נחסם באחד מהמיזמים, אתה עשוי לאבד את הגישה לחשבון ספריית ויקיפדיה שלך."
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:104
-msgid ""
-"Your eligibility to access The Wikipedia Library is assessed at each login. "
-"While more than half of the library's content is provided via this automated "
-"eligibility check, access to other publisher's content may be time limited, "
-"typically lapsing after one year, after which you will usually need to apply "
-"for renewal."
-msgstr ""
-"הזכאות שלך לגשת לספריית ויקיפדיה נבדקת בכל כניסה. אף שיותר ממחצית מהתוכן של "
-"הספרייה ניתן בבדיקת הזכאות האוטומטית הזאת, גישה לתוכן של מוציאים לאור אחרים "
-"יכולה להיות מוגבלת בזמן, ובדרך־כלל פגה אחרי שנה, ולאחר מכן עליך לבקש חידוש "
-"גישה."
+msgid "Your eligibility to access The Wikipedia Library is assessed at each login. While more than half of the library's content is provided via this automated eligibility check, access to other publisher's content may be time limited, typically lapsing after one year, after which you will usually need to apply for renewal."
+msgstr "הזכאות שלך לגשת לספריית ויקיפדיה נבדקת בכל כניסה. אף שיותר ממחצית מהתוכן של הספרייה ניתן בבדיקת הזכאות האוטומטית הזאת, גישה לתוכן של מוציאים לאור אחרים יכולה להיות מוגבלת בזמן, ובדרך־כלל פגה אחרי שנה, ולאחר מכן עליך לבקש חידוש גישה."
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:114
@@ -3383,62 +2705,28 @@ msgstr "בקשה דרך חשבון ספריית ויקיפדיה שלך"
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:118
-msgid ""
-"In order to apply for access to a partner resource, you must provide us with "
-"certain information, which we will use to evaluate your application. If your "
-"application is approved, we may transfer the information you have given us "
-"to the publishers whose resources you wish to access. They will either "
-"contact you with the account information directly or we will send access "
-"information to you ourselves."
-msgstr ""
-"כדי לבקש גישה למשאב של שותף, עליך לספק לנו מידע מסוים, שנשתמש בו כדי להעריך "
-"את הבקשה שלך. אם הבקשה שלך מאושרת, אנחנו יכולים להעביר מידע שנתת לנו "
-"למוציאים לאור שברצונך לגשת למשאבים שלהם. הם ייצרו איתך קשר עם המידע על "
-"החשבון או שנשלח לך את המידע על הכניסה בעצמנו."
+msgid "In order to apply for access to a partner resource, you must provide us with certain information, which we will use to evaluate your application. If your application is approved, we may transfer the information you have given us to the publishers whose resources you wish to access. They will either contact you with the account information directly or we will send access information to you ourselves."
+msgstr "כדי לבקש גישה למשאב של שותף, עליך לספק לנו מידע מסוים, שנשתמש בו כדי להעריך את הבקשה שלך. אם הבקשה שלך מאושרת, אנחנו יכולים להעביר מידע שנתת לנו למוציאים לאור שברצונך לגשת למשאבים שלהם. הם ייצרו איתך קשר עם המידע על החשבון או שנשלח לך את המידע על הכניסה בעצמנו."
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:130
-msgid ""
-"In addition to the basic information you provide to us, our system will "
-"retrieve some information directly from the Wikimedia projects: your "
-"username, email address, edit count, registration date, user ID number, "
-"groups to which you belong, and any special user rights."
-msgstr ""
-"בנוסף למידע הבסיסי שתספק לנו, המערכת שלנו תאחזר מידע מסוים ישר ממיזמי "
-"ויקימדיה: שם המשתמש, כתובת דוא״ל, מספר עריכות, תאריך הרישום, מספר מזהה "
-"המשתמש, קבוצות המשתמשים, והרשאות המשתמש המיוחדות שלך."
+msgid "In addition to the basic information you provide to us, our system will retrieve some information directly from the Wikimedia projects: your username, email address, edit count, registration date, user ID number, groups to which you belong, and any special user rights."
+msgstr "בנוסף למידע הבסיסי שתספק לנו, המערכת שלנו תאחזר מידע מסוים ישר ממיזמי ויקימדיה: שם המשתמש, כתובת דוא״ל, מספר עריכות, תאריך הרישום, מספר מזהה המשתמש, קבוצות המשתמשים, והרשאות המשתמש המיוחדות שלך."
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:140
-msgid ""
-"Each time you log in to the Wikipedia Library Card Platform, this "
-"information will be automatically updated."
-msgstr ""
-"בכל פעם שתיכנס לפלטפורמת כרטיס ספריית ויקיפדיה, המידע הזה יעודכן אוטומטית."
+msgid "Each time you log in to the Wikipedia Library Card Platform, this information will be automatically updated."
+msgstr "בכל פעם שתיכנס לפלטפורמת כרטיס ספריית ויקיפדיה, המידע הזה יעודכן אוטומטית."
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:148
-msgid ""
-"We will ask you to provide us with some information about your history of "
-"contributions to the Wikimedia projects. Information on contribution history "
-"is optional, but will greatly assist us in evaluating your application."
-msgstr ""
-"נבקש ממך לספק לנו מידע מסוים על היסטוריית העריכות שלך במיזמי ויקימדיה. לא "
-"חובה לספק מידע על היסטוריית התרומות, אבל הוא יעזור לנו מאוד בהערכת הבקשה שלך."
+msgid "We will ask you to provide us with some information about your history of contributions to the Wikimedia projects. Information on contribution history is optional, but will greatly assist us in evaluating your application."
+msgstr "נבקש ממך לספק לנו מידע מסוים על היסטוריית העריכות שלך במיזמי ויקימדיה. לא חובה לספק מידע על היסטוריית התרומות, אבל הוא יעזור לנו מאוד בהערכת הבקשה שלך."
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). WMF should not be translated. Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:157
-msgid ""
-"The information you provide when creating your account will be visible to "
-"you while on the site but not to others unless they are approved Wikipedia "
-"Library Coordinators, WMF Staff, or WMF Contractors who need access to this "
-"data in order to carry out their work with the Wikipedia Library, all of "
-"whom are subject to non-disclosure obligations."
-msgstr ""
-"המידע שתספק בעת יצירת החשבון יוצג לך בזמן שאתה באתר, אבל לא לאחרים אלא אם הם "
-"מתאמי ספריית ויקיפדיה מאושרים, סגל קרן ויקימדיה, או עובדים בחוזה של קרן "
-"ויקימדיה שזקוקים לנתונים האלה כדי לעשות את עבודתם עם ספריית ויקיפדיה, וכולם "
-"נתונים להסכמי סודיוּת."
+msgid "The information you provide when creating your account will be visible to you while on the site but not to others unless they are approved Wikipedia Library Coordinators, WMF Staff, or WMF Contractors who need access to this data in order to carry out their work with the Wikipedia Library, all of whom are subject to non-disclosure obligations."
+msgstr "המידע שתספק בעת יצירת החשבון יוצג לך בזמן שאתה באתר, אבל לא לאחרים אלא אם הם מתאמי ספריית ויקיפדיה מאושרים, סגל קרן ויקימדיה, או עובדים בחוזה של קרן ויקימדיה שזקוקים לנתונים האלה כדי לעשות את עבודתם עם ספריית ויקיפדיה, וכולם נתונים להסכמי סודיוּת."
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:167
@@ -3447,59 +2735,33 @@ msgstr "השימוש שלך במשאבי מוציא לאור"
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:171
-msgid ""
-"In order to access an individual publisher’s resources, you must agree to "
-"that publisher’s terms of use and privacy policy. You agree that you will "
-"not violate such terms and policies in connection with your use of the "
-"Wikipedia Library. Additionally, the following activities are prohibited "
-"while accessing publisher resources through the Wikipedia Library."
-msgstr ""
-"כדי לגשת למשאבים של מוציא לאור פרטני, יש לקבל את תנאי השימוש ואת מדיניות "
-"הפרטיות של המוציא לאור הזה. אתה מסכים לכך שלא תפר תנאים ומסמכי מדיניות כאלה "
-"בהקשר לשימושך בספריית ויקיפדיה. בנוסף, הפעילויות הבאות אסורות בזמן גישה "
-"למשאבי מוציא לאור דרך ספריית ויקיפדיה."
+msgid "In order to access an individual publisher’s resources, you must agree to that publisher’s terms of use and privacy policy. You agree that you will not violate such terms and policies in connection with your use of the Wikipedia Library. Additionally, the following activities are prohibited while accessing publisher resources through the Wikipedia Library."
+msgstr "כדי לגשת למשאבים של מוציא לאור פרטני, יש לקבל את תנאי השימוש ואת מדיניות הפרטיות של המוציא לאור הזה. אתה מסכים לכך שלא תפר תנאים ומסמכי מדיניות כאלה בהקשר לשימושך בספריית ויקיפדיה. בנוסף, הפעילויות הבאות אסורות בזמן גישה למשאבי מוציא לאור דרך ספריית ויקיפדיה."
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:184
-msgid ""
-"Sharing your Wikipedia account, usernames, passwords, or any access codes "
-"for publisher resources with others;"
-msgstr ""
-"שיתוף חשבון הוויקיפדיה שלך, שמות המשתמש, הסיסמאות, או קודי הגישה שלך למשאבי "
-"מוציא לאור עם אחרים;"
+msgid "Sharing your Wikipedia account, usernames, passwords, or any access codes for publisher resources with others;"
+msgstr "שיתוף חשבון הוויקיפדיה שלך, שמות המשתמש, הסיסמאות, או קודי הגישה שלך למשאבי מוציא לאור עם אחרים;"
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:191
-msgid ""
-"Automatically scraping or downloading restricted content from publishers;"
+msgid "Automatically scraping or downloading restricted content from publishers;"
 msgstr "גירוד (scraping) או הורדת תוכן מוגבל ממוציאים לאור;"
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:197
-msgid ""
-"Systematically making printed or electronic copies of multiple extracts of "
-"restricted content available for any purpose;"
-msgstr ""
-"יצירה שיטתית של עותקים מודפסים או אלקטרוניים של מובאות מרובות של תוכן מוגבל "
-"למטרה כלשהי;"
+msgid "Systematically making printed or electronic copies of multiple extracts of restricted content available for any purpose;"
+msgstr "יצירה שיטתית של עותקים מודפסים או אלקטרוניים של מובאות מרובות של תוכן מוגבל למטרה כלשהי;"
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:204
-msgid ""
-"Data mining metadata without permission—for example, in order to use "
-"metadata for auto-created stub articles;"
-msgstr ""
-"כריית נתונים ללא רשות – למשל, כדי להשתמש במטא־נתונים ליצירה אוטומטית של "
-"קצרמרים;"
+msgid "Data mining metadata without permission—for example, in order to use metadata for auto-created stub articles;"
+msgstr "כריית נתונים ללא רשות – למשל, כדי להשתמש במטא־נתונים ליצירה אוטומטית של קצרמרים;"
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:211
-msgid ""
-"Using the access you receive through the Wikipedia Library for profit by "
-"selling access to your account or resources which you have through it."
-msgstr ""
-"שימוש בגישה שקיבלת דרך ספריית ויקיפדיה למטרת רווח באמצעות מכירת גישה לחשבון "
-"שלך או למשאבים שיש לך דרכו."
+msgid "Using the access you receive through the Wikipedia Library for profit by selling access to your account or resources which you have through it."
+msgstr "שימוש בגישה שקיבלת דרך ספריית ויקיפדיה למטרת רווח באמצעות מכירת גישה לחשבון שלך או למשאבים שיש לך דרכו."
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:220
@@ -3508,25 +2770,13 @@ msgstr "שירותי חיפוש ותיווך (פרוקסי) חיצוניים"
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:224
-msgid ""
-"Certain resources may only be accessed using an external search service, "
-"such as the EBSCO Discovery Service, or a proxy service, such as OCLC "
-"EZProxy. If you use such external search and/or proxy services, please "
-"review the applicable terms of use and privacy policies."
-msgstr ""
-"אפשר לגשת למשאבים מסוימים באמצעות שירות חיפוש חיצוני, כגון EBSCO Discovery "
-"Service, או שירות תיווך (proxy) כגון איזיפרוקסי של OCLC. אם אתה משתמש בחיפוש "
-"חיצוני או שירותי תיווך כאלה, נא לבדוק את תנאי השימוש ואת מסמכי מדיניות "
-"הפרטיות המתאימים."
+msgid "Certain resources may only be accessed using an external search service, such as the EBSCO Discovery Service, or a proxy service, such as OCLC EZProxy. If you use such external search and/or proxy services, please review the applicable terms of use and privacy policies."
+msgstr "אפשר לגשת למשאבים מסוימים באמצעות שירות חיפוש חיצוני, כגון EBSCO Discovery Service, או שירות תיווך (proxy) כגון איזיפרוקסי של OCLC. אם אתה משתמש בחיפוש חיצוני או שירותי תיווך כאלה, נא לבדוק את תנאי השימוש ואת מסמכי מדיניות הפרטיות המתאימים."
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:234
-msgid ""
-"In addition, if you use OCLC EZProxy, please note that you may not use it "
-"for commercial purposes."
-msgstr ""
-"בנוסף, אם אתה משתמש באיזיפרוקסי של OCLC, נא לשים לב לכך שאסור לך להשתמש בו "
-"למטרות מסחריות."
+msgid "In addition, if you use OCLC EZProxy, please note that you may not use it for commercial purposes."
+msgstr "בנוסף, אם אתה משתמש באיזיפרוקסי של OCLC, נא לשים לב לכך שאסור לך להשתמש בו למטרות מסחריות."
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:241
@@ -3535,179 +2785,50 @@ msgstr "שמירת נתונים וטיפול בהם"
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Wikimedia Foundation should not be translated. Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:245
-msgid ""
-"The Wikimedia Foundation and our service providers use your information for "
-"the legitimate purpose of providing Wikipedia Library services in support of "
-"our charitable mission. When you apply for a Wikipedia Library account, or "
-"use your Wikipedia Library account, we may routinely collect the following "
-"information: your username, email address, edit count, registration date, "
-"user ID number, groups to which you belong, and any special user rights; "
-"your name, country of residence, and/or affiliation, if required by a "
-"partner to which you are applying; your narrative description of your "
-"contributions and reasons for applying for access to partner resources; and "
-"the date you agree to these terms of use."
-msgstr ""
-"קרן ויקימדיה וספקי השירות שלנו משתמשים במידע שלך למטרה הלגיטימית של אספקת "
-"שירותי ספריית ויקיפדיה כדי לתמוך במטרות הצדקה שלנו. כשאתה מבקש חשבון ספריית "
-"ויקיפדיה, או משתמש בחשבון ספריית ויקיפדיה שלך, אנחנו יכולים לאסוף בדרך שגרה "
-"את המידע הבא: שם המשתמש שלך, כתובת הדוא״ל שלך, מספר העריכות, תאריך הרישום, "
-"מספר מזהה המשתמש שלך, קבוצות שאתה שייך אליהן, וכל הרשאת משתמש מיוחדת; שמך, "
-"ארץ המגורים שלך או ההשתייכות שלך, אם זה נדרש על־ידי השותף שביקשת לגשת אליו; "
-"התיאור הסיפורי שלך של התרומות והסיבות שלך לבקש גישה למשאבי השותף; והתאריך "
-"שבו הסכמת לתנאי השימוש האלה."
+msgid "The Wikimedia Foundation and our service providers use your information for the legitimate purpose of providing Wikipedia Library services in support of our charitable mission. When you apply for a Wikipedia Library account, or use your Wikipedia Library account, we may routinely collect the following information: your username, email address, edit count, registration date, user ID number, groups to which you belong, and any special user rights; your name, country of residence, and/or affiliation, if required by a partner to which you are applying; your narrative description of your contributions and reasons for applying for access to partner resources; and the date you agree to these terms of use."
+msgstr "קרן ויקימדיה וספקי השירות שלנו משתמשים במידע שלך למטרה הלגיטימית של אספקת שירותי ספריית ויקיפדיה כדי לתמוך במטרות הצדקה שלנו. כשאתה מבקש חשבון ספריית ויקיפדיה, או משתמש בחשבון ספריית ויקיפדיה שלך, אנחנו יכולים לאסוף בדרך שגרה את המידע הבא: שם המשתמש שלך, כתובת הדוא״ל שלך, מספר העריכות, תאריך הרישום, מספר מזהה המשתמש שלך, קבוצות שאתה שייך אליהן, וכל הרשאת משתמש מיוחדת; שמך, ארץ המגורים שלך או ההשתייכות שלך, אם זה נדרש על־ידי השותף שביקשת לגשת אליו; התיאור הסיפורי שלך של התרומות והסיבות שלך לבקש גישה למשאבי השותף; והתאריך שבו הסכמת לתנאי השימוש האלה."
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:262
 #, python-format
-msgid ""
-"Each publisher who is a member of the Wikipedia Library program requires "
-"different specific information in the application. Some publishers may "
-"request only an email address, while others request more detailed data, such "
-"as your name, location, or institutional affiliation. When you complete your "
-"application, you will only be asked to supply information required by the "
-"publishers you have chosen, and each publisher will only receive the "
-"information they require for providing you with access. Please see our <a "
-"class=\"twl-links\" href=\"%(all_partners_url)s\">partner information</a> "
-"pages to learn what information is required by each publisher to gain access "
-"to their resources."
-msgstr ""
-"כל מוציא לאור שחבר בתוכנית ספריית ויקיפדיה דורש מידע שונה בבקשה. מו״לים "
-"אחדים יכולים לבקש רק כתובת דוא״ל, ואחרים יכולים לבקש נתונים מפורטים יותר, "
-"כגון שם, מיקום, או השתייכות מוסדית. כשתשלים את הבקשה שלך, תתבקש רק לספק מידע "
-"שנדרש על־ידי המו״לים שבחרת, וכל מו״ל יקבל רק את המידע שהוא דורש כדי לספק לך "
-"גישה. ר׳ את <a class=\"twl-links\" href=\"%(all_partners_url)s\">דפי המידע "
-"שלנו על השותפים</a> כדי ללמוד איזה מידע נדרש על־ידי כל מוציא לאור כדי לקבל "
-"גישה למשאבים שלהם."
+msgid "Each publisher who is a member of the Wikipedia Library program requires different specific information in the application. Some publishers may request only an email address, while others request more detailed data, such as your name, location, or institutional affiliation. When you complete your application, you will only be asked to supply information required by the publishers you have chosen, and each publisher will only receive the information they require for providing you with access. Please see our <a class=\"twl-links\" href=\"%(all_partners_url)s\">partner information</a> pages to learn what information is required by each publisher to gain access to their resources."
+msgstr "כל מוציא לאור שחבר בתוכנית ספריית ויקיפדיה דורש מידע שונה בבקשה. מו״לים אחדים יכולים לבקש רק כתובת דוא״ל, ואחרים יכולים לבקש נתונים מפורטים יותר, כגון שם, מיקום, או השתייכות מוסדית. כשתשלים את הבקשה שלך, תתבקש רק לספק מידע שנדרש על־ידי המו״לים שבחרת, וכל מו״ל יקבל רק את המידע שהוא דורש כדי לספק לך גישה. ר׳ את <a class=\"twl-links\" href=\"%(all_partners_url)s\">דפי המידע שלנו על השותפים</a> כדי ללמוד איזה מידע נדרש על־ידי כל מוציא לאור כדי לקבל גישה למשאבים שלהם."
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Wikimedia Foundation should not be translated. Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:277
-msgid ""
-"Some Wikipedia Library pages are visible without logging in, but you will "
-"need to log in to apply or access proprietary partner resources. We use the "
-"data provided by you via OAuth and Wikimedia API calls to assess your "
-"application for access and to process approved requests."
-msgstr ""
-"חלק מהדפים של ספריית ויקיפדיה מוצגים בלי כניסה לחשבון, אבל תצטרך להיכנס "
-"לחשבון כדי לשלוח בקשה או לגשת למשאבים קנייניים של שותפים. אנחנו משתמשים "
-"בנתונים שסיפקת באמצעות OAuth וקריאות ל־API של ויקימדיה כדי להעריך את הבקשה "
-"שלך לגישה ולטפל בבקשות מאושרות."
+msgid "Some Wikipedia Library pages are visible without logging in, but you will need to log in to apply or access proprietary partner resources. We use the data provided by you via OAuth and Wikimedia API calls to assess your application for access and to process approved requests."
+msgstr "חלק מהדפים של ספריית ויקיפדיה מוצגים בלי כניסה לחשבון, אבל תצטרך להיכנס לחשבון כדי לשלוח בקשה או לגשת למשאבים קנייניים של שותפים. אנחנו משתמשים בנתונים שסיפקת באמצעות OAuth וקריאות ל־API של ויקימדיה כדי להעריך את הבקשה שלך לגישה ולטפל בבקשות מאושרות."
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:288
 #, python-format
-msgid ""
-"In order to administer the Wikipedia Library program, we will retain the "
-"application data we collect from you for three years after your most recent "
-"login, unless you delete your account, as described below. You can log in "
-"and go to <a class=\"twl-links\" href=\"%(profile_url)s\">your profile page</"
-"a> in order to see the information associated with your account, and can "
-"download it in JSON format. You may access, update, restrict, or delete this "
-"information at any time, except for the information that is automatically "
-"retrieved from the projects. If you have any questions or concerns about the "
-"handling of your data, please contact <a class=\"twl-links\" href=\"mailto:"
-"wikipedialibrary@wikimedia.org?Subject=Wikipedia%%20Library%%20Card"
-"%%20account%%20deactivation\"> wikipedialibrary@wikimedia.org </a>."
-msgstr ""
-"כדי לנהל את תוכנית ספריית ויקיפדיה, אנחנו נשמור את נתוני הבקשה שאנחנו אוספים "
-"ממך לשלוש שנים אחרי הכניסה האחרונה שלך לחשבון, אלא אם תמחק את חשבונך, כפי "
-"שמתואר להלן. אתה יכול להיכנס לחשבון ולעבור ל<a class=\"twl-links\" href="
-"\"%(profile_url)s\">דף הפרופיל שלך</a> כדי לראות את המידע שמשויך לחשבון שלך, "
-"ואתה יכול להוריד אותו בתסדיר JSON. אתה יכול לגשת למידע הזה, לעדכן, להגביל או "
-"למחוק אותו בכל זמן, למעט המידע שמאוחזר אוטומטית מהמיזמים. אם יש לך שאלות או "
-"דאגות בקשר לטיפול בנתונים שלך, נא ליצור קשר עם <a class=\"twl-links\" href="
-"\"mailto:wikipedialibrary@wikimedia.org?Subject=Wikipedia%%20Library%%20Card"
-"%%20account%%20deactivation\">wikipedialibrary@wikimedia.org</a>."
+msgid "In order to administer the Wikipedia Library program, we will retain the application data we collect from you for three years after your most recent login, unless you delete your account, as described below. You can log in and go to <a class=\"twl-links\" href=\"%(profile_url)s\">your profile page</a> in order to see the information associated with your account, and can download it in JSON format. You may access, update, restrict, or delete this information at any time, except for the information that is automatically retrieved from the projects. If you have any questions or concerns about the handling of your data, please contact <a class=\"twl-links\" href=\"mailto:wikipedialibrary@wikimedia.org?Subject=Wikipedia%%20Library%%20Card%%20account%%20deactivation\"> wikipedialibrary@wikimedia.org </a>."
+msgstr "כדי לנהל את תוכנית ספריית ויקיפדיה, אנחנו נשמור את נתוני הבקשה שאנחנו אוספים ממך לשלוש שנים אחרי הכניסה האחרונה שלך לחשבון, אלא אם תמחק את חשבונך, כפי שמתואר להלן. אתה יכול להיכנס לחשבון ולעבור ל<a class=\"twl-links\" href=\"%(profile_url)s\">דף הפרופיל שלך</a> כדי לראות את המידע שמשויך לחשבון שלך, ואתה יכול להוריד אותו בתסדיר JSON. אתה יכול לגשת למידע הזה, לעדכן, להגביל או למחוק אותו בכל זמן, למעט המידע שמאוחזר אוטומטית מהמיזמים. אם יש לך שאלות או דאגות בקשר לטיפול בנתונים שלך, נא ליצור קשר עם <a class=\"twl-links\" href=\"mailto:wikipedialibrary@wikimedia.org?Subject=Wikipedia%%20Library%%20Card%%20account%%20deactivation\">wikipedialibrary@wikimedia.org</a>."
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:305
-msgid ""
-"If you decide to disable your Wikipedia Library account, you can use the "
-"delete button on your profile to delete certain personal information "
-"associated with your account. We will delete your real name, institutional "
-"affiliation, and country of residence. Please note that the system will "
-"retain a record of your username, the publishers to which you applied or had "
-"access, and the dates of that access. Note that deletion is not reversible. "
-"Deletion of your Wikipedia Library account may also correspond with the "
-"removal of any resource access to which you were eligible or approved. If "
-"you request the deletion of account information and later wish to apply for "
-"a new account, you will need to provide the necessary information again."
-msgstr ""
-"אם תחליט לכבות את חשבון ספריית ויקיפדיה שלך, תוכל להשתמש בכפתור המחיקה בדף "
-"הפרופיל שלך כדי למחוק מידע אישי מסוים שמשויך לחשבון שלך. אנחנו נמחק את השם "
-"האמיתי, ההשתייכות המוסדית, וארץ המגורים. נא לשים לב לכך שהמערכת תשמור רישום "
-"של שם המשתמש שלך, את המוציאים לאור ששלחת אליהם בקשה או קיבלת אליהם גישה, "
-"ותאריכי הגישה. נא לשים לב לכך שהמחיקה אינה הפיכה. מחיקה של חשבון ספריית "
-"ויקיפדיה שלך יכולה גם להיות קשורה להסרה של גישה של כל משאב שהיית זכאי לו או "
-"שאושרת לקבל. אם אתה מבקש מחיקה של מידע על החשבון, ואחר־כך רוצה חשבון חדש, "
-"תצטרך לספק את המידע הנחוץ שוב."
+msgid "If you decide to disable your Wikipedia Library account, you can use the delete button on your profile to delete certain personal information associated with your account. We will delete your real name, institutional affiliation, and country of residence. Please note that the system will retain a record of your username, the publishers to which you applied or had access, and the dates of that access. Note that deletion is not reversible. Deletion of your Wikipedia Library account may also correspond with the removal of any resource access to which you were eligible or approved. If you request the deletion of account information and later wish to apply for a new account, you will need to provide the necessary information again."
+msgstr "אם תחליט לכבות את חשבון ספריית ויקיפדיה שלך, תוכל להשתמש בכפתור המחיקה בדף הפרופיל שלך כדי למחוק מידע אישי מסוים שמשויך לחשבון שלך. אנחנו נמחק את השם האמיתי, ההשתייכות המוסדית, וארץ המגורים. נא לשים לב לכך שהמערכת תשמור רישום של שם המשתמש שלך, את המוציאים לאור ששלחת אליהם בקשה או קיבלת אליהם גישה, ותאריכי הגישה. נא לשים לב לכך שהמחיקה אינה הפיכה. מחיקה של חשבון ספריית ויקיפדיה שלך יכולה גם להיות קשורה להסרה של גישה של כל משאב שהיית זכאי לו או שאושרת לקבל. אם אתה מבקש מחיקה של מידע על החשבון, ואחר־כך רוצה חשבון חדש, תצטרך לספק את המידע הנחוץ שוב."
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). WMF should not be translated. Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:321
-msgid ""
-"The Wikipedia Library is run by WMF Staff, Contractors, and approved "
-"volunteer Coordinators. The data associated with your account will be shared "
-"with the WMF staff, contractors, service providers, and volunteer "
-"coordinators who need to process the information in connection with their "
-"work for the Wikipedia Library, and who are subject to confidentiality "
-"obligations. We will also use your data for internal Wikipedia Library "
-"purposes such as distributing user surveys and account notifications, and in "
-"a depersonalized or aggregated fashion for statistical analysis and "
-"administration. Finally, we will share your information with the publishers "
-"whom you specifically select in order to provide you with access to "
-"resources. Otherwise, your information will not be shared with third "
-"parties, with the exception of the circumstances described below."
-msgstr ""
-"ספריית ויקיפדיה מנוהלת על־ידי סגל קרן ויקימדיה (WMF), עובדים בחוזה, ומתאמים "
-"מתנדבים מאושרים. הנתונים המשויכים לחשבון שלך ישותפו עם סגל קרן ויקימדיה, "
-"עובדים בחוזה, נותני שירות, ומתאמים מתנדבים שצריכים לטפל במידע בהקשר של "
-"עבודתם עם ספריית ויקיפדיה, ושנתונים להתחייבויות סודיוּת. אנחנו גם נשתמש "
-"בנתונים שלך למטרות פנימיות של ספריית ויקיפדיה כגון הפצת סקרי משתמשים והודעות "
-"על חשבונות, ובאופן צובר שמסיר מידע אישי לניתוח סטטיסטי וניהול. לבסוף, נשתף "
-"את המידע שלך עם המוציאים לאור שאתה בוחר באופן פרטני כדי לספק לך גישה "
-"למשאבים. מלבד זאת, המידע שלך לא ישותף עם צדדים שלישיים, למעט נסיבות שמתוארות "
-"להלן."
+msgid "The Wikipedia Library is run by WMF Staff, Contractors, and approved volunteer Coordinators. The data associated with your account will be shared with the WMF staff, contractors, service providers, and volunteer coordinators who need to process the information in connection with their work for the Wikipedia Library, and who are subject to confidentiality obligations. We will also use your data for internal Wikipedia Library purposes such as distributing user surveys and account notifications, and in a depersonalized or aggregated fashion for statistical analysis and administration. Finally, we will share your information with the publishers whom you specifically select in order to provide you with access to resources. Otherwise, your information will not be shared with third parties, with the exception of the circumstances described below."
+msgstr "ספריית ויקיפדיה מנוהלת על־ידי סגל קרן ויקימדיה (WMF), עובדים בחוזה, ומתאמים מתנדבים מאושרים. הנתונים המשויכים לחשבון שלך ישותפו עם סגל קרן ויקימדיה, עובדים בחוזה, נותני שירות, ומתאמים מתנדבים שצריכים לטפל במידע בהקשר של עבודתם עם ספריית ויקיפדיה, ושנתונים להתחייבויות סודיוּת. אנחנו גם נשתמש בנתונים שלך למטרות פנימיות של ספריית ויקיפדיה כגון הפצת סקרי משתמשים והודעות על חשבונות, ובאופן צובר שמסיר מידע אישי לניתוח סטטיסטי וניהול. לבסוף, נשתף את המידע שלך עם המוציאים לאור שאתה בוחר באופן פרטני כדי לספק לך גישה למשאבים. מלבד זאת, המידע שלך לא ישותף עם צדדים שלישיים, למעט נסיבות שמתוארות להלן."
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). WMF should not be translated.
 #: TWLight/users/templates/users/terms.html:338
-msgid ""
-"We may disclose any collected information when required by law, when we have "
-"your permission, when needed to protect our rights, privacy, safety, users, "
-"or the general public, and when necessary to enforce these terms, WMF’s "
-"general <a class=\"twl-links\" href=\"https://foundation.wikimedia.org/wiki/"
-"Terms_of_Use\">Terms of Use</a>, or any other WMF policy."
-msgstr ""
-"אנחנו יכולים לחשוף כל מידע כאשר החוק דורש את זה, כשיש לנו רשות ממך, כשזה "
-"נחוץ להגנה על הזכויות, הפרטיוּת, האבטחה, המשתמשים שלנו, או הציבור הכללי, "
-"וכאשר זה נחוץ לאכיפה של התנאים האלה, <a class=\"twl-links\" href=\"https://"
-"foundation.wikimedia.org/wiki/Terms_of_Use\">תנאי השימוש</a> הכלליים של קרן "
-"ויקימדיה, או כל מדיניות קרן ויקימדיה אחרת."
+msgid "We may disclose any collected information when required by law, when we have your permission, when needed to protect our rights, privacy, safety, users, or the general public, and when necessary to enforce these terms, WMF’s general <a class=\"twl-links\" href=\"https://foundation.wikimedia.org/wiki/Terms_of_Use\">Terms of Use</a>, or any other WMF policy."
+msgstr "אנחנו יכולים לחשוף כל מידע כאשר החוק דורש את זה, כשיש לנו רשות ממך, כשזה נחוץ להגנה על הזכויות, הפרטיוּת, האבטחה, המשתמשים שלנו, או הציבור הכללי, וכאשר זה נחוץ לאכיפה של התנאים האלה, <a class=\"twl-links\" href=\"https://foundation.wikimedia.org/wiki/Terms_of_Use\">תנאי השימוש</a> הכלליים של קרן ויקימדיה, או כל מדיניות קרן ויקימדיה אחרת."
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:349
-msgid ""
-"We take the security of your personal data seriously, and take reasonable "
-"precautions to ensure your data is protected. These precautions include "
-"access controls to limit who has access to your data and security "
-"technologies to protect data stored on the server. However, we cannot "
-"guarantee the safety of your data as it is transmitted and stored."
-msgstr ""
-"אנחנו מתייחסים לבטיחות של הנתונים האישיים שלך ברצינות, ונוקטים באמצעי זהירות "
-"סבירים כדי לוודא שהנתונים שלך מוגנים. אמצעי הזהירות האלה כוללים בקרת גישה "
-"להגבלה על הזהות של מי שיכול לגשת לנתונים שלך וטכנולוגיות אבטחה להגנת הנתונים "
-"ששמורים על השרת. עם זאת, איננו יכולים להבטיח את הבטיחות של הנתונים שלך כשהם "
-"מועברים או מאוחסנים."
+msgid "We take the security of your personal data seriously, and take reasonable precautions to ensure your data is protected. These precautions include access controls to limit who has access to your data and security technologies to protect data stored on the server. However, we cannot guarantee the safety of your data as it is transmitted and stored."
+msgstr "אנחנו מתייחסים לבטיחות של הנתונים האישיים שלך ברצינות, ונוקטים באמצעי זהירות סבירים כדי לוודא שהנתונים שלך מוגנים. אמצעי הזהירות האלה כוללים בקרת גישה להגבלה על הזהות של מי שיכול לגשת לנתונים שלך וטכנולוגיות אבטחה להגנת הנתונים ששמורים על השרת. עם זאת, איננו יכולים להבטיח את הבטיחות של הנתונים שלך כשהם מועברים או מאוחסנים."
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:360
-msgid ""
-"Please note that these terms do not control the use and handling of your "
-"data by the publishers and service providers whose resources you access or "
-"apply to access. Please read their individual privacy policies for that "
-"information."
-msgstr ""
-"נא לשים לב לכך שהתנאים האלה אינם מפקחים על השימוש והטיפול בנתונים שלך של "
-"המוציאים לאור ושל נותני השירות שאתה ניגש או מבקש לגשת למשאבים שלהם. נא לקרוא "
-"את מדיניות הפרטיות של כל אחד מהם בשביל לקבל את המידע הזה."
+msgid "Please note that these terms do not control the use and handling of your data by the publishers and service providers whose resources you access or apply to access. Please read their individual privacy policies for that information."
+msgstr "נא לשים לב לכך שהתנאים האלה אינם מפקחים על השימוש והטיפול בנתונים שלך של המוציאים לאור ושל נותני השירות שאתה ניגש או מבקש לגשת למשאבים שלהם. נא לקרוא את מדיניות הפרטיות של כל אחד מהם בשביל לקבל את המידע הזה."
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:368
@@ -3716,48 +2837,18 @@ msgstr "הערה חשובה"
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Wikimedia Foundation should not be translated. Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:373
-msgid ""
-"The Wikimedia Foundation is a nonprofit organization based in San Francisco, "
-"California. The Wikipedia Library program provides access to resources held "
-"by publishers in multiple countries. If you apply for a Wikipedia Library "
-"account (whether you are inside or outside of the United States), you "
-"understand that your personal data will be collected, transferred, stored, "
-"processed, disclosed and otherwise used in the U.S. as described in this "
-"privacy policy. You also understand that your information may be transferred "
-"by us from the U.S. to other countries, which may have different or less "
-"stringent data protection laws than your country, in connection with "
-"providing services to you, including evaluating your application and "
-"securing access to your chosen publishers (locations for each publisher are "
-"outlined on their respective partner information pages)."
-msgstr ""
-"קרן ויקמדיה היא מוסד ללא כוונת רווח שמושבו בסן פרנסיסקו, קליפורניה. תוכנית "
-"ספריית ויקיפדיה מספקת גישה למשאבים שמוחזקים על־ידי מוציאים לאור במדינות "
-"רבות. אם אתה מבקש חשבון ספריית ויקיפדיה (אם אתה בתוך ארצות הברית או מחוץ "
-"לארצות הברית), אתה מבין שהנתונים האישיים שלך ייאספו, יועברו, יאוחסנו, "
-"יעובדו, יאוסגרו וישמשו בדרכים אחרות בארה״ב כפי שמתואר במדיניות הפרטיות. אתה "
-"גם מבין שהמידע שלך יועבר על־ידינו מארה״ב למדינות אחרות, שיכולים להיות בהן "
-"חוקי הגנת נתונים מחמירים פחות מאשר במדינה שלך, בהקשר לאספקת שירותים לך, כולל "
-"הערכת הבקשה שלך והבטחת גישה למוציאים לאור הנבחרים שלך (מיקומים של כל מוציא "
-"לאור מתוארים בדפי מידע השותף שלהם)."
+msgid "The Wikimedia Foundation is a nonprofit organization based in San Francisco, California. The Wikipedia Library program provides access to resources held by publishers in multiple countries. If you apply for a Wikipedia Library account (whether you are inside or outside of the United States), you understand that your personal data will be collected, transferred, stored, processed, disclosed and otherwise used in the U.S. as described in this privacy policy. You also understand that your information may be transferred by us from the U.S. to other countries, which may have different or less stringent data protection laws than your country, in connection with providing services to you, including evaluating your application and securing access to your chosen publishers (locations for each publisher are outlined on their respective partner information pages)."
+msgstr "קרן ויקמדיה היא מוסד ללא כוונת רווח שמושבו בסן פרנסיסקו, קליפורניה. תוכנית ספריית ויקיפדיה מספקת גישה למשאבים שמוחזקים על־ידי מוציאים לאור במדינות רבות. אם אתה מבקש חשבון ספריית ויקיפדיה (אם אתה בתוך ארצות הברית או מחוץ לארצות הברית), אתה מבין שהנתונים האישיים שלך ייאספו, יועברו, יאוחסנו, יעובדו, יאוסגרו וישמשו בדרכים אחרות בארה״ב כפי שמתואר במדיניות הפרטיות. אתה גם מבין שהמידע שלך יועבר על־ידינו מארה״ב למדינות אחרות, שיכולים להיות בהן חוקי הגנת נתונים מחמירים פחות מאשר במדינה שלך, בהקשר לאספקת שירותים לך, כולל הערכת הבקשה שלך והבטחת גישה למוציאים לאור הנבחרים שלך (מיקומים של כל מוציא לאור מתוארים בדפי מידע השותף שלהם)."
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:392
-msgid ""
-"Please note that in the event of any differences in meaning or "
-"interpretation between the original English version of these terms and a "
-"translation, the original English version takes precedence."
-msgstr ""
-"נא לשים לב לכך שבמקרה של הבדל במשמעות או בפרשנות בין הגרסה המקורית האנגלית "
-"של התנאים האלה לבין התרגום, הגרסה האנגלית המקורית קובעת."
+msgid "Please note that in the event of any differences in meaning or interpretation between the original English version of these terms and a translation, the original English version takes precedence."
+msgstr "נא לשים לב לכך שבמקרה של הבדל במשמעות או בפרשנות בין הגרסה המקורית האנגלית של התנאים האלה לבין התרגום, הגרסה האנגלית המקורית קובעת."
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Wikimedia Foundation should not be translated.
 #: TWLight/users/templates/users/terms.html:403
-msgid ""
-"See also the <a class=\"twl-links\" href=\"https://wikimediafoundation.org/"
-"wiki/Privacy_policy\">Wikimedia Foundation Privacy Policy</a>."
-msgstr ""
-"ר׳ גם את <a class=\"twl-links\" href=\"https://wikimediafoundation.org/wiki/"
-"Privacy_policy\">מדיניות הפרטיות של קרן ויקימדיה</a>."
+msgid "See also the <a class=\"twl-links\" href=\"https://wikimediafoundation.org/wiki/Privacy_policy\">Wikimedia Foundation Privacy Policy</a>."
+msgstr "ר׳ גם את <a class=\"twl-links\" href=\"https://wikimediafoundation.org/wiki/Privacy_policy\">מדיניות הפרטיות של קרן ויקימדיה</a>."
 
 #. Translators: This is the second to last line of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:412
@@ -3776,15 +2867,8 @@ msgstr "קרן ויקימדיה"
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:426
-msgid ""
-"By checking this box and clicking “Submit”, you agree that you have read the "
-"above terms and that you will adhere to the terms of use in your application "
-"to and use of the The Wikipedia Library, and the publishers’ services to "
-"which you gain access through The Wikipedia Library program."
-msgstr ""
-"סימון התיבה הזאת ולחיצה על \"שליחה\" מהווים את הסכמתך לכך שקראת את התנאים "
-"לעיל ושתפעל בהתאם לתנאי השימוש בבקשה שלך ובשימוש שלך בספריית ויקיפדיה, "
-"ולשירותי המוציאים לאור שתקבל גישה אליהם דרך תוכנית ספריית ויקיפדיה."
+msgid "By checking this box and clicking “Submit”, you agree that you have read the above terms and that you will adhere to the terms of use in your application to and use of the The Wikipedia Library, and the publishers’ services to which you gain access through The Wikipedia Library program."
+msgstr "סימון התיבה הזאת ולחיצה על \"שליחה\" מהווים את הסכמתך לכך שקראת את התנאים לעיל ושתפעל בהתאם לתנאי השימוש בבקשה שלך ובשימוש שלך בספריית ויקיפדיה, ולשירותי המוציאים לאור שתקבל גישה אליהם דרך תוכנית ספריית ויקיפדיה."
 
 #: TWLight/users/templates/users/user_collection_tile.html:32
 msgid "Remove this collection from favorites"
@@ -3836,38 +2920,19 @@ msgstr "מחיקת כל הנתונים"
 
 #. Translators: This message is displayed on the page where users can request the deletion of their data.
 #: TWLight/users/templates/users/user_confirm_delete.html:17
-msgid ""
-"<b>Warning:</b> Performing this action will delete your Wikipedia Library "
-"Card user account and all associated applications. This process is not "
-"reversible. You may lose any partner accounts you were granted, and will not "
-"be able to renew those accounts or apply for new ones."
-msgstr ""
-"<b>אזהרה:</b> ביצוע הפעולה הזאת ימחק את חשבון המשתמש שלך בספריית ויקיפדיה "
-"ואת כל הבקשות המשויכות. התהליך הזה בלתי־הפיך. ייתכן שתאבד את חשבונות השותף "
-"שקיבלת, ולא תוכל לחדש את החשבונות האלה או לבקש חדשים."
+msgid "<b>Warning:</b> Performing this action will delete your Wikipedia Library Card user account and all associated applications. This process is not reversible. You may lose any partner accounts you were granted, and will not be able to renew those accounts or apply for new ones."
+msgstr "<b>אזהרה:</b> ביצוע הפעולה הזאת ימחק את חשבון המשתמש שלך בספריית ויקיפדיה ואת כל הבקשות המשויכות. התהליך הזה בלתי־הפיך. ייתכן שתאבד את חשבונות השותף שקיבלת, ולא תוכל לחדש את החשבונות האלה או לבקש חדשים."
 
 #. Translators: this should show up for people who log in with a username/password and not OAuth, so we don't know what their Wikipedia identity is.
-#.
 #: TWLight/users/templates/users/user_detail.html:12
 #, python-format
-msgid ""
-"Hi, %(username)s! You don't have a Wikipedia editor profile attached to your "
-"account here, so you are probably a site administrator."
-msgstr ""
-"שלום, %(username)s! לא משויך אצלך פרופיל עורך ויקיפדיה כאן, אז אתה כנראה "
-"מנהל אתר."
+msgid "Hi, %(username)s! You don't have a Wikipedia editor profile attached to your account here, so you are probably a site administrator."
+msgstr "שלום, %(username)s! לא משויך אצלך פרופיל עורך ויקיפדיה כאן, אז אתה כנראה מנהל אתר."
 
 #. Translators: In the unlikely scenario that someone is able to register an account without using OAuth (thus leaving us without some of the information required for applications), users will see this message, encouraging them to re-register.
 #: TWLight/users/templates/users/user_detail.html:20
-msgid ""
-"If you aren't a site administrator, something weird has happened. You won't "
-"be able to apply for access without a Wikipedia editor profile. You should "
-"log out and create a new account by logging in via OAuth, or contact a site "
-"administrator for help."
-msgstr ""
-"אם אינך מנהל אתר, קרה משהו מוזר. לא תוכל לבקש גישה בלי פרופיל עורך ויקיפדיה. "
-"יש לצאת מהחשבון ולהיכנס חזרה באמצעות OAuth, או ליצור קשר עם מנהל אתר כדי "
-"לקבל עזרה."
+msgid "If you aren't a site administrator, something weird has happened. You won't be able to apply for access without a Wikipedia editor profile. You should log out and create a new account by logging in via OAuth, or contact a site administrator for help."
+msgstr "אם אינך מנהל אתר, קרה משהו מוזר. לא תוכל לבקש גישה בלי פרופיל עורך ויקיפדיה. יש לצאת מהחשבון ולהיכנס חזרה באמצעות OAuth, או ליצור קשר עם מנהל אתר כדי לקבל עזרה."
 
 #. Translators: Labels a sections where coordinators can select their email preferences.
 #: TWLight/users/templates/users/user_email_preferences.html:15
@@ -3877,22 +2942,13 @@ msgstr "רק מתאמים"
 #. Translators: This message is shown on user's own profile page, encouraging them to make sure their information is up to date, so that account coordinators can use the information to judge applications.
 #: TWLight/users/views.py:176
 #, python-brace-format
-msgid ""
-"Please <a class='twl-links' href='{url}'>update your contributions</a> to "
-"Wikipedia to help coordinators evaluate your applications."
-msgstr ""
-"נא <a class=\"twl-links\" href='{url}'>לעדכן את התרומות שלך</a> לוויקיפדיה "
-"כדי לעזור למתאמים להעריך את התרומות שלך."
+msgid "Please <a class='twl-links' href='{url}'>update your contributions</a> to Wikipedia to help coordinators evaluate your applications."
+msgstr "נא <a class=\"twl-links\" href='{url}'>לעדכן את התרומות שלך</a> לוויקיפדיה כדי לעזור למתאמים להעריך את התרומות שלך."
 
 #. Translators: Coordinators are shown this message when they unselect all three types of reminder email options under preferences.
 #: TWLight/users/views.py:288
-msgid ""
-"You have chosen not to receive reminder emails. As a coordinator, you should "
-"receive at least one type of reminder emails, so consider changing your "
-"preferences."
-msgstr ""
-"בחרת לא לקבל מכתבי תזכורת בדוא״ל. בתור מתאם, כדאי שתקבל לפחות סוג אחד של "
-"מכתבי תזכורת, אז מומלץ לשנות את ההעדפות שלך."
+msgid "You have chosen not to receive reminder emails. As a coordinator, you should receive at least one type of reminder emails, so consider changing your preferences."
+msgstr "בחרת לא לקבל מכתבי תזכורת בדוא״ל. בתור מתאם, כדאי שתקבל לפחות סוג אחד של מכתבי תזכורת, אז מומלץ לשנות את ההעדפות שלך."
 
 #. Translators: Coordinators are shown this message when they make changes to their reminder email options under preferences.
 #: TWLight/users/views.py:296
@@ -3925,12 +2981,8 @@ msgstr "הדוא\"ל שלך שונה ל־{email}."
 
 #. Translators: If the user has not filled out their email, they can browse the website but cannot apply for access to resources.
 #: TWLight/users/views.py:487
-msgid ""
-"Your email is blank. You can still explore the site, but you won't be able "
-"to apply for access to partner resources without an email."
-msgstr ""
-"הדוא״ל שלך ריק. אתה עדיין יכול לעיין באתר, אבל לא תוכל לבקש גישה למשאבי "
-"שותפים ללא דוא״ל."
+msgid "Your email is blank. You can still explore the site, but you won't be able to apply for access to partner resources without an email."
+msgstr "הדוא״ל שלך ריק. אתה עדיין יכול לעיין באתר, אבל לא תוכל לבקש גישה למשאבי שותפים ללא דוא״ל."
 
 #. Translators: This message is shown once the access to a partner has successfully been returned.
 #: TWLight/users/views.py:801
@@ -3962,31 +3014,3 @@ msgstr "אין חסימות פעילות"
 msgid "10+ edits in the last 30 days"
 msgstr "מעל 10 עריכות ב־30 הימים האחרונים"
 
-#: tests/shunit/data/bad_i18n_comment_1.py:3
-#: tests/shunit/data/bad_i18n_newline_1.py:5
-msgid "1"
-msgstr ""
-
-#. Translators: Lorem ipsum dolor sit amet, consectetur adipiscing elit. Mauris vitae ipsum ut purus faucibus pretium. Proin tempus neque et aliquet consectetur. Ut egestas sapien in consectetur sagittis. Mauris neque lacus, dapibus non viverra vitae, interdum ut aenean ipsum.
-#. Translators: Lorem ipsum dolor sit amet, consectetur adipiscing elit. Mauris vitae ipsum ut purus faucibus pretium. Proin tempus neque et aliquet consectetur. Ut egestas sapien in consectetur sagittis. Mauris neque lacus, dapibus non.
-#: tests/shunit/data/bad_i18n_comment_2.py:4
-#: tests/shunit/data/bad_i18n_newline_2.py:5 tests/shunit/data/good_i18n_1.py:2
-#: tests/shunit/data/good_i18n_2.py:2
-msgid "2"
-msgstr ""
-
-#: tests/shunit/data/bad_i18n_newline_3.py:5
-msgid "3"
-msgstr ""
-
-#: tests/shunit/data/bad_i18n_newline_4.py:5
-msgid "4"
-msgstr ""
-
-#: tests/shunit/data/bad_i18n_newline_5.py:5
-msgid "5"
-msgstr ""
-
-#: tests/shunit/data/bad_i18n_newline_6.py:5
-msgid "6"
-msgstr ""

--- a/locale/hi/LC_MESSAGES/django.po
+++ b/locale/hi/LC_MESSAGES/django.po
@@ -18,10 +18,11 @@
 # Author: UY Scuti
 msgid ""
 msgstr ""
+""
 "Project-Id-Version: Wikipedia Library Card Platform - Website\n"
-"Report-Msgid-Bugs-To: wikipedialibrary@wikimedia.org\n"
+"Report-Msgid-Bugs-To: translatewiki.net\n"
 "POT-Creation-Date: 2024-07-11 20:55+0000\n"
-"PO-Revision-Date: 2024-07-11 12:30:15+0000\n"
+"PO-Revision-Date: 2024-07-15 12:29:15+0000\n"
 "Language: hi\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
@@ -53,12 +54,8 @@ msgstr "आपके बारे में"
 #. Translators: This note appears in a section of a form where we ask users to enter info (like country of residence) when applying for resource access.
 #: TWLight/applications/forms.py:179
 #, python-brace-format
-msgid ""
-"<p><small><i>Your personal data will be processed according to our <a "
-"class='twl-links' href='{terms_url}'> privacy policy</a>.</i></small></p>"
-msgstr ""
-"<p><small>आपके व्यक्तिगत डेटा को हमारी <a class='twl-links' "
-"href='{terms_url}'>गोपनीयता नीति</a> के अनुसार संसाधित किया जाएगा।</small></p>"
+msgid "<p><small><i>Your personal data will be processed according to our <a class='twl-links' href='{terms_url}'> privacy policy</a>.</i></small></p>"
+msgstr "<p><small>आपके व्यक्तिगत डेटा को हमारी <a class='twl-links' href='{terms_url}'>गोपनीयता नीति</a> के अनुसार संसाधित किया जाएगा।</small></p>"
 
 #. Translators: This is the title of the application form page, where users enter information required for the application. It lets the user know which partner application they are entering data for. {partner}
 #: TWLight/applications/forms.py:189
@@ -99,9 +96,7 @@ msgstr "भागीदार की वेबसाइट पर आपके �
 #. Translators: This labels a choice field where users will have to select the number of months they wish to have their access for as part of the application renewal confirmation.
 #. Translators: When filling out an application, users may be required to enter the length of the account (expiry) they wish to have for proxy partners.
 #: TWLight/applications/forms.py:339 TWLight/applications/helpers.py:100
-msgid ""
-"The number of months you wish to have this access for before renewal is "
-"required"
+msgid "The number of months you wish to have this access for before renewal is required"
 msgstr "नवीकरण से पहले आप कितने महीनों तक यह अधिकार रखना चाहेंगे"
 
 #. Translators: When filling out an application, users may need to specify their name
@@ -190,12 +185,8 @@ msgstr "ईमेल"
 
 #. Translators: This comment is added to pending applications when our terms of use change.
 #: TWLight/applications/management/commands/notify_applicants_tou_changes.py:54
-msgid ""
-"Our terms of use have changed. Your applications will not be processed until "
-"you log in and agree to our updated terms."
-msgstr ""
-"हमारे उपयोग की शर्तें बदल गई हैं। जब तक आप लॉग-इन करके हमारी नई शर्तों को स्वीकार न "
-"करें, तब तक आपके आवेदनों को प्रोसेस नहीं किया जाएगा।"
+msgid "Our terms of use have changed. Your applications will not be processed until you log in and agree to our updated terms."
+msgstr "हमारे उपयोग की शर्तें बदल गई हैं। जब तक आप लॉग-इन करके हमारी नई शर्तों को स्वीकार न करें, तब तक आपके आवेदनों को प्रोसेस नहीं किया जाएगा।"
 
 #. Translators: This is the status of an application that has not yet been reviewed.
 #: TWLight/applications/models.py:54
@@ -261,40 +252,26 @@ msgstr "अधिकार का URL: {access_url}"
 
 #. Translators: This text goes into account approval emails in the case that we need to send the user's details to a publisher for manual account setup.
 #: TWLight/applications/models.py:331
-msgid ""
-"You can expect to receive access details within a week or two once it has "
-"been processed."
+msgid "You can expect to receive access details within a week or two once it has been processed."
 msgstr "अधिकार के प्रोसेस होने के एक या दो हफ़्तों के अंदर आपको सारी जानकारी मिल जाएगी।"
 
 #. Translators: This comment is added to open applications when a partner joins the Library Bundle, which does not require applications.
 #: TWLight/applications/signals.py:247
-msgid ""
-"This partner joined the Library Bundle, which does not require applications. "
-"This application will be marked as invalid."
-msgstr ""
-"इस भागीदार ने पुस्तकालय बंडल में हिस्सा लिया है, जिसे आवेदन की ज़रूरत नहीं। इस आवेदन को "
-"अमान्य चिह्नित कर दिया जाएगा।"
+msgid "This partner joined the Library Bundle, which does not require applications. This application will be marked as invalid."
+msgstr "इस भागीदार ने पुस्तकालय बंडल में हिस्सा लिया है, जिसे आवेदन की ज़रूरत नहीं। इस आवेदन को अमान्य चिह्नित कर दिया जाएगा।"
 
 #. Translators: This is shown to users if the application is to a partner for which we have run out of available accounts. The application is therefore on a 'waitlist', and will be reviewed when more accounts are available.
 #: TWLight/applications/templates/applications/application_evaluation.html:29
-msgid ""
-"This application is on the waitlist because this partner does not have any "
-"access grants available at this time."
-msgstr ""
-"यह आवेदन प्रतीक्षा सूची में है क्योंकि इस भागीदार के पास इस समय कोई अधिकार अनुदान उपलब्ध "
-"नहीं है।"
+msgid "This application is on the waitlist because this partner does not have any access grants available at this time."
+msgstr "यह आवेदन प्रतीक्षा सूची में है क्योंकि इस भागीदार के पास इस समय कोई अधिकार अनुदान उपलब्ध नहीं है।"
 
 #. Translators: This message is shown on pages where coordinators can see personal information about applicants.
 #: TWLight/applications/templates/applications/application_evaluation.html:36
 #: TWLight/applications/templates/applications/application_list_include.html:6
 #: TWLight/applications/templates/applications/send_partner.html:45
 #: TWLight/resources/templates/resources/partner_users.html:18
-msgid ""
-"Coordinators: This page may contain personal information such as real names "
-"and email addresses. Please remember that this information is confidential."
-msgstr ""
-"समन्वयक: इस पृष्ठ में असली नाम और ईमेल पते जैसी व्यक्तिगत जानकारी हो सकती है। कृपया याद "
-"रखें कि यह जानकारी गोपनीय है।"
+msgid "Coordinators: This page may contain personal information such as real names and email addresses. Please remember that this information is confidential."
+msgstr "समन्वयक: इस पृष्ठ में असली नाम और ईमेल पते जैसी व्यक्तिगत जानकारी हो सकती है। कृपया याद रखें कि यह जानकारी गोपनीय है।"
 
 #. Translators: This is the title of the application page shown to users who are a coordinator, and are able to accept or reject the application.
 #: TWLight/applications/templates/applications/application_evaluation.html:39
@@ -303,12 +280,8 @@ msgstr "आवेदन का मूल्यांकन करें"
 
 #. Translators: This text is shown to coordinators on application pages if the applicant has restricted processing of their data.
 #: TWLight/applications/templates/applications/application_evaluation.html:42
-msgid ""
-"This user has requested a restriction on the processing of their data, so "
-"you cannot change the status of their application."
-msgstr ""
-"इस सदस्य ने अपने डेटा के प्रोसेसिंग पर प्रतिबंध का अनुरोध किया है, इसलिए आप उनके आवेदन की "
-"स्थिति नहीं बदल सकते।"
+msgid "This user has requested a restriction on the processing of their data, so you cannot change the status of their application."
+msgstr "इस सदस्य ने अपने डेटा के प्रोसेसिंग पर प्रतिबंध का अनुरोध किया है, इसलिए आप उनके आवेदन की स्थिति नहीं बदल सकते।"
 
 #. Translators: This is the title of the application page shown to users who are not a coordinator.
 #: TWLight/applications/templates/applications/application_evaluation.html:48
@@ -381,11 +354,8 @@ msgstr "अज्ञात"
 
 #. Translators: This is the text displayed to coordinators when an applicant has no country of residence in their profile.
 #: TWLight/applications/templates/applications/application_evaluation.html:123
-msgid ""
-"Please request the applicant add their country of residence to their profile "
-"before proceeding further."
-msgstr ""
-"कृपया आगे बढ़ने से पहले आवेदक से अनुरोध करें कि वे अपने प्रोफ़ाइल पर अपना निवास देश जोड़ें।"
+msgid "Please request the applicant add their country of residence to their profile before proceeding further."
+msgstr "कृपया आगे बढ़ने से पहले आवेदक से अनुरोध करें कि वे अपने प्रोफ़ाइल पर अपना निवास देश जोड़ें।"
 
 #. Translators: This labels the section of an application showing the total number of accounts available for a partner or their collection.
 #: TWLight/applications/templates/applications/application_evaluation.html:134
@@ -396,12 +366,8 @@ msgstr "खातों की उपलब्धता"
 #. Translators: This labels the section of an application showing whether the user had agreed to the terms of use or not.
 #: TWLight/applications/templates/applications/application_evaluation.html:145
 #, python-format
-msgid ""
-"Has agreed to the site's <a class=\"twl-links\" href=\"%(terms_url)s\">terms "
-"of use</a>?"
-msgstr ""
-"साइट के <a class=\"twl-links\" href=\"%(terms_url)s\">उपयोग की शर्तों</a> को "
-"स्वीकार किया है?"
+msgid "Has agreed to the site's <a class=\"twl-links\" href=\"%(terms_url)s\">terms of use</a>?"
+msgstr "साइट के <a class=\"twl-links\" href=\"%(terms_url)s\">उपयोग की शर्तों</a> को स्वीकार किया है?"
 
 #. Translators: Displayed to coordinators when they've agreed to the terms of use.
 #. Translators: Displayed if the user has agreed to the terms of use.
@@ -436,12 +402,8 @@ msgstr "नहीं"
 
 #. Translators: This is the text displayed to coordinators when an applicant has not agreed to the terms of use.
 #: TWLight/applications/templates/applications/application_evaluation.html:159
-msgid ""
-"Please request the applicant agree to the site's terms of use before "
-"approving this application."
-msgstr ""
-"कृपया इस आवेदन को स्वीकार करने से पहले आवेदक से अनुरोध करें कि वे इस साइट के उपयोग की "
-"शर्तों को स्वीकार करें।"
+msgid "Please request the applicant agree to the site's terms of use before approving this application."
+msgstr "कृपया इस आवेदन को स्वीकार करने से पहले आवेदक से अनुरोध करें कि वे इस साइट के उपयोग की शर्तों को स्वीकार करें।"
 
 #. Translators: This labels the section of an application containing the user's motivation for wanting access to this resource.
 #: TWLight/applications/templates/applications/application_evaluation.html:176
@@ -461,8 +423,7 @@ msgstr "मौजूदा अधिकार अनुदान का नव�
 #. Translators: This message is shown next to the 'Renewal of existing access grant?' label if the application is a renewal. Don't translate HTML tags or parent_url.
 #: TWLight/applications/templates/applications/application_evaluation.html:195
 #, python-format
-msgid ""
-"Yes (<a class=\"twl-links\" href=\"%(parent_url)s\">previous application</a>)"
+msgid "Yes (<a class=\"twl-links\" href=\"%(parent_url)s\">previous application</a>)"
 msgstr "हाँ (<a class=\"twl-links\" href=\"%(parent_url)s\">पिछला आवेदन</a>)"
 
 #. Translators: This labels the section of the application showing the length of access remaining on the user's previous authorization.
@@ -497,9 +458,7 @@ msgstr "टिप्पणी जोड़ें"
 
 #. Translators: On an application page, this text tells users that the comments posted on the application are visible to coordinators and the submitting user only.
 #: TWLight/applications/templates/applications/application_evaluation.html:297
-msgid ""
-"Comments are visible to all coordinators and to the editor who submitted "
-"this application."
+msgid "Comments are visible to all coordinators and to the editor who submitted this application."
 msgstr "टिप्पणियाँ सभी समन्वयकों और आवेदन करने वाले संपादक को दिखाई देती हैं।"
 
 #. Translators: This is the title of the section of an application page which lists information about the user who submitted the application.
@@ -712,16 +671,8 @@ msgstr "स्थिति सेट करें"
 
 #: TWLight/applications/templates/applications/apply.html:20
 #, python-format
-msgid ""
-"If your application is successful we may share your email address with "
-"%(partner)s. This is required to set up your access to their resources. By "
-"submitting this form you agree to allow your email address to be shared with "
-"%(partner)s if your application is successful, for the purposes of account "
-"setup."
-msgstr ""
-"अगर आपका आवेदन सफल होता है, हम आपका ईमेल पता %(partner)s से साँझा करेंगे। उन संसाधनों "
-"पर अधिकार पाने के लिए यह ज़रूरी है। इस फ़ॉर्म को प्रस्तुत करके, अगर आवेदन सफल हो तो, खाते "
-"को सेटअप करने के लिए आप अपना ईमेल पता %(partner)s के साथ साँझा करने को तैयार होेंगे।"
+msgid "If your application is successful we may share your email address with %(partner)s. This is required to set up your access to their resources. By submitting this form you agree to allow your email address to be shared with %(partner)s if your application is successful, for the purposes of account setup."
+msgstr "अगर आपका आवेदन सफल होता है, हम आपका ईमेल पता %(partner)s से साँझा करेंगे। उन संसाधनों पर अधिकार पाने के लिए यह ज़रूरी है। इस फ़ॉर्म को प्रस्तुत करके, अगर आवेदन सफल हो तो, खाते को सेटअप करने के लिए आप अपना ईमेल पता %(partner)s के साथ साँझा करने को तैयार होेंगे।"
 
 #. Translators: This message is displayed on the page where users can confirm their renewal. Please do not translate partner.
 #: TWLight/applications/templates/applications/confirm_renewal.html:23
@@ -749,12 +700,8 @@ msgstr "आप किन संसाधनों का उपयोग कर�
 
 #. Translators: This text explains that Library Bundle partners are not shown in this list.
 #: TWLight/applications/templates/applications/request_for_application.html:26
-msgid ""
-"Library Bundle partners are not shown as eligibility is determined "
-"automatically."
-msgstr ""
-"पुस्तकालय बंडल के भागीदारों को नहीं दिखाया जाता है क्योंकि पात्रता का पता अपने आप लगा "
-"लिया जाता है।"
+msgid "Library Bundle partners are not shown as eligibility is determined automatically."
+msgstr "पुस्तकालय बंडल के भागीदारों को नहीं दिखाया जाता है क्योंकि पात्रता का पता अपने आप लगा लिया जाता है।"
 
 #. Translators: On the page where users can apply for multiple partners, this message shows next to the partner name, taking them to the full application page when clicked.
 #: TWLight/applications/templates/applications/request_for_application.html:48
@@ -768,14 +715,8 @@ msgstr "अभी तक कोई भागीदार डेटा नही�
 
 #. Translators: the HTML is so that the word 'waitlisted' will look the same as it does in the page above; please translate 'waitlisted' the same way you did elsewhere in this file.
 #: TWLight/applications/templates/applications/request_for_application.html:74
-msgid ""
-"You can apply to <span class=\"badge badge-warning\">Waitlisted</span> "
-"partners, but they don't have access grants available right now. We will "
-"process those applications when access becomes available."
-msgstr ""
-"आप <span class=\"badge badge-warning\">प्रतीक्षा सूची में</span> मौजूद भागीदारों को "
-"आवेदन कर सकते हैं, मगर उनके पास इस समय अधिकार अनुदान नहीं हैं। जब अधिकार उपलब्ध होगा, "
-"हम उन आवेदनों को प्रोसेस करेंगे।"
+msgid "You can apply to <span class=\"badge badge-warning\">Waitlisted</span> partners, but they don't have access grants available right now. We will process those applications when access becomes available."
+msgstr "आप <span class=\"badge badge-warning\">प्रतीक्षा सूची में</span> मौजूद भागीदारों को आवेदन कर सकते हैं, मगर उनके पास इस समय अधिकार अनुदान नहीं हैं। जब अधिकार उपलब्ध होगा, हम उन आवेदनों को प्रोसेस करेंगे।"
 
 #. Translators: On the page where coordinators can see approved applications which have not had their details sent to the partner, this message shows when there are applications ready to be processed.
 #: TWLight/applications/templates/applications/send.html:10
@@ -796,18 +737,13 @@ msgstr "%(object)s के लिए आवेदन डेटा"
 #. Translators: This message is shown when applications exceed the number of accounts available.
 #: TWLight/applications/templates/applications/send_partner.html:54
 #, python-format
-msgid ""
-"Application(s) for %(object)s, if sent, will exceed the total available "
-"accounts for the partner. Please proceed at your own discretion."
-msgstr ""
-"यदि %(object)s के लिए आवेदन भेजा तो वह भागीदार के कुल उपलब्ध खातों से अधिक हो जायेगा। "
-"कृपया अपने विवेक से आगे बढ़ें।"
+msgid "Application(s) for %(object)s, if sent, will exceed the total available accounts for the partner. Please proceed at your own discretion."
+msgstr "यदि %(object)s के लिए आवेदन भेजा तो वह भागीदार के कुल उपलब्ध खातों से अधिक हो जायेगा। कृपया अपने विवेक से आगे बढ़ें।"
 
 #. Translators: When viewing the list of applications ready to be sent for a particular partner, this is instructions for the coordinator to click the 'mark as sent' button after they have sent the information.
 #: TWLight/applications/templates/applications/send_partner.html:65
 msgid "When you've processed the data below, click the 'mark as sent' button."
-msgstr ""
-"जब आप नीचे दिए गए डेटा को संसाधित कर लेते हैं, तो 'प्रेषित चिन्हित करें' बटन पर क्लिक करें।"
+msgstr "जब आप नीचे दिए गए डेटा को संसाधित कर लेते हैं, तो 'प्रेषित चिन्हित करें' बटन पर क्लिक करें।"
 
 #. Translators: When viewing the list of applications ready to be sent for a particular partner, this is the title of the section containing contact information for the people applications should be sent to.
 #: TWLight/applications/templates/applications/send_partner.html:71
@@ -818,12 +754,8 @@ msgstr[1] "संपर्क"
 
 #. Translators: When viewing the list of applications ready to be sent for a particular partner, this message shows if there is no information about who the applications should be sent to. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/applications/templates/applications/send_partner.html:89
-msgid ""
-"Whoops, we don't have any listed contacts. Please notify Wikipedia Library "
-"administrators."
-msgstr ""
-"ओह, हमारे पास कोई सूचीबद्ध संपर्क नहीं है। कृपया विकिपीडिया पुस्तकालय प्रबंधकों को सूचित "
-"करें।"
+msgid "Whoops, we don't have any listed contacts. Please notify Wikipedia Library administrators."
+msgstr "ओह, हमारे पास कोई सूचीबद्ध संपर्क नहीं है। कृपया विकिपीडिया पुस्तकालय प्रबंधकों को सूचित करें।"
 
 #. Translators: When viewing the list of applications ready to be sent for a particular partner, this is the title of the section containing the information about those applications.
 #: TWLight/applications/templates/applications/send_partner.html:94
@@ -838,9 +770,7 @@ msgstr "प्रेषित चिह्नित करें"
 
 #. Translators: This text guides coordinators in using the code sending interface for approved applications.
 #: TWLight/applications/templates/applications/send_partner.html:152
-msgid ""
-"Use the dropdown menus to denote which editor will receive each code. Access "
-"codes will be sent to users automatically."
+msgid "Use the dropdown menus to denote which editor will receive each code. Access codes will be sent to users automatically."
 msgstr ""
 
 #. Translators: This labels a drop-down selection where staff can assign an access code to a user.
@@ -856,23 +786,14 @@ msgstr "कोई स्वीकृत, अप्रेषित आवेद�
 #. Translators: When a user applies for a set of resources, they receive this message if none are currently available. They are instead placed on a 'waitlist' for later approval.
 #. Translators: When a user renews their resource, they receive this message if none are currently available. They are instead placed on a 'waitlist' for later approval.
 #: TWLight/applications/views.py:140 TWLight/applications/views.py:1282
-msgid ""
-"This partner does not have any access grants available at this time. You may "
-"still apply for access; your application will be reviewed when access grants "
-"become available."
-msgstr ""
-"इस भागीदार के पास इस समय कोई एक्सेस अनुदान उपलब्ध नहीं है। आप अभी भी पहुंच के लिए आवेदन "
-"कर सकते हैं; जब अनुदान उपलब्ध हो जाएगा तो आपके आवेदन की समीक्षा की जाएगी।"
+msgid "This partner does not have any access grants available at this time. You may still apply for access; your application will be reviewed when access grants become available."
+msgstr "इस भागीदार के पास इस समय कोई एक्सेस अनुदान उपलब्ध नहीं है। आप अभी भी पहुंच के लिए आवेदन कर सकते हैं; जब अनुदान उपलब्ध हो जाएगा तो आपके आवेदन की समीक्षा की जाएगी।"
 
 #. Translators: This message is shown to users once they've successfully submitted their application for review.
 #: TWLight/applications/views.py:163
 #, fuzzy, python-brace-format
-msgid ""
-"Your application has been submitted for review. Head over to <a "
-"href='{applications_url}'>My Applications</a> to view the status."
-msgstr ""
-"आपका आवेदन समीक्षा के लिए प्रस्तुत किया गया है। आप इस पृष्ठ पर अपने आवेदनों की स्थिति देख "
-"सकते हैं।"
+msgid "Your application has been submitted for review. Head over to <a href='{applications_url}'>My Applications</a> to view the status."
+msgstr "आपका आवेदन समीक्षा के लिए प्रस्तुत किया गया है। आप इस पृष्ठ पर अपने आवेदनों की स्थिति देख सकते हैं।"
 
 #. Translators: This text is displayed to users when the user has chosen to restrict data and is trying to apply for multiple partners
 #: TWLight/applications/views.py:276
@@ -921,16 +842,12 @@ msgstr "प्रेषित आवेदन"
 
 #. Translators: After a coordinator has changed the status of an application to APPROVED, if the corresponding partner/collection is waitlisted this message appears.
 #: TWLight/applications/views.py:756
-msgid ""
-"Cannot approve application as partner with proxy authorization method is "
-"waitlisted."
+msgid "Cannot approve application as partner with proxy authorization method is waitlisted."
 msgstr ""
 
 #. Translators: After a coordinator has changed the status of an application to APPROVED, if the corresponding partner/collection has no accounts for distribution, this message appears.
 #: TWLight/applications/views.py:780
-msgid ""
-"Cannot approve application as partner with proxy authorization method is "
-"waitlisted and (or) has zero accounts available for distribution."
+msgid "Cannot approve application as partner with proxy authorization method is waitlisted and (or) has zero accounts available for distribution."
 msgstr ""
 
 #. Translators: This message appears on an "access denied" screen that stops users who attempt to authorize an editor to access a resource during a time period for which they are already authorized.
@@ -941,11 +858,7 @@ msgstr ""
 #. Translators: This message is shown to users when they access an application page of a now Bundle partner (new applications aren't allowed for Bundle partners and the status of old applications cannot be modified)
 #: TWLight/applications/views.py:857
 #, python-brace-format
-msgid ""
-"This application cannot be modified since this partner is now part of our <a "
-"href='{bundle}'>bundle access</a>. If you are eligible, you can access this "
-"resource from <a href='{library}'>your library</a>. <a "
-"href='{contact}'>Contact us</a> if you have any questions."
+msgid "This application cannot be modified since this partner is now part of our <a href='{bundle}'>bundle access</a>. If you are eligible, you can access this resource from <a href='{library}'>your library</a>. <a href='{contact}'>Contact us</a> if you have any questions."
 msgstr ""
 
 #. Translators: this lets a reviewer set the status of a single application.
@@ -955,9 +868,7 @@ msgstr "आवेदन की स्थिति निर्धारित �
 
 #. Translators: This warning is message is shown to applicants when the number of pending applications is greater than the number of accounts available.
 #: TWLight/applications/views.py:891
-msgid ""
-"There are more pending applications than available accounts. Your "
-"application might get waitlisted."
+msgid "There are more pending applications than available accounts. Your application might get waitlisted."
 msgstr ""
 
 #. Translators: this message is shown to coordinators who attempt to change an application's Status from INVALID to any other Status.
@@ -978,11 +889,7 @@ msgstr "बैच अद्यतन सफल।"
 
 #. Translators: After a coordinator has changed the status of a number of applications to APPROVED, if the corresponding partner(s) is/are waitlisted or has no accounts for distribution, this message appears.
 #: TWLight/applications/views.py:1051
-msgid ""
-"Cannot approve application(s) {} as partner(s) with proxy authorization "
-"method is/are waitlisted and (or) has/have not enough accounts available. If "
-"not enough accounts are available, prioritise the applications and then "
-"approve applications equal to the accounts available."
+msgid "Cannot approve application(s) {} as partner(s) with proxy authorization method is/are waitlisted and (or) has/have not enough accounts available. If not enough accounts are available, prioritise the applications and then approve applications equal to the accounts available."
 msgstr ""
 
 #. Translators: This message is shown to coordinators who attempt to assign the same access code to multiple users.
@@ -997,9 +904,7 @@ msgstr "सभी चयनित आवेदनों को प्रेष�
 
 #. Translators: When a user tries to renew their resource, they receive this message if the partner is not available.
 #: TWLight/applications/views.py:1272
-msgid ""
-"Cannot renew application at this time as partner is not available. Please "
-"check back later, or contact us for more information."
+msgid "Cannot renew application at this time as partner is not available. Please check back later, or contact us for more information."
 msgstr ""
 
 #. Translators: This message is displayed when an attempt by a user to renew an application has been denied for some reason.
@@ -1010,20 +915,13 @@ msgstr ""
 
 #. Translators: If a user requests the renewal of their account, but it wasn't renewed, this message is shown to them.
 #: TWLight/applications/views.py:1385
-msgid ""
-"This object cannot be renewed. (This probably means that you have already "
-"requested that it be renewed.)"
-msgstr ""
-"इस वस्तु को नवीनीकृत नहीं किया जा सकता है। (इसका संभवतः अर्थ है कि आपने पहले ही इसे "
-"नवीनीकृत करने का अनुरोध किया है।)"
+msgid "This object cannot be renewed. (This probably means that you have already requested that it be renewed.)"
+msgstr "इस वस्तु को नवीनीकृत नहीं किया जा सकता है। (इसका संभवतः अर्थ है कि आपने पहले ही इसे नवीनीकृत करने का अनुरोध किया है।)"
 
 #. Translators: If a user requests the renewal of their account, this message is shown to them.
 #: TWLight/applications/views.py:1395
-msgid ""
-"Your renewal request has been received. A coordinator will review your "
-"request."
-msgstr ""
-"आपका नवीनीकरण अनुरोध प्राप्त हो गया है। एक समन्वयक आपके अनुरोध की समीक्षा करेगा।"
+msgid "Your renewal request has been received. A coordinator will review your request."
+msgstr "आपका नवीनीकरण अनुरोध प्राप्त हो गया है। एक समन्वयक आपके अनुरोध की समीक्षा करेगा।"
 
 #. Translators: This labels a textfield where users can enter their email ID.
 #: TWLight/emails/forms.py:18
@@ -1033,9 +931,7 @@ msgstr "खाता ईमेल"
 
 #. Translators: This is the help text for the email field in the contact us form letting users know the field is updated by value pulled from their respective user profiles.
 #: TWLight/emails/forms.py:21
-msgid ""
-"This field is automatically updated with the email from your <a class='twl-"
-"links' href='{}'>user profile</a>."
+msgid "This field is automatically updated with the email from your <a class='twl-links' href='{}'>user profile</a>."
 msgstr ""
 
 #. Translators: This labels a textfield where users can enter their email message.
@@ -1059,19 +955,13 @@ msgstr "जमा करें"
 #. Translators: This email is sent to users with their access code. Don't translate Jinja variables in curly braces like user or partner. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/access_code_email-body-html.html:5
 #, python-format
-msgid ""
-"<p>Your approved application to %(partner)s has now been finalised. Your "
-"access code or login details can be found below:</p> <p><b>%(access_code)s</"
-"b></p> <p>%(user_instructions)s</p>"
+msgid "<p>Your approved application to %(partner)s has now been finalised. Your access code or login details can be found below:</p> <p><b>%(access_code)s</b></p> <p>%(user_instructions)s</p>"
 msgstr ""
 
 #. Translators: This email is sent to users with their access code. Don't translate Jinja variables in curly braces like user or partner. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/access_code_email-body-text.html:3
 #, python-format
-msgid ""
-"Your approved application to %(partner)s has now been finalised. Your access "
-"code or login details can be found below: %(access_code)s "
-"%(user_instructions)s"
+msgid "Your approved application to %(partner)s has now been finalised. Your access code or login details can be found below: %(access_code)s %(user_instructions)s"
 msgstr ""
 
 #. Translators: This is the subject line of an email sent to users with their access code.
@@ -1083,32 +973,14 @@ msgstr "विकिपीडिया पुस्तकालय दल"
 #. Translators: This email is sent to users when their application is approved. Don't translate Jinja variables in curly braces like user or partner; don't translate html tags either. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/approval_notification-body-html.html:5
 #, fuzzy, python-format
-msgid ""
-"<p>Dear %(user)s,</p> <p>Thank you for applying for access to %(partner)s "
-"resources through The Wikipedia Library. We are happy to inform you that "
-"your application has been approved.</p> <p>%(user_instructions)s</p> <p>You "
-"can view the collections you're authorized to access at My Library: "
-"%(link)s</p> <p>Cheers!</p> <p>The Wikipedia Library</p>"
-msgstr ""
-"<p>प्रिय %(user)s, </p> <p>विकिपीडिया पुस्तकालय के माध्यम से %(partner)s संसाधनों तक "
-"पहुँच के लिए आवेदन करने के लिए धन्यवाद। हमें आपको यह बताते हुए खुशी हो रही है कि आपका "
-"आवेदन स्वीकृत हो गया है। संसाधित होने के बाद आप एक या दो सप्ताह के भीतर पहुँच विवरण "
-"प्राप्त कर सकते हैं। </p> <p>शुभकामनाएँ! </p> <p> विकिपीडिया पुस्तकालय</p>"
+msgid "<p>Dear %(user)s,</p> <p>Thank you for applying for access to %(partner)s resources through The Wikipedia Library. We are happy to inform you that your application has been approved.</p> <p>%(user_instructions)s</p> <p>You can view the collections you're authorized to access at My Library: %(link)s</p> <p>Cheers!</p> <p>The Wikipedia Library</p>"
+msgstr "<p>प्रिय %(user)s, </p> <p>विकिपीडिया पुस्तकालय के माध्यम से %(partner)s संसाधनों तक पहुँच के लिए आवेदन करने के लिए धन्यवाद। हमें आपको यह बताते हुए खुशी हो रही है कि आपका आवेदन स्वीकृत हो गया है। संसाधित होने के बाद आप एक या दो सप्ताह के भीतर पहुँच विवरण प्राप्त कर सकते हैं। </p> <p>शुभकामनाएँ! </p> <p> विकिपीडिया पुस्तकालय</p>"
 
 #. Translators: This email is sent to users when their application is approved. Don't translate Jinja variables in curly braces like user or partner. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/approval_notification-body-text.html:3
 #, fuzzy, python-format
-msgid ""
-"Dear %(user)s, Thank you for applying for access to %(partner)s resources "
-"through The Wikipedia Library. We are happy to inform you that your "
-"application has been approved. %(user_instructions)s You can view the "
-"collections you're authorized to access at My Library: %(link)s Cheers! The "
-"Wikipedia Library"
-msgstr ""
-"प्रिय %(user)s, विकिपीडिया पुस्तकालय के माध्यम से %(partner)s संसाधनों तक पहुँच के लिए "
-"आवेदन करने के लिए धन्यवाद। हमें आपको यह बताते हुए खुशी हो रही है कि आपका आवेदन स्वीकृत हो "
-"गया है। संसाधित होने के बाद आप एक या दो सप्ताह के भीतर पहुँच विवरण प्राप्त कर सकते हैं। "
-"शुभकामनाएँ! विकिपीडिया पुस्तकालय"
+msgid "Dear %(user)s, Thank you for applying for access to %(partner)s resources through The Wikipedia Library. We are happy to inform you that your application has been approved. %(user_instructions)s You can view the collections you're authorized to access at My Library: %(link)s Cheers! The Wikipedia Library"
+msgstr "प्रिय %(user)s, विकिपीडिया पुस्तकालय के माध्यम से %(partner)s संसाधनों तक पहुँच के लिए आवेदन करने के लिए धन्यवाद। हमें आपको यह बताते हुए खुशी हो रही है कि आपका आवेदन स्वीकृत हो गया है। संसाधित होने के बाद आप एक या दो सप्ताह के भीतर पहुँच विवरण प्राप्त कर सकते हैं। शुभकामनाएँ! विकिपीडिया पुस्तकालय"
 
 #. Translators: This is the subject of an email which is sent to users when their application has been approved. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/approval_notification-subject.html:4
@@ -1118,19 +990,13 @@ msgstr "आपका विकिपीडिया पुस्तकालय 
 #. Translators: This email is sent to coordinators when a comment is left on an application they are processing. Don't translate Jinja variables in curly braces like user or partner. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/comment_notification_coordinator-body-html.html:5
 #, python-format
-msgid ""
-"<p style=\"color: #500050\">%(submit_date)s - %(commenter)s</p> "
-"<blockquote><p>%(comment)s</p></blockquote> <p>Please reply to these at: <a "
-"href=\"%(app_url)s\">%(app_url)s</a></p> <p>Best,</p> <p>The Wikipedia "
-"Library</p>"
+msgid "<p style=\"color: #500050\">%(submit_date)s - %(commenter)s</p> <blockquote><p>%(comment)s</p></blockquote> <p>Please reply to these at: <a href=\"%(app_url)s\">%(app_url)s</a></p> <p>Best,</p> <p>The Wikipedia Library</p>"
 msgstr ""
 
 #. Translators: This email is sent to coordinators when a comment is left on an application they are processing. Don't translate Jinja variables in curly braces like user or partner. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/comment_notification_coordinator-body-text.html:3
 #, python-format
-msgid ""
-"%(submit_date)s - %(commenter)s %(comment)s Please reply to this at: "
-"%(app_url)s Best, The Wikipedia Library"
+msgid "%(submit_date)s - %(commenter)s %(comment)s Please reply to this at: %(app_url)s Best, The Wikipedia Library"
 msgstr ""
 
 #. Translators: This is the subject line of an email sent to coordinators when a comment is left on an application they processed.
@@ -1141,23 +1007,13 @@ msgstr "आपके द्वारा संसाधित किये ग�
 #. Translators: This email is sent to users when they receive a comment on their application. Don't translate Jinja variables in curly braces like user or partner; don't translate html tags either. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/comment_notification_editors-body-html.html:5
 #, fuzzy, python-format
-msgid ""
-"<p style=\"color: #500050\">%(submit_date)s - %(commenter)s</p> "
-"<blockquote><p>%(comment)s</p></blockquote> <p>Please reply to these at <a "
-"href=\"%(app_url)s\">%(app_url)s</a> so we can evaluate your application.</"
-"p> <p>Best,</p> <p>The Wikipedia Library</p>"
-msgstr ""
-"<p>प्रिय %(user)s,</p> <p> विकिपीडिया पुस्तकालय के माध्यम से %(partner)s संसाधनों तक "
-"पहुँच के लिए आवेदन करने के लिए धन्यवाद। आपके आवेदन पर एक या एक से अधिक टिप्पणियाँ हैं, जिन "
-"पर आपसे प्रतिक्रिया की आवश्यकता है। कृपया इन पर यहाँ उत्तर दें %(app_url)s ताकि हम आपके "
-"आवेदन का मूल्यांकन कर सकें।</p> <p>शुभकामनाएँ,</p> <p>विकिपीडिया पुस्तकालय</p>"
+msgid "<p style=\"color: #500050\">%(submit_date)s - %(commenter)s</p> <blockquote><p>%(comment)s</p></blockquote> <p>Please reply to these at <a href=\"%(app_url)s\">%(app_url)s</a> so we can evaluate your application.</p> <p>Best,</p> <p>The Wikipedia Library</p>"
+msgstr "<p>प्रिय %(user)s,</p> <p> विकिपीडिया पुस्तकालय के माध्यम से %(partner)s संसाधनों तक पहुँच के लिए आवेदन करने के लिए धन्यवाद। आपके आवेदन पर एक या एक से अधिक टिप्पणियाँ हैं, जिन पर आपसे प्रतिक्रिया की आवश्यकता है। कृपया इन पर यहाँ उत्तर दें %(app_url)s ताकि हम आपके आवेदन का मूल्यांकन कर सकें।</p> <p>शुभकामनाएँ,</p> <p>विकिपीडिया पुस्तकालय</p>"
 
 #. Translators: This email is sent to users when they receive a comment on their application. Don't translate Jinja variables in curly braces like user or partner. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/comment_notification_editors-body-text.html:3
 #, python-format
-msgid ""
-"%(submit_date)s - %(commenter)s %(comment)s Please reply to these at: "
-"%(app_url)s so we can evaluate your application. Best, The Wikipedia Library"
+msgid "%(submit_date)s - %(commenter)s %(comment)s Please reply to these at: %(app_url)s so we can evaluate your application. Best, The Wikipedia Library"
 msgstr ""
 
 #. Translators: This is the subject line of an email sent to users who have a comment added to one of their applications. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
@@ -1168,26 +1024,14 @@ msgstr "आपके विकिपीडिया पुस्तकालय 
 #. Translators: This email is sent to users when an application they commented on receives another comment. Don't translate Jinja variables in curly braces like app_url; don't translate html tags either. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/comment_notification_others-body-html.html:5
 #, fuzzy, python-format
-msgid ""
-"<p style=\"color: #500050\">%(submit_date)s - %(commenter)s</p> "
-"<blockquote><p>%(comment)s</p></blockquote> See it at <a href=\"%(app_url)s"
-"\">%(app_url)s</a>. Thanks for helping review Wikipedia Library applications!"
-msgstr ""
-"विकिपीडिया पुस्तकालय आवेदन, जिस पर आपने भी टिप्पणी की है, पर एक नई टिप्पणी है। यह "
-"आपके द्वारा पूछे गए प्रश्न का उत्तर प्रदान कर सकता है। इसे <a href=\"%(app_url)s\">"
-"%(app_url)s</a> पर देखें। विकिपीडिया पुस्तकालय आवेदनों की समीक्षा में सहायता करने के लिए "
-"धन्यवाद!"
+msgid "<p style=\"color: #500050\">%(submit_date)s - %(commenter)s</p> <blockquote><p>%(comment)s</p></blockquote> See it at <a href=\"%(app_url)s\">%(app_url)s</a>. Thanks for helping review Wikipedia Library applications!"
+msgstr "विकिपीडिया पुस्तकालय आवेदन, जिस पर आपने भी टिप्पणी की है, पर एक नई टिप्पणी है। यह आपके द्वारा पूछे गए प्रश्न का उत्तर प्रदान कर सकता है। इसे <a href=\"%(app_url)s\">%(app_url)s</a> पर देखें। विकिपीडिया पुस्तकालय आवेदनों की समीक्षा में सहायता करने के लिए धन्यवाद!"
 
 #. Translators: This email is sent to users when an application they commented on receives another comment. Don't translate Jinja variables in curly braces like app_url. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/comment_notification_others-body-text.html:3
 #, fuzzy, python-format
-msgid ""
-"%(submit_date)s - %(commenter)s %(comment)s See it at: %(app_url)s Thanks "
-"for helping review Wikipedia Library applications!"
-msgstr ""
-"विकिपीडिया पुस्तकालय आवेदन, जिस पर आपने भी टिप्पणी की है, पर एक नई टिप्पणी है। यह "
-"आपके द्वारा पूछे गए प्रश्न का उत्तर प्रदान कर सकता है। इसे %(app_url)s पर देखें। "
-"विकिपीडिया पुस्तकालय आवेदनों की समीक्षा में सहायता करने के लिए धन्यवाद!"
+msgid "%(submit_date)s - %(commenter)s %(comment)s See it at: %(app_url)s Thanks for helping review Wikipedia Library applications!"
+msgstr "विकिपीडिया पुस्तकालय आवेदन, जिस पर आपने भी टिप्पणी की है, पर एक नई टिप्पणी है। यह आपके द्वारा पूछे गए प्रश्न का उत्तर प्रदान कर सकता है। इसे %(app_url)s पर देखें। विकिपीडिया पुस्तकालय आवेदनों की समीक्षा में सहायता करने के लिए धन्यवाद!"
 
 #. Translators: This is the subject line of an email sent to users who have a comment added to an application they also commented on. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/comment_notification_others-subject.html:4
@@ -1197,10 +1041,7 @@ msgstr "आपके द्वारा टिप्पणी किये ग�
 #. Translators: This text is part of a scheduled reminder email sent to coordinators who have applications requiring action. Don't translate Jinja variables in curly braces like total_apps, or user.
 #: TWLight/emails/templates/emails/coordinator_reminder_notification-body-html.html:5
 #, python-format
-msgid ""
-"<p>Dear %(user)s,</p> <p>Our records indicate that you are the designated "
-"coordinator for partners that have a total of %(total_apps)s applications.</"
-"p>"
+msgid "<p>Dear %(user)s,</p> <p>Our records indicate that you are the designated coordinator for partners that have a total of %(total_apps)s applications.</p>"
 msgstr ""
 
 #. Translators: Breakdown as in 'cost breakdown'; analysis.
@@ -1239,43 +1080,20 @@ msgstr[1] "स्वीकृत आवेदनों की संख्या
 #. Translators: This text is part of a scheduled reminder email sent to coordinators who have applications requiring action. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library). Don't translate Jinja variables in curly braces like link; don't translate email addresses or html tags either.
 #: TWLight/emails/templates/emails/coordinator_reminder_notification-body-html.html:39
 #, fuzzy, python-format
-msgid ""
-"<p>This is a gentle reminder that you may review applications at <a href="
-"\"%(link)s\">%(link)s</a>.</p> <p>You can customise your reminders under "
-"'preferences' in your user profile.</p> <p>If you received this message in "
-"error, drop us a line at wikipedialibrary@wikimedia.org.</p> <p>Thanks for "
-"helping review Wikipedia Library applications!</p>"
-msgstr ""
-"<p>प्रिय %(user)s,</p> <p>हमारे रिकॉर्ड बताते हैं कि आप ऐसे भागीदारों के लिए नामित "
-"समन्वयक हैं जिनके पास %(app_status)s की स्थिति वाले %(app_count)s आवेदन हैं। यह एक "
-"सौम्य अनुस्मारक है कि आप यहाँ दिए गए आवेदनों की समीक्षा कर सकते हैं:<a href=\"%(link)s"
-"\">%(link)s</a>।</p> <p>यदि आपको यह संदेश त्रुटी में मिला है, तो हमें यहाँ एक पंक्ति "
-"छोड़ें: wikipedialibrary@wikimedia.org।</p> <p> विकिपीडिया पुस्तकालय आवेदनों की "
-"समीक्षा में सहायता करने के लिए धन्यवाद!</p>"
+msgid "<p>This is a gentle reminder that you may review applications at <a href=\"%(link)s\">%(link)s</a>.</p> <p>You can customise your reminders under 'preferences' in your user profile.</p> <p>If you received this message in error, drop us a line at wikipedialibrary@wikimedia.org.</p> <p>Thanks for helping review Wikipedia Library applications!</p>"
+msgstr "<p>प्रिय %(user)s,</p> <p>हमारे रिकॉर्ड बताते हैं कि आप ऐसे भागीदारों के लिए नामित समन्वयक हैं जिनके पास %(app_status)s की स्थिति वाले %(app_count)s आवेदन हैं। यह एक सौम्य अनुस्मारक है कि आप यहाँ दिए गए आवेदनों की समीक्षा कर सकते हैं:<a href=\"%(link)s\">%(link)s</a>।</p> <p>यदि आपको यह संदेश त्रुटी में मिला है, तो हमें यहाँ एक पंक्ति छोड़ें: wikipedialibrary@wikimedia.org।</p> <p> विकिपीडिया पुस्तकालय आवेदनों की समीक्षा में सहायता करने के लिए धन्यवाद!</p>"
 
 #. Translators: This text is part of a scheduled reminder email sent to coordinators who have applications requiring action. Don't translate Jinja variables in curly braces like total_apps, or user.
 #: TWLight/emails/templates/emails/coordinator_reminder_notification-body-text.html:3
 #, python-format
-msgid ""
-"Dear %(user)s, Our records indicate that you are the designated coordinator "
-"for partners that have a total of %(total_apps)s applications."
+msgid "Dear %(user)s, Our records indicate that you are the designated coordinator for partners that have a total of %(total_apps)s applications."
 msgstr ""
 
 #. Translators: This text is part of a scheduled reminder email sent to coordinators who have applications requiring action. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library). Don't translate Jinja variables in curly braces like link; don't translate the email address either.
 #: TWLight/emails/templates/emails/coordinator_reminder_notification-body-text.html:38
 #, fuzzy, python-format
-msgid ""
-"This is a gentle reminder that you may review applications at: %(link)s. You "
-"can customise your reminders under 'preferences' in your user profile. If "
-"you received this message in error, drop us a line at: "
-"wikipedialibrary@wikimedia.org Thanks for helping review Wikipedia Library "
-"applications!"
-msgstr ""
-"प्रिय %(user)s, हमारे रिकॉर्ड बताते हैं कि आप ऐसे भागीदारों के लिए नामित समन्वयक हैं "
-"जिनके पास %(app_status)s की स्थिति वाले %(app_count)s आवेदन हैं। यह एक सौम्य "
-"अनुस्मारक है कि आप यहाँ दिए गए आवेदनों की समीक्षा कर सकते हैं:%(link)s। यदि आपको यह "
-"संदेश त्रुटी में मिला है, तो हमें यहाँ एक पंक्ति छोड़ें: wikipedialibrary@wikimedia.org। "
-"विकिपीडिया पुस्तकालय आवेदनों की समीक्षा में सहायता करने के लिए धन्यवाद!"
+msgid "This is a gentle reminder that you may review applications at: %(link)s. You can customise your reminders under 'preferences' in your user profile. If you received this message in error, drop us a line at: wikipedialibrary@wikimedia.org Thanks for helping review Wikipedia Library applications!"
+msgstr "प्रिय %(user)s, हमारे रिकॉर्ड बताते हैं कि आप ऐसे भागीदारों के लिए नामित समन्वयक हैं जिनके पास %(app_status)s की स्थिति वाले %(app_count)s आवेदन हैं। यह एक सौम्य अनुस्मारक है कि आप यहाँ दिए गए आवेदनों की समीक्षा कर सकते हैं:%(link)s। यदि आपको यह संदेश त्रुटी में मिला है, तो हमें यहाँ एक पंक्ति छोड़ें: wikipedialibrary@wikimedia.org। विकिपीडिया पुस्तकालय आवेदनों की समीक्षा में सहायता करने के लिए धन्यवाद!"
 
 #. Translators: This is the subject line of a scheduled reminder email sent to coordinators who have applications to review. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library). Do not translate items in curly braces.
 #: TWLight/emails/templates/emails/coordinator_reminder_notification-subject.html:4
@@ -1285,30 +1103,14 @@ msgstr "विकिपीडिया पुस्तकालय आवेद�
 #. Translators: This email is sent to users when their application is rejected. Don't translate Jinja variables in curly braces like user or partner; don't translate html tags either. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/rejection_notification-body-html.html:5
 #, python-format
-msgid ""
-"<p>Dear %(user)s,</p> <p>Thank you for applying for access to %(partner)s "
-"resources through The Wikipedia Library. Unfortunately at this time your "
-"application has not been approved. You can view your application and review "
-"comments at <a href=\"%(app_url)s\">%(app_url)s</a>.</p> <p>Best,</p> <p>The "
-"Wikipedia Library</p>"
-msgstr ""
-"<p>प्रिय %(user)s,</p> <p>विकिपीडिया पुस्तकालय के माध्यम से %(partner)s संसाधनों तक "
-"पहुँच के लिए आवेदन करने के लिए धन्यवाद। दुर्भाग्य से इस समय आपका आवेदन स्वीकृत नहीं हुआ है। "
-"आप अपने आवेदन और समीक्षा टिप्पणियों पर देख सकते हैं:<a href=\"%(app_url)s\">"
-"%(app_url)s</a>।</p> <p>शुभकामनाएँ!</p> <p>विकिपीडिया पुस्तकालय</p>"
+msgid "<p>Dear %(user)s,</p> <p>Thank you for applying for access to %(partner)s resources through The Wikipedia Library. Unfortunately at this time your application has not been approved. You can view your application and review comments at <a href=\"%(app_url)s\">%(app_url)s</a>.</p> <p>Best,</p> <p>The Wikipedia Library</p>"
+msgstr "<p>प्रिय %(user)s,</p> <p>विकिपीडिया पुस्तकालय के माध्यम से %(partner)s संसाधनों तक पहुँच के लिए आवेदन करने के लिए धन्यवाद। दुर्भाग्य से इस समय आपका आवेदन स्वीकृत नहीं हुआ है। आप अपने आवेदन और समीक्षा टिप्पणियों पर देख सकते हैं:<a href=\"%(app_url)s\">%(app_url)s</a>।</p> <p>शुभकामनाएँ!</p> <p>विकिपीडिया पुस्तकालय</p>"
 
 #. Translators: This email is sent to users when their application is rejected. Don't translate Jinja variables in curly braces like user or partner. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/rejection_notification-body-text.html:3
 #, python-format
-msgid ""
-"Dear %(user)s, Thank you for applying for access to %(partner)s resources "
-"through The Wikipedia Library. Unfortunately at this time your application "
-"has not been approved. You can view your application and review comments at: "
-"%(app_url)s Best, The Wikipedia Library"
-msgstr ""
-"प्रिय %(user)s, विकिपीडिया पुस्तकालय के माध्यम से %(partner)s संसाधनों तक पहुँच के लिए "
-"आवेदन करने के लिए धन्यवाद। दुर्भाग्य से इस समय आपका आवेदन स्वीकृत नहीं हुआ है। आप अपने आवेदन "
-"और समीक्षा टिप्पणियाँ यहाँ पर देख सकते हैं:%(app_url)s। शुभकामनाएँ! विकिपीडिया पुस्तकालय"
+msgid "Dear %(user)s, Thank you for applying for access to %(partner)s resources through The Wikipedia Library. Unfortunately at this time your application has not been approved. You can view your application and review comments at: %(app_url)s Best, The Wikipedia Library"
+msgstr "प्रिय %(user)s, विकिपीडिया पुस्तकालय के माध्यम से %(partner)s संसाधनों तक पहुँच के लिए आवेदन करने के लिए धन्यवाद। दुर्भाग्य से इस समय आपका आवेदन स्वीकृत नहीं हुआ है। आप अपने आवेदन और समीक्षा टिप्पणियाँ यहाँ पर देख सकते हैं:%(app_url)s। शुभकामनाएँ! विकिपीडिया पुस्तकालय"
 
 #. Translators: This is the subject of an email which is sent to users when their application has been rejected. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/rejection_notification-subject.html:4
@@ -1319,25 +1121,13 @@ msgstr "आपका विकिपीडिया पुस्तकालय 
 #. Translators: This email is sent to users when they have an account that is soon to expire. Don't translate Jinja variables in curly braces like partner_name or partner_link; don't translate html tags either. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/user_renewal_notice-body-html.html:5
 #, python-format
-msgid ""
-"<p>Dear %(user)s,</p> <p>According to our records, your access to "
-"%(partner_name)s will soon expire and you may lose access. If you want to "
-"continue making use of your free account, you can request renewal of your "
-"account by clicking the 'Renew' or 'Extend' button at %(partner_link)s.</p> "
-"<p>Best,</p> <p>The Wikipedia Library</p> <p>You can disable these emails in "
-"your user page preferences: https://wikipedialibrary.wmflabs.org/users/</p>"
+msgid "<p>Dear %(user)s,</p> <p>According to our records, your access to %(partner_name)s will soon expire and you may lose access. If you want to continue making use of your free account, you can request renewal of your account by clicking the 'Renew' or 'Extend' button at %(partner_link)s.</p> <p>Best,</p> <p>The Wikipedia Library</p> <p>You can disable these emails in your user page preferences: https://wikipedialibrary.wmflabs.org/users/</p>"
 msgstr ""
 
 #. Translators: This email is sent to users when they have an account that is soon to expire. Don't translate Jinja variables in curly braces like partner_name or partner_link; don't translate html tags either. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/user_renewal_notice-body-text.html:3
 #, python-format
-msgid ""
-"Dear %(user)s, According to our records, your access to %(partner_name)s "
-"will soon expire and you may lose access. If you want to continue making use "
-"of your free account, you can request renewal of your account by clicking "
-"the Renew button at %(partner_link)s. Best, The Wikipedia Library You can "
-"disable these emails in your user page preferences: https://wikipedialibrary."
-"wmflabs.org/users/"
+msgid "Dear %(user)s, According to our records, your access to %(partner_name)s will soon expire and you may lose access. If you want to continue making use of your free account, you can request renewal of your account by clicking the Renew button at %(partner_link)s. Best, The Wikipedia Library You can disable these emails in your user page preferences: https://wikipedialibrary.wmflabs.org/users/"
 msgstr ""
 
 #. Translators: This is the subject of an email sent to users when they have an account that is soon to expire. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
@@ -1349,35 +1139,14 @@ msgstr "विकिपीडिया पुस्तकालय दल"
 #. Translators: This email is sent to users when their application is waitlisted because there are no more accounts available. Don't translate Jinja variables in curly braces like user or partner; don't translate html tags either. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/waitlist_notification-body-html.html:5
 #, python-format
-msgid ""
-"<p>Dear %(user)s,</p> <p>Thank you for applying for access to %(partner)s "
-"resources through The Wikipedia Library. There are no accounts currently "
-"available so your application has been waitlisted. Your application will be "
-"evaluated if/when more accounts become available. You can see all available "
-"resources at <a href=\"%(link)s\">%(link)s</a>.</p> <p>Best,</p> <p>The "
-"Wikipedia Library</p>"
-msgstr ""
-"<p>प्रिय %(user)s,</p> <p>विकिपीडिया पुस्तकालय के माध्यम से %(partner)s संसाधनों तक "
-"पहुँच के लिए आवेदन करने के लिए धन्यवाद। वर्तमान में कोई खाते उपलब्ध नहीं हैं इसलिए आपके आवेदन "
-"को प्रतीक्षा सूची में डाल दिया गया है। आपके आवेदन का मूल्यांकन तब किया जाएगा अगर/जब "
-"अधिक खाते उपलब्ध हो जाएंगे। आप सभी उपलब्ध संसाधनों को <a href=\"%(link)s\">"
-"%(link)s</a> पर देख सकते हैं।</p> <p>शुभकामनाएँ,</p> <p>विकिपीडिया पुस्तकालय</p>"
+msgid "<p>Dear %(user)s,</p> <p>Thank you for applying for access to %(partner)s resources through The Wikipedia Library. There are no accounts currently available so your application has been waitlisted. Your application will be evaluated if/when more accounts become available. You can see all available resources at <a href=\"%(link)s\">%(link)s</a>.</p> <p>Best,</p> <p>The Wikipedia Library</p>"
+msgstr "<p>प्रिय %(user)s,</p> <p>विकिपीडिया पुस्तकालय के माध्यम से %(partner)s संसाधनों तक पहुँच के लिए आवेदन करने के लिए धन्यवाद। वर्तमान में कोई खाते उपलब्ध नहीं हैं इसलिए आपके आवेदन को प्रतीक्षा सूची में डाल दिया गया है। आपके आवेदन का मूल्यांकन तब किया जाएगा अगर/जब अधिक खाते उपलब्ध हो जाएंगे। आप सभी उपलब्ध संसाधनों को <a href=\"%(link)s\">%(link)s</a> पर देख सकते हैं।</p> <p>शुभकामनाएँ,</p> <p>विकिपीडिया पुस्तकालय</p>"
 
 #. Translators: This email is sent to users when their application is waitlisted because there are no more accounts available. Don't translate Jinja variables in curly braces like user or partner. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/waitlist_notification-body-text.html:3
 #, python-format
-msgid ""
-"Dear %(user)s, Thank you for applying for access to %(partner)s resources "
-"through The Wikipedia Library. There are no accounts currently available so "
-"your application has been waitlisted. Your application will be evaluated if/"
-"when more accounts become available. You can see all available resources at: "
-"%(link)s Best, The Wikipedia Library"
-msgstr ""
-"प्रिय %(user)s, विकिपीडिया पुस्तकालय के माध्यम से %(partner)s संसाधनों तक पहुँच के लिए "
-"आवेदन करने के लिए धन्यवाद। वर्तमान में कोई खाते उपलब्ध नहीं हैं इसलिए आपके आवेदन को "
-"प्रतीक्षा सूची में डाल दिया गया है। आपके आवेदन का मूल्यांकन तब किया जाएगा अगर/जब अधिक "
-"खाते उपलब्ध हो जाएंगे। आप सभी उपलब्ध संसाधनों को %(link)s पर देख सकते हैं। शुभकामनाएँ, "
-"विकिपीडिया पुस्तकालय"
+msgid "Dear %(user)s, Thank you for applying for access to %(partner)s resources through The Wikipedia Library. There are no accounts currently available so your application has been waitlisted. Your application will be evaluated if/when more accounts become available. You can see all available resources at: %(link)s Best, The Wikipedia Library"
+msgstr "प्रिय %(user)s, विकिपीडिया पुस्तकालय के माध्यम से %(partner)s संसाधनों तक पहुँच के लिए आवेदन करने के लिए धन्यवाद। वर्तमान में कोई खाते उपलब्ध नहीं हैं इसलिए आपके आवेदन को प्रतीक्षा सूची में डाल दिया गया है। आपके आवेदन का मूल्यांकन तब किया जाएगा अगर/जब अधिक खाते उपलब्ध हो जाएंगे। आप सभी उपलब्ध संसाधनों को %(link)s पर देख सकते हैं। शुभकामनाएँ, विकिपीडिया पुस्तकालय"
 
 #. Translators: This is the subject of an email sent to users when their application is waitlisted because there are no more accounts available. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/waitlist_notification-subject.html:4
@@ -1543,17 +1312,14 @@ msgstr "उपलब्ध नहीं है"
 #: TWLight/resources/templates/resources/filter_section.html:14
 #: TWLight/templates/about.html:12
 #: TWLight/users/templates/users/filter_section.html:13
-msgid ""
-"The Wikipedia Library allows active editors to access a wide range of "
-"collections of paywalled reliable sources for free!"
+msgid "The Wikipedia Library allows active editors to access a wide range of collections of paywalled reliable sources for free!"
 msgstr ""
 
 #. Translators: On the Browse Partners page (https://wikipedialibrary.wmflabs.org/partners/), this introduces users to The Wikipedia Library.
 #. Translators: On the MyLibrary page (https://wikipedialibrary.wmflabs.org/users/my_library), this introduces users to The Wikipedia Library.
 #: TWLight/resources/templates/resources/filter_section.html:17
 #: TWLight/users/templates/users/filter_section.html:15
-msgid ""
-"Start with the search bar at the top or browse publisher websites directly."
+msgid "Start with the search bar at the top or browse publisher websites directly."
 msgstr ""
 
 #. Translators: On the Browse Partners page (https://wikipedialibrary.wmflabs.org/partners/), this appears below introductory text and links to the 'About' page (https://wikipedialibrary.wmflabs.org/about/)
@@ -1634,57 +1400,38 @@ msgstr "भागीदार को भेजी गई"
 #. Translators: If we have no available accounts for a partner, the coordinator can change the application system to a waiting list.
 #: TWLight/resources/templates/resources/partner_detail.html:36
 #: TWLight/resources/templates/resources/partner_detail_apply.html:17
-msgid ""
-"There are no access grants available for this partner at this time. You can "
-"still apply for access; applications will be processed when access is "
-"available."
-msgstr ""
-"इस समय इस भागीदार के लिए कोई पहुँच अनुदान उपलब्ध नहीं हैं। आप अभी भी पहुंच के लिए आवेदन "
-"कर सकते हैं; पहुँच उपलब्ध होने पर आवेदनों पर कार्रवाई की जाएगी।"
+msgid "There are no access grants available for this partner at this time. You can still apply for access; applications will be processed when access is available."
+msgstr "इस समय इस भागीदार के लिए कोई पहुँच अनुदान उपलब्ध नहीं हैं। आप अभी भी पहुंच के लिए आवेदन कर सकते हैं; पहुँच उपलब्ध होने पर आवेदनों पर कार्रवाई की जाएगी।"
 
 #. Translators: This text links to the minimum user requirements and terms of use on the partner page.
 #: TWLight/resources/templates/resources/partner_detail.html:48
 #: TWLight/resources/templates/resources/partner_detail_apply.html:29
 #, python-format
-msgid ""
-"Before applying, please review the <strong><a class=\"twl-links\" href="
-"\"%(about)s#req\">minimum requirements</a></strong> for access and our "
-"<strong><a class=\"twl-links\" href=\"%(terms)s\">terms of use</a></strong>."
-msgstr ""
-"आवेदन करने से पहले, कृपया पहुँच के लिए <strong><a class=\"twl-links\" href="
-"\"%(about)s#req\"> न्यूनतम आवश्यकताओं </a></strong>  और हमारी <strong><a class="
-"\"twl-links\" href=\"%(terms)s\">उपयोग की शर्तों</a> </strong> की समीक्षा करें ।"
+msgid "Before applying, please review the <strong><a class=\"twl-links\" href=\"%(about)s#req\">minimum requirements</a></strong> for access and our <strong><a class=\"twl-links\" href=\"%(terms)s\">terms of use</a></strong>."
+msgstr "आवेदन करने से पहले, कृपया पहुँच के लिए <strong><a class=\"twl-links\" href=\"%(about)s#req\"> न्यूनतम आवश्यकताओं </a></strong>  और हमारी <strong><a class=\"twl-links\" href=\"%(terms)s\">उपयोग की शर्तों</a> </strong> की समीक्षा करें ।"
 
 #. Translators: This text refers to the page containing the content a user is authorized to access.
 #: TWLight/resources/templates/resources/partner_detail.html:69
 #, python-format
-msgid ""
-"View the status of your access in <strong><a class=\"twl-links\" href="
-"\"%(library_url)s\">My Library</a></strong> page."
+msgid "View the status of your access in <strong><a class=\"twl-links\" href=\"%(library_url)s\">My Library</a></strong> page."
 msgstr ""
 
 #. Translators: This message is shown when a user has open applications, linking to their respective applications page.
 #: TWLight/resources/templates/resources/partner_detail.html:78
 #, python-format
-msgid ""
-"View the status of your application(s) on your <strong><a class=\"twl-links"
-"\" href=\"%(applications_url)s\">My Applications</a></strong> page."
+msgid "View the status of your application(s) on your <strong><a class=\"twl-links\" href=\"%(applications_url)s\">My Applications</a></strong> page."
 msgstr ""
 
 #. Translators: This message is shown when a user has authorizations, linking to their respective collections page.
 #: TWLight/resources/templates/resources/partner_detail_apply.html:50
 #, python-format
-msgid ""
-"View the status of your access on your <strong><a href=\"%(library_url)s\" "
-"class=\"twl-links\">My Library</a></strong> page."
+msgid "View the status of your access on your <strong><a href=\"%(library_url)s\" class=\"twl-links\">My Library</a></strong> page."
 msgstr ""
 
 #. Translators: This message is shown when a user has open applications, linking to their respective applications page.
 #: TWLight/resources/templates/resources/partner_detail_apply.html:60
 #, python-format
-msgid ""
-"View the status of your application(s) on your <strong><a href="
-"\"%(applications_url)s\">My Applications</a></strong> page."
+msgid "View the status of your application(s) on your <strong><a href=\"%(applications_url)s\">My Applications</a></strong> page."
 msgstr ""
 
 #. Translators: One the partner detail page, this text labels the button which coordinators can click to remove a partner from waitlisted status.
@@ -1700,8 +1447,7 @@ msgstr "प्रतीक्षासूची में डाला के �
 #: TWLight/resources/templates/resources/partner_detail_apply.html:86
 #, python-format
 msgid "<strong>%(coordinator)s</strong> processes applications to %(partner)s."
-msgstr ""
-"<strong>%(coordinator)s</strong> %(partner)s के लिए आवेदनों को संसाधित करता है।"
+msgstr "<strong>%(coordinator)s</strong> %(partner)s के लिए आवेदनों को संसाधित करता है।"
 
 #. Translators: When a coordinator is assigned to a partner, their details are shown on the page. This text labels a link to their Talk page on Wikipedia, and should be translated to the text used for Talk pages in the language you are translating to.
 #: TWLight/resources/templates/resources/partner_detail_apply.html:95
@@ -1715,14 +1461,8 @@ msgstr "विशेष:ईमेल_करें पृष्ठ"
 
 #. Translators: If no account coordinator is assigned to a partner, the Wikipedia Library team will coordinate signups. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/resources/templates/resources/partner_detail_apply.html:112
-msgid ""
-"The Wikipedia Library team will process this application. Want to help? <a "
-"class=\"twl-links\" href=\"https://en.wikipedia.org/wiki/Wikipedia:"
-"The_Wikipedia_Library/Coordinators/Signup\">Sign up as a coordinator.</a>"
-msgstr ""
-"विकिपीडिया लाइब्रेरी टीम इस आवेदन पर कार्रवाई करेंगे। सहायता  करना चाहते हैं? <a class="
-"\"twl-links\" href=\"https://en.wikipedia.org/wiki/Wikipedia:"
-"The_Wikipedia_Library/Coordinators/Signup\"> समन्वयक के रूप में पंजीकरण करें। </a>"
+msgid "The Wikipedia Library team will process this application. Want to help? <a class=\"twl-links\" href=\"https://en.wikipedia.org/wiki/Wikipedia:The_Wikipedia_Library/Coordinators/Signup\">Sign up as a coordinator.</a>"
+msgstr "विकिपीडिया लाइब्रेरी टीम इस आवेदन पर कार्रवाई करेंगे। सहायता  करना चाहते हैं? <a class=\"twl-links\" href=\"https://en.wikipedia.org/wiki/Wikipedia:The_Wikipedia_Library/Coordinators/Signup\"> समन्वयक के रूप में पंजीकरण करें। </a>"
 
 #. Translators: This text labels a button coordinators can click to view a list of users who have applied for access for a particular partner
 #: TWLight/resources/templates/resources/partner_detail_apply.html:121
@@ -1752,18 +1492,13 @@ msgstr ""
 
 #. Translators: Text shown to authenticated, bundle eligible users when they visit a Bundle partner page.
 #: TWLight/resources/templates/resources/partner_detail_apply.html:138
-msgid ""
-"You are eligible to access Library Bundle partners. Click the button above "
-"to access the collection."
+msgid "You are eligible to access Library Bundle partners. Click the button above to access the collection."
 msgstr ""
 
 #. Translators: Text shown to authenticated, bundle ineligible users when they visit a Bundle partner page.
 #: TWLight/resources/templates/resources/partner_detail_apply.html:152
 #, python-format
-msgid ""
-"You are not eligible to access Library Bundle partners. Visit the <a class="
-"\"twl-links\" href=\"%(homepage)s\">homepage</a> to check the eligibility "
-"criteria."
+msgid "You are not eligible to access Library Bundle partners. Visit the <a class=\"twl-links\" href=\"%(homepage)s\">homepage</a> to check the eligibility criteria."
 msgstr ""
 
 #. Translators: Buttton prompting users to log in.
@@ -1775,10 +1510,7 @@ msgstr "लॉगिन करें"
 #. Translators: Text shown to unauthenticated users when they visit a Bundle partner page.
 #: TWLight/resources/templates/resources/partner_detail_apply.html:168
 #, python-format
-msgid ""
-"This resource is part of our <a class=\"twl-links\" href=\"%(about)s"
-"\">Library Bundle</a>, which you can access if you meet our minimum "
-"eligibility criteria. Log in to find out if you are eligible."
+msgid "This resource is part of our <a class=\"twl-links\" href=\"%(about)s\">Library Bundle</a>, which you can access if you meet our minimum eligibility criteria. Log in to find out if you are eligible."
 msgstr ""
 
 #. Translators: This is the label for a number which shows the total active accounts for one partner. (e.g. https://wikipedialibrary.wmflabs.org/partners/8/).
@@ -1829,33 +1561,20 @@ msgstr "अंश सीमा"
 #. Translators: If a partner has specified the excerpt limit both in words and percentage, this message will display the percentage of words and the number of words on the partner page.
 #: TWLight/resources/templates/resources/partner_detail_timeline.html:99
 #, python-format
-msgid ""
-"%(object)s allows a maximum of %(excerpt_limit)s words or "
-"%(excerpt_limit_percentage)s%% of an article be excerpted into a Wikipedia "
-"article."
-msgstr ""
-"%(object)s के किसी लेख के अधिकतम %(excerpt_limit)s शब्दों या "
-"%(excerpt_limit_percentage)s%% को एक विकिपीडिया लेख में प्रस्तुत किया जा सकता है।"
+msgid "%(object)s allows a maximum of %(excerpt_limit)s words or %(excerpt_limit_percentage)s%% of an article be excerpted into a Wikipedia article."
+msgstr "%(object)s के किसी लेख के अधिकतम %(excerpt_limit)s शब्दों या %(excerpt_limit_percentage)s%% को एक विकिपीडिया लेख में प्रस्तुत किया जा सकता है।"
 
 #. Translators: If a partner has specified the excerpt limit in words, this message will display the number of words on the partner page.
 #: TWLight/resources/templates/resources/partner_detail_timeline.html:106
 #, python-format
-msgid ""
-"%(object)s allows a maximum of %(excerpt_limit)s words be excerpted into a "
-"Wikipedia article."
-msgstr ""
-"%(object)s के किसी लेख के अधिकतम %(excerpt_limit)s शब्दों को एक विकिपीडिया लेख में "
-"प्रस्तुत किया जा सकता है।"
+msgid "%(object)s allows a maximum of %(excerpt_limit)s words be excerpted into a Wikipedia article."
+msgstr "%(object)s के किसी लेख के अधिकतम %(excerpt_limit)s शब्दों को एक विकिपीडिया लेख में प्रस्तुत किया जा सकता है।"
 
 #. Translators: If a partner has specified the excerpt limit in percentage, this message will display the percentage of words on the partner page.
 #: TWLight/resources/templates/resources/partner_detail_timeline.html:113
 #, python-format
-msgid ""
-"%(object)s allows a maximum of %(excerpt_limit_percentage)s%% of an article "
-"be excerpted into a Wikipedia article."
-msgstr ""
-"%(object)s के किसी लेख के अधिकतम %(excerpt_limit_percentage)s%% को एक "
-"विकिपीडिया लेख में प्रस्तुत किया जा सकता है।"
+msgid "%(object)s allows a maximum of %(excerpt_limit_percentage)s%% of an article be excerpted into a Wikipedia article."
+msgstr "%(object)s के किसी लेख के अधिकतम %(excerpt_limit_percentage)s%% को एक विकिपीडिया लेख में प्रस्तुत किया जा सकता है।"
 
 #. Translators: If a partner has other requirements for access, this text shows as the title for that information field. (e.g. https://wikipedialibrary.wmflabs.org/partners/10/).
 #: TWLight/resources/templates/resources/partner_detail_timeline.html:132
@@ -1865,12 +1584,8 @@ msgstr "आवेदकों के लिए विशेष आवश्य�
 #. Translators: If a user must agree to a Terms of Use document, they see this message, and must enter the name of the resource. Don't translate publisher or url.
 #: TWLight/resources/templates/resources/partner_detail_timeline.html:140
 #, python-format
-msgid ""
-"%(publisher)s requires that you agree with its <a href=\"%(url)s\">terms of "
-"use</a>."
-msgstr ""
-"%(publisher)s के लिए आवश्यक है कि आप इसकी <a href=\"%(url)s\">उपयोग की शर्तों</"
-"a>से सहमत हों।"
+msgid "%(publisher)s requires that you agree with its <a href=\"%(url)s\">terms of use</a>."
+msgstr "%(publisher)s के लिए आवश्यक है कि आप इसकी <a href=\"%(url)s\">उपयोग की शर्तों</a>से सहमत हों।"
 
 #. Translators: If a user must provide their real name to apply to a partner, they see this message, and must enter the name of the resource. Don't translate publisher.
 #: TWLight/resources/templates/resources/partner_detail_timeline.html:150
@@ -1893,22 +1608,14 @@ msgstr "%(publisher)s के लिए आवश्यक है कि आप �
 #. Translators: If a user must select a specific resource to apply for, they see this message, and must enter the name of the resource. Don't translate publisher.
 #: TWLight/resources/templates/resources/partner_detail_timeline.html:177
 #, python-format
-msgid ""
-"%(publisher)s requires that you specify a particular title that you want to "
-"access."
-msgstr ""
-"%(publisher)s के लिए आवश्यक है कि आप एक विशेष शीर्षक निर्दिष्ट करें जिस तक आप पहुँच "
-"प्राप्त करना चाहते हैं।"
+msgid "%(publisher)s requires that you specify a particular title that you want to access."
+msgstr "%(publisher)s के लिए आवश्यक है कि आप एक विशेष शीर्षक निर्दिष्ट करें जिस तक आप पहुँच प्राप्त करना चाहते हैं।"
 
 #. Translators: If a user must register on the partner website before applying, they see this message. Don't translate partner.
 #: TWLight/resources/templates/resources/partner_detail_timeline.html:187
 #, python-format
-msgid ""
-"%(publisher)s requires that you sign up for an account before applying for "
-"access."
-msgstr ""
-"%(publisher)s के लिए आवश्यक है कि आप पहुँच के लिए आवेदन करने से पहले एक खाते के लिए "
-"पंजीकरण करें।"
+msgid "%(publisher)s requires that you sign up for an account before applying for access."
+msgstr "%(publisher)s के लिए आवश्यक है कि आप पहुँच के लिए आवेदन करने से पहले एक खाते के लिए पंजीकरण करें।"
 
 #. Translators: If a partner has their location listed, this message is a label for that location
 #: TWLight/resources/templates/resources/partner_detail_timeline.html:206
@@ -2036,9 +1743,7 @@ msgstr "क्या आप वाकई <b>%(object)s</b> हटाना च�
 
 #. Translators: If multiple authorizations where returned for a collection, this message is shown to a user
 #: TWLight/resources/views.py:268
-msgid ""
-"Multiple authorizations were returned – something's wrong. Please contact us "
-"and don't forget to mention this message."
+msgid "Multiple authorizations were returned – something's wrong. Please contact us and don't forget to mention this message."
 msgstr ""
 
 #. Translators: This message is shown when user tries to access a NOT_AVAILABLE Partner
@@ -2080,23 +1785,8 @@ msgstr "क्षमा करें, हम नहीं जानते कि
 #. Translators: Shown on the website's 400 page, when a user sends a bad request. Don't translate path or Phabricator.
 #: TWLight/templates/400.html:20
 #, python-format
-msgid ""
-"If you think we should know what to do with that, please email us about this "
-"error at <a class=\"twl-links\" href=\"mailto:wikipedialibrary@wikimedia.org?"
-"Subject=Wikipedia%%20Library%%20%(path)s%%20Permission%%20denied"
-"\">wikipedialibrary@wikimedia.org</a> or report it to us on <a class=\"twl-"
-"links\" href=\"https://phabricator.wikimedia.org/maniphest/task/edit/form/1/?"
-"projectPHIDs=Library-Card-Platform&title=Wikipedia%%20Library%%20%(path)s"
-"%%20Bad%%20Request\">Phabricator</a>"
-msgstr ""
-"अगर आपको लगता है कि हमें पता होना चाहिए कि हमें क्या करना है, तो कृपया हमें इस त्रुटि के "
-"बारे में यहाँ पर ईमेल करें <a class=\"twl-links\" href=\"mailto:"
-"wikipedialibrary@wikimedia.org?Subject=Wikipedia%%20Library%%20%(path)s"
-"%%20Permission%%20denied\">wikipedialibrary@wikimedia.org</a> या फिर यहाँ पर "
-"हमें इसकी रिपोर्ट करें <a class=\"twl-links\" href=\"https://phabricator."
-"wikimedia.org/maniphest/task/edit/form/1/?projectPHIDs=Library-Card-"
-"Platform&title=Wikipedia%%20Library%%20%(path)s%%20Bad%%20Request"
-"\">Phabricator</a>"
+msgid "If you think we should know what to do with that, please email us about this error at <a class=\"twl-links\" href=\"mailto:wikipedialibrary@wikimedia.org?Subject=Wikipedia%%20Library%%20%(path)s%%20Permission%%20denied\">wikipedialibrary@wikimedia.org</a> or report it to us on <a class=\"twl-links\" href=\"https://phabricator.wikimedia.org/maniphest/task/edit/form/1/?projectPHIDs=Library-Card-Platform&title=Wikipedia%%20Library%%20%(path)s%%20Bad%%20Request\">Phabricator</a>"
+msgstr "अगर आपको लगता है कि हमें पता होना चाहिए कि हमें क्या करना है, तो कृपया हमें इस त्रुटि के बारे में यहाँ पर ईमेल करें <a class=\"twl-links\" href=\"mailto:wikipedialibrary@wikimedia.org?Subject=Wikipedia%%20Library%%20%(path)s%%20Permission%%20denied\">wikipedialibrary@wikimedia.org</a> या फिर यहाँ पर हमें इसकी रिपोर्ट करें <a class=\"twl-links\" href=\"https://phabricator.wikimedia.org/maniphest/task/edit/form/1/?projectPHIDs=Library-Card-Platform&title=Wikipedia%%20Library%%20%(path)s%%20Bad%%20Request\">Phabricator</a>"
 
 #. Translators: Alt text for an image shown on the 400 error page.
 #. Translators: Alt text for an image shown on the 403 error page.
@@ -2117,24 +1807,8 @@ msgstr "क्षमा करें, आपको ऐसा करने की
 #. Translators: Shown on the website's 403 page, when a user attempts to navigate to a page they don't have permission to view. Don't translate path or Phabricator.
 #: TWLight/templates/403.html:20
 #, python-format
-msgid ""
-"If you think your account should be able to do that, please email us about "
-"this error at <a class=\"twl-links\" href=\"mailto:"
-"wikipedialibrary@wikimedia.org?Subject=Wikipedia%%20Library%%20%(path)s"
-"%%20Permission%%20denied\">wikipedialibrary@wikimedia.org</a> or report it "
-"to us on <a class=\"twl-links\" href=\"https://phabricator.wikimedia.org/"
-"maniphest/task/edit/form/1/?projectPHIDs=Library-Card-"
-"Platform&title=Wikipedia%%20Library%%20%(path)s%%20Permission%%20denied"
-"\">Phabricator</a>"
-msgstr ""
-"यदि आपको लगता है कि आपका खाता ऐसा करने में सक्षम होना चाहिए, तो कृपया हमें इस त्रुटि के "
-"बारे में यहाँ पर ईमेल करें? <a class=\"twl-links\" href=\"mailto:"
-"wikipedialibrary@wikimedia.org?Subject=Wikipedia%%20Library%%20%(path)s"
-"%%20Permission%%20denied\">wikipedialibrary@wikimedia.org</a> या फिर यहाँ पर "
-"हमें इसकी रिपोर्ट करें <a class=\"twl-links\" href=\"https://phabricator."
-"wikimedia.org/maniphest/task/edit/form/1/?projectPHIDs=Library-Card-"
-"Platform&title=Wikipedia%%20Library%%20%(path)s%%20Permission%%20denied"
-"\">Phabricator</a>"
+msgid "If you think your account should be able to do that, please email us about this error at <a class=\"twl-links\" href=\"mailto:wikipedialibrary@wikimedia.org?Subject=Wikipedia%%20Library%%20%(path)s%%20Permission%%20denied\">wikipedialibrary@wikimedia.org</a> or report it to us on <a class=\"twl-links\" href=\"https://phabricator.wikimedia.org/maniphest/task/edit/form/1/?projectPHIDs=Library-Card-Platform&title=Wikipedia%%20Library%%20%(path)s%%20Permission%%20denied\">Phabricator</a>"
+msgstr "यदि आपको लगता है कि आपका खाता ऐसा करने में सक्षम होना चाहिए, तो कृपया हमें इस त्रुटि के बारे में यहाँ पर ईमेल करें? <a class=\"twl-links\" href=\"mailto:wikipedialibrary@wikimedia.org?Subject=Wikipedia%%20Library%%20%(path)s%%20Permission%%20denied\">wikipedialibrary@wikimedia.org</a> या फिर यहाँ पर हमें इसकी रिपोर्ट करें <a class=\"twl-links\" href=\"https://phabricator.wikimedia.org/maniphest/task/edit/form/1/?projectPHIDs=Library-Card-Platform&title=Wikipedia%%20Library%%20%(path)s%%20Permission%%20denied\">Phabricator</a>"
 
 #. Translators: Shown on the website's 404 page, when a user attempts to navigate to a page that doesn't exist.
 #: TWLight/templates/404.html:11
@@ -2149,22 +1823,8 @@ msgstr "क्षमा करें, हमें वह नहीं मिल
 #. Translators: Shown on the website's 404 page, when a user attempts to navigate to a page that doesn't exist. Don't translate path or Phabricator.
 #: TWLight/templates/404.html:19
 #, python-format
-msgid ""
-"If you are certain that something should be here, please email us about this "
-"error at <a class=\"twl-links\" href=\"mailto:wikipedialibrary@wikimedia.org?"
-"Subject=Wikipedia%%20Library%%20%(path)s%%20Not%%20found\"> "
-"wikipedialibrary@wikimedia.org</a> or report it to us on <a class=\"twl-links"
-"\" href=\"https://phabricator.wikimedia.org/maniphest/task/edit/form/1/?"
-"projectPHIDs=Library-Card-Platform&title=Wikipedia%%20Library%%20%(path)s"
-"%%20Not%%20found\">Phabricator</a>"
-msgstr ""
-"यदि आप निश्चित हैं कि कुछ यहाँ होना चाहिए, तो कृपया हमें इस त्रुटि के बारे में यहाँ ईमेल करें "
-"<a class=\"twl-links\" href=\"mailto:wikipedialibrary@wikimedia.org?"
-"Subject=Wikipedia%%20Library%%20%(path)s%%20Not%%20found\"> "
-"wikipedialibrary@wikimedia.org</a> या इस पर हमें यहाँ रिपोर्ट करें <a class=\"twl-"
-"links\" href=\"https://phabricator.wikimedia.org/maniphest/task/edit/form/1/?"
-"projectPHIDs=Library-Card-Platform&title=Wikipedia%%20Library%%20%(path)s"
-"%%20Not%%20found\">Phabricator</a>"
+msgid "If you are certain that something should be here, please email us about this error at <a class=\"twl-links\" href=\"mailto:wikipedialibrary@wikimedia.org?Subject=Wikipedia%%20Library%%20%(path)s%%20Not%%20found\"> wikipedialibrary@wikimedia.org</a> or report it to us on <a class=\"twl-links\" href=\"https://phabricator.wikimedia.org/maniphest/task/edit/form/1/?projectPHIDs=Library-Card-Platform&title=Wikipedia%%20Library%%20%(path)s%%20Not%%20found\">Phabricator</a>"
+msgstr "यदि आप निश्चित हैं कि कुछ यहाँ होना चाहिए, तो कृपया हमें इस त्रुटि के बारे में यहाँ ईमेल करें <a class=\"twl-links\" href=\"mailto:wikipedialibrary@wikimedia.org?Subject=Wikipedia%%20Library%%20%(path)s%%20Not%%20found\"> wikipedialibrary@wikimedia.org</a> या इस पर हमें यहाँ रिपोर्ट करें <a class=\"twl-links\" href=\"https://phabricator.wikimedia.org/maniphest/task/edit/form/1/?projectPHIDs=Library-Card-Platform&title=Wikipedia%%20Library%%20%(path)s%%20Not%%20found\">Phabricator</a>"
 
 #. Translators: Alt text for an image shown on the 404 error page.
 #: TWLight/templates/404.html:32
@@ -2179,50 +1839,20 @@ msgstr "विकिपीडिया पुस्तकालय के बा
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:20
 #, fuzzy
-msgid ""
-"This platform is our central tool for facilitating access to our available "
-"collections. Here you can see which partnerships are available, search their "
-"contents, and apply for and access the ones you’re interested in."
-msgstr ""
-"विकिपीडिया पुस्तकालय कार्ड मंच आवेदनों की समीक्षा करने और उन भागीदार संसाधनों तक पहुँच "
-"प्रदान करने के लिए हमारा केंद्रीय उपकरण है। यहां आप देख सकते हैं कि कौन सी भागीदारियाँ "
-"उपलब्ध हैं, प्रत्येक डेटाबेस किस प्रकार की सामग्री प्रदान करता है, और जो आप चाहते हैं उसके "
-"लिए आवेदन करें। स्वयंसेवी समन्वयक, जिन्होंने विकिमीडिया फ़ाउंडेशन के साथ गैर-प्रकटीकरण "
-"समझौतों पर हस्ताक्षर किए हैं, आवेदनों की समीक्षा करते हैं और आपको मुफ्त एक्सेस दिलाने के लिए "
-"भागीदारों के साथ काम करते हैं।"
+msgid "This platform is our central tool for facilitating access to our available collections. Here you can see which partnerships are available, search their contents, and apply for and access the ones you’re interested in."
+msgstr "विकिपीडिया पुस्तकालय कार्ड मंच आवेदनों की समीक्षा करने और उन भागीदार संसाधनों तक पहुँच प्रदान करने के लिए हमारा केंद्रीय उपकरण है। यहां आप देख सकते हैं कि कौन सी भागीदारियाँ उपलब्ध हैं, प्रत्येक डेटाबेस किस प्रकार की सामग्री प्रदान करता है, और जो आप चाहते हैं उसके लिए आवेदन करें। स्वयंसेवी समन्वयक, जिन्होंने विकिमीडिया फ़ाउंडेशन के साथ गैर-प्रकटीकरण समझौतों पर हस्ताक्षर किए हैं, आवेदनों की समीक्षा करते हैं और आपको मुफ्त एक्सेस दिलाने के लिए भागीदारों के साथ काम करते हैं।"
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/). Wikimedia Foundation should not be translated.
 #: TWLight/templates/about.html:29
 #, fuzzy
-msgid ""
-"All users receive immediate access to some collections, which can be browsed "
-"by clicking the 'Access collection' buttons or using the search bar at the "
-"top of the page. Other collections require an application before access is "
-"granted, and may be accessed directly or via an individual login or access "
-"code. Volunteer coordinators, who have signed non-disclosure agreements with "
-"the Wikimedia Foundation, review these applications and work with publishers "
-"to get you your free access."
-msgstr ""
-"विकिपीडिया पुस्तकालय कार्ड मंच आवेदनों की समीक्षा करने और उन भागीदार संसाधनों तक पहुँच "
-"प्रदान करने के लिए हमारा केंद्रीय उपकरण है। यहां आप देख सकते हैं कि कौन सी भागीदारियाँ "
-"उपलब्ध हैं, प्रत्येक डेटाबेस किस प्रकार की सामग्री प्रदान करता है, और जो आप चाहते हैं उसके "
-"लिए आवेदन करें। स्वयंसेवी समन्वयक, जिन्होंने विकिमीडिया फ़ाउंडेशन के साथ गैर-प्रकटीकरण "
-"समझौतों पर हस्ताक्षर किए हैं, आवेदनों की समीक्षा करते हैं और आपको मुफ्त एक्सेस दिलाने के लिए "
-"भागीदारों के साथ काम करते हैं।"
+msgid "All users receive immediate access to some collections, which can be browsed by clicking the 'Access collection' buttons or using the search bar at the top of the page. Other collections require an application before access is granted, and may be accessed directly or via an individual login or access code. Volunteer coordinators, who have signed non-disclosure agreements with the Wikimedia Foundation, review these applications and work with publishers to get you your free access."
+msgstr "विकिपीडिया पुस्तकालय कार्ड मंच आवेदनों की समीक्षा करने और उन भागीदार संसाधनों तक पहुँच प्रदान करने के लिए हमारा केंद्रीय उपकरण है। यहां आप देख सकते हैं कि कौन सी भागीदारियाँ उपलब्ध हैं, प्रत्येक डेटाबेस किस प्रकार की सामग्री प्रदान करता है, और जो आप चाहते हैं उसके लिए आवेदन करें। स्वयंसेवी समन्वयक, जिन्होंने विकिमीडिया फ़ाउंडेशन के साथ गैर-प्रकटीकरण समझौतों पर हस्ताक्षर किए हैं, आवेदनों की समीक्षा करते हैं और आपको मुफ्त एक्सेस दिलाने के लिए भागीदारों के साथ काम करते हैं।"
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/). Don't translate terms_url.
 #: TWLight/templates/about.html:43
 #, python-format
-msgid ""
-"For more information about how your information is stored and reviewed "
-"please see our <a class=\"twl-links\" href=\"%(terms_url)s\"> terms of use "
-"and privacy policy</a>. Accounts you apply for are also subject to the Terms "
-"of Use provided by each partner’s platform; please review them."
-msgstr ""
-"आवेदन की जानकारी कैसे संग्रहीत और समीक्षा की जाती है, इस बारे में अधिक जानकारी के लिए "
-"कृपया हमारी <a class=\"twl-links\" href=\"%(terms_url)s\"> उपयोग की शर्तें और "
-"गोपनीयता नीति </a> देखें। आपके द्वारा आवेदन किए गए खाते प्रत्येक भागीदार के मंच द्वारा "
-"प्रदान की गई उपयोग की शर्तों के अधीन हैं; कृपया उनकी समीक्षा करें।"
+msgid "For more information about how your information is stored and reviewed please see our <a class=\"twl-links\" href=\"%(terms_url)s\"> terms of use and privacy policy</a>. Accounts you apply for are also subject to the Terms of Use provided by each partner’s platform; please review them."
+msgstr "आवेदन की जानकारी कैसे संग्रहीत और समीक्षा की जाती है, इस बारे में अधिक जानकारी के लिए कृपया हमारी <a class=\"twl-links\" href=\"%(terms_url)s\"> उपयोग की शर्तें और गोपनीयता नीति </a> देखें। आपके द्वारा आवेदन किए गए खाते प्रत्येक भागीदार के मंच द्वारा प्रदान की गई उपयोग की शर्तों के अधीन हैं; कृपया उनकी समीक्षा करें।"
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:51
@@ -2232,17 +1862,8 @@ msgstr "एक्सेस कौन प्राप्त कर सकते �
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/). Wikimedia Foundation should not be translated.
 #: TWLight/templates/about.html:55
 #, fuzzy
-msgid ""
-"Any active editor in good standing can receive access. For publishers with "
-"limited numbers of accounts, applications are reviewed based on the editor’s "
-"needs and contributions. If you think you could use access to one of our "
-"partner resources and are an active editor in any project supported by the "
-"Wikimedia Foundation, please apply."
-msgstr ""
-"अच्छी स्थिति में कोई भी सक्रिय संपादक पहुंच प्राप्त कर सकता है। संपादक की आवश्यकता और "
-"योगदान के आधार पर आवेदनों की समीक्षा की जाती है। अगर आपको लगता है कि आप हमारे किसी "
-"भागीदार संसाधन तक पहुंच का उपयोग कर सकते हैं और विकिमीडिया फाउंडेशन द्वारा समर्थित "
-"किसी भी परियोजना में एक सक्रिय संपादक हैं, तो कृपया आवेदन करें।"
+msgid "Any active editor in good standing can receive access. For publishers with limited numbers of accounts, applications are reviewed based on the editor’s needs and contributions. If you think you could use access to one of our partner resources and are an active editor in any project supported by the Wikimedia Foundation, please apply."
+msgstr "अच्छी स्थिति में कोई भी सक्रिय संपादक पहुंच प्राप्त कर सकता है। संपादक की आवश्यकता और योगदान के आधार पर आवेदनों की समीक्षा की जाती है। अगर आपको लगता है कि आप हमारे किसी भागीदार संसाधन तक पहुंच का उपयोग कर सकते हैं और विकिमीडिया फाउंडेशन द्वारा समर्थित किसी भी परियोजना में एक सक्रिय संपादक हैं, तो कृपया आवेदन करें।"
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:65
@@ -2273,23 +1894,12 @@ msgstr "आप वर्तमान में विकिपीडिया �
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/)
 #: TWLight/templates/about.html:89
-msgid ""
-"If you are applying for an available collection, please first check that you "
-"don't already have access through another library or institution. If you do, "
-"please consider using that access rather than taking up a seat for this "
-"resource in The Wikipedia Library."
+msgid "If you are applying for an available collection, please first check that you don't already have access through another library or institution. If you do, please consider using that access rather than taking up a seat for this resource in The Wikipedia Library."
 msgstr ""
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/)
 #: TWLight/templates/about.html:99
-msgid ""
-"If your account is blocked on one or more Wikimedia projects, you may still "
-"be granted access to The Wikipedia Library. You will need to contact the "
-"Wikipedia Library team, who will review your blocks. If you have been "
-"blocked for content issues, most notably copyright violations, or have "
-"multiple long-term blocks, we may decline your request. Additionally, if "
-"your block status changes after being approved, you will need to request "
-"another review."
+msgid "If your account is blocked on one or more Wikimedia projects, you may still be granted access to The Wikipedia Library. You will need to contact the Wikipedia Library team, who will review your blocks. If you have been blocked for content issues, most notably copyright violations, or have multiple long-term blocks, we may decline your request. Additionally, if your block status changes after being approved, you will need to request another review."
 msgstr ""
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
@@ -2324,11 +1934,8 @@ msgstr "स्वीकृत संपादक  को <i>नहीं कर�
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:136
-msgid ""
-"Share their account logins or passwords with others, or sell their access to "
-"other parties"
-msgstr ""
-"अपना खाता लॉगिन या पासवर्ड दूसरों के साथ साँझा करें, या अपनी पहुँच अन्य दलों को बेच दें"
+msgid "Share their account logins or passwords with others, or sell their access to other parties"
+msgstr "अपना खाता लॉगिन या पासवर्ड दूसरों के साथ साँझा करें, या अपनी पहुँच अन्य दलों को बेच दें"
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:140
@@ -2337,31 +1944,19 @@ msgstr "भागीदार सामग्री के साथ बड़�
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:144
-msgid ""
-"Systematically make printed or electronic copies of multiple extracts of "
-"restricted content available for any purpose"
-msgstr ""
-"व्यवस्थित रूप से किसी भी उद्देश्य के लिए उपलब्ध प्रतिबंधित सामग्री के कई अंशों की मुद्रित या "
-"इलेक्ट्रॉनिक प्रतियाँ बनान"
+msgid "Systematically make printed or electronic copies of multiple extracts of restricted content available for any purpose"
+msgstr "व्यवस्थित रूप से किसी भी उद्देश्य के लिए उपलब्ध प्रतिबंधित सामग्री के कई अंशों की मुद्रित या इलेक्ट्रॉनिक प्रतियाँ बनान"
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/). Stub is a technical term for a short Wikipedia article, use the appropriate Wikipedia term in your language.
 #: TWLight/templates/about.html:148
-msgid ""
-"Datamine metadata without permission, in order, for instance, to use "
-"metadata for auto-created stub articles"
-msgstr ""
-"बिना अनुमति के मेटाडेटा को डेटामाइन करना, उदाहरण के लिए, ऑटो-निर्मित आधार लेखों के लिए "
-"मेटाडेटा का उपयोग करने के लिए"
+msgid "Datamine metadata without permission, in order, for instance, to use metadata for auto-created stub articles"
+msgstr "बिना अनुमति के मेटाडेटा को डेटामाइन करना, उदाहरण के लिए, ऑटो-निर्मित आधार लेखों के लिए मेटाडेटा का उपयोग करने के लिए"
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:154
 #, fuzzy
-msgid ""
-"Respecting these agreements allows us to continue growing the partnerships "
-"available to the community."
-msgstr ""
-"इन समझौतों का सम्मान करने से हम अपने पूरे समुदाय के लिए उपलब्ध भागीदारियों को बढ़ाना "
-"जारी रख सकते हैं।"
+msgid "Respecting these agreements allows us to continue growing the partnerships available to the community."
+msgstr "इन समझौतों का सम्मान करने से हम अपने पूरे समुदाय के लिए उपलब्ध भागीदारियों को बढ़ाना जारी रख सकते हैं।"
 
 #. Translators: This is the heading for a section on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:160
@@ -2370,41 +1965,22 @@ msgstr ""
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:164
-msgid ""
-"EZProxy is a proxy server used to authenticate users for many Wikipedia "
-"Library partners. Users sign into EZProxy via the Library Card platform to "
-"verify that they are authorized users, and then the server accesses "
-"requested resources using its own IP address."
+msgid "EZProxy is a proxy server used to authenticate users for many Wikipedia Library partners. Users sign into EZProxy via the Library Card platform to verify that they are authorized users, and then the server accesses requested resources using its own IP address."
 msgstr ""
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:173
-msgid ""
-"You may notice that when accessing resources via EZProxy that URLs are "
-"dynamically rewritten. This is why we recommend logging in via the Library "
-"Card platform rather than going directly to the unproxied partner website. "
-"When in doubt, check the URL for ‘idm.oclc’. If it’s there, then you’re "
-"connected via EZProxy."
+msgid "You may notice that when accessing resources via EZProxy that URLs are dynamically rewritten. This is why we recommend logging in via the Library Card platform rather than going directly to the unproxied partner website. When in doubt, check the URL for ‘idm.oclc’. If it’s there, then you’re connected via EZProxy."
 msgstr ""
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:182
-msgid ""
-"Typically once you’ve logged in your session will remain active in your "
-"browser for up to two hours after you’ve finished searching. Note that use "
-"of EZProxy requires you to enable cookies. If you are having problems you "
-"should also try clearing your cache and restarting your browser."
+msgid "Typically once you’ve logged in your session will remain active in your browser for up to two hours after you’ve finished searching. Note that use of EZProxy requires you to enable cookies. If you are having problems you should also try clearing your cache and restarting your browser."
 msgstr ""
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/)
 #: TWLight/templates/about.html:193
-msgid ""
-"The Library Bundle is a collection of resources for which no application is "
-"required. If you meet the criteria laid out above, you will be authorized "
-"for access automatically upon logging in to the platform. Only some of our "
-"content is currently included in the Library Bundle, however we hope to "
-"expand the collection as more publishers become comfortable with "
-"participating. All Bundle content is accessed via EZProxy."
+msgid "The Library Bundle is a collection of resources for which no application is required. If you meet the criteria laid out above, you will be authorized for access automatically upon logging in to the platform. Only some of our content is currently included in the Library Bundle, however we hope to expand the collection as more publishers become comfortable with participating. All Bundle content is accessed via EZProxy."
 msgstr ""
 
 #. Translators: This is the heading for a section on the About page (https://wikipedialibrary.wmflabs.org/about/).
@@ -2415,17 +1991,8 @@ msgstr ""
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:206
 #, fuzzy
-msgid ""
-"Citation practices vary by project and even by article. Generally, we "
-"support editors citing where they found information, in a form that allows "
-"others to check it for themselves. That often means providing both original "
-"source details as well as a link to the partner database in which the source "
-"was found."
-msgstr ""
-"उद्धरण प्रथा परियोजना और लेख के अनुसार बदलती रहती हैं। आम तौर पर, हम  समर्थन करते हैं "
-"की संपादक जहां उन्हें जानकारी मिलती है उसका उद्धरण एक ऐसे रूप में करें जो दूसरों को खुद के "
-"लिए इसे जांचने की अनुमति देता है। प्राय: इसका मतलब दोनों मूल स्रोत का विवरण और साथ-साथ "
-"भागीदार डेटाबेस जिसमें स्रोत पाया गया था की एक कड़ी प्रदान करन होता है।"
+msgid "Citation practices vary by project and even by article. Generally, we support editors citing where they found information, in a form that allows others to check it for themselves. That often means providing both original source details as well as a link to the partner database in which the source was found."
+msgstr "उद्धरण प्रथा परियोजना और लेख के अनुसार बदलती रहती हैं। आम तौर पर, हम  समर्थन करते हैं की संपादक जहां उन्हें जानकारी मिलती है उसका उद्धरण एक ऐसे रूप में करें जो दूसरों को खुद के लिए इसे जांचने की अनुमति देता है। प्राय: इसका मतलब दोनों मूल स्रोत का विवरण और साथ-साथ भागीदार डेटाबेस जिसमें स्रोत पाया गया था की एक कड़ी प्रदान करन होता है।"
 
 #. Translators: This is the heading for a section on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #. Translators: This link is at the bottom of every page and can be clicked by users to contact the wikipedia library team.
@@ -2436,9 +2003,7 @@ msgstr "हमें संपर्क करें"
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:218
 #, python-format
-msgid ""
-"If you have questions, need help, or want to volunteer to help, please see "
-"our <a class=\"twl-links\" href=\"%(contact_url)s\">contact page</a>."
+msgid "If you have questions, need help, or want to volunteer to help, please see our <a class=\"twl-links\" href=\"%(contact_url)s\">contact page</a>."
 msgstr ""
 
 #. Translators: This is the title of the panel box detailing the contact information for the Wikipedia Library team.
@@ -2483,9 +2048,7 @@ msgstr "विकिपीडिया पुस्तकालय दल"
 #. Translators: This is the text that appears at the bottom of the contact us form directing users to the suggestions form.
 #: TWLight/templates/contact.html:48
 #, python-format
-msgid ""
-"(If you would like to suggest a partner, <a class=\"twl-links\" href="
-"\"%(suggest)s\"><strong>go here</strong></a>.)"
+msgid "(If you would like to suggest a partner, <a class=\"twl-links\" href=\"%(suggest)s\"><strong>go here</strong></a>.)"
 msgstr ""
 
 #. Translators: On a special 'link to search' page, this message is shown if JavaScript is disabled.
@@ -2547,9 +2110,7 @@ msgstr "विकिपीडिया पुस्तकालय दल"
 #. Translators: Information about The Wikipedia Library.
 #: TWLight/templates/login_partial.html:53 TWLight/templates/new_base.html:21
 #, python-format
-msgid ""
-"More than 100 of the world's top subscription-only databases, with content "
-"in %(no_of_languages)s languages, free for Wikipedians of all backgrounds"
+msgid "More than 100 of the world's top subscription-only databases, with content in %(no_of_languages)s languages, free for Wikipedians of all backgrounds"
 msgstr ""
 
 #. Translators: Information about The Wikipedia Library.
@@ -2558,9 +2119,7 @@ msgid "Meet these criteria for automatic access"
 msgstr ""
 
 #: TWLight/templates/login_partial.html:69
-msgid ""
-"These criteria grant you access to certain collections but not all. Some "
-"collections are accessible on a per application basis only."
+msgid "These criteria grant you access to certain collections but not all. Some collections are accessible on a per application basis only."
 msgstr ""
 
 #: TWLight/templates/login_partial.html:89
@@ -2570,34 +2129,19 @@ msgstr "विकिपीडिया के माध्यम से प्�
 #. Translators: Shown if the current user doesn't have a registered email on their account. Don't translate contact_us_url or email_url.
 #: TWLight/templates/message_partial.html:15
 #, fuzzy, python-format
-msgid ""
-"You don't have an email on file. We can't finalize your access to partner "
-"resources, and you won't be able to <a class=\"twl-links\" href="
-"\"%(contact_us_url)s\">contact us</a> without an email. Please <a class="
-"\"twl-links\" href=\"%(email_url)s\">update your email</a>."
-msgstr ""
-"आपके पास फ़ाइल पर ईमेल नहीं है। हम बिना ईमेल के भागीदार संसाधनों तक आपकी पहुँच को अंतिम "
-"रूप नहीं दे सकते। कृपया <a href=\"%(email_url)s\">अपना ईमेल अपडेट करें</a>।"
+msgid "You don't have an email on file. We can't finalize your access to partner resources, and you won't be able to <a class=\"twl-links\" href=\"%(contact_us_url)s\">contact us</a> without an email. Please <a class=\"twl-links\" href=\"%(email_url)s\">update your email</a>."
+msgstr "आपके पास फ़ाइल पर ईमेल नहीं है। हम बिना ईमेल के भागीदार संसाधनों तक आपकी पहुँच को अंतिम रूप नहीं दे सकते। कृपया <a href=\"%(email_url)s\">अपना ईमेल अपडेट करें</a>।"
 
 #. Translators: Shown if the current user has requested the processing of their data should be restricted.
 #: TWLight/templates/message_partial.html:26
 #, python-format
-msgid ""
-"You have requested a restriction on the processing of your data. Most site "
-"functionality will not be available to you until you <a class=\"twl-links\" "
-"href=\"%(restrict_url)s\">lift this restriction</a>."
-msgstr ""
-"आपने अपने डेटा के प्रसंस्करण पर प्रतिबंध का अनुरोध किया है। जब तक आप <a class=\"twl-"
-"links\" href=\"%(restrict_url)s\">इस प्रतिबंध को नहीं उठाते हैं</a> तब तक अधिकांश "
-"साइट कार्यक्षमता आपके लिए उपलब्ध नहीं होगी।"
+msgid "You have requested a restriction on the processing of your data. Most site functionality will not be available to you until you <a class=\"twl-links\" href=\"%(restrict_url)s\">lift this restriction</a>."
+msgstr "आपने अपने डेटा के प्रसंस्करण पर प्रतिबंध का अनुरोध किया है। जब तक आप <a class=\"twl-links\" href=\"%(restrict_url)s\">इस प्रतिबंध को नहीं उठाते हैं</a> तब तक अधिकांश साइट कार्यक्षमता आपके लिए उपलब्ध नहीं होगी।"
 
 #. Translators: Shown if the current user has not agreed to the terms of use.
 #: TWLight/templates/message_partial.html:37
 #, python-format
-msgid ""
-"You have not agreed to the <a class=\"twl-links\" href=\"%(terms_url)s"
-"\">terms of use</a> of this site. Your applications will not be processed "
-"and you won't be able to apply or access resources you are approved for."
+msgid "You have not agreed to the <a class=\"twl-links\" href=\"%(terms_url)s\">terms of use</a> of this site. Your applications will not be processed and you won't be able to apply or access resources you are approved for."
 msgstr ""
 
 #. Translators: This link is at the bottom of every page and links to the 'About' page (https://wikipedialibrary.wmflabs.org/about/)
@@ -2645,12 +2189,8 @@ msgstr "कूटशब्द पुनःस्थापित करें"
 
 #. Translators: If a user goes to reset their password, this message asks them to enter their email to do so.
 #: TWLight/templates/registration/password_reset_form.html:13
-msgid ""
-"Forgot your password? Enter your email address below, and we'll email "
-"instructions for setting a new one."
-msgstr ""
-"अपना कूटशब्द भूल गए? नीचे अपना ईमेल पता दर्ज करें, और हम एक नया सेट करने के लिए निर्देश "
-"ईमेल करेंगे।"
+msgid "Forgot your password? Enter your email address below, and we'll email instructions for setting a new one."
+msgstr "अपना कूटशब्द भूल गए? नीचे अपना ईमेल पता दर्ज करें, और हम एक नया सेट करने के लिए निर्देश ईमेल करेंगे।"
 
 #. Translators: This is the label for a button that users click to update their public information.
 #: TWLight/users/forms.py:36
@@ -2698,22 +2238,14 @@ msgstr "मैं उपयोग की शर्तों से सहमत 
 #. Translators: This text explains how to disagree to the site's terms of use and the restrictions that will come into effect when users disagree to the terms of use.
 #: TWLight/users/forms.py:185
 #, fuzzy
-msgid ""
-"By unchecking this box and clicking “Update” you may explore the site, but "
-"you will not be able to apply for access to materials or evaluate "
-"applications unless you agree with the terms of use."
-msgstr ""
-"आपका ईमेल रिक्त है। आप अभी भी साइट को देख सकते हैं, लेकिन आप बिना ईमेल के भागीदार "
-"संसाधनों तक पहुंच के लिए आवेदन नहीं कर पाएंगे।"
+msgid "By unchecking this box and clicking “Update” you may explore the site, but you will not be able to apply for access to materials or evaluate applications unless you agree with the terms of use."
+msgstr "आपका ईमेल रिक्त है। आप अभी भी साइट को देख सकते हैं, लेकिन आप बिना ईमेल के भागीदार संसाधनों तक पहुंच के लिए आवेदन नहीं कर पाएंगे।"
 
 #. Translators: Users click this button to set their website email address to the one linked to their Wikipedia account.
 #: TWLight/users/forms.py:211
 #, fuzzy
-msgid ""
-"Use my Wikipedia email address (will be updated the next time you login)."
-msgstr ""
-"मेरे विकिपीडिया ईमेल पते का उपयोग करें (अगली बार जब आप लॉगिन करेंगे तो उसे अपडेट कर "
-"दिया जाएगा)।"
+msgid "Use my Wikipedia email address (will be updated the next time you login)."
+msgstr "मेरे विकिपीडिया ईमेल पते का उपयोग करें (अगली बार जब आप लॉगिन करेंगे तो उसे अपडेट कर दिया जाएगा)।"
 
 #. Translators: This labels a button which users click to change their email.
 #: TWLight/users/forms.py:232
@@ -2723,17 +2255,8 @@ msgstr "ईमेल अपडेट करें"
 #. Translators: Shown if the current user tried to 'favorite' a partner they can't access. Do not translate '{partner}'
 #: TWLight/users/models.py:201
 #, python-brace-format
-msgid ""
-"Cannot add partner {partner} to your favorites because you don't have access "
-"to it"
+msgid "Cannot add partner {partner} to your favorites because you don't have access to it"
 msgstr ""
-
-#. Translators: Do not translate.
-#: TWLight/users/models.py:869
-#, fuzzy, python-brace-format
-#| msgid "Username"
-msgid "{wp_username}"
-msgstr "सदस्यनाम"
 
 #. Translators: This error message is shown when there's a problem with the authenticated login process.
 #: TWLight/users/oauth.py:243
@@ -2753,9 +2276,7 @@ msgstr ""
 
 #. Translators: this message is displayed to users that don't have accounts and clicked on a proxied link.
 #: TWLight/users/oauth.py:388
-msgid ""
-"To view this link you need to be an eligible library user. Please login to "
-"continue."
+msgid "To view this link you need to be an eligible library user. Please login to continue."
 msgstr ""
 
 #. Translators: This warning message is shown to users when the response received from Wikimedia OAuth servers is not a valid one.
@@ -2793,23 +2314,13 @@ msgstr "सदस्य की जानकारी"
 
 #. Translators: If the user tries to log in, but their account does not meet certain requirements, they cannot login.
 #: TWLight/users/oauth.py:528
-msgid ""
-"Your Wikipedia account does not meet the eligibility criteria in the terms "
-"of use, so your Wikipedia Library Card Platform account cannot be activated."
-msgstr ""
-"आपका विकिपीडिया खाता उपयोग की शर्तों में पात्रता मानदंडों को पूरा नहीं करता है, इसलिए "
-"आपका विकिपीडिया पुस्तकालय कार्ड मंच खाता सक्रिय नहीं किया जा सकता है।"
+msgid "Your Wikipedia account does not meet the eligibility criteria in the terms of use, so your Wikipedia Library Card Platform account cannot be activated."
+msgstr "आपका विकिपीडिया खाता उपयोग की शर्तों में पात्रता मानदंडों को पूरा नहीं करता है, इसलिए आपका विकिपीडिया पुस्तकालय कार्ड मंच खाता सक्रिय नहीं किया जा सकता है।"
 
 #. Translators: If the user tries to log in, but their account does not meet certain requirements, they cannot login.
 #: TWLight/users/oauth.py:536
-msgid ""
-"Your Wikipedia account no longer meets the eligibility criteria in the terms "
-"of use, so you cannot be logged in. If you think you should be able to log "
-"in, please email wikipedialibrary@wikimedia.org."
-msgstr ""
-"आपका विकिपीडिया खाता अब उपयोग की शर्तों में पात्रता मानदंडों को पूरा नहीं करता है, "
-"इसलिए आपको लॉग इन नहीं किया जा सकता। अगर आपको लगता है कि आपको लॉग इन करने में "
-"सक्षम होना चाहिए, तो कृपया wikipedialibrary@wikimedia.org पर ईमेल करें।"
+msgid "Your Wikipedia account no longer meets the eligibility criteria in the terms of use, so you cannot be logged in. If you think you should be able to log in, please email wikipedialibrary@wikimedia.org."
+msgstr "आपका विकिपीडिया खाता अब उपयोग की शर्तों में पात्रता मानदंडों को पूरा नहीं करता है, इसलिए आपको लॉग इन नहीं किया जा सकता। अगर आपको लगता है कि आपको लॉग इन करने में सक्षम होना चाहिए, तो कृपया wikipedialibrary@wikimedia.org पर ईमेल करें।"
 
 #. Translators: this message is displayed to users with brand new accounts.
 #: TWLight/users/oauth.py:549
@@ -2819,10 +2330,7 @@ msgstr "आपका स्वागत है! कृपया उपयोग 
 #. Translators: This message is displayed on the confirmation page where users can return their access to partner collections.
 #: TWLight/users/templates/users/authorization_confirm_return.html:13
 #, python-format
-msgid ""
-"You will no longer be able to access <b>%(partner)s's</b> resources via the "
-"Library Card platform, but can request access again by clicking 'renew', if "
-"you change your mind. Are you sure you want to return your access?"
+msgid "You will no longer be able to access <b>%(partner)s's</b> resources via the Library Card platform, but can request access again by clicking 'renew', if you change your mind. Are you sure you want to return your access?"
 msgstr ""
 
 #. Translators: On the MyLibrary page (https://wikipedialibrary.wmflabs.org/users/my_library), this tab shows all favorite collections a user has.
@@ -2892,13 +2400,8 @@ msgstr "संपादक डेटा"
 
 #. Translators: This is shown on editor profiles, in their profile page or on applications.
 #: TWLight/users/templates/users/editor_detail.html:59
-msgid ""
-"Information with an * was retrieved from Wikipedia directly. Other "
-"information was entered directly by users or site admins, in their preferred "
-"language."
-msgstr ""
-"'*' वाली जानकारी सीधे विकिपीडिया से प्राप्त की गई थी। दूसरी जानकारी सीधे सदस्यों या "
-"साइट प्रबंधकों द्वारा उनकी पसंदीदा भाषा में डाली गई थी।"
+msgid "Information with an * was retrieved from Wikipedia directly. Other information was entered directly by users or site admins, in their preferred language."
+msgstr "'*' वाली जानकारी सीधे विकिपीडिया से प्राप्त की गई थी। दूसरी जानकारी सीधे सदस्यों या साइट प्रबंधकों द्वारा उनकी पसंदीदा भाषा में डाली गई थी।"
 
 #. Translators: This distinguishes users who have been flagged as account coordinators. Don't translate username.
 #: TWLight/users/templates/users/editor_detail.html:71
@@ -2908,14 +2411,8 @@ msgstr "%(username)s को इस साइट पर समन्वयक व
 
 #. Translators: This is shown on editor profiles, under the heading for Wikipedia editor data.
 #: TWLight/users/templates/users/editor_detail_data.html:5
-msgid ""
-"This information is updated automatically from your Wikimedia account each "
-"time you log in, except for the Contributions field, where you can describe "
-"your Wikimedia editing history."
-msgstr ""
-"यह जानकारी आपके विकिमीडिया खाते से हर बार आपके द्वारा लॉग इन करने पर अपने आप अपडेट "
-"हो जाती है, योगदान क्षेत्र को छोड़कर, जहाँ आप अपने विकिपीडिया संपादन इतिहास का वर्णन "
-"कर सकते हैं।"
+msgid "This information is updated automatically from your Wikimedia account each time you log in, except for the Contributions field, where you can describe your Wikimedia editing history."
+msgstr "यह जानकारी आपके विकिमीडिया खाते से हर बार आपके द्वारा लॉग इन करने पर अपने आप अपडेट हो जाती है, योगदान क्षेत्र को छोड़कर, जहाँ आप अपने विकिपीडिया संपादन इतिहास का वर्णन कर सकते हैं।"
 
 #. Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this labels the user's username.
 #: TWLight/users/templates/users/editor_detail_data.html:17
@@ -2944,19 +2441,13 @@ msgstr "उपयोग की शर्तें संतुष्ट कर�
 
 #. Translators: when viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this question has a yes or no answer.
 #: TWLight/users/templates/users/editor_detail_data.html:57
-msgid ""
-"at their last login, did this user meet the criteria set forth in the terms "
-"of use?"
-msgstr ""
-"उनके अंतिम लॉग-इन पर, क्या इस सदस्य ने उपयोग की शर्तों में निर्धारित मानदंडों को पूरा "
-"किया?"
+msgid "at their last login, did this user meet the criteria set forth in the terms of use?"
+msgstr "उनके अंतिम लॉग-इन पर, क्या इस सदस्य ने उपयोग की शर्तों में निर्धारित मानदंडों को पूरा किया?"
 
 #. Translators: When viewing a user's profile in an application, this message shows if the software doesn't think that the user is eligible for access. Don't translate username.
 #: TWLight/users/templates/users/editor_detail_data.html:72
 #, python-format
-msgid ""
-"%(username)s may still be eligible for access grants at the coordinators' "
-"discretion."
+msgid "%(username)s may still be eligible for access grants at the coordinators' discretion."
 msgstr "%(username)s अभी भी समन्वयकों के विवेक पर पहुँच अनुदान के लिए योग्य हो सकता है।"
 
 #. Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this is the heading for a Yes/No ToU question.
@@ -2993,10 +2484,7 @@ msgstr ""
 #. Translators: This message is shown on a user's profile if their Wikimedia account is blocked on one or more projects. They may still be granted access to the Library Bundle, but need to contact Wikipedia Library staff to verify.
 #: TWLight/users/templates/users/editor_detail_data.html:137
 #, python-format
-msgid ""
-"It looks like you have an active block on your account. If you meet the "
-"other criteria you may still be permitted access to the library - please <a "
-"class=\"twl-links\" href=\"%(contact_url)s\">contact us</a>."
+msgid "It looks like you have an active block on your account. If you meet the other criteria you may still be permitted access to the library - please <a class=\"twl-links\" href=\"%(contact_url)s\">contact us</a>."
 msgstr ""
 
 #. Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this is the heading for a Yes/No program eligibility question.
@@ -3007,13 +2495,8 @@ msgstr ""
 #. Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this question has a Yes or No answer.
 #: TWLight/users/templates/users/editor_detail_data.html:156
 #, fuzzy
-msgid ""
-"At their last login, did this user meet the criteria set forth in the "
-"Library Bundle? Note that satisfying terms of use is a prerequisite to "
-"bundle eligibility."
-msgstr ""
-"उनके अंतिम लॉगिन पर, क्या यह उपयोगकर्ता उपयोग की शर्तों में निर्धारित मानदंडों को पूरा "
-"करता है?"
+msgid "At their last login, did this user meet the criteria set forth in the Library Bundle? Note that satisfying terms of use is a prerequisite to bundle eligibility."
+msgstr "उनके अंतिम लॉगिन पर, क्या यह उपयोगकर्ता उपयोग की शर्तों में निर्धारित मानदंडों को पूरा करता है?"
 
 #. Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this is the heading for a Yes/No program eligibility question.
 #: TWLight/users/templates/users/editor_detail_data.html:177
@@ -3060,24 +2543,14 @@ msgstr ""
 
 #. Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this text is in the 'Personal data' section. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/users/templates/users/editor_detail_data.html:262
-msgid ""
-"The following information is visible only to you, site administrators, "
-"publishing partners (where required), and volunteer Wikipedia Library "
-"coordinators (who have signed a Non-Disclosure Agreement)."
-msgstr ""
-"निम्नलिखित जानकारी केवल आपको, साइट प्रबंधक, प्रकाशन भागीदार (जहाँ आवश्यक हो), और "
-"स्वयंसेवक विकिपीडिया पुस्तकालय समन्वयक (जिन्होंने गैर-प्रकटीकरण समझौते पर हस्ताक्षर किए "
-"हैं)को दिखाई देती है।"
+msgid "The following information is visible only to you, site administrators, publishing partners (where required), and volunteer Wikipedia Library coordinators (who have signed a Non-Disclosure Agreement)."
+msgstr "निम्नलिखित जानकारी केवल आपको, साइट प्रबंधक, प्रकाशन भागीदार (जहाँ आवश्यक हो), और स्वयंसेवक विकिपीडिया पुस्तकालय समन्वयक (जिन्होंने गैर-प्रकटीकरण समझौते पर हस्ताक्षर किए हैं)को दिखाई देती है।"
 
 #. Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this labels a button which users can click to update or remove their personal information. Don't translate update_url.
 #: TWLight/users/templates/users/editor_detail_data.html:272
 #, python-format
-msgid ""
-"You may <a class=\"twl-links\" href=\"%(update_url)s\">update or delete</a> "
-"your data at any time."
-msgstr ""
-"आप किसी भी समय अपना डेटा <a class=\"twl-links\" href=\"%(update_url)s\">अपडेट "
-"या हटा</a> कर सकते हैं।"
+msgid "You may <a class=\"twl-links\" href=\"%(update_url)s\">update or delete</a> your data at any time."
+msgstr "आप किसी भी समय अपना डेटा <a class=\"twl-links\" href=\"%(update_url)s\">अपडेट या हटा</a> कर सकते हैं।"
 
 #. Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this labels the user's email. Don't remove the *.
 #: TWLight/users/templates/users/editor_detail_data.html:283
@@ -3096,26 +2569,18 @@ msgstr "संस्थागत संबद्धता"
 
 #. Translators: This message tells users that they are not eligible to access The Wikipedia Library content.
 #: TWLight/users/templates/users/eligibility_modal.html:7
-msgid ""
-"Sorry, your Wikipedia account doesn’t currently qualify to access The "
-"Wikipedia Library."
+msgid "Sorry, your Wikipedia account doesn’t currently qualify to access The Wikipedia Library."
 msgstr ""
 
 #. Translators: This message tells users that they have not agreed to the terms of use, therefore are ineligible to access the content in The Wikipedia Library.
 #: TWLight/users/templates/users/eligibility_modal.html:30
 #, python-format
-msgid ""
-"Agreed with <a href=\"%(terms)s\" class=\"text-danger\"> terms of use </a>"
-msgstr ""
-"के लिए आवश्यक है कि आप इसकी <a href=\"%(terms)s\" class=\"text-danger\">उपयोग "
-"की शर्तों</a>से सहमत हों।"
+msgid "Agreed with <a href=\"%(terms)s\" class=\"text-danger\"> terms of use </a>"
+msgstr "के लिए आवश्यक है कि आप इसकी <a href=\"%(terms)s\" class=\"text-danger\">उपयोग की शर्तों</a>से सहमत हों।"
 
 #: TWLight/users/templates/users/eligibility_modal.html:40
 #, python-format
-msgid ""
-"It looks like you have an active block on your account. If you meet the "
-"other criteria you may still be permitted access to the library - please <a "
-"href=\"%(contact_url)s\">contact us</a>."
+msgid "It looks like you have an active block on your account. If you meet the other criteria you may still be permitted access to the library - please <a href=\"%(contact_url)s\">contact us</a>."
 msgstr ""
 
 #. Translators: Instructions to refresh a user's data.
@@ -3155,14 +2620,8 @@ msgstr "भाषा चुनें"
 
 #. Translators: This text on the user page helps users naviage to the TranslateWiki Wikipedia Library Card platform translation page.
 #: TWLight/users/templates/users/language_form.html:31
-msgid ""
-"You can help translate the tool at <a class=\"twl-links\" href=\"https://"
-"translatewiki.net/wiki/Translating:Wikipedia_Library_Card_Platform"
-"\">translatewiki.net</a>."
-msgstr ""
-"आप <a class=\"twl-links\" href=\"https://translatewiki.net/wiki/Translating:"
-"Wikipedia_Library_Card_Platform\">translatewiki.net</a> पर  टूल का अनुवाद करने "
-"में सहायता कर सकते हैं।"
+msgid "You can help translate the tool at <a class=\"twl-links\" href=\"https://translatewiki.net/wiki/Translating:Wikipedia_Library_Card_Platform\">translatewiki.net</a>."
+msgstr "आप <a class=\"twl-links\" href=\"https://translatewiki.net/wiki/Translating:Wikipedia_Library_Card_Platform\">translatewiki.net</a> पर  टूल का अनुवाद करने में सहायता कर सकते हैं।"
 
 #. Translators: When the user starts a new application and submits the application, the user can view the application and withdraw if need be. This changes the label for the Withdraw button.
 #: TWLight/users/templates/users/my_applications.html:65
@@ -3181,12 +2640,8 @@ msgstr "नवीनीकरण का अनुरोध करें"
 
 #. Translators: On the page listing applications, this text explains a user they cannot renew their application since they've already requested a renewal or there aren't any renewals available.
 #: TWLight/users/templates/users/my_applications.html:79
-msgid ""
-"Renewals are either not required, not available right now, or you have "
-"already requested a renewal."
-msgstr ""
-"नवीनीकरण की आवश्यकता नहीं है, अभी उपलब्ध नहीं है, या आपने पहले ही नवीनीकरण का अनुरोध "
-"किया है।"
+msgid "Renewals are either not required, not available right now, or you have already requested a renewal."
+msgstr "नवीनीकरण की आवश्यकता नहीं है, अभी उपलब्ध नहीं है, या आपने पहले ही नवीनीकरण का अनुरोध किया है।"
 
 #. Translators: This text is the heading of a section in a user's profile where they can change their preferences.
 #: TWLight/users/templates/users/preferences.html:6
@@ -3253,27 +2708,13 @@ msgstr "डेटा प्रोसेसिंग प्रतिबंधि�
 
 #. Translators: This message is displayed on the page where users can request we stop processing their data.
 #: TWLight/users/templates/users/restrict_data.html:15
-msgid ""
-"Checking this box and clicking “Restrict” will pause all processing of the "
-"data you have entered into this website. You will not be able to apply for "
-"access to resources, your applications will not be further processed, and "
-"none of your data will be altered, until you return to this page and uncheck "
-"the box. This is not the same as deleting your data."
-msgstr ""
-"इस बॉक्स को चेक करना और \"प्रतिबंधित\" पर क्लिक करना इस वेबसाइट में आपके द्वारा दर्ज "
-"किए गए डेटा के सभी प्रसंस्करण को रोक देगा। आप संसाधनों तक पहुंच के लिए आवेदन नहीं कर "
-"पाएंगे, आपके आवेदनों को आगे संसाधित नहीं किया जाएगा, और जब तक आप इस पृष्ठ पर लौट कर "
-"बॉक्स को अनचेक नहीं करते हैं, तब तक आपका कोई भी डेटा परिवर्तित नहीं किया जाएगा। यह "
-"आपके डेटा को हटाने के समान नहीं है।"
+msgid "Checking this box and clicking “Restrict” will pause all processing of the data you have entered into this website. You will not be able to apply for access to resources, your applications will not be further processed, and none of your data will be altered, until you return to this page and uncheck the box. This is not the same as deleting your data."
+msgstr "इस बॉक्स को चेक करना और \"प्रतिबंधित\" पर क्लिक करना इस वेबसाइट में आपके द्वारा दर्ज किए गए डेटा के सभी प्रसंस्करण को रोक देगा। आप संसाधनों तक पहुंच के लिए आवेदन नहीं कर पाएंगे, आपके आवेदनों को आगे संसाधित नहीं किया जाएगा, और जब तक आप इस पृष्ठ पर लौट कर बॉक्स को अनचेक नहीं करते हैं, तब तक आपका कोई भी डेटा परिवर्तित नहीं किया जाएगा। यह आपके डेटा को हटाने के समान नहीं है।"
 
 #. Translators: This warning message is shown to coordinators who view the data restriction page.
 #: TWLight/users/templates/users/restrict_data.html:26
-msgid ""
-"You are a coordinator on this site. If you restrict the processing of your "
-"data, your coordinator flag will be removed."
-msgstr ""
-"आप इस साइट पर एक समन्वयक हैं। यदि आप अपने डेटा के प्रसंस्करण को प्रतिबंधित करते हैं, तो "
-"आपका समन्वयक ध्वज हटा दिया जाएगा।"
+msgid "You are a coordinator on this site. If you restrict the processing of your data, your coordinator flag will be removed."
+msgstr "आप इस साइट पर एक समन्वयक हैं। यदि आप अपने डेटा के प्रसंस्करण को प्रतिबंधित करते हैं, तो आपका समन्वयक ध्वज हटा दिया जाएगा।"
 
 #. Translators: use the date *when you are translating*, in a language-appropriate format.
 #: TWLight/users/templates/users/terms.html:33
@@ -3294,40 +2735,14 @@ msgstr "विकिपीडिया पुस्तकालय कार्�
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:51
 #, fuzzy
-msgid ""
-"<a class=\"twl-links\" href=\"https://meta.wikimedia.org/wiki/"
-"The_Wikipedia_Library\"> The Wikipedia Library </a> has partnered with "
-"publishers around the world to allow users to access otherwise paywalled "
-"resources. This website allows Wikipedia editors to search and access these "
-"resources."
-msgstr ""
-"विकिपीडिया पुस्तकालय एक खुला शोध केंद्र है, जिसके माध्यम से सक्रिय विकिपीडिया संपादक अपने "
-"काम के लिए आवश्यक महत्वपूर्ण विश्वसनीय स्रोतों तक पहुँच प्राप्त कर सकते हैं और विश्वकोश को "
-"बेहतर बनाने के लिए उन संसाधनों का उपयोग करने में सहायता कर सकते हैं। हमने दुनिया भर के "
-"प्रकाशकों के साथ भागीदारी की है ताकि उपयोगकर्ताओं को स्वतंत्र रूप से अन्यथा भुगतान किए गए "
-"संसाधनों का उपयोग करने की अनुमति मिल सके। यह प्लेटफ़ॉर्म उपयोगकर्ताओं को एक साथ कई "
-"प्रकाशकों तक पहुँच के लिए आवेदन करने की अनुमति देता है, और विकिपीडिया पुस्तकालय खातों के "
-"प्रबंधन को आसान और कुशल बनाता है।"
+msgid "<a class=\"twl-links\" href=\"https://meta.wikimedia.org/wiki/The_Wikipedia_Library\"> The Wikipedia Library </a> has partnered with publishers around the world to allow users to access otherwise paywalled resources. This website allows Wikipedia editors to search and access these resources."
+msgstr "विकिपीडिया पुस्तकालय एक खुला शोध केंद्र है, जिसके माध्यम से सक्रिय विकिपीडिया संपादक अपने काम के लिए आवश्यक महत्वपूर्ण विश्वसनीय स्रोतों तक पहुँच प्राप्त कर सकते हैं और विश्वकोश को बेहतर बनाने के लिए उन संसाधनों का उपयोग करने में सहायता कर सकते हैं। हमने दुनिया भर के प्रकाशकों के साथ भागीदारी की है ताकि उपयोगकर्ताओं को स्वतंत्र रूप से अन्यथा भुगतान किए गए संसाधनों का उपयोग करने की अनुमति मिल सके। यह प्लेटफ़ॉर्म उपयोगकर्ताओं को एक साथ कई प्रकाशकों तक पहुँच के लिए आवेदन करने की अनुमति देता है, और विकिपीडिया पुस्तकालय खातों के प्रबंधन को आसान और कुशल बनाता है।"
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Wikimedia Foundation should not be translated. WMF should not be translated. Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:63
 #, fuzzy
-msgid ""
-"This program is administered by the Wikimedia Foundation (WMF). These terms "
-"of use and privacy notice pertain to your application for access to "
-"resources through the Wikipedia Library, your use of this website, and your "
-"access to and use of those resources. They also describe our handling of the "
-"information you provide to us in order to create and administer your "
-"Wikipedia Library account. If we make material changes to the terms, we will "
-"notify users."
-msgstr ""
-"ये शर्तें विकिपीडिया पुस्तकालय संसाधनों तक पहुँच के लिए आपके आवेदन और उन संसाधनों के आपके "
-"उपयोग से संबंधित हैं। ये आपके विकिपीडिया पुस्तकालय खाते को बनाने और प्रबंधित करने के लिए "
-"आपको हमारे द्वारा प्रदान की जाने वाली जानकारी के बारे में भी बताती हैं। विकिपीडिया "
-"पुस्तकालय प्रणाली विकसित हो रही है, और समय के साथ हम प्रौद्योगिकी में बदलाव के कारण इन "
-"शर्तों को अद्यतन कर सकते हैं। हम अनुशंसा करते हैं कि आप समय-समय पर शर्तों की समीक्षा करें। "
-"यदि हम शर्तों में पर्याप्त बदलाव करते हैं, तो हम विकिपीडिया पुस्तकालय उपयोगकर्ताओं को एक "
-"सूचना ईमेल भेजेंगे।"
+msgid "This program is administered by the Wikimedia Foundation (WMF). These terms of use and privacy notice pertain to your application for access to resources through the Wikipedia Library, your use of this website, and your access to and use of those resources. They also describe our handling of the information you provide to us in order to create and administer your Wikipedia Library account. If we make material changes to the terms, we will notify users."
+msgstr "ये शर्तें विकिपीडिया पुस्तकालय संसाधनों तक पहुँच के लिए आपके आवेदन और उन संसाधनों के आपके उपयोग से संबंधित हैं। ये आपके विकिपीडिया पुस्तकालय खाते को बनाने और प्रबंधित करने के लिए आपको हमारे द्वारा प्रदान की जाने वाली जानकारी के बारे में भी बताती हैं। विकिपीडिया पुस्तकालय प्रणाली विकसित हो रही है, और समय के साथ हम प्रौद्योगिकी में बदलाव के कारण इन शर्तों को अद्यतन कर सकते हैं। हम अनुशंसा करते हैं कि आप समय-समय पर शर्तों की समीक्षा करें। यदि हम शर्तों में पर्याप्त बदलाव करते हैं, तो हम विकिपीडिया पुस्तकालय उपयोगकर्ताओं को एक सूचना ईमेल भेजेंगे।"
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:74
@@ -3337,54 +2752,18 @@ msgstr "विकिपीडिया पुस्तकालय कार्�
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:78
 #, fuzzy
-msgid ""
-"Access to resources via The Wikipedia Library is reserved for community "
-"members who have demonstrated their commitment to the Wikimedia projects, "
-"and who will use their access to these resources to improve project content. "
-"To that end, in order to be eligible for The Wikipedia Library, we require "
-"that you be registered for a user account on the projects, with at least 500 "
-"edits, six (6) months of activity, and 10+ edits in the last month. We ask "
-"that you do not request access to any publishers with a limited number of "
-"available accounts whose resources you can already access for free through "
-"your local library or university, or another institution or organization, in "
-"order to provide that opportunity to others."
-msgstr ""
-"प्रारंभिक नोट के रूप में, विकिपीडिया पुस्तकालय खाते  समुदाय के उन सदस्यों के लिए आरक्षित हैं, "
-"जिन्होंने विकिमीडिया परियोजनाओं के लिए अपनी प्रतिबद्धता का प्रदर्शन किया है, और "
-"परियोजना की सामग्री में सुधार के लिए इन संसाधनों तक अपनी पहुँच का उपयोग करेंगे। फलतः "
-"विकिपीडिया पुस्तकालय कार्यक्रम के लिए पात्र होने के लिए, हमें चाहिए कि आप परियोजनाओं पर "
-"एक उपयोगकर्ता खाते के लिए पंजीकृत हों। हम आम तौर पर कम से कम 500 संपादन और छह (6) "
-"महीने की गतिविधि वाले उपयोगकर्ताओं को वरीयता देते हैं, लेकिन ये सख्त आवश्यकताएं नहीं हैं। "
-"आपके पास विकिपीडिया के कम से कम एक संस्करण पर विशेष:ईमेल_करें सुविधा सक्षम होनी चाहिए, "
-"और जब आप एक खाता बनाते हैं, तो आप उसे \"घर\" विकी के रूप में निश्चित करेंगे। हम पूछते हैं कि "
-"आप उन प्रकाशकों तक पहुँच का अनुरोध नहीं करते जिनके संसाधन आप पहले से ही अपने स्थानीय "
-"पुस्तकालय या विश्वविद्यालय, या किसी अन्य संस्था या संगठन के माध्यम से मुफ्त में उपयोग कर "
-"सकते हैं, ताकि दूसरों को वह अवसर प्रदान किया जा सके।"
+msgid "Access to resources via The Wikipedia Library is reserved for community members who have demonstrated their commitment to the Wikimedia projects, and who will use their access to these resources to improve project content. To that end, in order to be eligible for The Wikipedia Library, we require that you be registered for a user account on the projects, with at least 500 edits, six (6) months of activity, and 10+ edits in the last month. We ask that you do not request access to any publishers with a limited number of available accounts whose resources you can already access for free through your local library or university, or another institution or organization, in order to provide that opportunity to others."
+msgstr "प्रारंभिक नोट के रूप में, विकिपीडिया पुस्तकालय खाते  समुदाय के उन सदस्यों के लिए आरक्षित हैं, जिन्होंने विकिमीडिया परियोजनाओं के लिए अपनी प्रतिबद्धता का प्रदर्शन किया है, और परियोजना की सामग्री में सुधार के लिए इन संसाधनों तक अपनी पहुँच का उपयोग करेंगे। फलतः विकिपीडिया पुस्तकालय कार्यक्रम के लिए पात्र होने के लिए, हमें चाहिए कि आप परियोजनाओं पर एक उपयोगकर्ता खाते के लिए पंजीकृत हों। हम आम तौर पर कम से कम 500 संपादन और छह (6) महीने की गतिविधि वाले उपयोगकर्ताओं को वरीयता देते हैं, लेकिन ये सख्त आवश्यकताएं नहीं हैं। आपके पास विकिपीडिया के कम से कम एक संस्करण पर विशेष:ईमेल_करें सुविधा सक्षम होनी चाहिए, और जब आप एक खाता बनाते हैं, तो आप उसे \"घर\" विकी के रूप में निश्चित करेंगे। हम पूछते हैं कि आप उन प्रकाशकों तक पहुँच का अनुरोध नहीं करते जिनके संसाधन आप पहले से ही अपने स्थानीय पुस्तकालय या विश्वविद्यालय, या किसी अन्य संस्था या संगठन के माध्यम से मुफ्त में उपयोग कर सकते हैं, ताकि दूसरों को वह अवसर प्रदान किया जा सके।"
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:94
 #, fuzzy
-msgid ""
-"Additionally, if you are currently blocked or banned from a Wikimedia "
-"project, applications to resources may be rejected or restricted. If you "
-"obtain a Wikipedia Library account, but a block or ban is subsequently "
-"instituted against you on one of the projects, you may lose access to your "
-"Wikipedia Library account."
-msgstr ""
-"इसके अतिरिक्त, यदि आप वर्तमान में किसी विकिमीडिया परियोजना से अवरुद्ध या प्रतिबंधित हैं, "
-"तो विकिपीडिया पुस्तकालय खाते के लिए आवेदन करने पर आपको अस्वीकार किया जा सकता है। यदि "
-"आप एक विकिपीडिया पुस्तकालय खाता प्राप्त करते हैं, लेकिन बाद में आप को  किसी परियोजना "
-"पर एक लंबी अवधि के लिए ब्लॉक या प्रतिबंधित किया जाता है, तो आप अपने विकिपीडिया "
-"पुस्तकालय खाते तक पहुँच खो सकते हैं।"
+msgid "Additionally, if you are currently blocked or banned from a Wikimedia project, applications to resources may be rejected or restricted. If you obtain a Wikipedia Library account, but a block or ban is subsequently instituted against you on one of the projects, you may lose access to your Wikipedia Library account."
+msgstr "इसके अतिरिक्त, यदि आप वर्तमान में किसी विकिमीडिया परियोजना से अवरुद्ध या प्रतिबंधित हैं, तो विकिपीडिया पुस्तकालय खाते के लिए आवेदन करने पर आपको अस्वीकार किया जा सकता है। यदि आप एक विकिपीडिया पुस्तकालय खाता प्राप्त करते हैं, लेकिन बाद में आप को  किसी परियोजना पर एक लंबी अवधि के लिए ब्लॉक या प्रतिबंधित किया जाता है, तो आप अपने विकिपीडिया पुस्तकालय खाते तक पहुँच खो सकते हैं।"
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:104
-msgid ""
-"Your eligibility to access The Wikipedia Library is assessed at each login. "
-"While more than half of the library's content is provided via this automated "
-"eligibility check, access to other publisher's content may be time limited, "
-"typically lapsing after one year, after which you will usually need to apply "
-"for renewal."
+msgid "Your eligibility to access The Wikipedia Library is assessed at each login. While more than half of the library's content is provided via this automated eligibility check, access to other publisher's content may be time limited, typically lapsing after one year, after which you will usually need to apply for renewal."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
@@ -3396,75 +2775,31 @@ msgstr "अपने विकिपीडिया पुस्तकालय 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:118
 #, fuzzy
-msgid ""
-"In order to apply for access to a partner resource, you must provide us with "
-"certain information, which we will use to evaluate your application. If your "
-"application is approved, we may transfer the information you have given us "
-"to the publishers whose resources you wish to access. They will either "
-"contact you with the account information directly or we will send access "
-"information to you ourselves."
-msgstr ""
-"विकिपीडिया पुस्तकालय कार्ड खाते के लिए आवेदन करने के लिए, आपको हमें कुछ जानकारी प्रदान "
-"करनी होगी, जिसका उपयोग हम आपके आवेदन का मूल्यांकन करने के लिए करेंगे। यदि आपका आवेदन "
-"स्वीकृत हो जाता है, तो हम आपकी दी गई जानकारी को उन प्रकाशकों को हस्तांतरित कर सकते "
-"हैं, जिनके संसाधन आप एक्सेस करना चाहते हैं।  तब प्रकाशक आपके लिए एक निशुल्क खाता बनाएगा। "
-"ज्यादातर मामलों में, वे आपसे सीधे खाता जानकारी के साथ संपर्क करेंगे, हालांकि कभी-कभी हम "
-"आपको स्वयं भी जानकारी भेज देंगे।"
+msgid "In order to apply for access to a partner resource, you must provide us with certain information, which we will use to evaluate your application. If your application is approved, we may transfer the information you have given us to the publishers whose resources you wish to access. They will either contact you with the account information directly or we will send access information to you ourselves."
+msgstr "विकिपीडिया पुस्तकालय कार्ड खाते के लिए आवेदन करने के लिए, आपको हमें कुछ जानकारी प्रदान करनी होगी, जिसका उपयोग हम आपके आवेदन का मूल्यांकन करने के लिए करेंगे। यदि आपका आवेदन स्वीकृत हो जाता है, तो हम आपकी दी गई जानकारी को उन प्रकाशकों को हस्तांतरित कर सकते हैं, जिनके संसाधन आप एक्सेस करना चाहते हैं।  तब प्रकाशक आपके लिए एक निशुल्क खाता बनाएगा। ज्यादातर मामलों में, वे आपसे सीधे खाता जानकारी के साथ संपर्क करेंगे, हालांकि कभी-कभी हम आपको स्वयं भी जानकारी भेज देंगे।"
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:130
 #, fuzzy
-msgid ""
-"In addition to the basic information you provide to us, our system will "
-"retrieve some information directly from the Wikimedia projects: your "
-"username, email address, edit count, registration date, user ID number, "
-"groups to which you belong, and any special user rights."
-msgstr ""
-"आपके द्वारा हमें प्रदान की जाने वाली मूल जानकारी के अलावा, हमारी प्रणाली विकिमीडिया "
-"परियोजनाओं से सीधे कुछ जानकारी प्राप्त करेगी: आपका उपयोगकर्ता नाम, ईमेल पता, संपादन "
-"संख्या, पंजीकरण तिथि, उपयोगकर्ता आईडी संख्या, समूह जिनसे आप संबंधित हैं, और कोई विशेष "
-"उपयोगकर्ता अधिकार। जितनी बार आप विकिपीडिया पुस्तकालय  कार्ड मंच पर लॉग इन करेंगे, यह "
-"जानकारी स्वतः अपडेट हो जाएगी।"
+msgid "In addition to the basic information you provide to us, our system will retrieve some information directly from the Wikimedia projects: your username, email address, edit count, registration date, user ID number, groups to which you belong, and any special user rights."
+msgstr "आपके द्वारा हमें प्रदान की जाने वाली मूल जानकारी के अलावा, हमारी प्रणाली विकिमीडिया परियोजनाओं से सीधे कुछ जानकारी प्राप्त करेगी: आपका उपयोगकर्ता नाम, ईमेल पता, संपादन संख्या, पंजीकरण तिथि, उपयोगकर्ता आईडी संख्या, समूह जिनसे आप संबंधित हैं, और कोई विशेष उपयोगकर्ता अधिकार। जितनी बार आप विकिपीडिया पुस्तकालय  कार्ड मंच पर लॉग इन करेंगे, यह जानकारी स्वतः अपडेट हो जाएगी।"
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:140
-msgid ""
-"Each time you log in to the Wikipedia Library Card Platform, this "
-"information will be automatically updated."
+msgid "Each time you log in to the Wikipedia Library Card Platform, this information will be automatically updated."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:148
 #, fuzzy
-msgid ""
-"We will ask you to provide us with some information about your history of "
-"contributions to the Wikimedia projects. Information on contribution history "
-"is optional, but will greatly assist us in evaluating your application."
-msgstr ""
-"हम आपको अपने घर की विकी (या किसी भी विकिपीडिया संस्करण जहाँ आपने ईमेल को सक्षम किया "
-"है) की पहचान करने, और अंत में विकिमीडिया परियोजनाओं में आपके योगदान के इतिहास के बारे में "
-"कुछ जानकारी प्रदान करने के लिए कहेंगे। योगदान इतिहास की जानकारी वैकल्पिक है, लेकिन आपके "
-"आवेदन के मूल्यांकन में हमारी बहुत सहायता करेगी।"
+msgid "We will ask you to provide us with some information about your history of contributions to the Wikimedia projects. Information on contribution history is optional, but will greatly assist us in evaluating your application."
+msgstr "हम आपको अपने घर की विकी (या किसी भी विकिपीडिया संस्करण जहाँ आपने ईमेल को सक्षम किया है) की पहचान करने, और अंत में विकिमीडिया परियोजनाओं में आपके योगदान के इतिहास के बारे में कुछ जानकारी प्रदान करने के लिए कहेंगे। योगदान इतिहास की जानकारी वैकल्पिक है, लेकिन आपके आवेदन के मूल्यांकन में हमारी बहुत सहायता करेगी।"
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). WMF should not be translated. Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:157
 #, fuzzy
-msgid ""
-"The information you provide when creating your account will be visible to "
-"you while on the site but not to others unless they are approved Wikipedia "
-"Library Coordinators, WMF Staff, or WMF Contractors who need access to this "
-"data in order to carry out their work with the Wikipedia Library, all of "
-"whom are subject to non-disclosure obligations."
-msgstr ""
-"आपके खाते को बनाते समय आपके द्वारा दी गई जानकारी आपको साइट पर दिखाई देगी, लेकिन अन्य "
-"उपयोगकर्ताओं को नहीं जब तक कि वे उन्हें एक गैर-प्रकटीकरण समझौते (NDA) के तहत स्वीकृत "
-"समन्वयक, WMF कर्मचारी, या WMF ठेकेदार न हों, और जो  विकिपीडिया पुस्तकालय के साथ काम "
-"कर रहे हों। आपके द्वारा प्रदान की जाने वाली निम्न सीमित जानकारी डिफ़ॉल्ट रूप से सभी "
-"उपयोगकर्ताओं के लिए सार्वजनिक है: 1) जब आपने विकिपीडिया पुस्तकालय कार्ड खाता बनाया "
-"था; 2) जिन प्रकाशकों के संसाधनों को आपने एक्सेस करने के लिए आवेदन किया है; 3) प्रत्येक "
-"भागीदार के संसाधनों तक पहुँचने के लिए आप आवेदन करते हैं के लिए आपके तर्क का संक्षिप्त विवरण। "
-"संपादक जो इस जानकारी को सार्वजनिक नहीं करना चाहते हैं, वे WMF कर्मचारियों को निजी रूप "
-"से पहुंच का अनुरोध करने और प्राप्त करने के लिए आवश्यक जानकारी ईमेल कर सकते हैं।"
+msgid "The information you provide when creating your account will be visible to you while on the site but not to others unless they are approved Wikipedia Library Coordinators, WMF Staff, or WMF Contractors who need access to this data in order to carry out their work with the Wikipedia Library, all of whom are subject to non-disclosure obligations."
+msgstr "आपके खाते को बनाते समय आपके द्वारा दी गई जानकारी आपको साइट पर दिखाई देगी, लेकिन अन्य उपयोगकर्ताओं को नहीं जब तक कि वे उन्हें एक गैर-प्रकटीकरण समझौते (NDA) के तहत स्वीकृत समन्वयक, WMF कर्मचारी, या WMF ठेकेदार न हों, और जो  विकिपीडिया पुस्तकालय के साथ काम कर रहे हों। आपके द्वारा प्रदान की जाने वाली निम्न सीमित जानकारी डिफ़ॉल्ट रूप से सभी उपयोगकर्ताओं के लिए सार्वजनिक है: 1) जब आपने विकिपीडिया पुस्तकालय कार्ड खाता बनाया था; 2) जिन प्रकाशकों के संसाधनों को आपने एक्सेस करने के लिए आवेदन किया है; 3) प्रत्येक भागीदार के संसाधनों तक पहुँचने के लिए आप आवेदन करते हैं के लिए आपके तर्क का संक्षिप्त विवरण। संपादक जो इस जानकारी को सार्वजनिक नहीं करना चाहते हैं, वे WMF कर्मचारियों को निजी रूप से पहुंच का अनुरोध करने और प्राप्त करने के लिए आवश्यक जानकारी ईमेल कर सकते हैं।"
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:167
@@ -3474,58 +2809,35 @@ msgstr "प्रकाशक संसाधनों का आपका उ�
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:171
 #, fuzzy
-msgid ""
-"In order to access an individual publisher’s resources, you must agree to "
-"that publisher’s terms of use and privacy policy. You agree that you will "
-"not violate such terms and policies in connection with your use of the "
-"Wikipedia Library. Additionally, the following activities are prohibited "
-"while accessing publisher resources through the Wikipedia Library."
-msgstr ""
-"कृपया ध्यान दें कि किसी व्यक्तिगत प्रकाशक के संसाधनों तक पहुँचने के लिए, आप उस प्रकाशक की "
-"उपयोग की शर्तों और गोपनीयता नीति से सहमत होते हैं। इसके अतिरिक्त, विकिपीडिया पुस्तकालय "
-"के माध्यम से प्रकाशक संसाधनों तक आपकी पहुँच निम्नलिखित शर्तों के साथ है।"
+msgid "In order to access an individual publisher’s resources, you must agree to that publisher’s terms of use and privacy policy. You agree that you will not violate such terms and policies in connection with your use of the Wikipedia Library. Additionally, the following activities are prohibited while accessing publisher resources through the Wikipedia Library."
+msgstr "कृपया ध्यान दें कि किसी व्यक्तिगत प्रकाशक के संसाधनों तक पहुँचने के लिए, आप उस प्रकाशक की उपयोग की शर्तों और गोपनीयता नीति से सहमत होते हैं। इसके अतिरिक्त, विकिपीडिया पुस्तकालय के माध्यम से प्रकाशक संसाधनों तक आपकी पहुँच निम्नलिखित शर्तों के साथ है।"
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:184
 #, fuzzy
-msgid ""
-"Sharing your Wikipedia account, usernames, passwords, or any access codes "
-"for publisher resources with others;"
-msgstr ""
-"आपको प्रकाशक संसाधनों तक पहुँच के लिए अपने उपयोगकर्ता नाम और कूटशब्द दूसरों के साथ साँझा "
-"नहीं करने के लिए सहमत होना आवश्यक है।"
+msgid "Sharing your Wikipedia account, usernames, passwords, or any access codes for publisher resources with others;"
+msgstr "आपको प्रकाशक संसाधनों तक पहुँच के लिए अपने उपयोगकर्ता नाम और कूटशब्द दूसरों के साथ साँझा नहीं करने के लिए सहमत होना आवश्यक है।"
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:191
-msgid ""
-"Automatically scraping or downloading restricted content from publishers;"
+msgid "Automatically scraping or downloading restricted content from publishers;"
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:197
 #, fuzzy
-msgid ""
-"Systematically making printed or electronic copies of multiple extracts of "
-"restricted content available for any purpose;"
-msgstr ""
-"व्यवस्थित रूप से किसी भी उद्देश्य के लिए उपलब्ध प्रतिबंधित सामग्री के कई अंशों की मुद्रित या "
-"इलेक्ट्रॉनिक प्रतियाँ बनान"
+msgid "Systematically making printed or electronic copies of multiple extracts of restricted content available for any purpose;"
+msgstr "व्यवस्थित रूप से किसी भी उद्देश्य के लिए उपलब्ध प्रतिबंधित सामग्री के कई अंशों की मुद्रित या इलेक्ट्रॉनिक प्रतियाँ बनान"
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:204
 #, fuzzy
-msgid ""
-"Data mining metadata without permission—for example, in order to use "
-"metadata for auto-created stub articles;"
-msgstr ""
-"बिना अनुमति के मेटाडेटा को डेटामाइन करना, उदाहरण के लिए, ऑटो-निर्मित आधार लेखों के लिए "
-"मेटाडेटा का उपयोग करने के लिए"
+msgid "Data mining metadata without permission—for example, in order to use metadata for auto-created stub articles;"
+msgstr "बिना अनुमति के मेटाडेटा को डेटामाइन करना, उदाहरण के लिए, ऑटो-निर्मित आधार लेखों के लिए मेटाडेटा का उपयोग करने के लिए"
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:211
-msgid ""
-"Using the access you receive through the Wikipedia Library for profit by "
-"selling access to your account or resources which you have through it."
+msgid "Using the access you receive through the Wikipedia Library for profit by selling access to your account or resources which you have through it."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
@@ -3535,18 +2847,12 @@ msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:224
-msgid ""
-"Certain resources may only be accessed using an external search service, "
-"such as the EBSCO Discovery Service, or a proxy service, such as OCLC "
-"EZProxy. If you use such external search and/or proxy services, please "
-"review the applicable terms of use and privacy policies."
+msgid "Certain resources may only be accessed using an external search service, such as the EBSCO Discovery Service, or a proxy service, such as OCLC EZProxy. If you use such external search and/or proxy services, please review the applicable terms of use and privacy policies."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:234
-msgid ""
-"In addition, if you use OCLC EZProxy, please note that you may not use it "
-"for commercial purposes."
+msgid "In addition, if you use OCLC EZProxy, please note that you may not use it for commercial purposes."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
@@ -3556,161 +2862,54 @@ msgstr "डेटा प्रतिधारण और संचालन"
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Wikimedia Foundation should not be translated. Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:245
-msgid ""
-"The Wikimedia Foundation and our service providers use your information for "
-"the legitimate purpose of providing Wikipedia Library services in support of "
-"our charitable mission. When you apply for a Wikipedia Library account, or "
-"use your Wikipedia Library account, we may routinely collect the following "
-"information: your username, email address, edit count, registration date, "
-"user ID number, groups to which you belong, and any special user rights; "
-"your name, country of residence, and/or affiliation, if required by a "
-"partner to which you are applying; your narrative description of your "
-"contributions and reasons for applying for access to partner resources; and "
-"the date you agree to these terms of use."
+msgid "The Wikimedia Foundation and our service providers use your information for the legitimate purpose of providing Wikipedia Library services in support of our charitable mission. When you apply for a Wikipedia Library account, or use your Wikipedia Library account, we may routinely collect the following information: your username, email address, edit count, registration date, user ID number, groups to which you belong, and any special user rights; your name, country of residence, and/or affiliation, if required by a partner to which you are applying; your narrative description of your contributions and reasons for applying for access to partner resources; and the date you agree to these terms of use."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:262
 #, fuzzy, python-format
-msgid ""
-"Each publisher who is a member of the Wikipedia Library program requires "
-"different specific information in the application. Some publishers may "
-"request only an email address, while others request more detailed data, such "
-"as your name, location, or institutional affiliation. When you complete your "
-"application, you will only be asked to supply information required by the "
-"publishers you have chosen, and each publisher will only receive the "
-"information they require for providing you with access. Please see our <a "
-"class=\"twl-links\" href=\"%(all_partners_url)s\">partner information</a> "
-"pages to learn what information is required by each publisher to gain access "
-"to their resources."
-msgstr ""
-"प्रत्येक प्रकाशक, जो विकिपीडिया पुस्तकालय कार्यक्रम का सदस्य है, को आवेदन में विभिन्न "
-"विशिष्ट जानकारी की आवश्यकता होती है। कुछ प्रकाशक केवल एक ईमेल पते का अनुरोध कर सकते हैं, "
-"जबकि अन्य अधिक विस्तृत डेटा का अनुरोध करते हैं, जैसे कि आपका नाम, स्थान, व्यवसाय या "
-"संस्थागत संबद्धता। जब आप अपना आवेदन पूरा करते हैं, तो आपको केवल आपके द्वारा चुने गए "
-"प्रकाशकों द्वारा आवश्यक जानकारी की आपूर्ति करने के लिए कहा जाएगा, और प्रत्येक प्रकाशक को "
-"केवल वे सूचनाएँ दी जाएँगी जिनकी उन्हें आवश्यकता है। प्रत्येक प्रकाशक द्वारा अपने संसाधनों तक "
-"पहुँच प्राप्त करने के लिए क्या जानकारी आवश्यक है, यह जानने के लिए कृपया हमारे <a class="
-"\"twl-links\" href=\"%(all_partners_url)s\"> भागीदार जानकारी पृष्ठ </a> देखें।"
+msgid "Each publisher who is a member of the Wikipedia Library program requires different specific information in the application. Some publishers may request only an email address, while others request more detailed data, such as your name, location, or institutional affiliation. When you complete your application, you will only be asked to supply information required by the publishers you have chosen, and each publisher will only receive the information they require for providing you with access. Please see our <a class=\"twl-links\" href=\"%(all_partners_url)s\">partner information</a> pages to learn what information is required by each publisher to gain access to their resources."
+msgstr "प्रत्येक प्रकाशक, जो विकिपीडिया पुस्तकालय कार्यक्रम का सदस्य है, को आवेदन में विभिन्न विशिष्ट जानकारी की आवश्यकता होती है। कुछ प्रकाशक केवल एक ईमेल पते का अनुरोध कर सकते हैं, जबकि अन्य अधिक विस्तृत डेटा का अनुरोध करते हैं, जैसे कि आपका नाम, स्थान, व्यवसाय या संस्थागत संबद्धता। जब आप अपना आवेदन पूरा करते हैं, तो आपको केवल आपके द्वारा चुने गए प्रकाशकों द्वारा आवश्यक जानकारी की आपूर्ति करने के लिए कहा जाएगा, और प्रत्येक प्रकाशक को केवल वे सूचनाएँ दी जाएँगी जिनकी उन्हें आवश्यकता है। प्रत्येक प्रकाशक द्वारा अपने संसाधनों तक पहुँच प्राप्त करने के लिए क्या जानकारी आवश्यक है, यह जानने के लिए कृपया हमारे <a class=\"twl-links\" href=\"%(all_partners_url)s\"> भागीदार जानकारी पृष्ठ </a> देखें।"
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Wikimedia Foundation should not be translated. Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:277
-msgid ""
-"Some Wikipedia Library pages are visible without logging in, but you will "
-"need to log in to apply or access proprietary partner resources. We use the "
-"data provided by you via OAuth and Wikimedia API calls to assess your "
-"application for access and to process approved requests."
+msgid "Some Wikipedia Library pages are visible without logging in, but you will need to log in to apply or access proprietary partner resources. We use the data provided by you via OAuth and Wikimedia API calls to assess your application for access and to process approved requests."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:288
 #, fuzzy, python-format
-msgid ""
-"In order to administer the Wikipedia Library program, we will retain the "
-"application data we collect from you for three years after your most recent "
-"login, unless you delete your account, as described below. You can log in "
-"and go to <a class=\"twl-links\" href=\"%(profile_url)s\">your profile page</"
-"a> in order to see the information associated with your account, and can "
-"download it in JSON format. You may access, update, restrict, or delete this "
-"information at any time, except for the information that is automatically "
-"retrieved from the projects. If you have any questions or concerns about the "
-"handling of your data, please contact <a class=\"twl-links\" href=\"mailto:"
-"wikipedialibrary@wikimedia.org?Subject=Wikipedia%%20Library%%20Card"
-"%%20account%%20deactivation\"> wikipedialibrary@wikimedia.org </a>."
-msgstr ""
-"विकिपीडिया पुस्तकालय कार्यक्रम को प्रबंधित करने के लिए, हम डेटा को अनिश्चित काल के लिए "
-"एकत्र रखेंगे, जब तक कि आप अपना खाता नहीं हटाते, जैसा कि नीचे वर्णित है। अपने खाते से जुड़ी "
-"जानकारी देखने के लिए आप लॉग इन कर सकते हैं और अपने <a href=\"%(user_home_url)s\"> "
-"प्रोफ़ाइल पृष्ठ </a> पर जा सकते हैं। आप इस जानकारी को किसी भी समय अपडेट कर सकते हैं, "
-"केवल उन सूचनाओं को छोड़कर जो परियोजनाओं से स्वचालित रूप से पुनर्प्राप्त की जाती हैं।"
+msgid "In order to administer the Wikipedia Library program, we will retain the application data we collect from you for three years after your most recent login, unless you delete your account, as described below. You can log in and go to <a class=\"twl-links\" href=\"%(profile_url)s\">your profile page</a> in order to see the information associated with your account, and can download it in JSON format. You may access, update, restrict, or delete this information at any time, except for the information that is automatically retrieved from the projects. If you have any questions or concerns about the handling of your data, please contact <a class=\"twl-links\" href=\"mailto:wikipedialibrary@wikimedia.org?Subject=Wikipedia%%20Library%%20Card%%20account%%20deactivation\"> wikipedialibrary@wikimedia.org </a>."
+msgstr "विकिपीडिया पुस्तकालय कार्यक्रम को प्रबंधित करने के लिए, हम डेटा को अनिश्चित काल के लिए एकत्र रखेंगे, जब तक कि आप अपना खाता नहीं हटाते, जैसा कि नीचे वर्णित है। अपने खाते से जुड़ी जानकारी देखने के लिए आप लॉग इन कर सकते हैं और अपने <a href=\"%(user_home_url)s\"> प्रोफ़ाइल पृष्ठ </a> पर जा सकते हैं। आप इस जानकारी को किसी भी समय अपडेट कर सकते हैं, केवल उन सूचनाओं को छोड़कर जो परियोजनाओं से स्वचालित रूप से पुनर्प्राप्त की जाती हैं।"
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:305
 #, fuzzy
-msgid ""
-"If you decide to disable your Wikipedia Library account, you can use the "
-"delete button on your profile to delete certain personal information "
-"associated with your account. We will delete your real name, institutional "
-"affiliation, and country of residence. Please note that the system will "
-"retain a record of your username, the publishers to which you applied or had "
-"access, and the dates of that access. Note that deletion is not reversible. "
-"Deletion of your Wikipedia Library account may also correspond with the "
-"removal of any resource access to which you were eligible or approved. If "
-"you request the deletion of account information and later wish to apply for "
-"a new account, you will need to provide the necessary information again."
-msgstr ""
-"यदि आप अपने विकिपीडिया पुस्तकालय खाते को निष्क्रिय करने का निर्णय लेते हैं, तो आप हमें आपके "
-"खाते से जुड़ी कुछ व्यक्तिगत जानकारी को हटाने का अनुरोध करने के लिए<a href=\"mailto:"
-"wikipedialibrary@wikimedia.org?Subject=Wikipedia%%20Library%%20Card%%20accint"
-"%%20deactivation\"> wikipedialibrary@wikimedia.org </a> पर ईमेल कर सकते हैं। हम "
-"आपके वास्तविक नाम, व्यवसाय, संस्थागत संबद्धता और निवास स्थान को हटा देंगे। कृपया ध्यान दें "
-"कि प्रणाली आपके उपयोगकर्ता नाम, आपके द्वारा आवेदन किए गए या उपयोग किए गए प्रकाशकों "
-"और उस पहुँच की तारीखों का एक रिकॉर्ड रखेगा। यदि आप खाते की जानकारी को हटाने का "
-"अनुरोध करते हैं और बाद में नए खाते के लिए आवेदन करना चाहते हैं, तो आपको फिर से आवश्यक "
-"जानकारी प्रदान करनी होगी।"
+msgid "If you decide to disable your Wikipedia Library account, you can use the delete button on your profile to delete certain personal information associated with your account. We will delete your real name, institutional affiliation, and country of residence. Please note that the system will retain a record of your username, the publishers to which you applied or had access, and the dates of that access. Note that deletion is not reversible. Deletion of your Wikipedia Library account may also correspond with the removal of any resource access to which you were eligible or approved. If you request the deletion of account information and later wish to apply for a new account, you will need to provide the necessary information again."
+msgstr "यदि आप अपने विकिपीडिया पुस्तकालय खाते को निष्क्रिय करने का निर्णय लेते हैं, तो आप हमें आपके खाते से जुड़ी कुछ व्यक्तिगत जानकारी को हटाने का अनुरोध करने के लिए<a href=\"mailto:wikipedialibrary@wikimedia.org?Subject=Wikipedia%%20Library%%20Card%%20accint%%20deactivation\"> wikipedialibrary@wikimedia.org </a> पर ईमेल कर सकते हैं। हम आपके वास्तविक नाम, व्यवसाय, संस्थागत संबद्धता और निवास स्थान को हटा देंगे। कृपया ध्यान दें कि प्रणाली आपके उपयोगकर्ता नाम, आपके द्वारा आवेदन किए गए या उपयोग किए गए प्रकाशकों और उस पहुँच की तारीखों का एक रिकॉर्ड रखेगा। यदि आप खाते की जानकारी को हटाने का अनुरोध करते हैं और बाद में नए खाते के लिए आवेदन करना चाहते हैं, तो आपको फिर से आवश्यक जानकारी प्रदान करनी होगी।"
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). WMF should not be translated. Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:321
 #, fuzzy
-msgid ""
-"The Wikipedia Library is run by WMF Staff, Contractors, and approved "
-"volunteer Coordinators. The data associated with your account will be shared "
-"with the WMF staff, contractors, service providers, and volunteer "
-"coordinators who need to process the information in connection with their "
-"work for the Wikipedia Library, and who are subject to confidentiality "
-"obligations. We will also use your data for internal Wikipedia Library "
-"purposes such as distributing user surveys and account notifications, and in "
-"a depersonalized or aggregated fashion for statistical analysis and "
-"administration. Finally, we will share your information with the publishers "
-"whom you specifically select in order to provide you with access to "
-"resources. Otherwise, your information will not be shared with third "
-"parties, with the exception of the circumstances described below."
-msgstr ""
-"विकिपीडिया पुस्तकालय विकिमीडिया फ़ाउंडेशन के कर्मचारियों, ठेकेदारों, और स्वीकृत स्वयंसेवक "
-"समन्वयकों द्वारा संचालित की जाती है, जिनकी आपकी जानकारी तक पहुँच हो सकती है। आपके खाते "
-"से जुड़े डेटा को विकिमीडिया कर्मचारियों, ठेकेदारों, सेवा प्रदाताओं और स्वयंसेवक समन्वयकों के "
-"साथ साँझा किया जाएगा जिन्हें जानकारी को संसाधित करने की आवश्यकता है, और जो गैर-"
-"प्रकटीकरण दायित्वों के अधीन हैं। अन्यथा, विकिमीडिया फ़ाउंडेशन आपकी जानकारी केवल उन "
-"प्रकाशकों के साथ साँझा करेगी जिन्हें आप विशेष रूप से चुनते हैं, नीचे वर्णित परिस्थितियां इसके "
-"अपवाद हैं।"
+msgid "The Wikipedia Library is run by WMF Staff, Contractors, and approved volunteer Coordinators. The data associated with your account will be shared with the WMF staff, contractors, service providers, and volunteer coordinators who need to process the information in connection with their work for the Wikipedia Library, and who are subject to confidentiality obligations. We will also use your data for internal Wikipedia Library purposes such as distributing user surveys and account notifications, and in a depersonalized or aggregated fashion for statistical analysis and administration. Finally, we will share your information with the publishers whom you specifically select in order to provide you with access to resources. Otherwise, your information will not be shared with third parties, with the exception of the circumstances described below."
+msgstr "विकिपीडिया पुस्तकालय विकिमीडिया फ़ाउंडेशन के कर्मचारियों, ठेकेदारों, और स्वीकृत स्वयंसेवक समन्वयकों द्वारा संचालित की जाती है, जिनकी आपकी जानकारी तक पहुँच हो सकती है। आपके खाते से जुड़े डेटा को विकिमीडिया कर्मचारियों, ठेकेदारों, सेवा प्रदाताओं और स्वयंसेवक समन्वयकों के साथ साँझा किया जाएगा जिन्हें जानकारी को संसाधित करने की आवश्यकता है, और जो गैर-प्रकटीकरण दायित्वों के अधीन हैं। अन्यथा, विकिमीडिया फ़ाउंडेशन आपकी जानकारी केवल उन प्रकाशकों के साथ साँझा करेगी जिन्हें आप विशेष रूप से चुनते हैं, नीचे वर्णित परिस्थितियां इसके अपवाद हैं।"
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). WMF should not be translated.
 #: TWLight/users/templates/users/terms.html:338
 #, fuzzy
-msgid ""
-"We may disclose any collected information when required by law, when we have "
-"your permission, when needed to protect our rights, privacy, safety, users, "
-"or the general public, and when necessary to enforce these terms, WMF’s "
-"general <a class=\"twl-links\" href=\"https://foundation.wikimedia.org/wiki/"
-"Terms_of_Use\">Terms of Use</a>, or any other WMF policy."
-msgstr ""
-"हम कानून द्वारा आवश्यक होने पर, जब हमारे पास आपकी अनुमति हो, जब हमारे अधिकारों, "
-"गोपनीयता, सुरक्षा, उपयोगकर्ताओं या आम जनता की रक्षा के लिए आवश्यक हो, और जब इन "
-"शर्तों, हमारी सामान्य उपयोग की शर्तों, या कोई अन्य विकिमीडिया नीति को लागू करने के "
-"लिए आवश्यक हो, तो किसी भी एकत्रित जानकारी का खुलासा कर सकते हैं।"
+msgid "We may disclose any collected information when required by law, when we have your permission, when needed to protect our rights, privacy, safety, users, or the general public, and when necessary to enforce these terms, WMF’s general <a class=\"twl-links\" href=\"https://foundation.wikimedia.org/wiki/Terms_of_Use\">Terms of Use</a>, or any other WMF policy."
+msgstr "हम कानून द्वारा आवश्यक होने पर, जब हमारे पास आपकी अनुमति हो, जब हमारे अधिकारों, गोपनीयता, सुरक्षा, उपयोगकर्ताओं या आम जनता की रक्षा के लिए आवश्यक हो, और जब इन शर्तों, हमारी सामान्य उपयोग की शर्तों, या कोई अन्य विकिमीडिया नीति को लागू करने के लिए आवश्यक हो, तो किसी भी एकत्रित जानकारी का खुलासा कर सकते हैं।"
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:349
-msgid ""
-"We take the security of your personal data seriously, and take reasonable "
-"precautions to ensure your data is protected. These precautions include "
-"access controls to limit who has access to your data and security "
-"technologies to protect data stored on the server. However, we cannot "
-"guarantee the safety of your data as it is transmitted and stored."
+msgid "We take the security of your personal data seriously, and take reasonable precautions to ensure your data is protected. These precautions include access controls to limit who has access to your data and security technologies to protect data stored on the server. However, we cannot guarantee the safety of your data as it is transmitted and stored."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:360
 #, fuzzy
-msgid ""
-"Please note that these terms do not control the use and handling of your "
-"data by the publishers and service providers whose resources you access or "
-"apply to access. Please read their individual privacy policies for that "
-"information."
-msgstr ""
-"कृपया ध्यान दें कि ये शर्तें उन प्रकाशकों द्वारा आपके डेटा के उपयोग और संचालन करने को "
-"नियंत्रित नहीं करते हैं जिनके संसाधन आप एक्सेस करते हैं। कृपया उस जानकारी के लिए उनकी "
-"व्यक्तिगत गोपनीयता नीतियाँ पढ़ें।"
+msgid "Please note that these terms do not control the use and handling of your data by the publishers and service providers whose resources you access or apply to access. Please read their individual privacy policies for that information."
+msgstr "कृपया ध्यान दें कि ये शर्तें उन प्रकाशकों द्वारा आपके डेटा के उपयोग और संचालन करने को नियंत्रित नहीं करते हैं जिनके संसाधन आप एक्सेस करते हैं। कृपया उस जानकारी के लिए उनकी व्यक्तिगत गोपनीयता नीतियाँ पढ़ें।"
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:368
@@ -3721,45 +2920,17 @@ msgstr "आयातित"
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Wikimedia Foundation should not be translated. Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:373
 #, fuzzy
-msgid ""
-"The Wikimedia Foundation is a nonprofit organization based in San Francisco, "
-"California. The Wikipedia Library program provides access to resources held "
-"by publishers in multiple countries. If you apply for a Wikipedia Library "
-"account (whether you are inside or outside of the United States), you "
-"understand that your personal data will be collected, transferred, stored, "
-"processed, disclosed and otherwise used in the U.S. as described in this "
-"privacy policy. You also understand that your information may be transferred "
-"by us from the U.S. to other countries, which may have different or less "
-"stringent data protection laws than your country, in connection with "
-"providing services to you, including evaluating your application and "
-"securing access to your chosen publishers (locations for each publisher are "
-"outlined on their respective partner information pages)."
-msgstr ""
-"विकिमीडिया फाउंडेशन सैन फ्रांसिस्को, कैलिफोर्निया में स्थित एक गैर-लाभकारी संगठन है। "
-"विकिपीडिया पुस्तकालय कार्यक्रम कई देशों में प्रकाशकों द्वारा रखे गए संसाधनों तक पहुँच प्रदान "
-"करता है। विकिपीडिया पुस्तकालय खाते (चाहे आप अमेरिका के अंदर या बाहर हों) के लिए आवेदन "
-"करके, आप संयुक्त राज्य अमेरिका और अन्य स्थानों में संग्रहित सूचना के संग्रह, हस्तांतरण, भंडारण, "
-"प्रसंस्करण, प्रकटीकरण, और ऊपर चर्चा किए गए उद्देश्यों और उद्देश्यों को पूरा करने के लिए "
-"आवश्यक अन्य उपयोगों के लिए सहमती देते हैं। आपके आवेदन का मूल्यांकन करने और अपने चुने हुए "
-"प्रकाशकों तक पहुंच प्राप्त करने के लिए सेवाएँ प्रदान करने के लिए आप अमेरिका से दूसरे देशों में "
-"आपकी जानकारी के हस्तांतरण की सहमति भी देते हैं, जिसमें आपके देश के अलग-अलग या कम कड़े डेटा "
-"संरक्षण कानून हो सकते हैं।"
+msgid "The Wikimedia Foundation is a nonprofit organization based in San Francisco, California. The Wikipedia Library program provides access to resources held by publishers in multiple countries. If you apply for a Wikipedia Library account (whether you are inside or outside of the United States), you understand that your personal data will be collected, transferred, stored, processed, disclosed and otherwise used in the U.S. as described in this privacy policy. You also understand that your information may be transferred by us from the U.S. to other countries, which may have different or less stringent data protection laws than your country, in connection with providing services to you, including evaluating your application and securing access to your chosen publishers (locations for each publisher are outlined on their respective partner information pages)."
+msgstr "विकिमीडिया फाउंडेशन सैन फ्रांसिस्को, कैलिफोर्निया में स्थित एक गैर-लाभकारी संगठन है। विकिपीडिया पुस्तकालय कार्यक्रम कई देशों में प्रकाशकों द्वारा रखे गए संसाधनों तक पहुँच प्रदान करता है। विकिपीडिया पुस्तकालय खाते (चाहे आप अमेरिका के अंदर या बाहर हों) के लिए आवेदन करके, आप संयुक्त राज्य अमेरिका और अन्य स्थानों में संग्रहित सूचना के संग्रह, हस्तांतरण, भंडारण, प्रसंस्करण, प्रकटीकरण, और ऊपर चर्चा किए गए उद्देश्यों और उद्देश्यों को पूरा करने के लिए आवश्यक अन्य उपयोगों के लिए सहमती देते हैं। आपके आवेदन का मूल्यांकन करने और अपने चुने हुए प्रकाशकों तक पहुंच प्राप्त करने के लिए सेवाएँ प्रदान करने के लिए आप अमेरिका से दूसरे देशों में आपकी जानकारी के हस्तांतरण की सहमति भी देते हैं, जिसमें आपके देश के अलग-अलग या कम कड़े डेटा संरक्षण कानून हो सकते हैं।"
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:392
-msgid ""
-"Please note that in the event of any differences in meaning or "
-"interpretation between the original English version of these terms and a "
-"translation, the original English version takes precedence."
-msgstr ""
-"कृपया ध्यान दें कि इन शर्तों के मूल अंग्रेजी संस्करण और अनुवाद के बीच अर्थ या व्याख्या में कोई "
-"अंतर होने की स्थिति में, मूल अंग्रेजी संस्करण को प्राथमिकता मिलती है।"
+msgid "Please note that in the event of any differences in meaning or interpretation between the original English version of these terms and a translation, the original English version takes precedence."
+msgstr "कृपया ध्यान दें कि इन शर्तों के मूल अंग्रेजी संस्करण और अनुवाद के बीच अर्थ या व्याख्या में कोई अंतर होने की स्थिति में, मूल अंग्रेजी संस्करण को प्राथमिकता मिलती है।"
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Wikimedia Foundation should not be translated.
 #: TWLight/users/templates/users/terms.html:403
-msgid ""
-"See also the <a class=\"twl-links\" href=\"https://wikimediafoundation.org/"
-"wiki/Privacy_policy\">Wikimedia Foundation Privacy Policy</a>."
+msgid "See also the <a class=\"twl-links\" href=\"https://wikimediafoundation.org/wiki/Privacy_policy\">Wikimedia Foundation Privacy Policy</a>."
 msgstr ""
 
 #. Translators: This is the second to last line of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
@@ -3781,15 +2952,8 @@ msgstr "विकिमीडिया फाउंडेशन गोपनी�
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:426
 #, fuzzy
-msgid ""
-"By checking this box and clicking “Submit”, you agree that you have read the "
-"above terms and that you will adhere to the terms of use in your application "
-"to and use of the The Wikipedia Library, and the publishers’ services to "
-"which you gain access through The Wikipedia Library program."
-msgstr ""
-"इस बॉक्स को चेक करके और \"सहमत हूँ\" पर क्लिक करके, आप उपरोक्त गोपनीयता कथन और शर्तों "
-"पर सहमति देते हैं, और विकिपीडिया पुस्तकालय और प्रकाशक की सेवाओं के उपयोग और उपयोग के "
-"लिए अपने आवेदन में उनका पालन करने के लिए सहमत होते हैं। विकिपीडिया पुस्तकालय कार्यक्रम।"
+msgid "By checking this box and clicking “Submit”, you agree that you have read the above terms and that you will adhere to the terms of use in your application to and use of the The Wikipedia Library, and the publishers’ services to which you gain access through The Wikipedia Library program."
+msgstr "इस बॉक्स को चेक करके और \"सहमत हूँ\" पर क्लिक करके, आप उपरोक्त गोपनीयता कथन और शर्तों पर सहमति देते हैं, और विकिपीडिया पुस्तकालय और प्रकाशक की सेवाओं के उपयोग और उपयोग के लिए अपने आवेदन में उनका पालन करने के लिए सहमत होते हैं। विकिपीडिया पुस्तकालय कार्यक्रम।"
 
 #: TWLight/users/templates/users/user_collection_tile.html:32
 msgid "Remove this collection from favorites"
@@ -3844,39 +3008,19 @@ msgstr "सभी डेटा हटाएँ"
 
 #. Translators: This message is displayed on the page where users can request the deletion of their data.
 #: TWLight/users/templates/users/user_confirm_delete.html:17
-msgid ""
-"<b>Warning:</b> Performing this action will delete your Wikipedia Library "
-"Card user account and all associated applications. This process is not "
-"reversible. You may lose any partner accounts you were granted, and will not "
-"be able to renew those accounts or apply for new ones."
-msgstr ""
-"<b>चेतावनी:</b> इस क्रिया को करने से आपका विकिपीडिया पुस्तकालय कार्ड उपयोगकर्ता खाता "
-"और सभी संबद्ध आवेदन नष्ट हो जाएंगे। यह प्रक्रिया प्रतिवर्ती नहीं है। आप अपने द्वारा दिए गए "
-"किसी भी भागीदार खाते को खो सकते हैं, और उन खातों को नवीनीकृत नहीं कर पाएंगे या नए के "
-"लिए आवेदन नहीं कर पाएंगे।"
+msgid "<b>Warning:</b> Performing this action will delete your Wikipedia Library Card user account and all associated applications. This process is not reversible. You may lose any partner accounts you were granted, and will not be able to renew those accounts or apply for new ones."
+msgstr "<b>चेतावनी:</b> इस क्रिया को करने से आपका विकिपीडिया पुस्तकालय कार्ड उपयोगकर्ता खाता और सभी संबद्ध आवेदन नष्ट हो जाएंगे। यह प्रक्रिया प्रतिवर्ती नहीं है। आप अपने द्वारा दिए गए किसी भी भागीदार खाते को खो सकते हैं, और उन खातों को नवीनीकृत नहीं कर पाएंगे या नए के लिए आवेदन नहीं कर पाएंगे।"
 
 #. Translators: this should show up for people who log in with a username/password and not OAuth, so we don't know what their Wikipedia identity is.
-#.
 #: TWLight/users/templates/users/user_detail.html:12
 #, python-format
-msgid ""
-"Hi, %(username)s! You don't have a Wikipedia editor profile attached to your "
-"account here, so you are probably a site administrator."
-msgstr ""
-"नमस्ते, %(username)s! आपके पास अपने खाते में एक विकिपीडिया संपादक प्रोफ़ाइल संलग्न नहीं "
-"है, इसलिए आप शायद साइट प्रबंधक हैं।"
+msgid "Hi, %(username)s! You don't have a Wikipedia editor profile attached to your account here, so you are probably a site administrator."
+msgstr "नमस्ते, %(username)s! आपके पास अपने खाते में एक विकिपीडिया संपादक प्रोफ़ाइल संलग्न नहीं है, इसलिए आप शायद साइट प्रबंधक हैं।"
 
 #. Translators: In the unlikely scenario that someone is able to register an account without using OAuth (thus leaving us without some of the information required for applications), users will see this message, encouraging them to re-register.
 #: TWLight/users/templates/users/user_detail.html:20
-msgid ""
-"If you aren't a site administrator, something weird has happened. You won't "
-"be able to apply for access without a Wikipedia editor profile. You should "
-"log out and create a new account by logging in via OAuth, or contact a site "
-"administrator for help."
-msgstr ""
-"यदि आप एक साइट प्रबंधक नहीं हैं, तो कुछ अजीब हुआ है। आप विकिपीडिया संपादक प्रोफ़ाइल के "
-"बिना उपयोग के लिए आवेदन नहीं कर पाएंगे। आपको लॉग आउट करके OAuth के माध्यम से  एक नया "
-"खाता बनाना चाहिए, या सहायता के लिए किसी साइट प्रबंधक से संपर्क करना चाहिए।"
+msgid "If you aren't a site administrator, something weird has happened. You won't be able to apply for access without a Wikipedia editor profile. You should log out and create a new account by logging in via OAuth, or contact a site administrator for help."
+msgstr "यदि आप एक साइट प्रबंधक नहीं हैं, तो कुछ अजीब हुआ है। आप विकिपीडिया संपादक प्रोफ़ाइल के बिना उपयोग के लिए आवेदन नहीं कर पाएंगे। आपको लॉग आउट करके OAuth के माध्यम से  एक नया खाता बनाना चाहिए, या सहायता के लिए किसी साइट प्रबंधक से संपर्क करना चाहिए।"
 
 #. Translators: Labels a sections where coordinators can select their email preferences.
 #: TWLight/users/templates/users/user_email_preferences.html:15
@@ -3886,19 +3030,12 @@ msgstr ""
 #. Translators: This message is shown on user's own profile page, encouraging them to make sure their information is up to date, so that account coordinators can use the information to judge applications.
 #: TWLight/users/views.py:176
 #, python-brace-format
-msgid ""
-"Please <a class='twl-links' href='{url}'>update your contributions</a> to "
-"Wikipedia to help coordinators evaluate your applications."
-msgstr ""
-"समन्वयकों को आपके आवेदन का मूल्यांकन करने में सहायता करने के लिए कृपया विकिपीडिया पर <a "
-"class='twl-links' href='{url}'> अपने योगदान अपडेट करें </a>।"
+msgid "Please <a class='twl-links' href='{url}'>update your contributions</a> to Wikipedia to help coordinators evaluate your applications."
+msgstr "समन्वयकों को आपके आवेदन का मूल्यांकन करने में सहायता करने के लिए कृपया विकिपीडिया पर <a class='twl-links' href='{url}'> अपने योगदान अपडेट करें </a>।"
 
 #. Translators: Coordinators are shown this message when they unselect all three types of reminder email options under preferences.
 #: TWLight/users/views.py:288
-msgid ""
-"You have chosen not to receive reminder emails. As a coordinator, you should "
-"receive at least one type of reminder emails, so consider changing your "
-"preferences."
+msgid "You have chosen not to receive reminder emails. As a coordinator, you should receive at least one type of reminder emails, so consider changing your preferences."
 msgstr ""
 
 #. Translators: Coordinators are shown this message when they make changes to their reminder email options under preferences.
@@ -3933,12 +3070,8 @@ msgstr "आपका ईमेल {email} में बदल दिया ग�
 
 #. Translators: If the user has not filled out their email, they can browse the website but cannot apply for access to resources.
 #: TWLight/users/views.py:487
-msgid ""
-"Your email is blank. You can still explore the site, but you won't be able "
-"to apply for access to partner resources without an email."
-msgstr ""
-"आपका ईमेल रिक्त है। आप अभी भी साइट को देख सकते हैं, लेकिन आप बिना ईमेल के भागीदार "
-"संसाधनों तक पहुंच के लिए आवेदन नहीं कर पाएंगे।"
+msgid "Your email is blank. You can still explore the site, but you won't be able to apply for access to partner resources without an email."
+msgstr "आपका ईमेल रिक्त है। आप अभी भी साइट को देख सकते हैं, लेकिन आप बिना ईमेल के भागीदार संसाधनों तक पहुंच के लिए आवेदन नहीं कर पाएंगे।"
 
 #. Translators: This message is shown once the access to a partner has successfully been returned.
 #: TWLight/users/views.py:801
@@ -3972,31 +3105,3 @@ msgstr ""
 msgid "10+ edits in the last 30 days"
 msgstr ""
 
-#: tests/shunit/data/bad_i18n_comment_1.py:3
-#: tests/shunit/data/bad_i18n_newline_1.py:5
-msgid "1"
-msgstr ""
-
-#. Translators: Lorem ipsum dolor sit amet, consectetur adipiscing elit. Mauris vitae ipsum ut purus faucibus pretium. Proin tempus neque et aliquet consectetur. Ut egestas sapien in consectetur sagittis. Mauris neque lacus, dapibus non viverra vitae, interdum ut aenean ipsum.
-#. Translators: Lorem ipsum dolor sit amet, consectetur adipiscing elit. Mauris vitae ipsum ut purus faucibus pretium. Proin tempus neque et aliquet consectetur. Ut egestas sapien in consectetur sagittis. Mauris neque lacus, dapibus non.
-#: tests/shunit/data/bad_i18n_comment_2.py:4
-#: tests/shunit/data/bad_i18n_newline_2.py:5 tests/shunit/data/good_i18n_1.py:2
-#: tests/shunit/data/good_i18n_2.py:2
-msgid "2"
-msgstr ""
-
-#: tests/shunit/data/bad_i18n_newline_3.py:5
-msgid "3"
-msgstr ""
-
-#: tests/shunit/data/bad_i18n_newline_4.py:5
-msgid "4"
-msgstr ""
-
-#: tests/shunit/data/bad_i18n_newline_5.py:5
-msgid "5"
-msgstr ""
-
-#: tests/shunit/data/bad_i18n_newline_6.py:5
-msgid "6"
-msgstr ""

--- a/locale/ia/LC_MESSAGES/django.po
+++ b/locale/ia/LC_MESSAGES/django.po
@@ -4,10 +4,11 @@
 # Author: McDutchie
 msgid ""
 msgstr ""
+""
 "Project-Id-Version: Wikipedia Library Card Platform - Website\n"
-"Report-Msgid-Bugs-To: wikipedialibrary@wikimedia.org\n"
+"Report-Msgid-Bugs-To: translatewiki.net\n"
 "POT-Creation-Date: 2024-07-11 20:54+0000\n"
-"PO-Revision-Date: 2024-07-11 12:30:15+0000\n"
+"PO-Revision-Date: 2024-07-15 12:29:15+0000\n"
 "Language: ia\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
@@ -39,13 +40,8 @@ msgstr "A proposito de te"
 #. Translators: This note appears in a section of a form where we ask users to enter info (like country of residence) when applying for resource access.
 #: TWLight/applications/forms.py:179
 #, python-brace-format
-msgid ""
-"<p><small><i>Your personal data will be processed according to our <a "
-"class='twl-links' href='{terms_url}'> privacy policy</a>.</i></small></p>"
-msgstr ""
-"<p><small><i>Tu datos personal essera processate de accordo con nostre <a "
-"class='twl-links' href='{terms_url}'>politica de confidentialitate</a>.</i></"
-"small></p>"
+msgid "<p><small><i>Your personal data will be processed according to our <a class='twl-links' href='{terms_url}'> privacy policy</a>.</i></small></p>"
+msgstr "<p><small><i>Tu datos personal essera processate de accordo con nostre <a class='twl-links' href='{terms_url}'>politica de confidentialitate</a>.</i></small></p>"
 
 #. Translators: This is the title of the application form page, where users enter information required for the application. It lets the user know which partner application they are entering data for. {partner}
 #: TWLight/applications/forms.py:189
@@ -86,12 +82,8 @@ msgstr "Le adresse de e-mail de tu conto sur le sito web del partner"
 #. Translators: This labels a choice field where users will have to select the number of months they wish to have their access for as part of the application renewal confirmation.
 #. Translators: When filling out an application, users may be required to enter the length of the account (expiry) they wish to have for proxy partners.
 #: TWLight/applications/forms.py:339 TWLight/applications/helpers.py:100
-msgid ""
-"The number of months you wish to have this access for before renewal is "
-"required"
-msgstr ""
-"Le numero de menses durante le quales tu vole haber iste accesso ante que un "
-"renovation es necessari"
+msgid "The number of months you wish to have this access for before renewal is required"
+msgstr "Le numero de menses durante le quales tu vole haber iste accesso ante que un renovation es necessari"
 
 #. Translators: When filling out an application, users may need to specify their name
 #: TWLight/applications/helpers.py:81
@@ -179,12 +171,8 @@ msgstr "E-mail"
 
 #. Translators: This comment is added to pending applications when our terms of use change.
 #: TWLight/applications/management/commands/notify_applicants_tou_changes.py:54
-msgid ""
-"Our terms of use have changed. Your applications will not be processed until "
-"you log in and agree to our updated terms."
-msgstr ""
-"Nostre conditiones de uso ha cambiate. Tu demandas non essera processate "
-"ante que tu aperi session e accepta nostre nove conditiones."
+msgid "Our terms of use have changed. Your applications will not be processed until you log in and agree to our updated terms."
+msgstr "Nostre conditiones de uso ha cambiate. Tu demandas non essera processate ante que tu aperi session e accepta nostre nove conditiones."
 
 #. Translators: This is the status of an application that has not yet been reviewed.
 #: TWLight/applications/models.py:54
@@ -250,43 +238,26 @@ msgstr "URL de accesso: {access_url}"
 
 #. Translators: This text goes into account approval emails in the case that we need to send the user's details to a publisher for manual account setup.
 #: TWLight/applications/models.py:331
-msgid ""
-"You can expect to receive access details within a week or two once it has "
-"been processed."
-msgstr ""
-"Tu pote expectar a reciper le detalios de accesso in un septimana o duo post "
-"le tractamento de tu demanda."
+msgid "You can expect to receive access details within a week or two once it has been processed."
+msgstr "Tu pote expectar a reciper le detalios de accesso in un septimana o duo post le tractamento de tu demanda."
 
 #. Translators: This comment is added to open applications when a partner joins the Library Bundle, which does not require applications.
 #: TWLight/applications/signals.py:247
-msgid ""
-"This partner joined the Library Bundle, which does not require applications. "
-"This application will be marked as invalid."
-msgstr ""
-"Iste partner se ha unite a ‘Library Bundle’, le qual non require presentar "
-"un demanda. Iste demanda essera marcate como non valide."
+msgid "This partner joined the Library Bundle, which does not require applications. This application will be marked as invalid."
+msgstr "Iste partner se ha unite a ‘Library Bundle’, le qual non require presentar un demanda. Iste demanda essera marcate como non valide."
 
 #. Translators: This is shown to users if the application is to a partner for which we have run out of available accounts. The application is therefore on a 'waitlist', and will be reviewed when more accounts are available.
 #: TWLight/applications/templates/applications/application_evaluation.html:29
-msgid ""
-"This application is on the waitlist because this partner does not have any "
-"access grants available at this time."
-msgstr ""
-"Iste demanda es sur le lista de attender perque iste partner non ha "
-"concessiones de accesso disponibile al momento."
+msgid "This application is on the waitlist because this partner does not have any access grants available at this time."
+msgstr "Iste demanda es sur le lista de attender perque iste partner non ha concessiones de accesso disponibile al momento."
 
 #. Translators: This message is shown on pages where coordinators can see personal information about applicants.
 #: TWLight/applications/templates/applications/application_evaluation.html:36
 #: TWLight/applications/templates/applications/application_list_include.html:6
 #: TWLight/applications/templates/applications/send_partner.html:45
 #: TWLight/resources/templates/resources/partner_users.html:18
-msgid ""
-"Coordinators: This page may contain personal information such as real names "
-"and email addresses. Please remember that this information is confidential."
-msgstr ""
-"Coordinatores: Iste pagina pote continer information personal como nomines "
-"real e adresses de e-mail. Per favor non oblida que iste information es "
-"confidential."
+msgid "Coordinators: This page may contain personal information such as real names and email addresses. Please remember that this information is confidential."
+msgstr "Coordinatores: Iste pagina pote continer information personal como nomines real e adresses de e-mail. Per favor non oblida que iste information es confidential."
 
 #. Translators: This is the title of the application page shown to users who are a coordinator, and are able to accept or reject the application.
 #: TWLight/applications/templates/applications/application_evaluation.html:39
@@ -295,12 +266,8 @@ msgstr "Evalutar demanda"
 
 #. Translators: This text is shown to coordinators on application pages if the applicant has restricted processing of their data.
 #: TWLight/applications/templates/applications/application_evaluation.html:42
-msgid ""
-"This user has requested a restriction on the processing of their data, so "
-"you cannot change the status of their application."
-msgstr ""
-"Iste usator ha requestate un restriction del processamento de su datos, "
-"dunque tu non pote cambiar le stato de su demanda."
+msgid "This user has requested a restriction on the processing of their data, so you cannot change the status of their application."
+msgstr "Iste usator ha requestate un restriction del processamento de su datos, dunque tu non pote cambiar le stato de su demanda."
 
 #. Translators: This is the title of the application page shown to users who are not a coordinator.
 #: TWLight/applications/templates/applications/application_evaluation.html:48
@@ -373,12 +340,8 @@ msgstr "Incognite"
 
 #. Translators: This is the text displayed to coordinators when an applicant has no country of residence in their profile.
 #: TWLight/applications/templates/applications/application_evaluation.html:123
-msgid ""
-"Please request the applicant add their country of residence to their profile "
-"before proceeding further."
-msgstr ""
-"Per favor demanda al sollicitante de adder su pais de residentia a su "
-"profilo ante de continuar."
+msgid "Please request the applicant add their country of residence to their profile before proceeding further."
+msgstr "Per favor demanda al sollicitante de adder su pais de residentia a su profilo ante de continuar."
 
 #. Translators: This labels the section of an application showing the total number of accounts available for a partner or their collection.
 #: TWLight/applications/templates/applications/application_evaluation.html:134
@@ -388,12 +351,8 @@ msgstr "Contos disponibile"
 #. Translators: This labels the section of an application showing whether the user had agreed to the terms of use or not.
 #: TWLight/applications/templates/applications/application_evaluation.html:145
 #, python-format
-msgid ""
-"Has agreed to the site's <a class=\"twl-links\" href=\"%(terms_url)s\">terms "
-"of use</a>?"
-msgstr ""
-"Ha acceptate le <a class=\"twl-links\" href=\"%(terms_url)s\">conditiones de "
-"uso</a> del sito?"
+msgid "Has agreed to the site's <a class=\"twl-links\" href=\"%(terms_url)s\">terms of use</a>?"
+msgstr "Ha acceptate le <a class=\"twl-links\" href=\"%(terms_url)s\">conditiones de uso</a> del sito?"
 
 #. Translators: Displayed to coordinators when they've agreed to the terms of use.
 #. Translators: Displayed if the user has agreed to the terms of use.
@@ -428,12 +387,8 @@ msgstr "No"
 
 #. Translators: This is the text displayed to coordinators when an applicant has not agreed to the terms of use.
 #: TWLight/applications/templates/applications/application_evaluation.html:159
-msgid ""
-"Please request the applicant agree to the site's terms of use before "
-"approving this application."
-msgstr ""
-"Per favor demanda al sollicitante de acceptar le conditiones de uso del sito "
-"ante de approbar iste application."
+msgid "Please request the applicant agree to the site's terms of use before approving this application."
+msgstr "Per favor demanda al sollicitante de acceptar le conditiones de uso del sito ante de approbar iste application."
 
 #. Translators: This labels the section of an application containing the user's motivation for wanting access to this resource.
 #: TWLight/applications/templates/applications/application_evaluation.html:176
@@ -453,8 +408,7 @@ msgstr "Renovation de un concession de accesso existente?"
 #. Translators: This message is shown next to the 'Renewal of existing access grant?' label if the application is a renewal. Don't translate HTML tags or parent_url.
 #: TWLight/applications/templates/applications/application_evaluation.html:195
 #, python-format
-msgid ""
-"Yes (<a class=\"twl-links\" href=\"%(parent_url)s\">previous application</a>)"
+msgid "Yes (<a class=\"twl-links\" href=\"%(parent_url)s\">previous application</a>)"
 msgstr "Si (<a class=\"twl-links\" href=\"%(parent_url)s\">previe demanda</a>)"
 
 #. Translators: This labels the section of the application showing the length of access remaining on the user's previous authorization.
@@ -489,12 +443,8 @@ msgstr "Adder commento"
 
 #. Translators: On an application page, this text tells users that the comments posted on the application are visible to coordinators and the submitting user only.
 #: TWLight/applications/templates/applications/application_evaluation.html:297
-msgid ""
-"Comments are visible to all coordinators and to the editor who submitted "
-"this application."
-msgstr ""
-"Le commentos es visibile a tote le coordinatores e al redactor qui ha "
-"presentate iste demanda."
+msgid "Comments are visible to all coordinators and to the editor who submitted this application."
+msgstr "Le commentos es visibile a tote le coordinatores e al redactor qui ha presentate iste demanda."
 
 #. Translators: This is the title of the section of an application page which lists information about the user who submitted the application.
 #. Translators: On the page where coordinators can view data on applications to a partner they coordinate, this is a table column heading for the username.
@@ -705,18 +655,8 @@ msgstr "Definir stato"
 
 #: TWLight/applications/templates/applications/apply.html:20
 #, python-format
-msgid ""
-"If your application is successful we may share your email address with "
-"%(partner)s. This is required to set up your access to their resources. By "
-"submitting this form you agree to allow your email address to be shared with "
-"%(partner)s if your application is successful, for the purposes of account "
-"setup."
-msgstr ""
-"Si tu demanda es approbate, nos pote divulgar tu adresse de e-mail a "
-"%(partner)s. Isto es necessari pro establir tu accesso a lor ressources. "
-"Inviante iste formulario, tu consenti al divulgation de tu adresse de e-mail "
-"a %(partner)s si tu demanda es approbate, pro le scopo del configuration del "
-"conto."
+msgid "If your application is successful we may share your email address with %(partner)s. This is required to set up your access to their resources. By submitting this form you agree to allow your email address to be shared with %(partner)s if your application is successful, for the purposes of account setup."
+msgstr "Si tu demanda es approbate, nos pote divulgar tu adresse de e-mail a %(partner)s. Isto es necessari pro establir tu accesso a lor ressources. Inviante iste formulario, tu consenti al divulgation de tu adresse de e-mail a %(partner)s si tu demanda es approbate, pro le scopo del configuration del conto."
 
 #. Translators: This message is displayed on the page where users can confirm their renewal. Please do not translate partner.
 #: TWLight/applications/templates/applications/confirm_renewal.html:23
@@ -744,12 +684,8 @@ msgstr "A qual ressources vole tu acceder?"
 
 #. Translators: This text explains that Library Bundle partners are not shown in this list.
 #: TWLight/applications/templates/applications/request_for_application.html:26
-msgid ""
-"Library Bundle partners are not shown as eligibility is determined "
-"automatically."
-msgstr ""
-"Le partners de ‘Library Bundle’ non es monstrate perque le eligibilitate a "
-"illos se determina automaticamente."
+msgid "Library Bundle partners are not shown as eligibility is determined automatically."
+msgstr "Le partners de ‘Library Bundle’ non es monstrate perque le eligibilitate a illos se determina automaticamente."
 
 #. Translators: On the page where users can apply for multiple partners, this message shows next to the partner name, taking them to the full application page when clicked.
 #: TWLight/applications/templates/applications/request_for_application.html:48
@@ -763,15 +699,8 @@ msgstr "Necun dato de partner ha ancora essite addite."
 
 #. Translators: the HTML is so that the word 'waitlisted' will look the same as it does in the page above; please translate 'waitlisted' the same way you did elsewhere in this file.
 #: TWLight/applications/templates/applications/request_for_application.html:74
-msgid ""
-"You can apply to <span class=\"badge badge-warning\">Waitlisted</span> "
-"partners, but they don't have access grants available right now. We will "
-"process those applications when access becomes available."
-msgstr ""
-"Tu pote presentar un demanda a partners <span class=\"badge badge-warning"
-"\">con listas de attender</span>, ma illos non ha concessiones de accesso "
-"disponibile in iste momento. Nos tractara ille demandas quando le accesso "
-"devenira disponibile."
+msgid "You can apply to <span class=\"badge badge-warning\">Waitlisted</span> partners, but they don't have access grants available right now. We will process those applications when access becomes available."
+msgstr "Tu pote presentar un demanda a partners <span class=\"badge badge-warning\">con listas de attender</span>, ma illos non ha concessiones de accesso disponibile in iste momento. Nos tractara ille demandas quando le accesso devenira disponibile."
 
 #. Translators: On the page where coordinators can see approved applications which have not had their details sent to the partner, this message shows when there are applications ready to be processed.
 #: TWLight/applications/templates/applications/send.html:10
@@ -792,19 +721,13 @@ msgstr "Datos de demanda pro %(object)s"
 #. Translators: This message is shown when applications exceed the number of accounts available.
 #: TWLight/applications/templates/applications/send_partner.html:54
 #, python-format
-msgid ""
-"Application(s) for %(object)s, if sent, will exceed the total available "
-"accounts for the partner. Please proceed at your own discretion."
-msgstr ""
-"Le demanda(s) pro %(object)s, si inviate, excedera le numero total de contos "
-"disponibile pro le partner. Per favor continua a proprie risco."
+msgid "Application(s) for %(object)s, if sent, will exceed the total available accounts for the partner. Please proceed at your own discretion."
+msgstr "Le demanda(s) pro %(object)s, si inviate, excedera le numero total de contos disponibile pro le partner. Per favor continua a proprie risco."
 
 #. Translators: When viewing the list of applications ready to be sent for a particular partner, this is instructions for the coordinator to click the 'mark as sent' button after they have sent the information.
 #: TWLight/applications/templates/applications/send_partner.html:65
 msgid "When you've processed the data below, click the 'mark as sent' button."
-msgstr ""
-"Quando tu ha tractate le datos infra, clicca sur le button ‘Marcar como "
-"inviate’."
+msgstr "Quando tu ha tractate le datos infra, clicca sur le button ‘Marcar como inviate’."
 
 #. Translators: When viewing the list of applications ready to be sent for a particular partner, this is the title of the section containing contact information for the people applications should be sent to.
 #: TWLight/applications/templates/applications/send_partner.html:71
@@ -815,12 +738,8 @@ msgstr[1] "Contactos"
 
 #. Translators: When viewing the list of applications ready to be sent for a particular partner, this message shows if there is no information about who the applications should be sent to. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/applications/templates/applications/send_partner.html:89
-msgid ""
-"Whoops, we don't have any listed contacts. Please notify Wikipedia Library "
-"administrators."
-msgstr ""
-"Guai, nos non ha alcun contacto listate. Per favor notifica le "
-"administratores del Bibliotheca de Wikipedia."
+msgid "Whoops, we don't have any listed contacts. Please notify Wikipedia Library administrators."
+msgstr "Guai, nos non ha alcun contacto listate. Per favor notifica le administratores del Bibliotheca de Wikipedia."
 
 #. Translators: When viewing the list of applications ready to be sent for a particular partner, this is the title of the section containing the information about those applications.
 #: TWLight/applications/templates/applications/send_partner.html:94
@@ -835,12 +754,8 @@ msgstr "Marcar como inviate"
 
 #. Translators: This text guides coordinators in using the code sending interface for approved applications.
 #: TWLight/applications/templates/applications/send_partner.html:152
-msgid ""
-"Use the dropdown menus to denote which editor will receive each code. Access "
-"codes will be sent to users automatically."
-msgstr ""
-"Usa le menus disrolante pro indicar qual redactor recipera cata codice. Le "
-"codices de accesso essera inviate automaticamente al usatores."
+msgid "Use the dropdown menus to denote which editor will receive each code. Access codes will be sent to users automatically."
+msgstr "Usa le menus disrolante pro indicar qual redactor recipera cata codice. Le codices de accesso essera inviate automaticamente al usatores."
 
 #. Translators: This labels a drop-down selection where staff can assign an access code to a user.
 #: TWLight/applications/templates/applications/send_partner.html:173
@@ -855,24 +770,14 @@ msgstr "Il non ha demandas approbate e non inviate."
 #. Translators: When a user applies for a set of resources, they receive this message if none are currently available. They are instead placed on a 'waitlist' for later approval.
 #. Translators: When a user renews their resource, they receive this message if none are currently available. They are instead placed on a 'waitlist' for later approval.
 #: TWLight/applications/views.py:140 TWLight/applications/views.py:1282
-msgid ""
-"This partner does not have any access grants available at this time. You may "
-"still apply for access; your application will be reviewed when access grants "
-"become available."
-msgstr ""
-"Iste partner non ha concessiones de accesso disponibile al momento. Tu pote "
-"totevia demandar le accesso; tu demanda essera revidite quando concessiones "
-"de accesso devenira disponibile."
+msgid "This partner does not have any access grants available at this time. You may still apply for access; your application will be reviewed when access grants become available."
+msgstr "Iste partner non ha concessiones de accesso disponibile al momento. Tu pote totevia demandar le accesso; tu demanda essera revidite quando concessiones de accesso devenira disponibile."
 
 #. Translators: This message is shown to users once they've successfully submitted their application for review.
 #: TWLight/applications/views.py:163
 #, python-brace-format
-msgid ""
-"Your application has been submitted for review. Head over to <a "
-"href='{applications_url}'>My Applications</a> to view the status."
-msgstr ""
-"Le demanda ha essite submittite pro revision. Consulta <a "
-"href='{applications_url}'>Mi demandas</a> pro vider su stato."
+msgid "Your application has been submitted for review. Head over to <a href='{applications_url}'>My Applications</a> to view the status."
+msgstr "Le demanda ha essite submittite pro revision. Consulta <a href='{applications_url}'>Mi demandas</a> pro vider su stato."
 
 #. Translators: This text is displayed to users when the user has chosen to restrict data and is trying to apply for multiple partners
 #: TWLight/applications/views.py:276
@@ -920,22 +825,13 @@ msgstr "Demandas inviate"
 
 #. Translators: After a coordinator has changed the status of an application to APPROVED, if the corresponding partner/collection is waitlisted this message appears.
 #: TWLight/applications/views.py:756
-msgid ""
-"Cannot approve application as partner with proxy authorization method is "
-"waitlisted."
-msgstr ""
-"Non es possibile approbar le demanda perque le partner con un methodo de "
-"autorisation per mandatario es in le lista de attender."
+msgid "Cannot approve application as partner with proxy authorization method is waitlisted."
+msgstr "Non es possibile approbar le demanda perque le partner con un methodo de autorisation per mandatario es in le lista de attender."
 
 #. Translators: After a coordinator has changed the status of an application to APPROVED, if the corresponding partner/collection has no accounts for distribution, this message appears.
 #: TWLight/applications/views.py:780
-msgid ""
-"Cannot approve application as partner with proxy authorization method is "
-"waitlisted and (or) has zero accounts available for distribution."
-msgstr ""
-"Non es possibile approbar le demanda perque le partner con un methodo de "
-"autorisation per mandatario es in le lista de attender e/o ha zero contos "
-"disponibile pro distribution."
+msgid "Cannot approve application as partner with proxy authorization method is waitlisted and (or) has zero accounts available for distribution."
+msgstr "Non es possibile approbar le demanda perque le partner con un methodo de autorisation per mandatario es in le lista de attender e/o ha zero contos disponibile pro distribution."
 
 #. Translators: This message appears on an "access denied" screen that stops users who attempt to authorize an editor to access a resource during a time period for which they are already authorized.
 #: TWLight/applications/views.py:803
@@ -945,16 +841,8 @@ msgstr "Tu ha tentate crear un autorisation duple."
 #. Translators: This message is shown to users when they access an application page of a now Bundle partner (new applications aren't allowed for Bundle partners and the status of old applications cannot be modified)
 #: TWLight/applications/views.py:857
 #, python-brace-format
-msgid ""
-"This application cannot be modified since this partner is now part of our <a "
-"href='{bundle}'>bundle access</a>. If you are eligible, you can access this "
-"resource from <a href='{library}'>your library</a>. <a "
-"href='{contact}'>Contact us</a> if you have any questions."
-msgstr ""
-"Iste demanda non pote esser modificate perque iste partner face ora parte de "
-"nostre <a href='{bundle}'>accesso gruppate</a>. Si tu es eligibile, tu pote "
-"acceder a iste ressource a partir de <a href='{library}'>tu bibliotheca</a>. "
-"<a href='{contact}'>Contact nos</a> si tu ha questiones."
+msgid "This application cannot be modified since this partner is now part of our <a href='{bundle}'>bundle access</a>. If you are eligible, you can access this resource from <a href='{library}'>your library</a>. <a href='{contact}'>Contact us</a> if you have any questions."
+msgstr "Iste demanda non pote esser modificate perque iste partner face ora parte de nostre <a href='{bundle}'>accesso gruppate</a>. Si tu es eligibile, tu pote acceder a iste ressource a partir de <a href='{library}'>tu bibliotheca</a>. <a href='{contact}'>Contact nos</a> si tu ha questiones."
 
 #. Translators: this lets a reviewer set the status of a single application.
 #: TWLight/applications/views.py:873
@@ -963,12 +851,8 @@ msgstr "Modificar le stato del demanda"
 
 #. Translators: This warning is message is shown to applicants when the number of pending applications is greater than the number of accounts available.
 #: TWLight/applications/views.py:891
-msgid ""
-"There are more pending applications than available accounts. Your "
-"application might get waitlisted."
-msgstr ""
-"Il ha plus demandas attendente que contos disponibile. Tu demanda pote esser "
-"mittite in le lista de attender."
+msgid "There are more pending applications than available accounts. Your application might get waitlisted."
+msgstr "Il ha plus demandas attendente que contos disponibile. Tu demanda pote esser mittite in le lista de attender."
 
 #. Translators: this message is shown to coordinators who attempt to change an application's Status from INVALID to any other Status.
 #: TWLight/applications/views.py:904
@@ -987,16 +871,8 @@ msgstr "Le actualisation in lot del demanda(s) {} ha succedite."
 
 #. Translators: After a coordinator has changed the status of a number of applications to APPROVED, if the corresponding partner(s) is/are waitlisted or has no accounts for distribution, this message appears.
 #: TWLight/applications/views.py:1051
-msgid ""
-"Cannot approve application(s) {} as partner(s) with proxy authorization "
-"method is/are waitlisted and (or) has/have not enough accounts available. If "
-"not enough accounts are available, prioritise the applications and then "
-"approve applications equal to the accounts available."
-msgstr ""
-"Non es possibile approbar le demanda(s) {} perque il ha partner(s) con "
-"methodo de autorisation per mandatario in le lista de attender e/o sin satis "
-"contos disponibile. Si il non ha satis contos disponibile, da prioritate al "
-"demandas e alora approba tante demandas que contos disponibile."
+msgid "Cannot approve application(s) {} as partner(s) with proxy authorization method is/are waitlisted and (or) has/have not enough accounts available. If not enough accounts are available, prioritise the applications and then approve applications equal to the accounts available."
+msgstr "Non es possibile approbar le demanda(s) {} perque il ha partner(s) con methodo de autorisation per mandatario in le lista de attender e/o sin satis contos disponibile. Si il non ha satis contos disponibile, da prioritate al demandas e alora approba tante demandas que contos disponibile."
 
 #. Translators: This message is shown to coordinators who attempt to assign the same access code to multiple users.
 #: TWLight/applications/views.py:1191
@@ -1010,38 +886,24 @@ msgstr "Tote le demandas seligite ha essite marcate como inviate."
 
 #. Translators: When a user tries to renew their resource, they receive this message if the partner is not available.
 #: TWLight/applications/views.py:1272
-msgid ""
-"Cannot renew application at this time as partner is not available. Please "
-"check back later, or contact us for more information."
-msgstr ""
-"Non es possibile renovar le demanda al momento perque le partner non es "
-"disponibile. Per favor reveni plus tarde, o contacta nos pro plus "
-"information."
+msgid "Cannot renew application at this time as partner is not available. Please check back later, or contact us for more information."
+msgstr "Non es possibile renovar le demanda al momento perque le partner non es disponibile. Per favor reveni plus tarde, o contacta nos pro plus information."
 
 #. Translators: This message is displayed when an attempt by a user to renew an application has been denied for some reason.
 #: TWLight/applications/views.py:1308
 #, python-brace-format
 msgid "Attempt to renew unapproved application #{pk} has been denied"
-msgstr ""
-"Le tentativa de renovar le demanda non approbate №{pk} ha essite refusate"
+msgstr "Le tentativa de renovar le demanda non approbate №{pk} ha essite refusate"
 
 #. Translators: If a user requests the renewal of their account, but it wasn't renewed, this message is shown to them.
 #: TWLight/applications/views.py:1385
-msgid ""
-"This object cannot be renewed. (This probably means that you have already "
-"requested that it be renewed.)"
-msgstr ""
-"Iste objecto non pote esser renovate. (Isto significa probabilemente que tu "
-"ha ja requestate su renovation.)"
+msgid "This object cannot be renewed. (This probably means that you have already requested that it be renewed.)"
+msgstr "Iste objecto non pote esser renovate. (Isto significa probabilemente que tu ha ja requestate su renovation.)"
 
 #. Translators: If a user requests the renewal of their account, this message is shown to them.
 #: TWLight/applications/views.py:1395
-msgid ""
-"Your renewal request has been received. A coordinator will review your "
-"request."
-msgstr ""
-"Tu requesta de renovation ha essite recipite. Un coordinator revidera tu "
-"requesta."
+msgid "Your renewal request has been received. A coordinator will review your request."
+msgstr "Tu requesta de renovation ha essite recipite. Un coordinator revidera tu requesta."
 
 #. Translators: This labels a textfield where users can enter their email ID.
 #: TWLight/emails/forms.py:18
@@ -1050,12 +912,8 @@ msgstr "Tu adresse de e-mail"
 
 #. Translators: This is the help text for the email field in the contact us form letting users know the field is updated by value pulled from their respective user profiles.
 #: TWLight/emails/forms.py:21
-msgid ""
-"This field is automatically updated with the email from your <a class='twl-"
-"links' href='{}'>user profile</a>."
-msgstr ""
-"Iste campo se actualisa automaticamente con le adresse de e-mail de tu <a "
-"class='twl-links' href='{}'>profilo de usator</a>."
+msgid "This field is automatically updated with the email from your <a class='twl-links' href='{}'>user profile</a>."
+msgstr "Iste campo se actualisa automaticamente con le adresse de e-mail de tu <a class='twl-links' href='{}'>profilo de usator</a>."
 
 #. Translators: This labels a textfield where users can enter their email message.
 #: TWLight/emails/forms.py:26
@@ -1078,26 +936,14 @@ msgstr "Inviar"
 #. Translators: This email is sent to users with their access code. Don't translate Jinja variables in curly braces like user or partner. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/access_code_email-body-html.html:5
 #, python-format
-msgid ""
-"<p>Your approved application to %(partner)s has now been finalised. Your "
-"access code or login details can be found below:</p> <p><b>%(access_code)s</"
-"b></p> <p>%(user_instructions)s</p>"
-msgstr ""
-"<p>Tu demanda approbate a %(partner)s ha ora essite finalisate. Tu codice de "
-"accesso o detalios pro aperir session se trova hic infra:</p> <p><b>"
-"%(access_code)s</b></p> <p>%(user_instructions)s</p>"
+msgid "<p>Your approved application to %(partner)s has now been finalised. Your access code or login details can be found below:</p> <p><b>%(access_code)s</b></p> <p>%(user_instructions)s</p>"
+msgstr "<p>Tu demanda approbate a %(partner)s ha ora essite finalisate. Tu codice de accesso o detalios pro aperir session se trova hic infra:</p> <p><b>%(access_code)s</b></p> <p>%(user_instructions)s</p>"
 
 #. Translators: This email is sent to users with their access code. Don't translate Jinja variables in curly braces like user or partner. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/access_code_email-body-text.html:3
 #, python-format
-msgid ""
-"Your approved application to %(partner)s has now been finalised. Your access "
-"code or login details can be found below: %(access_code)s "
-"%(user_instructions)s"
-msgstr ""
-"Tu demanda approbate a %(partner)s ha ora essite finalisate. Tu codice de "
-"accesso o detalios pro aperir session se trova hic infra: %(access_code)s "
-"%(user_instructions)s"
+msgid "Your approved application to %(partner)s has now been finalised. Your access code or login details can be found below: %(access_code)s %(user_instructions)s"
+msgstr "Tu demanda approbate a %(partner)s ha ora essite finalisate. Tu codice de accesso o detalios pro aperir session se trova hic infra: %(access_code)s %(user_instructions)s"
 
 #. Translators: This is the subject line of an email sent to users with their access code.
 #: TWLight/emails/templates/emails/access_code_email-subject.html:3
@@ -1107,35 +953,14 @@ msgstr "Tu codice de accesso al Bibliotheca de Wikipedia"
 #. Translators: This email is sent to users when their application is approved. Don't translate Jinja variables in curly braces like user or partner; don't translate html tags either. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/approval_notification-body-html.html:5
 #, python-format
-msgid ""
-"<p>Dear %(user)s,</p> <p>Thank you for applying for access to %(partner)s "
-"resources through The Wikipedia Library. We are happy to inform you that "
-"your application has been approved.</p> <p>%(user_instructions)s</p> <p>You "
-"can view the collections you're authorized to access at My Library: "
-"%(link)s</p> <p>Cheers!</p> <p>The Wikipedia Library</p>"
-msgstr ""
-"<p>Car %(user)s,</p> <p>Gratias pro tu demanda de accesso al ressources de "
-"%(partner)s per medio del Bibliotheca de Wikipedia. Nos es felice de "
-"informar te que tu demanda ha essite approbate.</p> <p>"
-"%(user_instructions)s</p> <p>Tu pote vider le collectiones al quales tu es "
-"autorisate de acceder a Mi Bibliotheca: %(link)s</p> <p>Gratias!</p> <p>Le "
-"Bibliotheca de Wikipedia</p>"
+msgid "<p>Dear %(user)s,</p> <p>Thank you for applying for access to %(partner)s resources through The Wikipedia Library. We are happy to inform you that your application has been approved.</p> <p>%(user_instructions)s</p> <p>You can view the collections you're authorized to access at My Library: %(link)s</p> <p>Cheers!</p> <p>The Wikipedia Library</p>"
+msgstr "<p>Car %(user)s,</p> <p>Gratias pro tu demanda de accesso al ressources de %(partner)s per medio del Bibliotheca de Wikipedia. Nos es felice de informar te que tu demanda ha essite approbate.</p> <p>%(user_instructions)s</p> <p>Tu pote vider le collectiones al quales tu es autorisate de acceder a Mi Bibliotheca: %(link)s</p> <p>Gratias!</p> <p>Le Bibliotheca de Wikipedia</p>"
 
 #. Translators: This email is sent to users when their application is approved. Don't translate Jinja variables in curly braces like user or partner. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/approval_notification-body-text.html:3
 #, python-format
-msgid ""
-"Dear %(user)s, Thank you for applying for access to %(partner)s resources "
-"through The Wikipedia Library. We are happy to inform you that your "
-"application has been approved. %(user_instructions)s You can view the "
-"collections you're authorized to access at My Library: %(link)s Cheers! The "
-"Wikipedia Library"
-msgstr ""
-"Car %(user)s, Gratias pro tu demanda de accesso al ressources de %(partner)s "
-"per medio del Bibliotheca de Wikipedia. Nos es felice de informar te que tu "
-"demanda ha essite approbate. %(user_instructions)s Tu pote vider le "
-"collectiones al quales tu es autorisate de acceder a Mi Bibliotheca: "
-"%(link)s Gratias! Le Bibliotheca de Wikipedia"
+msgid "Dear %(user)s, Thank you for applying for access to %(partner)s resources through The Wikipedia Library. We are happy to inform you that your application has been approved. %(user_instructions)s You can view the collections you're authorized to access at My Library: %(link)s Cheers! The Wikipedia Library"
+msgstr "Car %(user)s, Gratias pro tu demanda de accesso al ressources de %(partner)s per medio del Bibliotheca de Wikipedia. Nos es felice de informar te que tu demanda ha essite approbate. %(user_instructions)s Tu pote vider le collectiones al quales tu es autorisate de acceder a Mi Bibliotheca: %(link)s Gratias! Le Bibliotheca de Wikipedia"
 
 #. Translators: This is the subject of an email which is sent to users when their application has been approved. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/approval_notification-subject.html:4
@@ -1145,57 +970,31 @@ msgstr "Tu demanda al Bibliotheca de Wikipedia ha essite approbate"
 #. Translators: This email is sent to coordinators when a comment is left on an application they are processing. Don't translate Jinja variables in curly braces like user or partner. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/comment_notification_coordinator-body-html.html:5
 #, python-format
-msgid ""
-"<p style=\"color: #500050\">%(submit_date)s - %(commenter)s</p> "
-"<blockquote><p>%(comment)s</p></blockquote> <p>Please reply to these at: <a "
-"href=\"%(app_url)s\">%(app_url)s</a></p> <p>Best,</p> <p>The Wikipedia "
-"Library</p>"
-msgstr ""
-"<p style=\"color: #500050\">%(submit_date)s - %(commenter)s</p> "
-"<blockquote><p>%(comment)s</p></blockquote> <p>Per favor responde a isto "
-"sur: <a href=\"%(app_url)s\">%(app_url)s</a></p> <p>Cordialmente,</p> <p>Le "
-"Bibliotheca de Wikipedia</p>"
+msgid "<p style=\"color: #500050\">%(submit_date)s - %(commenter)s</p> <blockquote><p>%(comment)s</p></blockquote> <p>Please reply to these at: <a href=\"%(app_url)s\">%(app_url)s</a></p> <p>Best,</p> <p>The Wikipedia Library</p>"
+msgstr "<p style=\"color: #500050\">%(submit_date)s - %(commenter)s</p> <blockquote><p>%(comment)s</p></blockquote> <p>Per favor responde a isto sur: <a href=\"%(app_url)s\">%(app_url)s</a></p> <p>Cordialmente,</p> <p>Le Bibliotheca de Wikipedia</p>"
 
 #. Translators: This email is sent to coordinators when a comment is left on an application they are processing. Don't translate Jinja variables in curly braces like user or partner. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/comment_notification_coordinator-body-text.html:3
 #, python-format
-msgid ""
-"%(submit_date)s - %(commenter)s %(comment)s Please reply to this at: "
-"%(app_url)s Best, The Wikipedia Library"
-msgstr ""
-"%(submit_date)s - %(commenter)s %(comment)s Per favor responde a isto sur: "
-"%(app_url)s Cordialmente, Le Bibliotheca de Wikipedia"
+msgid "%(submit_date)s - %(commenter)s %(comment)s Please reply to this at: %(app_url)s Best, The Wikipedia Library"
+msgstr "%(submit_date)s - %(commenter)s %(comment)s Per favor responde a isto sur: %(app_url)s Cordialmente, Le Bibliotheca de Wikipedia"
 
 #. Translators: This is the subject line of an email sent to coordinators when a comment is left on an application they processed.
 #: TWLight/emails/templates/emails/comment_notification_coordinator-subject.html:3
 msgid "New comment on a Wikipedia Library application you processed"
-msgstr ""
-"Nove commento sur un demanda al Bibliotheca de Wikipedia que tu ha tractate"
+msgstr "Nove commento sur un demanda al Bibliotheca de Wikipedia que tu ha tractate"
 
 #. Translators: This email is sent to users when they receive a comment on their application. Don't translate Jinja variables in curly braces like user or partner; don't translate html tags either. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/comment_notification_editors-body-html.html:5
 #, python-format
-msgid ""
-"<p style=\"color: #500050\">%(submit_date)s - %(commenter)s</p> "
-"<blockquote><p>%(comment)s</p></blockquote> <p>Please reply to these at <a "
-"href=\"%(app_url)s\">%(app_url)s</a> so we can evaluate your application.</"
-"p> <p>Best,</p> <p>The Wikipedia Library</p>"
-msgstr ""
-"<p style=\"color: #500050\">%(submit_date)s - %(commenter)s</p> "
-"<blockquote><p>%(comment)s</p></blockquote> <p>Per favor responde a istes "
-"sur <a href=\"%(app_url)s\">%(app_url)s</a> de maniera que nos pote evalutar "
-"tu demanda.</p> <p>Cordialmente,</p> <p>Le Bibliotheca de Wikipedia</p>"
+msgid "<p style=\"color: #500050\">%(submit_date)s - %(commenter)s</p> <blockquote><p>%(comment)s</p></blockquote> <p>Please reply to these at <a href=\"%(app_url)s\">%(app_url)s</a> so we can evaluate your application.</p> <p>Best,</p> <p>The Wikipedia Library</p>"
+msgstr "<p style=\"color: #500050\">%(submit_date)s - %(commenter)s</p> <blockquote><p>%(comment)s</p></blockquote> <p>Per favor responde a istes sur <a href=\"%(app_url)s\">%(app_url)s</a> de maniera que nos pote evalutar tu demanda.</p> <p>Cordialmente,</p> <p>Le Bibliotheca de Wikipedia</p>"
 
 #. Translators: This email is sent to users when they receive a comment on their application. Don't translate Jinja variables in curly braces like user or partner. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/comment_notification_editors-body-text.html:3
 #, python-format
-msgid ""
-"%(submit_date)s - %(commenter)s %(comment)s Please reply to these at: "
-"%(app_url)s so we can evaluate your application. Best, The Wikipedia Library"
-msgstr ""
-"%(submit_date)s - %(commenter)s %(comment)s Per favor responde a istes sur "
-"%(app_url)s de maniera que nos pote evalutar tu demanda. Cordialmente, Le "
-"Bibliotheca de Wikipedia"
+msgid "%(submit_date)s - %(commenter)s %(comment)s Please reply to these at: %(app_url)s so we can evaluate your application. Best, The Wikipedia Library"
+msgstr "%(submit_date)s - %(commenter)s %(comment)s Per favor responde a istes sur %(app_url)s de maniera que nos pote evalutar tu demanda. Cordialmente, Le Bibliotheca de Wikipedia"
 
 #. Translators: This is the subject line of an email sent to users who have a comment added to one of their applications. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/comment_notification_editors-subject.html:3
@@ -1205,42 +1004,25 @@ msgstr "Nove commento sur tu demanda al Bibliotheca de Wikipedia"
 #. Translators: This email is sent to users when an application they commented on receives another comment. Don't translate Jinja variables in curly braces like app_url; don't translate html tags either. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/comment_notification_others-body-html.html:5
 #, python-format
-msgid ""
-"<p style=\"color: #500050\">%(submit_date)s - %(commenter)s</p> "
-"<blockquote><p>%(comment)s</p></blockquote> See it at <a href=\"%(app_url)s"
-"\">%(app_url)s</a>. Thanks for helping review Wikipedia Library applications!"
-msgstr ""
-"<p style=\"color: #500050\">%(submit_date)s - %(commenter)s</p> "
-"<blockquote><p>%(comment)s</p></blockquote> Vide lo sur: <a href="
-"\"%(app_url)s\">%(app_url)s</a>. Gratias pro adjutar a revider le demandas "
-"al Bibliotheca de Wikipedia!"
+msgid "<p style=\"color: #500050\">%(submit_date)s - %(commenter)s</p> <blockquote><p>%(comment)s</p></blockquote> See it at <a href=\"%(app_url)s\">%(app_url)s</a>. Thanks for helping review Wikipedia Library applications!"
+msgstr "<p style=\"color: #500050\">%(submit_date)s - %(commenter)s</p> <blockquote><p>%(comment)s</p></blockquote> Vide lo sur: <a href=\"%(app_url)s\">%(app_url)s</a>. Gratias pro adjutar a revider le demandas al Bibliotheca de Wikipedia!"
 
 #. Translators: This email is sent to users when an application they commented on receives another comment. Don't translate Jinja variables in curly braces like app_url. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/comment_notification_others-body-text.html:3
 #, python-format
-msgid ""
-"%(submit_date)s - %(commenter)s %(comment)s See it at: %(app_url)s Thanks "
-"for helping review Wikipedia Library applications!"
-msgstr ""
-"%(submit_date)s - %(commenter)s %(comment)s Vide lo sur: %(app_url)s Gratias "
-"pro adjutar a revider le demandas al Bibliotheca de Wikipedia!"
+msgid "%(submit_date)s - %(commenter)s %(comment)s See it at: %(app_url)s Thanks for helping review Wikipedia Library applications!"
+msgstr "%(submit_date)s - %(commenter)s %(comment)s Vide lo sur: %(app_url)s Gratias pro adjutar a revider le demandas al Bibliotheca de Wikipedia!"
 
 #. Translators: This is the subject line of an email sent to users who have a comment added to an application they also commented on. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/comment_notification_others-subject.html:4
 msgid "New comment on a Wikipedia Library application you commented on"
-msgstr ""
-"Nove commento sur un demanda al Bibliotheca de Wikipedia que tu ha commentate"
+msgstr "Nove commento sur un demanda al Bibliotheca de Wikipedia que tu ha commentate"
 
 #. Translators: This text is part of a scheduled reminder email sent to coordinators who have applications requiring action. Don't translate Jinja variables in curly braces like total_apps, or user.
 #: TWLight/emails/templates/emails/coordinator_reminder_notification-body-html.html:5
 #, python-format
-msgid ""
-"<p>Dear %(user)s,</p> <p>Our records indicate that you are the designated "
-"coordinator for partners that have a total of %(total_apps)s applications.</"
-"p>"
-msgstr ""
-"<p>Car %(user)s,</p> <p>Nostre datos indica que tu es le coordinator "
-"designate pro le partners que ha un total de %(total_apps)s demandas.</p>"
+msgid "<p>Dear %(user)s,</p> <p>Our records indicate that you are the designated coordinator for partners that have a total of %(total_apps)s applications.</p>"
+msgstr "<p>Car %(user)s,</p> <p>Nostre datos indica que tu es le coordinator designate pro le partners que ha un total de %(total_apps)s demandas.</p>"
 
 #. Translators: Breakdown as in 'cost breakdown'; analysis.
 #: TWLight/emails/templates/emails/coordinator_reminder_notification-body-html.html:11
@@ -1278,45 +1060,20 @@ msgstr[1] "%(counter)s demandas approbate."
 #. Translators: This text is part of a scheduled reminder email sent to coordinators who have applications requiring action. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library). Don't translate Jinja variables in curly braces like link; don't translate email addresses or html tags either.
 #: TWLight/emails/templates/emails/coordinator_reminder_notification-body-html.html:39
 #, python-format
-msgid ""
-"<p>This is a gentle reminder that you may review applications at <a href="
-"\"%(link)s\">%(link)s</a>.</p> <p>You can customise your reminders under "
-"'preferences' in your user profile.</p> <p>If you received this message in "
-"error, drop us a line at wikipedialibrary@wikimedia.org.</p> <p>Thanks for "
-"helping review Wikipedia Library applications!</p>"
-msgstr ""
-"<p>Isto es pro rememorar te del possibilitate de revider demandas sur <a "
-"href=\"%(link)s\">%(link)s</a>.</p> <p>Tu pote personalisar tu "
-"rememorationes sub ‘Preferentias’ in tu profilo de usator.</p> <p>Si tu ha "
-"recipite iste message in error, contacta nos sur wikipedialibrary@wikimedia."
-"org.</p> <p>Gratias pro adjutar a revider le demandas al Bibliotheca de "
-"Wikipedia!</p>"
+msgid "<p>This is a gentle reminder that you may review applications at <a href=\"%(link)s\">%(link)s</a>.</p> <p>You can customise your reminders under 'preferences' in your user profile.</p> <p>If you received this message in error, drop us a line at wikipedialibrary@wikimedia.org.</p> <p>Thanks for helping review Wikipedia Library applications!</p>"
+msgstr "<p>Isto es pro rememorar te del possibilitate de revider demandas sur <a href=\"%(link)s\">%(link)s</a>.</p> <p>Tu pote personalisar tu rememorationes sub ‘Preferentias’ in tu profilo de usator.</p> <p>Si tu ha recipite iste message in error, contacta nos sur wikipedialibrary@wikimedia.org.</p> <p>Gratias pro adjutar a revider le demandas al Bibliotheca de Wikipedia!</p>"
 
 #. Translators: This text is part of a scheduled reminder email sent to coordinators who have applications requiring action. Don't translate Jinja variables in curly braces like total_apps, or user.
 #: TWLight/emails/templates/emails/coordinator_reminder_notification-body-text.html:3
 #, python-format
-msgid ""
-"Dear %(user)s, Our records indicate that you are the designated coordinator "
-"for partners that have a total of %(total_apps)s applications."
-msgstr ""
-"Car %(user)s, Nostre datos indica que tu es le coordinator designate pro le "
-"partners que ha un total de %(total_apps)s demandas."
+msgid "Dear %(user)s, Our records indicate that you are the designated coordinator for partners that have a total of %(total_apps)s applications."
+msgstr "Car %(user)s, Nostre datos indica que tu es le coordinator designate pro le partners que ha un total de %(total_apps)s demandas."
 
 #. Translators: This text is part of a scheduled reminder email sent to coordinators who have applications requiring action. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library). Don't translate Jinja variables in curly braces like link; don't translate the email address either.
 #: TWLight/emails/templates/emails/coordinator_reminder_notification-body-text.html:38
 #, python-format
-msgid ""
-"This is a gentle reminder that you may review applications at: %(link)s. You "
-"can customise your reminders under 'preferences' in your user profile. If "
-"you received this message in error, drop us a line at: "
-"wikipedialibrary@wikimedia.org Thanks for helping review Wikipedia Library "
-"applications!"
-msgstr ""
-"Isto es pro rememorar te del possibilitate de revider demandas sur: "
-"%(link)s. Tu pote personalisar tu rememorationes sub ‘Preferentias’ in tu "
-"profilo de usator. Si tu ha recipite iste message in error, contacta nos sur "
-"wikipedialibrary@wikimedia.org. Gratias pro adjutar a revider le demandas al "
-"Bibliotheca de Wikipedia!"
+msgid "This is a gentle reminder that you may review applications at: %(link)s. You can customise your reminders under 'preferences' in your user profile. If you received this message in error, drop us a line at: wikipedialibrary@wikimedia.org Thanks for helping review Wikipedia Library applications!"
+msgstr "Isto es pro rememorar te del possibilitate de revider demandas sur: %(link)s. Tu pote personalisar tu rememorationes sub ‘Preferentias’ in tu profilo de usator. Si tu ha recipite iste message in error, contacta nos sur wikipedialibrary@wikimedia.org. Gratias pro adjutar a revider le demandas al Bibliotheca de Wikipedia!"
 
 #. Translators: This is the subject line of a scheduled reminder email sent to coordinators who have applications to review. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library). Do not translate items in curly braces.
 #: TWLight/emails/templates/emails/coordinator_reminder_notification-subject.html:4
@@ -1326,32 +1083,14 @@ msgstr "Demandas al Bibliotheca de Wikipedia attende tu revision"
 #. Translators: This email is sent to users when their application is rejected. Don't translate Jinja variables in curly braces like user or partner; don't translate html tags either. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/rejection_notification-body-html.html:5
 #, python-format
-msgid ""
-"<p>Dear %(user)s,</p> <p>Thank you for applying for access to %(partner)s "
-"resources through The Wikipedia Library. Unfortunately at this time your "
-"application has not been approved. You can view your application and review "
-"comments at <a href=\"%(app_url)s\">%(app_url)s</a>.</p> <p>Best,</p> <p>The "
-"Wikipedia Library</p>"
-msgstr ""
-"<p>Car %(user)s,</p> <p>Gratias pro tu demanda de accesso al ressources de "
-"%(partner)s per medio del Bibliotheca de Wikipedia. Infortunatemente tu "
-"demanda non ha essite approbate. Tu pote vider tu demanda e leger le "
-"commentos sur <a href=\"%(app_url)s\">%(app_url)s</a>.</p> <p>Cordialmente,</"
-"p> <p>Le Bibliotheca de Wikipedia</p>"
+msgid "<p>Dear %(user)s,</p> <p>Thank you for applying for access to %(partner)s resources through The Wikipedia Library. Unfortunately at this time your application has not been approved. You can view your application and review comments at <a href=\"%(app_url)s\">%(app_url)s</a>.</p> <p>Best,</p> <p>The Wikipedia Library</p>"
+msgstr "<p>Car %(user)s,</p> <p>Gratias pro tu demanda de accesso al ressources de %(partner)s per medio del Bibliotheca de Wikipedia. Infortunatemente tu demanda non ha essite approbate. Tu pote vider tu demanda e leger le commentos sur <a href=\"%(app_url)s\">%(app_url)s</a>.</p> <p>Cordialmente,</p> <p>Le Bibliotheca de Wikipedia</p>"
 
 #. Translators: This email is sent to users when their application is rejected. Don't translate Jinja variables in curly braces like user or partner. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/rejection_notification-body-text.html:3
 #, python-format
-msgid ""
-"Dear %(user)s, Thank you for applying for access to %(partner)s resources "
-"through The Wikipedia Library. Unfortunately at this time your application "
-"has not been approved. You can view your application and review comments at: "
-"%(app_url)s Best, The Wikipedia Library"
-msgstr ""
-"Car %(user)s, Gratias pro tu demanda de accesso al ressources de %(partner)s "
-"per medio del Bibliotheca de Wikipedia. Infortunatemente tu demanda non ha "
-"essite approbate. Tu pote vider tu demanda e leger le commentos sur "
-"%(app_url)s Cordialmente, Le Bibliotheca de Wikipedia"
+msgid "Dear %(user)s, Thank you for applying for access to %(partner)s resources through The Wikipedia Library. Unfortunately at this time your application has not been approved. You can view your application and review comments at: %(app_url)s Best, The Wikipedia Library"
+msgstr "Car %(user)s, Gratias pro tu demanda de accesso al ressources de %(partner)s per medio del Bibliotheca de Wikipedia. Infortunatemente tu demanda non ha essite approbate. Tu pote vider tu demanda e leger le commentos sur %(app_url)s Cordialmente, Le Bibliotheca de Wikipedia"
 
 #. Translators: This is the subject of an email which is sent to users when their application has been rejected. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/rejection_notification-subject.html:4
@@ -1361,39 +1100,14 @@ msgstr "Tu demanda al Bibliotheca de Wikipedia"
 #. Translators: This email is sent to users when they have an account that is soon to expire. Don't translate Jinja variables in curly braces like partner_name or partner_link; don't translate html tags either. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/user_renewal_notice-body-html.html:5
 #, python-format
-msgid ""
-"<p>Dear %(user)s,</p> <p>According to our records, your access to "
-"%(partner_name)s will soon expire and you may lose access. If you want to "
-"continue making use of your free account, you can request renewal of your "
-"account by clicking the 'Renew' or 'Extend' button at %(partner_link)s.</p> "
-"<p>Best,</p> <p>The Wikipedia Library</p> <p>You can disable these emails in "
-"your user page preferences: https://wikipedialibrary.wmflabs.org/users/</p>"
-msgstr ""
-"<p>Car %(user)s,</p> <p>Secundo nostre informationes, tu accesso a "
-"%(partner_name)s expirara tosto e tu pote perder le accesso. Si tu vole "
-"continuar a utilisar tu conto gratuite, tu pote requestar le renovation de "
-"tu conto cliccante sur le button ‘Renovar’ o ‘Extender’ sur %(partner_link)s."
-"</p> <p>Cordialmente,</p> <p>Le bibliotheca de Wikipedia</p> <p>Tu pote "
-"disactivar le invio de messages como iste sur tu pagina de preferentias: "
-"https://wikipedialibrary.wmflabs.org/users/</p>"
+msgid "<p>Dear %(user)s,</p> <p>According to our records, your access to %(partner_name)s will soon expire and you may lose access. If you want to continue making use of your free account, you can request renewal of your account by clicking the 'Renew' or 'Extend' button at %(partner_link)s.</p> <p>Best,</p> <p>The Wikipedia Library</p> <p>You can disable these emails in your user page preferences: https://wikipedialibrary.wmflabs.org/users/</p>"
+msgstr "<p>Car %(user)s,</p> <p>Secundo nostre informationes, tu accesso a %(partner_name)s expirara tosto e tu pote perder le accesso. Si tu vole continuar a utilisar tu conto gratuite, tu pote requestar le renovation de tu conto cliccante sur le button ‘Renovar’ o ‘Extender’ sur %(partner_link)s.</p> <p>Cordialmente,</p> <p>Le bibliotheca de Wikipedia</p> <p>Tu pote disactivar le invio de messages como iste sur tu pagina de preferentias: https://wikipedialibrary.wmflabs.org/users/</p>"
 
 #. Translators: This email is sent to users when they have an account that is soon to expire. Don't translate Jinja variables in curly braces like partner_name or partner_link; don't translate html tags either. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/user_renewal_notice-body-text.html:3
 #, python-format
-msgid ""
-"Dear %(user)s, According to our records, your access to %(partner_name)s "
-"will soon expire and you may lose access. If you want to continue making use "
-"of your free account, you can request renewal of your account by clicking "
-"the Renew button at %(partner_link)s. Best, The Wikipedia Library You can "
-"disable these emails in your user page preferences: https://wikipedialibrary."
-"wmflabs.org/users/"
-msgstr ""
-"Car %(user)s, Secundo nostre informationes, tu accesso a %(partner_name)s "
-"expirara tosto e tu pote perder le accesso. Si tu vole continuar a utilisar "
-"tu conto gratuite, tu pote requestar le renovation de tu conto cliccante sur "
-"le button ‘Renovar’ o ‘Extender’ sur %(partner_link)s. Cordialmente, Le "
-"bibliotheca de Wikipedia Tu pote disactivar le invio de messages como iste "
-"sur tu pagina de preferentias: https://wikipedialibrary.wmflabs.org/users/"
+msgid "Dear %(user)s, According to our records, your access to %(partner_name)s will soon expire and you may lose access. If you want to continue making use of your free account, you can request renewal of your account by clicking the Renew button at %(partner_link)s. Best, The Wikipedia Library You can disable these emails in your user page preferences: https://wikipedialibrary.wmflabs.org/users/"
+msgstr "Car %(user)s, Secundo nostre informationes, tu accesso a %(partner_name)s expirara tosto e tu pote perder le accesso. Si tu vole continuar a utilisar tu conto gratuite, tu pote requestar le renovation de tu conto cliccante sur le button ‘Renovar’ o ‘Extender’ sur %(partner_link)s. Cordialmente, Le bibliotheca de Wikipedia Tu pote disactivar le invio de messages como iste sur tu pagina de preferentias: https://wikipedialibrary.wmflabs.org/users/"
 
 #. Translators: This is the subject of an email sent to users when they have an account that is soon to expire. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/user_renewal_notice-subject.html:4
@@ -1403,45 +1117,19 @@ msgstr "Tu accesso al Bibliotheca de Wikipedia pote expirar tosto"
 #. Translators: This email is sent to users when their application is waitlisted because there are no more accounts available. Don't translate Jinja variables in curly braces like user or partner; don't translate html tags either. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/waitlist_notification-body-html.html:5
 #, python-format
-msgid ""
-"<p>Dear %(user)s,</p> <p>Thank you for applying for access to %(partner)s "
-"resources through The Wikipedia Library. There are no accounts currently "
-"available so your application has been waitlisted. Your application will be "
-"evaluated if/when more accounts become available. You can see all available "
-"resources at <a href=\"%(link)s\">%(link)s</a>.</p> <p>Best,</p> <p>The "
-"Wikipedia Library</p>"
-msgstr ""
-"<p>Car %(user)s,</p> <p>Gratias pro tu demanda de accesso al ressources de "
-"%(partner)s per medio del Bibliotheca de Wikipedia. Al momento il non ha "
-"contos disponibile, tu demanda ha dunque essite mittite in lista de "
-"attender. Tu demanda essera evalutate si/quando plus contos devenira "
-"disponibile. Tu pote vider tote le ressources disponibile sur <a href="
-"\"%(link)s\">%(link)s</a>.</p> <p>Cordialmente,</p> <p>Le Bibliotheca de "
-"Wikipedia</p>"
+msgid "<p>Dear %(user)s,</p> <p>Thank you for applying for access to %(partner)s resources through The Wikipedia Library. There are no accounts currently available so your application has been waitlisted. Your application will be evaluated if/when more accounts become available. You can see all available resources at <a href=\"%(link)s\">%(link)s</a>.</p> <p>Best,</p> <p>The Wikipedia Library</p>"
+msgstr "<p>Car %(user)s,</p> <p>Gratias pro tu demanda de accesso al ressources de %(partner)s per medio del Bibliotheca de Wikipedia. Al momento il non ha contos disponibile, tu demanda ha dunque essite mittite in lista de attender. Tu demanda essera evalutate si/quando plus contos devenira disponibile. Tu pote vider tote le ressources disponibile sur <a href=\"%(link)s\">%(link)s</a>.</p> <p>Cordialmente,</p> <p>Le Bibliotheca de Wikipedia</p>"
 
 #. Translators: This email is sent to users when their application is waitlisted because there are no more accounts available. Don't translate Jinja variables in curly braces like user or partner. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/waitlist_notification-body-text.html:3
 #, python-format
-msgid ""
-"Dear %(user)s, Thank you for applying for access to %(partner)s resources "
-"through The Wikipedia Library. There are no accounts currently available so "
-"your application has been waitlisted. Your application will be evaluated if/"
-"when more accounts become available. You can see all available resources at: "
-"%(link)s Best, The Wikipedia Library"
-msgstr ""
-"Car %(user)s Gratias pro tu demanda de accesso al ressources de %(partner)s "
-"per medio del Bibliotheca de Wikipedia. Al momento il non ha contos "
-"disponibile, tu demanda ha dunque essite mittite in lista de attender. Tu "
-"demanda essera evalutate si/quando plus contos devenira disponibile. Tu pote "
-"vider tote le ressources disponibile sur: %(link)s Cordialmente, Le "
-"Bibliotheca de Wikipedia"
+msgid "Dear %(user)s, Thank you for applying for access to %(partner)s resources through The Wikipedia Library. There are no accounts currently available so your application has been waitlisted. Your application will be evaluated if/when more accounts become available. You can see all available resources at: %(link)s Best, The Wikipedia Library"
+msgstr "Car %(user)s Gratias pro tu demanda de accesso al ressources de %(partner)s per medio del Bibliotheca de Wikipedia. Al momento il non ha contos disponibile, tu demanda ha dunque essite mittite in lista de attender. Tu demanda essera evalutate si/quando plus contos devenira disponibile. Tu pote vider tote le ressources disponibile sur: %(link)s Cordialmente, Le Bibliotheca de Wikipedia"
 
 #. Translators: This is the subject of an email sent to users when their application is waitlisted because there are no more accounts available. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/waitlist_notification-subject.html:4
 msgid "Your Wikipedia Library application has been waitlisted"
-msgstr ""
-"Tu demanda al Bibliotheca de Wikipedia ha essite mittite in le lista de "
-"attender"
+msgstr "Tu demanda al Bibliotheca de Wikipedia ha essite mittite in le lista de attender"
 
 #. Translators: Shown to users when they successfully submit a new message using the contact us form.
 #: TWLight/emails/views.py:51
@@ -1597,17 +1285,14 @@ msgstr ""
 #: TWLight/resources/templates/resources/filter_section.html:14
 #: TWLight/templates/about.html:12
 #: TWLight/users/templates/users/filter_section.html:13
-msgid ""
-"The Wikipedia Library allows active editors to access a wide range of "
-"collections of paywalled reliable sources for free!"
+msgid "The Wikipedia Library allows active editors to access a wide range of collections of paywalled reliable sources for free!"
 msgstr ""
 
 #. Translators: On the Browse Partners page (https://wikipedialibrary.wmflabs.org/partners/), this introduces users to The Wikipedia Library.
 #. Translators: On the MyLibrary page (https://wikipedialibrary.wmflabs.org/users/my_library), this introduces users to The Wikipedia Library.
 #: TWLight/resources/templates/resources/filter_section.html:17
 #: TWLight/users/templates/users/filter_section.html:15
-msgid ""
-"Start with the search bar at the top or browse publisher websites directly."
+msgid "Start with the search bar at the top or browse publisher websites directly."
 msgstr ""
 
 #. Translators: On the Browse Partners page (https://wikipedialibrary.wmflabs.org/partners/), this appears below introductory text and links to the 'About' page (https://wikipedialibrary.wmflabs.org/about/)
@@ -1681,64 +1366,39 @@ msgstr ""
 #. Translators: If we have no available accounts for a partner, the coordinator can change the application system to a waiting list.
 #: TWLight/resources/templates/resources/partner_detail.html:36
 #: TWLight/resources/templates/resources/partner_detail_apply.html:17
-msgid ""
-"There are no access grants available for this partner at this time. You can "
-"still apply for access; applications will be processed when access is "
-"available."
-msgstr ""
-"Il non ha concessiones de accesso disponibile pro site partner al momento. "
-"Tu pote totevia demandar accesso; le demandas essera tractate quando le "
-"accesso essera disponibile."
+msgid "There are no access grants available for this partner at this time. You can still apply for access; applications will be processed when access is available."
+msgstr "Il non ha concessiones de accesso disponibile pro site partner al momento. Tu pote totevia demandar accesso; le demandas essera tractate quando le accesso essera disponibile."
 
 #. Translators: This text links to the minimum user requirements and terms of use on the partner page.
 #: TWLight/resources/templates/resources/partner_detail.html:48
 #: TWLight/resources/templates/resources/partner_detail_apply.html:29
 #, python-format
-msgid ""
-"Before applying, please review the <strong><a class=\"twl-links\" href="
-"\"%(about)s#req\">minimum requirements</a></strong> for access and our "
-"<strong><a class=\"twl-links\" href=\"%(terms)s\">terms of use</a></strong>."
-msgstr ""
-"Ante de demandar, per favor relege le <strong><a class=\"twl-links\" href="
-"\"%(about)s#req\">requisios minime</a></strong> pro le accesso e nostre "
-"<strong><a class=\"twl-links\" href=\"%(terms)s\">conditiones de uso</a></"
-"strong>."
+msgid "Before applying, please review the <strong><a class=\"twl-links\" href=\"%(about)s#req\">minimum requirements</a></strong> for access and our <strong><a class=\"twl-links\" href=\"%(terms)s\">terms of use</a></strong>."
+msgstr "Ante de demandar, per favor relege le <strong><a class=\"twl-links\" href=\"%(about)s#req\">requisios minime</a></strong> pro le accesso e nostre <strong><a class=\"twl-links\" href=\"%(terms)s\">conditiones de uso</a></strong>."
 
 #. Translators: This text refers to the page containing the content a user is authorized to access.
 #: TWLight/resources/templates/resources/partner_detail.html:69
 #, python-format
-msgid ""
-"View the status of your access in <strong><a class=\"twl-links\" href="
-"\"%(library_url)s\">My Library</a></strong> page."
+msgid "View the status of your access in <strong><a class=\"twl-links\" href=\"%(library_url)s\">My Library</a></strong> page."
 msgstr ""
 
 #. Translators: This message is shown when a user has open applications, linking to their respective applications page.
 #: TWLight/resources/templates/resources/partner_detail.html:78
 #, python-format
-msgid ""
-"View the status of your application(s) on your <strong><a class=\"twl-links"
-"\" href=\"%(applications_url)s\">My Applications</a></strong> page."
-msgstr ""
-"Vide le stato de tu demanda(s) sur tu pagina <strong><a class=\"twl-links\" "
-"href=\"%(applications_url)s\">Mi demandas</a></strong>."
+msgid "View the status of your application(s) on your <strong><a class=\"twl-links\" href=\"%(applications_url)s\">My Applications</a></strong> page."
+msgstr "Vide le stato de tu demanda(s) sur tu pagina <strong><a class=\"twl-links\" href=\"%(applications_url)s\">Mi demandas</a></strong>."
 
 #. Translators: This message is shown when a user has authorizations, linking to their respective collections page.
 #: TWLight/resources/templates/resources/partner_detail_apply.html:50
 #, python-format
-msgid ""
-"View the status of your access on your <strong><a href=\"%(library_url)s\" "
-"class=\"twl-links\">My Library</a></strong> page."
+msgid "View the status of your access on your <strong><a href=\"%(library_url)s\" class=\"twl-links\">My Library</a></strong> page."
 msgstr ""
 
 #. Translators: This message is shown when a user has open applications, linking to their respective applications page.
 #: TWLight/resources/templates/resources/partner_detail_apply.html:60
 #, python-format
-msgid ""
-"View the status of your application(s) on your <strong><a href="
-"\"%(applications_url)s\">My Applications</a></strong> page."
-msgstr ""
-"Vide le stato de tu demanda(s) sur tu pagina <strong><a href="
-"\"%(applications_url)s\">Mi demandas</a></strong>."
+msgid "View the status of your application(s) on your <strong><a href=\"%(applications_url)s\">My Applications</a></strong> page."
+msgstr "Vide le stato de tu demanda(s) sur tu pagina <strong><a href=\"%(applications_url)s\">Mi demandas</a></strong>."
 
 #. Translators: One the partner detail page, this text labels the button which coordinators can click to remove a partner from waitlisted status.
 #: TWLight/resources/templates/resources/partner_detail_apply.html:73
@@ -1767,10 +1427,7 @@ msgstr ""
 
 #. Translators: If no account coordinator is assigned to a partner, the Wikipedia Library team will coordinate signups. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/resources/templates/resources/partner_detail_apply.html:112
-msgid ""
-"The Wikipedia Library team will process this application. Want to help? <a "
-"class=\"twl-links\" href=\"https://en.wikipedia.org/wiki/Wikipedia:"
-"The_Wikipedia_Library/Coordinators/Signup\">Sign up as a coordinator.</a>"
+msgid "The Wikipedia Library team will process this application. Want to help? <a class=\"twl-links\" href=\"https://en.wikipedia.org/wiki/Wikipedia:The_Wikipedia_Library/Coordinators/Signup\">Sign up as a coordinator.</a>"
 msgstr ""
 
 #. Translators: This text labels a button coordinators can click to view a list of users who have applied for access for a particular partner
@@ -1800,18 +1457,13 @@ msgstr ""
 
 #. Translators: Text shown to authenticated, bundle eligible users when they visit a Bundle partner page.
 #: TWLight/resources/templates/resources/partner_detail_apply.html:138
-msgid ""
-"You are eligible to access Library Bundle partners. Click the button above "
-"to access the collection."
+msgid "You are eligible to access Library Bundle partners. Click the button above to access the collection."
 msgstr ""
 
 #. Translators: Text shown to authenticated, bundle ineligible users when they visit a Bundle partner page.
 #: TWLight/resources/templates/resources/partner_detail_apply.html:152
 #, python-format
-msgid ""
-"You are not eligible to access Library Bundle partners. Visit the <a class="
-"\"twl-links\" href=\"%(homepage)s\">homepage</a> to check the eligibility "
-"criteria."
+msgid "You are not eligible to access Library Bundle partners. Visit the <a class=\"twl-links\" href=\"%(homepage)s\">homepage</a> to check the eligibility criteria."
 msgstr ""
 
 #. Translators: Buttton prompting users to log in.
@@ -1823,10 +1475,7 @@ msgstr ""
 #. Translators: Text shown to unauthenticated users when they visit a Bundle partner page.
 #: TWLight/resources/templates/resources/partner_detail_apply.html:168
 #, python-format
-msgid ""
-"This resource is part of our <a class=\"twl-links\" href=\"%(about)s"
-"\">Library Bundle</a>, which you can access if you meet our minimum "
-"eligibility criteria. Log in to find out if you are eligible."
+msgid "This resource is part of our <a class=\"twl-links\" href=\"%(about)s\">Library Bundle</a>, which you can access if you meet our minimum eligibility criteria. Log in to find out if you are eligible."
 msgstr ""
 
 #. Translators: This is the label for a number which shows the total active accounts for one partner. (e.g. https://wikipedialibrary.wmflabs.org/partners/8/).
@@ -1877,26 +1526,19 @@ msgstr ""
 #. Translators: If a partner has specified the excerpt limit both in words and percentage, this message will display the percentage of words and the number of words on the partner page.
 #: TWLight/resources/templates/resources/partner_detail_timeline.html:99
 #, python-format
-msgid ""
-"%(object)s allows a maximum of %(excerpt_limit)s words or "
-"%(excerpt_limit_percentage)s%% of an article be excerpted into a Wikipedia "
-"article."
+msgid "%(object)s allows a maximum of %(excerpt_limit)s words or %(excerpt_limit_percentage)s%% of an article be excerpted into a Wikipedia article."
 msgstr ""
 
 #. Translators: If a partner has specified the excerpt limit in words, this message will display the number of words on the partner page.
 #: TWLight/resources/templates/resources/partner_detail_timeline.html:106
 #, python-format
-msgid ""
-"%(object)s allows a maximum of %(excerpt_limit)s words be excerpted into a "
-"Wikipedia article."
+msgid "%(object)s allows a maximum of %(excerpt_limit)s words be excerpted into a Wikipedia article."
 msgstr ""
 
 #. Translators: If a partner has specified the excerpt limit in percentage, this message will display the percentage of words on the partner page.
 #: TWLight/resources/templates/resources/partner_detail_timeline.html:113
 #, python-format
-msgid ""
-"%(object)s allows a maximum of %(excerpt_limit_percentage)s%% of an article "
-"be excerpted into a Wikipedia article."
+msgid "%(object)s allows a maximum of %(excerpt_limit_percentage)s%% of an article be excerpted into a Wikipedia article."
 msgstr ""
 
 #. Translators: If a partner has other requirements for access, this text shows as the title for that information field. (e.g. https://wikipedialibrary.wmflabs.org/partners/10/).
@@ -1907,9 +1549,7 @@ msgstr ""
 #. Translators: If a user must agree to a Terms of Use document, they see this message, and must enter the name of the resource. Don't translate publisher or url.
 #: TWLight/resources/templates/resources/partner_detail_timeline.html:140
 #, python-format
-msgid ""
-"%(publisher)s requires that you agree with its <a href=\"%(url)s\">terms of "
-"use</a>."
+msgid "%(publisher)s requires that you agree with its <a href=\"%(url)s\">terms of use</a>."
 msgstr ""
 
 #. Translators: If a user must provide their real name to apply to a partner, they see this message, and must enter the name of the resource. Don't translate publisher.
@@ -1933,17 +1573,13 @@ msgstr ""
 #. Translators: If a user must select a specific resource to apply for, they see this message, and must enter the name of the resource. Don't translate publisher.
 #: TWLight/resources/templates/resources/partner_detail_timeline.html:177
 #, python-format
-msgid ""
-"%(publisher)s requires that you specify a particular title that you want to "
-"access."
+msgid "%(publisher)s requires that you specify a particular title that you want to access."
 msgstr ""
 
 #. Translators: If a user must register on the partner website before applying, they see this message. Don't translate partner.
 #: TWLight/resources/templates/resources/partner_detail_timeline.html:187
 #, python-format
-msgid ""
-"%(publisher)s requires that you sign up for an account before applying for "
-"access."
+msgid "%(publisher)s requires that you sign up for an account before applying for access."
 msgstr "%(publisher)s require que tu crea un conto ante de demandar accesso."
 
 #. Translators: If a partner has their location listed, this message is a label for that location
@@ -2070,9 +1706,7 @@ msgstr ""
 
 #. Translators: If multiple authorizations where returned for a collection, this message is shown to a user
 #: TWLight/resources/views.py:268
-msgid ""
-"Multiple authorizations were returned – something's wrong. Please contact us "
-"and don't forget to mention this message."
+msgid "Multiple authorizations were returned – something's wrong. Please contact us and don't forget to mention this message."
 msgstr ""
 
 #. Translators: This message is shown when user tries to access a NOT_AVAILABLE Partner
@@ -2113,14 +1747,7 @@ msgstr ""
 #. Translators: Shown on the website's 400 page, when a user sends a bad request. Don't translate path or Phabricator.
 #: TWLight/templates/400.html:20
 #, python-format
-msgid ""
-"If you think we should know what to do with that, please email us about this "
-"error at <a class=\"twl-links\" href=\"mailto:wikipedialibrary@wikimedia.org?"
-"Subject=Wikipedia%%20Library%%20%(path)s%%20Permission%%20denied"
-"\">wikipedialibrary@wikimedia.org</a> or report it to us on <a class=\"twl-"
-"links\" href=\"https://phabricator.wikimedia.org/maniphest/task/edit/form/1/?"
-"projectPHIDs=Library-Card-Platform&title=Wikipedia%%20Library%%20%(path)s"
-"%%20Bad%%20Request\">Phabricator</a>"
+msgid "If you think we should know what to do with that, please email us about this error at <a class=\"twl-links\" href=\"mailto:wikipedialibrary@wikimedia.org?Subject=Wikipedia%%20Library%%20%(path)s%%20Permission%%20denied\">wikipedialibrary@wikimedia.org</a> or report it to us on <a class=\"twl-links\" href=\"https://phabricator.wikimedia.org/maniphest/task/edit/form/1/?projectPHIDs=Library-Card-Platform&title=Wikipedia%%20Library%%20%(path)s%%20Bad%%20Request\">Phabricator</a>"
 msgstr ""
 
 #. Translators: Alt text for an image shown on the 400 error page.
@@ -2142,15 +1769,7 @@ msgstr ""
 #. Translators: Shown on the website's 403 page, when a user attempts to navigate to a page they don't have permission to view. Don't translate path or Phabricator.
 #: TWLight/templates/403.html:20
 #, python-format
-msgid ""
-"If you think your account should be able to do that, please email us about "
-"this error at <a class=\"twl-links\" href=\"mailto:"
-"wikipedialibrary@wikimedia.org?Subject=Wikipedia%%20Library%%20%(path)s"
-"%%20Permission%%20denied\">wikipedialibrary@wikimedia.org</a> or report it "
-"to us on <a class=\"twl-links\" href=\"https://phabricator.wikimedia.org/"
-"maniphest/task/edit/form/1/?projectPHIDs=Library-Card-"
-"Platform&title=Wikipedia%%20Library%%20%(path)s%%20Permission%%20denied"
-"\">Phabricator</a>"
+msgid "If you think your account should be able to do that, please email us about this error at <a class=\"twl-links\" href=\"mailto:wikipedialibrary@wikimedia.org?Subject=Wikipedia%%20Library%%20%(path)s%%20Permission%%20denied\">wikipedialibrary@wikimedia.org</a> or report it to us on <a class=\"twl-links\" href=\"https://phabricator.wikimedia.org/maniphest/task/edit/form/1/?projectPHIDs=Library-Card-Platform&title=Wikipedia%%20Library%%20%(path)s%%20Permission%%20denied\">Phabricator</a>"
 msgstr ""
 
 #. Translators: Shown on the website's 404 page, when a user attempts to navigate to a page that doesn't exist.
@@ -2166,14 +1785,7 @@ msgstr ""
 #. Translators: Shown on the website's 404 page, when a user attempts to navigate to a page that doesn't exist. Don't translate path or Phabricator.
 #: TWLight/templates/404.html:19
 #, python-format
-msgid ""
-"If you are certain that something should be here, please email us about this "
-"error at <a class=\"twl-links\" href=\"mailto:wikipedialibrary@wikimedia.org?"
-"Subject=Wikipedia%%20Library%%20%(path)s%%20Not%%20found\"> "
-"wikipedialibrary@wikimedia.org</a> or report it to us on <a class=\"twl-links"
-"\" href=\"https://phabricator.wikimedia.org/maniphest/task/edit/form/1/?"
-"projectPHIDs=Library-Card-Platform&title=Wikipedia%%20Library%%20%(path)s"
-"%%20Not%%20found\">Phabricator</a>"
+msgid "If you are certain that something should be here, please email us about this error at <a class=\"twl-links\" href=\"mailto:wikipedialibrary@wikimedia.org?Subject=Wikipedia%%20Library%%20%(path)s%%20Not%%20found\"> wikipedialibrary@wikimedia.org</a> or report it to us on <a class=\"twl-links\" href=\"https://phabricator.wikimedia.org/maniphest/task/edit/form/1/?projectPHIDs=Library-Card-Platform&title=Wikipedia%%20Library%%20%(path)s%%20Not%%20found\">Phabricator</a>"
 msgstr ""
 
 #. Translators: Alt text for an image shown on the 404 error page.
@@ -2188,41 +1800,19 @@ msgstr ""
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:20
-msgid ""
-"This platform is our central tool for facilitating access to our available "
-"collections. Here you can see which partnerships are available, search their "
-"contents, and apply for and access the ones you’re interested in."
-msgstr ""
-"Iste platteforma es nostre instrumento central pro facilitar le accesso a "
-"nostre collectiones disponibile. Hic tu pote vider le partners disponibile, "
-"cercar lor contento, demandar accesso, e acceder a illos de tu interesse."
+msgid "This platform is our central tool for facilitating access to our available collections. Here you can see which partnerships are available, search their contents, and apply for and access the ones you’re interested in."
+msgstr "Iste platteforma es nostre instrumento central pro facilitar le accesso a nostre collectiones disponibile. Hic tu pote vider le partners disponibile, cercar lor contento, demandar accesso, e acceder a illos de tu interesse."
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/). Wikimedia Foundation should not be translated.
 #: TWLight/templates/about.html:29
-msgid ""
-"All users receive immediate access to some collections, which can be browsed "
-"by clicking the 'Access collection' buttons or using the search bar at the "
-"top of the page. Other collections require an application before access is "
-"granted, and may be accessed directly or via an individual login or access "
-"code. Volunteer coordinators, who have signed non-disclosure agreements with "
-"the Wikimedia Foundation, review these applications and work with publishers "
-"to get you your free access."
+msgid "All users receive immediate access to some collections, which can be browsed by clicking the 'Access collection' buttons or using the search bar at the top of the page. Other collections require an application before access is granted, and may be accessed directly or via an individual login or access code. Volunteer coordinators, who have signed non-disclosure agreements with the Wikimedia Foundation, review these applications and work with publishers to get you your free access."
 msgstr ""
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/). Don't translate terms_url.
 #: TWLight/templates/about.html:43
 #, python-format
-msgid ""
-"For more information about how your information is stored and reviewed "
-"please see our <a class=\"twl-links\" href=\"%(terms_url)s\"> terms of use "
-"and privacy policy</a>. Accounts you apply for are also subject to the Terms "
-"of Use provided by each partner’s platform; please review them."
-msgstr ""
-"Pro plus information sur como tu information es immagazinate e revidite, "
-"consulta nostre <a class=\"twl-links\" href=\"%(terms_url)s\"> conditiones "
-"de uso e politica de confidentialitate</a>. Le contos que tu demanda es "
-"tamben subjecte al conditiones de uso fornite per le platteforma de cata "
-"partner; per favor lege los."
+msgid "For more information about how your information is stored and reviewed please see our <a class=\"twl-links\" href=\"%(terms_url)s\"> terms of use and privacy policy</a>. Accounts you apply for are also subject to the Terms of Use provided by each partner’s platform; please review them."
+msgstr "Pro plus information sur como tu information es immagazinate e revidite, consulta nostre <a class=\"twl-links\" href=\"%(terms_url)s\"> conditiones de uso e politica de confidentialitate</a>. Le contos que tu demanda es tamben subjecte al conditiones de uso fornite per le platteforma de cata partner; per favor lege los."
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:51
@@ -2231,19 +1821,8 @@ msgstr ""
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/). Wikimedia Foundation should not be translated.
 #: TWLight/templates/about.html:55
-msgid ""
-"Any active editor in good standing can receive access. For publishers with "
-"limited numbers of accounts, applications are reviewed based on the editor’s "
-"needs and contributions. If you think you could use access to one of our "
-"partner resources and are an active editor in any project supported by the "
-"Wikimedia Foundation, please apply."
-msgstr ""
-"Omne redactor de bon reputation pote reciper accesso. Pro editores con un "
-"numero limitate de contos, le demandas se revide a base del besonios e "
-"contributiones del redactor. Si tu pensa que le accesso al ressources de un "
-"de nostre partners te esserea utile e si tu e un redactor active in "
-"qualcunque projecto supportate per le Fundation Wikimedia, per favor "
-"presenta un demanda."
+msgid "Any active editor in good standing can receive access. For publishers with limited numbers of accounts, applications are reviewed based on the editor’s needs and contributions. If you think you could use access to one of our partner resources and are an active editor in any project supported by the Wikimedia Foundation, please apply."
+msgstr "Omne redactor de bon reputation pote reciper accesso. Pro editores con un numero limitate de contos, le demandas se revide a base del besonios e contributiones del redactor. Si tu pensa que le accesso al ressources de un de nostre partners te esserea utile e si tu e un redactor active in qualcunque projecto supportate per le Fundation Wikimedia, per favor presenta un demanda."
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:65
@@ -2272,28 +1851,12 @@ msgstr ""
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/)
 #: TWLight/templates/about.html:89
-msgid ""
-"If you are applying for an available collection, please first check that you "
-"don't already have access through another library or institution. If you do, "
-"please consider using that access rather than taking up a seat for this "
-"resource in The Wikipedia Library."
-msgstr ""
-"Si tu vole presentar un demanda pro un collection disponibile, per favor "
-"verifica primo que tu non ha ja accesso a illo per medio de un altere "
-"bibliotheca o institution. Si tu ha tal accesso, per favor considera "
-"utilisar lo in loco de occupar un placia pro iste ressource in le "
-"Bibliotheca de Wikipedia."
+msgid "If you are applying for an available collection, please first check that you don't already have access through another library or institution. If you do, please consider using that access rather than taking up a seat for this resource in The Wikipedia Library."
+msgstr "Si tu vole presentar un demanda pro un collection disponibile, per favor verifica primo que tu non ha ja accesso a illo per medio de un altere bibliotheca o institution. Si tu ha tal accesso, per favor considera utilisar lo in loco de occupar un placia pro iste ressource in le Bibliotheca de Wikipedia."
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/)
 #: TWLight/templates/about.html:99
-msgid ""
-"If your account is blocked on one or more Wikimedia projects, you may still "
-"be granted access to The Wikipedia Library. You will need to contact the "
-"Wikipedia Library team, who will review your blocks. If you have been "
-"blocked for content issues, most notably copyright violations, or have "
-"multiple long-term blocks, we may decline your request. Additionally, if "
-"your block status changes after being approved, you will need to request "
-"another review."
+msgid "If your account is blocked on one or more Wikimedia projects, you may still be granted access to The Wikipedia Library. You will need to contact the Wikipedia Library team, who will review your blocks. If you have been blocked for content issues, most notably copyright violations, or have multiple long-term blocks, we may decline your request. Additionally, if your block status changes after being approved, you will need to request another review."
 msgstr ""
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
@@ -2328,9 +1891,7 @@ msgstr ""
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:136
-msgid ""
-"Share their account logins or passwords with others, or sell their access to "
-"other parties"
+msgid "Share their account logins or passwords with others, or sell their access to other parties"
 msgstr ""
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
@@ -2340,23 +1901,17 @@ msgstr ""
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:144
-msgid ""
-"Systematically make printed or electronic copies of multiple extracts of "
-"restricted content available for any purpose"
+msgid "Systematically make printed or electronic copies of multiple extracts of restricted content available for any purpose"
 msgstr ""
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/). Stub is a technical term for a short Wikipedia article, use the appropriate Wikipedia term in your language.
 #: TWLight/templates/about.html:148
-msgid ""
-"Datamine metadata without permission, in order, for instance, to use "
-"metadata for auto-created stub articles"
+msgid "Datamine metadata without permission, in order, for instance, to use metadata for auto-created stub articles"
 msgstr ""
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:154
-msgid ""
-"Respecting these agreements allows us to continue growing the partnerships "
-"available to the community."
+msgid "Respecting these agreements allows us to continue growing the partnerships available to the community."
 msgstr ""
 
 #. Translators: This is the heading for a section on the About page (https://wikipedialibrary.wmflabs.org/about/).
@@ -2366,46 +1921,22 @@ msgstr ""
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:164
-msgid ""
-"EZProxy is a proxy server used to authenticate users for many Wikipedia "
-"Library partners. Users sign into EZProxy via the Library Card platform to "
-"verify that they are authorized users, and then the server accesses "
-"requested resources using its own IP address."
-msgstr ""
-"EZProxy es un servitor de mandatario usate pro authenticar usatores pro "
-"multe partners del Bibliotheca de Wikipedia. Le usatores aperi session sur "
-"EZProxy per medio del platteforma del Carta de Bibliotheca pro verificar lor "
-"autorisation, e alora le servitor accede al ressources requestate desde su "
-"proprie adresse IP."
+msgid "EZProxy is a proxy server used to authenticate users for many Wikipedia Library partners. Users sign into EZProxy via the Library Card platform to verify that they are authorized users, and then the server accesses requested resources using its own IP address."
+msgstr "EZProxy es un servitor de mandatario usate pro authenticar usatores pro multe partners del Bibliotheca de Wikipedia. Le usatores aperi session sur EZProxy per medio del platteforma del Carta de Bibliotheca pro verificar lor autorisation, e alora le servitor accede al ressources requestate desde su proprie adresse IP."
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:173
-msgid ""
-"You may notice that when accessing resources via EZProxy that URLs are "
-"dynamically rewritten. This is why we recommend logging in via the Library "
-"Card platform rather than going directly to the unproxied partner website. "
-"When in doubt, check the URL for ‘idm.oclc’. If it’s there, then you’re "
-"connected via EZProxy."
+msgid "You may notice that when accessing resources via EZProxy that URLs are dynamically rewritten. This is why we recommend logging in via the Library Card platform rather than going directly to the unproxied partner website. When in doubt, check the URL for ‘idm.oclc’. If it’s there, then you’re connected via EZProxy."
 msgstr ""
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:182
-msgid ""
-"Typically once you’ve logged in your session will remain active in your "
-"browser for up to two hours after you’ve finished searching. Note that use "
-"of EZProxy requires you to enable cookies. If you are having problems you "
-"should also try clearing your cache and restarting your browser."
+msgid "Typically once you’ve logged in your session will remain active in your browser for up to two hours after you’ve finished searching. Note that use of EZProxy requires you to enable cookies. If you are having problems you should also try clearing your cache and restarting your browser."
 msgstr ""
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/)
 #: TWLight/templates/about.html:193
-msgid ""
-"The Library Bundle is a collection of resources for which no application is "
-"required. If you meet the criteria laid out above, you will be authorized "
-"for access automatically upon logging in to the platform. Only some of our "
-"content is currently included in the Library Bundle, however we hope to "
-"expand the collection as more publishers become comfortable with "
-"participating. All Bundle content is accessed via EZProxy."
+msgid "The Library Bundle is a collection of resources for which no application is required. If you meet the criteria laid out above, you will be authorized for access automatically upon logging in to the platform. Only some of our content is currently included in the Library Bundle, however we hope to expand the collection as more publishers become comfortable with participating. All Bundle content is accessed via EZProxy."
 msgstr ""
 
 #. Translators: This is the heading for a section on the About page (https://wikipedialibrary.wmflabs.org/about/).
@@ -2415,12 +1946,7 @@ msgstr ""
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:206
-msgid ""
-"Citation practices vary by project and even by article. Generally, we "
-"support editors citing where they found information, in a form that allows "
-"others to check it for themselves. That often means providing both original "
-"source details as well as a link to the partner database in which the source "
-"was found."
+msgid "Citation practices vary by project and even by article. Generally, we support editors citing where they found information, in a form that allows others to check it for themselves. That often means providing both original source details as well as a link to the partner database in which the source was found."
 msgstr ""
 
 #. Translators: This is the heading for a section on the About page (https://wikipedialibrary.wmflabs.org/about/).
@@ -2432,9 +1958,7 @@ msgstr ""
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:218
 #, python-format
-msgid ""
-"If you have questions, need help, or want to volunteer to help, please see "
-"our <a class=\"twl-links\" href=\"%(contact_url)s\">contact page</a>."
+msgid "If you have questions, need help, or want to volunteer to help, please see our <a class=\"twl-links\" href=\"%(contact_url)s\">contact page</a>."
 msgstr ""
 
 #. Translators: This is the title of the panel box detailing the contact information for the Wikipedia Library team.
@@ -2474,9 +1998,7 @@ msgstr ""
 #. Translators: This is the text that appears at the bottom of the contact us form directing users to the suggestions form.
 #: TWLight/templates/contact.html:48
 #, python-format
-msgid ""
-"(If you would like to suggest a partner, <a class=\"twl-links\" href="
-"\"%(suggest)s\"><strong>go here</strong></a>.)"
+msgid "(If you would like to suggest a partner, <a class=\"twl-links\" href=\"%(suggest)s\"><strong>go here</strong></a>.)"
 msgstr ""
 
 #. Translators: On a special 'link to search' page, this message is shown if JavaScript is disabled.
@@ -2533,9 +2055,7 @@ msgstr ""
 #. Translators: Information about The Wikipedia Library.
 #: TWLight/templates/login_partial.html:53 TWLight/templates/new_base.html:21
 #, python-format
-msgid ""
-"More than 100 of the world's top subscription-only databases, with content "
-"in %(no_of_languages)s languages, free for Wikipedians of all backgrounds"
+msgid "More than 100 of the world's top subscription-only databases, with content in %(no_of_languages)s languages, free for Wikipedians of all backgrounds"
 msgstr ""
 
 #. Translators: Information about The Wikipedia Library.
@@ -2544,12 +2064,8 @@ msgid "Meet these criteria for automatic access"
 msgstr "Satisface iste criterios pro accesso automatic"
 
 #: TWLight/templates/login_partial.html:69
-msgid ""
-"These criteria grant you access to certain collections but not all. Some "
-"collections are accessible on a per application basis only."
-msgstr ""
-"Iste criterios te da accesso a certe collectiones, ma non totes. Alcun "
-"collectiones es solmente disponibile a demanda."
+msgid "These criteria grant you access to certain collections but not all. Some collections are accessible on a per application basis only."
+msgstr "Iste criterios te da accesso a certe collectiones, ma non totes. Alcun collectiones es solmente disponibile a demanda."
 
 #: TWLight/templates/login_partial.html:89
 msgid "Login via Wikipedia"
@@ -2558,34 +2074,20 @@ msgstr ""
 #. Translators: Shown if the current user doesn't have a registered email on their account. Don't translate contact_us_url or email_url.
 #: TWLight/templates/message_partial.html:15
 #, python-format
-msgid ""
-"You don't have an email on file. We can't finalize your access to partner "
-"resources, and you won't be able to <a class=\"twl-links\" href="
-"\"%(contact_us_url)s\">contact us</a> without an email. Please <a class="
-"\"twl-links\" href=\"%(email_url)s\">update your email</a>."
+msgid "You don't have an email on file. We can't finalize your access to partner resources, and you won't be able to <a class=\"twl-links\" href=\"%(contact_us_url)s\">contact us</a> without an email. Please <a class=\"twl-links\" href=\"%(email_url)s\">update your email</a>."
 msgstr ""
 
 #. Translators: Shown if the current user has requested the processing of their data should be restricted.
 #: TWLight/templates/message_partial.html:26
 #, python-format
-msgid ""
-"You have requested a restriction on the processing of your data. Most site "
-"functionality will not be available to you until you <a class=\"twl-links\" "
-"href=\"%(restrict_url)s\">lift this restriction</a>."
+msgid "You have requested a restriction on the processing of your data. Most site functionality will not be available to you until you <a class=\"twl-links\" href=\"%(restrict_url)s\">lift this restriction</a>."
 msgstr ""
 
 #. Translators: Shown if the current user has not agreed to the terms of use.
 #: TWLight/templates/message_partial.html:37
 #, python-format
-msgid ""
-"You have not agreed to the <a class=\"twl-links\" href=\"%(terms_url)s"
-"\">terms of use</a> of this site. Your applications will not be processed "
-"and you won't be able to apply or access resources you are approved for."
-msgstr ""
-"Tu non ha acceptate le <a class=\"twl-links\" href=\"%(terms_url)s"
-"\">conditiones de uso</a> de iste sito. Tu demanda non essera tractate e tu "
-"non potera presentar demandas ni acceder al ressources pro le quales tu es "
-"approbate."
+msgid "You have not agreed to the <a class=\"twl-links\" href=\"%(terms_url)s\">terms of use</a> of this site. Your applications will not be processed and you won't be able to apply or access resources you are approved for."
+msgstr "Tu non ha acceptate le <a class=\"twl-links\" href=\"%(terms_url)s\">conditiones de uso</a> de iste sito. Tu demanda non essera tractate e tu non potera presentar demandas ni acceder al ressources pro le quales tu es approbate."
 
 #. Translators: This link is at the bottom of every page and links to the 'About' page (https://wikipedialibrary.wmflabs.org/about/)
 #: TWLight/templates/new_base.html:107
@@ -2631,9 +2133,7 @@ msgstr ""
 
 #. Translators: If a user goes to reset their password, this message asks them to enter their email to do so.
 #: TWLight/templates/registration/password_reset_form.html:13
-msgid ""
-"Forgot your password? Enter your email address below, and we'll email "
-"instructions for setting a new one."
+msgid "Forgot your password? Enter your email address below, and we'll email instructions for setting a new one."
 msgstr ""
 
 #. Translators: This is the label for a button that users click to update their public information.
@@ -2678,19 +2178,12 @@ msgstr ""
 
 #. Translators: This text explains how to disagree to the site's terms of use and the restrictions that will come into effect when users disagree to the terms of use.
 #: TWLight/users/forms.py:185
-msgid ""
-"By unchecking this box and clicking “Update” you may explore the site, but "
-"you will not be able to apply for access to materials or evaluate "
-"applications unless you agree with the terms of use."
-msgstr ""
-"Si tu dismarca iste quadrato e clicca sur “Actualisar”, tu poterea explorar "
-"le sito, ma tu non poterea demandar le accesso a materiales ni evalutar "
-"demandas sin haber acceptate le conditiones de uso."
+msgid "By unchecking this box and clicking “Update” you may explore the site, but you will not be able to apply for access to materials or evaluate applications unless you agree with the terms of use."
+msgstr "Si tu dismarca iste quadrato e clicca sur “Actualisar”, tu poterea explorar le sito, ma tu non poterea demandar le accesso a materiales ni evalutar demandas sin haber acceptate le conditiones de uso."
 
 #. Translators: Users click this button to set their website email address to the one linked to their Wikipedia account.
 #: TWLight/users/forms.py:211
-msgid ""
-"Use my Wikipedia email address (will be updated the next time you login)."
+msgid "Use my Wikipedia email address (will be updated the next time you login)."
 msgstr ""
 
 #. Translators: This labels a button which users click to change their email.
@@ -2701,19 +2194,8 @@ msgstr ""
 #. Translators: Shown if the current user tried to 'favorite' a partner they can't access. Do not translate '{partner}'
 #: TWLight/users/models.py:201
 #, python-brace-format
-msgid ""
-"Cannot add partner {partner} to your favorites because you don't have access "
-"to it"
-msgstr ""
-"Non pote adder le partner {partner} a tu favorites perque tu non ha accesso "
-"a illo"
-
-#. Translators: Do not translate.
-#: TWLight/users/models.py:869
-#, fuzzy, python-brace-format
-#| msgid "Username"
-msgid "{wp_username}"
-msgstr "Nomine de usator"
+msgid "Cannot add partner {partner} to your favorites because you don't have access to it"
+msgstr "Non pote adder le partner {partner} a tu favorites perque tu non ha accesso a illo"
 
 #. Translators: This error message is shown when there's a problem with the authenticated login process.
 #: TWLight/users/oauth.py:243
@@ -2733,9 +2215,7 @@ msgstr ""
 
 #. Translators: this message is displayed to users that don't have accounts and clicked on a proxied link.
 #: TWLight/users/oauth.py:388
-msgid ""
-"To view this link you need to be an eligible library user. Please login to "
-"continue."
+msgid "To view this link you need to be an eligible library user. Please login to continue."
 msgstr ""
 
 #. Translators: This warning message is shown to users when the response received from Wikimedia OAuth servers is not a valid one.
@@ -2771,17 +2251,12 @@ msgstr ""
 
 #. Translators: If the user tries to log in, but their account does not meet certain requirements, they cannot login.
 #: TWLight/users/oauth.py:528
-msgid ""
-"Your Wikipedia account does not meet the eligibility criteria in the terms "
-"of use, so your Wikipedia Library Card Platform account cannot be activated."
+msgid "Your Wikipedia account does not meet the eligibility criteria in the terms of use, so your Wikipedia Library Card Platform account cannot be activated."
 msgstr ""
 
 #. Translators: If the user tries to log in, but their account does not meet certain requirements, they cannot login.
 #: TWLight/users/oauth.py:536
-msgid ""
-"Your Wikipedia account no longer meets the eligibility criteria in the terms "
-"of use, so you cannot be logged in. If you think you should be able to log "
-"in, please email wikipedialibrary@wikimedia.org."
+msgid "Your Wikipedia account no longer meets the eligibility criteria in the terms of use, so you cannot be logged in. If you think you should be able to log in, please email wikipedialibrary@wikimedia.org."
 msgstr ""
 
 #. Translators: this message is displayed to users with brand new accounts.
@@ -2792,10 +2267,7 @@ msgstr ""
 #. Translators: This message is displayed on the confirmation page where users can return their access to partner collections.
 #: TWLight/users/templates/users/authorization_confirm_return.html:13
 #, python-format
-msgid ""
-"You will no longer be able to access <b>%(partner)s's</b> resources via the "
-"Library Card platform, but can request access again by clicking 'renew', if "
-"you change your mind. Are you sure you want to return your access?"
+msgid "You will no longer be able to access <b>%(partner)s's</b> resources via the Library Card platform, but can request access again by clicking 'renew', if you change your mind. Are you sure you want to return your access?"
 msgstr ""
 
 #. Translators: On the MyLibrary page (https://wikipedialibrary.wmflabs.org/users/my_library), this tab shows all favorite collections a user has.
@@ -2865,10 +2337,7 @@ msgstr ""
 
 #. Translators: This is shown on editor profiles, in their profile page or on applications.
 #: TWLight/users/templates/users/editor_detail.html:59
-msgid ""
-"Information with an * was retrieved from Wikipedia directly. Other "
-"information was entered directly by users or site admins, in their preferred "
-"language."
+msgid "Information with an * was retrieved from Wikipedia directly. Other information was entered directly by users or site admins, in their preferred language."
 msgstr ""
 
 #. Translators: This distinguishes users who have been flagged as account coordinators. Don't translate username.
@@ -2879,10 +2348,7 @@ msgstr ""
 
 #. Translators: This is shown on editor profiles, under the heading for Wikipedia editor data.
 #: TWLight/users/templates/users/editor_detail_data.html:5
-msgid ""
-"This information is updated automatically from your Wikimedia account each "
-"time you log in, except for the Contributions field, where you can describe "
-"your Wikimedia editing history."
+msgid "This information is updated automatically from your Wikimedia account each time you log in, except for the Contributions field, where you can describe your Wikimedia editing history."
 msgstr ""
 
 #. Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this labels the user's username.
@@ -2912,17 +2378,13 @@ msgstr ""
 
 #. Translators: when viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this question has a yes or no answer.
 #: TWLight/users/templates/users/editor_detail_data.html:57
-msgid ""
-"at their last login, did this user meet the criteria set forth in the terms "
-"of use?"
+msgid "at their last login, did this user meet the criteria set forth in the terms of use?"
 msgstr ""
 
 #. Translators: When viewing a user's profile in an application, this message shows if the software doesn't think that the user is eligible for access. Don't translate username.
 #: TWLight/users/templates/users/editor_detail_data.html:72
 #, python-format
-msgid ""
-"%(username)s may still be eligible for access grants at the coordinators' "
-"discretion."
+msgid "%(username)s may still be eligible for access grants at the coordinators' discretion."
 msgstr ""
 
 #. Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this is the heading for a Yes/No ToU question.
@@ -2957,10 +2419,7 @@ msgstr ""
 #. Translators: This message is shown on a user's profile if their Wikimedia account is blocked on one or more projects. They may still be granted access to the Library Bundle, but need to contact Wikipedia Library staff to verify.
 #: TWLight/users/templates/users/editor_detail_data.html:137
 #, python-format
-msgid ""
-"It looks like you have an active block on your account. If you meet the "
-"other criteria you may still be permitted access to the library - please <a "
-"class=\"twl-links\" href=\"%(contact_url)s\">contact us</a>."
+msgid "It looks like you have an active block on your account. If you meet the other criteria you may still be permitted access to the library - please <a class=\"twl-links\" href=\"%(contact_url)s\">contact us</a>."
 msgstr ""
 
 #. Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this is the heading for a Yes/No program eligibility question.
@@ -2970,10 +2429,7 @@ msgstr ""
 
 #. Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this question has a Yes or No answer.
 #: TWLight/users/templates/users/editor_detail_data.html:156
-msgid ""
-"At their last login, did this user meet the criteria set forth in the "
-"Library Bundle? Note that satisfying terms of use is a prerequisite to "
-"bundle eligibility."
+msgid "At their last login, did this user meet the criteria set forth in the Library Bundle? Note that satisfying terms of use is a prerequisite to bundle eligibility."
 msgstr ""
 
 #. Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this is the heading for a Yes/No program eligibility question.
@@ -3018,18 +2474,13 @@ msgstr ""
 
 #. Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this text is in the 'Personal data' section. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/users/templates/users/editor_detail_data.html:262
-msgid ""
-"The following information is visible only to you, site administrators, "
-"publishing partners (where required), and volunteer Wikipedia Library "
-"coordinators (who have signed a Non-Disclosure Agreement)."
+msgid "The following information is visible only to you, site administrators, publishing partners (where required), and volunteer Wikipedia Library coordinators (who have signed a Non-Disclosure Agreement)."
 msgstr ""
 
 #. Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this labels a button which users can click to update or remove their personal information. Don't translate update_url.
 #: TWLight/users/templates/users/editor_detail_data.html:272
 #, python-format
-msgid ""
-"You may <a class=\"twl-links\" href=\"%(update_url)s\">update or delete</a> "
-"your data at any time."
+msgid "You may <a class=\"twl-links\" href=\"%(update_url)s\">update or delete</a> your data at any time."
 msgstr ""
 
 #. Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this labels the user's email. Don't remove the *.
@@ -3049,24 +2500,18 @@ msgstr ""
 
 #. Translators: This message tells users that they are not eligible to access The Wikipedia Library content.
 #: TWLight/users/templates/users/eligibility_modal.html:7
-msgid ""
-"Sorry, your Wikipedia account doesn’t currently qualify to access The "
-"Wikipedia Library."
+msgid "Sorry, your Wikipedia account doesn’t currently qualify to access The Wikipedia Library."
 msgstr ""
 
 #. Translators: This message tells users that they have not agreed to the terms of use, therefore are ineligible to access the content in The Wikipedia Library.
 #: TWLight/users/templates/users/eligibility_modal.html:30
 #, python-format
-msgid ""
-"Agreed with <a href=\"%(terms)s\" class=\"text-danger\"> terms of use </a>"
+msgid "Agreed with <a href=\"%(terms)s\" class=\"text-danger\"> terms of use </a>"
 msgstr ""
 
 #: TWLight/users/templates/users/eligibility_modal.html:40
 #, python-format
-msgid ""
-"It looks like you have an active block on your account. If you meet the "
-"other criteria you may still be permitted access to the library - please <a "
-"href=\"%(contact_url)s\">contact us</a>."
+msgid "It looks like you have an active block on your account. If you meet the other criteria you may still be permitted access to the library - please <a href=\"%(contact_url)s\">contact us</a>."
 msgstr ""
 
 #. Translators: Instructions to refresh a user's data.
@@ -3106,10 +2551,7 @@ msgstr ""
 
 #. Translators: This text on the user page helps users naviage to the TranslateWiki Wikipedia Library Card platform translation page.
 #: TWLight/users/templates/users/language_form.html:31
-msgid ""
-"You can help translate the tool at <a class=\"twl-links\" href=\"https://"
-"translatewiki.net/wiki/Translating:Wikipedia_Library_Card_Platform"
-"\">translatewiki.net</a>."
+msgid "You can help translate the tool at <a class=\"twl-links\" href=\"https://translatewiki.net/wiki/Translating:Wikipedia_Library_Card_Platform\">translatewiki.net</a>."
 msgstr ""
 
 #. Translators: When the user starts a new application and submits the application, the user can view the application and withdraw if need be. This changes the label for the Withdraw button.
@@ -3129,9 +2571,7 @@ msgstr ""
 
 #. Translators: On the page listing applications, this text explains a user they cannot renew their application since they've already requested a renewal or there aren't any renewals available.
 #: TWLight/users/templates/users/my_applications.html:79
-msgid ""
-"Renewals are either not required, not available right now, or you have "
-"already requested a renewal."
+msgid "Renewals are either not required, not available right now, or you have already requested a renewal."
 msgstr ""
 
 #. Translators: This text is the heading of a section in a user's profile where they can change their preferences.
@@ -3195,24 +2635,12 @@ msgstr ""
 
 #. Translators: This message is displayed on the page where users can request we stop processing their data.
 #: TWLight/users/templates/users/restrict_data.html:15
-msgid ""
-"Checking this box and clicking “Restrict” will pause all processing of the "
-"data you have entered into this website. You will not be able to apply for "
-"access to resources, your applications will not be further processed, and "
-"none of your data will be altered, until you return to this page and uncheck "
-"the box. This is not the same as deleting your data."
-msgstr ""
-"Si tu marca iste quadrato e clicca sur “Restringer”, tote le tractamento del "
-"datos que tu ha inserite in iste sito web essera pausate. Tu non potera "
-"demandar accesso a ressources, tu demandas non essera plus tractate, e necun "
-"de tu datos essera alterate, usque tu reveni a iste pagina e dismarca le "
-"quadrato. Isto non es le mesme cosa que eliminar tu datos."
+msgid "Checking this box and clicking “Restrict” will pause all processing of the data you have entered into this website. You will not be able to apply for access to resources, your applications will not be further processed, and none of your data will be altered, until you return to this page and uncheck the box. This is not the same as deleting your data."
+msgstr "Si tu marca iste quadrato e clicca sur “Restringer”, tote le tractamento del datos que tu ha inserite in iste sito web essera pausate. Tu non potera demandar accesso a ressources, tu demandas non essera plus tractate, e necun de tu datos essera alterate, usque tu reveni a iste pagina e dismarca le quadrato. Isto non es le mesme cosa que eliminar tu datos."
 
 #. Translators: This warning message is shown to coordinators who view the data restriction page.
 #: TWLight/users/templates/users/restrict_data.html:26
-msgid ""
-"You are a coordinator on this site. If you restrict the processing of your "
-"data, your coordinator flag will be removed."
+msgid "You are a coordinator on this site. If you restrict the processing of your data, your coordinator flag will be removed."
 msgstr ""
 
 #. Translators: use the date *when you are translating*, in a language-appropriate format.
@@ -3232,24 +2660,12 @@ msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:51
-msgid ""
-"<a class=\"twl-links\" href=\"https://meta.wikimedia.org/wiki/"
-"The_Wikipedia_Library\"> The Wikipedia Library </a> has partnered with "
-"publishers around the world to allow users to access otherwise paywalled "
-"resources. This website allows Wikipedia editors to search and access these "
-"resources."
+msgid "<a class=\"twl-links\" href=\"https://meta.wikimedia.org/wiki/The_Wikipedia_Library\"> The Wikipedia Library </a> has partnered with publishers around the world to allow users to access otherwise paywalled resources. This website allows Wikipedia editors to search and access these resources."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Wikimedia Foundation should not be translated. WMF should not be translated. Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:63
-msgid ""
-"This program is administered by the Wikimedia Foundation (WMF). These terms "
-"of use and privacy notice pertain to your application for access to "
-"resources through the Wikipedia Library, your use of this website, and your "
-"access to and use of those resources. They also describe our handling of the "
-"information you provide to us in order to create and administer your "
-"Wikipedia Library account. If we make material changes to the terms, we will "
-"notify users."
+msgid "This program is administered by the Wikimedia Foundation (WMF). These terms of use and privacy notice pertain to your application for access to resources through the Wikipedia Library, your use of this website, and your access to and use of those resources. They also describe our handling of the information you provide to us in order to create and administer your Wikipedia Library account. If we make material changes to the terms, we will notify users."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
@@ -3259,100 +2675,47 @@ msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:78
-msgid ""
-"Access to resources via The Wikipedia Library is reserved for community "
-"members who have demonstrated their commitment to the Wikimedia projects, "
-"and who will use their access to these resources to improve project content. "
-"To that end, in order to be eligible for The Wikipedia Library, we require "
-"that you be registered for a user account on the projects, with at least 500 "
-"edits, six (6) months of activity, and 10+ edits in the last month. We ask "
-"that you do not request access to any publishers with a limited number of "
-"available accounts whose resources you can already access for free through "
-"your local library or university, or another institution or organization, in "
-"order to provide that opportunity to others."
+msgid "Access to resources via The Wikipedia Library is reserved for community members who have demonstrated their commitment to the Wikimedia projects, and who will use their access to these resources to improve project content. To that end, in order to be eligible for The Wikipedia Library, we require that you be registered for a user account on the projects, with at least 500 edits, six (6) months of activity, and 10+ edits in the last month. We ask that you do not request access to any publishers with a limited number of available accounts whose resources you can already access for free through your local library or university, or another institution or organization, in order to provide that opportunity to others."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:94
-msgid ""
-"Additionally, if you are currently blocked or banned from a Wikimedia "
-"project, applications to resources may be rejected or restricted. If you "
-"obtain a Wikipedia Library account, but a block or ban is subsequently "
-"instituted against you on one of the projects, you may lose access to your "
-"Wikipedia Library account."
+msgid "Additionally, if you are currently blocked or banned from a Wikimedia project, applications to resources may be rejected or restricted. If you obtain a Wikipedia Library account, but a block or ban is subsequently instituted against you on one of the projects, you may lose access to your Wikipedia Library account."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:104
-msgid ""
-"Your eligibility to access The Wikipedia Library is assessed at each login. "
-"While more than half of the library's content is provided via this automated "
-"eligibility check, access to other publisher's content may be time limited, "
-"typically lapsing after one year, after which you will usually need to apply "
-"for renewal."
-msgstr ""
-"Tu eligibilitate de acceder al Bibliotheca de Wikipedia se evaluta a cata "
-"apertura de session. Benque plus del medietate del contento del bibliotheca "
-"se forni per medio de iste verification automatic de eligibilitate, le "
-"accesso al contento de altere editores pote esser subjecte a limites "
-"temporal, typicamente expirante post un anno, post le qual tu debera "
-"generalmente presentar un demanda de renovation."
+msgid "Your eligibility to access The Wikipedia Library is assessed at each login. While more than half of the library's content is provided via this automated eligibility check, access to other publisher's content may be time limited, typically lapsing after one year, after which you will usually need to apply for renewal."
+msgstr "Tu eligibilitate de acceder al Bibliotheca de Wikipedia se evaluta a cata apertura de session. Benque plus del medietate del contento del bibliotheca se forni per medio de iste verification automatic de eligibilitate, le accesso al contento de altere editores pote esser subjecte a limites temporal, typicamente expirante post un anno, post le qual tu debera generalmente presentar un demanda de renovation."
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:114
 msgid "Applying via Your Wikipedia Library Card Account"
-msgstr ""
-"Presentar un demanda per medio de tu conto Carta de Bibliotheca de Wikipedia"
+msgstr "Presentar un demanda per medio de tu conto Carta de Bibliotheca de Wikipedia"
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:118
-msgid ""
-"In order to apply for access to a partner resource, you must provide us with "
-"certain information, which we will use to evaluate your application. If your "
-"application is approved, we may transfer the information you have given us "
-"to the publishers whose resources you wish to access. They will either "
-"contact you with the account information directly or we will send access "
-"information to you ourselves."
-msgstr ""
-"A fin de sollicitar le accesso a un ressource de partner, es necessari "
-"fornir nos certe informationes, le quales nos usara pro evalutar tu demanda. "
-"Si tu demanda es approbate, nos pote transferer le informationes que tu nos "
-"ha date al editores a cuje ressources tu vole acceder. Illes te contactara "
-"directemente usante le informationes de tu conto, o nos te inviara le "
-"informationes de accesso nos mesme."
+msgid "In order to apply for access to a partner resource, you must provide us with certain information, which we will use to evaluate your application. If your application is approved, we may transfer the information you have given us to the publishers whose resources you wish to access. They will either contact you with the account information directly or we will send access information to you ourselves."
+msgstr "A fin de sollicitar le accesso a un ressource de partner, es necessari fornir nos certe informationes, le quales nos usara pro evalutar tu demanda. Si tu demanda es approbate, nos pote transferer le informationes que tu nos ha date al editores a cuje ressources tu vole acceder. Illes te contactara directemente usante le informationes de tu conto, o nos te inviara le informationes de accesso nos mesme."
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:130
-msgid ""
-"In addition to the basic information you provide to us, our system will "
-"retrieve some information directly from the Wikimedia projects: your "
-"username, email address, edit count, registration date, user ID number, "
-"groups to which you belong, and any special user rights."
+msgid "In addition to the basic information you provide to us, our system will retrieve some information directly from the Wikimedia projects: your username, email address, edit count, registration date, user ID number, groups to which you belong, and any special user rights."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:140
-msgid ""
-"Each time you log in to the Wikipedia Library Card Platform, this "
-"information will be automatically updated."
+msgid "Each time you log in to the Wikipedia Library Card Platform, this information will be automatically updated."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:148
-msgid ""
-"We will ask you to provide us with some information about your history of "
-"contributions to the Wikimedia projects. Information on contribution history "
-"is optional, but will greatly assist us in evaluating your application."
+msgid "We will ask you to provide us with some information about your history of contributions to the Wikimedia projects. Information on contribution history is optional, but will greatly assist us in evaluating your application."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). WMF should not be translated. Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:157
-msgid ""
-"The information you provide when creating your account will be visible to "
-"you while on the site but not to others unless they are approved Wikipedia "
-"Library Coordinators, WMF Staff, or WMF Contractors who need access to this "
-"data in order to carry out their work with the Wikipedia Library, all of "
-"whom are subject to non-disclosure obligations."
+msgid "The information you provide when creating your account will be visible to you while on the site but not to others unless they are approved Wikipedia Library Coordinators, WMF Staff, or WMF Contractors who need access to this data in order to carry out their work with the Wikipedia Library, all of whom are subject to non-disclosure obligations."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
@@ -3362,46 +2725,32 @@ msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:171
-msgid ""
-"In order to access an individual publisher’s resources, you must agree to "
-"that publisher’s terms of use and privacy policy. You agree that you will "
-"not violate such terms and policies in connection with your use of the "
-"Wikipedia Library. Additionally, the following activities are prohibited "
-"while accessing publisher resources through the Wikipedia Library."
+msgid "In order to access an individual publisher’s resources, you must agree to that publisher’s terms of use and privacy policy. You agree that you will not violate such terms and policies in connection with your use of the Wikipedia Library. Additionally, the following activities are prohibited while accessing publisher resources through the Wikipedia Library."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:184
-msgid ""
-"Sharing your Wikipedia account, usernames, passwords, or any access codes "
-"for publisher resources with others;"
+msgid "Sharing your Wikipedia account, usernames, passwords, or any access codes for publisher resources with others;"
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:191
-msgid ""
-"Automatically scraping or downloading restricted content from publishers;"
+msgid "Automatically scraping or downloading restricted content from publishers;"
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:197
-msgid ""
-"Systematically making printed or electronic copies of multiple extracts of "
-"restricted content available for any purpose;"
+msgid "Systematically making printed or electronic copies of multiple extracts of restricted content available for any purpose;"
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:204
-msgid ""
-"Data mining metadata without permission—for example, in order to use "
-"metadata for auto-created stub articles;"
+msgid "Data mining metadata without permission—for example, in order to use metadata for auto-created stub articles;"
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:211
-msgid ""
-"Using the access you receive through the Wikipedia Library for profit by "
-"selling access to your account or resources which you have through it."
+msgid "Using the access you receive through the Wikipedia Library for profit by selling access to your account or resources which you have through it."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
@@ -3411,22 +2760,12 @@ msgstr "Servicios externe de recerca e de mandatario"
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:224
-msgid ""
-"Certain resources may only be accessed using an external search service, "
-"such as the EBSCO Discovery Service, or a proxy service, such as OCLC "
-"EZProxy. If you use such external search and/or proxy services, please "
-"review the applicable terms of use and privacy policies."
-msgstr ""
-"Certe ressources es solmente accessibile per medio de un servicio de recerca "
-"externe, como EBSCO Discovery Service, o un servicio de mandatario, como "
-"OCLC EZProxy. Si tu usa tal servicios externe de recerca e/o mandatario, per "
-"favor lege lor conditiones de uso e politicas de confidentialitate."
+msgid "Certain resources may only be accessed using an external search service, such as the EBSCO Discovery Service, or a proxy service, such as OCLC EZProxy. If you use such external search and/or proxy services, please review the applicable terms of use and privacy policies."
+msgstr "Certe ressources es solmente accessibile per medio de un servicio de recerca externe, como EBSCO Discovery Service, o un servicio de mandatario, como OCLC EZProxy. Si tu usa tal servicios externe de recerca e/o mandatario, per favor lege lor conditiones de uso e politicas de confidentialitate."
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:234
-msgid ""
-"In addition, if you use OCLC EZProxy, please note that you may not use it "
-"for commercial purposes."
+msgid "In addition, if you use OCLC EZProxy, please note that you may not use it for commercial purposes."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
@@ -3436,152 +2775,50 @@ msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Wikimedia Foundation should not be translated. Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:245
-msgid ""
-"The Wikimedia Foundation and our service providers use your information for "
-"the legitimate purpose of providing Wikipedia Library services in support of "
-"our charitable mission. When you apply for a Wikipedia Library account, or "
-"use your Wikipedia Library account, we may routinely collect the following "
-"information: your username, email address, edit count, registration date, "
-"user ID number, groups to which you belong, and any special user rights; "
-"your name, country of residence, and/or affiliation, if required by a "
-"partner to which you are applying; your narrative description of your "
-"contributions and reasons for applying for access to partner resources; and "
-"the date you agree to these terms of use."
-msgstr ""
-"Le Fundation Wikimedia e nostre fornitores de servicio usa tu information "
-"pro le scopo legitime de fornir servicios de Bibliotheca de Wikipedia in "
-"appoio de nostre mission caritative. Quando tu sollicita un conto de "
-"Bibliotheca de Wikipedia, nos pote colliger ordinarimente le informationes "
-"sequente: tu nomine de usator, adresse de e-mail, numero de modificationes, "
-"data de inscription, numero de ID de usator, le gruppos al quales tu "
-"pertine, e omne derectos special de usator; tu nomine, pais de residentia, e/"
-"o affiliation, si exigite per un partner al qual tu presenta un demanda; tu "
-"description narrative de tu contributiones e motivos pro sollicitar le "
-"accesso a ressources de partner; e le data al qual tu accepta iste "
-"conditiones de uso."
+msgid "The Wikimedia Foundation and our service providers use your information for the legitimate purpose of providing Wikipedia Library services in support of our charitable mission. When you apply for a Wikipedia Library account, or use your Wikipedia Library account, we may routinely collect the following information: your username, email address, edit count, registration date, user ID number, groups to which you belong, and any special user rights; your name, country of residence, and/or affiliation, if required by a partner to which you are applying; your narrative description of your contributions and reasons for applying for access to partner resources; and the date you agree to these terms of use."
+msgstr "Le Fundation Wikimedia e nostre fornitores de servicio usa tu information pro le scopo legitime de fornir servicios de Bibliotheca de Wikipedia in appoio de nostre mission caritative. Quando tu sollicita un conto de Bibliotheca de Wikipedia, nos pote colliger ordinarimente le informationes sequente: tu nomine de usator, adresse de e-mail, numero de modificationes, data de inscription, numero de ID de usator, le gruppos al quales tu pertine, e omne derectos special de usator; tu nomine, pais de residentia, e/o affiliation, si exigite per un partner al qual tu presenta un demanda; tu description narrative de tu contributiones e motivos pro sollicitar le accesso a ressources de partner; e le data al qual tu accepta iste conditiones de uso."
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:262
 #, python-format
-msgid ""
-"Each publisher who is a member of the Wikipedia Library program requires "
-"different specific information in the application. Some publishers may "
-"request only an email address, while others request more detailed data, such "
-"as your name, location, or institutional affiliation. When you complete your "
-"application, you will only be asked to supply information required by the "
-"publishers you have chosen, and each publisher will only receive the "
-"information they require for providing you with access. Please see our <a "
-"class=\"twl-links\" href=\"%(all_partners_url)s\">partner information</a> "
-"pages to learn what information is required by each publisher to gain access "
-"to their resources."
+msgid "Each publisher who is a member of the Wikipedia Library program requires different specific information in the application. Some publishers may request only an email address, while others request more detailed data, such as your name, location, or institutional affiliation. When you complete your application, you will only be asked to supply information required by the publishers you have chosen, and each publisher will only receive the information they require for providing you with access. Please see our <a class=\"twl-links\" href=\"%(all_partners_url)s\">partner information</a> pages to learn what information is required by each publisher to gain access to their resources."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Wikimedia Foundation should not be translated. Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:277
-msgid ""
-"Some Wikipedia Library pages are visible without logging in, but you will "
-"need to log in to apply or access proprietary partner resources. We use the "
-"data provided by you via OAuth and Wikimedia API calls to assess your "
-"application for access and to process approved requests."
-msgstr ""
-"Alcun paginas del Bibliotheca de Wikipedia es visibile sin aperir session, "
-"ma es necessari aperir session pro presentar un demanda o pro acceder a "
-"ressources proprietari de partners. Nos usa le datos que tu forni per medio "
-"de OAuth e appellos API de Wikimedia pro acceder tu demanda de accesso e pro "
-"tractar le demandas approbate."
+msgid "Some Wikipedia Library pages are visible without logging in, but you will need to log in to apply or access proprietary partner resources. We use the data provided by you via OAuth and Wikimedia API calls to assess your application for access and to process approved requests."
+msgstr "Alcun paginas del Bibliotheca de Wikipedia es visibile sin aperir session, ma es necessari aperir session pro presentar un demanda o pro acceder a ressources proprietari de partners. Nos usa le datos que tu forni per medio de OAuth e appellos API de Wikimedia pro acceder tu demanda de accesso e pro tractar le demandas approbate."
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:288
 #, python-format
-msgid ""
-"In order to administer the Wikipedia Library program, we will retain the "
-"application data we collect from you for three years after your most recent "
-"login, unless you delete your account, as described below. You can log in "
-"and go to <a class=\"twl-links\" href=\"%(profile_url)s\">your profile page</"
-"a> in order to see the information associated with your account, and can "
-"download it in JSON format. You may access, update, restrict, or delete this "
-"information at any time, except for the information that is automatically "
-"retrieved from the projects. If you have any questions or concerns about the "
-"handling of your data, please contact <a class=\"twl-links\" href=\"mailto:"
-"wikipedialibrary@wikimedia.org?Subject=Wikipedia%%20Library%%20Card"
-"%%20account%%20deactivation\"> wikipedialibrary@wikimedia.org </a>."
+msgid "In order to administer the Wikipedia Library program, we will retain the application data we collect from you for three years after your most recent login, unless you delete your account, as described below. You can log in and go to <a class=\"twl-links\" href=\"%(profile_url)s\">your profile page</a> in order to see the information associated with your account, and can download it in JSON format. You may access, update, restrict, or delete this information at any time, except for the information that is automatically retrieved from the projects. If you have any questions or concerns about the handling of your data, please contact <a class=\"twl-links\" href=\"mailto:wikipedialibrary@wikimedia.org?Subject=Wikipedia%%20Library%%20Card%%20account%%20deactivation\"> wikipedialibrary@wikimedia.org </a>."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:305
-msgid ""
-"If you decide to disable your Wikipedia Library account, you can use the "
-"delete button on your profile to delete certain personal information "
-"associated with your account. We will delete your real name, institutional "
-"affiliation, and country of residence. Please note that the system will "
-"retain a record of your username, the publishers to which you applied or had "
-"access, and the dates of that access. Note that deletion is not reversible. "
-"Deletion of your Wikipedia Library account may also correspond with the "
-"removal of any resource access to which you were eligible or approved. If "
-"you request the deletion of account information and later wish to apply for "
-"a new account, you will need to provide the necessary information again."
-msgstr ""
-"Si tu decide disactivar tu conto del Bibliotheca de Wikipedia, tu pote usar "
-"le button de deletion in tu profilo pro deler certe informationes personal "
-"associate con tu conto. Nos delera tu nomine real, affiliation "
-"institutional, e pais de residentia. Per favor nota que le systema retenera "
-"un registro de tu nomine de usator, le editores al quales tu ha presentate "
-"un demanda o habeva accesso, e le datas de iste accesso. Nota que le "
-"deletion non es reversibile. Le deletion de tu conto del Bibliotheca de "
-"Wikipedia pote etiam corresponder con le elimination de omne accesso a "
-"ressources pro le qual tu esseva eligibile o approbate. Si tu requesta le "
-"deletion de informationes de conto e plus tarde desira sollicitar un nove "
-"conto, tu debera fornir le informationes necessari de novo."
+msgid "If you decide to disable your Wikipedia Library account, you can use the delete button on your profile to delete certain personal information associated with your account. We will delete your real name, institutional affiliation, and country of residence. Please note that the system will retain a record of your username, the publishers to which you applied or had access, and the dates of that access. Note that deletion is not reversible. Deletion of your Wikipedia Library account may also correspond with the removal of any resource access to which you were eligible or approved. If you request the deletion of account information and later wish to apply for a new account, you will need to provide the necessary information again."
+msgstr "Si tu decide disactivar tu conto del Bibliotheca de Wikipedia, tu pote usar le button de deletion in tu profilo pro deler certe informationes personal associate con tu conto. Nos delera tu nomine real, affiliation institutional, e pais de residentia. Per favor nota que le systema retenera un registro de tu nomine de usator, le editores al quales tu ha presentate un demanda o habeva accesso, e le datas de iste accesso. Nota que le deletion non es reversibile. Le deletion de tu conto del Bibliotheca de Wikipedia pote etiam corresponder con le elimination de omne accesso a ressources pro le qual tu esseva eligibile o approbate. Si tu requesta le deletion de informationes de conto e plus tarde desira sollicitar un nove conto, tu debera fornir le informationes necessari de novo."
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). WMF should not be translated. Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:321
-msgid ""
-"The Wikipedia Library is run by WMF Staff, Contractors, and approved "
-"volunteer Coordinators. The data associated with your account will be shared "
-"with the WMF staff, contractors, service providers, and volunteer "
-"coordinators who need to process the information in connection with their "
-"work for the Wikipedia Library, and who are subject to confidentiality "
-"obligations. We will also use your data for internal Wikipedia Library "
-"purposes such as distributing user surveys and account notifications, and in "
-"a depersonalized or aggregated fashion for statistical analysis and "
-"administration. Finally, we will share your information with the publishers "
-"whom you specifically select in order to provide you with access to "
-"resources. Otherwise, your information will not be shared with third "
-"parties, with the exception of the circumstances described below."
+msgid "The Wikipedia Library is run by WMF Staff, Contractors, and approved volunteer Coordinators. The data associated with your account will be shared with the WMF staff, contractors, service providers, and volunteer coordinators who need to process the information in connection with their work for the Wikipedia Library, and who are subject to confidentiality obligations. We will also use your data for internal Wikipedia Library purposes such as distributing user surveys and account notifications, and in a depersonalized or aggregated fashion for statistical analysis and administration. Finally, we will share your information with the publishers whom you specifically select in order to provide you with access to resources. Otherwise, your information will not be shared with third parties, with the exception of the circumstances described below."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). WMF should not be translated.
 #: TWLight/users/templates/users/terms.html:338
-msgid ""
-"We may disclose any collected information when required by law, when we have "
-"your permission, when needed to protect our rights, privacy, safety, users, "
-"or the general public, and when necessary to enforce these terms, WMF’s "
-"general <a class=\"twl-links\" href=\"https://foundation.wikimedia.org/wiki/"
-"Terms_of_Use\">Terms of Use</a>, or any other WMF policy."
+msgid "We may disclose any collected information when required by law, when we have your permission, when needed to protect our rights, privacy, safety, users, or the general public, and when necessary to enforce these terms, WMF’s general <a class=\"twl-links\" href=\"https://foundation.wikimedia.org/wiki/Terms_of_Use\">Terms of Use</a>, or any other WMF policy."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:349
-msgid ""
-"We take the security of your personal data seriously, and take reasonable "
-"precautions to ensure your data is protected. These precautions include "
-"access controls to limit who has access to your data and security "
-"technologies to protect data stored on the server. However, we cannot "
-"guarantee the safety of your data as it is transmitted and stored."
+msgid "We take the security of your personal data seriously, and take reasonable precautions to ensure your data is protected. These precautions include access controls to limit who has access to your data and security technologies to protect data stored on the server. However, we cannot guarantee the safety of your data as it is transmitted and stored."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:360
-msgid ""
-"Please note that these terms do not control the use and handling of your "
-"data by the publishers and service providers whose resources you access or "
-"apply to access. Please read their individual privacy policies for that "
-"information."
-msgstr ""
-"Per favor nota que iste terminos non controla le uso e gestion de tu datos "
-"per le editores e fornitores de servicios a cuje ressources tu accede o "
-"sollicita de acceder. Per favor lege lor politicas de confidentialitate "
-"individual pro iste information."
+msgid "Please note that these terms do not control the use and handling of your data by the publishers and service providers whose resources you access or apply to access. Please read their individual privacy policies for that information."
+msgstr "Per favor nota que iste terminos non controla le uso e gestion de tu datos per le editores e fornitores de servicios a cuje ressources tu accede o sollicita de acceder. Per favor lege lor politicas de confidentialitate individual pro iste information."
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:368
@@ -3590,47 +2827,17 @@ msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Wikimedia Foundation should not be translated. Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:373
-msgid ""
-"The Wikimedia Foundation is a nonprofit organization based in San Francisco, "
-"California. The Wikipedia Library program provides access to resources held "
-"by publishers in multiple countries. If you apply for a Wikipedia Library "
-"account (whether you are inside or outside of the United States), you "
-"understand that your personal data will be collected, transferred, stored, "
-"processed, disclosed and otherwise used in the U.S. as described in this "
-"privacy policy. You also understand that your information may be transferred "
-"by us from the U.S. to other countries, which may have different or less "
-"stringent data protection laws than your country, in connection with "
-"providing services to you, including evaluating your application and "
-"securing access to your chosen publishers (locations for each publisher are "
-"outlined on their respective partner information pages)."
-msgstr ""
-"Le Fundation Wikimedia es un organisation sin scopo lucrative, basate in San "
-"Francisco, California. Le programma del Bibliotheca de Wikipedia forni "
-"accesso a ressources possedite per editores in plure paises. Si tu sollicita "
-"un conto del Bibliotheca de Wikipedia (non importa si tu es in o foras del "
-"Statos Unite), tu comprende que tu datos personal essera colligite, "
-"transferite, immagazinate, tractate, divulgate e alteremente utilisate in le "
-"Statos Unite como describite in iste politica de confidentialitate. Tu etiam "
-"comprende que tu informationes pote esser transferite per nos del Statos "
-"Unite a altere paises, le quales pote haber leges de protection de datos "
-"differente o minus stricte que tu pais, in connexion con le provision de "
-"servicios a te, includente le evalutation de tu demanda e le securisation "
-"del accesso al editores que tu ha seligite (le locos de iste editores se "
-"delinea sur le respective paginas de information de partner)."
+msgid "The Wikimedia Foundation is a nonprofit organization based in San Francisco, California. The Wikipedia Library program provides access to resources held by publishers in multiple countries. If you apply for a Wikipedia Library account (whether you are inside or outside of the United States), you understand that your personal data will be collected, transferred, stored, processed, disclosed and otherwise used in the U.S. as described in this privacy policy. You also understand that your information may be transferred by us from the U.S. to other countries, which may have different or less stringent data protection laws than your country, in connection with providing services to you, including evaluating your application and securing access to your chosen publishers (locations for each publisher are outlined on their respective partner information pages)."
+msgstr "Le Fundation Wikimedia es un organisation sin scopo lucrative, basate in San Francisco, California. Le programma del Bibliotheca de Wikipedia forni accesso a ressources possedite per editores in plure paises. Si tu sollicita un conto del Bibliotheca de Wikipedia (non importa si tu es in o foras del Statos Unite), tu comprende que tu datos personal essera colligite, transferite, immagazinate, tractate, divulgate e alteremente utilisate in le Statos Unite como describite in iste politica de confidentialitate. Tu etiam comprende que tu informationes pote esser transferite per nos del Statos Unite a altere paises, le quales pote haber leges de protection de datos differente o minus stricte que tu pais, in connexion con le provision de servicios a te, includente le evalutation de tu demanda e le securisation del accesso al editores que tu ha seligite (le locos de iste editores se delinea sur le respective paginas de information de partner)."
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:392
-msgid ""
-"Please note that in the event of any differences in meaning or "
-"interpretation between the original English version of these terms and a "
-"translation, the original English version takes precedence."
+msgid "Please note that in the event of any differences in meaning or interpretation between the original English version of these terms and a translation, the original English version takes precedence."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Wikimedia Foundation should not be translated.
 #: TWLight/users/templates/users/terms.html:403
-msgid ""
-"See also the <a class=\"twl-links\" href=\"https://wikimediafoundation.org/"
-"wiki/Privacy_policy\">Wikimedia Foundation Privacy Policy</a>."
+msgid "See also the <a class=\"twl-links\" href=\"https://wikimediafoundation.org/wiki/Privacy_policy\">Wikimedia Foundation Privacy Policy</a>."
 msgstr ""
 
 #. Translators: This is the second to last line of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
@@ -3650,11 +2857,7 @@ msgstr "Fundation Wikimedia"
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:426
-msgid ""
-"By checking this box and clicking “Submit”, you agree that you have read the "
-"above terms and that you will adhere to the terms of use in your application "
-"to and use of the The Wikipedia Library, and the publishers’ services to "
-"which you gain access through The Wikipedia Library program."
+msgid "By checking this box and clicking “Submit”, you agree that you have read the above terms and that you will adhere to the terms of use in your application to and use of the The Wikipedia Library, and the publishers’ services to which you gain access through The Wikipedia Library program."
 msgstr ""
 
 #: TWLight/users/templates/users/user_collection_tile.html:32
@@ -3707,38 +2910,19 @@ msgstr ""
 
 #. Translators: This message is displayed on the page where users can request the deletion of their data.
 #: TWLight/users/templates/users/user_confirm_delete.html:17
-msgid ""
-"<b>Warning:</b> Performing this action will delete your Wikipedia Library "
-"Card user account and all associated applications. This process is not "
-"reversible. You may lose any partner accounts you were granted, and will not "
-"be able to renew those accounts or apply for new ones."
-msgstr ""
-"<b>Attention:</b> Exequer iste action eliminara tu conto de usator del Carta "
-"del Bibliotheca de Wikipedia e tote le demandas associate. Iste processo non "
-"es reversibile. Tu pote perder omne contos de partner que te esseva "
-"concedite, e non potera renovar iste contos ni sollicitar noves."
+msgid "<b>Warning:</b> Performing this action will delete your Wikipedia Library Card user account and all associated applications. This process is not reversible. You may lose any partner accounts you were granted, and will not be able to renew those accounts or apply for new ones."
+msgstr "<b>Attention:</b> Exequer iste action eliminara tu conto de usator del Carta del Bibliotheca de Wikipedia e tote le demandas associate. Iste processo non es reversibile. Tu pote perder omne contos de partner que te esseva concedite, e non potera renovar iste contos ni sollicitar noves."
 
 #. Translators: this should show up for people who log in with a username/password and not OAuth, so we don't know what their Wikipedia identity is.
-#.
 #: TWLight/users/templates/users/user_detail.html:12
 #, python-format
-msgid ""
-"Hi, %(username)s! You don't have a Wikipedia editor profile attached to your "
-"account here, so you are probably a site administrator."
+msgid "Hi, %(username)s! You don't have a Wikipedia editor profile attached to your account here, so you are probably a site administrator."
 msgstr ""
 
 #. Translators: In the unlikely scenario that someone is able to register an account without using OAuth (thus leaving us without some of the information required for applications), users will see this message, encouraging them to re-register.
 #: TWLight/users/templates/users/user_detail.html:20
-msgid ""
-"If you aren't a site administrator, something weird has happened. You won't "
-"be able to apply for access without a Wikipedia editor profile. You should "
-"log out and create a new account by logging in via OAuth, or contact a site "
-"administrator for help."
-msgstr ""
-"Si tu non es un administrator del sito, qualcosa estranie ha occurrite. Tu "
-"non potera sollicitar le accesso sin profilo de redactor de Wikipedia. Tu "
-"debe clauder session e crear un nove conto per medio de aperir session con "
-"OAuth, o contactar un administrator del sito pro adjuta."
+msgid "If you aren't a site administrator, something weird has happened. You won't be able to apply for access without a Wikipedia editor profile. You should log out and create a new account by logging in via OAuth, or contact a site administrator for help."
+msgstr "Si tu non es un administrator del sito, qualcosa estranie ha occurrite. Tu non potera sollicitar le accesso sin profilo de redactor de Wikipedia. Tu debe clauder session e crear un nove conto per medio de aperir session con OAuth, o contactar un administrator del sito pro adjuta."
 
 #. Translators: Labels a sections where coordinators can select their email preferences.
 #: TWLight/users/templates/users/user_email_preferences.html:15
@@ -3748,17 +2932,12 @@ msgstr ""
 #. Translators: This message is shown on user's own profile page, encouraging them to make sure their information is up to date, so that account coordinators can use the information to judge applications.
 #: TWLight/users/views.py:176
 #, python-brace-format
-msgid ""
-"Please <a class='twl-links' href='{url}'>update your contributions</a> to "
-"Wikipedia to help coordinators evaluate your applications."
+msgid "Please <a class='twl-links' href='{url}'>update your contributions</a> to Wikipedia to help coordinators evaluate your applications."
 msgstr ""
 
 #. Translators: Coordinators are shown this message when they unselect all three types of reminder email options under preferences.
 #: TWLight/users/views.py:288
-msgid ""
-"You have chosen not to receive reminder emails. As a coordinator, you should "
-"receive at least one type of reminder emails, so consider changing your "
-"preferences."
+msgid "You have chosen not to receive reminder emails. As a coordinator, you should receive at least one type of reminder emails, so consider changing your preferences."
 msgstr ""
 
 #. Translators: Coordinators are shown this message when they make changes to their reminder email options under preferences.
@@ -3792,13 +2971,8 @@ msgstr ""
 
 #. Translators: If the user has not filled out their email, they can browse the website but cannot apply for access to resources.
 #: TWLight/users/views.py:487
-msgid ""
-"Your email is blank. You can still explore the site, but you won't be able "
-"to apply for access to partner resources without an email."
-msgstr ""
-"Tu non ha fornite un adresse de e-mail. Tu pote totevia explorar le sito, ma "
-"tu non potera demandar accesso a ressources de partners sin adresse de e-"
-"mail."
+msgid "Your email is blank. You can still explore the site, but you won't be able to apply for access to partner resources without an email."
+msgstr "Tu non ha fornite un adresse de e-mail. Tu pote totevia explorar le sito, ma tu non potera demandar accesso a ressources de partners sin adresse de e-mail."
 
 #. Translators: This message is shown once the access to a partner has successfully been returned.
 #: TWLight/users/views.py:801
@@ -3830,31 +3004,3 @@ msgstr ""
 msgid "10+ edits in the last 30 days"
 msgstr ""
 
-#: tests/shunit/data/bad_i18n_comment_1.py:3
-#: tests/shunit/data/bad_i18n_newline_1.py:5
-msgid "1"
-msgstr ""
-
-#. Translators: Lorem ipsum dolor sit amet, consectetur adipiscing elit. Mauris vitae ipsum ut purus faucibus pretium. Proin tempus neque et aliquet consectetur. Ut egestas sapien in consectetur sagittis. Mauris neque lacus, dapibus non viverra vitae, interdum ut aenean ipsum.
-#. Translators: Lorem ipsum dolor sit amet, consectetur adipiscing elit. Mauris vitae ipsum ut purus faucibus pretium. Proin tempus neque et aliquet consectetur. Ut egestas sapien in consectetur sagittis. Mauris neque lacus, dapibus non.
-#: tests/shunit/data/bad_i18n_comment_2.py:4
-#: tests/shunit/data/bad_i18n_newline_2.py:5 tests/shunit/data/good_i18n_1.py:2
-#: tests/shunit/data/good_i18n_2.py:2
-msgid "2"
-msgstr ""
-
-#: tests/shunit/data/bad_i18n_newline_3.py:5
-msgid "3"
-msgstr ""
-
-#: tests/shunit/data/bad_i18n_newline_4.py:5
-msgid "4"
-msgstr ""
-
-#: tests/shunit/data/bad_i18n_newline_5.py:5
-msgid "5"
-msgstr ""
-
-#: tests/shunit/data/bad_i18n_newline_6.py:5
-msgid "6"
-msgstr ""

--- a/locale/id/LC_MESSAGES/django.po
+++ b/locale/id/LC_MESSAGES/django.po
@@ -22,10 +22,11 @@
 # Author: Ärkhézja
 msgid ""
 msgstr ""
+""
 "Project-Id-Version: Wikipedia Library Card Platform - Website\n"
-"Report-Msgid-Bugs-To: wikipedialibrary@wikimedia.org\n"
+"Report-Msgid-Bugs-To: translatewiki.net\n"
 "POT-Creation-Date: 2024-07-11 20:54+0000\n"
-"PO-Revision-Date: 2024-07-11 12:30:15+0000\n"
+"PO-Revision-Date: 2024-07-15 12:29:16+0000\n"
 "Language: id\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
@@ -57,12 +58,8 @@ msgstr "Tentang Anda"
 #. Translators: This note appears in a section of a form where we ask users to enter info (like country of residence) when applying for resource access.
 #: TWLight/applications/forms.py:179
 #, python-brace-format
-msgid ""
-"<p><small><i>Your personal data will be processed according to our <a "
-"class='twl-links' href='{terms_url}'> privacy policy</a>.</i></small></p>"
-msgstr ""
-"<p><small><i>Data pribadi Anda akan diproses sesuai <a class='twl-links' "
-"href='{terms_url}'>kebijakan privasi</a> kami.</i></small></p>"
+msgid "<p><small><i>Your personal data will be processed according to our <a class='twl-links' href='{terms_url}'> privacy policy</a>.</i></small></p>"
+msgstr "<p><small><i>Data pribadi Anda akan diproses sesuai <a class='twl-links' href='{terms_url}'>kebijakan privasi</a> kami.</i></small></p>"
 
 #. Translators: This is the title of the application form page, where users enter information required for the application. It lets the user know which partner application they are entering data for. {partner}
 #: TWLight/applications/forms.py:189
@@ -103,12 +100,8 @@ msgstr "Surel untuk akun Anda di situs web mitra"
 #. Translators: This labels a choice field where users will have to select the number of months they wish to have their access for as part of the application renewal confirmation.
 #. Translators: When filling out an application, users may be required to enter the length of the account (expiry) they wish to have for proxy partners.
 #: TWLight/applications/forms.py:339 TWLight/applications/helpers.py:100
-msgid ""
-"The number of months you wish to have this access for before renewal is "
-"required"
-msgstr ""
-"Durasi (dalam bulan) yang Anda butuhkan sebelum harus memperpanjang "
-"permohonan ini"
+msgid "The number of months you wish to have this access for before renewal is required"
+msgstr "Durasi (dalam bulan) yang Anda butuhkan sebelum harus memperpanjang permohonan ini"
 
 #. Translators: When filling out an application, users may need to specify their name
 #: TWLight/applications/helpers.py:81
@@ -196,12 +189,8 @@ msgstr "Surel"
 
 #. Translators: This comment is added to pending applications when our terms of use change.
 #: TWLight/applications/management/commands/notify_applicants_tou_changes.py:54
-msgid ""
-"Our terms of use have changed. Your applications will not be processed until "
-"you log in and agree to our updated terms."
-msgstr ""
-"Syarat penggunaan kami telah berubah. Permohonan Anda tidak akan diproses "
-"hingga Anda masuk log dan menyetujui syarat penggunaan yang baru."
+msgid "Our terms of use have changed. Your applications will not be processed until you log in and agree to our updated terms."
+msgstr "Syarat penggunaan kami telah berubah. Permohonan Anda tidak akan diproses hingga Anda masuk log dan menyetujui syarat penggunaan yang baru."
 
 #. Translators: This is the status of an application that has not yet been reviewed.
 #: TWLight/applications/models.py:54
@@ -267,43 +256,26 @@ msgstr "URL untuk mengakses: {access_url}"
 
 #. Translators: This text goes into account approval emails in the case that we need to send the user's details to a publisher for manual account setup.
 #: TWLight/applications/models.py:331
-msgid ""
-"You can expect to receive access details within a week or two once it has "
-"been processed."
-msgstr ""
-"Kira-kira, Anda akan menerima informasi untuk akses dalam satu atau dua "
-"minggu setelah ini diproses."
+msgid "You can expect to receive access details within a week or two once it has been processed."
+msgstr "Kira-kira, Anda akan menerima informasi untuk akses dalam satu atau dua minggu setelah ini diproses."
 
 #. Translators: This comment is added to open applications when a partner joins the Library Bundle, which does not require applications.
 #: TWLight/applications/signals.py:247
-msgid ""
-"This partner joined the Library Bundle, which does not require applications. "
-"This application will be marked as invalid."
-msgstr ""
-"Mitra ini telah bergabung dengan Bundel Perpustakaan, yang tidak "
-"mensyaratkan pembuatan permohonan. Permohonan ini akan ditandai sebagai "
-"tidak sah."
+msgid "This partner joined the Library Bundle, which does not require applications. This application will be marked as invalid."
+msgstr "Mitra ini telah bergabung dengan Bundel Perpustakaan, yang tidak mensyaratkan pembuatan permohonan. Permohonan ini akan ditandai sebagai tidak sah."
 
 #. Translators: This is shown to users if the application is to a partner for which we have run out of available accounts. The application is therefore on a 'waitlist', and will be reviewed when more accounts are available.
 #: TWLight/applications/templates/applications/application_evaluation.html:29
-msgid ""
-"This application is on the waitlist because this partner does not have any "
-"access grants available at this time."
-msgstr ""
-"Permohonan ini dalam daftar tunggu karena mitra tidak menyediakan hibah hak "
-"akses untuk saat ini."
+msgid "This application is on the waitlist because this partner does not have any access grants available at this time."
+msgstr "Permohonan ini dalam daftar tunggu karena mitra tidak menyediakan hibah hak akses untuk saat ini."
 
 #. Translators: This message is shown on pages where coordinators can see personal information about applicants.
 #: TWLight/applications/templates/applications/application_evaluation.html:36
 #: TWLight/applications/templates/applications/application_list_include.html:6
 #: TWLight/applications/templates/applications/send_partner.html:45
 #: TWLight/resources/templates/resources/partner_users.html:18
-msgid ""
-"Coordinators: This page may contain personal information such as real names "
-"and email addresses. Please remember that this information is confidential."
-msgstr ""
-"Untuk koordinator: Halaman ini mungkin mengandung informasi pribadi seperti "
-"nama asli dan alamat surel. Ingat bahwa informasi ini bersifat rahasia."
+msgid "Coordinators: This page may contain personal information such as real names and email addresses. Please remember that this information is confidential."
+msgstr "Untuk koordinator: Halaman ini mungkin mengandung informasi pribadi seperti nama asli dan alamat surel. Ingat bahwa informasi ini bersifat rahasia."
 
 #. Translators: This is the title of the application page shown to users who are a coordinator, and are able to accept or reject the application.
 #: TWLight/applications/templates/applications/application_evaluation.html:39
@@ -312,12 +284,8 @@ msgstr "Evaluasi permohonan"
 
 #. Translators: This text is shown to coordinators on application pages if the applicant has restricted processing of their data.
 #: TWLight/applications/templates/applications/application_evaluation.html:42
-msgid ""
-"This user has requested a restriction on the processing of their data, so "
-"you cannot change the status of their application."
-msgstr ""
-"Pengguna ini telah meminta pembatasan terhadap pemrosesan datanya, sehingga "
-"Anda tidak dapat mengganti status permohonan ini."
+msgid "This user has requested a restriction on the processing of their data, so you cannot change the status of their application."
+msgstr "Pengguna ini telah meminta pembatasan terhadap pemrosesan datanya, sehingga Anda tidak dapat mengganti status permohonan ini."
 
 #. Translators: This is the title of the application page shown to users who are not a coordinator.
 #: TWLight/applications/templates/applications/application_evaluation.html:48
@@ -390,12 +358,8 @@ msgstr "Tidak diketahui"
 
 #. Translators: This is the text displayed to coordinators when an applicant has no country of residence in their profile.
 #: TWLight/applications/templates/applications/application_evaluation.html:123
-msgid ""
-"Please request the applicant add their country of residence to their profile "
-"before proceeding further."
-msgstr ""
-"Silakan meminta pemohon untuk menambahkan negara kediaman ke profil mereka "
-"sebelum diproses lebih lanjut."
+msgid "Please request the applicant add their country of residence to their profile before proceeding further."
+msgstr "Silakan meminta pemohon untuk menambahkan negara kediaman ke profil mereka sebelum diproses lebih lanjut."
 
 #. Translators: This labels the section of an application showing the total number of accounts available for a partner or their collection.
 #: TWLight/applications/templates/applications/application_evaluation.html:134
@@ -405,12 +369,8 @@ msgstr "Akun tersedia"
 #. Translators: This labels the section of an application showing whether the user had agreed to the terms of use or not.
 #: TWLight/applications/templates/applications/application_evaluation.html:145
 #, python-format
-msgid ""
-"Has agreed to the site's <a class=\"twl-links\" href=\"%(terms_url)s\">terms "
-"of use</a>?"
-msgstr ""
-"Sudah menyetujui <a class=\"twl-links\" href=\"%(terms_url)s\">syarat "
-"penggunaan</a> situs?"
+msgid "Has agreed to the site's <a class=\"twl-links\" href=\"%(terms_url)s\">terms of use</a>?"
+msgstr "Sudah menyetujui <a class=\"twl-links\" href=\"%(terms_url)s\">syarat penggunaan</a> situs?"
 
 #. Translators: Displayed to coordinators when they've agreed to the terms of use.
 #. Translators: Displayed if the user has agreed to the terms of use.
@@ -445,12 +405,8 @@ msgstr "Tidak"
 
 #. Translators: This is the text displayed to coordinators when an applicant has not agreed to the terms of use.
 #: TWLight/applications/templates/applications/application_evaluation.html:159
-msgid ""
-"Please request the applicant agree to the site's terms of use before "
-"approving this application."
-msgstr ""
-"Silakan meminta pemohon untuk menyetujui syarat penggunaan situs ini sebelum "
-"mengabulkan permohonan ini."
+msgid "Please request the applicant agree to the site's terms of use before approving this application."
+msgstr "Silakan meminta pemohon untuk menyetujui syarat penggunaan situs ini sebelum mengabulkan permohonan ini."
 
 #. Translators: This labels the section of an application containing the user's motivation for wanting access to this resource.
 #: TWLight/applications/templates/applications/application_evaluation.html:176
@@ -470,10 +426,8 @@ msgstr "Perpanjangan akses yang telah diberikan sebelumnya?"
 #. Translators: This message is shown next to the 'Renewal of existing access grant?' label if the application is a renewal. Don't translate HTML tags or parent_url.
 #: TWLight/applications/templates/applications/application_evaluation.html:195
 #, python-format
-msgid ""
-"Yes (<a class=\"twl-links\" href=\"%(parent_url)s\">previous application</a>)"
-msgstr ""
-"Ya (<a class=\"twl-links\" href=\"%(parent_url)s\">permohonan sebelumnya</a>)"
+msgid "Yes (<a class=\"twl-links\" href=\"%(parent_url)s\">previous application</a>)"
+msgstr "Ya (<a class=\"twl-links\" href=\"%(parent_url)s\">permohonan sebelumnya</a>)"
 
 #. Translators: This labels the section of the application showing the length of access remaining on the user's previous authorization.
 #: TWLight/applications/templates/applications/application_evaluation.html:208
@@ -507,12 +461,8 @@ msgstr "Tambahkan komentar"
 
 #. Translators: On an application page, this text tells users that the comments posted on the application are visible to coordinators and the submitting user only.
 #: TWLight/applications/templates/applications/application_evaluation.html:297
-msgid ""
-"Comments are visible to all coordinators and to the editor who submitted "
-"this application."
-msgstr ""
-"Komentar dapat dilihat oleh semua koordinator dan oleh pengguna yang "
-"mengirim permohonan ini"
+msgid "Comments are visible to all coordinators and to the editor who submitted this application."
+msgstr "Komentar dapat dilihat oleh semua koordinator dan oleh pengguna yang mengirim permohonan ini"
 
 #. Translators: This is the title of the section of an application page which lists information about the user who submitted the application.
 #. Translators: On the page where coordinators can view data on applications to a partner they coordinate, this is a table column heading for the username.
@@ -723,25 +673,14 @@ msgstr "Tetapkan status"
 
 #: TWLight/applications/templates/applications/apply.html:20
 #, python-format
-msgid ""
-"If your application is successful we may share your email address with "
-"%(partner)s. This is required to set up your access to their resources. By "
-"submitting this form you agree to allow your email address to be shared with "
-"%(partner)s if your application is successful, for the purposes of account "
-"setup."
-msgstr ""
-"Jika permohonan Anda berhasil, kami mungkin membagikan alamat surel Anda "
-"kepada %(partner)s. Ini diperlukan untuk mengatur akses Anda ke sumber daya "
-"mereka. Dengan mengirimkan formulir ini, Anda setuju untuk mengizinkan "
-"alamat surel Anda dibagikan kepada %(partner)s jika permohonan Anda "
-"berhasil, untuk tujuan pengaturan akun."
+msgid "If your application is successful we may share your email address with %(partner)s. This is required to set up your access to their resources. By submitting this form you agree to allow your email address to be shared with %(partner)s if your application is successful, for the purposes of account setup."
+msgstr "Jika permohonan Anda berhasil, kami mungkin membagikan alamat surel Anda kepada %(partner)s. Ini diperlukan untuk mengatur akses Anda ke sumber daya mereka. Dengan mengirimkan formulir ini, Anda setuju untuk mengizinkan alamat surel Anda dibagikan kepada %(partner)s jika permohonan Anda berhasil, untuk tujuan pengaturan akun."
 
 #. Translators: This message is displayed on the page where users can confirm their renewal. Please do not translate partner.
 #: TWLight/applications/templates/applications/confirm_renewal.html:23
 #, python-format
 msgid "Click 'confirm' to renew your application for %(partner)s"
-msgstr ""
-"Klik 'Konfirmasi' untuk memperpanjang permohonan Anda untuk %(partner)s"
+msgstr "Klik 'Konfirmasi' untuk memperpanjang permohonan Anda untuk %(partner)s"
 
 #. Translators: Labels the submit button requesting confirmation of application renewal.
 #. Translators: This is the button coordinators click to confirm deletion of a suggestion.
@@ -763,12 +702,8 @@ msgstr "Sumber mana yang Anda ingin akses?"
 
 #. Translators: This text explains that Library Bundle partners are not shown in this list.
 #: TWLight/applications/templates/applications/request_for_application.html:26
-msgid ""
-"Library Bundle partners are not shown as eligibility is determined "
-"automatically."
-msgstr ""
-"Mitra Bundel Perpustakaan tidak ditampilkan karena pemenuhan syarat "
-"ditentukan secara otomatis."
+msgid "Library Bundle partners are not shown as eligibility is determined automatically."
+msgstr "Mitra Bundel Perpustakaan tidak ditampilkan karena pemenuhan syarat ditentukan secara otomatis."
 
 #. Translators: On the page where users can apply for multiple partners, this message shows next to the partner name, taking them to the full application page when clicked.
 #: TWLight/applications/templates/applications/request_for_application.html:48
@@ -782,14 +717,8 @@ msgstr "Data mengenai partner belum ditambahkan"
 
 #. Translators: the HTML is so that the word 'waitlisted' will look the same as it does in the page above; please translate 'waitlisted' the same way you did elsewhere in this file.
 #: TWLight/applications/templates/applications/request_for_application.html:74
-msgid ""
-"You can apply to <span class=\"badge badge-warning\">Waitlisted</span> "
-"partners, but they don't have access grants available right now. We will "
-"process those applications when access becomes available."
-msgstr ""
-"Anda dapat mengirim permohonan untuk partner dalam <span class=\"badge badge-"
-"warning\">Daftar tunggu</span>, tetapi pemberian akses partner ini tidak "
-"tersedia untuk saat ini. Kami akan memprosesnya setelah akses tersedia."
+msgid "You can apply to <span class=\"badge badge-warning\">Waitlisted</span> partners, but they don't have access grants available right now. We will process those applications when access becomes available."
+msgstr "Anda dapat mengirim permohonan untuk partner dalam <span class=\"badge badge-warning\">Daftar tunggu</span>, tetapi pemberian akses partner ini tidak tersedia untuk saat ini. Kami akan memprosesnya setelah akses tersedia."
 
 #. Translators: On the page where coordinators can see approved applications which have not had their details sent to the partner, this message shows when there are applications ready to be processed.
 #: TWLight/applications/templates/applications/send.html:10
@@ -810,19 +739,13 @@ msgstr "Data aplikasi untuk %(object)s"
 #. Translators: This message is shown when applications exceed the number of accounts available.
 #: TWLight/applications/templates/applications/send_partner.html:54
 #, python-format
-msgid ""
-"Application(s) for %(object)s, if sent, will exceed the total available "
-"accounts for the partner. Please proceed at your own discretion."
-msgstr ""
-"Jika permohonan untuk %(object)s dikirim, akan melebihi jumlah akun tersedia "
-"untuk partner ini. Silakan dipertimbangkan sebelum melanjutkan."
+msgid "Application(s) for %(object)s, if sent, will exceed the total available accounts for the partner. Please proceed at your own discretion."
+msgstr "Jika permohonan untuk %(object)s dikirim, akan melebihi jumlah akun tersedia untuk partner ini. Silakan dipertimbangkan sebelum melanjutkan."
 
 #. Translators: When viewing the list of applications ready to be sent for a particular partner, this is instructions for the coordinator to click the 'mark as sent' button after they have sent the information.
 #: TWLight/applications/templates/applications/send_partner.html:65
 msgid "When you've processed the data below, click the 'mark as sent' button."
-msgstr ""
-"Saat Anda telah memproses data di bawah ini, klik tombol 'tandai telah "
-"dikirim'."
+msgstr "Saat Anda telah memproses data di bawah ini, klik tombol 'tandai telah dikirim'."
 
 #. Translators: When viewing the list of applications ready to be sent for a particular partner, this is the title of the section containing contact information for the people applications should be sent to.
 #: TWLight/applications/templates/applications/send_partner.html:71
@@ -832,12 +755,8 @@ msgstr[0] "Kontak"
 
 #. Translators: When viewing the list of applications ready to be sent for a particular partner, this message shows if there is no information about who the applications should be sent to. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/applications/templates/applications/send_partner.html:89
-msgid ""
-"Whoops, we don't have any listed contacts. Please notify Wikipedia Library "
-"administrators."
-msgstr ""
-"Maaf, kami tidak memiliki daftar kontak. Harap beritahu pengurus "
-"Perpustakaan Wikipedia."
+msgid "Whoops, we don't have any listed contacts. Please notify Wikipedia Library administrators."
+msgstr "Maaf, kami tidak memiliki daftar kontak. Harap beritahu pengurus Perpustakaan Wikipedia."
 
 #. Translators: When viewing the list of applications ready to be sent for a particular partner, this is the title of the section containing the information about those applications.
 #: TWLight/applications/templates/applications/send_partner.html:94
@@ -852,12 +771,8 @@ msgstr "Tandai telah dikirim"
 
 #. Translators: This text guides coordinators in using the code sending interface for approved applications.
 #: TWLight/applications/templates/applications/send_partner.html:152
-msgid ""
-"Use the dropdown menus to denote which editor will receive each code. Access "
-"codes will be sent to users automatically."
-msgstr ""
-"Gunakan menu ''dropdown'' untuk menandai penyunting mana yang akan menerima "
-"kode. Kode akses akan dikirim kepada pengguna secara otomatis."
+msgid "Use the dropdown menus to denote which editor will receive each code. Access codes will be sent to users automatically."
+msgstr "Gunakan menu ''dropdown'' untuk menandai penyunting mana yang akan menerima kode. Kode akses akan dikirim kepada pengguna secara otomatis."
 
 #. Translators: This labels a drop-down selection where staff can assign an access code to a user.
 #: TWLight/applications/templates/applications/send_partner.html:173
@@ -872,24 +787,14 @@ msgstr "Tidak ada aplikasi yang disetujui dan tidak terkirim."
 #. Translators: When a user applies for a set of resources, they receive this message if none are currently available. They are instead placed on a 'waitlist' for later approval.
 #. Translators: When a user renews their resource, they receive this message if none are currently available. They are instead placed on a 'waitlist' for later approval.
 #: TWLight/applications/views.py:140 TWLight/applications/views.py:1282
-msgid ""
-"This partner does not have any access grants available at this time. You may "
-"still apply for access; your application will be reviewed when access grants "
-"become available."
-msgstr ""
-"Mitra ini tidak memiliki pemberian akses apa pun yang tersedia untuk saat "
-"ini. Anda masih dapat mengajukan permohonan untuk mendapatkan akses; "
-"permohonan Anda akan ditinjau ketika pemberian akses tersedia."
+msgid "This partner does not have any access grants available at this time. You may still apply for access; your application will be reviewed when access grants become available."
+msgstr "Mitra ini tidak memiliki pemberian akses apa pun yang tersedia untuk saat ini. Anda masih dapat mengajukan permohonan untuk mendapatkan akses; permohonan Anda akan ditinjau ketika pemberian akses tersedia."
 
 #. Translators: This message is shown to users once they've successfully submitted their application for review.
 #: TWLight/applications/views.py:163
 #, python-brace-format
-msgid ""
-"Your application has been submitted for review. Head over to <a "
-"href='{applications_url}'>My Applications</a> to view the status."
-msgstr ""
-"Aplikasi Anda telah dikirim untuk ditinjau. Kunjungi <a "
-"href='{applications_url}'>aplikasi saya</a> untuk melihat status."
+msgid "Your application has been submitted for review. Head over to <a href='{applications_url}'>My Applications</a> to view the status."
+msgstr "Aplikasi Anda telah dikirim untuk ditinjau. Kunjungi <a href='{applications_url}'>aplikasi saya</a> untuk melihat status."
 
 #. Translators: This text is displayed to users when the user has chosen to restrict data and is trying to apply for multiple partners
 #: TWLight/applications/views.py:276
@@ -937,21 +842,13 @@ msgstr "Aplikasi terkirim"
 
 #. Translators: After a coordinator has changed the status of an application to APPROVED, if the corresponding partner/collection is waitlisted this message appears.
 #: TWLight/applications/views.py:756
-msgid ""
-"Cannot approve application as partner with proxy authorization method is "
-"waitlisted."
-msgstr ""
-"Tidak dapat menyetujui permohonan karena mitra dengan metode otorisasi "
-"proksi sedang menunggu."
+msgid "Cannot approve application as partner with proxy authorization method is waitlisted."
+msgstr "Tidak dapat menyetujui permohonan karena mitra dengan metode otorisasi proksi sedang menunggu."
 
 #. Translators: After a coordinator has changed the status of an application to APPROVED, if the corresponding partner/collection has no accounts for distribution, this message appears.
 #: TWLight/applications/views.py:780
-msgid ""
-"Cannot approve application as partner with proxy authorization method is "
-"waitlisted and (or) has zero accounts available for distribution."
-msgstr ""
-"Tidak dapat menyetujui permohonan karena mitra dengan metode otorisasi "
-"proksi sedang menunggu dan (atau) tidak memiliki akun untuk distribusinya."
+msgid "Cannot approve application as partner with proxy authorization method is waitlisted and (or) has zero accounts available for distribution."
+msgstr "Tidak dapat menyetujui permohonan karena mitra dengan metode otorisasi proksi sedang menunggu dan (atau) tidak memiliki akun untuk distribusinya."
 
 #. Translators: This message appears on an "access denied" screen that stops users who attempt to authorize an editor to access a resource during a time period for which they are already authorized.
 #: TWLight/applications/views.py:803
@@ -961,16 +858,8 @@ msgstr "Anda mencoba membuat otorisasi kedua."
 #. Translators: This message is shown to users when they access an application page of a now Bundle partner (new applications aren't allowed for Bundle partners and the status of old applications cannot be modified)
 #: TWLight/applications/views.py:857
 #, python-brace-format
-msgid ""
-"This application cannot be modified since this partner is now part of our <a "
-"href='{bundle}'>bundle access</a>. If you are eligible, you can access this "
-"resource from <a href='{library}'>your library</a>. <a "
-"href='{contact}'>Contact us</a> if you have any questions."
-msgstr ""
-"Permohonan ini tidak dapat diubah semenjak partner ini kini menjadi bagian "
-"dari <a href='{bundle}'>akses berkas</a> kami. Jika Anda memenuhi, Anda "
-"dapat mengakses sumber daya ini dari <a href='{library}'>perpustakaan Anda</"
-"a>. <a href='{contact}'>Hubungi kami</a> jika Anda memiliki pertanyaan."
+msgid "This application cannot be modified since this partner is now part of our <a href='{bundle}'>bundle access</a>. If you are eligible, you can access this resource from <a href='{library}'>your library</a>. <a href='{contact}'>Contact us</a> if you have any questions."
+msgstr "Permohonan ini tidak dapat diubah semenjak partner ini kini menjadi bagian dari <a href='{bundle}'>akses berkas</a> kami. Jika Anda memenuhi, Anda dapat mengakses sumber daya ini dari <a href='{library}'>perpustakaan Anda</a>. <a href='{contact}'>Hubungi kami</a> jika Anda memiliki pertanyaan."
 
 #. Translators: this lets a reviewer set the status of a single application.
 #: TWLight/applications/views.py:873
@@ -979,12 +868,8 @@ msgstr "Tetapkan status permohonan"
 
 #. Translators: This warning is message is shown to applicants when the number of pending applications is greater than the number of accounts available.
 #: TWLight/applications/views.py:891
-msgid ""
-"There are more pending applications than available accounts. Your "
-"application might get waitlisted."
-msgstr ""
-"Terdapat lebih banyak permohonan yang menunggu daripada akun yang tersedia. "
-"Permohonan Anda kemungkinan akan masuk daftar tunggu."
+msgid "There are more pending applications than available accounts. Your application might get waitlisted."
+msgstr "Terdapat lebih banyak permohonan yang menunggu daripada akun yang tersedia. Permohonan Anda kemungkinan akan masuk daftar tunggu."
 
 #. Translators: this message is shown to coordinators who attempt to change an application's Status from INVALID to any other Status.
 #: TWLight/applications/views.py:904
@@ -1003,16 +888,8 @@ msgstr "Pembaruan batch aplikasi {} berhasil."
 
 #. Translators: After a coordinator has changed the status of a number of applications to APPROVED, if the corresponding partner(s) is/are waitlisted or has no accounts for distribution, this message appears.
 #: TWLight/applications/views.py:1051
-msgid ""
-"Cannot approve application(s) {} as partner(s) with proxy authorization "
-"method is/are waitlisted and (or) has/have not enough accounts available. If "
-"not enough accounts are available, prioritise the applications and then "
-"approve applications equal to the accounts available."
-msgstr ""
-"Tidak dapat menerima permohonan {} karena partner dengan metode otorisasi "
-"proxy masuk ke dalam daftar tunggu dan (atau) tidak memiliki cukup akun yang "
-"tersedia. Jika akun yang tersedia tidak cukup, prioritaskan permohonan dan "
-"kemudian setujui permohonan sesuai dengan jumlah akun yang tersedia."
+msgid "Cannot approve application(s) {} as partner(s) with proxy authorization method is/are waitlisted and (or) has/have not enough accounts available. If not enough accounts are available, prioritise the applications and then approve applications equal to the accounts available."
+msgstr "Tidak dapat menerima permohonan {} karena partner dengan metode otorisasi proxy masuk ke dalam daftar tunggu dan (atau) tidak memiliki cukup akun yang tersedia. Jika akun yang tersedia tidak cukup, prioritaskan permohonan dan kemudian setujui permohonan sesuai dengan jumlah akun yang tersedia."
 
 #. Translators: This message is shown to coordinators who attempt to assign the same access code to multiple users.
 #: TWLight/applications/views.py:1191
@@ -1026,12 +903,8 @@ msgstr "Semua permohonan yang dipilih telah diberi tanda sudah terkirim."
 
 #. Translators: When a user tries to renew their resource, they receive this message if the partner is not available.
 #: TWLight/applications/views.py:1272
-msgid ""
-"Cannot renew application at this time as partner is not available. Please "
-"check back later, or contact us for more information."
-msgstr ""
-"Tidak dapat memperbarui permohonan sekarang karena mitra tidak tersedia. "
-"Silakan periksa lagi nanti atau hubungi kami untuk informasi lebih lanjut."
+msgid "Cannot renew application at this time as partner is not available. Please check back later, or contact us for more information."
+msgstr "Tidak dapat memperbarui permohonan sekarang karena mitra tidak tersedia. Silakan periksa lagi nanti atau hubungi kami untuk informasi lebih lanjut."
 
 #. Translators: This message is displayed when an attempt by a user to renew an application has been denied for some reason.
 #: TWLight/applications/views.py:1308
@@ -1041,21 +914,13 @@ msgstr "Usaha memperbarui permohonan #{pk} yang belum disetujui telah ditolak"
 
 #. Translators: If a user requests the renewal of their account, but it wasn't renewed, this message is shown to them.
 #: TWLight/applications/views.py:1385
-msgid ""
-"This object cannot be renewed. (This probably means that you have already "
-"requested that it be renewed.)"
-msgstr ""
-"Objek ini tidak bisa diperbarui. (Ini mungkin berarti Anda telah meminta "
-"agar ia diperbarui.)"
+msgid "This object cannot be renewed. (This probably means that you have already requested that it be renewed.)"
+msgstr "Objek ini tidak bisa diperbarui. (Ini mungkin berarti Anda telah meminta agar ia diperbarui.)"
 
 #. Translators: If a user requests the renewal of their account, this message is shown to them.
 #: TWLight/applications/views.py:1395
-msgid ""
-"Your renewal request has been received. A coordinator will review your "
-"request."
-msgstr ""
-"Permintaan pembaruan Anda telah diterima. Koordinator akan memeriksa "
-"permintaan Anda."
+msgid "Your renewal request has been received. A coordinator will review your request."
+msgstr "Permintaan pembaruan Anda telah diterima. Koordinator akan memeriksa permintaan Anda."
 
 #. Translators: This labels a textfield where users can enter their email ID.
 #: TWLight/emails/forms.py:18
@@ -1064,12 +929,8 @@ msgstr "Surel Anda"
 
 #. Translators: This is the help text for the email field in the contact us form letting users know the field is updated by value pulled from their respective user profiles.
 #: TWLight/emails/forms.py:21
-msgid ""
-"This field is automatically updated with the email from your <a class='twl-"
-"links' href='{}'>user profile</a>."
-msgstr ""
-"Isian ini diperbarui secara otomatis dengan surel dari <a href=\"{}\" class="
-"\"twl-links\">profil pengguna</a> Anda."
+msgid "This field is automatically updated with the email from your <a class='twl-links' href='{}'>user profile</a>."
+msgstr "Isian ini diperbarui secara otomatis dengan surel dari <a href=\"{}\" class=\"twl-links\">profil pengguna</a> Anda."
 
 #. Translators: This labels a textfield where users can enter their email message.
 #: TWLight/emails/forms.py:26
@@ -1092,26 +953,14 @@ msgstr "Kirim"
 #. Translators: This email is sent to users with their access code. Don't translate Jinja variables in curly braces like user or partner. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/access_code_email-body-html.html:5
 #, python-format
-msgid ""
-"<p>Your approved application to %(partner)s has now been finalised. Your "
-"access code or login details can be found below:</p> <p><b>%(access_code)s</"
-"b></p> <p>%(user_instructions)s</p>"
-msgstr ""
-"<p>Permohonan Anda ke %(partner)s telah  diselesaikan. Kode akses atau "
-"detail masuk log Anda dapat ditemukan di bawah:</p> <p><b>%(access_code)s</"
-"b></p> <p>%(user_instructions)s</p>"
+msgid "<p>Your approved application to %(partner)s has now been finalised. Your access code or login details can be found below:</p> <p><b>%(access_code)s</b></p> <p>%(user_instructions)s</p>"
+msgstr "<p>Permohonan Anda ke %(partner)s telah  diselesaikan. Kode akses atau detail masuk log Anda dapat ditemukan di bawah:</p> <p><b>%(access_code)s</b></p> <p>%(user_instructions)s</p>"
 
 #. Translators: This email is sent to users with their access code. Don't translate Jinja variables in curly braces like user or partner. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/access_code_email-body-text.html:3
 #, python-format
-msgid ""
-"Your approved application to %(partner)s has now been finalised. Your access "
-"code or login details can be found below: %(access_code)s "
-"%(user_instructions)s"
-msgstr ""
-"Permohonan Anda yang disetujui ke %(partner)s kini telah diselesaikan. Kode "
-"akses atau detail login Anda dapat ditemukan di bawah: %(access_code)s "
-"%(user_instructions)s"
+msgid "Your approved application to %(partner)s has now been finalised. Your access code or login details can be found below: %(access_code)s %(user_instructions)s"
+msgstr "Permohonan Anda yang disetujui ke %(partner)s kini telah diselesaikan. Kode akses atau detail login Anda dapat ditemukan di bawah: %(access_code)s %(user_instructions)s"
 
 #. Translators: This is the subject line of an email sent to users with their access code.
 #: TWLight/emails/templates/emails/access_code_email-subject.html:3
@@ -1121,34 +970,14 @@ msgstr "Kode akses Perpustakaan Wikipedia Anda"
 #. Translators: This email is sent to users when their application is approved. Don't translate Jinja variables in curly braces like user or partner; don't translate html tags either. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/approval_notification-body-html.html:5
 #, python-format
-msgid ""
-"<p>Dear %(user)s,</p> <p>Thank you for applying for access to %(partner)s "
-"resources through The Wikipedia Library. We are happy to inform you that "
-"your application has been approved.</p> <p>%(user_instructions)s</p> <p>You "
-"can view the collections you're authorized to access at My Library: "
-"%(link)s</p> <p>Cheers!</p> <p>The Wikipedia Library</p>"
-msgstr ""
-"<p>Halo %(user)s,</p> <p>Terima kasih telah memohon akses ke sumber daya "
-"%(partner)s melalui Perpustakaan Wikipedia. Kami merasa senang memberi tahu "
-"Anda bahwa permohonannya disetujui.</p> <p>%(user_instructions)s</p> <p>Anda "
-"dapat melihat koleksi yang telah diizinkan untuk diakses oleh Anda di "
-"Perpustakaan Saya: %(link)s</p> <p>Selamat!</p> <p>Perpustakaan Wikipedia</p>"
+msgid "<p>Dear %(user)s,</p> <p>Thank you for applying for access to %(partner)s resources through The Wikipedia Library. We are happy to inform you that your application has been approved.</p> <p>%(user_instructions)s</p> <p>You can view the collections you're authorized to access at My Library: %(link)s</p> <p>Cheers!</p> <p>The Wikipedia Library</p>"
+msgstr "<p>Halo %(user)s,</p> <p>Terima kasih telah memohon akses ke sumber daya %(partner)s melalui Perpustakaan Wikipedia. Kami merasa senang memberi tahu Anda bahwa permohonannya disetujui.</p> <p>%(user_instructions)s</p> <p>Anda dapat melihat koleksi yang telah diizinkan untuk diakses oleh Anda di Perpustakaan Saya: %(link)s</p> <p>Selamat!</p> <p>Perpustakaan Wikipedia</p>"
 
 #. Translators: This email is sent to users when their application is approved. Don't translate Jinja variables in curly braces like user or partner. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/approval_notification-body-text.html:3
 #, python-format
-msgid ""
-"Dear %(user)s, Thank you for applying for access to %(partner)s resources "
-"through The Wikipedia Library. We are happy to inform you that your "
-"application has been approved. %(user_instructions)s You can view the "
-"collections you're authorized to access at My Library: %(link)s Cheers! The "
-"Wikipedia Library"
-msgstr ""
-"Halo %(user)s, Terima kasih telah memohon akses ke sumber daya %(partner)s "
-"melalui Perpustakaan Wikipedia. Kami merasa senang memberi tahu Anda bahwa "
-"permohonannya disetujui. %(user_instructions)s Anda dapat melihat koleksi "
-"yang telah diizinkan untuk diakses oleh Anda di Perpustakaan Saya: %(link)s "
-"Selamat! Perpustakaan Wikipedia"
+msgid "Dear %(user)s, Thank you for applying for access to %(partner)s resources through The Wikipedia Library. We are happy to inform you that your application has been approved. %(user_instructions)s You can view the collections you're authorized to access at My Library: %(link)s Cheers! The Wikipedia Library"
+msgstr "Halo %(user)s, Terima kasih telah memohon akses ke sumber daya %(partner)s melalui Perpustakaan Wikipedia. Kami merasa senang memberi tahu Anda bahwa permohonannya disetujui. %(user_instructions)s Anda dapat melihat koleksi yang telah diizinkan untuk diakses oleh Anda di Perpustakaan Saya: %(link)s Selamat! Perpustakaan Wikipedia"
 
 #. Translators: This is the subject of an email which is sent to users when their application has been approved. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/approval_notification-subject.html:4
@@ -1158,26 +987,14 @@ msgstr "Permohonan Perpustakaan Wikipedia Anda telah disetujui"
 #. Translators: This email is sent to coordinators when a comment is left on an application they are processing. Don't translate Jinja variables in curly braces like user or partner. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/comment_notification_coordinator-body-html.html:5
 #, python-format
-msgid ""
-"<p style=\"color: #500050\">%(submit_date)s - %(commenter)s</p> "
-"<blockquote><p>%(comment)s</p></blockquote> <p>Please reply to these at: <a "
-"href=\"%(app_url)s\">%(app_url)s</a></p> <p>Best,</p> <p>The Wikipedia "
-"Library</p>"
-msgstr ""
-"<p style=\"color: #500050\">%(submit_date)s - %(commenter)s</p> "
-"<blockquote><p>%(comment)s</p></blockquote> <p>Tolong balas ini di: <a href="
-"\"%(app_url)s\">%(app_url)s</a></p> <p>Salam,</p> <p>Perpustakaan Wikipedia</"
-"p>"
+msgid "<p style=\"color: #500050\">%(submit_date)s - %(commenter)s</p> <blockquote><p>%(comment)s</p></blockquote> <p>Please reply to these at: <a href=\"%(app_url)s\">%(app_url)s</a></p> <p>Best,</p> <p>The Wikipedia Library</p>"
+msgstr "<p style=\"color: #500050\">%(submit_date)s - %(commenter)s</p> <blockquote><p>%(comment)s</p></blockquote> <p>Tolong balas ini di: <a href=\"%(app_url)s\">%(app_url)s</a></p> <p>Salam,</p> <p>Perpustakaan Wikipedia</p>"
 
 #. Translators: This email is sent to coordinators when a comment is left on an application they are processing. Don't translate Jinja variables in curly braces like user or partner. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/comment_notification_coordinator-body-text.html:3
 #, python-format
-msgid ""
-"%(submit_date)s - %(commenter)s %(comment)s Please reply to this at: "
-"%(app_url)s Best, The Wikipedia Library"
-msgstr ""
-"%(submit_date)s - %(commenter)s %(comment)s Tolong balas ini di: %(app_url)s "
-"Salam, Perpustakaan Wikipedia"
+msgid "%(submit_date)s - %(commenter)s %(comment)s Please reply to this at: %(app_url)s Best, The Wikipedia Library"
+msgstr "%(submit_date)s - %(commenter)s %(comment)s Tolong balas ini di: %(app_url)s Salam, Perpustakaan Wikipedia"
 
 #. Translators: This is the subject line of an email sent to coordinators when a comment is left on an application they processed.
 #: TWLight/emails/templates/emails/comment_notification_coordinator-subject.html:3
@@ -1187,27 +1004,14 @@ msgstr "Komentar baru di permohonan Perpustakaan Wikipedia yang Anda proses"
 #. Translators: This email is sent to users when they receive a comment on their application. Don't translate Jinja variables in curly braces like user or partner; don't translate html tags either. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/comment_notification_editors-body-html.html:5
 #, python-format
-msgid ""
-"<p style=\"color: #500050\">%(submit_date)s - %(commenter)s</p> "
-"<blockquote><p>%(comment)s</p></blockquote> <p>Please reply to these at <a "
-"href=\"%(app_url)s\">%(app_url)s</a> so we can evaluate your application.</"
-"p> <p>Best,</p> <p>The Wikipedia Library</p>"
-msgstr ""
-"<p style=\"color: #500050\">%(submit_date)s - %(commenter)s</p> "
-"<blockquote><p>%(comment)s</p></blockquote> <p>Tolong balas ini di <a href="
-"\"%(app_url)s\">%(app_url)s</a> sehingga kami dapat mengevaluasi permohonan "
-"Anda.</p> <p>Salam,</p> <p>Perpustakaan Wikipedia</p>"
+msgid "<p style=\"color: #500050\">%(submit_date)s - %(commenter)s</p> <blockquote><p>%(comment)s</p></blockquote> <p>Please reply to these at <a href=\"%(app_url)s\">%(app_url)s</a> so we can evaluate your application.</p> <p>Best,</p> <p>The Wikipedia Library</p>"
+msgstr "<p style=\"color: #500050\">%(submit_date)s - %(commenter)s</p> <blockquote><p>%(comment)s</p></blockquote> <p>Tolong balas ini di <a href=\"%(app_url)s\">%(app_url)s</a> sehingga kami dapat mengevaluasi permohonan Anda.</p> <p>Salam,</p> <p>Perpustakaan Wikipedia</p>"
 
 #. Translators: This email is sent to users when they receive a comment on their application. Don't translate Jinja variables in curly braces like user or partner. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/comment_notification_editors-body-text.html:3
 #, python-format
-msgid ""
-"%(submit_date)s - %(commenter)s %(comment)s Please reply to these at: "
-"%(app_url)s so we can evaluate your application. Best, The Wikipedia Library"
-msgstr ""
-"%(submit_date)s - %(commenter)s %(comment)s Tolong balas ini di: %(app_url)s "
-"sehingga kami dapat mengevaluasi permohonan Anda. Salam, Perpustakaan "
-"Wikipedia"
+msgid "%(submit_date)s - %(commenter)s %(comment)s Please reply to these at: %(app_url)s so we can evaluate your application. Best, The Wikipedia Library"
+msgstr "%(submit_date)s - %(commenter)s %(comment)s Tolong balas ini di: %(app_url)s sehingga kami dapat mengevaluasi permohonan Anda. Salam, Perpustakaan Wikipedia"
 
 #. Translators: This is the subject line of an email sent to users who have a comment added to one of their applications. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/comment_notification_editors-subject.html:3
@@ -1217,25 +1021,14 @@ msgstr "Komentar baru pada permohonan Perpustakaan Wikipedia Anda"
 #. Translators: This email is sent to users when an application they commented on receives another comment. Don't translate Jinja variables in curly braces like app_url; don't translate html tags either. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/comment_notification_others-body-html.html:5
 #, python-format
-msgid ""
-"<p style=\"color: #500050\">%(submit_date)s - %(commenter)s</p> "
-"<blockquote><p>%(comment)s</p></blockquote> See it at <a href=\"%(app_url)s"
-"\">%(app_url)s</a>. Thanks for helping review Wikipedia Library applications!"
-msgstr ""
-"<p style=\"color: #500050\">%(submit_date)s - %(commenter)s</p> "
-"<blockquote><p>%(comment)s</p></blockquote> Lihat itu di <a href="
-"\"%(app_url)s\">%(app_url)s</a>. Terima kasih telah membantu meninjau "
-"permohonan Perpustakaan Wikipedia!"
+msgid "<p style=\"color: #500050\">%(submit_date)s - %(commenter)s</p> <blockquote><p>%(comment)s</p></blockquote> See it at <a href=\"%(app_url)s\">%(app_url)s</a>. Thanks for helping review Wikipedia Library applications!"
+msgstr "<p style=\"color: #500050\">%(submit_date)s - %(commenter)s</p> <blockquote><p>%(comment)s</p></blockquote> Lihat itu di <a href=\"%(app_url)s\">%(app_url)s</a>. Terima kasih telah membantu meninjau permohonan Perpustakaan Wikipedia!"
 
 #. Translators: This email is sent to users when an application they commented on receives another comment. Don't translate Jinja variables in curly braces like app_url. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/comment_notification_others-body-text.html:3
 #, python-format
-msgid ""
-"%(submit_date)s - %(commenter)s %(comment)s See it at: %(app_url)s Thanks "
-"for helping review Wikipedia Library applications!"
-msgstr ""
-"%(submit_date)s - %(commenter)s %(comment)s Lihat itu di: %(app_url)s Terima "
-"kasih telah membantu meninjau permohonan Perpustakaan Wikipedia!"
+msgid "%(submit_date)s - %(commenter)s %(comment)s See it at: %(app_url)s Thanks for helping review Wikipedia Library applications!"
+msgstr "%(submit_date)s - %(commenter)s %(comment)s Lihat itu di: %(app_url)s Terima kasih telah membantu meninjau permohonan Perpustakaan Wikipedia!"
 
 #. Translators: This is the subject line of an email sent to users who have a comment added to an application they also commented on. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/comment_notification_others-subject.html:4
@@ -1245,13 +1038,8 @@ msgstr "Komentar baru di permohonan Perpustakaan Wikipedia yang Anda komentari"
 #. Translators: This text is part of a scheduled reminder email sent to coordinators who have applications requiring action. Don't translate Jinja variables in curly braces like total_apps, or user.
 #: TWLight/emails/templates/emails/coordinator_reminder_notification-body-html.html:5
 #, python-format
-msgid ""
-"<p>Dear %(user)s,</p> <p>Our records indicate that you are the designated "
-"coordinator for partners that have a total of %(total_apps)s applications.</"
-"p>"
-msgstr ""
-"<p>Halo %(user)s,</p> <p>Catatan kami menunjukkan bahwa Anda adalah calon "
-"koordinator untuk partner yang mempunyai total %(total_apps)s permohonan.</p>"
+msgid "<p>Dear %(user)s,</p> <p>Our records indicate that you are the designated coordinator for partners that have a total of %(total_apps)s applications.</p>"
+msgstr "<p>Halo %(user)s,</p> <p>Catatan kami menunjukkan bahwa Anda adalah calon koordinator untuk partner yang mempunyai total %(total_apps)s permohonan.</p>"
 
 #. Translators: Breakdown as in 'cost breakdown'; analysis.
 #: TWLight/emails/templates/emails/coordinator_reminder_notification-body-html.html:11
@@ -1286,46 +1074,20 @@ msgstr[0] "%(counter)s permohonan yang disetujui"
 #. Translators: This text is part of a scheduled reminder email sent to coordinators who have applications requiring action. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library). Don't translate Jinja variables in curly braces like link; don't translate email addresses or html tags either.
 #: TWLight/emails/templates/emails/coordinator_reminder_notification-body-html.html:39
 #, python-format
-msgid ""
-"<p>This is a gentle reminder that you may review applications at <a href="
-"\"%(link)s\">%(link)s</a>.</p> <p>You can customise your reminders under "
-"'preferences' in your user profile.</p> <p>If you received this message in "
-"error, drop us a line at wikipedialibrary@wikimedia.org.</p> <p>Thanks for "
-"helping review Wikipedia Library applications!</p>"
-msgstr ""
-"<p>Ini adalah pengingat bahwa Anda dapat meninjau permohonan di <a href="
-"\"%(link)s\">% (link)s</a> .</p><p> Anda dapat menyesuaikan pengingat Anda "
-"di bawah 'preferensi' di profil pengguna Anda.</p><p> Jika Anda menerima "
-"pesan ini karena kesalahan, kirimkan pesan kepada kami di "
-"wikipedialibrary@wikimedia.org.</p><p> Terima kasih telah membantu meninjau "
-"permohonan Perpustakaan Wikipedia!</p>"
+msgid "<p>This is a gentle reminder that you may review applications at <a href=\"%(link)s\">%(link)s</a>.</p> <p>You can customise your reminders under 'preferences' in your user profile.</p> <p>If you received this message in error, drop us a line at wikipedialibrary@wikimedia.org.</p> <p>Thanks for helping review Wikipedia Library applications!</p>"
+msgstr "<p>Ini adalah pengingat bahwa Anda dapat meninjau permohonan di <a href=\"%(link)s\">% (link)s</a> .</p><p> Anda dapat menyesuaikan pengingat Anda di bawah 'preferensi' di profil pengguna Anda.</p><p> Jika Anda menerima pesan ini karena kesalahan, kirimkan pesan kepada kami di wikipedialibrary@wikimedia.org.</p><p> Terima kasih telah membantu meninjau permohonan Perpustakaan Wikipedia!</p>"
 
 #. Translators: This text is part of a scheduled reminder email sent to coordinators who have applications requiring action. Don't translate Jinja variables in curly braces like total_apps, or user.
 #: TWLight/emails/templates/emails/coordinator_reminder_notification-body-text.html:3
 #, python-format
-msgid ""
-"Dear %(user)s, Our records indicate that you are the designated coordinator "
-"for partners that have a total of %(total_apps)s applications."
-msgstr ""
-"%(user)s yang terhormat, Catatan kami menunjukkan bahwa Anda adalah "
-"koordinator yang ditunjuk untuk mitra yang memiliki total %(total_apps)s "
-"permohonan."
+msgid "Dear %(user)s, Our records indicate that you are the designated coordinator for partners that have a total of %(total_apps)s applications."
+msgstr "%(user)s yang terhormat, Catatan kami menunjukkan bahwa Anda adalah koordinator yang ditunjuk untuk mitra yang memiliki total %(total_apps)s permohonan."
 
 #. Translators: This text is part of a scheduled reminder email sent to coordinators who have applications requiring action. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library). Don't translate Jinja variables in curly braces like link; don't translate the email address either.
 #: TWLight/emails/templates/emails/coordinator_reminder_notification-body-text.html:38
 #, python-format
-msgid ""
-"This is a gentle reminder that you may review applications at: %(link)s. You "
-"can customise your reminders under 'preferences' in your user profile. If "
-"you received this message in error, drop us a line at: "
-"wikipedialibrary@wikimedia.org Thanks for helping review Wikipedia Library "
-"applications!"
-msgstr ""
-"Ini adalah pengingat bahwa Anda dapat meninjau permohonan di: %(link)s. Anda "
-"dapat menyesuaikan pengingat Anda di bawah 'preferensi' di profil pengguna "
-"Anda. Jika Anda menerima pesan ini karena kesalahan, kirimkan pesan kepada "
-"kami di: wikipedialibrary@wikimedia.org Terima kasih telah membantu meninjau "
-"aplikasi Perpustakaan Wikipedia!"
+msgid "This is a gentle reminder that you may review applications at: %(link)s. You can customise your reminders under 'preferences' in your user profile. If you received this message in error, drop us a line at: wikipedialibrary@wikimedia.org Thanks for helping review Wikipedia Library applications!"
+msgstr "Ini adalah pengingat bahwa Anda dapat meninjau permohonan di: %(link)s. Anda dapat menyesuaikan pengingat Anda di bawah 'preferensi' di profil pengguna Anda. Jika Anda menerima pesan ini karena kesalahan, kirimkan pesan kepada kami di: wikipedialibrary@wikimedia.org Terima kasih telah membantu meninjau aplikasi Perpustakaan Wikipedia!"
 
 #. Translators: This is the subject line of a scheduled reminder email sent to coordinators who have applications to review. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library). Do not translate items in curly braces.
 #: TWLight/emails/templates/emails/coordinator_reminder_notification-subject.html:4
@@ -1335,34 +1097,14 @@ msgstr "Permohonan Perpustakaan Wikipedia menunggu tinjauan Anda"
 #. Translators: This email is sent to users when their application is rejected. Don't translate Jinja variables in curly braces like user or partner; don't translate html tags either. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/rejection_notification-body-html.html:5
 #, python-format
-msgid ""
-"<p>Dear %(user)s,</p> <p>Thank you for applying for access to %(partner)s "
-"resources through The Wikipedia Library. Unfortunately at this time your "
-"application has not been approved. You can view your application and review "
-"comments at <a href=\"%(app_url)s\">%(app_url)s</a>.</p> <p>Best,</p> <p>The "
-"Wikipedia Library</p>"
-msgstr ""
-"<p>Dear %(user)s,</p>\n"
-"<p>Terima kasih telah mengajukan permohonan akses ke sumber daya %(partner)s "
-"melalui Perpustakaan Wikipedia. Sayangnya saat ini aplikasi Anda belum "
-"disetujui. Anda dapat melihat permohonan Anda dan meninjau komentarnya di <a "
-"href=\"%(app_url)s\">% (app_url) s</a>.</p>\n"
-"\n"
-"<p>Salam, Perpustakaan Wikipedia</p>"
+msgid "<p>Dear %(user)s,</p> <p>Thank you for applying for access to %(partner)s resources through The Wikipedia Library. Unfortunately at this time your application has not been approved. You can view your application and review comments at <a href=\"%(app_url)s\">%(app_url)s</a>.</p> <p>Best,</p> <p>The Wikipedia Library</p>"
+msgstr "<p>Dear %(user)s,</p>\n<p>Terima kasih telah mengajukan permohonan akses ke sumber daya %(partner)s melalui Perpustakaan Wikipedia. Sayangnya saat ini aplikasi Anda belum disetujui. Anda dapat melihat permohonan Anda dan meninjau komentarnya di <a href=\"%(app_url)s\">% (app_url) s</a>.</p>\n\n<p>Salam, Perpustakaan Wikipedia</p>"
 
 #. Translators: This email is sent to users when their application is rejected. Don't translate Jinja variables in curly braces like user or partner. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/rejection_notification-body-text.html:3
 #, python-format
-msgid ""
-"Dear %(user)s, Thank you for applying for access to %(partner)s resources "
-"through The Wikipedia Library. Unfortunately at this time your application "
-"has not been approved. You can view your application and review comments at: "
-"%(app_url)s Best, The Wikipedia Library"
-msgstr ""
-"%(user)s yang terhormat, Terima kasih telah mengajukan permohonan akses ke "
-"sumber daya %(partner)s melalui Perpustakaan Wikipedia. Sayangnya saat ini "
-"permohonan Anda belum disetujui. Anda dapat melihat permohonan Anda dan "
-"meninjau komentarnya di: %(app_url)s Salam, Perpustakaan Wikipedia"
+msgid "Dear %(user)s, Thank you for applying for access to %(partner)s resources through The Wikipedia Library. Unfortunately at this time your application has not been approved. You can view your application and review comments at: %(app_url)s Best, The Wikipedia Library"
+msgstr "%(user)s yang terhormat, Terima kasih telah mengajukan permohonan akses ke sumber daya %(partner)s melalui Perpustakaan Wikipedia. Sayangnya saat ini permohonan Anda belum disetujui. Anda dapat melihat permohonan Anda dan meninjau komentarnya di: %(app_url)s Salam, Perpustakaan Wikipedia"
 
 #. Translators: This is the subject of an email which is sent to users when their application has been rejected. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/rejection_notification-subject.html:4
@@ -1372,32 +1114,14 @@ msgstr "Permohonan Perpustakaan Wikipedia Anda"
 #. Translators: This email is sent to users when they have an account that is soon to expire. Don't translate Jinja variables in curly braces like partner_name or partner_link; don't translate html tags either. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/user_renewal_notice-body-html.html:5
 #, python-format
-msgid ""
-"<p>Dear %(user)s,</p> <p>According to our records, your access to "
-"%(partner_name)s will soon expire and you may lose access. If you want to "
-"continue making use of your free account, you can request renewal of your "
-"account by clicking the 'Renew' or 'Extend' button at %(partner_link)s.</p> "
-"<p>Best,</p> <p>The Wikipedia Library</p> <p>You can disable these emails in "
-"your user page preferences: https://wikipedialibrary.wmflabs.org/users/</p>"
+msgid "<p>Dear %(user)s,</p> <p>According to our records, your access to %(partner_name)s will soon expire and you may lose access. If you want to continue making use of your free account, you can request renewal of your account by clicking the 'Renew' or 'Extend' button at %(partner_link)s.</p> <p>Best,</p> <p>The Wikipedia Library</p> <p>You can disable these emails in your user page preferences: https://wikipedialibrary.wmflabs.org/users/</p>"
 msgstr ""
 
 #. Translators: This email is sent to users when they have an account that is soon to expire. Don't translate Jinja variables in curly braces like partner_name or partner_link; don't translate html tags either. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/user_renewal_notice-body-text.html:3
 #, python-format
-msgid ""
-"Dear %(user)s, According to our records, your access to %(partner_name)s "
-"will soon expire and you may lose access. If you want to continue making use "
-"of your free account, you can request renewal of your account by clicking "
-"the Renew button at %(partner_link)s. Best, The Wikipedia Library You can "
-"disable these emails in your user page preferences: https://wikipedialibrary."
-"wmflabs.org/users/"
-msgstr ""
-"%(user)s yang terhormat, berdasarkan catatan kami, akses anda ke "
-"%(partner_name)s akan berakhir tidak lama lagi dan Anda mungkin akan "
-"kehilangan akses. Jika anda ingin terus memanfaatkan akun gratis anda, Anda "
-"bisa meminta pembaruan akun Anda dengan mengklik tombol Perbaharui di "
-"%(partner_link)s. Salam, Perpustakaan Wikipedia Anda bisa mematikan surel "
-"ini di preferensi pengguna anda: https://wikipedialibrary.wmflabs.org/users/"
+msgid "Dear %(user)s, According to our records, your access to %(partner_name)s will soon expire and you may lose access. If you want to continue making use of your free account, you can request renewal of your account by clicking the Renew button at %(partner_link)s. Best, The Wikipedia Library You can disable these emails in your user page preferences: https://wikipedialibrary.wmflabs.org/users/"
+msgstr "%(user)s yang terhormat, berdasarkan catatan kami, akses anda ke %(partner_name)s akan berakhir tidak lama lagi dan Anda mungkin akan kehilangan akses. Jika anda ingin terus memanfaatkan akun gratis anda, Anda bisa meminta pembaruan akun Anda dengan mengklik tombol Perbaharui di %(partner_link)s. Salam, Perpustakaan Wikipedia Anda bisa mematikan surel ini di preferensi pengguna anda: https://wikipedialibrary.wmflabs.org/users/"
 
 #. Translators: This is the subject of an email sent to users when they have an account that is soon to expire. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/user_renewal_notice-subject.html:4
@@ -1407,24 +1131,13 @@ msgstr "Akses Perpustakaan Wikipedia Anda akan segera kedaluwarsa"
 #. Translators: This email is sent to users when their application is waitlisted because there are no more accounts available. Don't translate Jinja variables in curly braces like user or partner; don't translate html tags either. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/waitlist_notification-body-html.html:5
 #, python-format
-msgid ""
-"<p>Dear %(user)s,</p> <p>Thank you for applying for access to %(partner)s "
-"resources through The Wikipedia Library. There are no accounts currently "
-"available so your application has been waitlisted. Your application will be "
-"evaluated if/when more accounts become available. You can see all available "
-"resources at <a href=\"%(link)s\">%(link)s</a>.</p> <p>Best,</p> <p>The "
-"Wikipedia Library</p>"
+msgid "<p>Dear %(user)s,</p> <p>Thank you for applying for access to %(partner)s resources through The Wikipedia Library. There are no accounts currently available so your application has been waitlisted. Your application will be evaluated if/when more accounts become available. You can see all available resources at <a href=\"%(link)s\">%(link)s</a>.</p> <p>Best,</p> <p>The Wikipedia Library</p>"
 msgstr ""
 
 #. Translators: This email is sent to users when their application is waitlisted because there are no more accounts available. Don't translate Jinja variables in curly braces like user or partner. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/waitlist_notification-body-text.html:3
 #, python-format
-msgid ""
-"Dear %(user)s, Thank you for applying for access to %(partner)s resources "
-"through The Wikipedia Library. There are no accounts currently available so "
-"your application has been waitlisted. Your application will be evaluated if/"
-"when more accounts become available. You can see all available resources at: "
-"%(link)s Best, The Wikipedia Library"
+msgid "Dear %(user)s, Thank you for applying for access to %(partner)s resources through The Wikipedia Library. There are no accounts currently available so your application has been waitlisted. Your application will be evaluated if/when more accounts become available. You can see all available resources at: %(link)s Best, The Wikipedia Library"
 msgstr ""
 
 #. Translators: This is the subject of an email sent to users when their application is waitlisted because there are no more accounts available. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
@@ -1435,8 +1148,7 @@ msgstr "Permohonan Perpustakaan Wikipedia Anda telah masuk daftar tunggu"
 #. Translators: Shown to users when they successfully submit a new message using the contact us form.
 #: TWLight/emails/views.py:51
 msgid "Your message has been sent. We'll get back to you soon!"
-msgstr ""
-"Pesan Anda telah dikirim. Kami akan menghubungi Anda kembali tidak lama lagi!"
+msgstr "Pesan Anda telah dikirim. Kami akan menghubungi Anda kembali tidak lama lagi!"
 
 #. Translators: This message is shown to non-wikipedia editors who attempt to post data to the contact us form.
 #. Translators: This message is shown to non-wikipedia editors who attempt to post data to suggestion form.
@@ -1587,22 +1299,15 @@ msgstr "Tidak Tersedia"
 #: TWLight/resources/templates/resources/filter_section.html:14
 #: TWLight/templates/about.html:12
 #: TWLight/users/templates/users/filter_section.html:13
-msgid ""
-"The Wikipedia Library allows active editors to access a wide range of "
-"collections of paywalled reliable sources for free!"
-msgstr ""
-"Perpustakaan Wikipedia membolehkan para penyunting aktif mengakses banyak "
-"koleksi sumber tepercaya berbayar secara gratis!"
+msgid "The Wikipedia Library allows active editors to access a wide range of collections of paywalled reliable sources for free!"
+msgstr "Perpustakaan Wikipedia membolehkan para penyunting aktif mengakses banyak koleksi sumber tepercaya berbayar secara gratis!"
 
 #. Translators: On the Browse Partners page (https://wikipedialibrary.wmflabs.org/partners/), this introduces users to The Wikipedia Library.
 #. Translators: On the MyLibrary page (https://wikipedialibrary.wmflabs.org/users/my_library), this introduces users to The Wikipedia Library.
 #: TWLight/resources/templates/resources/filter_section.html:17
 #: TWLight/users/templates/users/filter_section.html:15
-msgid ""
-"Start with the search bar at the top or browse publisher websites directly."
-msgstr ""
-"Mulai dengan kotak pencarian di atas atau jelajahi situs web penerbit secara "
-"langsung."
+msgid "Start with the search bar at the top or browse publisher websites directly."
+msgstr "Mulai dengan kotak pencarian di atas atau jelajahi situs web penerbit secara langsung."
 
 #. Translators: On the Browse Partners page (https://wikipedialibrary.wmflabs.org/partners/), this appears below introductory text and links to the 'About' page (https://wikipedialibrary.wmflabs.org/about/)
 #. Translators: On the MyLibrary page (https://wikipedialibrary.wmflabs.org/users/my_library), this appears below introductory text and links to the 'About' page (https://wikipedialibrary.wmflabs.org/about/)
@@ -1675,52 +1380,38 @@ msgstr "Kembali ke mitra"
 #. Translators: If we have no available accounts for a partner, the coordinator can change the application system to a waiting list.
 #: TWLight/resources/templates/resources/partner_detail.html:36
 #: TWLight/resources/templates/resources/partner_detail_apply.html:17
-msgid ""
-"There are no access grants available for this partner at this time. You can "
-"still apply for access; applications will be processed when access is "
-"available."
+msgid "There are no access grants available for this partner at this time. You can still apply for access; applications will be processed when access is available."
 msgstr ""
 
 #. Translators: This text links to the minimum user requirements and terms of use on the partner page.
 #: TWLight/resources/templates/resources/partner_detail.html:48
 #: TWLight/resources/templates/resources/partner_detail_apply.html:29
 #, python-format
-msgid ""
-"Before applying, please review the <strong><a class=\"twl-links\" href="
-"\"%(about)s#req\">minimum requirements</a></strong> for access and our "
-"<strong><a class=\"twl-links\" href=\"%(terms)s\">terms of use</a></strong>."
+msgid "Before applying, please review the <strong><a class=\"twl-links\" href=\"%(about)s#req\">minimum requirements</a></strong> for access and our <strong><a class=\"twl-links\" href=\"%(terms)s\">terms of use</a></strong>."
 msgstr ""
 
 #. Translators: This text refers to the page containing the content a user is authorized to access.
 #: TWLight/resources/templates/resources/partner_detail.html:69
 #, python-format
-msgid ""
-"View the status of your access in <strong><a class=\"twl-links\" href="
-"\"%(library_url)s\">My Library</a></strong> page."
+msgid "View the status of your access in <strong><a class=\"twl-links\" href=\"%(library_url)s\">My Library</a></strong> page."
 msgstr ""
 
 #. Translators: This message is shown when a user has open applications, linking to their respective applications page.
 #: TWLight/resources/templates/resources/partner_detail.html:78
 #, python-format
-msgid ""
-"View the status of your application(s) on your <strong><a class=\"twl-links"
-"\" href=\"%(applications_url)s\">My Applications</a></strong> page."
+msgid "View the status of your application(s) on your <strong><a class=\"twl-links\" href=\"%(applications_url)s\">My Applications</a></strong> page."
 msgstr ""
 
 #. Translators: This message is shown when a user has authorizations, linking to their respective collections page.
 #: TWLight/resources/templates/resources/partner_detail_apply.html:50
 #, python-format
-msgid ""
-"View the status of your access on your <strong><a href=\"%(library_url)s\" "
-"class=\"twl-links\">My Library</a></strong> page."
+msgid "View the status of your access on your <strong><a href=\"%(library_url)s\" class=\"twl-links\">My Library</a></strong> page."
 msgstr ""
 
 #. Translators: This message is shown when a user has open applications, linking to their respective applications page.
 #: TWLight/resources/templates/resources/partner_detail_apply.html:60
 #, python-format
-msgid ""
-"View the status of your application(s) on your <strong><a href="
-"\"%(applications_url)s\">My Applications</a></strong> page."
+msgid "View the status of your application(s) on your <strong><a href=\"%(applications_url)s\">My Applications</a></strong> page."
 msgstr ""
 
 #. Translators: One the partner detail page, this text labels the button which coordinators can click to remove a partner from waitlisted status.
@@ -1750,14 +1441,8 @@ msgstr "Halaman Istimewa:Surel_pengguna (Special:EmailUser)"
 
 #. Translators: If no account coordinator is assigned to a partner, the Wikipedia Library team will coordinate signups. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/resources/templates/resources/partner_detail_apply.html:112
-msgid ""
-"The Wikipedia Library team will process this application. Want to help? <a "
-"class=\"twl-links\" href=\"https://en.wikipedia.org/wiki/Wikipedia:"
-"The_Wikipedia_Library/Coordinators/Signup\">Sign up as a coordinator.</a>"
-msgstr ""
-"Tim Perpustakaan Wikipedia akan memproses permohonan ini. Ingin membantu? <a "
-"href=\"https://en.wikipedia.org/wiki/Wikipedia:The_Wikipedia_Library/"
-"Coordinators/Signup\" class=\"twl-links\">Daftar menjadi koordinator</a>."
+msgid "The Wikipedia Library team will process this application. Want to help? <a class=\"twl-links\" href=\"https://en.wikipedia.org/wiki/Wikipedia:The_Wikipedia_Library/Coordinators/Signup\">Sign up as a coordinator.</a>"
+msgstr "Tim Perpustakaan Wikipedia akan memproses permohonan ini. Ingin membantu? <a href=\"https://en.wikipedia.org/wiki/Wikipedia:The_Wikipedia_Library/Coordinators/Signup\" class=\"twl-links\">Daftar menjadi koordinator</a>."
 
 #. Translators: This text labels a button coordinators can click to view a list of users who have applied for access for a particular partner
 #: TWLight/resources/templates/resources/partner_detail_apply.html:121
@@ -1786,24 +1471,14 @@ msgstr "Akses bundel perpustakaan"
 
 #. Translators: Text shown to authenticated, bundle eligible users when they visit a Bundle partner page.
 #: TWLight/resources/templates/resources/partner_detail_apply.html:138
-msgid ""
-"You are eligible to access Library Bundle partners. Click the button above "
-"to access the collection."
-msgstr ""
-"Anda memenuhi syarat untuk mengakses mitra Bundel Perpustakaan. Tekan tombol "
-"di atas untuk mengakses koleksinya."
+msgid "You are eligible to access Library Bundle partners. Click the button above to access the collection."
+msgstr "Anda memenuhi syarat untuk mengakses mitra Bundel Perpustakaan. Tekan tombol di atas untuk mengakses koleksinya."
 
 #. Translators: Text shown to authenticated, bundle ineligible users when they visit a Bundle partner page.
 #: TWLight/resources/templates/resources/partner_detail_apply.html:152
 #, python-format
-msgid ""
-"You are not eligible to access Library Bundle partners. Visit the <a class="
-"\"twl-links\" href=\"%(homepage)s\">homepage</a> to check the eligibility "
-"criteria."
-msgstr ""
-"Anda tidak memenuhi syarat untuk mengakses mitra Bundel Perpustakaan. "
-"Kunjungi <a class=\"twl-links\" href=\"%(homepage)s\">halaman rumah</a> "
-"untuk melihat syarat-syaratnya."
+msgid "You are not eligible to access Library Bundle partners. Visit the <a class=\"twl-links\" href=\"%(homepage)s\">homepage</a> to check the eligibility criteria."
+msgstr "Anda tidak memenuhi syarat untuk mengakses mitra Bundel Perpustakaan. Kunjungi <a class=\"twl-links\" href=\"%(homepage)s\">halaman rumah</a> untuk melihat syarat-syaratnya."
 
 #. Translators: Buttton prompting users to log in.
 #: TWLight/resources/templates/resources/partner_detail_apply.html:160
@@ -1814,15 +1489,8 @@ msgstr "Masuk log"
 #. Translators: Text shown to unauthenticated users when they visit a Bundle partner page.
 #: TWLight/resources/templates/resources/partner_detail_apply.html:168
 #, python-format
-msgid ""
-"This resource is part of our <a class=\"twl-links\" href=\"%(about)s"
-"\">Library Bundle</a>, which you can access if you meet our minimum "
-"eligibility criteria. Log in to find out if you are eligible."
-msgstr ""
-"Sumber daya ini merupakan bagian dari <a class=\"twl-links\" href=\"%(about)s"
-"\">Bundel Perpustakaan</a> kami, yang bisa Anda akses apabila memenuhi "
-"persyaratan minimum kami. Masuk log untuk mengetahui apakah Anda memenuhi "
-"syarat."
+msgid "This resource is part of our <a class=\"twl-links\" href=\"%(about)s\">Library Bundle</a>, which you can access if you meet our minimum eligibility criteria. Log in to find out if you are eligible."
+msgstr "Sumber daya ini merupakan bagian dari <a class=\"twl-links\" href=\"%(about)s\">Bundel Perpustakaan</a> kami, yang bisa Anda akses apabila memenuhi persyaratan minimum kami. Masuk log untuk mengetahui apakah Anda memenuhi syarat."
 
 #. Translators: This is the label for a number which shows the total active accounts for one partner. (e.g. https://wikipedialibrary.wmflabs.org/partners/8/).
 #: TWLight/resources/templates/resources/partner_detail_stats.html:21
@@ -1872,26 +1540,19 @@ msgstr ""
 #. Translators: If a partner has specified the excerpt limit both in words and percentage, this message will display the percentage of words and the number of words on the partner page.
 #: TWLight/resources/templates/resources/partner_detail_timeline.html:99
 #, python-format
-msgid ""
-"%(object)s allows a maximum of %(excerpt_limit)s words or "
-"%(excerpt_limit_percentage)s%% of an article be excerpted into a Wikipedia "
-"article."
+msgid "%(object)s allows a maximum of %(excerpt_limit)s words or %(excerpt_limit_percentage)s%% of an article be excerpted into a Wikipedia article."
 msgstr ""
 
 #. Translators: If a partner has specified the excerpt limit in words, this message will display the number of words on the partner page.
 #: TWLight/resources/templates/resources/partner_detail_timeline.html:106
 #, python-format
-msgid ""
-"%(object)s allows a maximum of %(excerpt_limit)s words be excerpted into a "
-"Wikipedia article."
+msgid "%(object)s allows a maximum of %(excerpt_limit)s words be excerpted into a Wikipedia article."
 msgstr ""
 
 #. Translators: If a partner has specified the excerpt limit in percentage, this message will display the percentage of words on the partner page.
 #: TWLight/resources/templates/resources/partner_detail_timeline.html:113
 #, python-format
-msgid ""
-"%(object)s allows a maximum of %(excerpt_limit_percentage)s%% of an article "
-"be excerpted into a Wikipedia article."
+msgid "%(object)s allows a maximum of %(excerpt_limit_percentage)s%% of an article be excerpted into a Wikipedia article."
 msgstr ""
 
 #. Translators: If a partner has other requirements for access, this text shows as the title for that information field. (e.g. https://wikipedialibrary.wmflabs.org/partners/10/).
@@ -1902,12 +1563,8 @@ msgstr "Persyaratan khusus untuk pemohon"
 #. Translators: If a user must agree to a Terms of Use document, they see this message, and must enter the name of the resource. Don't translate publisher or url.
 #: TWLight/resources/templates/resources/partner_detail_timeline.html:140
 #, python-format
-msgid ""
-"%(publisher)s requires that you agree with its <a href=\"%(url)s\">terms of "
-"use</a>."
-msgstr ""
-"%(publisher)s mewajibkan Anda menyetujui <a href=\"%(url)s\">ketentuan "
-"penggunaan</a> mereka."
+msgid "%(publisher)s requires that you agree with its <a href=\"%(url)s\">terms of use</a>."
+msgstr "%(publisher)s mewajibkan Anda menyetujui <a href=\"%(url)s\">ketentuan penggunaan</a> mereka."
 
 #. Translators: If a user must provide their real name to apply to a partner, they see this message, and must enter the name of the resource. Don't translate publisher.
 #: TWLight/resources/templates/resources/partner_detail_timeline.html:150
@@ -1930,18 +1587,13 @@ msgstr "%(publisher)s mewajibkan Anda memberitahukan afiliasi lembaga Anda."
 #. Translators: If a user must select a specific resource to apply for, they see this message, and must enter the name of the resource. Don't translate publisher.
 #: TWLight/resources/templates/resources/partner_detail_timeline.html:177
 #, python-format
-msgid ""
-"%(publisher)s requires that you specify a particular title that you want to "
-"access."
-msgstr ""
-"%(publisher)s mewajibkan Anda menyebutkan judul tertentu yang Anda mau akses."
+msgid "%(publisher)s requires that you specify a particular title that you want to access."
+msgstr "%(publisher)s mewajibkan Anda menyebutkan judul tertentu yang Anda mau akses."
 
 #. Translators: If a user must register on the partner website before applying, they see this message. Don't translate partner.
 #: TWLight/resources/templates/resources/partner_detail_timeline.html:187
 #, python-format
-msgid ""
-"%(publisher)s requires that you sign up for an account before applying for "
-"access."
+msgid "%(publisher)s requires that you sign up for an account before applying for access."
 msgstr "%(publisher)s mewajibkan Anda untuk mendaftar sebelum meminta akses."
 
 #. Translators: If a partner has their location listed, this message is a label for that location
@@ -2068,12 +1720,8 @@ msgstr "Apakah Anda yakin ingin menghapus <b>%(object)s</b>?"
 
 #. Translators: If multiple authorizations where returned for a collection, this message is shown to a user
 #: TWLight/resources/views.py:268
-msgid ""
-"Multiple authorizations were returned – something's wrong. Please contact us "
-"and don't forget to mention this message."
-msgstr ""
-"Beberapa otorisasi dikembalikan - ada yang salah. Silakan hubungi kami dan "
-"jangan lupa untuk menyebutkan pesan ini."
+msgid "Multiple authorizations were returned – something's wrong. Please contact us and don't forget to mention this message."
+msgstr "Beberapa otorisasi dikembalikan - ada yang salah. Silakan hubungi kami dan jangan lupa untuk menyebutkan pesan ini."
 
 #. Translators: This message is shown when user tries to access a NOT_AVAILABLE Partner
 #: TWLight/resources/views.py:316
@@ -2113,23 +1761,8 @@ msgstr "Maaf; kami tidak tahu cara melakukan itu."
 #. Translators: Shown on the website's 400 page, when a user sends a bad request. Don't translate path or Phabricator.
 #: TWLight/templates/400.html:20
 #, python-format
-msgid ""
-"If you think we should know what to do with that, please email us about this "
-"error at <a class=\"twl-links\" href=\"mailto:wikipedialibrary@wikimedia.org?"
-"Subject=Wikipedia%%20Library%%20%(path)s%%20Permission%%20denied"
-"\">wikipedialibrary@wikimedia.org</a> or report it to us on <a class=\"twl-"
-"links\" href=\"https://phabricator.wikimedia.org/maniphest/task/edit/form/1/?"
-"projectPHIDs=Library-Card-Platform&title=Wikipedia%%20Library%%20%(path)s"
-"%%20Bad%%20Request\">Phabricator</a>"
-msgstr ""
-"Jika Anda rasa kami seharusnya tahu apa yang harus dikerjakan dengan "
-"permintaan itu, kirimkan surel kepada kami tentang galat ini di <a class="
-"\"twl-links\" href=\"mailto:wikipedialibrary@wikimedia.org?Subject=Wikipedia"
-"%%20Library%%20%(path)s%%20Permission%%20denied\">wikipedialibrary@wikimedia."
-"org</a> atau laporkan kepada kami di <a class=\"twl-links\" href=\"https://"
-"phabricator.wikimedia.org/maniphest/task/edit/form/1/?projectPHIDs=Library-"
-"Card-Platform&title=Wikipedia%%20Library%%20%(path)s%%20Bad%%20Request"
-"\">Phabricator</a>"
+msgid "If you think we should know what to do with that, please email us about this error at <a class=\"twl-links\" href=\"mailto:wikipedialibrary@wikimedia.org?Subject=Wikipedia%%20Library%%20%(path)s%%20Permission%%20denied\">wikipedialibrary@wikimedia.org</a> or report it to us on <a class=\"twl-links\" href=\"https://phabricator.wikimedia.org/maniphest/task/edit/form/1/?projectPHIDs=Library-Card-Platform&title=Wikipedia%%20Library%%20%(path)s%%20Bad%%20Request\">Phabricator</a>"
+msgstr "Jika Anda rasa kami seharusnya tahu apa yang harus dikerjakan dengan permintaan itu, kirimkan surel kepada kami tentang galat ini di <a class=\"twl-links\" href=\"mailto:wikipedialibrary@wikimedia.org?Subject=Wikipedia%%20Library%%20%(path)s%%20Permission%%20denied\">wikipedialibrary@wikimedia.org</a> atau laporkan kepada kami di <a class=\"twl-links\" href=\"https://phabricator.wikimedia.org/maniphest/task/edit/form/1/?projectPHIDs=Library-Card-Platform&title=Wikipedia%%20Library%%20%(path)s%%20Bad%%20Request\">Phabricator</a>"
 
 #. Translators: Alt text for an image shown on the 400 error page.
 #. Translators: Alt text for an image shown on the 403 error page.
@@ -2150,24 +1783,8 @@ msgstr "Maaf; Anda tidak boleh melakukan itu."
 #. Translators: Shown on the website's 403 page, when a user attempts to navigate to a page they don't have permission to view. Don't translate path or Phabricator.
 #: TWLight/templates/403.html:20
 #, python-format
-msgid ""
-"If you think your account should be able to do that, please email us about "
-"this error at <a class=\"twl-links\" href=\"mailto:"
-"wikipedialibrary@wikimedia.org?Subject=Wikipedia%%20Library%%20%(path)s"
-"%%20Permission%%20denied\">wikipedialibrary@wikimedia.org</a> or report it "
-"to us on <a class=\"twl-links\" href=\"https://phabricator.wikimedia.org/"
-"maniphest/task/edit/form/1/?projectPHIDs=Library-Card-"
-"Platform&title=Wikipedia%%20Library%%20%(path)s%%20Permission%%20denied"
-"\">Phabricator</a>"
-msgstr ""
-"Jika Anda rasa akun Anda seharusnya bisa melakukan itu, kirimkan surel "
-"kepada kami tentang galat ini di <a class=\"twl-links\" href=\"mailto:"
-"wikipedialibrary@wikimedia.org?Subject=Wikipedia%%20Library%%20%(path)s"
-"%%20Permission%%20denied\">wikipedialibrary@wikimedia.org</a> atau laporkan "
-"kepada kami di <a class=\"twl-links\" href=\"https://phabricator.wikimedia."
-"org/maniphest/task/edit/form/1/?projectPHIDs=Library-Card-"
-"Platform&title=Wikipedia%%20Library%%20%(path)s%%20Permission%%20denied"
-"\">Phabricator</a>"
+msgid "If you think your account should be able to do that, please email us about this error at <a class=\"twl-links\" href=\"mailto:wikipedialibrary@wikimedia.org?Subject=Wikipedia%%20Library%%20%(path)s%%20Permission%%20denied\">wikipedialibrary@wikimedia.org</a> or report it to us on <a class=\"twl-links\" href=\"https://phabricator.wikimedia.org/maniphest/task/edit/form/1/?projectPHIDs=Library-Card-Platform&title=Wikipedia%%20Library%%20%(path)s%%20Permission%%20denied\">Phabricator</a>"
+msgstr "Jika Anda rasa akun Anda seharusnya bisa melakukan itu, kirimkan surel kepada kami tentang galat ini di <a class=\"twl-links\" href=\"mailto:wikipedialibrary@wikimedia.org?Subject=Wikipedia%%20Library%%20%(path)s%%20Permission%%20denied\">wikipedialibrary@wikimedia.org</a> atau laporkan kepada kami di <a class=\"twl-links\" href=\"https://phabricator.wikimedia.org/maniphest/task/edit/form/1/?projectPHIDs=Library-Card-Platform&title=Wikipedia%%20Library%%20%(path)s%%20Permission%%20denied\">Phabricator</a>"
 
 #. Translators: Shown on the website's 404 page, when a user attempts to navigate to a page that doesn't exist.
 #: TWLight/templates/404.html:11
@@ -2182,23 +1799,8 @@ msgstr "Maaf; kami tidak dapat menemukannya"
 #. Translators: Shown on the website's 404 page, when a user attempts to navigate to a page that doesn't exist. Don't translate path or Phabricator.
 #: TWLight/templates/404.html:19
 #, python-format
-msgid ""
-"If you are certain that something should be here, please email us about this "
-"error at <a class=\"twl-links\" href=\"mailto:wikipedialibrary@wikimedia.org?"
-"Subject=Wikipedia%%20Library%%20%(path)s%%20Not%%20found\"> "
-"wikipedialibrary@wikimedia.org</a> or report it to us on <a class=\"twl-links"
-"\" href=\"https://phabricator.wikimedia.org/maniphest/task/edit/form/1/?"
-"projectPHIDs=Library-Card-Platform&title=Wikipedia%%20Library%%20%(path)s"
-"%%20Not%%20found\">Phabricator</a>"
-msgstr ""
-"Jika Anda yakin sesuatu seharusnya ada di sini, kirimkan surel kepada kami "
-"tentang galat ini di <a class=\"twl-links\" href=\"mailto:"
-"wikipedialibrary@wikimedia.org?Subject=Wikipedia%%20Library%%20%(path)s"
-"%%20Not%%20found\"> wikipedialibrary@wikimedia.org</a> atau laporkan kepada "
-"kami di <a class=\"twl-links\" href=\"https://phabricator.wikimedia.org/"
-"maniphest/task/edit/form/1/?projectPHIDs=Library-Card-"
-"Platform&title=Wikipedia%%20Library%%20%(path)s%%20Not%%20found"
-"\">Phabricator</a>"
+msgid "If you are certain that something should be here, please email us about this error at <a class=\"twl-links\" href=\"mailto:wikipedialibrary@wikimedia.org?Subject=Wikipedia%%20Library%%20%(path)s%%20Not%%20found\"> wikipedialibrary@wikimedia.org</a> or report it to us on <a class=\"twl-links\" href=\"https://phabricator.wikimedia.org/maniphest/task/edit/form/1/?projectPHIDs=Library-Card-Platform&title=Wikipedia%%20Library%%20%(path)s%%20Not%%20found\">Phabricator</a>"
+msgstr "Jika Anda yakin sesuatu seharusnya ada di sini, kirimkan surel kepada kami tentang galat ini di <a class=\"twl-links\" href=\"mailto:wikipedialibrary@wikimedia.org?Subject=Wikipedia%%20Library%%20%(path)s%%20Not%%20found\"> wikipedialibrary@wikimedia.org</a> atau laporkan kepada kami di <a class=\"twl-links\" href=\"https://phabricator.wikimedia.org/maniphest/task/edit/form/1/?projectPHIDs=Library-Card-Platform&title=Wikipedia%%20Library%%20%(path)s%%20Not%%20found\">Phabricator</a>"
 
 #. Translators: Alt text for an image shown on the 404 error page.
 #: TWLight/templates/404.html:32
@@ -2212,35 +1814,18 @@ msgstr "Tentang Perpustakaan Wikipedia"
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:20
-msgid ""
-"This platform is our central tool for facilitating access to our available "
-"collections. Here you can see which partnerships are available, search their "
-"contents, and apply for and access the ones you’re interested in."
-msgstr ""
-"Platform ini adalah alat inti kami untuk memfasilitasi akses kepada koleksi "
-"yang kami miliki. Di sini, Anda bisa melihat kemitraan mana yang tersedia, "
-"mencari konten mereka, dan memohon akses kepada mitra yang Anda minati."
+msgid "This platform is our central tool for facilitating access to our available collections. Here you can see which partnerships are available, search their contents, and apply for and access the ones you’re interested in."
+msgstr "Platform ini adalah alat inti kami untuk memfasilitasi akses kepada koleksi yang kami miliki. Di sini, Anda bisa melihat kemitraan mana yang tersedia, mencari konten mereka, dan memohon akses kepada mitra yang Anda minati."
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/). Wikimedia Foundation should not be translated.
 #: TWLight/templates/about.html:29
-msgid ""
-"All users receive immediate access to some collections, which can be browsed "
-"by clicking the 'Access collection' buttons or using the search bar at the "
-"top of the page. Other collections require an application before access is "
-"granted, and may be accessed directly or via an individual login or access "
-"code. Volunteer coordinators, who have signed non-disclosure agreements with "
-"the Wikimedia Foundation, review these applications and work with publishers "
-"to get you your free access."
+msgid "All users receive immediate access to some collections, which can be browsed by clicking the 'Access collection' buttons or using the search bar at the top of the page. Other collections require an application before access is granted, and may be accessed directly or via an individual login or access code. Volunteer coordinators, who have signed non-disclosure agreements with the Wikimedia Foundation, review these applications and work with publishers to get you your free access."
 msgstr ""
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/). Don't translate terms_url.
 #: TWLight/templates/about.html:43
 #, python-format
-msgid ""
-"For more information about how your information is stored and reviewed "
-"please see our <a class=\"twl-links\" href=\"%(terms_url)s\"> terms of use "
-"and privacy policy</a>. Accounts you apply for are also subject to the Terms "
-"of Use provided by each partner’s platform; please review them."
+msgid "For more information about how your information is stored and reviewed please see our <a class=\"twl-links\" href=\"%(terms_url)s\"> terms of use and privacy policy</a>. Accounts you apply for are also subject to the Terms of Use provided by each partner’s platform; please review them."
 msgstr ""
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
@@ -2250,12 +1835,7 @@ msgstr "Siapa yang bisa mendapatkan akses?"
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/). Wikimedia Foundation should not be translated.
 #: TWLight/templates/about.html:55
-msgid ""
-"Any active editor in good standing can receive access. For publishers with "
-"limited numbers of accounts, applications are reviewed based on the editor’s "
-"needs and contributions. If you think you could use access to one of our "
-"partner resources and are an active editor in any project supported by the "
-"Wikimedia Foundation, please apply."
+msgid "Any active editor in good standing can receive access. For publishers with limited numbers of accounts, applications are reviewed based on the editor’s needs and contributions. If you think you could use access to one of our partner resources and are an active editor in any project supported by the Wikimedia Foundation, please apply."
 msgstr ""
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
@@ -2276,9 +1856,7 @@ msgstr "Anda telah membuat minimal 500 suntingan di proyek-proyek Wikimedia;"
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:79
 msgid "You have made at least 10 edits to Wikimedia projects in the last month"
-msgstr ""
-"Anda telah membuat setidaknya 10 suntingan di proyek-proyek Wikimedia dalam "
-"sebulan terakhir;"
+msgstr "Anda telah membuat setidaknya 10 suntingan di proyek-proyek Wikimedia dalam sebulan terakhir;"
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:83
@@ -2287,23 +1865,12 @@ msgstr "Anda saat ini tidak sedang diblokir untuk menyunting proyek Wikimedia."
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/)
 #: TWLight/templates/about.html:89
-msgid ""
-"If you are applying for an available collection, please first check that you "
-"don't already have access through another library or institution. If you do, "
-"please consider using that access rather than taking up a seat for this "
-"resource in The Wikipedia Library."
+msgid "If you are applying for an available collection, please first check that you don't already have access through another library or institution. If you do, please consider using that access rather than taking up a seat for this resource in The Wikipedia Library."
 msgstr ""
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/)
 #: TWLight/templates/about.html:99
-msgid ""
-"If your account is blocked on one or more Wikimedia projects, you may still "
-"be granted access to The Wikipedia Library. You will need to contact the "
-"Wikipedia Library team, who will review your blocks. If you have been "
-"blocked for content issues, most notably copyright violations, or have "
-"multiple long-term blocks, we may decline your request. Additionally, if "
-"your block status changes after being approved, you will need to request "
-"another review."
+msgid "If your account is blocked on one or more Wikimedia projects, you may still be granted access to The Wikipedia Library. You will need to contact the Wikipedia Library team, who will review your blocks. If you have been blocked for content issues, most notably copyright violations, or have multiple long-term blocks, we may decline your request. Additionally, if your block status changes after being approved, you will need to request another review."
 msgstr ""
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
@@ -2314,8 +1881,7 @@ msgstr "Apa yang dapat saya lakukan setelah mendapat akses?"
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:114
 msgid "Approved editors <i>may</i> use their access to:"
-msgstr ""
-"Penyunting yang disetujui <i>mungkin</i> menggunakan akses mereka untuk:"
+msgstr "Penyunting yang disetujui <i>mungkin</i> menggunakan akses mereka untuk:"
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:118
@@ -2339,9 +1905,7 @@ msgstr "Penyunting yang disetujui <i>dilarang</i>:"
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:136
-msgid ""
-"Share their account logins or passwords with others, or sell their access to "
-"other parties"
+msgid "Share their account logins or passwords with others, or sell their access to other parties"
 msgstr ""
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
@@ -2351,23 +1915,17 @@ msgstr ""
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:144
-msgid ""
-"Systematically make printed or electronic copies of multiple extracts of "
-"restricted content available for any purpose"
+msgid "Systematically make printed or electronic copies of multiple extracts of restricted content available for any purpose"
 msgstr ""
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/). Stub is a technical term for a short Wikipedia article, use the appropriate Wikipedia term in your language.
 #: TWLight/templates/about.html:148
-msgid ""
-"Datamine metadata without permission, in order, for instance, to use "
-"metadata for auto-created stub articles"
+msgid "Datamine metadata without permission, in order, for instance, to use metadata for auto-created stub articles"
 msgstr ""
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:154
-msgid ""
-"Respecting these agreements allows us to continue growing the partnerships "
-"available to the community."
+msgid "Respecting these agreements allows us to continue growing the partnerships available to the community."
 msgstr ""
 
 #. Translators: This is the heading for a section on the About page (https://wikipedialibrary.wmflabs.org/about/).
@@ -2377,41 +1935,22 @@ msgstr "EZProxy"
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:164
-msgid ""
-"EZProxy is a proxy server used to authenticate users for many Wikipedia "
-"Library partners. Users sign into EZProxy via the Library Card platform to "
-"verify that they are authorized users, and then the server accesses "
-"requested resources using its own IP address."
+msgid "EZProxy is a proxy server used to authenticate users for many Wikipedia Library partners. Users sign into EZProxy via the Library Card platform to verify that they are authorized users, and then the server accesses requested resources using its own IP address."
 msgstr ""
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:173
-msgid ""
-"You may notice that when accessing resources via EZProxy that URLs are "
-"dynamically rewritten. This is why we recommend logging in via the Library "
-"Card platform rather than going directly to the unproxied partner website. "
-"When in doubt, check the URL for ‘idm.oclc’. If it’s there, then you’re "
-"connected via EZProxy."
+msgid "You may notice that when accessing resources via EZProxy that URLs are dynamically rewritten. This is why we recommend logging in via the Library Card platform rather than going directly to the unproxied partner website. When in doubt, check the URL for ‘idm.oclc’. If it’s there, then you’re connected via EZProxy."
 msgstr ""
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:182
-msgid ""
-"Typically once you’ve logged in your session will remain active in your "
-"browser for up to two hours after you’ve finished searching. Note that use "
-"of EZProxy requires you to enable cookies. If you are having problems you "
-"should also try clearing your cache and restarting your browser."
+msgid "Typically once you’ve logged in your session will remain active in your browser for up to two hours after you’ve finished searching. Note that use of EZProxy requires you to enable cookies. If you are having problems you should also try clearing your cache and restarting your browser."
 msgstr ""
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/)
 #: TWLight/templates/about.html:193
-msgid ""
-"The Library Bundle is a collection of resources for which no application is "
-"required. If you meet the criteria laid out above, you will be authorized "
-"for access automatically upon logging in to the platform. Only some of our "
-"content is currently included in the Library Bundle, however we hope to "
-"expand the collection as more publishers become comfortable with "
-"participating. All Bundle content is accessed via EZProxy."
+msgid "The Library Bundle is a collection of resources for which no application is required. If you meet the criteria laid out above, you will be authorized for access automatically upon logging in to the platform. Only some of our content is currently included in the Library Bundle, however we hope to expand the collection as more publishers become comfortable with participating. All Bundle content is accessed via EZProxy."
 msgstr ""
 
 #. Translators: This is the heading for a section on the About page (https://wikipedialibrary.wmflabs.org/about/).
@@ -2421,12 +1960,7 @@ msgstr "Praktek kutipan"
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:206
-msgid ""
-"Citation practices vary by project and even by article. Generally, we "
-"support editors citing where they found information, in a form that allows "
-"others to check it for themselves. That often means providing both original "
-"source details as well as a link to the partner database in which the source "
-"was found."
+msgid "Citation practices vary by project and even by article. Generally, we support editors citing where they found information, in a form that allows others to check it for themselves. That often means providing both original source details as well as a link to the partner database in which the source was found."
 msgstr ""
 
 #. Translators: This is the heading for a section on the About page (https://wikipedialibrary.wmflabs.org/about/).
@@ -2438,13 +1972,8 @@ msgstr "Hubungi kami"
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:218
 #, python-format
-msgid ""
-"If you have questions, need help, or want to volunteer to help, please see "
-"our <a class=\"twl-links\" href=\"%(contact_url)s\">contact page</a>."
-msgstr ""
-"Jika Anda memiliki pertanyaan, membutuhkan bantuan, atau ingin menjadi "
-"sukarelawan untuk membantu, silakan lihat <a class=\"twl-links\" href="
-"\"%(contact_url)s\">halaman kontak</a> kami."
+msgid "If you have questions, need help, or want to volunteer to help, please see our <a class=\"twl-links\" href=\"%(contact_url)s\">contact page</a>."
+msgstr "Jika Anda memiliki pertanyaan, membutuhkan bantuan, atau ingin menjadi sukarelawan untuk membantu, silakan lihat <a class=\"twl-links\" href=\"%(contact_url)s\">halaman kontak</a> kami."
 
 #. Translators: This is the title of the panel box detailing the contact information for the Wikipedia Library team.
 #: TWLight/templates/contact.html:14
@@ -2483,12 +2012,8 @@ msgstr "Halaman Twitter Perpustakaan Wikipedia"
 #. Translators: This is the text that appears at the bottom of the contact us form directing users to the suggestions form.
 #: TWLight/templates/contact.html:48
 #, python-format
-msgid ""
-"(If you would like to suggest a partner, <a class=\"twl-links\" href="
-"\"%(suggest)s\"><strong>go here</strong></a>.)"
-msgstr ""
-"(Jika Anda ingin mengusulkan mitra, <a href=\"%(suggest)s\" class=\"twl-links"
-"\"><strong>pergi ke sini</strong></a>.)"
+msgid "(If you would like to suggest a partner, <a class=\"twl-links\" href=\"%(suggest)s\"><strong>go here</strong></a>.)"
+msgstr "(Jika Anda ingin mengusulkan mitra, <a href=\"%(suggest)s\" class=\"twl-links\"><strong>pergi ke sini</strong></a>.)"
 
 #. Translators: On a special 'link to search' page, this message is shown if JavaScript is disabled.
 #: TWLight/templates/eds_search_endpoint.html:7
@@ -2544,13 +2069,8 @@ msgstr "Perpustakaan Wikipedia"
 #. Translators: Information about The Wikipedia Library.
 #: TWLight/templates/login_partial.html:53 TWLight/templates/new_base.html:21
 #, python-format
-msgid ""
-"More than 100 of the world's top subscription-only databases, with content "
-"in %(no_of_languages)s languages, free for Wikipedians of all backgrounds"
-msgstr ""
-"Lebih dari 100 pangkalan data terkemuka di dunia yang hanya bisa diakses "
-"dengan berlangganan, dengan konten dalam %(no_of_languages)s bahasa, gratis "
-"untuk Wikipediawan dari semua latar belakang"
+msgid "More than 100 of the world's top subscription-only databases, with content in %(no_of_languages)s languages, free for Wikipedians of all backgrounds"
+msgstr "Lebih dari 100 pangkalan data terkemuka di dunia yang hanya bisa diakses dengan berlangganan, dengan konten dalam %(no_of_languages)s bahasa, gratis untuk Wikipediawan dari semua latar belakang"
 
 #. Translators: Information about The Wikipedia Library.
 #: TWLight/templates/login_partial.html:64
@@ -2558,12 +2078,8 @@ msgid "Meet these criteria for automatic access"
 msgstr "Penuhi kriteria berikut untuk akses otomatis"
 
 #: TWLight/templates/login_partial.html:69
-msgid ""
-"These criteria grant you access to certain collections but not all. Some "
-"collections are accessible on a per application basis only."
-msgstr ""
-"Kriteria berikut ini memberi Anda akses ke koleksi tertentu, tetapi tidak "
-"semua. Beberapa koleksi hanya dapat diakses berdasarkan permohonan saja."
+msgid "These criteria grant you access to certain collections but not all. Some collections are accessible on a per application basis only."
+msgstr "Kriteria berikut ini memberi Anda akses ke koleksi tertentu, tetapi tidak semua. Beberapa koleksi hanya dapat diakses berdasarkan permohonan saja."
 
 #: TWLight/templates/login_partial.html:89
 msgid "Login via Wikipedia"
@@ -2572,29 +2088,19 @@ msgstr "Masuk log dengan Wikipedia"
 #. Translators: Shown if the current user doesn't have a registered email on their account. Don't translate contact_us_url or email_url.
 #: TWLight/templates/message_partial.html:15
 #, python-format
-msgid ""
-"You don't have an email on file. We can't finalize your access to partner "
-"resources, and you won't be able to <a class=\"twl-links\" href="
-"\"%(contact_us_url)s\">contact us</a> without an email. Please <a class="
-"\"twl-links\" href=\"%(email_url)s\">update your email</a>."
+msgid "You don't have an email on file. We can't finalize your access to partner resources, and you won't be able to <a class=\"twl-links\" href=\"%(contact_us_url)s\">contact us</a> without an email. Please <a class=\"twl-links\" href=\"%(email_url)s\">update your email</a>."
 msgstr ""
 
 #. Translators: Shown if the current user has requested the processing of their data should be restricted.
 #: TWLight/templates/message_partial.html:26
 #, python-format
-msgid ""
-"You have requested a restriction on the processing of your data. Most site "
-"functionality will not be available to you until you <a class=\"twl-links\" "
-"href=\"%(restrict_url)s\">lift this restriction</a>."
+msgid "You have requested a restriction on the processing of your data. Most site functionality will not be available to you until you <a class=\"twl-links\" href=\"%(restrict_url)s\">lift this restriction</a>."
 msgstr ""
 
 #. Translators: Shown if the current user has not agreed to the terms of use.
 #: TWLight/templates/message_partial.html:37
 #, python-format
-msgid ""
-"You have not agreed to the <a class=\"twl-links\" href=\"%(terms_url)s"
-"\">terms of use</a> of this site. Your applications will not be processed "
-"and you won't be able to apply or access resources you are approved for."
+msgid "You have not agreed to the <a class=\"twl-links\" href=\"%(terms_url)s\">terms of use</a> of this site. Your applications will not be processed and you won't be able to apply or access resources you are approved for."
 msgstr ""
 
 #. Translators: This link is at the bottom of every page and links to the 'About' page (https://wikipedialibrary.wmflabs.org/about/)
@@ -2641,9 +2147,7 @@ msgstr "Setel ulang kata sandi"
 
 #. Translators: If a user goes to reset their password, this message asks them to enter their email to do so.
 #: TWLight/templates/registration/password_reset_form.html:13
-msgid ""
-"Forgot your password? Enter your email address below, and we'll email "
-"instructions for setting a new one."
+msgid "Forgot your password? Enter your email address below, and we'll email instructions for setting a new one."
 msgstr ""
 
 #. Translators: This is the label for a button that users click to update their public information.
@@ -2688,23 +2192,13 @@ msgstr "Saya setuju dengan ketentuan pemakaian"
 
 #. Translators: This text explains how to disagree to the site's terms of use and the restrictions that will come into effect when users disagree to the terms of use.
 #: TWLight/users/forms.py:185
-msgid ""
-"By unchecking this box and clicking “Update” you may explore the site, but "
-"you will not be able to apply for access to materials or evaluate "
-"applications unless you agree with the terms of use."
-msgstr ""
-"Dengan menghapus centang pada kotak ini dan mengeklik “Perbarui” Anda dapat "
-"menjelajahi situs ini, namun Anda tidak akan dapat mengajukan permohonan "
-"akses ke materi atau mengevaluasi permohonan kecuali Anda menyetujui "
-"ketentuan penggunaan."
+msgid "By unchecking this box and clicking “Update” you may explore the site, but you will not be able to apply for access to materials or evaluate applications unless you agree with the terms of use."
+msgstr "Dengan menghapus centang pada kotak ini dan mengeklik “Perbarui” Anda dapat menjelajahi situs ini, namun Anda tidak akan dapat mengajukan permohonan akses ke materi atau mengevaluasi permohonan kecuali Anda menyetujui ketentuan penggunaan."
 
 #. Translators: Users click this button to set their website email address to the one linked to their Wikipedia account.
 #: TWLight/users/forms.py:211
-msgid ""
-"Use my Wikipedia email address (will be updated the next time you login)."
-msgstr ""
-"Gunakan alamat surel Wikipedia saya (akan diperbarui saat Anda masuk log "
-"berikutnya)."
+msgid "Use my Wikipedia email address (will be updated the next time you login)."
+msgstr "Gunakan alamat surel Wikipedia saya (akan diperbarui saat Anda masuk log berikutnya)."
 
 #. Translators: This labels a button which users click to change their email.
 #: TWLight/users/forms.py:232
@@ -2714,17 +2208,8 @@ msgstr "Perbarui surel"
 #. Translators: Shown if the current user tried to 'favorite' a partner they can't access. Do not translate '{partner}'
 #: TWLight/users/models.py:201
 #, python-brace-format
-msgid ""
-"Cannot add partner {partner} to your favorites because you don't have access "
-"to it"
+msgid "Cannot add partner {partner} to your favorites because you don't have access to it"
 msgstr ""
-
-#. Translators: Do not translate.
-#: TWLight/users/models.py:869
-#, fuzzy, python-brace-format
-#| msgid "Username"
-msgid "{wp_username}"
-msgstr "Nama pengguna"
 
 #. Translators: This error message is shown when there's a problem with the authenticated login process.
 #: TWLight/users/oauth.py:243
@@ -2744,12 +2229,8 @@ msgstr ""
 
 #. Translators: this message is displayed to users that don't have accounts and clicked on a proxied link.
 #: TWLight/users/oauth.py:388
-msgid ""
-"To view this link you need to be an eligible library user. Please login to "
-"continue."
-msgstr ""
-"Untuk melihat pranala ini, Anda mesti menjadi pengguna perpustakaan yang "
-"memenuhi syarat. Silahkan masuk log untuk melanjutkan."
+msgid "To view this link you need to be an eligible library user. Please login to continue."
+msgstr "Untuk melihat pranala ini, Anda mesti menjadi pengguna perpustakaan yang memenuhi syarat. Silahkan masuk log untuk melanjutkan."
 
 #. Translators: This warning message is shown to users when the response received from Wikimedia OAuth servers is not a valid one.
 #: TWLight/users/oauth.py:430
@@ -2784,20 +2265,12 @@ msgstr "Lihat {issue} untuk informasi selengkapnya."
 
 #. Translators: If the user tries to log in, but their account does not meet certain requirements, they cannot login.
 #: TWLight/users/oauth.py:528
-msgid ""
-"Your Wikipedia account does not meet the eligibility criteria in the terms "
-"of use, so your Wikipedia Library Card Platform account cannot be activated."
-msgstr ""
-"Akun Wikipedia Anda tidak memenuhi kriteria kelayakan dalam syarat "
-"penggunaan, sehingga akun Platform Kartu Perpustakaan Wikipedia Anda tidak "
-"dapat diaktifkan."
+msgid "Your Wikipedia account does not meet the eligibility criteria in the terms of use, so your Wikipedia Library Card Platform account cannot be activated."
+msgstr "Akun Wikipedia Anda tidak memenuhi kriteria kelayakan dalam syarat penggunaan, sehingga akun Platform Kartu Perpustakaan Wikipedia Anda tidak dapat diaktifkan."
 
 #. Translators: If the user tries to log in, but their account does not meet certain requirements, they cannot login.
 #: TWLight/users/oauth.py:536
-msgid ""
-"Your Wikipedia account no longer meets the eligibility criteria in the terms "
-"of use, so you cannot be logged in. If you think you should be able to log "
-"in, please email wikipedialibrary@wikimedia.org."
+msgid "Your Wikipedia account no longer meets the eligibility criteria in the terms of use, so you cannot be logged in. If you think you should be able to log in, please email wikipedialibrary@wikimedia.org."
 msgstr ""
 
 #. Translators: this message is displayed to users with brand new accounts.
@@ -2808,10 +2281,7 @@ msgstr ""
 #. Translators: This message is displayed on the confirmation page where users can return their access to partner collections.
 #: TWLight/users/templates/users/authorization_confirm_return.html:13
 #, python-format
-msgid ""
-"You will no longer be able to access <b>%(partner)s's</b> resources via the "
-"Library Card platform, but can request access again by clicking 'renew', if "
-"you change your mind. Are you sure you want to return your access?"
+msgid "You will no longer be able to access <b>%(partner)s's</b> resources via the Library Card platform, but can request access again by clicking 'renew', if you change your mind. Are you sure you want to return your access?"
 msgstr ""
 
 #. Translators: On the MyLibrary page (https://wikipedialibrary.wmflabs.org/users/my_library), this tab shows all favorite collections a user has.
@@ -2881,14 +2351,8 @@ msgstr "Data penyunting"
 
 #. Translators: This is shown on editor profiles, in their profile page or on applications.
 #: TWLight/users/templates/users/editor_detail.html:59
-msgid ""
-"Information with an * was retrieved from Wikipedia directly. Other "
-"information was entered directly by users or site admins, in their preferred "
-"language."
-msgstr ""
-"Informasi dengan tanda * diambil dari Wikipedia secara langsung. Informasi "
-"lainnya dimasukkan langsung oleh pengguna atau admin situs, dalam bahasa "
-"pilihan mereka."
+msgid "Information with an * was retrieved from Wikipedia directly. Other information was entered directly by users or site admins, in their preferred language."
+msgstr "Informasi dengan tanda * diambil dari Wikipedia secara langsung. Informasi lainnya dimasukkan langsung oleh pengguna atau admin situs, dalam bahasa pilihan mereka."
 
 #. Translators: This distinguishes users who have been flagged as account coordinators. Don't translate username.
 #: TWLight/users/templates/users/editor_detail.html:71
@@ -2898,10 +2362,7 @@ msgstr ""
 
 #. Translators: This is shown on editor profiles, under the heading for Wikipedia editor data.
 #: TWLight/users/templates/users/editor_detail_data.html:5
-msgid ""
-"This information is updated automatically from your Wikimedia account each "
-"time you log in, except for the Contributions field, where you can describe "
-"your Wikimedia editing history."
+msgid "This information is updated automatically from your Wikimedia account each time you log in, except for the Contributions field, where you can describe your Wikimedia editing history."
 msgstr ""
 
 #. Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this labels the user's username.
@@ -2931,17 +2392,13 @@ msgstr ""
 
 #. Translators: when viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this question has a yes or no answer.
 #: TWLight/users/templates/users/editor_detail_data.html:57
-msgid ""
-"at their last login, did this user meet the criteria set forth in the terms "
-"of use?"
+msgid "at their last login, did this user meet the criteria set forth in the terms of use?"
 msgstr ""
 
 #. Translators: When viewing a user's profile in an application, this message shows if the software doesn't think that the user is eligible for access. Don't translate username.
 #: TWLight/users/templates/users/editor_detail_data.html:72
 #, python-format
-msgid ""
-"%(username)s may still be eligible for access grants at the coordinators' "
-"discretion."
+msgid "%(username)s may still be eligible for access grants at the coordinators' discretion."
 msgstr ""
 
 #. Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this is the heading for a Yes/No ToU question.
@@ -2976,14 +2433,8 @@ msgstr ""
 #. Translators: This message is shown on a user's profile if their Wikimedia account is blocked on one or more projects. They may still be granted access to the Library Bundle, but need to contact Wikipedia Library staff to verify.
 #: TWLight/users/templates/users/editor_detail_data.html:137
 #, python-format
-msgid ""
-"It looks like you have an active block on your account. If you meet the "
-"other criteria you may still be permitted access to the library - please <a "
-"class=\"twl-links\" href=\"%(contact_url)s\">contact us</a>."
-msgstr ""
-"Anda kemungkinan memiliki masa blokir aktif saat ini. Anda masih dapat "
-"mengakses perpustakaan jika anda masih termasuk dalam kriteria yang lain - "
-"silahkan <a class=\"twl-links\" href=\"%(contact_url)s\">hubungi kami</a>."
+msgid "It looks like you have an active block on your account. If you meet the other criteria you may still be permitted access to the library - please <a class=\"twl-links\" href=\"%(contact_url)s\">contact us</a>."
+msgstr "Anda kemungkinan memiliki masa blokir aktif saat ini. Anda masih dapat mengakses perpustakaan jika anda masih termasuk dalam kriteria yang lain - silahkan <a class=\"twl-links\" href=\"%(contact_url)s\">hubungi kami</a>."
 
 #. Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this is the heading for a Yes/No program eligibility question.
 #: TWLight/users/templates/users/editor_detail_data.html:153
@@ -2992,10 +2443,7 @@ msgstr ""
 
 #. Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this question has a Yes or No answer.
 #: TWLight/users/templates/users/editor_detail_data.html:156
-msgid ""
-"At their last login, did this user meet the criteria set forth in the "
-"Library Bundle? Note that satisfying terms of use is a prerequisite to "
-"bundle eligibility."
+msgid "At their last login, did this user meet the criteria set forth in the Library Bundle? Note that satisfying terms of use is a prerequisite to bundle eligibility."
 msgstr ""
 
 #. Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this is the heading for a Yes/No program eligibility question.
@@ -3021,8 +2469,7 @@ msgstr "Jumlah suntingan global terkini *"
 #. Translators: This text is shown next to a user's recent global edit count if less than 30 days has passed since they first logged in to the Library Card. In this case, we don't yet know if they're eligible.
 #: TWLight/users/templates/users/editor_detail_data.html:220
 msgid "Unknown (requires 30 days from initial user login)"
-msgstr ""
-"Tidak ditemukan (membutuhkan 30 hari dari pertama kali pengguna masuk log)"
+msgstr "Tidak ditemukan (membutuhkan 30 hari dari pertama kali pengguna masuk log)"
 
 #. Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this labels the date the user registered their Meta-wiki account or the date their account was merged by the SUL merge process. Don't remove the *
 #: TWLight/users/templates/users/editor_detail_data.html:232
@@ -3041,23 +2488,13 @@ msgstr "Informasi pribadi"
 
 #. Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this text is in the 'Personal data' section. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/users/templates/users/editor_detail_data.html:262
-msgid ""
-"The following information is visible only to you, site administrators, "
-"publishing partners (where required), and volunteer Wikipedia Library "
-"coordinators (who have signed a Non-Disclosure Agreement)."
-msgstr ""
-"Informasi berikut ini hanya dapat dilihat oleh Anda, administrator situs, "
-"mitra penerbitan (jika diperlukan), dan sukarelawan koordinator Perpustakaan "
-"Wikipedia (yang telah menandatangani Perjanjian Kerahasiaan).\n"
-"\n"
-"Anda dapat memperbarui atau menghapus data Anda kapan saja."
+msgid "The following information is visible only to you, site administrators, publishing partners (where required), and volunteer Wikipedia Library coordinators (who have signed a Non-Disclosure Agreement)."
+msgstr "Informasi berikut ini hanya dapat dilihat oleh Anda, administrator situs, mitra penerbitan (jika diperlukan), dan sukarelawan koordinator Perpustakaan Wikipedia (yang telah menandatangani Perjanjian Kerahasiaan).\n\nAnda dapat memperbarui atau menghapus data Anda kapan saja."
 
 #. Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this labels a button which users can click to update or remove their personal information. Don't translate update_url.
 #: TWLight/users/templates/users/editor_detail_data.html:272
 #, python-format
-msgid ""
-"You may <a class=\"twl-links\" href=\"%(update_url)s\">update or delete</a> "
-"your data at any time."
+msgid "You may <a class=\"twl-links\" href=\"%(update_url)s\">update or delete</a> your data at any time."
 msgstr ""
 
 #. Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this labels the user's email. Don't remove the *.
@@ -3077,32 +2514,19 @@ msgstr "Institusi"
 
 #. Translators: This message tells users that they are not eligible to access The Wikipedia Library content.
 #: TWLight/users/templates/users/eligibility_modal.html:7
-msgid ""
-"Sorry, your Wikipedia account doesn’t currently qualify to access The "
-"Wikipedia Library."
-msgstr ""
-"Maaf, akun Wikipedia Anda saat ini tidak memenuhi syarat untuk mengakses "
-"Perpustakaan Wikipedia."
+msgid "Sorry, your Wikipedia account doesn’t currently qualify to access The Wikipedia Library."
+msgstr "Maaf, akun Wikipedia Anda saat ini tidak memenuhi syarat untuk mengakses Perpustakaan Wikipedia."
 
 #. Translators: This message tells users that they have not agreed to the terms of use, therefore are ineligible to access the content in The Wikipedia Library.
 #: TWLight/users/templates/users/eligibility_modal.html:30
 #, python-format
-msgid ""
-"Agreed with <a href=\"%(terms)s\" class=\"text-danger\"> terms of use </a>"
-msgstr ""
-"Sudah menyetujui <a href=\"%(terms)s\" class=\"text-danger\">syarat "
-"penggunaan</a> situs?"
+msgid "Agreed with <a href=\"%(terms)s\" class=\"text-danger\"> terms of use </a>"
+msgstr "Sudah menyetujui <a href=\"%(terms)s\" class=\"text-danger\">syarat penggunaan</a> situs?"
 
 #: TWLight/users/templates/users/eligibility_modal.html:40
 #, python-format
-msgid ""
-"It looks like you have an active block on your account. If you meet the "
-"other criteria you may still be permitted access to the library - please <a "
-"href=\"%(contact_url)s\">contact us</a>."
-msgstr ""
-"Sepertinya Anda memiliki blok aktif di akun Anda. Jika Anda memenuhi "
-"kriteria lain, Anda mungkin masih diizinkan mengakses perpustakaan - silakan "
-"<a href=\"%(contact_url)s\">hubungi kami</a>."
+msgid "It looks like you have an active block on your account. If you meet the other criteria you may still be permitted access to the library - please <a href=\"%(contact_url)s\">contact us</a>."
+msgstr "Sepertinya Anda memiliki blok aktif di akun Anda. Jika Anda memenuhi kriteria lain, Anda mungkin masih diizinkan mengakses perpustakaan - silakan <a href=\"%(contact_url)s\">hubungi kami</a>."
 
 #. Translators: Instructions to refresh a user's data.
 #: TWLight/users/templates/users/eligibility_modal.html:50
@@ -3141,10 +2565,7 @@ msgstr "Pilih bahasa"
 
 #. Translators: This text on the user page helps users naviage to the TranslateWiki Wikipedia Library Card platform translation page.
 #: TWLight/users/templates/users/language_form.html:31
-msgid ""
-"You can help translate the tool at <a class=\"twl-links\" href=\"https://"
-"translatewiki.net/wiki/Translating:Wikipedia_Library_Card_Platform"
-"\">translatewiki.net</a>."
+msgid "You can help translate the tool at <a class=\"twl-links\" href=\"https://translatewiki.net/wiki/Translating:Wikipedia_Library_Card_Platform\">translatewiki.net</a>."
 msgstr ""
 
 #. Translators: When the user starts a new application and submits the application, the user can view the application and withdraw if need be. This changes the label for the Withdraw button.
@@ -3164,9 +2585,7 @@ msgstr "Minta pembaruan"
 
 #. Translators: On the page listing applications, this text explains a user they cannot renew their application since they've already requested a renewal or there aren't any renewals available.
 #: TWLight/users/templates/users/my_applications.html:79
-msgid ""
-"Renewals are either not required, not available right now, or you have "
-"already requested a renewal."
+msgid "Renewals are either not required, not available right now, or you have already requested a renewal."
 msgstr ""
 
 #. Translators: This text is the heading of a section in a user's profile where they can change their preferences.
@@ -3230,19 +2649,12 @@ msgstr ""
 
 #. Translators: This message is displayed on the page where users can request we stop processing their data.
 #: TWLight/users/templates/users/restrict_data.html:15
-msgid ""
-"Checking this box and clicking “Restrict” will pause all processing of the "
-"data you have entered into this website. You will not be able to apply for "
-"access to resources, your applications will not be further processed, and "
-"none of your data will be altered, until you return to this page and uncheck "
-"the box. This is not the same as deleting your data."
+msgid "Checking this box and clicking “Restrict” will pause all processing of the data you have entered into this website. You will not be able to apply for access to resources, your applications will not be further processed, and none of your data will be altered, until you return to this page and uncheck the box. This is not the same as deleting your data."
 msgstr ""
 
 #. Translators: This warning message is shown to coordinators who view the data restriction page.
 #: TWLight/users/templates/users/restrict_data.html:26
-msgid ""
-"You are a coordinator on this site. If you restrict the processing of your "
-"data, your coordinator flag will be removed."
+msgid "You are a coordinator on this site. If you restrict the processing of your data, your coordinator flag will be removed."
 msgstr ""
 
 #. Translators: use the date *when you are translating*, in a language-appropriate format.
@@ -3262,24 +2674,12 @@ msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:51
-msgid ""
-"<a class=\"twl-links\" href=\"https://meta.wikimedia.org/wiki/"
-"The_Wikipedia_Library\"> The Wikipedia Library </a> has partnered with "
-"publishers around the world to allow users to access otherwise paywalled "
-"resources. This website allows Wikipedia editors to search and access these "
-"resources."
+msgid "<a class=\"twl-links\" href=\"https://meta.wikimedia.org/wiki/The_Wikipedia_Library\"> The Wikipedia Library </a> has partnered with publishers around the world to allow users to access otherwise paywalled resources. This website allows Wikipedia editors to search and access these resources."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Wikimedia Foundation should not be translated. WMF should not be translated. Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:63
-msgid ""
-"This program is administered by the Wikimedia Foundation (WMF). These terms "
-"of use and privacy notice pertain to your application for access to "
-"resources through the Wikipedia Library, your use of this website, and your "
-"access to and use of those resources. They also describe our handling of the "
-"information you provide to us in order to create and administer your "
-"Wikipedia Library account. If we make material changes to the terms, we will "
-"notify users."
+msgid "This program is administered by the Wikimedia Foundation (WMF). These terms of use and privacy notice pertain to your application for access to resources through the Wikipedia Library, your use of this website, and your access to and use of those resources. They also describe our handling of the information you provide to us in order to create and administer your Wikipedia Library account. If we make material changes to the terms, we will notify users."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
@@ -3289,37 +2689,17 @@ msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:78
-msgid ""
-"Access to resources via The Wikipedia Library is reserved for community "
-"members who have demonstrated their commitment to the Wikimedia projects, "
-"and who will use their access to these resources to improve project content. "
-"To that end, in order to be eligible for The Wikipedia Library, we require "
-"that you be registered for a user account on the projects, with at least 500 "
-"edits, six (6) months of activity, and 10+ edits in the last month. We ask "
-"that you do not request access to any publishers with a limited number of "
-"available accounts whose resources you can already access for free through "
-"your local library or university, or another institution or organization, in "
-"order to provide that opportunity to others."
+msgid "Access to resources via The Wikipedia Library is reserved for community members who have demonstrated their commitment to the Wikimedia projects, and who will use their access to these resources to improve project content. To that end, in order to be eligible for The Wikipedia Library, we require that you be registered for a user account on the projects, with at least 500 edits, six (6) months of activity, and 10+ edits in the last month. We ask that you do not request access to any publishers with a limited number of available accounts whose resources you can already access for free through your local library or university, or another institution or organization, in order to provide that opportunity to others."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:94
-msgid ""
-"Additionally, if you are currently blocked or banned from a Wikimedia "
-"project, applications to resources may be rejected or restricted. If you "
-"obtain a Wikipedia Library account, but a block or ban is subsequently "
-"instituted against you on one of the projects, you may lose access to your "
-"Wikipedia Library account."
+msgid "Additionally, if you are currently blocked or banned from a Wikimedia project, applications to resources may be rejected or restricted. If you obtain a Wikipedia Library account, but a block or ban is subsequently instituted against you on one of the projects, you may lose access to your Wikipedia Library account."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:104
-msgid ""
-"Your eligibility to access The Wikipedia Library is assessed at each login. "
-"While more than half of the library's content is provided via this automated "
-"eligibility check, access to other publisher's content may be time limited, "
-"typically lapsing after one year, after which you will usually need to apply "
-"for renewal."
+msgid "Your eligibility to access The Wikipedia Library is assessed at each login. While more than half of the library's content is provided via this automated eligibility check, access to other publisher's content may be time limited, typically lapsing after one year, after which you will usually need to apply for renewal."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
@@ -3329,47 +2709,27 @@ msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:118
-msgid ""
-"In order to apply for access to a partner resource, you must provide us with "
-"certain information, which we will use to evaluate your application. If your "
-"application is approved, we may transfer the information you have given us "
-"to the publishers whose resources you wish to access. They will either "
-"contact you with the account information directly or we will send access "
-"information to you ourselves."
+msgid "In order to apply for access to a partner resource, you must provide us with certain information, which we will use to evaluate your application. If your application is approved, we may transfer the information you have given us to the publishers whose resources you wish to access. They will either contact you with the account information directly or we will send access information to you ourselves."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:130
-msgid ""
-"In addition to the basic information you provide to us, our system will "
-"retrieve some information directly from the Wikimedia projects: your "
-"username, email address, edit count, registration date, user ID number, "
-"groups to which you belong, and any special user rights."
+msgid "In addition to the basic information you provide to us, our system will retrieve some information directly from the Wikimedia projects: your username, email address, edit count, registration date, user ID number, groups to which you belong, and any special user rights."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:140
-msgid ""
-"Each time you log in to the Wikipedia Library Card Platform, this "
-"information will be automatically updated."
+msgid "Each time you log in to the Wikipedia Library Card Platform, this information will be automatically updated."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:148
-msgid ""
-"We will ask you to provide us with some information about your history of "
-"contributions to the Wikimedia projects. Information on contribution history "
-"is optional, but will greatly assist us in evaluating your application."
+msgid "We will ask you to provide us with some information about your history of contributions to the Wikimedia projects. Information on contribution history is optional, but will greatly assist us in evaluating your application."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). WMF should not be translated. Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:157
-msgid ""
-"The information you provide when creating your account will be visible to "
-"you while on the site but not to others unless they are approved Wikipedia "
-"Library Coordinators, WMF Staff, or WMF Contractors who need access to this "
-"data in order to carry out their work with the Wikipedia Library, all of "
-"whom are subject to non-disclosure obligations."
+msgid "The information you provide when creating your account will be visible to you while on the site but not to others unless they are approved Wikipedia Library Coordinators, WMF Staff, or WMF Contractors who need access to this data in order to carry out their work with the Wikipedia Library, all of whom are subject to non-disclosure obligations."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
@@ -3379,46 +2739,32 @@ msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:171
-msgid ""
-"In order to access an individual publisher’s resources, you must agree to "
-"that publisher’s terms of use and privacy policy. You agree that you will "
-"not violate such terms and policies in connection with your use of the "
-"Wikipedia Library. Additionally, the following activities are prohibited "
-"while accessing publisher resources through the Wikipedia Library."
+msgid "In order to access an individual publisher’s resources, you must agree to that publisher’s terms of use and privacy policy. You agree that you will not violate such terms and policies in connection with your use of the Wikipedia Library. Additionally, the following activities are prohibited while accessing publisher resources through the Wikipedia Library."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:184
-msgid ""
-"Sharing your Wikipedia account, usernames, passwords, or any access codes "
-"for publisher resources with others;"
+msgid "Sharing your Wikipedia account, usernames, passwords, or any access codes for publisher resources with others;"
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:191
-msgid ""
-"Automatically scraping or downloading restricted content from publishers;"
+msgid "Automatically scraping or downloading restricted content from publishers;"
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:197
-msgid ""
-"Systematically making printed or electronic copies of multiple extracts of "
-"restricted content available for any purpose;"
+msgid "Systematically making printed or electronic copies of multiple extracts of restricted content available for any purpose;"
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:204
-msgid ""
-"Data mining metadata without permission—for example, in order to use "
-"metadata for auto-created stub articles;"
+msgid "Data mining metadata without permission—for example, in order to use metadata for auto-created stub articles;"
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:211
-msgid ""
-"Using the access you receive through the Wikipedia Library for profit by "
-"selling access to your account or resources which you have through it."
+msgid "Using the access you receive through the Wikipedia Library for profit by selling access to your account or resources which you have through it."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
@@ -3428,18 +2774,12 @@ msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:224
-msgid ""
-"Certain resources may only be accessed using an external search service, "
-"such as the EBSCO Discovery Service, or a proxy service, such as OCLC "
-"EZProxy. If you use such external search and/or proxy services, please "
-"review the applicable terms of use and privacy policies."
+msgid "Certain resources may only be accessed using an external search service, such as the EBSCO Discovery Service, or a proxy service, such as OCLC EZProxy. If you use such external search and/or proxy services, please review the applicable terms of use and privacy policies."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:234
-msgid ""
-"In addition, if you use OCLC EZProxy, please note that you may not use it "
-"for commercial purposes."
+msgid "In addition, if you use OCLC EZProxy, please note that you may not use it for commercial purposes."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
@@ -3449,120 +2789,49 @@ msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Wikimedia Foundation should not be translated. Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:245
-msgid ""
-"The Wikimedia Foundation and our service providers use your information for "
-"the legitimate purpose of providing Wikipedia Library services in support of "
-"our charitable mission. When you apply for a Wikipedia Library account, or "
-"use your Wikipedia Library account, we may routinely collect the following "
-"information: your username, email address, edit count, registration date, "
-"user ID number, groups to which you belong, and any special user rights; "
-"your name, country of residence, and/or affiliation, if required by a "
-"partner to which you are applying; your narrative description of your "
-"contributions and reasons for applying for access to partner resources; and "
-"the date you agree to these terms of use."
+msgid "The Wikimedia Foundation and our service providers use your information for the legitimate purpose of providing Wikipedia Library services in support of our charitable mission. When you apply for a Wikipedia Library account, or use your Wikipedia Library account, we may routinely collect the following information: your username, email address, edit count, registration date, user ID number, groups to which you belong, and any special user rights; your name, country of residence, and/or affiliation, if required by a partner to which you are applying; your narrative description of your contributions and reasons for applying for access to partner resources; and the date you agree to these terms of use."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:262
 #, python-format
-msgid ""
-"Each publisher who is a member of the Wikipedia Library program requires "
-"different specific information in the application. Some publishers may "
-"request only an email address, while others request more detailed data, such "
-"as your name, location, or institutional affiliation. When you complete your "
-"application, you will only be asked to supply information required by the "
-"publishers you have chosen, and each publisher will only receive the "
-"information they require for providing you with access. Please see our <a "
-"class=\"twl-links\" href=\"%(all_partners_url)s\">partner information</a> "
-"pages to learn what information is required by each publisher to gain access "
-"to their resources."
+msgid "Each publisher who is a member of the Wikipedia Library program requires different specific information in the application. Some publishers may request only an email address, while others request more detailed data, such as your name, location, or institutional affiliation. When you complete your application, you will only be asked to supply information required by the publishers you have chosen, and each publisher will only receive the information they require for providing you with access. Please see our <a class=\"twl-links\" href=\"%(all_partners_url)s\">partner information</a> pages to learn what information is required by each publisher to gain access to their resources."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Wikimedia Foundation should not be translated. Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:277
-msgid ""
-"Some Wikipedia Library pages are visible without logging in, but you will "
-"need to log in to apply or access proprietary partner resources. We use the "
-"data provided by you via OAuth and Wikimedia API calls to assess your "
-"application for access and to process approved requests."
+msgid "Some Wikipedia Library pages are visible without logging in, but you will need to log in to apply or access proprietary partner resources. We use the data provided by you via OAuth and Wikimedia API calls to assess your application for access and to process approved requests."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:288
 #, python-format
-msgid ""
-"In order to administer the Wikipedia Library program, we will retain the "
-"application data we collect from you for three years after your most recent "
-"login, unless you delete your account, as described below. You can log in "
-"and go to <a class=\"twl-links\" href=\"%(profile_url)s\">your profile page</"
-"a> in order to see the information associated with your account, and can "
-"download it in JSON format. You may access, update, restrict, or delete this "
-"information at any time, except for the information that is automatically "
-"retrieved from the projects. If you have any questions or concerns about the "
-"handling of your data, please contact <a class=\"twl-links\" href=\"mailto:"
-"wikipedialibrary@wikimedia.org?Subject=Wikipedia%%20Library%%20Card"
-"%%20account%%20deactivation\"> wikipedialibrary@wikimedia.org </a>."
+msgid "In order to administer the Wikipedia Library program, we will retain the application data we collect from you for three years after your most recent login, unless you delete your account, as described below. You can log in and go to <a class=\"twl-links\" href=\"%(profile_url)s\">your profile page</a> in order to see the information associated with your account, and can download it in JSON format. You may access, update, restrict, or delete this information at any time, except for the information that is automatically retrieved from the projects. If you have any questions or concerns about the handling of your data, please contact <a class=\"twl-links\" href=\"mailto:wikipedialibrary@wikimedia.org?Subject=Wikipedia%%20Library%%20Card%%20account%%20deactivation\"> wikipedialibrary@wikimedia.org </a>."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:305
-msgid ""
-"If you decide to disable your Wikipedia Library account, you can use the "
-"delete button on your profile to delete certain personal information "
-"associated with your account. We will delete your real name, institutional "
-"affiliation, and country of residence. Please note that the system will "
-"retain a record of your username, the publishers to which you applied or had "
-"access, and the dates of that access. Note that deletion is not reversible. "
-"Deletion of your Wikipedia Library account may also correspond with the "
-"removal of any resource access to which you were eligible or approved. If "
-"you request the deletion of account information and later wish to apply for "
-"a new account, you will need to provide the necessary information again."
+msgid "If you decide to disable your Wikipedia Library account, you can use the delete button on your profile to delete certain personal information associated with your account. We will delete your real name, institutional affiliation, and country of residence. Please note that the system will retain a record of your username, the publishers to which you applied or had access, and the dates of that access. Note that deletion is not reversible. Deletion of your Wikipedia Library account may also correspond with the removal of any resource access to which you were eligible or approved. If you request the deletion of account information and later wish to apply for a new account, you will need to provide the necessary information again."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). WMF should not be translated. Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:321
-msgid ""
-"The Wikipedia Library is run by WMF Staff, Contractors, and approved "
-"volunteer Coordinators. The data associated with your account will be shared "
-"with the WMF staff, contractors, service providers, and volunteer "
-"coordinators who need to process the information in connection with their "
-"work for the Wikipedia Library, and who are subject to confidentiality "
-"obligations. We will also use your data for internal Wikipedia Library "
-"purposes such as distributing user surveys and account notifications, and in "
-"a depersonalized or aggregated fashion for statistical analysis and "
-"administration. Finally, we will share your information with the publishers "
-"whom you specifically select in order to provide you with access to "
-"resources. Otherwise, your information will not be shared with third "
-"parties, with the exception of the circumstances described below."
+msgid "The Wikipedia Library is run by WMF Staff, Contractors, and approved volunteer Coordinators. The data associated with your account will be shared with the WMF staff, contractors, service providers, and volunteer coordinators who need to process the information in connection with their work for the Wikipedia Library, and who are subject to confidentiality obligations. We will also use your data for internal Wikipedia Library purposes such as distributing user surveys and account notifications, and in a depersonalized or aggregated fashion for statistical analysis and administration. Finally, we will share your information with the publishers whom you specifically select in order to provide you with access to resources. Otherwise, your information will not be shared with third parties, with the exception of the circumstances described below."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). WMF should not be translated.
 #: TWLight/users/templates/users/terms.html:338
-msgid ""
-"We may disclose any collected information when required by law, when we have "
-"your permission, when needed to protect our rights, privacy, safety, users, "
-"or the general public, and when necessary to enforce these terms, WMF’s "
-"general <a class=\"twl-links\" href=\"https://foundation.wikimedia.org/wiki/"
-"Terms_of_Use\">Terms of Use</a>, or any other WMF policy."
+msgid "We may disclose any collected information when required by law, when we have your permission, when needed to protect our rights, privacy, safety, users, or the general public, and when necessary to enforce these terms, WMF’s general <a class=\"twl-links\" href=\"https://foundation.wikimedia.org/wiki/Terms_of_Use\">Terms of Use</a>, or any other WMF policy."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:349
-msgid ""
-"We take the security of your personal data seriously, and take reasonable "
-"precautions to ensure your data is protected. These precautions include "
-"access controls to limit who has access to your data and security "
-"technologies to protect data stored on the server. However, we cannot "
-"guarantee the safety of your data as it is transmitted and stored."
+msgid "We take the security of your personal data seriously, and take reasonable precautions to ensure your data is protected. These precautions include access controls to limit who has access to your data and security technologies to protect data stored on the server. However, we cannot guarantee the safety of your data as it is transmitted and stored."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:360
-msgid ""
-"Please note that these terms do not control the use and handling of your "
-"data by the publishers and service providers whose resources you access or "
-"apply to access. Please read their individual privacy policies for that "
-"information."
+msgid "Please note that these terms do not control the use and handling of your data by the publishers and service providers whose resources you access or apply to access. Please read their individual privacy policies for that information."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
@@ -3572,34 +2841,17 @@ msgstr "Catatan Penting"
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Wikimedia Foundation should not be translated. Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:373
-msgid ""
-"The Wikimedia Foundation is a nonprofit organization based in San Francisco, "
-"California. The Wikipedia Library program provides access to resources held "
-"by publishers in multiple countries. If you apply for a Wikipedia Library "
-"account (whether you are inside or outside of the United States), you "
-"understand that your personal data will be collected, transferred, stored, "
-"processed, disclosed and otherwise used in the U.S. as described in this "
-"privacy policy. You also understand that your information may be transferred "
-"by us from the U.S. to other countries, which may have different or less "
-"stringent data protection laws than your country, in connection with "
-"providing services to you, including evaluating your application and "
-"securing access to your chosen publishers (locations for each publisher are "
-"outlined on their respective partner information pages)."
+msgid "The Wikimedia Foundation is a nonprofit organization based in San Francisco, California. The Wikipedia Library program provides access to resources held by publishers in multiple countries. If you apply for a Wikipedia Library account (whether you are inside or outside of the United States), you understand that your personal data will be collected, transferred, stored, processed, disclosed and otherwise used in the U.S. as described in this privacy policy. You also understand that your information may be transferred by us from the U.S. to other countries, which may have different or less stringent data protection laws than your country, in connection with providing services to you, including evaluating your application and securing access to your chosen publishers (locations for each publisher are outlined on their respective partner information pages)."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:392
-msgid ""
-"Please note that in the event of any differences in meaning or "
-"interpretation between the original English version of these terms and a "
-"translation, the original English version takes precedence."
+msgid "Please note that in the event of any differences in meaning or interpretation between the original English version of these terms and a translation, the original English version takes precedence."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Wikimedia Foundation should not be translated.
 #: TWLight/users/templates/users/terms.html:403
-msgid ""
-"See also the <a class=\"twl-links\" href=\"https://wikimediafoundation.org/"
-"wiki/Privacy_policy\">Wikimedia Foundation Privacy Policy</a>."
+msgid "See also the <a class=\"twl-links\" href=\"https://wikimediafoundation.org/wiki/Privacy_policy\">Wikimedia Foundation Privacy Policy</a>."
 msgstr ""
 
 #. Translators: This is the second to last line of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
@@ -3619,16 +2871,8 @@ msgstr "Yayasan Wikimedia"
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:426
-msgid ""
-"By checking this box and clicking “Submit”, you agree that you have read the "
-"above terms and that you will adhere to the terms of use in your application "
-"to and use of the The Wikipedia Library, and the publishers’ services to "
-"which you gain access through The Wikipedia Library program."
-msgstr ""
-"Dengan mencentang kotak ini dan menekan \"Kirim\", Anda setuju bahwa Anda "
-"telah membaca syarat di atas dan bahwa Anda akan mematuhi ketentuan "
-"penggunaan dalam permohonan dan penggunaan Perpustakaan Wikipedia, serta "
-"layanan penerbit yang Anda akses melalui program Perpustakaan Wikipedia."
+msgid "By checking this box and clicking “Submit”, you agree that you have read the above terms and that you will adhere to the terms of use in your application to and use of the The Wikipedia Library, and the publishers’ services to which you gain access through The Wikipedia Library program."
+msgstr "Dengan mencentang kotak ini dan menekan \"Kirim\", Anda setuju bahwa Anda telah membaca syarat di atas dan bahwa Anda akan mematuhi ketentuan penggunaan dalam permohonan dan penggunaan Perpustakaan Wikipedia, serta layanan penerbit yang Anda akses melalui program Perpustakaan Wikipedia."
 
 #: TWLight/users/templates/users/user_collection_tile.html:32
 msgid "Remove this collection from favorites"
@@ -3680,42 +2924,19 @@ msgstr "Hapus semua data"
 
 #. Translators: This message is displayed on the page where users can request the deletion of their data.
 #: TWLight/users/templates/users/user_confirm_delete.html:17
-msgid ""
-"<b>Warning:</b> Performing this action will delete your Wikipedia Library "
-"Card user account and all associated applications. This process is not "
-"reversible. You may lose any partner accounts you were granted, and will not "
-"be able to renew those accounts or apply for new ones."
-msgstr ""
-"<b>Peringatan:</b> Melakukan tindakan ini akan menghapus akun pengguna Kartu "
-"Perpustakaan Wikipedia dan semua permohonan yang terkiat. Proses ini tidak "
-"bisa dikembalikan. Anda bisa jadi kehilangan semua akun mitra yang telah "
-"diberikan, dan tidak akan bisa memperbarui akun tersebut atau memohon akun "
-"baru."
+msgid "<b>Warning:</b> Performing this action will delete your Wikipedia Library Card user account and all associated applications. This process is not reversible. You may lose any partner accounts you were granted, and will not be able to renew those accounts or apply for new ones."
+msgstr "<b>Peringatan:</b> Melakukan tindakan ini akan menghapus akun pengguna Kartu Perpustakaan Wikipedia dan semua permohonan yang terkiat. Proses ini tidak bisa dikembalikan. Anda bisa jadi kehilangan semua akun mitra yang telah diberikan, dan tidak akan bisa memperbarui akun tersebut atau memohon akun baru."
 
 #. Translators: this should show up for people who log in with a username/password and not OAuth, so we don't know what their Wikipedia identity is.
-#.
 #: TWLight/users/templates/users/user_detail.html:12
 #, python-format
-msgid ""
-"Hi, %(username)s! You don't have a Wikipedia editor profile attached to your "
-"account here, so you are probably a site administrator."
-msgstr ""
-"Hai, %(username)s! Anda tidak punya profil penyunting Wikipedia yang terkait "
-"dengan akun Anda di sini, jadi kemungkinan Anda adalah administrator situs."
+msgid "Hi, %(username)s! You don't have a Wikipedia editor profile attached to your account here, so you are probably a site administrator."
+msgstr "Hai, %(username)s! Anda tidak punya profil penyunting Wikipedia yang terkait dengan akun Anda di sini, jadi kemungkinan Anda adalah administrator situs."
 
 #. Translators: In the unlikely scenario that someone is able to register an account without using OAuth (thus leaving us without some of the information required for applications), users will see this message, encouraging them to re-register.
 #: TWLight/users/templates/users/user_detail.html:20
-msgid ""
-"If you aren't a site administrator, something weird has happened. You won't "
-"be able to apply for access without a Wikipedia editor profile. You should "
-"log out and create a new account by logging in via OAuth, or contact a site "
-"administrator for help."
-msgstr ""
-"Jika Anda bukan administrator situs, berarti sesuatu yang aneh telah "
-"terjadi. Anda tidak akan bisa memohon akses tanpa profil penyunting "
-"Wikipedia. Anda sebaiknya keluar log dan membuat akun baru dengan cara masuk "
-"log melalui OAuth, atau menghubungi administrator sistem untuk meminta "
-"bantuan."
+msgid "If you aren't a site administrator, something weird has happened. You won't be able to apply for access without a Wikipedia editor profile. You should log out and create a new account by logging in via OAuth, or contact a site administrator for help."
+msgstr "Jika Anda bukan administrator situs, berarti sesuatu yang aneh telah terjadi. Anda tidak akan bisa memohon akses tanpa profil penyunting Wikipedia. Anda sebaiknya keluar log dan membuat akun baru dengan cara masuk log melalui OAuth, atau menghubungi administrator sistem untuk meminta bantuan."
 
 #. Translators: Labels a sections where coordinators can select their email preferences.
 #: TWLight/users/templates/users/user_email_preferences.html:15
@@ -3725,21 +2946,13 @@ msgstr "Khusus koordinator"
 #. Translators: This message is shown on user's own profile page, encouraging them to make sure their information is up to date, so that account coordinators can use the information to judge applications.
 #: TWLight/users/views.py:176
 #, python-brace-format
-msgid ""
-"Please <a class='twl-links' href='{url}'>update your contributions</a> to "
-"Wikipedia to help coordinators evaluate your applications."
+msgid "Please <a class='twl-links' href='{url}'>update your contributions</a> to Wikipedia to help coordinators evaluate your applications."
 msgstr ""
 
 #. Translators: Coordinators are shown this message when they unselect all three types of reminder email options under preferences.
 #: TWLight/users/views.py:288
-msgid ""
-"You have chosen not to receive reminder emails. As a coordinator, you should "
-"receive at least one type of reminder emails, so consider changing your "
-"preferences."
-msgstr ""
-"Anda telah memilih untuk tidak menerima email pengingat. Sebagai "
-"koordinator, Anda harus menerima setidaknya satu jenis email pengingat, jadi "
-"pertimbangkan untuk mengubah preferensi Anda."
+msgid "You have chosen not to receive reminder emails. As a coordinator, you should receive at least one type of reminder emails, so consider changing your preferences."
+msgstr "Anda telah memilih untuk tidak menerima email pengingat. Sebagai koordinator, Anda harus menerima setidaknya satu jenis email pengingat, jadi pertimbangkan untuk mengubah preferensi Anda."
 
 #. Translators: Coordinators are shown this message when they make changes to their reminder email options under preferences.
 #: TWLight/users/views.py:296
@@ -3772,9 +2985,7 @@ msgstr "Surel Anda telah diganti menjadi {email}"
 
 #. Translators: If the user has not filled out their email, they can browse the website but cannot apply for access to resources.
 #: TWLight/users/views.py:487
-msgid ""
-"Your email is blank. You can still explore the site, but you won't be able "
-"to apply for access to partner resources without an email."
+msgid "Your email is blank. You can still explore the site, but you won't be able to apply for access to partner resources without an email."
 msgstr ""
 
 #. Translators: This message is shown once the access to a partner has successfully been returned.
@@ -3807,31 +3018,3 @@ msgstr "Akun tidak diblokir"
 msgid "10+ edits in the last 30 days"
 msgstr "10+ suntingan dalam 30 hari terakhir"
 
-#: tests/shunit/data/bad_i18n_comment_1.py:3
-#: tests/shunit/data/bad_i18n_newline_1.py:5
-msgid "1"
-msgstr ""
-
-#. Translators: Lorem ipsum dolor sit amet, consectetur adipiscing elit. Mauris vitae ipsum ut purus faucibus pretium. Proin tempus neque et aliquet consectetur. Ut egestas sapien in consectetur sagittis. Mauris neque lacus, dapibus non viverra vitae, interdum ut aenean ipsum.
-#. Translators: Lorem ipsum dolor sit amet, consectetur adipiscing elit. Mauris vitae ipsum ut purus faucibus pretium. Proin tempus neque et aliquet consectetur. Ut egestas sapien in consectetur sagittis. Mauris neque lacus, dapibus non.
-#: tests/shunit/data/bad_i18n_comment_2.py:4
-#: tests/shunit/data/bad_i18n_newline_2.py:5 tests/shunit/data/good_i18n_1.py:2
-#: tests/shunit/data/good_i18n_2.py:2
-msgid "2"
-msgstr ""
-
-#: tests/shunit/data/bad_i18n_newline_3.py:5
-msgid "3"
-msgstr ""
-
-#: tests/shunit/data/bad_i18n_newline_4.py:5
-msgid "4"
-msgstr ""
-
-#: tests/shunit/data/bad_i18n_newline_5.py:5
-msgid "5"
-msgstr ""
-
-#: tests/shunit/data/bad_i18n_newline_6.py:5
-msgid "6"
-msgstr ""

--- a/locale/it/LC_MESSAGES/django.po
+++ b/locale/it/LC_MESSAGES/django.po
@@ -12,10 +12,11 @@
 # Author: Stefano
 msgid ""
 msgstr ""
+""
 "Project-Id-Version: Wikipedia Library Card Platform - Website\n"
-"Report-Msgid-Bugs-To: wikipedialibrary@wikimedia.org\n"
+"Report-Msgid-Bugs-To: translatewiki.net\n"
 "POT-Creation-Date: 2024-07-11 20:54+0000\n"
-"PO-Revision-Date: 2024-07-11 12:30:15+0000\n"
+"PO-Revision-Date: 2024-07-15 12:29:16+0000\n"
 "Language: it\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
@@ -47,13 +48,8 @@ msgstr "Su di te"
 #. Translators: This note appears in a section of a form where we ask users to enter info (like country of residence) when applying for resource access.
 #: TWLight/applications/forms.py:179
 #, python-brace-format
-msgid ""
-"<p><small><i>Your personal data will be processed according to our <a "
-"class='twl-links' href='{terms_url}'> privacy policy</a>.</i></small></p>"
-msgstr ""
-"<p><small><i>I tuoi dati personali saranno gestiti in base alle nostre <a "
-"class='twl-links' href='{terms_url}'>condizioni di pruivacy</a>.</i></"
-"small></p>"
+msgid "<p><small><i>Your personal data will be processed according to our <a class='twl-links' href='{terms_url}'> privacy policy</a>.</i></small></p>"
+msgstr "<p><small><i>I tuoi dati personali saranno gestiti in base alle nostre <a class='twl-links' href='{terms_url}'>condizioni di pruivacy</a>.</i></small></p>"
 
 #. Translators: This is the title of the application form page, where users enter information required for the application. It lets the user know which partner application they are entering data for. {partner}
 #: TWLight/applications/forms.py:189
@@ -89,19 +85,13 @@ msgstr "Conferma di rinnovo"
 #. Translators: When filling out an application, users may be required to enter an email they have used to register on the partner's website.
 #: TWLight/applications/forms.py:329 TWLight/applications/helpers.py:97
 msgid "The email for your account on the partner's website"
-msgstr ""
-"L'indirizzo di posta elettronica del tuo account sul sito internet del "
-"partner"
+msgstr "L'indirizzo di posta elettronica del tuo account sul sito internet del partner"
 
 #. Translators: This labels a choice field where users will have to select the number of months they wish to have their access for as part of the application renewal confirmation.
 #. Translators: When filling out an application, users may be required to enter the length of the account (expiry) they wish to have for proxy partners.
 #: TWLight/applications/forms.py:339 TWLight/applications/helpers.py:100
-msgid ""
-"The number of months you wish to have this access for before renewal is "
-"required"
-msgstr ""
-"È obbligatorio indicare il numero di mesi per cui desideri ottenere questo "
-"accesso."
+msgid "The number of months you wish to have this access for before renewal is required"
+msgstr "È obbligatorio indicare il numero di mesi per cui desideri ottenere questo accesso."
 
 #. Translators: When filling out an application, users may need to specify their name
 #: TWLight/applications/helpers.py:81
@@ -189,13 +179,8 @@ msgstr "Posta elettronica"
 
 #. Translators: This comment is added to pending applications when our terms of use change.
 #: TWLight/applications/management/commands/notify_applicants_tou_changes.py:54
-msgid ""
-"Our terms of use have changed. Your applications will not be processed until "
-"you log in and agree to our updated terms."
-msgstr ""
-"Le nostre condizioni di utilizzo sono cambiate. La tua richiesta non sarà "
-"gestita finché non ti sarai autenticato e non avrai dato il consenso alle "
-"nuove condizioni."
+msgid "Our terms of use have changed. Your applications will not be processed until you log in and agree to our updated terms."
+msgstr "Le nostre condizioni di utilizzo sono cambiate. La tua richiesta non sarà gestita finché non ti sarai autenticato e non avrai dato il consenso alle nuove condizioni."
 
 #. Translators: This is the status of an application that has not yet been reviewed.
 #: TWLight/applications/models.py:54
@@ -261,43 +246,26 @@ msgstr "URL di accesso: {access_url}"
 
 #. Translators: This text goes into account approval emails in the case that we need to send the user's details to a publisher for manual account setup.
 #: TWLight/applications/models.py:331
-msgid ""
-"You can expect to receive access details within a week or two once it has "
-"been processed."
-msgstr ""
-"Aspettati di ricevere istruzioni di accesso entro una settimana o due una "
-"volta che sia stata elaborata."
+msgid "You can expect to receive access details within a week or two once it has been processed."
+msgstr "Aspettati di ricevere istruzioni di accesso entro una settimana o due una volta che sia stata elaborata."
 
 #. Translators: This comment is added to open applications when a partner joins the Library Bundle, which does not require applications.
 #: TWLight/applications/signals.py:247
-msgid ""
-"This partner joined the Library Bundle, which does not require applications. "
-"This application will be marked as invalid."
-msgstr ""
-"Questo partner si è unito al Library Bundle, che non obbliga a una "
-"richiesta. Questa richiesta sarà considerata come non valida."
+msgid "This partner joined the Library Bundle, which does not require applications. This application will be marked as invalid."
+msgstr "Questo partner si è unito al Library Bundle, che non obbliga a una richiesta. Questa richiesta sarà considerata come non valida."
 
 #. Translators: This is shown to users if the application is to a partner for which we have run out of available accounts. The application is therefore on a 'waitlist', and will be reviewed when more accounts are available.
 #: TWLight/applications/templates/applications/application_evaluation.html:29
-msgid ""
-"This application is on the waitlist because this partner does not have any "
-"access grants available at this time."
-msgstr ""
-"Questa richiesta è in lisa d'attesa perché questo partner non ha al momento "
-"alcuna autorizzazione di accesso disponibile."
+msgid "This application is on the waitlist because this partner does not have any access grants available at this time."
+msgstr "Questa richiesta è in lisa d'attesa perché questo partner non ha al momento alcuna autorizzazione di accesso disponibile."
 
 #. Translators: This message is shown on pages where coordinators can see personal information about applicants.
 #: TWLight/applications/templates/applications/application_evaluation.html:36
 #: TWLight/applications/templates/applications/application_list_include.html:6
 #: TWLight/applications/templates/applications/send_partner.html:45
 #: TWLight/resources/templates/resources/partner_users.html:18
-msgid ""
-"Coordinators: This page may contain personal information such as real names "
-"and email addresses. Please remember that this information is confidential."
-msgstr ""
-"Coordinatori: questa pagina potrebbe contenere informazioni personali come "
-"nomi reali e indirizzi di posta elettronica. Per favore ricordate che queste "
-"informazioni sono confidenziali."
+msgid "Coordinators: This page may contain personal information such as real names and email addresses. Please remember that this information is confidential."
+msgstr "Coordinatori: questa pagina potrebbe contenere informazioni personali come nomi reali e indirizzi di posta elettronica. Per favore ricordate che queste informazioni sono confidenziali."
 
 #. Translators: This is the title of the application page shown to users who are a coordinator, and are able to accept or reject the application.
 #: TWLight/applications/templates/applications/application_evaluation.html:39
@@ -306,12 +274,8 @@ msgstr "Valuta la richiesta"
 
 #. Translators: This text is shown to coordinators on application pages if the applicant has restricted processing of their data.
 #: TWLight/applications/templates/applications/application_evaluation.html:42
-msgid ""
-"This user has requested a restriction on the processing of their data, so "
-"you cannot change the status of their application."
-msgstr ""
-"Questo utente ha richiesto una restrizione all'elaborazione dei loro dati, "
-"sicché non puoi cambiare lo stato della loro richiesta"
+msgid "This user has requested a restriction on the processing of their data, so you cannot change the status of their application."
+msgstr "Questo utente ha richiesto una restrizione all'elaborazione dei loro dati, sicché non puoi cambiare lo stato della loro richiesta"
 
 #. Translators: This is the title of the application page shown to users who are not a coordinator.
 #: TWLight/applications/templates/applications/application_evaluation.html:48
@@ -384,12 +348,8 @@ msgstr "Sconosciuto"
 
 #. Translators: This is the text displayed to coordinators when an applicant has no country of residence in their profile.
 #: TWLight/applications/templates/applications/application_evaluation.html:123
-msgid ""
-"Please request the applicant add their country of residence to their profile "
-"before proceeding further."
-msgstr ""
-"Gentilmente, chiedi all'utente di aggiungere il paese di residenza al suo "
-"profilo prima di procedere oltre."
+msgid "Please request the applicant add their country of residence to their profile before proceeding further."
+msgstr "Gentilmente, chiedi all'utente di aggiungere il paese di residenza al suo profilo prima di procedere oltre."
 
 #. Translators: This labels the section of an application showing the total number of accounts available for a partner or their collection.
 #: TWLight/applications/templates/applications/application_evaluation.html:134
@@ -399,12 +359,8 @@ msgstr "Utenze disponibili"
 #. Translators: This labels the section of an application showing whether the user had agreed to the terms of use or not.
 #: TWLight/applications/templates/applications/application_evaluation.html:145
 #, python-format
-msgid ""
-"Has agreed to the site's <a class=\"twl-links\" href=\"%(terms_url)s\">terms "
-"of use</a>?"
-msgstr ""
-"Ha sottoscritto le <a class=\"twl-links\" href=\"%(terms_url)s\">condizioni "
-"di utilizzo</a> del sito?"
+msgid "Has agreed to the site's <a class=\"twl-links\" href=\"%(terms_url)s\">terms of use</a>?"
+msgstr "Ha sottoscritto le <a class=\"twl-links\" href=\"%(terms_url)s\">condizioni di utilizzo</a> del sito?"
 
 #. Translators: Displayed to coordinators when they've agreed to the terms of use.
 #. Translators: Displayed if the user has agreed to the terms of use.
@@ -439,12 +395,8 @@ msgstr "No"
 
 #. Translators: This is the text displayed to coordinators when an applicant has not agreed to the terms of use.
 #: TWLight/applications/templates/applications/application_evaluation.html:159
-msgid ""
-"Please request the applicant agree to the site's terms of use before "
-"approving this application."
-msgstr ""
-"Gentilmente, richiedi all'utente di sottoscrivere le condizioni di utilizzo "
-"del sito prima di approvare la sua richiesta"
+msgid "Please request the applicant agree to the site's terms of use before approving this application."
+msgstr "Gentilmente, richiedi all'utente di sottoscrivere le condizioni di utilizzo del sito prima di approvare la sua richiesta"
 
 #. Translators: This labels the section of an application containing the user's motivation for wanting access to this resource.
 #: TWLight/applications/templates/applications/application_evaluation.html:176
@@ -464,10 +416,8 @@ msgstr "Rinnovo di un'autorizzazione all'accesso esistente?"
 #. Translators: This message is shown next to the 'Renewal of existing access grant?' label if the application is a renewal. Don't translate HTML tags or parent_url.
 #: TWLight/applications/templates/applications/application_evaluation.html:195
 #, python-format
-msgid ""
-"Yes (<a class=\"twl-links\" href=\"%(parent_url)s\">previous application</a>)"
-msgstr ""
-"Sì (<a class=\"twl-links\" href=\"%(parent_url)s\">richiesta precedente</a>)"
+msgid "Yes (<a class=\"twl-links\" href=\"%(parent_url)s\">previous application</a>)"
+msgstr "Sì (<a class=\"twl-links\" href=\"%(parent_url)s\">richiesta precedente</a>)"
 
 #. Translators: This labels the section of the application showing the length of access remaining on the user's previous authorization.
 #: TWLight/applications/templates/applications/application_evaluation.html:208
@@ -487,8 +437,7 @@ msgstr "Richieste recenti (ultimi 90 giorni)"
 #. Translators: This text is shown to Coordinators when applicant has not made any application in the last 90 days.
 #: TWLight/applications/templates/applications/application_evaluation.html:264
 msgid "No applications were made in last 90 days by the applicant"
-msgstr ""
-"Nessuna richiesta è stata presentata dall'utente negli ultimi 90 giorni"
+msgstr "Nessuna richiesta è stata presentata dall'utente negli ultimi 90 giorni"
 
 #. Translators: This is the title of the section of an application page which contains the comment thread between the user and account coordinator.
 #: TWLight/applications/templates/applications/application_evaluation.html:268
@@ -502,12 +451,8 @@ msgstr "Aggiungi commento"
 
 #. Translators: On an application page, this text tells users that the comments posted on the application are visible to coordinators and the submitting user only.
 #: TWLight/applications/templates/applications/application_evaluation.html:297
-msgid ""
-"Comments are visible to all coordinators and to the editor who submitted "
-"this application."
-msgstr ""
-"I commenti sono visibili a tutti i coordinatori e all'utente che ha "
-"presentato questa richiesta."
+msgid "Comments are visible to all coordinators and to the editor who submitted this application."
+msgstr "I commenti sono visibili a tutti i coordinatori e all'utente che ha presentato questa richiesta."
 
 #. Translators: This is the title of the section of an application page which lists information about the user who submitted the application.
 #. Translators: On the page where coordinators can view data on applications to a partner they coordinate, this is a table column heading for the username.
@@ -718,12 +663,7 @@ msgstr "Imposta stato"
 
 #: TWLight/applications/templates/applications/apply.html:20
 #, python-format
-msgid ""
-"If your application is successful we may share your email address with "
-"%(partner)s. This is required to set up your access to their resources. By "
-"submitting this form you agree to allow your email address to be shared with "
-"%(partner)s if your application is successful, for the purposes of account "
-"setup."
+msgid "If your application is successful we may share your email address with %(partner)s. This is required to set up your access to their resources. By submitting this form you agree to allow your email address to be shared with %(partner)s if your application is successful, for the purposes of account setup."
 msgstr ""
 
 #. Translators: This message is displayed on the page where users can confirm their renewal. Please do not translate partner.
@@ -752,12 +692,8 @@ msgstr "A quali risorse vuoi accedere?"
 
 #. Translators: This text explains that Library Bundle partners are not shown in this list.
 #: TWLight/applications/templates/applications/request_for_application.html:26
-msgid ""
-"Library Bundle partners are not shown as eligibility is determined "
-"automatically."
-msgstr ""
-"I partner di Library Bundle non sono mostrati perché la loro ammissibilità è "
-"determinata automaticamente."
+msgid "Library Bundle partners are not shown as eligibility is determined automatically."
+msgstr "I partner di Library Bundle non sono mostrati perché la loro ammissibilità è determinata automaticamente."
 
 #. Translators: On the page where users can apply for multiple partners, this message shows next to the partner name, taking them to the full application page when clicked.
 #: TWLight/applications/templates/applications/request_for_application.html:48
@@ -771,10 +707,7 @@ msgstr "Nessun dato di partner è stato ancora aggiunto."
 
 #. Translators: the HTML is so that the word 'waitlisted' will look the same as it does in the page above; please translate 'waitlisted' the same way you did elsewhere in this file.
 #: TWLight/applications/templates/applications/request_for_application.html:74
-msgid ""
-"You can apply to <span class=\"badge badge-warning\">Waitlisted</span> "
-"partners, but they don't have access grants available right now. We will "
-"process those applications when access becomes available."
+msgid "You can apply to <span class=\"badge badge-warning\">Waitlisted</span> partners, but they don't have access grants available right now. We will process those applications when access becomes available."
 msgstr ""
 
 #. Translators: On the page where coordinators can see approved applications which have not had their details sent to the partner, this message shows when there are applications ready to be processed.
@@ -796,9 +729,7 @@ msgstr ""
 #. Translators: This message is shown when applications exceed the number of accounts available.
 #: TWLight/applications/templates/applications/send_partner.html:54
 #, python-format
-msgid ""
-"Application(s) for %(object)s, if sent, will exceed the total available "
-"accounts for the partner. Please proceed at your own discretion."
+msgid "Application(s) for %(object)s, if sent, will exceed the total available accounts for the partner. Please proceed at your own discretion."
 msgstr ""
 
 #. Translators: When viewing the list of applications ready to be sent for a particular partner, this is instructions for the coordinator to click the 'mark as sent' button after they have sent the information.
@@ -815,9 +746,7 @@ msgstr[1] ""
 
 #. Translators: When viewing the list of applications ready to be sent for a particular partner, this message shows if there is no information about who the applications should be sent to. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/applications/templates/applications/send_partner.html:89
-msgid ""
-"Whoops, we don't have any listed contacts. Please notify Wikipedia Library "
-"administrators."
+msgid "Whoops, we don't have any listed contacts. Please notify Wikipedia Library administrators."
 msgstr ""
 
 #. Translators: When viewing the list of applications ready to be sent for a particular partner, this is the title of the section containing the information about those applications.
@@ -833,9 +762,7 @@ msgstr "Segna come inviato"
 
 #. Translators: This text guides coordinators in using the code sending interface for approved applications.
 #: TWLight/applications/templates/applications/send_partner.html:152
-msgid ""
-"Use the dropdown menus to denote which editor will receive each code. Access "
-"codes will be sent to users automatically."
+msgid "Use the dropdown menus to denote which editor will receive each code. Access codes will be sent to users automatically."
 msgstr ""
 
 #. Translators: This labels a drop-down selection where staff can assign an access code to a user.
@@ -851,18 +778,13 @@ msgstr ""
 #. Translators: When a user applies for a set of resources, they receive this message if none are currently available. They are instead placed on a 'waitlist' for later approval.
 #. Translators: When a user renews their resource, they receive this message if none are currently available. They are instead placed on a 'waitlist' for later approval.
 #: TWLight/applications/views.py:140 TWLight/applications/views.py:1282
-msgid ""
-"This partner does not have any access grants available at this time. You may "
-"still apply for access; your application will be reviewed when access grants "
-"become available."
+msgid "This partner does not have any access grants available at this time. You may still apply for access; your application will be reviewed when access grants become available."
 msgstr ""
 
 #. Translators: This message is shown to users once they've successfully submitted their application for review.
 #: TWLight/applications/views.py:163
 #, python-brace-format
-msgid ""
-"Your application has been submitted for review. Head over to <a "
-"href='{applications_url}'>My Applications</a> to view the status."
+msgid "Your application has been submitted for review. Head over to <a href='{applications_url}'>My Applications</a> to view the status."
 msgstr ""
 
 #. Translators: This text is displayed to users when the user has chosen to restrict data and is trying to apply for multiple partners
@@ -911,16 +833,12 @@ msgstr ""
 
 #. Translators: After a coordinator has changed the status of an application to APPROVED, if the corresponding partner/collection is waitlisted this message appears.
 #: TWLight/applications/views.py:756
-msgid ""
-"Cannot approve application as partner with proxy authorization method is "
-"waitlisted."
+msgid "Cannot approve application as partner with proxy authorization method is waitlisted."
 msgstr ""
 
 #. Translators: After a coordinator has changed the status of an application to APPROVED, if the corresponding partner/collection has no accounts for distribution, this message appears.
 #: TWLight/applications/views.py:780
-msgid ""
-"Cannot approve application as partner with proxy authorization method is "
-"waitlisted and (or) has zero accounts available for distribution."
+msgid "Cannot approve application as partner with proxy authorization method is waitlisted and (or) has zero accounts available for distribution."
 msgstr ""
 
 #. Translators: This message appears on an "access denied" screen that stops users who attempt to authorize an editor to access a resource during a time period for which they are already authorized.
@@ -931,11 +849,7 @@ msgstr ""
 #. Translators: This message is shown to users when they access an application page of a now Bundle partner (new applications aren't allowed for Bundle partners and the status of old applications cannot be modified)
 #: TWLight/applications/views.py:857
 #, python-brace-format
-msgid ""
-"This application cannot be modified since this partner is now part of our <a "
-"href='{bundle}'>bundle access</a>. If you are eligible, you can access this "
-"resource from <a href='{library}'>your library</a>. <a "
-"href='{contact}'>Contact us</a> if you have any questions."
+msgid "This application cannot be modified since this partner is now part of our <a href='{bundle}'>bundle access</a>. If you are eligible, you can access this resource from <a href='{library}'>your library</a>. <a href='{contact}'>Contact us</a> if you have any questions."
 msgstr ""
 
 #. Translators: this lets a reviewer set the status of a single application.
@@ -945,9 +859,7 @@ msgstr ""
 
 #. Translators: This warning is message is shown to applicants when the number of pending applications is greater than the number of accounts available.
 #: TWLight/applications/views.py:891
-msgid ""
-"There are more pending applications than available accounts. Your "
-"application might get waitlisted."
+msgid "There are more pending applications than available accounts. Your application might get waitlisted."
 msgstr ""
 
 #. Translators: this message is shown to coordinators who attempt to change an application's Status from INVALID to any other Status.
@@ -967,11 +879,7 @@ msgstr ""
 
 #. Translators: After a coordinator has changed the status of a number of applications to APPROVED, if the corresponding partner(s) is/are waitlisted or has no accounts for distribution, this message appears.
 #: TWLight/applications/views.py:1051
-msgid ""
-"Cannot approve application(s) {} as partner(s) with proxy authorization "
-"method is/are waitlisted and (or) has/have not enough accounts available. If "
-"not enough accounts are available, prioritise the applications and then "
-"approve applications equal to the accounts available."
+msgid "Cannot approve application(s) {} as partner(s) with proxy authorization method is/are waitlisted and (or) has/have not enough accounts available. If not enough accounts are available, prioritise the applications and then approve applications equal to the accounts available."
 msgstr ""
 
 #. Translators: This message is shown to coordinators who attempt to assign the same access code to multiple users.
@@ -986,9 +894,7 @@ msgstr ""
 
 #. Translators: When a user tries to renew their resource, they receive this message if the partner is not available.
 #: TWLight/applications/views.py:1272
-msgid ""
-"Cannot renew application at this time as partner is not available. Please "
-"check back later, or contact us for more information."
+msgid "Cannot renew application at this time as partner is not available. Please check back later, or contact us for more information."
 msgstr ""
 
 #. Translators: This message is displayed when an attempt by a user to renew an application has been denied for some reason.
@@ -999,16 +905,12 @@ msgstr ""
 
 #. Translators: If a user requests the renewal of their account, but it wasn't renewed, this message is shown to them.
 #: TWLight/applications/views.py:1385
-msgid ""
-"This object cannot be renewed. (This probably means that you have already "
-"requested that it be renewed.)"
+msgid "This object cannot be renewed. (This probably means that you have already requested that it be renewed.)"
 msgstr ""
 
 #. Translators: If a user requests the renewal of their account, this message is shown to them.
 #: TWLight/applications/views.py:1395
-msgid ""
-"Your renewal request has been received. A coordinator will review your "
-"request."
+msgid "Your renewal request has been received. A coordinator will review your request."
 msgstr ""
 
 #. Translators: This labels a textfield where users can enter their email ID.
@@ -1018,12 +920,8 @@ msgstr "La tua email"
 
 #. Translators: This is the help text for the email field in the contact us form letting users know the field is updated by value pulled from their respective user profiles.
 #: TWLight/emails/forms.py:21
-msgid ""
-"This field is automatically updated with the email from your <a class='twl-"
-"links' href='{}'>user profile</a>."
-msgstr ""
-"Questo campo è aggiornato automaticamente con l'indirizzo di posta "
-"elettronica dal tuo <a class='twl-links' href='{}'>profilo utente</a>."
+msgid "This field is automatically updated with the email from your <a class='twl-links' href='{}'>user profile</a>."
+msgstr "Questo campo è aggiornato automaticamente con l'indirizzo di posta elettronica dal tuo <a class='twl-links' href='{}'>profilo utente</a>."
 
 #. Translators: This labels a textfield where users can enter their email message.
 #: TWLight/emails/forms.py:26
@@ -1046,19 +944,13 @@ msgstr "Invia"
 #. Translators: This email is sent to users with their access code. Don't translate Jinja variables in curly braces like user or partner. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/access_code_email-body-html.html:5
 #, python-format
-msgid ""
-"<p>Your approved application to %(partner)s has now been finalised. Your "
-"access code or login details can be found below:</p> <p><b>%(access_code)s</"
-"b></p> <p>%(user_instructions)s</p>"
+msgid "<p>Your approved application to %(partner)s has now been finalised. Your access code or login details can be found below:</p> <p><b>%(access_code)s</b></p> <p>%(user_instructions)s</p>"
 msgstr ""
 
 #. Translators: This email is sent to users with their access code. Don't translate Jinja variables in curly braces like user or partner. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/access_code_email-body-text.html:3
 #, python-format
-msgid ""
-"Your approved application to %(partner)s has now been finalised. Your access "
-"code or login details can be found below: %(access_code)s "
-"%(user_instructions)s"
+msgid "Your approved application to %(partner)s has now been finalised. Your access code or login details can be found below: %(access_code)s %(user_instructions)s"
 msgstr ""
 
 #. Translators: This is the subject line of an email sent to users with their access code.
@@ -1069,23 +961,13 @@ msgstr ""
 #. Translators: This email is sent to users when their application is approved. Don't translate Jinja variables in curly braces like user or partner; don't translate html tags either. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/approval_notification-body-html.html:5
 #, python-format
-msgid ""
-"<p>Dear %(user)s,</p> <p>Thank you for applying for access to %(partner)s "
-"resources through The Wikipedia Library. We are happy to inform you that "
-"your application has been approved.</p> <p>%(user_instructions)s</p> <p>You "
-"can view the collections you're authorized to access at My Library: "
-"%(link)s</p> <p>Cheers!</p> <p>The Wikipedia Library</p>"
+msgid "<p>Dear %(user)s,</p> <p>Thank you for applying for access to %(partner)s resources through The Wikipedia Library. We are happy to inform you that your application has been approved.</p> <p>%(user_instructions)s</p> <p>You can view the collections you're authorized to access at My Library: %(link)s</p> <p>Cheers!</p> <p>The Wikipedia Library</p>"
 msgstr ""
 
 #. Translators: This email is sent to users when their application is approved. Don't translate Jinja variables in curly braces like user or partner. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/approval_notification-body-text.html:3
 #, python-format
-msgid ""
-"Dear %(user)s, Thank you for applying for access to %(partner)s resources "
-"through The Wikipedia Library. We are happy to inform you that your "
-"application has been approved. %(user_instructions)s You can view the "
-"collections you're authorized to access at My Library: %(link)s Cheers! The "
-"Wikipedia Library"
+msgid "Dear %(user)s, Thank you for applying for access to %(partner)s resources through The Wikipedia Library. We are happy to inform you that your application has been approved. %(user_instructions)s You can view the collections you're authorized to access at My Library: %(link)s Cheers! The Wikipedia Library"
 msgstr ""
 
 #. Translators: This is the subject of an email which is sent to users when their application has been approved. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
@@ -1096,19 +978,13 @@ msgstr ""
 #. Translators: This email is sent to coordinators when a comment is left on an application they are processing. Don't translate Jinja variables in curly braces like user or partner. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/comment_notification_coordinator-body-html.html:5
 #, python-format
-msgid ""
-"<p style=\"color: #500050\">%(submit_date)s - %(commenter)s</p> "
-"<blockquote><p>%(comment)s</p></blockquote> <p>Please reply to these at: <a "
-"href=\"%(app_url)s\">%(app_url)s</a></p> <p>Best,</p> <p>The Wikipedia "
-"Library</p>"
+msgid "<p style=\"color: #500050\">%(submit_date)s - %(commenter)s</p> <blockquote><p>%(comment)s</p></blockquote> <p>Please reply to these at: <a href=\"%(app_url)s\">%(app_url)s</a></p> <p>Best,</p> <p>The Wikipedia Library</p>"
 msgstr ""
 
 #. Translators: This email is sent to coordinators when a comment is left on an application they are processing. Don't translate Jinja variables in curly braces like user or partner. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/comment_notification_coordinator-body-text.html:3
 #, python-format
-msgid ""
-"%(submit_date)s - %(commenter)s %(comment)s Please reply to this at: "
-"%(app_url)s Best, The Wikipedia Library"
+msgid "%(submit_date)s - %(commenter)s %(comment)s Please reply to this at: %(app_url)s Best, The Wikipedia Library"
 msgstr ""
 
 #. Translators: This is the subject line of an email sent to coordinators when a comment is left on an application they processed.
@@ -1119,19 +995,13 @@ msgstr ""
 #. Translators: This email is sent to users when they receive a comment on their application. Don't translate Jinja variables in curly braces like user or partner; don't translate html tags either. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/comment_notification_editors-body-html.html:5
 #, python-format
-msgid ""
-"<p style=\"color: #500050\">%(submit_date)s - %(commenter)s</p> "
-"<blockquote><p>%(comment)s</p></blockquote> <p>Please reply to these at <a "
-"href=\"%(app_url)s\">%(app_url)s</a> so we can evaluate your application.</"
-"p> <p>Best,</p> <p>The Wikipedia Library</p>"
+msgid "<p style=\"color: #500050\">%(submit_date)s - %(commenter)s</p> <blockquote><p>%(comment)s</p></blockquote> <p>Please reply to these at <a href=\"%(app_url)s\">%(app_url)s</a> so we can evaluate your application.</p> <p>Best,</p> <p>The Wikipedia Library</p>"
 msgstr ""
 
 #. Translators: This email is sent to users when they receive a comment on their application. Don't translate Jinja variables in curly braces like user or partner. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/comment_notification_editors-body-text.html:3
 #, python-format
-msgid ""
-"%(submit_date)s - %(commenter)s %(comment)s Please reply to these at: "
-"%(app_url)s so we can evaluate your application. Best, The Wikipedia Library"
+msgid "%(submit_date)s - %(commenter)s %(comment)s Please reply to these at: %(app_url)s so we can evaluate your application. Best, The Wikipedia Library"
 msgstr ""
 
 #. Translators: This is the subject line of an email sent to users who have a comment added to one of their applications. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
@@ -1142,18 +1012,13 @@ msgstr ""
 #. Translators: This email is sent to users when an application they commented on receives another comment. Don't translate Jinja variables in curly braces like app_url; don't translate html tags either. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/comment_notification_others-body-html.html:5
 #, python-format
-msgid ""
-"<p style=\"color: #500050\">%(submit_date)s - %(commenter)s</p> "
-"<blockquote><p>%(comment)s</p></blockquote> See it at <a href=\"%(app_url)s"
-"\">%(app_url)s</a>. Thanks for helping review Wikipedia Library applications!"
+msgid "<p style=\"color: #500050\">%(submit_date)s - %(commenter)s</p> <blockquote><p>%(comment)s</p></blockquote> See it at <a href=\"%(app_url)s\">%(app_url)s</a>. Thanks for helping review Wikipedia Library applications!"
 msgstr ""
 
 #. Translators: This email is sent to users when an application they commented on receives another comment. Don't translate Jinja variables in curly braces like app_url. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/comment_notification_others-body-text.html:3
 #, python-format
-msgid ""
-"%(submit_date)s - %(commenter)s %(comment)s See it at: %(app_url)s Thanks "
-"for helping review Wikipedia Library applications!"
+msgid "%(submit_date)s - %(commenter)s %(comment)s See it at: %(app_url)s Thanks for helping review Wikipedia Library applications!"
 msgstr ""
 
 #. Translators: This is the subject line of an email sent to users who have a comment added to an application they also commented on. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
@@ -1164,10 +1029,7 @@ msgstr ""
 #. Translators: This text is part of a scheduled reminder email sent to coordinators who have applications requiring action. Don't translate Jinja variables in curly braces like total_apps, or user.
 #: TWLight/emails/templates/emails/coordinator_reminder_notification-body-html.html:5
 #, python-format
-msgid ""
-"<p>Dear %(user)s,</p> <p>Our records indicate that you are the designated "
-"coordinator for partners that have a total of %(total_apps)s applications.</"
-"p>"
+msgid "<p>Dear %(user)s,</p> <p>Our records indicate that you are the designated coordinator for partners that have a total of %(total_apps)s applications.</p>"
 msgstr ""
 
 #. Translators: Breakdown as in 'cost breakdown'; analysis.
@@ -1206,31 +1068,19 @@ msgstr[1] ""
 #. Translators: This text is part of a scheduled reminder email sent to coordinators who have applications requiring action. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library). Don't translate Jinja variables in curly braces like link; don't translate email addresses or html tags either.
 #: TWLight/emails/templates/emails/coordinator_reminder_notification-body-html.html:39
 #, python-format
-msgid ""
-"<p>This is a gentle reminder that you may review applications at <a href="
-"\"%(link)s\">%(link)s</a>.</p> <p>You can customise your reminders under "
-"'preferences' in your user profile.</p> <p>If you received this message in "
-"error, drop us a line at wikipedialibrary@wikimedia.org.</p> <p>Thanks for "
-"helping review Wikipedia Library applications!</p>"
+msgid "<p>This is a gentle reminder that you may review applications at <a href=\"%(link)s\">%(link)s</a>.</p> <p>You can customise your reminders under 'preferences' in your user profile.</p> <p>If you received this message in error, drop us a line at wikipedialibrary@wikimedia.org.</p> <p>Thanks for helping review Wikipedia Library applications!</p>"
 msgstr ""
 
 #. Translators: This text is part of a scheduled reminder email sent to coordinators who have applications requiring action. Don't translate Jinja variables in curly braces like total_apps, or user.
 #: TWLight/emails/templates/emails/coordinator_reminder_notification-body-text.html:3
 #, python-format
-msgid ""
-"Dear %(user)s, Our records indicate that you are the designated coordinator "
-"for partners that have a total of %(total_apps)s applications."
+msgid "Dear %(user)s, Our records indicate that you are the designated coordinator for partners that have a total of %(total_apps)s applications."
 msgstr ""
 
 #. Translators: This text is part of a scheduled reminder email sent to coordinators who have applications requiring action. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library). Don't translate Jinja variables in curly braces like link; don't translate the email address either.
 #: TWLight/emails/templates/emails/coordinator_reminder_notification-body-text.html:38
 #, python-format
-msgid ""
-"This is a gentle reminder that you may review applications at: %(link)s. You "
-"can customise your reminders under 'preferences' in your user profile. If "
-"you received this message in error, drop us a line at: "
-"wikipedialibrary@wikimedia.org Thanks for helping review Wikipedia Library "
-"applications!"
+msgid "This is a gentle reminder that you may review applications at: %(link)s. You can customise your reminders under 'preferences' in your user profile. If you received this message in error, drop us a line at: wikipedialibrary@wikimedia.org Thanks for helping review Wikipedia Library applications!"
 msgstr ""
 
 #. Translators: This is the subject line of a scheduled reminder email sent to coordinators who have applications to review. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library). Do not translate items in curly braces.
@@ -1241,22 +1091,13 @@ msgstr ""
 #. Translators: This email is sent to users when their application is rejected. Don't translate Jinja variables in curly braces like user or partner; don't translate html tags either. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/rejection_notification-body-html.html:5
 #, python-format
-msgid ""
-"<p>Dear %(user)s,</p> <p>Thank you for applying for access to %(partner)s "
-"resources through The Wikipedia Library. Unfortunately at this time your "
-"application has not been approved. You can view your application and review "
-"comments at <a href=\"%(app_url)s\">%(app_url)s</a>.</p> <p>Best,</p> <p>The "
-"Wikipedia Library</p>"
+msgid "<p>Dear %(user)s,</p> <p>Thank you for applying for access to %(partner)s resources through The Wikipedia Library. Unfortunately at this time your application has not been approved. You can view your application and review comments at <a href=\"%(app_url)s\">%(app_url)s</a>.</p> <p>Best,</p> <p>The Wikipedia Library</p>"
 msgstr ""
 
 #. Translators: This email is sent to users when their application is rejected. Don't translate Jinja variables in curly braces like user or partner. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/rejection_notification-body-text.html:3
 #, python-format
-msgid ""
-"Dear %(user)s, Thank you for applying for access to %(partner)s resources "
-"through The Wikipedia Library. Unfortunately at this time your application "
-"has not been approved. You can view your application and review comments at: "
-"%(app_url)s Best, The Wikipedia Library"
+msgid "Dear %(user)s, Thank you for applying for access to %(partner)s resources through The Wikipedia Library. Unfortunately at this time your application has not been approved. You can view your application and review comments at: %(app_url)s Best, The Wikipedia Library"
 msgstr ""
 
 #. Translators: This is the subject of an email which is sent to users when their application has been rejected. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
@@ -1267,25 +1108,13 @@ msgstr ""
 #. Translators: This email is sent to users when they have an account that is soon to expire. Don't translate Jinja variables in curly braces like partner_name or partner_link; don't translate html tags either. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/user_renewal_notice-body-html.html:5
 #, python-format
-msgid ""
-"<p>Dear %(user)s,</p> <p>According to our records, your access to "
-"%(partner_name)s will soon expire and you may lose access. If you want to "
-"continue making use of your free account, you can request renewal of your "
-"account by clicking the 'Renew' or 'Extend' button at %(partner_link)s.</p> "
-"<p>Best,</p> <p>The Wikipedia Library</p> <p>You can disable these emails in "
-"your user page preferences: https://wikipedialibrary.wmflabs.org/users/</p>"
+msgid "<p>Dear %(user)s,</p> <p>According to our records, your access to %(partner_name)s will soon expire and you may lose access. If you want to continue making use of your free account, you can request renewal of your account by clicking the 'Renew' or 'Extend' button at %(partner_link)s.</p> <p>Best,</p> <p>The Wikipedia Library</p> <p>You can disable these emails in your user page preferences: https://wikipedialibrary.wmflabs.org/users/</p>"
 msgstr ""
 
 #. Translators: This email is sent to users when they have an account that is soon to expire. Don't translate Jinja variables in curly braces like partner_name or partner_link; don't translate html tags either. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/user_renewal_notice-body-text.html:3
 #, python-format
-msgid ""
-"Dear %(user)s, According to our records, your access to %(partner_name)s "
-"will soon expire and you may lose access. If you want to continue making use "
-"of your free account, you can request renewal of your account by clicking "
-"the Renew button at %(partner_link)s. Best, The Wikipedia Library You can "
-"disable these emails in your user page preferences: https://wikipedialibrary."
-"wmflabs.org/users/"
+msgid "Dear %(user)s, According to our records, your access to %(partner_name)s will soon expire and you may lose access. If you want to continue making use of your free account, you can request renewal of your account by clicking the Renew button at %(partner_link)s. Best, The Wikipedia Library You can disable these emails in your user page preferences: https://wikipedialibrary.wmflabs.org/users/"
 msgstr ""
 
 #. Translators: This is the subject of an email sent to users when they have an account that is soon to expire. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
@@ -1296,24 +1125,13 @@ msgstr ""
 #. Translators: This email is sent to users when their application is waitlisted because there are no more accounts available. Don't translate Jinja variables in curly braces like user or partner; don't translate html tags either. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/waitlist_notification-body-html.html:5
 #, python-format
-msgid ""
-"<p>Dear %(user)s,</p> <p>Thank you for applying for access to %(partner)s "
-"resources through The Wikipedia Library. There are no accounts currently "
-"available so your application has been waitlisted. Your application will be "
-"evaluated if/when more accounts become available. You can see all available "
-"resources at <a href=\"%(link)s\">%(link)s</a>.</p> <p>Best,</p> <p>The "
-"Wikipedia Library</p>"
+msgid "<p>Dear %(user)s,</p> <p>Thank you for applying for access to %(partner)s resources through The Wikipedia Library. There are no accounts currently available so your application has been waitlisted. Your application will be evaluated if/when more accounts become available. You can see all available resources at <a href=\"%(link)s\">%(link)s</a>.</p> <p>Best,</p> <p>The Wikipedia Library</p>"
 msgstr ""
 
 #. Translators: This email is sent to users when their application is waitlisted because there are no more accounts available. Don't translate Jinja variables in curly braces like user or partner. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/waitlist_notification-body-text.html:3
 #, python-format
-msgid ""
-"Dear %(user)s, Thank you for applying for access to %(partner)s resources "
-"through The Wikipedia Library. There are no accounts currently available so "
-"your application has been waitlisted. Your application will be evaluated if/"
-"when more accounts become available. You can see all available resources at: "
-"%(link)s Best, The Wikipedia Library"
+msgid "Dear %(user)s, Thank you for applying for access to %(partner)s resources through The Wikipedia Library. There are no accounts currently available so your application has been waitlisted. Your application will be evaluated if/when more accounts become available. You can see all available resources at: %(link)s Best, The Wikipedia Library"
 msgstr ""
 
 #. Translators: This is the subject of an email sent to users when their application is waitlisted because there are no more accounts available. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
@@ -1475,17 +1293,14 @@ msgstr "Non disponibile"
 #: TWLight/resources/templates/resources/filter_section.html:14
 #: TWLight/templates/about.html:12
 #: TWLight/users/templates/users/filter_section.html:13
-msgid ""
-"The Wikipedia Library allows active editors to access a wide range of "
-"collections of paywalled reliable sources for free!"
+msgid "The Wikipedia Library allows active editors to access a wide range of collections of paywalled reliable sources for free!"
 msgstr ""
 
 #. Translators: On the Browse Partners page (https://wikipedialibrary.wmflabs.org/partners/), this introduces users to The Wikipedia Library.
 #. Translators: On the MyLibrary page (https://wikipedialibrary.wmflabs.org/users/my_library), this introduces users to The Wikipedia Library.
 #: TWLight/resources/templates/resources/filter_section.html:17
 #: TWLight/users/templates/users/filter_section.html:15
-msgid ""
-"Start with the search bar at the top or browse publisher websites directly."
+msgid "Start with the search bar at the top or browse publisher websites directly."
 msgstr ""
 
 #. Translators: On the Browse Partners page (https://wikipedialibrary.wmflabs.org/partners/), this appears below introductory text and links to the 'About' page (https://wikipedialibrary.wmflabs.org/about/)
@@ -1559,52 +1374,38 @@ msgstr ""
 #. Translators: If we have no available accounts for a partner, the coordinator can change the application system to a waiting list.
 #: TWLight/resources/templates/resources/partner_detail.html:36
 #: TWLight/resources/templates/resources/partner_detail_apply.html:17
-msgid ""
-"There are no access grants available for this partner at this time. You can "
-"still apply for access; applications will be processed when access is "
-"available."
+msgid "There are no access grants available for this partner at this time. You can still apply for access; applications will be processed when access is available."
 msgstr ""
 
 #. Translators: This text links to the minimum user requirements and terms of use on the partner page.
 #: TWLight/resources/templates/resources/partner_detail.html:48
 #: TWLight/resources/templates/resources/partner_detail_apply.html:29
 #, python-format
-msgid ""
-"Before applying, please review the <strong><a class=\"twl-links\" href="
-"\"%(about)s#req\">minimum requirements</a></strong> for access and our "
-"<strong><a class=\"twl-links\" href=\"%(terms)s\">terms of use</a></strong>."
+msgid "Before applying, please review the <strong><a class=\"twl-links\" href=\"%(about)s#req\">minimum requirements</a></strong> for access and our <strong><a class=\"twl-links\" href=\"%(terms)s\">terms of use</a></strong>."
 msgstr ""
 
 #. Translators: This text refers to the page containing the content a user is authorized to access.
 #: TWLight/resources/templates/resources/partner_detail.html:69
 #, python-format
-msgid ""
-"View the status of your access in <strong><a class=\"twl-links\" href="
-"\"%(library_url)s\">My Library</a></strong> page."
+msgid "View the status of your access in <strong><a class=\"twl-links\" href=\"%(library_url)s\">My Library</a></strong> page."
 msgstr ""
 
 #. Translators: This message is shown when a user has open applications, linking to their respective applications page.
 #: TWLight/resources/templates/resources/partner_detail.html:78
 #, python-format
-msgid ""
-"View the status of your application(s) on your <strong><a class=\"twl-links"
-"\" href=\"%(applications_url)s\">My Applications</a></strong> page."
+msgid "View the status of your application(s) on your <strong><a class=\"twl-links\" href=\"%(applications_url)s\">My Applications</a></strong> page."
 msgstr ""
 
 #. Translators: This message is shown when a user has authorizations, linking to their respective collections page.
 #: TWLight/resources/templates/resources/partner_detail_apply.html:50
 #, python-format
-msgid ""
-"View the status of your access on your <strong><a href=\"%(library_url)s\" "
-"class=\"twl-links\">My Library</a></strong> page."
+msgid "View the status of your access on your <strong><a href=\"%(library_url)s\" class=\"twl-links\">My Library</a></strong> page."
 msgstr ""
 
 #. Translators: This message is shown when a user has open applications, linking to their respective applications page.
 #: TWLight/resources/templates/resources/partner_detail_apply.html:60
 #, python-format
-msgid ""
-"View the status of your application(s) on your <strong><a href="
-"\"%(applications_url)s\">My Applications</a></strong> page."
+msgid "View the status of your application(s) on your <strong><a href=\"%(applications_url)s\">My Applications</a></strong> page."
 msgstr ""
 
 #. Translators: One the partner detail page, this text labels the button which coordinators can click to remove a partner from waitlisted status.
@@ -1634,10 +1435,7 @@ msgstr ""
 
 #. Translators: If no account coordinator is assigned to a partner, the Wikipedia Library team will coordinate signups. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/resources/templates/resources/partner_detail_apply.html:112
-msgid ""
-"The Wikipedia Library team will process this application. Want to help? <a "
-"class=\"twl-links\" href=\"https://en.wikipedia.org/wiki/Wikipedia:"
-"The_Wikipedia_Library/Coordinators/Signup\">Sign up as a coordinator.</a>"
+msgid "The Wikipedia Library team will process this application. Want to help? <a class=\"twl-links\" href=\"https://en.wikipedia.org/wiki/Wikipedia:The_Wikipedia_Library/Coordinators/Signup\">Sign up as a coordinator.</a>"
 msgstr ""
 
 #. Translators: This text labels a button coordinators can click to view a list of users who have applied for access for a particular partner
@@ -1667,18 +1465,13 @@ msgstr ""
 
 #. Translators: Text shown to authenticated, bundle eligible users when they visit a Bundle partner page.
 #: TWLight/resources/templates/resources/partner_detail_apply.html:138
-msgid ""
-"You are eligible to access Library Bundle partners. Click the button above "
-"to access the collection."
+msgid "You are eligible to access Library Bundle partners. Click the button above to access the collection."
 msgstr ""
 
 #. Translators: Text shown to authenticated, bundle ineligible users when they visit a Bundle partner page.
 #: TWLight/resources/templates/resources/partner_detail_apply.html:152
 #, python-format
-msgid ""
-"You are not eligible to access Library Bundle partners. Visit the <a class="
-"\"twl-links\" href=\"%(homepage)s\">homepage</a> to check the eligibility "
-"criteria."
+msgid "You are not eligible to access Library Bundle partners. Visit the <a class=\"twl-links\" href=\"%(homepage)s\">homepage</a> to check the eligibility criteria."
 msgstr ""
 
 #. Translators: Buttton prompting users to log in.
@@ -1690,10 +1483,7 @@ msgstr "Entra"
 #. Translators: Text shown to unauthenticated users when they visit a Bundle partner page.
 #: TWLight/resources/templates/resources/partner_detail_apply.html:168
 #, python-format
-msgid ""
-"This resource is part of our <a class=\"twl-links\" href=\"%(about)s"
-"\">Library Bundle</a>, which you can access if you meet our minimum "
-"eligibility criteria. Log in to find out if you are eligible."
+msgid "This resource is part of our <a class=\"twl-links\" href=\"%(about)s\">Library Bundle</a>, which you can access if you meet our minimum eligibility criteria. Log in to find out if you are eligible."
 msgstr ""
 
 #. Translators: This is the label for a number which shows the total active accounts for one partner. (e.g. https://wikipedialibrary.wmflabs.org/partners/8/).
@@ -1744,26 +1534,19 @@ msgstr ""
 #. Translators: If a partner has specified the excerpt limit both in words and percentage, this message will display the percentage of words and the number of words on the partner page.
 #: TWLight/resources/templates/resources/partner_detail_timeline.html:99
 #, python-format
-msgid ""
-"%(object)s allows a maximum of %(excerpt_limit)s words or "
-"%(excerpt_limit_percentage)s%% of an article be excerpted into a Wikipedia "
-"article."
+msgid "%(object)s allows a maximum of %(excerpt_limit)s words or %(excerpt_limit_percentage)s%% of an article be excerpted into a Wikipedia article."
 msgstr ""
 
 #. Translators: If a partner has specified the excerpt limit in words, this message will display the number of words on the partner page.
 #: TWLight/resources/templates/resources/partner_detail_timeline.html:106
 #, python-format
-msgid ""
-"%(object)s allows a maximum of %(excerpt_limit)s words be excerpted into a "
-"Wikipedia article."
+msgid "%(object)s allows a maximum of %(excerpt_limit)s words be excerpted into a Wikipedia article."
 msgstr ""
 
 #. Translators: If a partner has specified the excerpt limit in percentage, this message will display the percentage of words on the partner page.
 #: TWLight/resources/templates/resources/partner_detail_timeline.html:113
 #, python-format
-msgid ""
-"%(object)s allows a maximum of %(excerpt_limit_percentage)s%% of an article "
-"be excerpted into a Wikipedia article."
+msgid "%(object)s allows a maximum of %(excerpt_limit_percentage)s%% of an article be excerpted into a Wikipedia article."
 msgstr ""
 
 #. Translators: If a partner has other requirements for access, this text shows as the title for that information field. (e.g. https://wikipedialibrary.wmflabs.org/partners/10/).
@@ -1774,9 +1557,7 @@ msgstr ""
 #. Translators: If a user must agree to a Terms of Use document, they see this message, and must enter the name of the resource. Don't translate publisher or url.
 #: TWLight/resources/templates/resources/partner_detail_timeline.html:140
 #, python-format
-msgid ""
-"%(publisher)s requires that you agree with its <a href=\"%(url)s\">terms of "
-"use</a>."
+msgid "%(publisher)s requires that you agree with its <a href=\"%(url)s\">terms of use</a>."
 msgstr ""
 
 #. Translators: If a user must provide their real name to apply to a partner, they see this message, and must enter the name of the resource. Don't translate publisher.
@@ -1800,17 +1581,13 @@ msgstr ""
 #. Translators: If a user must select a specific resource to apply for, they see this message, and must enter the name of the resource. Don't translate publisher.
 #: TWLight/resources/templates/resources/partner_detail_timeline.html:177
 #, python-format
-msgid ""
-"%(publisher)s requires that you specify a particular title that you want to "
-"access."
+msgid "%(publisher)s requires that you specify a particular title that you want to access."
 msgstr ""
 
 #. Translators: If a user must register on the partner website before applying, they see this message. Don't translate partner.
 #: TWLight/resources/templates/resources/partner_detail_timeline.html:187
 #, python-format
-msgid ""
-"%(publisher)s requires that you sign up for an account before applying for "
-"access."
+msgid "%(publisher)s requires that you sign up for an account before applying for access."
 msgstr ""
 
 #. Translators: If a partner has their location listed, this message is a label for that location
@@ -1937,9 +1714,7 @@ msgstr "Sei sicuro di voler cancellare <b>%(object)s</b>?"
 
 #. Translators: If multiple authorizations where returned for a collection, this message is shown to a user
 #: TWLight/resources/views.py:268
-msgid ""
-"Multiple authorizations were returned – something's wrong. Please contact us "
-"and don't forget to mention this message."
+msgid "Multiple authorizations were returned – something's wrong. Please contact us and don't forget to mention this message."
 msgstr ""
 
 #. Translators: This message is shown when user tries to access a NOT_AVAILABLE Partner
@@ -1980,14 +1755,7 @@ msgstr ""
 #. Translators: Shown on the website's 400 page, when a user sends a bad request. Don't translate path or Phabricator.
 #: TWLight/templates/400.html:20
 #, python-format
-msgid ""
-"If you think we should know what to do with that, please email us about this "
-"error at <a class=\"twl-links\" href=\"mailto:wikipedialibrary@wikimedia.org?"
-"Subject=Wikipedia%%20Library%%20%(path)s%%20Permission%%20denied"
-"\">wikipedialibrary@wikimedia.org</a> or report it to us on <a class=\"twl-"
-"links\" href=\"https://phabricator.wikimedia.org/maniphest/task/edit/form/1/?"
-"projectPHIDs=Library-Card-Platform&title=Wikipedia%%20Library%%20%(path)s"
-"%%20Bad%%20Request\">Phabricator</a>"
+msgid "If you think we should know what to do with that, please email us about this error at <a class=\"twl-links\" href=\"mailto:wikipedialibrary@wikimedia.org?Subject=Wikipedia%%20Library%%20%(path)s%%20Permission%%20denied\">wikipedialibrary@wikimedia.org</a> or report it to us on <a class=\"twl-links\" href=\"https://phabricator.wikimedia.org/maniphest/task/edit/form/1/?projectPHIDs=Library-Card-Platform&title=Wikipedia%%20Library%%20%(path)s%%20Bad%%20Request\">Phabricator</a>"
 msgstr ""
 
 #. Translators: Alt text for an image shown on the 400 error page.
@@ -2009,15 +1777,7 @@ msgstr ""
 #. Translators: Shown on the website's 403 page, when a user attempts to navigate to a page they don't have permission to view. Don't translate path or Phabricator.
 #: TWLight/templates/403.html:20
 #, python-format
-msgid ""
-"If you think your account should be able to do that, please email us about "
-"this error at <a class=\"twl-links\" href=\"mailto:"
-"wikipedialibrary@wikimedia.org?Subject=Wikipedia%%20Library%%20%(path)s"
-"%%20Permission%%20denied\">wikipedialibrary@wikimedia.org</a> or report it "
-"to us on <a class=\"twl-links\" href=\"https://phabricator.wikimedia.org/"
-"maniphest/task/edit/form/1/?projectPHIDs=Library-Card-"
-"Platform&title=Wikipedia%%20Library%%20%(path)s%%20Permission%%20denied"
-"\">Phabricator</a>"
+msgid "If you think your account should be able to do that, please email us about this error at <a class=\"twl-links\" href=\"mailto:wikipedialibrary@wikimedia.org?Subject=Wikipedia%%20Library%%20%(path)s%%20Permission%%20denied\">wikipedialibrary@wikimedia.org</a> or report it to us on <a class=\"twl-links\" href=\"https://phabricator.wikimedia.org/maniphest/task/edit/form/1/?projectPHIDs=Library-Card-Platform&title=Wikipedia%%20Library%%20%(path)s%%20Permission%%20denied\">Phabricator</a>"
 msgstr ""
 
 #. Translators: Shown on the website's 404 page, when a user attempts to navigate to a page that doesn't exist.
@@ -2033,14 +1793,7 @@ msgstr ""
 #. Translators: Shown on the website's 404 page, when a user attempts to navigate to a page that doesn't exist. Don't translate path or Phabricator.
 #: TWLight/templates/404.html:19
 #, python-format
-msgid ""
-"If you are certain that something should be here, please email us about this "
-"error at <a class=\"twl-links\" href=\"mailto:wikipedialibrary@wikimedia.org?"
-"Subject=Wikipedia%%20Library%%20%(path)s%%20Not%%20found\"> "
-"wikipedialibrary@wikimedia.org</a> or report it to us on <a class=\"twl-links"
-"\" href=\"https://phabricator.wikimedia.org/maniphest/task/edit/form/1/?"
-"projectPHIDs=Library-Card-Platform&title=Wikipedia%%20Library%%20%(path)s"
-"%%20Not%%20found\">Phabricator</a>"
+msgid "If you are certain that something should be here, please email us about this error at <a class=\"twl-links\" href=\"mailto:wikipedialibrary@wikimedia.org?Subject=Wikipedia%%20Library%%20%(path)s%%20Not%%20found\"> wikipedialibrary@wikimedia.org</a> or report it to us on <a class=\"twl-links\" href=\"https://phabricator.wikimedia.org/maniphest/task/edit/form/1/?projectPHIDs=Library-Card-Platform&title=Wikipedia%%20Library%%20%(path)s%%20Not%%20found\">Phabricator</a>"
 msgstr ""
 
 #. Translators: Alt text for an image shown on the 404 error page.
@@ -2055,32 +1808,18 @@ msgstr ""
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:20
-msgid ""
-"This platform is our central tool for facilitating access to our available "
-"collections. Here you can see which partnerships are available, search their "
-"contents, and apply for and access the ones you’re interested in."
+msgid "This platform is our central tool for facilitating access to our available collections. Here you can see which partnerships are available, search their contents, and apply for and access the ones you’re interested in."
 msgstr ""
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/). Wikimedia Foundation should not be translated.
 #: TWLight/templates/about.html:29
-msgid ""
-"All users receive immediate access to some collections, which can be browsed "
-"by clicking the 'Access collection' buttons or using the search bar at the "
-"top of the page. Other collections require an application before access is "
-"granted, and may be accessed directly or via an individual login or access "
-"code. Volunteer coordinators, who have signed non-disclosure agreements with "
-"the Wikimedia Foundation, review these applications and work with publishers "
-"to get you your free access."
+msgid "All users receive immediate access to some collections, which can be browsed by clicking the 'Access collection' buttons or using the search bar at the top of the page. Other collections require an application before access is granted, and may be accessed directly or via an individual login or access code. Volunteer coordinators, who have signed non-disclosure agreements with the Wikimedia Foundation, review these applications and work with publishers to get you your free access."
 msgstr ""
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/). Don't translate terms_url.
 #: TWLight/templates/about.html:43
 #, python-format
-msgid ""
-"For more information about how your information is stored and reviewed "
-"please see our <a class=\"twl-links\" href=\"%(terms_url)s\"> terms of use "
-"and privacy policy</a>. Accounts you apply for are also subject to the Terms "
-"of Use provided by each partner’s platform; please review them."
+msgid "For more information about how your information is stored and reviewed please see our <a class=\"twl-links\" href=\"%(terms_url)s\"> terms of use and privacy policy</a>. Accounts you apply for are also subject to the Terms of Use provided by each partner’s platform; please review them."
 msgstr ""
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
@@ -2090,12 +1829,7 @@ msgstr ""
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/). Wikimedia Foundation should not be translated.
 #: TWLight/templates/about.html:55
-msgid ""
-"Any active editor in good standing can receive access. For publishers with "
-"limited numbers of accounts, applications are reviewed based on the editor’s "
-"needs and contributions. If you think you could use access to one of our "
-"partner resources and are an active editor in any project supported by the "
-"Wikimedia Foundation, please apply."
+msgid "Any active editor in good standing can receive access. For publishers with limited numbers of accounts, applications are reviewed based on the editor’s needs and contributions. If you think you could use access to one of our partner resources and are an active editor in any project supported by the Wikimedia Foundation, please apply."
 msgstr ""
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
@@ -2125,23 +1859,12 @@ msgstr ""
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/)
 #: TWLight/templates/about.html:89
-msgid ""
-"If you are applying for an available collection, please first check that you "
-"don't already have access through another library or institution. If you do, "
-"please consider using that access rather than taking up a seat for this "
-"resource in The Wikipedia Library."
+msgid "If you are applying for an available collection, please first check that you don't already have access through another library or institution. If you do, please consider using that access rather than taking up a seat for this resource in The Wikipedia Library."
 msgstr ""
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/)
 #: TWLight/templates/about.html:99
-msgid ""
-"If your account is blocked on one or more Wikimedia projects, you may still "
-"be granted access to The Wikipedia Library. You will need to contact the "
-"Wikipedia Library team, who will review your blocks. If you have been "
-"blocked for content issues, most notably copyright violations, or have "
-"multiple long-term blocks, we may decline your request. Additionally, if "
-"your block status changes after being approved, you will need to request "
-"another review."
+msgid "If your account is blocked on one or more Wikimedia projects, you may still be granted access to The Wikipedia Library. You will need to contact the Wikipedia Library team, who will review your blocks. If you have been blocked for content issues, most notably copyright violations, or have multiple long-term blocks, we may decline your request. Additionally, if your block status changes after being approved, you will need to request another review."
 msgstr ""
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
@@ -2176,9 +1899,7 @@ msgstr ""
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:136
-msgid ""
-"Share their account logins or passwords with others, or sell their access to "
-"other parties"
+msgid "Share their account logins or passwords with others, or sell their access to other parties"
 msgstr ""
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
@@ -2188,23 +1909,17 @@ msgstr ""
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:144
-msgid ""
-"Systematically make printed or electronic copies of multiple extracts of "
-"restricted content available for any purpose"
+msgid "Systematically make printed or electronic copies of multiple extracts of restricted content available for any purpose"
 msgstr ""
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/). Stub is a technical term for a short Wikipedia article, use the appropriate Wikipedia term in your language.
 #: TWLight/templates/about.html:148
-msgid ""
-"Datamine metadata without permission, in order, for instance, to use "
-"metadata for auto-created stub articles"
+msgid "Datamine metadata without permission, in order, for instance, to use metadata for auto-created stub articles"
 msgstr ""
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:154
-msgid ""
-"Respecting these agreements allows us to continue growing the partnerships "
-"available to the community."
+msgid "Respecting these agreements allows us to continue growing the partnerships available to the community."
 msgstr ""
 
 #. Translators: This is the heading for a section on the About page (https://wikipedialibrary.wmflabs.org/about/).
@@ -2214,41 +1929,22 @@ msgstr "EZProxy"
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:164
-msgid ""
-"EZProxy is a proxy server used to authenticate users for many Wikipedia "
-"Library partners. Users sign into EZProxy via the Library Card platform to "
-"verify that they are authorized users, and then the server accesses "
-"requested resources using its own IP address."
+msgid "EZProxy is a proxy server used to authenticate users for many Wikipedia Library partners. Users sign into EZProxy via the Library Card platform to verify that they are authorized users, and then the server accesses requested resources using its own IP address."
 msgstr ""
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:173
-msgid ""
-"You may notice that when accessing resources via EZProxy that URLs are "
-"dynamically rewritten. This is why we recommend logging in via the Library "
-"Card platform rather than going directly to the unproxied partner website. "
-"When in doubt, check the URL for ‘idm.oclc’. If it’s there, then you’re "
-"connected via EZProxy."
+msgid "You may notice that when accessing resources via EZProxy that URLs are dynamically rewritten. This is why we recommend logging in via the Library Card platform rather than going directly to the unproxied partner website. When in doubt, check the URL for ‘idm.oclc’. If it’s there, then you’re connected via EZProxy."
 msgstr ""
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:182
-msgid ""
-"Typically once you’ve logged in your session will remain active in your "
-"browser for up to two hours after you’ve finished searching. Note that use "
-"of EZProxy requires you to enable cookies. If you are having problems you "
-"should also try clearing your cache and restarting your browser."
+msgid "Typically once you’ve logged in your session will remain active in your browser for up to two hours after you’ve finished searching. Note that use of EZProxy requires you to enable cookies. If you are having problems you should also try clearing your cache and restarting your browser."
 msgstr ""
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/)
 #: TWLight/templates/about.html:193
-msgid ""
-"The Library Bundle is a collection of resources for which no application is "
-"required. If you meet the criteria laid out above, you will be authorized "
-"for access automatically upon logging in to the platform. Only some of our "
-"content is currently included in the Library Bundle, however we hope to "
-"expand the collection as more publishers become comfortable with "
-"participating. All Bundle content is accessed via EZProxy."
+msgid "The Library Bundle is a collection of resources for which no application is required. If you meet the criteria laid out above, you will be authorized for access automatically upon logging in to the platform. Only some of our content is currently included in the Library Bundle, however we hope to expand the collection as more publishers become comfortable with participating. All Bundle content is accessed via EZProxy."
 msgstr ""
 
 #. Translators: This is the heading for a section on the About page (https://wikipedialibrary.wmflabs.org/about/).
@@ -2258,12 +1954,7 @@ msgstr ""
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:206
-msgid ""
-"Citation practices vary by project and even by article. Generally, we "
-"support editors citing where they found information, in a form that allows "
-"others to check it for themselves. That often means providing both original "
-"source details as well as a link to the partner database in which the source "
-"was found."
+msgid "Citation practices vary by project and even by article. Generally, we support editors citing where they found information, in a form that allows others to check it for themselves. That often means providing both original source details as well as a link to the partner database in which the source was found."
 msgstr ""
 
 #. Translators: This is the heading for a section on the About page (https://wikipedialibrary.wmflabs.org/about/).
@@ -2275,9 +1966,7 @@ msgstr ""
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:218
 #, python-format
-msgid ""
-"If you have questions, need help, or want to volunteer to help, please see "
-"our <a class=\"twl-links\" href=\"%(contact_url)s\">contact page</a>."
+msgid "If you have questions, need help, or want to volunteer to help, please see our <a class=\"twl-links\" href=\"%(contact_url)s\">contact page</a>."
 msgstr ""
 
 #. Translators: This is the title of the panel box detailing the contact information for the Wikipedia Library team.
@@ -2317,9 +2006,7 @@ msgstr ""
 #. Translators: This is the text that appears at the bottom of the contact us form directing users to the suggestions form.
 #: TWLight/templates/contact.html:48
 #, python-format
-msgid ""
-"(If you would like to suggest a partner, <a class=\"twl-links\" href="
-"\"%(suggest)s\"><strong>go here</strong></a>.)"
+msgid "(If you would like to suggest a partner, <a class=\"twl-links\" href=\"%(suggest)s\"><strong>go here</strong></a>.)"
 msgstr ""
 
 #. Translators: On a special 'link to search' page, this message is shown if JavaScript is disabled.
@@ -2376,9 +2063,7 @@ msgstr ""
 #. Translators: Information about The Wikipedia Library.
 #: TWLight/templates/login_partial.html:53 TWLight/templates/new_base.html:21
 #, python-format
-msgid ""
-"More than 100 of the world's top subscription-only databases, with content "
-"in %(no_of_languages)s languages, free for Wikipedians of all backgrounds"
+msgid "More than 100 of the world's top subscription-only databases, with content in %(no_of_languages)s languages, free for Wikipedians of all backgrounds"
 msgstr ""
 
 #. Translators: Information about The Wikipedia Library.
@@ -2387,12 +2072,8 @@ msgid "Meet these criteria for automatic access"
 msgstr "Soddisfa questi criteri per l'accesso automatico"
 
 #: TWLight/templates/login_partial.html:69
-msgid ""
-"These criteria grant you access to certain collections but not all. Some "
-"collections are accessible on a per application basis only."
-msgstr ""
-"Questi criteri ti danno accesso solamente ad alcune collezioni. Alcune "
-"collezioni sono disponibili esclusivamente dietro richieste."
+msgid "These criteria grant you access to certain collections but not all. Some collections are accessible on a per application basis only."
+msgstr "Questi criteri ti danno accesso solamente ad alcune collezioni. Alcune collezioni sono disponibili esclusivamente dietro richieste."
 
 #: TWLight/templates/login_partial.html:89
 msgid "Login via Wikipedia"
@@ -2401,29 +2082,19 @@ msgstr "Accedi tramite Wikipedia"
 #. Translators: Shown if the current user doesn't have a registered email on their account. Don't translate contact_us_url or email_url.
 #: TWLight/templates/message_partial.html:15
 #, python-format
-msgid ""
-"You don't have an email on file. We can't finalize your access to partner "
-"resources, and you won't be able to <a class=\"twl-links\" href="
-"\"%(contact_us_url)s\">contact us</a> without an email. Please <a class="
-"\"twl-links\" href=\"%(email_url)s\">update your email</a>."
+msgid "You don't have an email on file. We can't finalize your access to partner resources, and you won't be able to <a class=\"twl-links\" href=\"%(contact_us_url)s\">contact us</a> without an email. Please <a class=\"twl-links\" href=\"%(email_url)s\">update your email</a>."
 msgstr ""
 
 #. Translators: Shown if the current user has requested the processing of their data should be restricted.
 #: TWLight/templates/message_partial.html:26
 #, python-format
-msgid ""
-"You have requested a restriction on the processing of your data. Most site "
-"functionality will not be available to you until you <a class=\"twl-links\" "
-"href=\"%(restrict_url)s\">lift this restriction</a>."
+msgid "You have requested a restriction on the processing of your data. Most site functionality will not be available to you until you <a class=\"twl-links\" href=\"%(restrict_url)s\">lift this restriction</a>."
 msgstr ""
 
 #. Translators: Shown if the current user has not agreed to the terms of use.
 #: TWLight/templates/message_partial.html:37
 #, python-format
-msgid ""
-"You have not agreed to the <a class=\"twl-links\" href=\"%(terms_url)s"
-"\">terms of use</a> of this site. Your applications will not be processed "
-"and you won't be able to apply or access resources you are approved for."
+msgid "You have not agreed to the <a class=\"twl-links\" href=\"%(terms_url)s\">terms of use</a> of this site. Your applications will not be processed and you won't be able to apply or access resources you are approved for."
 msgstr ""
 
 #. Translators: This link is at the bottom of every page and links to the 'About' page (https://wikipedialibrary.wmflabs.org/about/)
@@ -2470,9 +2141,7 @@ msgstr "Reimposta password"
 
 #. Translators: If a user goes to reset their password, this message asks them to enter their email to do so.
 #: TWLight/templates/registration/password_reset_form.html:13
-msgid ""
-"Forgot your password? Enter your email address below, and we'll email "
-"instructions for setting a new one."
+msgid "Forgot your password? Enter your email address below, and we'll email instructions for setting a new one."
 msgstr ""
 
 #. Translators: This is the label for a button that users click to update their public information.
@@ -2517,16 +2186,12 @@ msgstr "Sono d'accordo con le condizioni d'uso"
 
 #. Translators: This text explains how to disagree to the site's terms of use and the restrictions that will come into effect when users disagree to the terms of use.
 #: TWLight/users/forms.py:185
-msgid ""
-"By unchecking this box and clicking “Update” you may explore the site, but "
-"you will not be able to apply for access to materials or evaluate "
-"applications unless you agree with the terms of use."
+msgid "By unchecking this box and clicking “Update” you may explore the site, but you will not be able to apply for access to materials or evaluate applications unless you agree with the terms of use."
 msgstr ""
 
 #. Translators: Users click this button to set their website email address to the one linked to their Wikipedia account.
 #: TWLight/users/forms.py:211
-msgid ""
-"Use my Wikipedia email address (will be updated the next time you login)."
+msgid "Use my Wikipedia email address (will be updated the next time you login)."
 msgstr ""
 
 #. Translators: This labels a button which users click to change their email.
@@ -2537,17 +2202,8 @@ msgstr "Aggiorna email"
 #. Translators: Shown if the current user tried to 'favorite' a partner they can't access. Do not translate '{partner}'
 #: TWLight/users/models.py:201
 #, python-brace-format
-msgid ""
-"Cannot add partner {partner} to your favorites because you don't have access "
-"to it"
+msgid "Cannot add partner {partner} to your favorites because you don't have access to it"
 msgstr ""
-
-#. Translators: Do not translate.
-#: TWLight/users/models.py:869
-#, fuzzy, python-brace-format
-#| msgid "Username"
-msgid "{wp_username}"
-msgstr "Nome utente"
 
 #. Translators: This error message is shown when there's a problem with the authenticated login process.
 #: TWLight/users/oauth.py:243
@@ -2567,9 +2223,7 @@ msgstr ""
 
 #. Translators: this message is displayed to users that don't have accounts and clicked on a proxied link.
 #: TWLight/users/oauth.py:388
-msgid ""
-"To view this link you need to be an eligible library user. Please login to "
-"continue."
+msgid "To view this link you need to be an eligible library user. Please login to continue."
 msgstr ""
 
 #. Translators: This warning message is shown to users when the response received from Wikimedia OAuth servers is not a valid one.
@@ -2605,17 +2259,12 @@ msgstr "Vedi {issue} per ulteriori informazioni."
 
 #. Translators: If the user tries to log in, but their account does not meet certain requirements, they cannot login.
 #: TWLight/users/oauth.py:528
-msgid ""
-"Your Wikipedia account does not meet the eligibility criteria in the terms "
-"of use, so your Wikipedia Library Card Platform account cannot be activated."
+msgid "Your Wikipedia account does not meet the eligibility criteria in the terms of use, so your Wikipedia Library Card Platform account cannot be activated."
 msgstr ""
 
 #. Translators: If the user tries to log in, but their account does not meet certain requirements, they cannot login.
 #: TWLight/users/oauth.py:536
-msgid ""
-"Your Wikipedia account no longer meets the eligibility criteria in the terms "
-"of use, so you cannot be logged in. If you think you should be able to log "
-"in, please email wikipedialibrary@wikimedia.org."
+msgid "Your Wikipedia account no longer meets the eligibility criteria in the terms of use, so you cannot be logged in. If you think you should be able to log in, please email wikipedialibrary@wikimedia.org."
 msgstr ""
 
 #. Translators: this message is displayed to users with brand new accounts.
@@ -2626,10 +2275,7 @@ msgstr ""
 #. Translators: This message is displayed on the confirmation page where users can return their access to partner collections.
 #: TWLight/users/templates/users/authorization_confirm_return.html:13
 #, python-format
-msgid ""
-"You will no longer be able to access <b>%(partner)s's</b> resources via the "
-"Library Card platform, but can request access again by clicking 'renew', if "
-"you change your mind. Are you sure you want to return your access?"
+msgid "You will no longer be able to access <b>%(partner)s's</b> resources via the Library Card platform, but can request access again by clicking 'renew', if you change your mind. Are you sure you want to return your access?"
 msgstr ""
 
 #. Translators: On the MyLibrary page (https://wikipedialibrary.wmflabs.org/users/my_library), this tab shows all favorite collections a user has.
@@ -2699,10 +2345,7 @@ msgstr ""
 
 #. Translators: This is shown on editor profiles, in their profile page or on applications.
 #: TWLight/users/templates/users/editor_detail.html:59
-msgid ""
-"Information with an * was retrieved from Wikipedia directly. Other "
-"information was entered directly by users or site admins, in their preferred "
-"language."
+msgid "Information with an * was retrieved from Wikipedia directly. Other information was entered directly by users or site admins, in their preferred language."
 msgstr ""
 
 #. Translators: This distinguishes users who have been flagged as account coordinators. Don't translate username.
@@ -2713,10 +2356,7 @@ msgstr ""
 
 #. Translators: This is shown on editor profiles, under the heading for Wikipedia editor data.
 #: TWLight/users/templates/users/editor_detail_data.html:5
-msgid ""
-"This information is updated automatically from your Wikimedia account each "
-"time you log in, except for the Contributions field, where you can describe "
-"your Wikimedia editing history."
+msgid "This information is updated automatically from your Wikimedia account each time you log in, except for the Contributions field, where you can describe your Wikimedia editing history."
 msgstr ""
 
 #. Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this labels the user's username.
@@ -2746,17 +2386,13 @@ msgstr ""
 
 #. Translators: when viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this question has a yes or no answer.
 #: TWLight/users/templates/users/editor_detail_data.html:57
-msgid ""
-"at their last login, did this user meet the criteria set forth in the terms "
-"of use?"
+msgid "at their last login, did this user meet the criteria set forth in the terms of use?"
 msgstr ""
 
 #. Translators: When viewing a user's profile in an application, this message shows if the software doesn't think that the user is eligible for access. Don't translate username.
 #: TWLight/users/templates/users/editor_detail_data.html:72
 #, python-format
-msgid ""
-"%(username)s may still be eligible for access grants at the coordinators' "
-"discretion."
+msgid "%(username)s may still be eligible for access grants at the coordinators' discretion."
 msgstr ""
 
 #. Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this is the heading for a Yes/No ToU question.
@@ -2791,10 +2427,7 @@ msgstr ""
 #. Translators: This message is shown on a user's profile if their Wikimedia account is blocked on one or more projects. They may still be granted access to the Library Bundle, but need to contact Wikipedia Library staff to verify.
 #: TWLight/users/templates/users/editor_detail_data.html:137
 #, python-format
-msgid ""
-"It looks like you have an active block on your account. If you meet the "
-"other criteria you may still be permitted access to the library - please <a "
-"class=\"twl-links\" href=\"%(contact_url)s\">contact us</a>."
+msgid "It looks like you have an active block on your account. If you meet the other criteria you may still be permitted access to the library - please <a class=\"twl-links\" href=\"%(contact_url)s\">contact us</a>."
 msgstr ""
 
 #. Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this is the heading for a Yes/No program eligibility question.
@@ -2804,10 +2437,7 @@ msgstr ""
 
 #. Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this question has a Yes or No answer.
 #: TWLight/users/templates/users/editor_detail_data.html:156
-msgid ""
-"At their last login, did this user meet the criteria set forth in the "
-"Library Bundle? Note that satisfying terms of use is a prerequisite to "
-"bundle eligibility."
+msgid "At their last login, did this user meet the criteria set forth in the Library Bundle? Note that satisfying terms of use is a prerequisite to bundle eligibility."
 msgstr ""
 
 #. Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this is the heading for a Yes/No program eligibility question.
@@ -2852,18 +2482,13 @@ msgstr ""
 
 #. Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this text is in the 'Personal data' section. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/users/templates/users/editor_detail_data.html:262
-msgid ""
-"The following information is visible only to you, site administrators, "
-"publishing partners (where required), and volunteer Wikipedia Library "
-"coordinators (who have signed a Non-Disclosure Agreement)."
+msgid "The following information is visible only to you, site administrators, publishing partners (where required), and volunteer Wikipedia Library coordinators (who have signed a Non-Disclosure Agreement)."
 msgstr ""
 
 #. Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this labels a button which users can click to update or remove their personal information. Don't translate update_url.
 #: TWLight/users/templates/users/editor_detail_data.html:272
 #, python-format
-msgid ""
-"You may <a class=\"twl-links\" href=\"%(update_url)s\">update or delete</a> "
-"your data at any time."
+msgid "You may <a class=\"twl-links\" href=\"%(update_url)s\">update or delete</a> your data at any time."
 msgstr ""
 
 #. Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this labels the user's email. Don't remove the *.
@@ -2883,26 +2508,18 @@ msgstr ""
 
 #. Translators: This message tells users that they are not eligible to access The Wikipedia Library content.
 #: TWLight/users/templates/users/eligibility_modal.html:7
-msgid ""
-"Sorry, your Wikipedia account doesn’t currently qualify to access The "
-"Wikipedia Library."
-msgstr ""
-"Spiacenti, il tuo account Wikipedia non è attualmente idoneo per accedere "
-"alla Biblioteca di Wikipedia."
+msgid "Sorry, your Wikipedia account doesn’t currently qualify to access The Wikipedia Library."
+msgstr "Spiacenti, il tuo account Wikipedia non è attualmente idoneo per accedere alla Biblioteca di Wikipedia."
 
 #. Translators: This message tells users that they have not agreed to the terms of use, therefore are ineligible to access the content in The Wikipedia Library.
 #: TWLight/users/templates/users/eligibility_modal.html:30
 #, python-format
-msgid ""
-"Agreed with <a href=\"%(terms)s\" class=\"text-danger\"> terms of use </a>"
+msgid "Agreed with <a href=\"%(terms)s\" class=\"text-danger\"> terms of use </a>"
 msgstr ""
 
 #: TWLight/users/templates/users/eligibility_modal.html:40
 #, python-format
-msgid ""
-"It looks like you have an active block on your account. If you meet the "
-"other criteria you may still be permitted access to the library - please <a "
-"href=\"%(contact_url)s\">contact us</a>."
+msgid "It looks like you have an active block on your account. If you meet the other criteria you may still be permitted access to the library - please <a href=\"%(contact_url)s\">contact us</a>."
 msgstr ""
 
 #. Translators: Instructions to refresh a user's data.
@@ -2942,10 +2559,7 @@ msgstr "Imposta lingua"
 
 #. Translators: This text on the user page helps users naviage to the TranslateWiki Wikipedia Library Card platform translation page.
 #: TWLight/users/templates/users/language_form.html:31
-msgid ""
-"You can help translate the tool at <a class=\"twl-links\" href=\"https://"
-"translatewiki.net/wiki/Translating:Wikipedia_Library_Card_Platform"
-"\">translatewiki.net</a>."
+msgid "You can help translate the tool at <a class=\"twl-links\" href=\"https://translatewiki.net/wiki/Translating:Wikipedia_Library_Card_Platform\">translatewiki.net</a>."
 msgstr ""
 
 #. Translators: When the user starts a new application and submits the application, the user can view the application and withdraw if need be. This changes the label for the Withdraw button.
@@ -2965,9 +2579,7 @@ msgstr ""
 
 #. Translators: On the page listing applications, this text explains a user they cannot renew their application since they've already requested a renewal or there aren't any renewals available.
 #: TWLight/users/templates/users/my_applications.html:79
-msgid ""
-"Renewals are either not required, not available right now, or you have "
-"already requested a renewal."
+msgid "Renewals are either not required, not available right now, or you have already requested a renewal."
 msgstr ""
 
 #. Translators: This text is the heading of a section in a user's profile where they can change their preferences.
@@ -3031,19 +2643,12 @@ msgstr ""
 
 #. Translators: This message is displayed on the page where users can request we stop processing their data.
 #: TWLight/users/templates/users/restrict_data.html:15
-msgid ""
-"Checking this box and clicking “Restrict” will pause all processing of the "
-"data you have entered into this website. You will not be able to apply for "
-"access to resources, your applications will not be further processed, and "
-"none of your data will be altered, until you return to this page and uncheck "
-"the box. This is not the same as deleting your data."
+msgid "Checking this box and clicking “Restrict” will pause all processing of the data you have entered into this website. You will not be able to apply for access to resources, your applications will not be further processed, and none of your data will be altered, until you return to this page and uncheck the box. This is not the same as deleting your data."
 msgstr ""
 
 #. Translators: This warning message is shown to coordinators who view the data restriction page.
 #: TWLight/users/templates/users/restrict_data.html:26
-msgid ""
-"You are a coordinator on this site. If you restrict the processing of your "
-"data, your coordinator flag will be removed."
+msgid "You are a coordinator on this site. If you restrict the processing of your data, your coordinator flag will be removed."
 msgstr ""
 
 #. Translators: use the date *when you are translating*, in a language-appropriate format.
@@ -3063,24 +2668,12 @@ msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:51
-msgid ""
-"<a class=\"twl-links\" href=\"https://meta.wikimedia.org/wiki/"
-"The_Wikipedia_Library\"> The Wikipedia Library </a> has partnered with "
-"publishers around the world to allow users to access otherwise paywalled "
-"resources. This website allows Wikipedia editors to search and access these "
-"resources."
+msgid "<a class=\"twl-links\" href=\"https://meta.wikimedia.org/wiki/The_Wikipedia_Library\"> The Wikipedia Library </a> has partnered with publishers around the world to allow users to access otherwise paywalled resources. This website allows Wikipedia editors to search and access these resources."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Wikimedia Foundation should not be translated. WMF should not be translated. Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:63
-msgid ""
-"This program is administered by the Wikimedia Foundation (WMF). These terms "
-"of use and privacy notice pertain to your application for access to "
-"resources through the Wikipedia Library, your use of this website, and your "
-"access to and use of those resources. They also describe our handling of the "
-"information you provide to us in order to create and administer your "
-"Wikipedia Library account. If we make material changes to the terms, we will "
-"notify users."
+msgid "This program is administered by the Wikimedia Foundation (WMF). These terms of use and privacy notice pertain to your application for access to resources through the Wikipedia Library, your use of this website, and your access to and use of those resources. They also describe our handling of the information you provide to us in order to create and administer your Wikipedia Library account. If we make material changes to the terms, we will notify users."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
@@ -3090,37 +2683,17 @@ msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:78
-msgid ""
-"Access to resources via The Wikipedia Library is reserved for community "
-"members who have demonstrated their commitment to the Wikimedia projects, "
-"and who will use their access to these resources to improve project content. "
-"To that end, in order to be eligible for The Wikipedia Library, we require "
-"that you be registered for a user account on the projects, with at least 500 "
-"edits, six (6) months of activity, and 10+ edits in the last month. We ask "
-"that you do not request access to any publishers with a limited number of "
-"available accounts whose resources you can already access for free through "
-"your local library or university, or another institution or organization, in "
-"order to provide that opportunity to others."
+msgid "Access to resources via The Wikipedia Library is reserved for community members who have demonstrated their commitment to the Wikimedia projects, and who will use their access to these resources to improve project content. To that end, in order to be eligible for The Wikipedia Library, we require that you be registered for a user account on the projects, with at least 500 edits, six (6) months of activity, and 10+ edits in the last month. We ask that you do not request access to any publishers with a limited number of available accounts whose resources you can already access for free through your local library or university, or another institution or organization, in order to provide that opportunity to others."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:94
-msgid ""
-"Additionally, if you are currently blocked or banned from a Wikimedia "
-"project, applications to resources may be rejected or restricted. If you "
-"obtain a Wikipedia Library account, but a block or ban is subsequently "
-"instituted against you on one of the projects, you may lose access to your "
-"Wikipedia Library account."
+msgid "Additionally, if you are currently blocked or banned from a Wikimedia project, applications to resources may be rejected or restricted. If you obtain a Wikipedia Library account, but a block or ban is subsequently instituted against you on one of the projects, you may lose access to your Wikipedia Library account."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:104
-msgid ""
-"Your eligibility to access The Wikipedia Library is assessed at each login. "
-"While more than half of the library's content is provided via this automated "
-"eligibility check, access to other publisher's content may be time limited, "
-"typically lapsing after one year, after which you will usually need to apply "
-"for renewal."
+msgid "Your eligibility to access The Wikipedia Library is assessed at each login. While more than half of the library's content is provided via this automated eligibility check, access to other publisher's content may be time limited, typically lapsing after one year, after which you will usually need to apply for renewal."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
@@ -3130,47 +2703,27 @@ msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:118
-msgid ""
-"In order to apply for access to a partner resource, you must provide us with "
-"certain information, which we will use to evaluate your application. If your "
-"application is approved, we may transfer the information you have given us "
-"to the publishers whose resources you wish to access. They will either "
-"contact you with the account information directly or we will send access "
-"information to you ourselves."
+msgid "In order to apply for access to a partner resource, you must provide us with certain information, which we will use to evaluate your application. If your application is approved, we may transfer the information you have given us to the publishers whose resources you wish to access. They will either contact you with the account information directly or we will send access information to you ourselves."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:130
-msgid ""
-"In addition to the basic information you provide to us, our system will "
-"retrieve some information directly from the Wikimedia projects: your "
-"username, email address, edit count, registration date, user ID number, "
-"groups to which you belong, and any special user rights."
+msgid "In addition to the basic information you provide to us, our system will retrieve some information directly from the Wikimedia projects: your username, email address, edit count, registration date, user ID number, groups to which you belong, and any special user rights."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:140
-msgid ""
-"Each time you log in to the Wikipedia Library Card Platform, this "
-"information will be automatically updated."
+msgid "Each time you log in to the Wikipedia Library Card Platform, this information will be automatically updated."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:148
-msgid ""
-"We will ask you to provide us with some information about your history of "
-"contributions to the Wikimedia projects. Information on contribution history "
-"is optional, but will greatly assist us in evaluating your application."
+msgid "We will ask you to provide us with some information about your history of contributions to the Wikimedia projects. Information on contribution history is optional, but will greatly assist us in evaluating your application."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). WMF should not be translated. Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:157
-msgid ""
-"The information you provide when creating your account will be visible to "
-"you while on the site but not to others unless they are approved Wikipedia "
-"Library Coordinators, WMF Staff, or WMF Contractors who need access to this "
-"data in order to carry out their work with the Wikipedia Library, all of "
-"whom are subject to non-disclosure obligations."
+msgid "The information you provide when creating your account will be visible to you while on the site but not to others unless they are approved Wikipedia Library Coordinators, WMF Staff, or WMF Contractors who need access to this data in order to carry out their work with the Wikipedia Library, all of whom are subject to non-disclosure obligations."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
@@ -3180,48 +2733,32 @@ msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:171
-msgid ""
-"In order to access an individual publisher’s resources, you must agree to "
-"that publisher’s terms of use and privacy policy. You agree that you will "
-"not violate such terms and policies in connection with your use of the "
-"Wikipedia Library. Additionally, the following activities are prohibited "
-"while accessing publisher resources through the Wikipedia Library."
+msgid "In order to access an individual publisher’s resources, you must agree to that publisher’s terms of use and privacy policy. You agree that you will not violate such terms and policies in connection with your use of the Wikipedia Library. Additionally, the following activities are prohibited while accessing publisher resources through the Wikipedia Library."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:184
-msgid ""
-"Sharing your Wikipedia account, usernames, passwords, or any access codes "
-"for publisher resources with others;"
-msgstr ""
-"Condividere il tuo account Wikipedia, nomi utente, password o qualsiasi "
-"codice di accesso per le risorse dell'editore con altri;"
+msgid "Sharing your Wikipedia account, usernames, passwords, or any access codes for publisher resources with others;"
+msgstr "Condividere il tuo account Wikipedia, nomi utente, password o qualsiasi codice di accesso per le risorse dell'editore con altri;"
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:191
-msgid ""
-"Automatically scraping or downloading restricted content from publishers;"
+msgid "Automatically scraping or downloading restricted content from publishers;"
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:197
-msgid ""
-"Systematically making printed or electronic copies of multiple extracts of "
-"restricted content available for any purpose;"
+msgid "Systematically making printed or electronic copies of multiple extracts of restricted content available for any purpose;"
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:204
-msgid ""
-"Data mining metadata without permission—for example, in order to use "
-"metadata for auto-created stub articles;"
+msgid "Data mining metadata without permission—for example, in order to use metadata for auto-created stub articles;"
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:211
-msgid ""
-"Using the access you receive through the Wikipedia Library for profit by "
-"selling access to your account or resources which you have through it."
+msgid "Using the access you receive through the Wikipedia Library for profit by selling access to your account or resources which you have through it."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
@@ -3231,18 +2768,12 @@ msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:224
-msgid ""
-"Certain resources may only be accessed using an external search service, "
-"such as the EBSCO Discovery Service, or a proxy service, such as OCLC "
-"EZProxy. If you use such external search and/or proxy services, please "
-"review the applicable terms of use and privacy policies."
+msgid "Certain resources may only be accessed using an external search service, such as the EBSCO Discovery Service, or a proxy service, such as OCLC EZProxy. If you use such external search and/or proxy services, please review the applicable terms of use and privacy policies."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:234
-msgid ""
-"In addition, if you use OCLC EZProxy, please note that you may not use it "
-"for commercial purposes."
+msgid "In addition, if you use OCLC EZProxy, please note that you may not use it for commercial purposes."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
@@ -3252,120 +2783,49 @@ msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Wikimedia Foundation should not be translated. Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:245
-msgid ""
-"The Wikimedia Foundation and our service providers use your information for "
-"the legitimate purpose of providing Wikipedia Library services in support of "
-"our charitable mission. When you apply for a Wikipedia Library account, or "
-"use your Wikipedia Library account, we may routinely collect the following "
-"information: your username, email address, edit count, registration date, "
-"user ID number, groups to which you belong, and any special user rights; "
-"your name, country of residence, and/or affiliation, if required by a "
-"partner to which you are applying; your narrative description of your "
-"contributions and reasons for applying for access to partner resources; and "
-"the date you agree to these terms of use."
+msgid "The Wikimedia Foundation and our service providers use your information for the legitimate purpose of providing Wikipedia Library services in support of our charitable mission. When you apply for a Wikipedia Library account, or use your Wikipedia Library account, we may routinely collect the following information: your username, email address, edit count, registration date, user ID number, groups to which you belong, and any special user rights; your name, country of residence, and/or affiliation, if required by a partner to which you are applying; your narrative description of your contributions and reasons for applying for access to partner resources; and the date you agree to these terms of use."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:262
 #, python-format
-msgid ""
-"Each publisher who is a member of the Wikipedia Library program requires "
-"different specific information in the application. Some publishers may "
-"request only an email address, while others request more detailed data, such "
-"as your name, location, or institutional affiliation. When you complete your "
-"application, you will only be asked to supply information required by the "
-"publishers you have chosen, and each publisher will only receive the "
-"information they require for providing you with access. Please see our <a "
-"class=\"twl-links\" href=\"%(all_partners_url)s\">partner information</a> "
-"pages to learn what information is required by each publisher to gain access "
-"to their resources."
+msgid "Each publisher who is a member of the Wikipedia Library program requires different specific information in the application. Some publishers may request only an email address, while others request more detailed data, such as your name, location, or institutional affiliation. When you complete your application, you will only be asked to supply information required by the publishers you have chosen, and each publisher will only receive the information they require for providing you with access. Please see our <a class=\"twl-links\" href=\"%(all_partners_url)s\">partner information</a> pages to learn what information is required by each publisher to gain access to their resources."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Wikimedia Foundation should not be translated. Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:277
-msgid ""
-"Some Wikipedia Library pages are visible without logging in, but you will "
-"need to log in to apply or access proprietary partner resources. We use the "
-"data provided by you via OAuth and Wikimedia API calls to assess your "
-"application for access and to process approved requests."
+msgid "Some Wikipedia Library pages are visible without logging in, but you will need to log in to apply or access proprietary partner resources. We use the data provided by you via OAuth and Wikimedia API calls to assess your application for access and to process approved requests."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:288
 #, python-format
-msgid ""
-"In order to administer the Wikipedia Library program, we will retain the "
-"application data we collect from you for three years after your most recent "
-"login, unless you delete your account, as described below. You can log in "
-"and go to <a class=\"twl-links\" href=\"%(profile_url)s\">your profile page</"
-"a> in order to see the information associated with your account, and can "
-"download it in JSON format. You may access, update, restrict, or delete this "
-"information at any time, except for the information that is automatically "
-"retrieved from the projects. If you have any questions or concerns about the "
-"handling of your data, please contact <a class=\"twl-links\" href=\"mailto:"
-"wikipedialibrary@wikimedia.org?Subject=Wikipedia%%20Library%%20Card"
-"%%20account%%20deactivation\"> wikipedialibrary@wikimedia.org </a>."
+msgid "In order to administer the Wikipedia Library program, we will retain the application data we collect from you for three years after your most recent login, unless you delete your account, as described below. You can log in and go to <a class=\"twl-links\" href=\"%(profile_url)s\">your profile page</a> in order to see the information associated with your account, and can download it in JSON format. You may access, update, restrict, or delete this information at any time, except for the information that is automatically retrieved from the projects. If you have any questions or concerns about the handling of your data, please contact <a class=\"twl-links\" href=\"mailto:wikipedialibrary@wikimedia.org?Subject=Wikipedia%%20Library%%20Card%%20account%%20deactivation\"> wikipedialibrary@wikimedia.org </a>."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:305
-msgid ""
-"If you decide to disable your Wikipedia Library account, you can use the "
-"delete button on your profile to delete certain personal information "
-"associated with your account. We will delete your real name, institutional "
-"affiliation, and country of residence. Please note that the system will "
-"retain a record of your username, the publishers to which you applied or had "
-"access, and the dates of that access. Note that deletion is not reversible. "
-"Deletion of your Wikipedia Library account may also correspond with the "
-"removal of any resource access to which you were eligible or approved. If "
-"you request the deletion of account information and later wish to apply for "
-"a new account, you will need to provide the necessary information again."
+msgid "If you decide to disable your Wikipedia Library account, you can use the delete button on your profile to delete certain personal information associated with your account. We will delete your real name, institutional affiliation, and country of residence. Please note that the system will retain a record of your username, the publishers to which you applied or had access, and the dates of that access. Note that deletion is not reversible. Deletion of your Wikipedia Library account may also correspond with the removal of any resource access to which you were eligible or approved. If you request the deletion of account information and later wish to apply for a new account, you will need to provide the necessary information again."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). WMF should not be translated. Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:321
-msgid ""
-"The Wikipedia Library is run by WMF Staff, Contractors, and approved "
-"volunteer Coordinators. The data associated with your account will be shared "
-"with the WMF staff, contractors, service providers, and volunteer "
-"coordinators who need to process the information in connection with their "
-"work for the Wikipedia Library, and who are subject to confidentiality "
-"obligations. We will also use your data for internal Wikipedia Library "
-"purposes such as distributing user surveys and account notifications, and in "
-"a depersonalized or aggregated fashion for statistical analysis and "
-"administration. Finally, we will share your information with the publishers "
-"whom you specifically select in order to provide you with access to "
-"resources. Otherwise, your information will not be shared with third "
-"parties, with the exception of the circumstances described below."
+msgid "The Wikipedia Library is run by WMF Staff, Contractors, and approved volunteer Coordinators. The data associated with your account will be shared with the WMF staff, contractors, service providers, and volunteer coordinators who need to process the information in connection with their work for the Wikipedia Library, and who are subject to confidentiality obligations. We will also use your data for internal Wikipedia Library purposes such as distributing user surveys and account notifications, and in a depersonalized or aggregated fashion for statistical analysis and administration. Finally, we will share your information with the publishers whom you specifically select in order to provide you with access to resources. Otherwise, your information will not be shared with third parties, with the exception of the circumstances described below."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). WMF should not be translated.
 #: TWLight/users/templates/users/terms.html:338
-msgid ""
-"We may disclose any collected information when required by law, when we have "
-"your permission, when needed to protect our rights, privacy, safety, users, "
-"or the general public, and when necessary to enforce these terms, WMF’s "
-"general <a class=\"twl-links\" href=\"https://foundation.wikimedia.org/wiki/"
-"Terms_of_Use\">Terms of Use</a>, or any other WMF policy."
+msgid "We may disclose any collected information when required by law, when we have your permission, when needed to protect our rights, privacy, safety, users, or the general public, and when necessary to enforce these terms, WMF’s general <a class=\"twl-links\" href=\"https://foundation.wikimedia.org/wiki/Terms_of_Use\">Terms of Use</a>, or any other WMF policy."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:349
-msgid ""
-"We take the security of your personal data seriously, and take reasonable "
-"precautions to ensure your data is protected. These precautions include "
-"access controls to limit who has access to your data and security "
-"technologies to protect data stored on the server. However, we cannot "
-"guarantee the safety of your data as it is transmitted and stored."
+msgid "We take the security of your personal data seriously, and take reasonable precautions to ensure your data is protected. These precautions include access controls to limit who has access to your data and security technologies to protect data stored on the server. However, we cannot guarantee the safety of your data as it is transmitted and stored."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:360
-msgid ""
-"Please note that these terms do not control the use and handling of your "
-"data by the publishers and service providers whose resources you access or "
-"apply to access. Please read their individual privacy policies for that "
-"information."
+msgid "Please note that these terms do not control the use and handling of your data by the publishers and service providers whose resources you access or apply to access. Please read their individual privacy policies for that information."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
@@ -3375,34 +2835,17 @@ msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Wikimedia Foundation should not be translated. Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:373
-msgid ""
-"The Wikimedia Foundation is a nonprofit organization based in San Francisco, "
-"California. The Wikipedia Library program provides access to resources held "
-"by publishers in multiple countries. If you apply for a Wikipedia Library "
-"account (whether you are inside or outside of the United States), you "
-"understand that your personal data will be collected, transferred, stored, "
-"processed, disclosed and otherwise used in the U.S. as described in this "
-"privacy policy. You also understand that your information may be transferred "
-"by us from the U.S. to other countries, which may have different or less "
-"stringent data protection laws than your country, in connection with "
-"providing services to you, including evaluating your application and "
-"securing access to your chosen publishers (locations for each publisher are "
-"outlined on their respective partner information pages)."
+msgid "The Wikimedia Foundation is a nonprofit organization based in San Francisco, California. The Wikipedia Library program provides access to resources held by publishers in multiple countries. If you apply for a Wikipedia Library account (whether you are inside or outside of the United States), you understand that your personal data will be collected, transferred, stored, processed, disclosed and otherwise used in the U.S. as described in this privacy policy. You also understand that your information may be transferred by us from the U.S. to other countries, which may have different or less stringent data protection laws than your country, in connection with providing services to you, including evaluating your application and securing access to your chosen publishers (locations for each publisher are outlined on their respective partner information pages)."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:392
-msgid ""
-"Please note that in the event of any differences in meaning or "
-"interpretation between the original English version of these terms and a "
-"translation, the original English version takes precedence."
+msgid "Please note that in the event of any differences in meaning or interpretation between the original English version of these terms and a translation, the original English version takes precedence."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Wikimedia Foundation should not be translated.
 #: TWLight/users/templates/users/terms.html:403
-msgid ""
-"See also the <a class=\"twl-links\" href=\"https://wikimediafoundation.org/"
-"wiki/Privacy_policy\">Wikimedia Foundation Privacy Policy</a>."
+msgid "See also the <a class=\"twl-links\" href=\"https://wikimediafoundation.org/wiki/Privacy_policy\">Wikimedia Foundation Privacy Policy</a>."
 msgstr ""
 
 #. Translators: This is the second to last line of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
@@ -3422,11 +2865,7 @@ msgstr "Wikimedia Foundation"
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:426
-msgid ""
-"By checking this box and clicking “Submit”, you agree that you have read the "
-"above terms and that you will adhere to the terms of use in your application "
-"to and use of the The Wikipedia Library, and the publishers’ services to "
-"which you gain access through The Wikipedia Library program."
+msgid "By checking this box and clicking “Submit”, you agree that you have read the above terms and that you will adhere to the terms of use in your application to and use of the The Wikipedia Library, and the publishers’ services to which you gain access through The Wikipedia Library program."
 msgstr ""
 
 #: TWLight/users/templates/users/user_collection_tile.html:32
@@ -3479,29 +2918,18 @@ msgstr ""
 
 #. Translators: This message is displayed on the page where users can request the deletion of their data.
 #: TWLight/users/templates/users/user_confirm_delete.html:17
-msgid ""
-"<b>Warning:</b> Performing this action will delete your Wikipedia Library "
-"Card user account and all associated applications. This process is not "
-"reversible. You may lose any partner accounts you were granted, and will not "
-"be able to renew those accounts or apply for new ones."
+msgid "<b>Warning:</b> Performing this action will delete your Wikipedia Library Card user account and all associated applications. This process is not reversible. You may lose any partner accounts you were granted, and will not be able to renew those accounts or apply for new ones."
 msgstr ""
 
 #. Translators: this should show up for people who log in with a username/password and not OAuth, so we don't know what their Wikipedia identity is.
-#.
 #: TWLight/users/templates/users/user_detail.html:12
 #, python-format
-msgid ""
-"Hi, %(username)s! You don't have a Wikipedia editor profile attached to your "
-"account here, so you are probably a site administrator."
+msgid "Hi, %(username)s! You don't have a Wikipedia editor profile attached to your account here, so you are probably a site administrator."
 msgstr ""
 
 #. Translators: In the unlikely scenario that someone is able to register an account without using OAuth (thus leaving us without some of the information required for applications), users will see this message, encouraging them to re-register.
 #: TWLight/users/templates/users/user_detail.html:20
-msgid ""
-"If you aren't a site administrator, something weird has happened. You won't "
-"be able to apply for access without a Wikipedia editor profile. You should "
-"log out and create a new account by logging in via OAuth, or contact a site "
-"administrator for help."
+msgid "If you aren't a site administrator, something weird has happened. You won't be able to apply for access without a Wikipedia editor profile. You should log out and create a new account by logging in via OAuth, or contact a site administrator for help."
 msgstr ""
 
 #. Translators: Labels a sections where coordinators can select their email preferences.
@@ -3512,17 +2940,12 @@ msgstr ""
 #. Translators: This message is shown on user's own profile page, encouraging them to make sure their information is up to date, so that account coordinators can use the information to judge applications.
 #: TWLight/users/views.py:176
 #, python-brace-format
-msgid ""
-"Please <a class='twl-links' href='{url}'>update your contributions</a> to "
-"Wikipedia to help coordinators evaluate your applications."
+msgid "Please <a class='twl-links' href='{url}'>update your contributions</a> to Wikipedia to help coordinators evaluate your applications."
 msgstr ""
 
 #. Translators: Coordinators are shown this message when they unselect all three types of reminder email options under preferences.
 #: TWLight/users/views.py:288
-msgid ""
-"You have chosen not to receive reminder emails. As a coordinator, you should "
-"receive at least one type of reminder emails, so consider changing your "
-"preferences."
+msgid "You have chosen not to receive reminder emails. As a coordinator, you should receive at least one type of reminder emails, so consider changing your preferences."
 msgstr ""
 
 #. Translators: Coordinators are shown this message when they make changes to their reminder email options under preferences.
@@ -3556,9 +2979,7 @@ msgstr ""
 
 #. Translators: If the user has not filled out their email, they can browse the website but cannot apply for access to resources.
 #: TWLight/users/views.py:487
-msgid ""
-"Your email is blank. You can still explore the site, but you won't be able "
-"to apply for access to partner resources without an email."
+msgid "Your email is blank. You can still explore the site, but you won't be able to apply for access to partner resources without an email."
 msgstr ""
 
 #. Translators: This message is shown once the access to a partner has successfully been returned.
@@ -3591,31 +3012,3 @@ msgstr "Nessun blocco attivo"
 msgid "10+ edits in the last 30 days"
 msgstr "Più di 10 modifiche negli ultimi 30 giorni"
 
-#: tests/shunit/data/bad_i18n_comment_1.py:3
-#: tests/shunit/data/bad_i18n_newline_1.py:5
-msgid "1"
-msgstr ""
-
-#. Translators: Lorem ipsum dolor sit amet, consectetur adipiscing elit. Mauris vitae ipsum ut purus faucibus pretium. Proin tempus neque et aliquet consectetur. Ut egestas sapien in consectetur sagittis. Mauris neque lacus, dapibus non viverra vitae, interdum ut aenean ipsum.
-#. Translators: Lorem ipsum dolor sit amet, consectetur adipiscing elit. Mauris vitae ipsum ut purus faucibus pretium. Proin tempus neque et aliquet consectetur. Ut egestas sapien in consectetur sagittis. Mauris neque lacus, dapibus non.
-#: tests/shunit/data/bad_i18n_comment_2.py:4
-#: tests/shunit/data/bad_i18n_newline_2.py:5 tests/shunit/data/good_i18n_1.py:2
-#: tests/shunit/data/good_i18n_2.py:2
-msgid "2"
-msgstr ""
-
-#: tests/shunit/data/bad_i18n_newline_3.py:5
-msgid "3"
-msgstr ""
-
-#: tests/shunit/data/bad_i18n_newline_4.py:5
-msgid "4"
-msgstr ""
-
-#: tests/shunit/data/bad_i18n_newline_5.py:5
-msgid "5"
-msgstr ""
-
-#: tests/shunit/data/bad_i18n_newline_6.py:5
-msgid "6"
-msgstr ""

--- a/locale/ja/LC_MESSAGES/django.po
+++ b/locale/ja/LC_MESSAGES/django.po
@@ -25,10 +25,11 @@
 # Author: 紅い目の女の子
 msgid ""
 msgstr ""
+""
 "Project-Id-Version: Wikipedia Library Card Platform - Website\n"
-"Report-Msgid-Bugs-To: wikipedialibrary@wikimedia.org\n"
+"Report-Msgid-Bugs-To: translatewiki.net\n"
 "POT-Creation-Date: 2024-07-11 20:54+0000\n"
-"PO-Revision-Date: 2024-07-11 12:30:16+0000\n"
+"PO-Revision-Date: 2024-07-15 12:29:16+0000\n"
 "Language: ja\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
@@ -60,13 +61,8 @@ msgstr "利用者情報"
 #. Translators: This note appears in a section of a form where we ask users to enter info (like country of residence) when applying for resource access.
 #: TWLight/applications/forms.py:179
 #, python-brace-format
-msgid ""
-"<p><small><i>Your personal data will be processed according to our <a "
-"class='twl-links' href='{terms_url}'> privacy policy</a>.</i></small></p>"
-msgstr ""
-"<p><small><i>利用者の個人情報は\n"
-"当方の<a class='twl-links'>href='{terms_url}'個人情報保護の方針</a>に従って扱"
-"います。</i></small></p>"
+msgid "<p><small><i>Your personal data will be processed according to our <a class='twl-links' href='{terms_url}'> privacy policy</a>.</i></small></p>"
+msgstr "<p><small><i>利用者の個人情報は\n当方の<a class='twl-links'>href='{terms_url}'個人情報保護の方針</a>に従って扱います。</i></small></p>"
 
 #. Translators: This is the title of the application form page, where users enter information required for the application. It lets the user know which partner application they are entering data for. {partner}
 #: TWLight/applications/forms.py:189
@@ -107,9 +103,7 @@ msgstr "提携組織に登録したメールアドレス"
 #. Translators: This labels a choice field where users will have to select the number of months they wish to have their access for as part of the application renewal confirmation.
 #. Translators: When filling out an application, users may be required to enter the length of the account (expiry) they wish to have for proxy partners.
 #: TWLight/applications/forms.py:339 TWLight/applications/helpers.py:100
-msgid ""
-"The number of months you wish to have this access for before renewal is "
-"required"
+msgid "The number of months you wish to have this access for before renewal is required"
 msgstr "更新時期以前にアクセスを希望する月数（必須）"
 
 #. Translators: When filling out an application, users may need to specify their name
@@ -198,12 +192,8 @@ msgstr "メール"
 
 #. Translators: This comment is added to pending applications when our terms of use change.
 #: TWLight/applications/management/commands/notify_applicants_tou_changes.py:54
-msgid ""
-"Our terms of use have changed. Your applications will not be processed until "
-"you log in and agree to our updated terms."
-msgstr ""
-"利用者規定が更新されました。利用者がログインして最新の規約に同意するまで、申"
-"請は保留されます。"
+msgid "Our terms of use have changed. Your applications will not be processed until you log in and agree to our updated terms."
+msgstr "利用者規定が更新されました。利用者がログインして最新の規約に同意するまで、申請は保留されます。"
 
 #. Translators: This is the status of an application that has not yet been reviewed.
 #: TWLight/applications/models.py:54
@@ -269,40 +259,26 @@ msgstr "参照先のURL: {access_url}"
 
 #. Translators: This text goes into account approval emails in the case that we need to send the user's details to a publisher for manual account setup.
 #: TWLight/applications/models.py:331
-msgid ""
-"You can expect to receive access details within a week or two once it has "
-"been processed."
+msgid "You can expect to receive access details within a week or two once it has been processed."
 msgstr "申し込みが受理された後、1から2週間以内に詳細情報が届く予定です。"
 
 #. Translators: This comment is added to open applications when a partner joins the Library Bundle, which does not require applications.
 #: TWLight/applications/signals.py:247
-msgid ""
-"This partner joined the Library Bundle, which does not require applications. "
-"This application will be marked as invalid."
-msgstr ""
-"この提携組織は図書館バンドル制度に加盟しており、申請の必要はありません。その"
-"ためこの申請は無効とします。"
+msgid "This partner joined the Library Bundle, which does not require applications. This application will be marked as invalid."
+msgstr "この提携組織は図書館バンドル制度に加盟しており、申請の必要はありません。そのためこの申請は無効とします。"
 
 #. Translators: This is shown to users if the application is to a partner for which we have run out of available accounts. The application is therefore on a 'waitlist', and will be reviewed when more accounts are available.
 #: TWLight/applications/templates/applications/application_evaluation.html:29
-msgid ""
-"This application is on the waitlist because this partner does not have any "
-"access grants available at this time."
-msgstr ""
-"この申請は保留されています。現在、提携組織から提供されている利用可能なアクセ"
-"ス権が不足しているためです。"
+msgid "This application is on the waitlist because this partner does not have any access grants available at this time."
+msgstr "この申請は保留されています。現在、提携組織から提供されている利用可能なアクセス権が不足しているためです。"
 
 #. Translators: This message is shown on pages where coordinators can see personal information about applicants.
 #: TWLight/applications/templates/applications/application_evaluation.html:36
 #: TWLight/applications/templates/applications/application_list_include.html:6
 #: TWLight/applications/templates/applications/send_partner.html:45
 #: TWLight/resources/templates/resources/partner_users.html:18
-msgid ""
-"Coordinators: This page may contain personal information such as real names "
-"and email addresses. Please remember that this information is confidential."
-msgstr ""
-"調整役の皆さんへ: このページには、本名やメールアドレスなどの個人情報が含まれ"
-"ている可能性があります。これらは秘匿すべき情報であることに注意してください。"
+msgid "Coordinators: This page may contain personal information such as real names and email addresses. Please remember that this information is confidential."
+msgstr "調整役の皆さんへ: このページには、本名やメールアドレスなどの個人情報が含まれている可能性があります。これらは秘匿すべき情報であることに注意してください。"
 
 #. Translators: This is the title of the application page shown to users who are a coordinator, and are able to accept or reject the application.
 #: TWLight/applications/templates/applications/application_evaluation.html:39
@@ -311,12 +287,8 @@ msgstr "申請を評価してください"
 
 #. Translators: This text is shown to coordinators on application pages if the applicant has restricted processing of their data.
 #: TWLight/applications/templates/applications/application_evaluation.html:42
-msgid ""
-"This user has requested a restriction on the processing of their data, so "
-"you cannot change the status of their application."
-msgstr ""
-"この利用者からデータの扱いに制限をかけるように要請を受けたため、申請の状態を"
-"変更することはできません。"
+msgid "This user has requested a restriction on the processing of their data, so you cannot change the status of their application."
+msgstr "この利用者からデータの扱いに制限をかけるように要請を受けたため、申請の状態を変更することはできません。"
 
 #. Translators: This is the title of the application page shown to users who are not a coordinator.
 #: TWLight/applications/templates/applications/application_evaluation.html:48
@@ -389,12 +361,8 @@ msgstr "不明"
 
 #. Translators: This is the text displayed to coordinators when an applicant has no country of residence in their profile.
 #: TWLight/applications/templates/applications/application_evaluation.html:123
-msgid ""
-"Please request the applicant add their country of residence to their profile "
-"before proceeding further."
-msgstr ""
-"利用者情報を入力するさい、まず居住国を優先して入力するよう申請者にお勧めくだ"
-"さい。"
+msgid "Please request the applicant add their country of residence to their profile before proceeding further."
+msgstr "利用者情報を入力するさい、まず居住国を優先して入力するよう申請者にお勧めください。"
 
 #. Translators: This labels the section of an application showing the total number of accounts available for a partner or their collection.
 #: TWLight/applications/templates/applications/application_evaluation.html:134
@@ -404,12 +372,8 @@ msgstr "受付アカウント数"
 #. Translators: This labels the section of an application showing whether the user had agreed to the terms of use or not.
 #: TWLight/applications/templates/applications/application_evaluation.html:145
 #, python-format
-msgid ""
-"Has agreed to the site's <a class=\"twl-links\" href=\"%(terms_url)s\">terms "
-"of use</a>?"
-msgstr ""
-"当該のサイトの<a class=\"twl-links\" href=\"%(terms_url)s\">利用規約</a>に同"
-"意しましたか？"
+msgid "Has agreed to the site's <a class=\"twl-links\" href=\"%(terms_url)s\">terms of use</a>?"
+msgstr "当該のサイトの<a class=\"twl-links\" href=\"%(terms_url)s\">利用規約</a>に同意しましたか？"
 
 #. Translators: Displayed to coordinators when they've agreed to the terms of use.
 #. Translators: Displayed if the user has agreed to the terms of use.
@@ -444,12 +408,8 @@ msgstr "いいえ"
 
 #. Translators: This is the text displayed to coordinators when an applicant has not agreed to the terms of use.
 #: TWLight/applications/templates/applications/application_evaluation.html:159
-msgid ""
-"Please request the applicant agree to the site's terms of use before "
-"approving this application."
-msgstr ""
-"この申請を承認する前に、サイトの利用規約に同意するよう申請者にお勧めくださ"
-"い。"
+msgid "Please request the applicant agree to the site's terms of use before approving this application."
+msgstr "この申請を承認する前に、サイトの利用規約に同意するよう申請者にお勧めください。"
 
 #. Translators: This labels the section of an application containing the user's motivation for wanting access to this resource.
 #: TWLight/applications/templates/applications/application_evaluation.html:176
@@ -469,11 +429,8 @@ msgstr "現在の利用権助成金を更新しますか？"
 #. Translators: This message is shown next to the 'Renewal of existing access grant?' label if the application is a renewal. Don't translate HTML tags or parent_url.
 #: TWLight/applications/templates/applications/application_evaluation.html:195
 #, python-format
-msgid ""
-"Yes (<a class=\"twl-links\" href=\"%(parent_url)s\">previous application</a>)"
-msgstr ""
-"はい（<a class=\"twl-links\" href=\"%(parent_url)s\">前回の申請を更新します</"
-"a>）"
+msgid "Yes (<a class=\"twl-links\" href=\"%(parent_url)s\">previous application</a>)"
+msgstr "はい（<a class=\"twl-links\" href=\"%(parent_url)s\">前回の申請を更新します</a>）"
 
 #. Translators: This labels the section of the application showing the length of access remaining on the user's previous authorization.
 #: TWLight/applications/templates/applications/application_evaluation.html:208
@@ -507,9 +464,7 @@ msgstr "コメントを追加する"
 
 #. Translators: On an application page, this text tells users that the comments posted on the application are visible to coordinators and the submitting user only.
 #: TWLight/applications/templates/applications/application_evaluation.html:297
-msgid ""
-"Comments are visible to all coordinators and to the editor who submitted "
-"this application."
+msgid "Comments are visible to all coordinators and to the editor who submitted this application."
 msgstr "ここに記入したコメントは、全調整役と申請者自身が閲覧できます。"
 
 #. Translators: This is the title of the section of an application page which lists information about the user who submitted the application.
@@ -722,18 +677,8 @@ msgstr "状態を設定"
 
 #: TWLight/applications/templates/applications/apply.html:20
 #, python-format
-msgid ""
-"If your application is successful we may share your email address with "
-"%(partner)s. This is required to set up your access to their resources. By "
-"submitting this form you agree to allow your email address to be shared with "
-"%(partner)s if your application is successful, for the purposes of account "
-"setup."
-msgstr ""
-"応募が成功した場合、当財団は申請者のメールアドレスを%(partner)sと共有すること"
-"があります。これは申請者のリソースへのアクセス権設定の要件です。このフォーム"
-"を送信される申請者は、もし申請が受理されたならアカウント設定のためにご自身の"
-"メールアドレスが%(partner)sと共有される点について、あらかじめ同意されたものと"
-"みなされます。"
+msgid "If your application is successful we may share your email address with %(partner)s. This is required to set up your access to their resources. By submitting this form you agree to allow your email address to be shared with %(partner)s if your application is successful, for the purposes of account setup."
+msgstr "応募が成功した場合、当財団は申請者のメールアドレスを%(partner)sと共有することがあります。これは申請者のリソースへのアクセス権設定の要件です。このフォームを送信される申請者は、もし申請が受理されたならアカウント設定のためにご自身のメールアドレスが%(partner)sと共有される点について、あらかじめ同意されたものとみなされます。"
 
 #. Translators: This message is displayed on the page where users can confirm their renewal. Please do not translate partner.
 #: TWLight/applications/templates/applications/confirm_renewal.html:23
@@ -761,9 +706,7 @@ msgstr "どのリソースのアクセス権をご希望ですか？"
 
 #. Translators: This text explains that Library Bundle partners are not shown in this list.
 #: TWLight/applications/templates/applications/request_for_application.html:26
-msgid ""
-"Library Bundle partners are not shown as eligibility is determined "
-"automatically."
+msgid "Library Bundle partners are not shown as eligibility is determined automatically."
 msgstr "Library Bundle は自動確認の利用資格により表示されません。"
 
 #. Translators: On the page where users can apply for multiple partners, this message shows next to the partner name, taking them to the full application page when clicked.
@@ -778,14 +721,8 @@ msgstr "提携先のデータは未記入です。"
 
 #. Translators: the HTML is so that the word 'waitlisted' will look the same as it does in the page above; please translate 'waitlisted' the same way you did elsewhere in this file.
 #: TWLight/applications/templates/applications/request_for_application.html:74
-msgid ""
-"You can apply to <span class=\"badge badge-warning\">Waitlisted</span> "
-"partners, but they don't have access grants available right now. We will "
-"process those applications when access becomes available."
-msgstr ""
-"提携先が<span class=\"badge badge-warning\">受付保留中</span>でも申請は可能で"
-"すが、その場合、先方にはアクセス権の空きがない状態です。これらの申請はアクセ"
-"スが可能になった時点で処理します。"
+msgid "You can apply to <span class=\"badge badge-warning\">Waitlisted</span> partners, but they don't have access grants available right now. We will process those applications when access becomes available."
+msgstr "提携先が<span class=\"badge badge-warning\">受付保留中</span>でも申請は可能ですが、その場合、先方にはアクセス権の空きがない状態です。これらの申請はアクセスが可能になった時点で処理します。"
 
 #. Translators: On the page where coordinators can see approved applications which have not had their details sent to the partner, this message shows when there are applications ready to be processed.
 #: TWLight/applications/templates/applications/send.html:10
@@ -806,19 +743,13 @@ msgstr "%(object)sに対する申請データ"
 #. Translators: This message is shown when applications exceed the number of accounts available.
 #: TWLight/applications/templates/applications/send_partner.html:54
 #, python-format
-msgid ""
-"Application(s) for %(object)s, if sent, will exceed the total available "
-"accounts for the partner. Please proceed at your own discretion."
-msgstr ""
-"%(object)s対象の申請が送信された場合、提携いただいているアカウント総数を超え"
-"ます。ご自身の判断で進めてください。"
+msgid "Application(s) for %(object)s, if sent, will exceed the total available accounts for the partner. Please proceed at your own discretion."
+msgstr "%(object)s対象の申請が送信された場合、提携いただいているアカウント総数を超えます。ご自身の判断で進めてください。"
 
 #. Translators: When viewing the list of applications ready to be sent for a particular partner, this is instructions for the coordinator to click the 'mark as sent' button after they have sent the information.
 #: TWLight/applications/templates/applications/send_partner.html:65
 msgid "When you've processed the data below, click the 'mark as sent' button."
-msgstr ""
-"下記のデータを処理したら、「送信済みとしてマーク」ボタンをクリックしてくださ"
-"い。"
+msgstr "下記のデータを処理したら、「送信済みとしてマーク」ボタンをクリックしてください。"
 
 #. Translators: When viewing the list of applications ready to be sent for a particular partner, this is the title of the section containing contact information for the people applications should be sent to.
 #: TWLight/applications/templates/applications/send_partner.html:71
@@ -828,12 +759,8 @@ msgstr[0] "連絡先"
 
 #. Translators: When viewing the list of applications ready to be sent for a particular partner, this message shows if there is no information about who the applications should be sent to. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/applications/templates/applications/send_partner.html:89
-msgid ""
-"Whoops, we don't have any listed contacts. Please notify Wikipedia Library "
-"administrators."
-msgstr ""
-"どうやら連絡先が未登録のようです。ウィキペディア図書館の管理者に知らせてくだ"
-"さい。"
+msgid "Whoops, we don't have any listed contacts. Please notify Wikipedia Library administrators."
+msgstr "どうやら連絡先が未登録のようです。ウィキペディア図書館の管理者に知らせてください。"
 
 #. Translators: When viewing the list of applications ready to be sent for a particular partner, this is the title of the section containing the information about those applications.
 #: TWLight/applications/templates/applications/send_partner.html:94
@@ -848,12 +775,8 @@ msgstr "送信済みにする"
 
 #. Translators: This text guides coordinators in using the code sending interface for approved applications.
 #: TWLight/applications/templates/applications/send_partner.html:152
-msgid ""
-"Use the dropdown menus to denote which editor will receive each code. Access "
-"codes will be sent to users automatically."
-msgstr ""
-"どのコードをどの編集者に送るか、ドロップダウンメニューから選択して示します。"
-"アクセスコードは自動で送信されます。"
+msgid "Use the dropdown menus to denote which editor will receive each code. Access codes will be sent to users automatically."
+msgstr "どのコードをどの編集者に送るか、ドロップダウンメニューから選択して示します。アクセスコードは自動で送信されます。"
 
 #. Translators: This labels a drop-down selection where staff can assign an access code to a user.
 #: TWLight/applications/templates/applications/send_partner.html:173
@@ -868,23 +791,14 @@ msgstr "承認済みで更新手続きが済んでいない申請はありませ
 #. Translators: When a user applies for a set of resources, they receive this message if none are currently available. They are instead placed on a 'waitlist' for later approval.
 #. Translators: When a user renews their resource, they receive this message if none are currently available. They are instead placed on a 'waitlist' for later approval.
 #: TWLight/applications/views.py:140 TWLight/applications/views.py:1282
-msgid ""
-"This partner does not have any access grants available at this time. You may "
-"still apply for access; your application will be reviewed when access grants "
-"become available."
-msgstr ""
-"現時点で、この提携組織ではアクセス権の無料提供はしていません。応募は受け付け"
-"ています。申請は無料提供のアクセス権が再開された時に、審査過程へ送られます。"
+msgid "This partner does not have any access grants available at this time. You may still apply for access; your application will be reviewed when access grants become available."
+msgstr "現時点で、この提携組織ではアクセス権の無料提供はしていません。応募は受け付けています。申請は無料提供のアクセス権が再開された時に、審査過程へ送られます。"
 
 #. Translators: This message is shown to users once they've successfully submitted their application for review.
 #: TWLight/applications/views.py:163
 #, python-brace-format
-msgid ""
-"Your application has been submitted for review. Head over to <a "
-"href='{applications_url}'>My Applications</a> to view the status."
-msgstr ""
-"申請は審査過程に送られました。<a href='{applications_url}'>My Applications</"
-"a>で処理の状況を確認できます。"
+msgid "Your application has been submitted for review. Head over to <a href='{applications_url}'>My Applications</a> to view the status."
+msgstr "申請は審査過程に送られました。<a href='{applications_url}'>My Applications</a>で処理の状況を確認できます。"
 
 #. Translators: This text is displayed to users when the user has chosen to restrict data and is trying to apply for multiple partners
 #: TWLight/applications/views.py:276
@@ -932,19 +846,13 @@ msgstr "申請を送付"
 
 #. Translators: After a coordinator has changed the status of an application to APPROVED, if the corresponding partner/collection is waitlisted this message appears.
 #: TWLight/applications/views.py:756
-msgid ""
-"Cannot approve application as partner with proxy authorization method is "
-"waitlisted."
+msgid "Cannot approve application as partner with proxy authorization method is waitlisted."
 msgstr "提携組織のプロキシ承認方式が順番待ちのため、申請の処理ができません。"
 
 #. Translators: After a coordinator has changed the status of an application to APPROVED, if the corresponding partner/collection has no accounts for distribution, this message appears.
 #: TWLight/applications/views.py:780
-msgid ""
-"Cannot approve application as partner with proxy authorization method is "
-"waitlisted and (or) has zero accounts available for distribution."
-msgstr ""
-"提携組織のプロキシ承認方式が順番待ち（かつ／もしくは）配布できる無料アクセス"
-"権がゼロのため、申請の処理ができません。"
+msgid "Cannot approve application as partner with proxy authorization method is waitlisted and (or) has zero accounts available for distribution."
+msgstr "提携組織のプロキシ承認方式が順番待ち（かつ／もしくは）配布できる無料アクセス権がゼロのため、申請の処理ができません。"
 
 #. Translators: This message appears on an "access denied" screen that stops users who attempt to authorize an editor to access a resource during a time period for which they are already authorized.
 #: TWLight/applications/views.py:803
@@ -954,16 +862,8 @@ msgstr "すでに申請済みのアクセス権について、申請手続きが
 #. Translators: This message is shown to users when they access an application page of a now Bundle partner (new applications aren't allowed for Bundle partners and the status of old applications cannot be modified)
 #: TWLight/applications/views.py:857
 #, python-brace-format
-msgid ""
-"This application cannot be modified since this partner is now part of our <a "
-"href='{bundle}'>bundle access</a>. If you are eligible, you can access this "
-"resource from <a href='{library}'>your library</a>. <a "
-"href='{contact}'>Contact us</a> if you have any questions."
-msgstr ""
-"当該の提携組織が<a href='{bundle}'>バンドル制度</a>に加盟済みのため、この申請"
-"は修正できません。要件を満たす利用者は<a href='{library}'>図書館</a>タブを開"
-"くと先方にアクセスできます。ご質問はなんでも<a href='{contact}'>ご連絡</a>く"
-"ださい。"
+msgid "This application cannot be modified since this partner is now part of our <a href='{bundle}'>bundle access</a>. If you are eligible, you can access this resource from <a href='{library}'>your library</a>. <a href='{contact}'>Contact us</a> if you have any questions."
+msgstr "当該の提携組織が<a href='{bundle}'>バンドル制度</a>に加盟済みのため、この申請は修正できません。要件を満たす利用者は<a href='{library}'>図書館</a>タブを開くと先方にアクセスできます。ご質問はなんでも<a href='{contact}'>ご連絡</a>ください。"
 
 #. Translators: this lets a reviewer set the status of a single application.
 #: TWLight/applications/views.py:873
@@ -972,9 +872,7 @@ msgstr "申請の処理状態を設定"
 
 #. Translators: This warning is message is shown to applicants when the number of pending applications is greater than the number of accounts available.
 #: TWLight/applications/views.py:891
-msgid ""
-"There are more pending applications than available accounts. Your "
-"application might get waitlisted."
+msgid "There are more pending applications than available accounts. Your application might get waitlisted."
 msgstr "申請は保留されました。設定を上回る件数が審査待ちです。"
 
 #. Translators: this message is shown to coordinators who attempt to change an application's Status from INVALID to any other Status.
@@ -994,15 +892,8 @@ msgstr "申請 {} の一括更新に成功しました。"
 
 #. Translators: After a coordinator has changed the status of a number of applications to APPROVED, if the corresponding partner(s) is/are waitlisted or has no accounts for distribution, this message appears.
 #: TWLight/applications/views.py:1051
-msgid ""
-"Cannot approve application(s) {} as partner(s) with proxy authorization "
-"method is/are waitlisted and (or) has/have not enough accounts available. If "
-"not enough accounts are available, prioritise the applications and then "
-"approve applications equal to the accounts available."
-msgstr ""
-"申請が承認ができません。 {}プロキシ認証を指定する提携組織は承認アカウント数が"
-"不足もしくは申請を保留中です。アカウント数の不足に該当する場合は申請を優先"
-"し、承認アカウント数の上限の範囲で申請を承認します。"
+msgid "Cannot approve application(s) {} as partner(s) with proxy authorization method is/are waitlisted and (or) has/have not enough accounts available. If not enough accounts are available, prioritise the applications and then approve applications equal to the accounts available."
+msgstr "申請が承認ができません。 {}プロキシ認証を指定する提携組織は承認アカウント数が不足もしくは申請を保留中です。アカウント数の不足に該当する場合は申請を優先し、承認アカウント数の上限の範囲で申請を承認します。"
 
 #. Translators: This message is shown to coordinators who attempt to assign the same access code to multiple users.
 #: TWLight/applications/views.py:1191
@@ -1016,12 +907,8 @@ msgstr "選択した申請はすべて送信済みです。"
 
 #. Translators: When a user tries to renew their resource, they receive this message if the partner is not available.
 #: TWLight/applications/views.py:1272
-msgid ""
-"Cannot renew application at this time as partner is not available. Please "
-"check back later, or contact us for more information."
-msgstr ""
-"現在、提携先が連絡不能のため申請を更新できません。後ほどご確認いただくか、詳"
-"細情報をお問い合わせください。"
+msgid "Cannot renew application at this time as partner is not available. Please check back later, or contact us for more information."
+msgstr "現在、提携先が連絡不能のため申請を更新できません。後ほどご確認いただくか、詳細情報をお問い合わせください。"
 
 #. Translators: This message is displayed when an attempt by a user to renew an application has been denied for some reason.
 #: TWLight/applications/views.py:1308
@@ -1031,18 +918,12 @@ msgstr "却下された申請#{pk}の更新を試みましたが拒否されま�
 
 #. Translators: If a user requests the renewal of their account, but it wasn't renewed, this message is shown to them.
 #: TWLight/applications/views.py:1385
-msgid ""
-"This object cannot be renewed. (This probably means that you have already "
-"requested that it be renewed.)"
-msgstr ""
-"この対象は更新の対象外です。（すでに更新のお申し込みが済んでいる場合を含みま"
-"す。）"
+msgid "This object cannot be renewed. (This probably means that you have already requested that it be renewed.)"
+msgstr "この対象は更新の対象外です。（すでに更新のお申し込みが済んでいる場合を含みます。）"
 
 #. Translators: If a user requests the renewal of their account, this message is shown to them.
 #: TWLight/applications/views.py:1395
-msgid ""
-"Your renewal request has been received. A coordinator will review your "
-"request."
+msgid "Your renewal request has been received. A coordinator will review your request."
 msgstr "更新の申請を受け付けました。調整役による審査へ進む予定です。"
 
 #. Translators: This labels a textfield where users can enter their email ID.
@@ -1052,12 +933,8 @@ msgstr "ご利用のメールアドレス"
 
 #. Translators: This is the help text for the email field in the contact us form letting users know the field is updated by value pulled from their respective user profiles.
 #: TWLight/emails/forms.py:21
-msgid ""
-"This field is automatically updated with the email from your <a class='twl-"
-"links' href='{}'>user profile</a>."
-msgstr ""
-"この欄はあなたの<a class='twl-links' href='{}'>利用者プロフィール</a>に記入さ"
-"れたメールアドレスを用いて自動的に更新されます。"
+msgid "This field is automatically updated with the email from your <a class='twl-links' href='{}'>user profile</a>."
+msgstr "この欄はあなたの<a class='twl-links' href='{}'>利用者プロフィール</a>に記入されたメールアドレスを用いて自動的に更新されます。"
 
 #. Translators: This labels a textfield where users can enter their email message.
 #: TWLight/emails/forms.py:26
@@ -1080,25 +957,14 @@ msgstr "提出"
 #. Translators: This email is sent to users with their access code. Don't translate Jinja variables in curly braces like user or partner. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/access_code_email-body-html.html:5
 #, python-format
-msgid ""
-"<p>Your approved application to %(partner)s has now been finalised. Your "
-"access code or login details can be found below:</p> <p><b>%(access_code)s</"
-"b></p> <p>%(user_instructions)s</p>"
-msgstr ""
-"<p>%(partner)s件の承認済み申請の手続きが完了しました。アクセスコードもしくは"
-"ログイン情報は次をご参照ください。</p> <p><b>%(access_code)s</b></p> <p>"
-"%(user_instructions)s</p>"
+msgid "<p>Your approved application to %(partner)s has now been finalised. Your access code or login details can be found below:</p> <p><b>%(access_code)s</b></p> <p>%(user_instructions)s</p>"
+msgstr "<p>%(partner)s件の承認済み申請の手続きが完了しました。アクセスコードもしくはログイン情報は次をご参照ください。</p> <p><b>%(access_code)s</b></p> <p>%(user_instructions)s</p>"
 
 #. Translators: This email is sent to users with their access code. Don't translate Jinja variables in curly braces like user or partner. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/access_code_email-body-text.html:3
 #, python-format
-msgid ""
-"Your approved application to %(partner)s has now been finalised. Your access "
-"code or login details can be found below: %(access_code)s "
-"%(user_instructions)s"
-msgstr ""
-"%(partner)s件の承認済み申請の手続きが完了しました。アクセスコードもしくはログ"
-"イン情報は次をご参照ください。%(access_code)s %(user_instructions)s"
+msgid "Your approved application to %(partner)s has now been finalised. Your access code or login details can be found below: %(access_code)s %(user_instructions)s"
+msgstr "%(partner)s件の承認済み申請の手続きが完了しました。アクセスコードもしくはログイン情報は次をご参照ください。%(access_code)s %(user_instructions)s"
 
 #. Translators: This is the subject line of an email sent to users with their access code.
 #: TWLight/emails/templates/emails/access_code_email-subject.html:3
@@ -1108,34 +974,14 @@ msgstr "ウィキペディア図書館のアクセスコード"
 #. Translators: This email is sent to users when their application is approved. Don't translate Jinja variables in curly braces like user or partner; don't translate html tags either. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/approval_notification-body-html.html:5
 #, python-format
-msgid ""
-"<p>Dear %(user)s,</p> <p>Thank you for applying for access to %(partner)s "
-"resources through The Wikipedia Library. We are happy to inform you that "
-"your application has been approved.</p> <p>%(user_instructions)s</p> <p>You "
-"can view the collections you're authorized to access at My Library: "
-"%(link)s</p> <p>Cheers!</p> <p>The Wikipedia Library</p>"
-msgstr ""
-"<p>拝啓 %(user)s様、</p> <p>このたびはウィキペディア図書館経由で%(partner)sリ"
-"ソース向けアクセス権を申請していただきありがとうございます。申請を承認したこ"
-"とをお知らせします。</p> <p>%(user_instructions)s</p> <p>アクセス承認済みのコ"
-"レクションは「私の図書館」リンクを開いてご確認ください。%(link)s</p> <p>よろ"
-"しくお願いします。</p> <p>ウィキペディア図書館一同</p>"
+msgid "<p>Dear %(user)s,</p> <p>Thank you for applying for access to %(partner)s resources through The Wikipedia Library. We are happy to inform you that your application has been approved.</p> <p>%(user_instructions)s</p> <p>You can view the collections you're authorized to access at My Library: %(link)s</p> <p>Cheers!</p> <p>The Wikipedia Library</p>"
+msgstr "<p>拝啓 %(user)s様、</p> <p>このたびはウィキペディア図書館経由で%(partner)sリソース向けアクセス権を申請していただきありがとうございます。申請を承認したことをお知らせします。</p> <p>%(user_instructions)s</p> <p>アクセス承認済みのコレクションは「私の図書館」リンクを開いてご確認ください。%(link)s</p> <p>よろしくお願いします。</p> <p>ウィキペディア図書館一同</p>"
 
 #. Translators: This email is sent to users when their application is approved. Don't translate Jinja variables in curly braces like user or partner. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/approval_notification-body-text.html:3
 #, python-format
-msgid ""
-"Dear %(user)s, Thank you for applying for access to %(partner)s resources "
-"through The Wikipedia Library. We are happy to inform you that your "
-"application has been approved. %(user_instructions)s You can view the "
-"collections you're authorized to access at My Library: %(link)s Cheers! The "
-"Wikipedia Library"
-msgstr ""
-"<p>拝啓 %(user)s様、このたびはウィキペディア図書館経由で%(partner)sのリソース"
-"につきアクセス権を申請していただきありがとうございます。申請を承認したことを"
-"お知らせします。%(user_instructions)s アクセス承認済みのコレクションは「図書"
-"館」リンクを開いてご確認ください。%(link)s よろしくお願いします。ウィキペディ"
-"ア図書館一同"
+msgid "Dear %(user)s, Thank you for applying for access to %(partner)s resources through The Wikipedia Library. We are happy to inform you that your application has been approved. %(user_instructions)s You can view the collections you're authorized to access at My Library: %(link)s Cheers! The Wikipedia Library"
+msgstr "<p>拝啓 %(user)s様、このたびはウィキペディア図書館経由で%(partner)sのリソースにつきアクセス権を申請していただきありがとうございます。申請を承認したことをお知らせします。%(user_instructions)s アクセス承認済みのコレクションは「図書館」リンクを開いてご確認ください。%(link)s よろしくお願いします。ウィキペディア図書館一同"
 
 #. Translators: This is the subject of an email which is sent to users when their application has been approved. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/approval_notification-subject.html:4
@@ -1145,26 +991,14 @@ msgstr "ウィキペディア図書館の申請が承認されました"
 #. Translators: This email is sent to coordinators when a comment is left on an application they are processing. Don't translate Jinja variables in curly braces like user or partner. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/comment_notification_coordinator-body-html.html:5
 #, python-format
-msgid ""
-"<p style=\"color: #500050\">%(submit_date)s - %(commenter)s</p> "
-"<blockquote><p>%(comment)s</p></blockquote> <p>Please reply to these at: <a "
-"href=\"%(app_url)s\">%(app_url)s</a></p> <p>Best,</p> <p>The Wikipedia "
-"Library</p>"
-msgstr ""
-"<p style=\"color: #500050\">%(submit_date)s - %(commenter)s</p> "
-"<blockquote><p>%(comment)s</p></blockquote> <p>返信は右の宛先へ送信してくださ"
-"い。<a href=\"%(app_url)s\">%(app_url)s</a></p> <p>よろしくお願いします。</"
-"p> <p>ウィキペディア図書館一同</p>"
+msgid "<p style=\"color: #500050\">%(submit_date)s - %(commenter)s</p> <blockquote><p>%(comment)s</p></blockquote> <p>Please reply to these at: <a href=\"%(app_url)s\">%(app_url)s</a></p> <p>Best,</p> <p>The Wikipedia Library</p>"
+msgstr "<p style=\"color: #500050\">%(submit_date)s - %(commenter)s</p> <blockquote><p>%(comment)s</p></blockquote> <p>返信は右の宛先へ送信してください。<a href=\"%(app_url)s\">%(app_url)s</a></p> <p>よろしくお願いします。</p> <p>ウィキペディア図書館一同</p>"
 
 #. Translators: This email is sent to coordinators when a comment is left on an application they are processing. Don't translate Jinja variables in curly braces like user or partner. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/comment_notification_coordinator-body-text.html:3
 #, python-format
-msgid ""
-"%(submit_date)s - %(commenter)s %(comment)s Please reply to this at: "
-"%(app_url)s Best, The Wikipedia Library"
-msgstr ""
-"%(submit_date)s - %(commenter)s %(comment)s 返信するには次のリンク先をご利用"
-"ください。%(app_url)s 草々、ウィキペディア図書館担当一同"
+msgid "%(submit_date)s - %(commenter)s %(comment)s Please reply to this at: %(app_url)s Best, The Wikipedia Library"
+msgstr "%(submit_date)s - %(commenter)s %(comment)s 返信するには次のリンク先をご利用ください。%(app_url)s 草々、ウィキペディア図書館担当一同"
 
 #. Translators: This is the subject line of an email sent to coordinators when a comment is left on an application they processed.
 #: TWLight/emails/templates/emails/comment_notification_coordinator-subject.html:3
@@ -1174,26 +1008,14 @@ msgstr "自分が申請手続きをしたウィキペディア図書館に関す
 #. Translators: This email is sent to users when they receive a comment on their application. Don't translate Jinja variables in curly braces like user or partner; don't translate html tags either. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/comment_notification_editors-body-html.html:5
 #, python-format
-msgid ""
-"<p style=\"color: #500050\">%(submit_date)s - %(commenter)s</p> "
-"<blockquote><p>%(comment)s</p></blockquote> <p>Please reply to these at <a "
-"href=\"%(app_url)s\">%(app_url)s</a> so we can evaluate your application.</"
-"p> <p>Best,</p> <p>The Wikipedia Library</p>"
-msgstr ""
-"<p style=\"color: #500050\">%(submit_date)s - %(commenter)s</p> "
-"<blockquote><p>%(comment)s</p></blockquote> <p>これらに返信するには次のリンク"
-"<a href=\"%(app_url)s\">%(app_url)s</a>をご利用いただくと、申請の審査を進行で"
-"きます。</p> <p>草々、</p> <p>ウィキペディア図書館担当一同</p>"
+msgid "<p style=\"color: #500050\">%(submit_date)s - %(commenter)s</p> <blockquote><p>%(comment)s</p></blockquote> <p>Please reply to these at <a href=\"%(app_url)s\">%(app_url)s</a> so we can evaluate your application.</p> <p>Best,</p> <p>The Wikipedia Library</p>"
+msgstr "<p style=\"color: #500050\">%(submit_date)s - %(commenter)s</p> <blockquote><p>%(comment)s</p></blockquote> <p>これらに返信するには次のリンク<a href=\"%(app_url)s\">%(app_url)s</a>をご利用いただくと、申請の審査を進行できます。</p> <p>草々、</p> <p>ウィキペディア図書館担当一同</p>"
 
 #. Translators: This email is sent to users when they receive a comment on their application. Don't translate Jinja variables in curly braces like user or partner. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/comment_notification_editors-body-text.html:3
 #, python-format
-msgid ""
-"%(submit_date)s - %(commenter)s %(comment)s Please reply to these at: "
-"%(app_url)s so we can evaluate your application. Best, The Wikipedia Library"
-msgstr ""
-"%(submit_date)s - %(commenter)s %(comment)s 返信に次のリンク%(app_url)sをご利"
-"用いただくと、審査の進行ができます。草々、ウィキペメディア図書館担当一同"
+msgid "%(submit_date)s - %(commenter)s %(comment)s Please reply to these at: %(app_url)s so we can evaluate your application. Best, The Wikipedia Library"
+msgstr "%(submit_date)s - %(commenter)s %(comment)s 返信に次のリンク%(app_url)sをご利用いただくと、審査の進行ができます。草々、ウィキペメディア図書館担当一同"
 
 #. Translators: This is the subject line of an email sent to users who have a comment added to one of their applications. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/comment_notification_editors-subject.html:3
@@ -1203,42 +1025,25 @@ msgstr "利用者のウィキペディア図書館の申請に新しいコメン
 #. Translators: This email is sent to users when an application they commented on receives another comment. Don't translate Jinja variables in curly braces like app_url; don't translate html tags either. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/comment_notification_others-body-html.html:5
 #, python-format
-msgid ""
-"<p style=\"color: #500050\">%(submit_date)s - %(commenter)s</p> "
-"<blockquote><p>%(comment)s</p></blockquote> See it at <a href=\"%(app_url)s"
-"\">%(app_url)s</a>. Thanks for helping review Wikipedia Library applications!"
-msgstr ""
-"<p style=\"color: #500050\">%(submit_date)s - %(commenter)s</p> "
-"<blockquote><p>%(comment)s</p></blockquote>閲覧するには<a href=\"%(app_url)s"
-"\">%(app_url)s</a>をご参照ください。ウィキペディア図書館の申請の審査にご協力"
-"いただきありがとうございます。"
+msgid "<p style=\"color: #500050\">%(submit_date)s - %(commenter)s</p> <blockquote><p>%(comment)s</p></blockquote> See it at <a href=\"%(app_url)s\">%(app_url)s</a>. Thanks for helping review Wikipedia Library applications!"
+msgstr "<p style=\"color: #500050\">%(submit_date)s - %(commenter)s</p> <blockquote><p>%(comment)s</p></blockquote>閲覧するには<a href=\"%(app_url)s\">%(app_url)s</a>をご参照ください。ウィキペディア図書館の申請の審査にご協力いただきありがとうございます。"
 
 #. Translators: This email is sent to users when an application they commented on receives another comment. Don't translate Jinja variables in curly braces like app_url. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/comment_notification_others-body-text.html:3
 #, python-format
-msgid ""
-"%(submit_date)s - %(commenter)s %(comment)s See it at: %(app_url)s Thanks "
-"for helping review Wikipedia Library applications!"
-msgstr ""
-"%(submit_date)s - %(commenter)s %(comment)s 閲覧はこちら。%(app_url)s ウィキ"
-"ペディア図書館の申請の審査にご協力いただき、ありがとうございます。"
+msgid "%(submit_date)s - %(commenter)s %(comment)s See it at: %(app_url)s Thanks for helping review Wikipedia Library applications!"
+msgstr "%(submit_date)s - %(commenter)s %(comment)s 閲覧はこちら。%(app_url)s ウィキペディア図書館の申請の審査にご協力いただき、ありがとうございます。"
 
 #. Translators: This is the subject line of an email sent to users who have a comment added to an application they also commented on. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/comment_notification_others-subject.html:4
 msgid "New comment on a Wikipedia Library application you commented on"
-msgstr ""
-"利用者がコメントしたウィキペディア図書館の申請に、新しいコメントがつきました"
+msgstr "利用者がコメントしたウィキペディア図書館の申請に、新しいコメントがつきました"
 
 #. Translators: This text is part of a scheduled reminder email sent to coordinators who have applications requiring action. Don't translate Jinja variables in curly braces like total_apps, or user.
 #: TWLight/emails/templates/emails/coordinator_reminder_notification-body-html.html:5
 #, python-format
-msgid ""
-"<p>Dear %(user)s,</p> <p>Our records indicate that you are the designated "
-"coordinator for partners that have a total of %(total_apps)s applications.</"
-"p>"
-msgstr ""
-"<p>拝啓 %(user)s様、</p> <p>記録によりますと、あなたは合計 %(total_apps)s件の"
-"申請を受け付けた出版社から承認されたコーディネーターです。</p>"
+msgid "<p>Dear %(user)s,</p> <p>Our records indicate that you are the designated coordinator for partners that have a total of %(total_apps)s applications.</p>"
+msgstr "<p>拝啓 %(user)s様、</p> <p>記録によりますと、あなたは合計 %(total_apps)s件の申請を受け付けた出版社から承認されたコーディネーターです。</p>"
 
 #. Translators: Breakdown as in 'cost breakdown'; analysis.
 #: TWLight/emails/templates/emails/coordinator_reminder_notification-body-html.html:11
@@ -1273,45 +1078,20 @@ msgstr[0] "承認済み申請%(counter)s件。"
 #. Translators: This text is part of a scheduled reminder email sent to coordinators who have applications requiring action. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library). Don't translate Jinja variables in curly braces like link; don't translate email addresses or html tags either.
 #: TWLight/emails/templates/emails/coordinator_reminder_notification-body-html.html:39
 #, python-format
-msgid ""
-"<p>This is a gentle reminder that you may review applications at <a href="
-"\"%(link)s\">%(link)s</a>.</p> <p>You can customise your reminders under "
-"'preferences' in your user profile.</p> <p>If you received this message in "
-"error, drop us a line at wikipedialibrary@wikimedia.org.</p> <p>Thanks for "
-"helping review Wikipedia Library applications!</p>"
-msgstr ""
-"<p>確認ですが、申請の審査は<a href=\"%(link)s\">%(link)s</a>で実行されている"
-"でしょうか。</p> <p>利用者プロフィールの '個人設定' 欄で確認通知を好みに設定"
-"できます。</p> <p>もしこの通知の受信が何かのエラーによる場合は、お手数ですが "
-"wikipedialibrary@wikimedia.org あてにご連絡いただけないでしょうか。</p> <p>"
-"ウィキペディア図書館アプリケーションの動作確認へのご協力ありがとうございま"
-"す。</p>"
+msgid "<p>This is a gentle reminder that you may review applications at <a href=\"%(link)s\">%(link)s</a>.</p> <p>You can customise your reminders under 'preferences' in your user profile.</p> <p>If you received this message in error, drop us a line at wikipedialibrary@wikimedia.org.</p> <p>Thanks for helping review Wikipedia Library applications!</p>"
+msgstr "<p>確認ですが、申請の審査は<a href=\"%(link)s\">%(link)s</a>で実行されているでしょうか。</p> <p>利用者プロフィールの '個人設定' 欄で確認通知を好みに設定できます。</p> <p>もしこの通知の受信が何かのエラーによる場合は、お手数ですが wikipedialibrary@wikimedia.org あてにご連絡いただけないでしょうか。</p> <p>ウィキペディア図書館アプリケーションの動作確認へのご協力ありがとうございます。</p>"
 
 #. Translators: This text is part of a scheduled reminder email sent to coordinators who have applications requiring action. Don't translate Jinja variables in curly braces like total_apps, or user.
 #: TWLight/emails/templates/emails/coordinator_reminder_notification-body-text.html:3
 #, python-format
-msgid ""
-"Dear %(user)s, Our records indicate that you are the designated coordinator "
-"for partners that have a total of %(total_apps)s applications."
-msgstr ""
-"啓 %(user)s様、記録によりますと、あなたは合計 %(total_apps)s件の申請を受け付"
-"けた出版社から承認されたコーディネーターです。"
+msgid "Dear %(user)s, Our records indicate that you are the designated coordinator for partners that have a total of %(total_apps)s applications."
+msgstr "啓 %(user)s様、記録によりますと、あなたは合計 %(total_apps)s件の申請を受け付けた出版社から承認されたコーディネーターです。"
 
 #. Translators: This text is part of a scheduled reminder email sent to coordinators who have applications requiring action. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library). Don't translate Jinja variables in curly braces like link; don't translate the email address either.
 #: TWLight/emails/templates/emails/coordinator_reminder_notification-body-text.html:38
 #, python-format
-msgid ""
-"This is a gentle reminder that you may review applications at: %(link)s. You "
-"can customise your reminders under 'preferences' in your user profile. If "
-"you received this message in error, drop us a line at: "
-"wikipedialibrary@wikimedia.org Thanks for helping review Wikipedia Library "
-"applications!"
-msgstr ""
-"確認ですが、申請の審査は<a href=\"%(link)s\">%(link)s</a>で実行されているで"
-"しょうか。利用者プロフィールの '個人設定' 欄で確認通知を好みに設定できます。"
-"もしこの通知の受信が何かのエラーによる場合は、お手数ですが "
-"wikipedialibrary@wikimedia.org あてにご連絡いただけないでしょうか。ウィキペ"
-"ディア図書館アプリケーションの動作確認へのご協力ありがとうございます。</p>"
+msgid "This is a gentle reminder that you may review applications at: %(link)s. You can customise your reminders under 'preferences' in your user profile. If you received this message in error, drop us a line at: wikipedialibrary@wikimedia.org Thanks for helping review Wikipedia Library applications!"
+msgstr "確認ですが、申請の審査は<a href=\"%(link)s\">%(link)s</a>で実行されているでしょうか。利用者プロフィールの '個人設定' 欄で確認通知を好みに設定できます。もしこの通知の受信が何かのエラーによる場合は、お手数ですが wikipedialibrary@wikimedia.org あてにご連絡いただけないでしょうか。ウィキペディア図書館アプリケーションの動作確認へのご協力ありがとうございます。</p>"
 
 #. Translators: This is the subject line of a scheduled reminder email sent to coordinators who have applications to review. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library). Do not translate items in curly braces.
 #: TWLight/emails/templates/emails/coordinator_reminder_notification-subject.html:4
@@ -1321,33 +1101,14 @@ msgstr "ウィキペディア図書館アプリでは査読をお待ちしてい
 #. Translators: This email is sent to users when their application is rejected. Don't translate Jinja variables in curly braces like user or partner; don't translate html tags either. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/rejection_notification-body-html.html:5
 #, python-format
-msgid ""
-"<p>Dear %(user)s,</p> <p>Thank you for applying for access to %(partner)s "
-"resources through The Wikipedia Library. Unfortunately at this time your "
-"application has not been approved. You can view your application and review "
-"comments at <a href=\"%(app_url)s\">%(app_url)s</a>.</p> <p>Best,</p> <p>The "
-"Wikipedia Library</p>"
-msgstr ""
-"<p>拝啓　%(user)s様、</p> <p>ウィキペディア図書館を経由して%(partner)sのリ"
-"ソースへのアクセス権をお申し込みいただきありがとうございます。誠に残念なが"
-"ら、このたび、お申し込みを承認することができませんでした。申請内容のご確認と"
-"コメントの閲覧は<a href=\"%(app_url)s\">%(app_url)s</a>をご利用ください。</"
-"p> <p>草々　</p> <p>ウィキペディア図書館担当一同</p>"
+msgid "<p>Dear %(user)s,</p> <p>Thank you for applying for access to %(partner)s resources through The Wikipedia Library. Unfortunately at this time your application has not been approved. You can view your application and review comments at <a href=\"%(app_url)s\">%(app_url)s</a>.</p> <p>Best,</p> <p>The Wikipedia Library</p>"
+msgstr "<p>拝啓　%(user)s様、</p> <p>ウィキペディア図書館を経由して%(partner)sのリソースへのアクセス権をお申し込みいただきありがとうございます。誠に残念ながら、このたび、お申し込みを承認することができませんでした。申請内容のご確認とコメントの閲覧は<a href=\"%(app_url)s\">%(app_url)s</a>をご利用ください。</p> <p>草々　</p> <p>ウィキペディア図書館担当一同</p>"
 
 #. Translators: This email is sent to users when their application is rejected. Don't translate Jinja variables in curly braces like user or partner. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/rejection_notification-body-text.html:3
 #, python-format
-msgid ""
-"Dear %(user)s, Thank you for applying for access to %(partner)s resources "
-"through The Wikipedia Library. Unfortunately at this time your application "
-"has not been approved. You can view your application and review comments at: "
-"%(app_url)s Best, The Wikipedia Library"
-msgstr ""
-"拝啓　%(user)s様、ウィキペディア図書館を経由して%(partner)sのリソースへのアク"
-"セス権をお申し込みいただきありがとうございます。誠に残念ながら、このたび、お"
-"申し込みを承認することができませんでした。申請内容のご確認とコメントの閲覧は"
-"<a href=\"%(app_url)s\">%(app_url)s</a>をご利用ください。草々、　ウィキペディ"
-"ア図書館担当一同"
+msgid "Dear %(user)s, Thank you for applying for access to %(partner)s resources through The Wikipedia Library. Unfortunately at this time your application has not been approved. You can view your application and review comments at: %(app_url)s Best, The Wikipedia Library"
+msgstr "拝啓　%(user)s様、ウィキペディア図書館を経由して%(partner)sのリソースへのアクセス権をお申し込みいただきありがとうございます。誠に残念ながら、このたび、お申し込みを承認することができませんでした。申請内容のご確認とコメントの閲覧は<a href=\"%(app_url)s\">%(app_url)s</a>をご利用ください。草々、　ウィキペディア図書館担当一同"
 
 #. Translators: This is the subject of an email which is sent to users when their application has been rejected. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/rejection_notification-subject.html:4
@@ -1357,38 +1118,14 @@ msgstr "あなたのウィキペディア図書館の申請"
 #. Translators: This email is sent to users when they have an account that is soon to expire. Don't translate Jinja variables in curly braces like partner_name or partner_link; don't translate html tags either. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/user_renewal_notice-body-html.html:5
 #, python-format
-msgid ""
-"<p>Dear %(user)s,</p> <p>According to our records, your access to "
-"%(partner_name)s will soon expire and you may lose access. If you want to "
-"continue making use of your free account, you can request renewal of your "
-"account by clicking the 'Renew' or 'Extend' button at %(partner_link)s.</p> "
-"<p>Best,</p> <p>The Wikipedia Library</p> <p>You can disable these emails in "
-"your user page preferences: https://wikipedialibrary.wmflabs.org/users/</p>"
-msgstr ""
-"<p>拝啓 %(user)s様、</p> <p>記録に照会したところ、まもなく%(partner_name)sア"
-"クセス権が満了してご利用いただけなくなる見込みです。無料のアクセス権のご利用"
-"を今後も希望される場合は、%(partner_link)sの「更新」もしくは「延長」ボタンか"
-"らお手続きください。</p> <p>よろしくお願いします。</p> <p>ウィキペディア図書"
-"館担当一同</p> <p>今後、この種のメール配信がご不用でしたら、右の個人設定で無"
-"効にできます。https://wikipedialibrary.wmflabs.org/users/</p>"
+msgid "<p>Dear %(user)s,</p> <p>According to our records, your access to %(partner_name)s will soon expire and you may lose access. If you want to continue making use of your free account, you can request renewal of your account by clicking the 'Renew' or 'Extend' button at %(partner_link)s.</p> <p>Best,</p> <p>The Wikipedia Library</p> <p>You can disable these emails in your user page preferences: https://wikipedialibrary.wmflabs.org/users/</p>"
+msgstr "<p>拝啓 %(user)s様、</p> <p>記録に照会したところ、まもなく%(partner_name)sアクセス権が満了してご利用いただけなくなる見込みです。無料のアクセス権のご利用を今後も希望される場合は、%(partner_link)sの「更新」もしくは「延長」ボタンからお手続きください。</p> <p>よろしくお願いします。</p> <p>ウィキペディア図書館担当一同</p> <p>今後、この種のメール配信がご不用でしたら、右の個人設定で無効にできます。https://wikipedialibrary.wmflabs.org/users/</p>"
 
 #. Translators: This email is sent to users when they have an account that is soon to expire. Don't translate Jinja variables in curly braces like partner_name or partner_link; don't translate html tags either. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/user_renewal_notice-body-text.html:3
 #, python-format
-msgid ""
-"Dear %(user)s, According to our records, your access to %(partner_name)s "
-"will soon expire and you may lose access. If you want to continue making use "
-"of your free account, you can request renewal of your account by clicking "
-"the Renew button at %(partner_link)s. Best, The Wikipedia Library You can "
-"disable these emails in your user page preferences: https://wikipedialibrary."
-"wmflabs.org/users/"
-msgstr ""
-"<p>拝啓 %(user)s様、記録に照会したところ、まもなく%(partner_name)sアクセス権"
-"が満了してご利用いただけなくなる見込みです。無料のアクセス権のご利用を今後も"
-"希望される場合は、%(partner_link)sの「更新」ボタンからお手続きください。よろ"
-"しくお願いします。ウィキペディア図書館担当一同 今後、この種のメール配信がご不"
-"用でしたら、右の個人設定で無効にできます。https://wikipedialibrary.wmflabs."
-"org/users/"
+msgid "Dear %(user)s, According to our records, your access to %(partner_name)s will soon expire and you may lose access. If you want to continue making use of your free account, you can request renewal of your account by clicking the Renew button at %(partner_link)s. Best, The Wikipedia Library You can disable these emails in your user page preferences: https://wikipedialibrary.wmflabs.org/users/"
+msgstr "<p>拝啓 %(user)s様、記録に照会したところ、まもなく%(partner_name)sアクセス権が満了してご利用いただけなくなる見込みです。無料のアクセス権のご利用を今後も希望される場合は、%(partner_link)sの「更新」ボタンからお手続きください。よろしくお願いします。ウィキペディア図書館担当一同 今後、この種のメール配信がご不用でしたら、右の個人設定で無効にできます。https://wikipedialibrary.wmflabs.org/users/"
 
 #. Translators: This is the subject of an email sent to users when they have an account that is soon to expire. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/user_renewal_notice-subject.html:4
@@ -1398,36 +1135,14 @@ msgstr "ウィキペディア図書館のアクセスがまもなく期限切れ
 #. Translators: This email is sent to users when their application is waitlisted because there are no more accounts available. Don't translate Jinja variables in curly braces like user or partner; don't translate html tags either. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/waitlist_notification-body-html.html:5
 #, python-format
-msgid ""
-"<p>Dear %(user)s,</p> <p>Thank you for applying for access to %(partner)s "
-"resources through The Wikipedia Library. There are no accounts currently "
-"available so your application has been waitlisted. Your application will be "
-"evaluated if/when more accounts become available. You can see all available "
-"resources at <a href=\"%(link)s\">%(link)s</a>.</p> <p>Best,</p> <p>The "
-"Wikipedia Library</p>"
-msgstr ""
-"<p>拝啓 %(user)s様、</p> <p>ウィキペディア図書館経由で%(partner)sの情報源アク"
-"セス権をお申し込みいただきありがとうございます。現在、空きアカウントがないた"
-"めお申し込みはウェイティングリストに追加されました。アカウントが利用可能に"
-"なった段階でお申し込みの審査を開始します。ご利用いただける情報源の一覧は<a "
-"href=\"%(link)s\">%(link)s</a>でご確認ください。</p> <p>草々、</p> <p>ウィキ"
-"ペディア図書館担当一同</p>"
+msgid "<p>Dear %(user)s,</p> <p>Thank you for applying for access to %(partner)s resources through The Wikipedia Library. There are no accounts currently available so your application has been waitlisted. Your application will be evaluated if/when more accounts become available. You can see all available resources at <a href=\"%(link)s\">%(link)s</a>.</p> <p>Best,</p> <p>The Wikipedia Library</p>"
+msgstr "<p>拝啓 %(user)s様、</p> <p>ウィキペディア図書館経由で%(partner)sの情報源アクセス権をお申し込みいただきありがとうございます。現在、空きアカウントがないためお申し込みはウェイティングリストに追加されました。アカウントが利用可能になった段階でお申し込みの審査を開始します。ご利用いただける情報源の一覧は<a href=\"%(link)s\">%(link)s</a>でご確認ください。</p> <p>草々、</p> <p>ウィキペディア図書館担当一同</p>"
 
 #. Translators: This email is sent to users when their application is waitlisted because there are no more accounts available. Don't translate Jinja variables in curly braces like user or partner. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/waitlist_notification-body-text.html:3
 #, python-format
-msgid ""
-"Dear %(user)s, Thank you for applying for access to %(partner)s resources "
-"through The Wikipedia Library. There are no accounts currently available so "
-"your application has been waitlisted. Your application will be evaluated if/"
-"when more accounts become available. You can see all available resources at: "
-"%(link)s Best, The Wikipedia Library"
-msgstr ""
-"拝啓 %(user)sさん、このたびは%(partner)s の情報源へのアクセス権をウィキペディ"
-"ア図書館経由でお申し込みいただきありがとうございました。現状でアカウントに空"
-"きがないため、あなたの申請は待機リストにあがっています。申請はアカウントが空"
-"いたとき/適用できる場合に審査を開始します。利用可能な情報源の総覧は%(link)sを"
-"ご参照ください。草々 ウィキペディア図書館担当一同"
+msgid "Dear %(user)s, Thank you for applying for access to %(partner)s resources through The Wikipedia Library. There are no accounts currently available so your application has been waitlisted. Your application will be evaluated if/when more accounts become available. You can see all available resources at: %(link)s Best, The Wikipedia Library"
+msgstr "拝啓 %(user)sさん、このたびは%(partner)s の情報源へのアクセス権をウィキペディア図書館経由でお申し込みいただきありがとうございました。現状でアカウントに空きがないため、あなたの申請は待機リストにあがっています。申請はアカウントが空いたとき/適用できる場合に審査を開始します。利用可能な情報源の総覧は%(link)sをご参照ください。草々 ウィキペディア図書館担当一同"
 
 #. Translators: This is the subject of an email sent to users when their application is waitlisted because there are no more accounts available. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/waitlist_notification-subject.html:4
@@ -1588,22 +1303,15 @@ msgstr "利用できません"
 #: TWLight/resources/templates/resources/filter_section.html:14
 #: TWLight/templates/about.html:12
 #: TWLight/users/templates/users/filter_section.html:13
-msgid ""
-"The Wikipedia Library allows active editors to access a wide range of "
-"collections of paywalled reliable sources for free!"
-msgstr ""
-"ウィキペディア図書館 (The Wikipedia Library) は、活発な編集者の皆さんが信頼性"
-"の高い有償 (ペイウォール) 情報源を無料で広範に利用できるようにします。"
+msgid "The Wikipedia Library allows active editors to access a wide range of collections of paywalled reliable sources for free!"
+msgstr "ウィキペディア図書館 (The Wikipedia Library) は、活発な編集者の皆さんが信頼性の高い有償 (ペイウォール) 情報源を無料で広範に利用できるようにします。"
 
 #. Translators: On the Browse Partners page (https://wikipedialibrary.wmflabs.org/partners/), this introduces users to The Wikipedia Library.
 #. Translators: On the MyLibrary page (https://wikipedialibrary.wmflabs.org/users/my_library), this introduces users to The Wikipedia Library.
 #: TWLight/resources/templates/resources/filter_section.html:17
 #: TWLight/users/templates/users/filter_section.html:15
-msgid ""
-"Start with the search bar at the top or browse publisher websites directly."
-msgstr ""
-"ページ上部の検索バーを使うか、直接、それぞれの出版社のウェブサイトを開いて閲"
-"覧しましょう。"
+msgid "Start with the search bar at the top or browse publisher websites directly."
+msgstr "ページ上部の検索バーを使うか、直接、それぞれの出版社のウェブサイトを開いて閲覧しましょう。"
 
 #. Translators: On the Browse Partners page (https://wikipedialibrary.wmflabs.org/partners/), this appears below introductory text and links to the 'About' page (https://wikipedialibrary.wmflabs.org/about/)
 #. Translators: On the MyLibrary page (https://wikipedialibrary.wmflabs.org/users/my_library), this appears below introductory text and links to the 'About' page (https://wikipedialibrary.wmflabs.org/about/)
@@ -1676,67 +1384,39 @@ msgstr "提携組織一覧に戻る"
 #. Translators: If we have no available accounts for a partner, the coordinator can change the application system to a waiting list.
 #: TWLight/resources/templates/resources/partner_detail.html:36
 #: TWLight/resources/templates/resources/partner_detail_apply.html:17
-msgid ""
-"There are no access grants available for this partner at this time. You can "
-"still apply for access; applications will be processed when access is "
-"available."
-msgstr ""
-"現在、この提携組織ではアクセス権の提供を行っていません。アクセス権の申請は受"
-"け付けています。アクセス権の提供開始の時期に申請の処理が開始されます。"
+msgid "There are no access grants available for this partner at this time. You can still apply for access; applications will be processed when access is available."
+msgstr "現在、この提携組織ではアクセス権の提供を行っていません。アクセス権の申請は受け付けています。アクセス権の提供開始の時期に申請の処理が開始されます。"
 
 #. Translators: This text links to the minimum user requirements and terms of use on the partner page.
 #: TWLight/resources/templates/resources/partner_detail.html:48
 #: TWLight/resources/templates/resources/partner_detail_apply.html:29
 #, python-format
-msgid ""
-"Before applying, please review the <strong><a class=\"twl-links\" href="
-"\"%(about)s#req\">minimum requirements</a></strong> for access and our "
-"<strong><a class=\"twl-links\" href=\"%(terms)s\">terms of use</a></strong>."
-msgstr ""
-"申請に先立ち、まずアクセスの<strong><a class=\"twl-links\" href="
-"\"%(about)s#req\">最低要件</a></strong>ならびにウィキメディア財団の"
-"<strong><a class=\"twl-links\" href=\"%(terms)s\">利用規約</a></strong>を精査"
-"してください。"
+msgid "Before applying, please review the <strong><a class=\"twl-links\" href=\"%(about)s#req\">minimum requirements</a></strong> for access and our <strong><a class=\"twl-links\" href=\"%(terms)s\">terms of use</a></strong>."
+msgstr "申請に先立ち、まずアクセスの<strong><a class=\"twl-links\" href=\"%(about)s#req\">最低要件</a></strong>ならびにウィキメディア財団の<strong><a class=\"twl-links\" href=\"%(terms)s\">利用規約</a></strong>を精査してください。"
 
 #. Translators: This text refers to the page containing the content a user is authorized to access.
 #: TWLight/resources/templates/resources/partner_detail.html:69
 #, python-format
-msgid ""
-"View the status of your access in <strong><a class=\"twl-links\" href="
-"\"%(library_url)s\">My Library</a></strong> page."
-msgstr ""
-"アクセス権の状況を確認するには<strong><a class=\"twl-links\" href="
-"\"%(library_url)s\">私の図書館</a></strong>ページをご覧ください。"
+msgid "View the status of your access in <strong><a class=\"twl-links\" href=\"%(library_url)s\">My Library</a></strong> page."
+msgstr "アクセス権の状況を確認するには<strong><a class=\"twl-links\" href=\"%(library_url)s\">私の図書館</a></strong>ページをご覧ください。"
 
 #. Translators: This message is shown when a user has open applications, linking to their respective applications page.
 #: TWLight/resources/templates/resources/partner_detail.html:78
 #, python-format
-msgid ""
-"View the status of your application(s) on your <strong><a class=\"twl-links"
-"\" href=\"%(applications_url)s\">My Applications</a></strong> page."
-msgstr ""
-"提出した申請の進行状況は<strong><a class=\"twl-links\" href="
-"\"%(applications_url)s\">My Applications</a></strong>ページで確認できます。"
+msgid "View the status of your application(s) on your <strong><a class=\"twl-links\" href=\"%(applications_url)s\">My Applications</a></strong> page."
+msgstr "提出した申請の進行状況は<strong><a class=\"twl-links\" href=\"%(applications_url)s\">My Applications</a></strong>ページで確認できます。"
 
 #. Translators: This message is shown when a user has authorizations, linking to their respective collections page.
 #: TWLight/resources/templates/resources/partner_detail_apply.html:50
 #, python-format
-msgid ""
-"View the status of your access on your <strong><a href=\"%(library_url)s\" "
-"class=\"twl-links\">My Library</a></strong> page."
-msgstr ""
-"アクセス権の状況を確認するには<strong><a href=\"%(library_url)s\"class=\"twl-"
-"links\">私の図書館</a></strong>ページをご覧ください。"
+msgid "View the status of your access on your <strong><a href=\"%(library_url)s\" class=\"twl-links\">My Library</a></strong> page."
+msgstr "アクセス権の状況を確認するには<strong><a href=\"%(library_url)s\"class=\"twl-links\">私の図書館</a></strong>ページをご覧ください。"
 
 #. Translators: This message is shown when a user has open applications, linking to their respective applications page.
 #: TWLight/resources/templates/resources/partner_detail_apply.html:60
 #, python-format
-msgid ""
-"View the status of your application(s) on your <strong><a href="
-"\"%(applications_url)s\">My Applications</a></strong> page."
-msgstr ""
-"提出した申請の進行状況は<strong><a href=\"%(applications_url)s\">My "
-"Applications</a></strong>ページで確認できます。"
+msgid "View the status of your application(s) on your <strong><a href=\"%(applications_url)s\">My Applications</a></strong> page."
+msgstr "提出した申請の進行状況は<strong><a href=\"%(applications_url)s\">My Applications</a></strong>ページで確認できます。"
 
 #. Translators: One the partner detail page, this text labels the button which coordinators can click to remove a partner from waitlisted status.
 #: TWLight/resources/templates/resources/partner_detail_apply.html:73
@@ -1751,8 +1431,7 @@ msgstr "待機中に設定"
 #: TWLight/resources/templates/resources/partner_detail_apply.html:86
 #, python-format
 msgid "<strong>%(coordinator)s</strong> processes applications to %(partner)s."
-msgstr ""
-"<strong>%(coordinator)s</strong>は%(partner)sに対する申請を取り扱います。"
+msgstr "<strong>%(coordinator)s</strong>は%(partner)sに対する申請を取り扱います。"
 
 #. Translators: When a coordinator is assigned to a partner, their details are shown on the page. This text labels a link to their Talk page on Wikipedia, and should be translated to the text used for Talk pages in the language you are translating to.
 #: TWLight/resources/templates/resources/partner_detail_apply.html:95
@@ -1766,15 +1445,8 @@ msgstr "Special:EmailUser page"
 
 #. Translators: If no account coordinator is assigned to a partner, the Wikipedia Library team will coordinate signups. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/resources/templates/resources/partner_detail_apply.html:112
-msgid ""
-"The Wikipedia Library team will process this application. Want to help? <a "
-"class=\"twl-links\" href=\"https://en.wikipedia.org/wiki/Wikipedia:"
-"The_Wikipedia_Library/Coordinators/Signup\">Sign up as a coordinator.</a>"
-msgstr ""
-"この申請はウィキペディア図書館チームが取り扱います。手を貸してくれませんか？"
-"<a class=\"twl-links\" href=\"https://en.wikipedia.org/wiki/Wikipedia:"
-"The_Wikipedia_Library/Coordinators/Signup\">コーディネーターとして登録する。"
-"</a>"
+msgid "The Wikipedia Library team will process this application. Want to help? <a class=\"twl-links\" href=\"https://en.wikipedia.org/wiki/Wikipedia:The_Wikipedia_Library/Coordinators/Signup\">Sign up as a coordinator.</a>"
+msgstr "この申請はウィキペディア図書館チームが取り扱います。手を貸してくれませんか？<a class=\"twl-links\" href=\"https://en.wikipedia.org/wiki/Wikipedia:The_Wikipedia_Library/Coordinators/Signup\">コーディネーターとして登録する。</a>"
 
 #. Translators: This text labels a button coordinators can click to view a list of users who have applied for access for a particular partner
 #: TWLight/resources/templates/resources/partner_detail_apply.html:121
@@ -1803,24 +1475,14 @@ msgstr "図書館バンドルアクセス"
 
 #. Translators: Text shown to authenticated, bundle eligible users when they visit a Bundle partner page.
 #: TWLight/resources/templates/resources/partner_detail_apply.html:138
-msgid ""
-"You are eligible to access Library Bundle partners. Click the button above "
-"to access the collection."
-msgstr ""
-"図書館バンドル制度の提携組織へのアクセス権は有効です。コレクションにアクセス"
-"するには、上のボタンを押します。"
+msgid "You are eligible to access Library Bundle partners. Click the button above to access the collection."
+msgstr "図書館バンドル制度の提携組織へのアクセス権は有効です。コレクションにアクセスするには、上のボタンを押します。"
 
 #. Translators: Text shown to authenticated, bundle ineligible users when they visit a Bundle partner page.
 #: TWLight/resources/templates/resources/partner_detail_apply.html:152
 #, python-format
-msgid ""
-"You are not eligible to access Library Bundle partners. Visit the <a class="
-"\"twl-links\" href=\"%(homepage)s\">homepage</a> to check the eligibility "
-"criteria."
-msgstr ""
-"あいにく図書館バンドル制度の提携組織にあなたのアクセス権は認可されていませ"
-"ん。認可の要件は<a class=\"twl-links\" href=\"%(homepage)s\">ホームページ</a>"
-"でご確認ください。"
+msgid "You are not eligible to access Library Bundle partners. Visit the <a class=\"twl-links\" href=\"%(homepage)s\">homepage</a> to check the eligibility criteria."
+msgstr "あいにく図書館バンドル制度の提携組織にあなたのアクセス権は認可されていません。認可の要件は<a class=\"twl-links\" href=\"%(homepage)s\">ホームページ</a>でご確認ください。"
 
 #. Translators: Buttton prompting users to log in.
 #: TWLight/resources/templates/resources/partner_detail_apply.html:160
@@ -1831,15 +1493,8 @@ msgstr "ログイン"
 #. Translators: Text shown to unauthenticated users when they visit a Bundle partner page.
 #: TWLight/resources/templates/resources/partner_detail_apply.html:168
 #, python-format
-msgid ""
-"This resource is part of our <a class=\"twl-links\" href=\"%(about)s"
-"\">Library Bundle</a>, which you can access if you meet our minimum "
-"eligibility criteria. Log in to find out if you are eligible."
-msgstr ""
-"この情報源は<a class=\"twl-links\" href=\"%(about)s\">図書館バンドル制度</a>"
-"の一環として設け、ウィキペディア図書館の定める必須条件を満たす利用者であれば"
-"アクセスできます。ログインして、ご自分のアクセス権が有効かどうか確認してくだ"
-"さい。"
+msgid "This resource is part of our <a class=\"twl-links\" href=\"%(about)s\">Library Bundle</a>, which you can access if you meet our minimum eligibility criteria. Log in to find out if you are eligible."
+msgstr "この情報源は<a class=\"twl-links\" href=\"%(about)s\">図書館バンドル制度</a>の一環として設け、ウィキペディア図書館の定める必須条件を満たす利用者であればアクセスできます。ログインして、ご自分のアクセス権が有効かどうか確認してください。"
 
 #. Translators: This is the label for a number which shows the total active accounts for one partner. (e.g. https://wikipedialibrary.wmflabs.org/partners/8/).
 #: TWLight/resources/templates/resources/partner_detail_stats.html:21
@@ -1889,34 +1544,20 @@ msgstr "引用の制限"
 #. Translators: If a partner has specified the excerpt limit both in words and percentage, this message will display the percentage of words and the number of words on the partner page.
 #: TWLight/resources/templates/resources/partner_detail_timeline.html:99
 #, python-format
-msgid ""
-"%(object)s allows a maximum of %(excerpt_limit)s words or "
-"%(excerpt_limit_percentage)s%% of an article be excerpted into a Wikipedia "
-"article."
-msgstr ""
-"%(object)sでは特定記事をウィキペディアの特定の記事に引用する場"
-"合、%(excerpt_limit)s 単語以内もしくは\n"
-"%(excerpt_limit_percentage)s%%以内という制限を設けています。"
+msgid "%(object)s allows a maximum of %(excerpt_limit)s words or %(excerpt_limit_percentage)s%% of an article be excerpted into a Wikipedia article."
+msgstr "%(object)sでは特定記事をウィキペディアの特定の記事に引用する場合、%(excerpt_limit)s 単語以内もしくは\n%(excerpt_limit_percentage)s%%以内という制限を設けています。"
 
 #. Translators: If a partner has specified the excerpt limit in words, this message will display the number of words on the partner page.
 #: TWLight/resources/templates/resources/partner_detail_timeline.html:106
 #, python-format
-msgid ""
-"%(object)s allows a maximum of %(excerpt_limit)s words be excerpted into a "
-"Wikipedia article."
-msgstr ""
-"%(object)sでは特定記事をウィキペディアの特定の記事に引用する場"
-"合、%(excerpt_limit)s 単語以内という制限を設けています。"
+msgid "%(object)s allows a maximum of %(excerpt_limit)s words be excerpted into a Wikipedia article."
+msgstr "%(object)sでは特定記事をウィキペディアの特定の記事に引用する場合、%(excerpt_limit)s 単語以内という制限を設けています。"
 
 #. Translators: If a partner has specified the excerpt limit in percentage, this message will display the percentage of words on the partner page.
 #: TWLight/resources/templates/resources/partner_detail_timeline.html:113
 #, python-format
-msgid ""
-"%(object)s allows a maximum of %(excerpt_limit_percentage)s%% of an article "
-"be excerpted into a Wikipedia article."
-msgstr ""
-"%(object)sでは特定記事をウィキペディアの特定の記事に引用する場"
-"合、%(excerpt_limit_percentage)s%%以内という制限を設けています。"
+msgid "%(object)s allows a maximum of %(excerpt_limit_percentage)s%% of an article be excerpted into a Wikipedia article."
+msgstr "%(object)sでは特定記事をウィキペディアの特定の記事に引用する場合、%(excerpt_limit_percentage)s%%以内という制限を設けています。"
 
 #. Translators: If a partner has other requirements for access, this text shows as the title for that information field. (e.g. https://wikipedialibrary.wmflabs.org/partners/10/).
 #: TWLight/resources/templates/resources/partner_detail_timeline.html:132
@@ -1926,12 +1567,8 @@ msgstr "申請要件の特記事項"
 #. Translators: If a user must agree to a Terms of Use document, they see this message, and must enter the name of the resource. Don't translate publisher or url.
 #: TWLight/resources/templates/resources/partner_detail_timeline.html:140
 #, python-format
-msgid ""
-"%(publisher)s requires that you agree with its <a href=\"%(url)s\">terms of "
-"use</a>."
-msgstr ""
-"%(publisher)s では利用者に先方の<a href=\"%(url)s\">利用規約</a>への同意が必"
-"須条件です。"
+msgid "%(publisher)s requires that you agree with its <a href=\"%(url)s\">terms of use</a>."
+msgstr "%(publisher)s では利用者に先方の<a href=\"%(url)s\">利用規約</a>への同意が必須条件です。"
 
 #. Translators: If a user must provide their real name to apply to a partner, they see this message, and must enter the name of the resource. Don't translate publisher.
 #: TWLight/resources/templates/resources/partner_detail_timeline.html:150
@@ -1954,21 +1591,14 @@ msgstr "%(publisher)s では利用者の所属期間名の登録が必須条件�
 #. Translators: If a user must select a specific resource to apply for, they see this message, and must enter the name of the resource. Don't translate publisher.
 #: TWLight/resources/templates/resources/partner_detail_timeline.html:177
 #, python-format
-msgid ""
-"%(publisher)s requires that you specify a particular title that you want to "
-"access."
-msgstr ""
-"%(publisher)s では利用者にアクセスを希望する刊行物名の指定が必須条件です。"
+msgid "%(publisher)s requires that you specify a particular title that you want to access."
+msgstr "%(publisher)s では利用者にアクセスを希望する刊行物名の指定が必須条件です。"
 
 #. Translators: If a user must register on the partner website before applying, they see this message. Don't translate partner.
 #: TWLight/resources/templates/resources/partner_detail_timeline.html:187
 #, python-format
-msgid ""
-"%(publisher)s requires that you sign up for an account before applying for "
-"access."
-msgstr ""
-"%(publisher)s ではアクセス権の申請手続き前に、アカウントにログインすることが"
-"必須条件です。"
+msgid "%(publisher)s requires that you sign up for an account before applying for access."
+msgstr "%(publisher)s ではアクセス権の申請手続き前に、アカウントにログインすることが必須条件です。"
 
 #. Translators: If a partner has their location listed, this message is a label for that location
 #: TWLight/resources/templates/resources/partner_detail_timeline.html:206
@@ -2094,12 +1724,8 @@ msgstr "ほんとうに<b>%(object)s</b>を削除してよろしいですか？"
 
 #. Translators: If multiple authorizations where returned for a collection, this message is shown to a user
 #: TWLight/resources/views.py:268
-msgid ""
-"Multiple authorizations were returned – something's wrong. Please contact us "
-"and don't forget to mention this message."
-msgstr ""
-"多重認証が返されました – 問題があったようです。お手数ですが担当までご連絡をい"
-"ただき、このメッセージが表示されたことを必ずお伝えください。"
+msgid "Multiple authorizations were returned – something's wrong. Please contact us and don't forget to mention this message."
+msgstr "多重認証が返されました – 問題があったようです。お手数ですが担当までご連絡をいただき、このメッセージが表示されたことを必ずお伝えください。"
 
 #. Translators: This message is shown when user tries to access a NOT_AVAILABLE Partner
 #: TWLight/resources/views.py:316
@@ -2139,22 +1765,8 @@ msgstr "あいにくですが、その処理の仕方が規定されていませ
 #. Translators: Shown on the website's 400 page, when a user sends a bad request. Don't translate path or Phabricator.
 #: TWLight/templates/400.html:20
 #, python-format
-msgid ""
-"If you think we should know what to do with that, please email us about this "
-"error at <a class=\"twl-links\" href=\"mailto:wikipedialibrary@wikimedia.org?"
-"Subject=Wikipedia%%20Library%%20%(path)s%%20Permission%%20denied"
-"\">wikipedialibrary@wikimedia.org</a> or report it to us on <a class=\"twl-"
-"links\" href=\"https://phabricator.wikimedia.org/maniphest/task/edit/form/1/?"
-"projectPHIDs=Library-Card-Platform&title=Wikipedia%%20Library%%20%(path)s"
-"%%20Bad%%20Request\">Phabricator</a>"
-msgstr ""
-"もしエラーの修正方法について特筆すべきことがある場合は、エラーに関する情報を"
-"<a class=\"twl-links\" href=\"mailto:wikipedialibrary@wikimedia.org?"
-"Subject=Wikipedia%%20Library%%20%(path)s%%20Permission%%20denied"
-"\">wikipedialibrary@wikimedia.org</a>までメールで送信するか、<a class=\"twl-"
-"links\" href=\"https://phabricator.wikimedia.org/maniphest/task/edit/form/1/?"
-"projectPHIDs=Library-Card-Platform&title=Wikipedia%%20Library%%20%(path)s"
-"%%20Bad%%20Request\">Phabricator</a>にてエラー報告の投稿をお願いします。"
+msgid "If you think we should know what to do with that, please email us about this error at <a class=\"twl-links\" href=\"mailto:wikipedialibrary@wikimedia.org?Subject=Wikipedia%%20Library%%20%(path)s%%20Permission%%20denied\">wikipedialibrary@wikimedia.org</a> or report it to us on <a class=\"twl-links\" href=\"https://phabricator.wikimedia.org/maniphest/task/edit/form/1/?projectPHIDs=Library-Card-Platform&title=Wikipedia%%20Library%%20%(path)s%%20Bad%%20Request\">Phabricator</a>"
+msgstr "もしエラーの修正方法について特筆すべきことがある場合は、エラーに関する情報を<a class=\"twl-links\" href=\"mailto:wikipedialibrary@wikimedia.org?Subject=Wikipedia%%20Library%%20%(path)s%%20Permission%%20denied\">wikipedialibrary@wikimedia.org</a>までメールで送信するか、<a class=\"twl-links\" href=\"https://phabricator.wikimedia.org/maniphest/task/edit/form/1/?projectPHIDs=Library-Card-Platform&title=Wikipedia%%20Library%%20%(path)s%%20Bad%%20Request\">Phabricator</a>にてエラー報告の投稿をお願いします。"
 
 #. Translators: Alt text for an image shown on the 400 error page.
 #. Translators: Alt text for an image shown on the 403 error page.
@@ -2175,24 +1787,8 @@ msgstr "あいにくですが、その処理は認可されていません。"
 #. Translators: Shown on the website's 403 page, when a user attempts to navigate to a page they don't have permission to view. Don't translate path or Phabricator.
 #: TWLight/templates/403.html:20
 #, python-format
-msgid ""
-"If you think your account should be able to do that, please email us about "
-"this error at <a class=\"twl-links\" href=\"mailto:"
-"wikipedialibrary@wikimedia.org?Subject=Wikipedia%%20Library%%20%(path)s"
-"%%20Permission%%20denied\">wikipedialibrary@wikimedia.org</a> or report it "
-"to us on <a class=\"twl-links\" href=\"https://phabricator.wikimedia.org/"
-"maniphest/task/edit/form/1/?projectPHIDs=Library-Card-"
-"Platform&title=Wikipedia%%20Library%%20%(path)s%%20Permission%%20denied"
-"\">Phabricator</a>"
-msgstr ""
-"もしご利用の利用者登録アカウントで処理ができるとお考えの節は、エラーに関する"
-"情報をメールで\n"
-"<a class=\"twl-links\" href=\"mailto:wikipedialibrary@wikimedia.org?"
-"Subject=Wikipedia%%20Library%%20%(path)s%%20Permission%%20denied"
-"\">wikipedialibrary@wikimedia.org</a>まで届け出るか、<a class=\"twl-links\" "
-"href=\"https://phabricator.wikimedia.org/maniphest/task/edit/form/1/?"
-"projectPHIDs=Library-Card-Platform&title=Wikipedia%%20Library%%20%(path)s"
-"%%20Permission%%20denied\">Phabricator</a>にてエラー報告を投稿してください。"
+msgid "If you think your account should be able to do that, please email us about this error at <a class=\"twl-links\" href=\"mailto:wikipedialibrary@wikimedia.org?Subject=Wikipedia%%20Library%%20%(path)s%%20Permission%%20denied\">wikipedialibrary@wikimedia.org</a> or report it to us on <a class=\"twl-links\" href=\"https://phabricator.wikimedia.org/maniphest/task/edit/form/1/?projectPHIDs=Library-Card-Platform&title=Wikipedia%%20Library%%20%(path)s%%20Permission%%20denied\">Phabricator</a>"
+msgstr "もしご利用の利用者登録アカウントで処理ができるとお考えの節は、エラーに関する情報をメールで\n<a class=\"twl-links\" href=\"mailto:wikipedialibrary@wikimedia.org?Subject=Wikipedia%%20Library%%20%(path)s%%20Permission%%20denied\">wikipedialibrary@wikimedia.org</a>まで届け出るか、<a class=\"twl-links\" href=\"https://phabricator.wikimedia.org/maniphest/task/edit/form/1/?projectPHIDs=Library-Card-Platform&title=Wikipedia%%20Library%%20%(path)s%%20Permission%%20denied\">Phabricator</a>にてエラー報告を投稿してください。"
 
 #. Translators: Shown on the website's 404 page, when a user attempts to navigate to a page that doesn't exist.
 #: TWLight/templates/404.html:11
@@ -2207,25 +1803,8 @@ msgstr "あいにくですが、見つかりませんでした。"
 #. Translators: Shown on the website's 404 page, when a user attempts to navigate to a page that doesn't exist. Don't translate path or Phabricator.
 #: TWLight/templates/404.html:19
 #, python-format
-msgid ""
-"If you are certain that something should be here, please email us about this "
-"error at <a class=\"twl-links\" href=\"mailto:wikipedialibrary@wikimedia.org?"
-"Subject=Wikipedia%%20Library%%20%(path)s%%20Not%%20found\"> "
-"wikipedialibrary@wikimedia.org</a> or report it to us on <a class=\"twl-links"
-"\" href=\"https://phabricator.wikimedia.org/maniphest/task/edit/form/1/?"
-"projectPHIDs=Library-Card-Platform&title=Wikipedia%%20Library%%20%(path)s"
-"%%20Not%%20found\">Phabricator</a>"
-msgstr ""
-"もしこの欄に記入済みの情報があるはずとお考えの節は、エラーに関する情報を<a "
-"class=\"twl-links\" href=\"mailto:wikipedialibrary@wikimedia.org?"
-"Subject=Wikipedia%%20Library%%20%(path)s%%20Not%%20found"
-"\">wikipedialibrary@wikimedia.org</a>までメールで送信するか、<a class=\"twl-"
-"links\" href=\"https://phabricator.wikimedia.org/maniphest/task/edit/form/1/?"
-"projectPHIDs=Library-Card-Platform&title=Wikipedia%%20Library%%20%(path)s"
-"%%20Not%%20found\"><a class=\"twl-links\" href=\"https://phabricator."
-"wikimedia.org/maniphest/task/edit/form/1/?projectPHIDs=Library-Card-"
-"Platform&title=Wikipedia%%20Library%%20%(path)s%%20Not%%20found"
-"\">Phabricator</a>にてエラー報告の投稿をお願いします。"
+msgid "If you are certain that something should be here, please email us about this error at <a class=\"twl-links\" href=\"mailto:wikipedialibrary@wikimedia.org?Subject=Wikipedia%%20Library%%20%(path)s%%20Not%%20found\"> wikipedialibrary@wikimedia.org</a> or report it to us on <a class=\"twl-links\" href=\"https://phabricator.wikimedia.org/maniphest/task/edit/form/1/?projectPHIDs=Library-Card-Platform&title=Wikipedia%%20Library%%20%(path)s%%20Not%%20found\">Phabricator</a>"
+msgstr "もしこの欄に記入済みの情報があるはずとお考えの節は、エラーに関する情報を<a class=\"twl-links\" href=\"mailto:wikipedialibrary@wikimedia.org?Subject=Wikipedia%%20Library%%20%(path)s%%20Not%%20found\">wikipedialibrary@wikimedia.org</a>までメールで送信するか、<a class=\"twl-links\" href=\"https://phabricator.wikimedia.org/maniphest/task/edit/form/1/?projectPHIDs=Library-Card-Platform&title=Wikipedia%%20Library%%20%(path)s%%20Not%%20found\"><a class=\"twl-links\" href=\"https://phabricator.wikimedia.org/maniphest/task/edit/form/1/?projectPHIDs=Library-Card-Platform&title=Wikipedia%%20Library%%20%(path)s%%20Not%%20found\">Phabricator</a>にてエラー報告の投稿をお願いします。"
 
 #. Translators: Alt text for an image shown on the 404 error page.
 #: TWLight/templates/404.html:32
@@ -2239,47 +1818,19 @@ msgstr "ウィキペディア図書館について"
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:20
-msgid ""
-"This platform is our central tool for facilitating access to our available "
-"collections. Here you can see which partnerships are available, search their "
-"contents, and apply for and access the ones you’re interested in."
-msgstr ""
-"このプラットフォームは、ご用意したデータベースへのアクセスを調整する中核の"
-"ツールです。ここでは利用できる提携機関を確認し、その内容を検索したり、関心を"
-"持ったデータベースの利用申請や、実際の利用ができます。"
+msgid "This platform is our central tool for facilitating access to our available collections. Here you can see which partnerships are available, search their contents, and apply for and access the ones you’re interested in."
+msgstr "このプラットフォームは、ご用意したデータベースへのアクセスを調整する中核のツールです。ここでは利用できる提携機関を確認し、その内容を検索したり、関心を持ったデータベースの利用申請や、実際の利用ができます。"
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/). Wikimedia Foundation should not be translated.
 #: TWLight/templates/about.html:29
-msgid ""
-"All users receive immediate access to some collections, which can be browsed "
-"by clicking the 'Access collection' buttons or using the search bar at the "
-"top of the page. Other collections require an application before access is "
-"granted, and may be accessed directly or via an individual login or access "
-"code. Volunteer coordinators, who have signed non-disclosure agreements with "
-"the Wikimedia Foundation, review these applications and work with publishers "
-"to get you your free access."
-msgstr ""
-"コレクションによっては、「コレクションにアクセス」というボタンを押す、もしく"
-"はページ上部の「検索バー」を利用すると、誰でもすぐに利用できるものがありま"
-"す。そのほかに、事前に利用申請を求められるコレクションがあります。利用資格を"
-"得た後は、直接利用できる場合と、個別のログインもしくはアクセスコードを通して"
-"利用できる場合があります。ウィキメディア図書館と守秘義務契約を結んだボラン"
-"ティアのコーディネーターが、皆さんの申請を審査し、無料アクセス権設定のために"
-"出版社と交渉します。"
+msgid "All users receive immediate access to some collections, which can be browsed by clicking the 'Access collection' buttons or using the search bar at the top of the page. Other collections require an application before access is granted, and may be accessed directly or via an individual login or access code. Volunteer coordinators, who have signed non-disclosure agreements with the Wikimedia Foundation, review these applications and work with publishers to get you your free access."
+msgstr "コレクションによっては、「コレクションにアクセス」というボタンを押す、もしくはページ上部の「検索バー」を利用すると、誰でもすぐに利用できるものがあります。そのほかに、事前に利用申請を求められるコレクションがあります。利用資格を得た後は、直接利用できる場合と、個別のログインもしくはアクセスコードを通して利用できる場合があります。ウィキメディア図書館と守秘義務契約を結んだボランティアのコーディネーターが、皆さんの申請を審査し、無料アクセス権設定のために出版社と交渉します。"
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/). Don't translate terms_url.
 #: TWLight/templates/about.html:43
 #, python-format
-msgid ""
-"For more information about how your information is stored and reviewed "
-"please see our <a class=\"twl-links\" href=\"%(terms_url)s\"> terms of use "
-"and privacy policy</a>. Accounts you apply for are also subject to the Terms "
-"of Use provided by each partner’s platform; please review them."
-msgstr ""
-"個人情報の保存方法と審査の詳細は、<a class=\"twl-links\" href=\"%(terms_url)s"
-"\"> 利用規約ならびに個人情報方針</a>をご参照ください。申請するアカウントは個"
-"別の提携組織のプラットフォームの利用規約の対象となりますので、そちらもご確認"
-"願います。"
+msgid "For more information about how your information is stored and reviewed please see our <a class=\"twl-links\" href=\"%(terms_url)s\"> terms of use and privacy policy</a>. Accounts you apply for are also subject to the Terms of Use provided by each partner’s platform; please review them."
+msgstr "個人情報の保存方法と審査の詳細は、<a class=\"twl-links\" href=\"%(terms_url)s\"> 利用規約ならびに個人情報方針</a>をご参照ください。申請するアカウントは個別の提携組織のプラットフォームの利用規約の対象となりますので、そちらもご確認願います。"
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:51
@@ -2288,25 +1839,13 @@ msgstr "アクセス権を受けられるのはどんな人？"
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/). Wikimedia Foundation should not be translated.
 #: TWLight/templates/about.html:55
-msgid ""
-"Any active editor in good standing can receive access. For publishers with "
-"limited numbers of accounts, applications are reviewed based on the editor’s "
-"needs and contributions. If you think you could use access to one of our "
-"partner resources and are an active editor in any project supported by the "
-"Wikimedia Foundation, please apply."
-msgstr ""
-"要件を満たし活動中の編集者であれば、誰でもアクセス権限の対象です。アカウント"
-"数に上限を設けた出版社の場合、申請した編集者の需要と貢献に照らして審査しま"
-"す。皆さんがウィキメディア財団が支援するいずれかのプロジェクト群で編集者とし"
-"て活動中で、編集活動のためにウィキペディア図書館の提携組織にアクセスを希望さ"
-"れる場合は、申請してください。"
+msgid "Any active editor in good standing can receive access. For publishers with limited numbers of accounts, applications are reviewed based on the editor’s needs and contributions. If you think you could use access to one of our partner resources and are an active editor in any project supported by the Wikimedia Foundation, please apply."
+msgstr "要件を満たし活動中の編集者であれば、誰でもアクセス権限の対象です。アカウント数に上限を設けた出版社の場合、申請した編集者の需要と貢献に照らして審査します。皆さんがウィキメディア財団が支援するいずれかのプロジェクト群で編集者として活動中で、編集活動のためにウィキペディア図書館の提携組織にアクセスを希望される場合は、申請してください。"
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:65
 msgid "Any editor can use the library if they meet a few basic requirements:"
-msgstr ""
-"編集者の皆さんは、ごく基本的な要件を満たすとどなたでもこの図書館をご利用いた"
-"だけます。"
+msgstr "編集者の皆さんは、ごく基本的な要件を満たすとどなたでもこの図書館をご利用いただけます。"
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:71
@@ -2326,40 +1865,17 @@ msgstr "直近1ヶ月に10回以上編集していること"
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:83
 msgid "You are not currently blocked from editing a Wikimedia project"
-msgstr ""
-"現状でウィキメディアのいずれのプロジェクトでもブロックを受けていないこと"
+msgstr "現状でウィキメディアのいずれのプロジェクトでもブロックを受けていないこと"
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/)
 #: TWLight/templates/about.html:89
-msgid ""
-"If you are applying for an available collection, please first check that you "
-"don't already have access through another library or institution. If you do, "
-"please consider using that access rather than taking up a seat for this "
-"resource in The Wikipedia Library."
-msgstr ""
-"利用可能なコレクションに申し込む場合、まず、他の図書館や機関を通じて既にアク"
-"セス権を持っていないかどうかを確認してください。もしお持ちであれば、この資料"
-"のためにWikipedia Libraryを使用する代わりに、そのアクセスを利用することをご検"
-"討ください。"
+msgid "If you are applying for an available collection, please first check that you don't already have access through another library or institution. If you do, please consider using that access rather than taking up a seat for this resource in The Wikipedia Library."
+msgstr "利用可能なコレクションに申し込む場合、まず、他の図書館や機関を通じて既にアクセス権を持っていないかどうかを確認してください。もしお持ちであれば、この資料のためにWikipedia Libraryを使用する代わりに、そのアクセスを利用することをご検討ください。"
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/)
 #: TWLight/templates/about.html:99
-msgid ""
-"If your account is blocked on one or more Wikimedia projects, you may still "
-"be granted access to The Wikipedia Library. You will need to contact the "
-"Wikipedia Library team, who will review your blocks. If you have been "
-"blocked for content issues, most notably copyright violations, or have "
-"multiple long-term blocks, we may decline your request. Additionally, if "
-"your block status changes after being approved, you will need to request "
-"another review."
-msgstr ""
-"もし利用者のアカウントがウィキメディアのプロジェクト1件以上でブロックされた場"
-"合も、ウィキペディア図書館制度を継続して利用できる場合があります。ウィキペ"
-"ディア図書館の担当者に連絡して、ブロックの内容審査を申し込んでください。ブ"
-"ロックの原因がコンテンツ、とりわけ著作権違反である場合、または複数の長期ブ"
-"ロックを受けている場合、利用をお断りする場合があります。この他、バンドル制度"
-"の利用承認後にブロックの状態が変わった利用者も、必ずブロックの内容審査を申し"
-"込んでください。"
+msgid "If your account is blocked on one or more Wikimedia projects, you may still be granted access to The Wikipedia Library. You will need to contact the Wikipedia Library team, who will review your blocks. If you have been blocked for content issues, most notably copyright violations, or have multiple long-term blocks, we may decline your request. Additionally, if your block status changes after being approved, you will need to request another review."
+msgstr "もし利用者のアカウントがウィキメディアのプロジェクト1件以上でブロックされた場合も、ウィキペディア図書館制度を継続して利用できる場合があります。ウィキペディア図書館の担当者に連絡して、ブロックの内容審査を申し込んでください。ブロックの原因がコンテンツ、とりわけ著作権違反である場合、または複数の長期ブロックを受けている場合、利用をお断りする場合があります。この他、バンドル制度の利用承認後にブロックの状態が変わった利用者も、必ずブロックの内容審査を申し込んでください。"
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:110
@@ -2369,8 +1885,7 @@ msgstr "アクセス権を取得したら何をしたらよいですか？"
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:114
 msgid "Approved editors <i>may</i> use their access to:"
-msgstr ""
-"認可された編集者はアクセス権を使って次の活動が<i>認められています</i>。"
+msgstr "認可された編集者はアクセス権を使って次の活動が<i>認められています</i>。"
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:118
@@ -2394,45 +1909,28 @@ msgstr "認可された編集者の<i>禁止事項</i>："
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:136
-msgid ""
-"Share their account logins or passwords with others, or sell their access to "
-"other parties"
-msgstr ""
-"利用者のアカウントログイン情報、パスワードを第三者と共有もしくは譲渡すること"
+msgid "Share their account logins or passwords with others, or sell their access to other parties"
+msgstr "利用者のアカウントログイン情報、パスワードを第三者と共有もしくは譲渡すること"
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:140
 msgid "Mass scrape or mass download partner content"
-msgstr ""
-"提携組織のコンテンツを大量に（無選別に）かき集めるもしくはダウンロードするこ"
-"と"
+msgstr "提携組織のコンテンツを大量に（無選別に）かき集めるもしくはダウンロードすること"
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:144
-msgid ""
-"Systematically make printed or electronic copies of multiple extracts of "
-"restricted content available for any purpose"
-msgstr ""
-"目的のいかんに関わらず、制限されたコンテンツから複数の抽出物を体系的に印刷物"
-"または電子コピーとして複製物を作成すること"
+msgid "Systematically make printed or electronic copies of multiple extracts of restricted content available for any purpose"
+msgstr "目的のいかんに関わらず、制限されたコンテンツから複数の抽出物を体系的に印刷物または電子コピーとして複製物を作成すること"
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/). Stub is a technical term for a short Wikipedia article, use the appropriate Wikipedia term in your language.
 #: TWLight/templates/about.html:148
-msgid ""
-"Datamine metadata without permission, in order, for instance, to use "
-"metadata for auto-created stub articles"
-msgstr ""
-"たとえばスタブ記事の自動作成に、許可を得ずにメタデータをデータマイニングする"
-"こと"
+msgid "Datamine metadata without permission, in order, for instance, to use metadata for auto-created stub articles"
+msgstr "たとえばスタブ記事の自動作成に、許可を得ずにメタデータをデータマイニングすること"
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:154
-msgid ""
-"Respecting these agreements allows us to continue growing the partnerships "
-"available to the community."
-msgstr ""
-"これらの契約を尊重することにより、コミュニティに提供する提携組織を増やし続け"
-"る道ができます。"
+msgid "Respecting these agreements allows us to continue growing the partnerships available to the community."
+msgstr "これらの契約を尊重することにより、コミュニティに提供する提携組織を増やし続ける道ができます。"
 
 #. Translators: This is the heading for a section on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:160
@@ -2441,62 +1939,23 @@ msgstr "EZProxy"
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:164
-msgid ""
-"EZProxy is a proxy server used to authenticate users for many Wikipedia "
-"Library partners. Users sign into EZProxy via the Library Card platform to "
-"verify that they are authorized users, and then the server accesses "
-"requested resources using its own IP address."
-msgstr ""
-"EZProxyとは多くのウィキペディア図書館提携組織が採用する利用者認証用のプロキシ"
-"サーバの名称です。図書館カードプラットフォーム経由でEZProxyにログインすると認"
-"証済みの利用者であることの認証を得て、サーバ自体のIPアドレスから利用者が使い"
-"たい情報源へアクセスが成立します。"
+msgid "EZProxy is a proxy server used to authenticate users for many Wikipedia Library partners. Users sign into EZProxy via the Library Card platform to verify that they are authorized users, and then the server accesses requested resources using its own IP address."
+msgstr "EZProxyとは多くのウィキペディア図書館提携組織が採用する利用者認証用のプロキシサーバの名称です。図書館カードプラットフォーム経由でEZProxyにログインすると認証済みの利用者であることの認証を得て、サーバ自体のIPアドレスから利用者が使いたい情報源へアクセスが成立します。"
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:173
-msgid ""
-"You may notice that when accessing resources via EZProxy that URLs are "
-"dynamically rewritten. This is why we recommend logging in via the Library "
-"Card platform rather than going directly to the unproxied partner website. "
-"When in doubt, check the URL for ‘idm.oclc’. If it’s there, then you’re "
-"connected via EZProxy."
-msgstr ""
-"利用者がEZProx経由で情報源にアクセスした場合、先方のURLが動的に書き換えられる"
-"点にお気づきかもしれません。この点こそ、プロキシを経由せず直接、提携先組織の"
-"ウェブサイトからログインするのではなく、皆さんに図書館カードプラットフォーム"
-"経由でのログインを推奨する理由です。それでもまだ疑念がある場合は、たとえば"
-"「idm.oclc」のURLを試してください。そのURLが有効な状態は、EZProxy経由のアクセ"
-"スであることを示します。"
+msgid "You may notice that when accessing resources via EZProxy that URLs are dynamically rewritten. This is why we recommend logging in via the Library Card platform rather than going directly to the unproxied partner website. When in doubt, check the URL for ‘idm.oclc’. If it’s there, then you’re connected via EZProxy."
+msgstr "利用者がEZProx経由で情報源にアクセスした場合、先方のURLが動的に書き換えられる点にお気づきかもしれません。この点こそ、プロキシを経由せず直接、提携先組織のウェブサイトからログインするのではなく、皆さんに図書館カードプラットフォーム経由でのログインを推奨する理由です。それでもまだ疑念がある場合は、たとえば「idm.oclc」のURLを試してください。そのURLが有効な状態は、EZProxy経由のアクセスであることを示します。"
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:182
-msgid ""
-"Typically once you’ve logged in your session will remain active in your "
-"browser for up to two hours after you’ve finished searching. Note that use "
-"of EZProxy requires you to enable cookies. If you are having problems you "
-"should also try clearing your cache and restarting your browser."
-msgstr ""
-"一般的に、一度ログインすると利用者が検索を終了した後も、2時間を上限にご利用の"
-"ブラウザでセッションは有効です。EZProxyの利用にはクッキーを有効にする必要があ"
-"りますのでご注意ください。問題に遭遇した場合は、キャッシュの消去ならびにブラ"
-"ウザの再起動もお試しください。"
+msgid "Typically once you’ve logged in your session will remain active in your browser for up to two hours after you’ve finished searching. Note that use of EZProxy requires you to enable cookies. If you are having problems you should also try clearing your cache and restarting your browser."
+msgstr "一般的に、一度ログインすると利用者が検索を終了した後も、2時間を上限にご利用のブラウザでセッションは有効です。EZProxyの利用にはクッキーを有効にする必要がありますのでご注意ください。問題に遭遇した場合は、キャッシュの消去ならびにブラウザの再起動もお試しください。"
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/)
 #: TWLight/templates/about.html:193
-msgid ""
-"The Library Bundle is a collection of resources for which no application is "
-"required. If you meet the criteria laid out above, you will be authorized "
-"for access automatically upon logging in to the platform. Only some of our "
-"content is currently included in the Library Bundle, however we hope to "
-"expand the collection as more publishers become comfortable with "
-"participating. All Bundle content is accessed via EZProxy."
-msgstr ""
-"図書館バンドル制度（Library Bundle）は申請をしなくても利用できる情報源集のこ"
-"とです。上述の必須条件を満たす利用者であれば、プラットフォームにログインする"
-"と自動的にアクセスが承認されます。現在はこの制度に加入したコンテンツはごく限"
-"られていますが、出版社に使い勝手を認められるに従い、さらに件数を増やしていけ"
-"ると望んでいます。バンドル制度のコンテンツはすべてEZProxy経由でアクセスしま"
-"す。"
+msgid "The Library Bundle is a collection of resources for which no application is required. If you meet the criteria laid out above, you will be authorized for access automatically upon logging in to the platform. Only some of our content is currently included in the Library Bundle, however we hope to expand the collection as more publishers become comfortable with participating. All Bundle content is accessed via EZProxy."
+msgstr "図書館バンドル制度（Library Bundle）は申請をしなくても利用できる情報源集のことです。上述の必須条件を満たす利用者であれば、プラットフォームにログインすると自動的にアクセスが承認されます。現在はこの制度に加入したコンテンツはごく限られていますが、出版社に使い勝手を認められるに従い、さらに件数を増やしていけると望んでいます。バンドル制度のコンテンツはすべてEZProxy経由でアクセスします。"
 
 #. Translators: This is the heading for a section on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:202
@@ -2505,17 +1964,8 @@ msgstr "出典の付け方"
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:206
-msgid ""
-"Citation practices vary by project and even by article. Generally, we "
-"support editors citing where they found information, in a form that allows "
-"others to check it for themselves. That often means providing both original "
-"source details as well as a link to the partner database in which the source "
-"was found."
-msgstr ""
-"出典の提示方法はプロジェクト単位の慣習により、また（同じプロジェクト内でも）"
-"記事と記事でさえ異なります。一般に情報源を出典として明示し、他の利用者が自ら"
-"確認できる形式を採用する編集者を支持します。出典の詳細とともに、どの提携組織"
-"のデータベースで参照したか、情報を両方とも記述することを意味します。"
+msgid "Citation practices vary by project and even by article. Generally, we support editors citing where they found information, in a form that allows others to check it for themselves. That often means providing both original source details as well as a link to the partner database in which the source was found."
+msgstr "出典の提示方法はプロジェクト単位の慣習により、また（同じプロジェクト内でも）記事と記事でさえ異なります。一般に情報源を出典として明示し、他の利用者が自ら確認できる形式を採用する編集者を支持します。出典の詳細とともに、どの提携組織のデータベースで参照したか、情報を両方とも記述することを意味します。"
 
 #. Translators: This is the heading for a section on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #. Translators: This link is at the bottom of every page and can be clicked by users to contact the wikipedia library team.
@@ -2526,13 +1976,8 @@ msgstr "連絡先"
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:218
 #, python-format
-msgid ""
-"If you have questions, need help, or want to volunteer to help, please see "
-"our <a class=\"twl-links\" href=\"%(contact_url)s\">contact page</a>."
-msgstr ""
-"質問があるとき、助力が必要なとき、あるいはヘルプ対応のボランティアを志望する"
-"場合は、<a class=\"twl-links\" href=\"%(contact_url)s\">連絡先ページ</a>をご"
-"参照ください。"
+msgid "If you have questions, need help, or want to volunteer to help, please see our <a class=\"twl-links\" href=\"%(contact_url)s\">contact page</a>."
+msgstr "質問があるとき、助力が必要なとき、あるいはヘルプ対応のボランティアを志望する場合は、<a class=\"twl-links\" href=\"%(contact_url)s\">連絡先ページ</a>をご参照ください。"
 
 #. Translators: This is the title of the panel box detailing the contact information for the Wikipedia Library team.
 #: TWLight/templates/contact.html:14
@@ -2571,12 +2016,8 @@ msgstr "ウィキペディア図書館 Twitter ページ"
 #. Translators: This is the text that appears at the bottom of the contact us form directing users to the suggestions form.
 #: TWLight/templates/contact.html:48
 #, python-format
-msgid ""
-"(If you would like to suggest a partner, <a class=\"twl-links\" href="
-"\"%(suggest)s\"><strong>go here</strong></a>.)"
-msgstr ""
-"（提携組織の推薦をご希望の場合は、<a class=\"twl-links\" href=\"%(suggest)s"
-"\"><strong>こちらを開いてください</strong></a>。）"
+msgid "(If you would like to suggest a partner, <a class=\"twl-links\" href=\"%(suggest)s\"><strong>go here</strong></a>.)"
+msgstr "（提携組織の推薦をご希望の場合は、<a class=\"twl-links\" href=\"%(suggest)s\"><strong>こちらを開いてください</strong></a>。）"
 
 #. Translators: On a special 'link to search' page, this message is shown if JavaScript is disabled.
 #: TWLight/templates/eds_search_endpoint.html:7
@@ -2632,12 +2073,8 @@ msgstr "ウィキペディア図書館"
 #. Translators: Information about The Wikipedia Library.
 #: TWLight/templates/login_partial.html:53 TWLight/templates/new_base.html:21
 #, python-format
-msgid ""
-"More than 100 of the world's top subscription-only databases, with content "
-"in %(no_of_languages)s languages, free for Wikipedians of all backgrounds"
-msgstr ""
-"%(no_of_languages)s言語のコンテンツからなる100件以上の世界でもトップクラスの"
-"有償データベースを、あらゆる立場のウィキペディアンが無償で利用できます。"
+msgid "More than 100 of the world's top subscription-only databases, with content in %(no_of_languages)s languages, free for Wikipedians of all backgrounds"
+msgstr "%(no_of_languages)s言語のコンテンツからなる100件以上の世界でもトップクラスの有償データベースを、あらゆる立場のウィキペディアンが無償で利用できます。"
 
 #. Translators: Information about The Wikipedia Library.
 #: TWLight/templates/login_partial.html:64
@@ -2645,12 +2082,8 @@ msgid "Meet these criteria for automatic access"
 msgstr "自動アクセスの要件に合う人はぜひどうぞ"
 
 #: TWLight/templates/login_partial.html:69
-msgid ""
-"These criteria grant you access to certain collections but not all. Some "
-"collections are accessible on a per application basis only."
-msgstr ""
-"これらの要件は利用者の皆さんに全件から特定のコレクションへのアクセスを提供し"
-"ます。コレクションによっては応募制を採用しています。"
+msgid "These criteria grant you access to certain collections but not all. Some collections are accessible on a per application basis only."
+msgstr "これらの要件は利用者の皆さんに全件から特定のコレクションへのアクセスを提供します。コレクションによっては応募制を採用しています。"
 
 #: TWLight/templates/login_partial.html:89
 msgid "Login via Wikipedia"
@@ -2659,41 +2092,20 @@ msgstr "ウィキペディアでログイン"
 #. Translators: Shown if the current user doesn't have a registered email on their account. Don't translate contact_us_url or email_url.
 #: TWLight/templates/message_partial.html:15
 #, python-format
-msgid ""
-"You don't have an email on file. We can't finalize your access to partner "
-"resources, and you won't be able to <a class=\"twl-links\" href="
-"\"%(contact_us_url)s\">contact us</a> without an email. Please <a class="
-"\"twl-links\" href=\"%(email_url)s\">update your email</a>."
-msgstr ""
-"メールアドレスが未登録です。提携組織へのアクセス権設定の手続きが進められない"
-"上、メールアドレスの登録が済むまでそちら様からも<a class=\"twl-links\" href="
-"\"%(contact_us_url)s\">こちらへの連絡を</a>していただけません。ぜひ<a class="
-"\"twl-links\" href=\"%(email_url)s\">メールアドレスの更新</a>を済ませてくださ"
-"い。"
+msgid "You don't have an email on file. We can't finalize your access to partner resources, and you won't be able to <a class=\"twl-links\" href=\"%(contact_us_url)s\">contact us</a> without an email. Please <a class=\"twl-links\" href=\"%(email_url)s\">update your email</a>."
+msgstr "メールアドレスが未登録です。提携組織へのアクセス権設定の手続きが進められない上、メールアドレスの登録が済むまでそちら様からも<a class=\"twl-links\" href=\"%(contact_us_url)s\">こちらへの連絡を</a>していただけません。ぜひ<a class=\"twl-links\" href=\"%(email_url)s\">メールアドレスの更新</a>を済ませてください。"
 
 #. Translators: Shown if the current user has requested the processing of their data should be restricted.
 #: TWLight/templates/message_partial.html:26
 #, python-format
-msgid ""
-"You have requested a restriction on the processing of your data. Most site "
-"functionality will not be available to you until you <a class=\"twl-links\" "
-"href=\"%(restrict_url)s\">lift this restriction</a>."
-msgstr ""
-"そちら様からデータ処理を制限するよう申請を受け付けました。サイトの機能のほと"
-"んどは、<a class=\"twl-links\" href=\"%(restrict_url)s\">ご自分でこの制限を解"
-"除されるまで</a>ご利用になれません。"
+msgid "You have requested a restriction on the processing of your data. Most site functionality will not be available to you until you <a class=\"twl-links\" href=\"%(restrict_url)s\">lift this restriction</a>."
+msgstr "そちら様からデータ処理を制限するよう申請を受け付けました。サイトの機能のほとんどは、<a class=\"twl-links\" href=\"%(restrict_url)s\">ご自分でこの制限を解除されるまで</a>ご利用になれません。"
 
 #. Translators: Shown if the current user has not agreed to the terms of use.
 #: TWLight/templates/message_partial.html:37
 #, python-format
-msgid ""
-"You have not agreed to the <a class=\"twl-links\" href=\"%(terms_url)s"
-"\">terms of use</a> of this site. Your applications will not be processed "
-"and you won't be able to apply or access resources you are approved for."
-msgstr ""
-"まだこのサイトの<a class=\"twl-links\" href=\"%(terms_url)s\">利用規約</a>に"
-"同意されていません。（訳注：そのため）あなたの申請は手続きが止まっており、す"
-"でに認可された情報源への申請やアクセスができない状態です。"
+msgid "You have not agreed to the <a class=\"twl-links\" href=\"%(terms_url)s\">terms of use</a> of this site. Your applications will not be processed and you won't be able to apply or access resources you are approved for."
+msgstr "まだこのサイトの<a class=\"twl-links\" href=\"%(terms_url)s\">利用規約</a>に同意されていません。（訳注：そのため）あなたの申請は手続きが止まっており、すでに認可された情報源への申請やアクセスができない状態です。"
 
 #. Translators: This link is at the bottom of every page and links to the 'About' page (https://wikipedialibrary.wmflabs.org/about/)
 #: TWLight/templates/new_base.html:107
@@ -2739,12 +2151,8 @@ msgstr "パスワードを再設定"
 
 #. Translators: If a user goes to reset their password, this message asks them to enter their email to do so.
 #: TWLight/templates/registration/password_reset_form.html:13
-msgid ""
-"Forgot your password? Enter your email address below, and we'll email "
-"instructions for setting a new one."
-msgstr ""
-"パスワードをお忘れですか？ 下記にメールアドレスを記入すると、新しいパスワード"
-"設定用の手順がメールで届きます。"
+msgid "Forgot your password? Enter your email address below, and we'll email instructions for setting a new one."
+msgstr "パスワードをお忘れですか？ 下記にメールアドレスを記入すると、新しいパスワード設定用の手順がメールで届きます。"
 
 #. Translators: This is the label for a button that users click to update their public information.
 #: TWLight/users/forms.py:36
@@ -2788,22 +2196,13 @@ msgstr "利用規約に賛同します"
 
 #. Translators: This text explains how to disagree to the site's terms of use and the restrictions that will come into effect when users disagree to the terms of use.
 #: TWLight/users/forms.py:185
-msgid ""
-"By unchecking this box and clicking “Update” you may explore the site, but "
-"you will not be able to apply for access to materials or evaluate "
-"applications unless you agree with the terms of use."
-msgstr ""
-"このチェックを外して「更新する」ボタンを押すと、サイト内を閲覧することはでき"
-"ますが、利用規約に同意しない限り資料へのアクセスやアプリケーションの試用を申"
-"請することはできなくなります。"
+msgid "By unchecking this box and clicking “Update” you may explore the site, but you will not be able to apply for access to materials or evaluate applications unless you agree with the terms of use."
+msgstr "このチェックを外して「更新する」ボタンを押すと、サイト内を閲覧することはできますが、利用規約に同意しない限り資料へのアクセスやアプリケーションの試用を申請することはできなくなります。"
 
 #. Translators: Users click this button to set their website email address to the one linked to their Wikipedia account.
 #: TWLight/users/forms.py:211
-msgid ""
-"Use my Wikipedia email address (will be updated the next time you login)."
-msgstr ""
-"ウィキペディアに登録したメールアドレスを使用（次回のログイン時に有効になりま"
-"す）"
+msgid "Use my Wikipedia email address (will be updated the next time you login)."
+msgstr "ウィキペディアに登録したメールアドレスを使用（次回のログイン時に有効になります）"
 
 #. Translators: This labels a button which users click to change their email.
 #: TWLight/users/forms.py:232
@@ -2813,19 +2212,8 @@ msgstr "メールアドレスを更新"
 #. Translators: Shown if the current user tried to 'favorite' a partner they can't access. Do not translate '{partner}'
 #: TWLight/users/models.py:201
 #, python-brace-format
-msgid ""
-"Cannot add partner {partner} to your favorites because you don't have access "
-"to it"
-msgstr ""
-"先方へのアクセス権がないため、パートナー組織の {partner} をお気に入りに追加で"
-"きませんでした"
-
-#. Translators: Do not translate.
-#: TWLight/users/models.py:869
-#, fuzzy, python-brace-format
-#| msgid "Username"
-msgid "{wp_username}"
-msgstr "利用者名"
+msgid "Cannot add partner {partner} to your favorites because you don't have access to it"
+msgstr "先方へのアクセス権がないため、パートナー組織の {partner} をお気に入りに追加できませんでした"
 
 #. Translators: This error message is shown when there's a problem with the authenticated login process.
 #: TWLight/users/oauth.py:243
@@ -2841,17 +2229,12 @@ msgstr "{domain}は許可されていないホストです。"
 #. Translators: This warning message is shown to users when OAuth handshaker can't be initiated.
 #: TWLight/users/oauth.py:364
 msgid "Handshaker not initiated, please try logging in again."
-msgstr ""
-"Handshaker が立ち上がりませんでした。もう一度ログインをしてみてください。"
+msgstr "Handshaker が立ち上がりませんでした。もう一度ログインをしてみてください。"
 
 #. Translators: this message is displayed to users that don't have accounts and clicked on a proxied link.
 #: TWLight/users/oauth.py:388
-msgid ""
-"To view this link you need to be an eligible library user. Please login to "
-"continue."
-msgstr ""
-"このリンクの閲覧には、図書館利用者として要件を満たす必要があります。先にログ"
-"インしてからご利用ください。"
+msgid "To view this link you need to be an eligible library user. Please login to continue."
+msgstr "このリンクの閲覧には、図書館利用者として要件を満たす必要があります。先にログインしてからご利用ください。"
 
 #. Translators: This warning message is shown to users when the response received from Wikimedia OAuth servers is not a valid one.
 #: TWLight/users/oauth.py:430
@@ -2876,8 +2259,7 @@ msgstr "リクエストトークンがありません。"
 #. Translators: This message is shown when the OAuth login process fails.
 #: TWLight/users/oauth.py:498
 msgid "Access token generation failed, please try logging in again."
-msgstr ""
-"アクセストークンの生成に失敗しました。もう一度、ログインをしてみてください。"
+msgstr "アクセストークンの生成に失敗しました。もう一度、ログインをしてみてください。"
 
 #. Translators: This message is shown when more information is available on another page. Do not translate {issue}
 #: TWLight/users/oauth.py:507
@@ -2887,24 +2269,13 @@ msgstr "詳細は、{issue} を参照"
 
 #. Translators: If the user tries to log in, but their account does not meet certain requirements, they cannot login.
 #: TWLight/users/oauth.py:528
-msgid ""
-"Your Wikipedia account does not meet the eligibility criteria in the terms "
-"of use, so your Wikipedia Library Card Platform account cannot be activated."
-msgstr ""
-"ウィキペディアにおけるあなたのアカウントは利用期間の点で申請要件を満たしてい"
-"ないため、ウィキペディア図書館カードのプラットフォームにおけるアカウントは無"
-"効です。"
+msgid "Your Wikipedia account does not meet the eligibility criteria in the terms of use, so your Wikipedia Library Card Platform account cannot be activated."
+msgstr "ウィキペディアにおけるあなたのアカウントは利用期間の点で申請要件を満たしていないため、ウィキペディア図書館カードのプラットフォームにおけるアカウントは無効です。"
 
 #. Translators: If the user tries to log in, but their account does not meet certain requirements, they cannot login.
 #: TWLight/users/oauth.py:536
-msgid ""
-"Your Wikipedia account no longer meets the eligibility criteria in the terms "
-"of use, so you cannot be logged in. If you think you should be able to log "
-"in, please email wikipedialibrary@wikimedia.org."
-msgstr ""
-"ご利用のウィキペディアのアカウントは利用者規約の要件の適用外になったため、ロ"
-"グインができません。これが間違いだとお考えの節は、wikipedialibrary@wikimedia."
-"orgまでメールでご連絡ください。"
+msgid "Your Wikipedia account no longer meets the eligibility criteria in the terms of use, so you cannot be logged in. If you think you should be able to log in, please email wikipedialibrary@wikimedia.org."
+msgstr "ご利用のウィキペディアのアカウントは利用者規約の要件の適用外になったため、ログインができません。これが間違いだとお考えの節は、wikipedialibrary@wikimedia.orgまでメールでご連絡ください。"
 
 #. Translators: this message is displayed to users with brand new accounts.
 #: TWLight/users/oauth.py:549
@@ -2914,14 +2285,8 @@ msgstr "ようこそ。ご利用には使用規約に同意していただきま
 #. Translators: This message is displayed on the confirmation page where users can return their access to partner collections.
 #: TWLight/users/templates/users/authorization_confirm_return.html:13
 #, python-format
-msgid ""
-"You will no longer be able to access <b>%(partner)s's</b> resources via the "
-"Library Card platform, but can request access again by clicking 'renew', if "
-"you change your mind. Are you sure you want to return your access?"
-msgstr ""
-"図書館カードプラットフォーム経由のアクセス権は<b>%(partner)sの</b>情報源に対"
-"して失効しますが、もし後日、利用再開をご希望なら'renew'ボタンを押してアクセス"
-"権の再申請ができます。ほんとうに権利を返納してよろしいですか？"
+msgid "You will no longer be able to access <b>%(partner)s's</b> resources via the Library Card platform, but can request access again by clicking 'renew', if you change your mind. Are you sure you want to return your access?"
+msgstr "図書館カードプラットフォーム経由のアクセス権は<b>%(partner)sの</b>情報源に対して失効しますが、もし後日、利用再開をご希望なら'renew'ボタンを押してアクセス権の再申請ができます。ほんとうに権利を返納してよろしいですか？"
 
 #. Translators: On the MyLibrary page (https://wikipedialibrary.wmflabs.org/users/my_library), this tab shows all favorite collections a user has.
 #: TWLight/users/templates/users/collections_section.html:9
@@ -2990,13 +2355,8 @@ msgstr "編集者データ"
 
 #. Translators: This is shown on editor profiles, in their profile page or on applications.
 #: TWLight/users/templates/users/editor_detail.html:59
-msgid ""
-"Information with an * was retrieved from Wikipedia directly. Other "
-"information was entered directly by users or site admins, in their preferred "
-"language."
-msgstr ""
-"「*」印付きの情報は、ウィキペディアから直接、抽出してあります。その他の情報は"
-"使用言語を含め、利用者もしくはサイト管理者による入力を示します。"
+msgid "Information with an * was retrieved from Wikipedia directly. Other information was entered directly by users or site admins, in their preferred language."
+msgstr "「*」印付きの情報は、ウィキペディアから直接、抽出してあります。その他の情報は使用言語を含め、利用者もしくはサイト管理者による入力を示します。"
 
 #. Translators: This distinguishes users who have been flagged as account coordinators. Don't translate username.
 #: TWLight/users/templates/users/editor_detail.html:71
@@ -3006,14 +2366,8 @@ msgstr "%(username)sさんはこのサイトについて、コーディネータ
 
 #. Translators: This is shown on editor profiles, under the heading for Wikipedia editor data.
 #: TWLight/users/templates/users/editor_detail_data.html:5
-msgid ""
-"This information is updated automatically from your Wikimedia account each "
-"time you log in, except for the Contributions field, where you can describe "
-"your Wikimedia editing history."
-msgstr ""
-"この情報は利用者のウィキメディアのアカウントからログインの都度、自動で更新さ"
-"れますが、貢献欄は除外され、利用者がウィキメディアにおける自分の編集履歴を記"
-"述します。"
+msgid "This information is updated automatically from your Wikimedia account each time you log in, except for the Contributions field, where you can describe your Wikimedia editing history."
+msgstr "この情報は利用者のウィキメディアのアカウントからログインの都度、自動で更新されますが、貢献欄は除外され、利用者がウィキメディアにおける自分の編集履歴を記述します。"
 
 #. Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this labels the user's username.
 #: TWLight/users/templates/users/editor_detail_data.html:17
@@ -3042,21 +2396,14 @@ msgstr "利用規約に合致しますか？"
 
 #. Translators: when viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this question has a yes or no answer.
 #: TWLight/users/templates/users/editor_detail_data.html:57
-msgid ""
-"at their last login, did this user meet the criteria set forth in the terms "
-"of use?"
-msgstr ""
-"直近のログイン時に、この利用者は利用者規約の定める要件を満たしていましたか？"
+msgid "at their last login, did this user meet the criteria set forth in the terms of use?"
+msgstr "直近のログイン時に、この利用者は利用者規約の定める要件を満たしていましたか？"
 
 #. Translators: When viewing a user's profile in an application, this message shows if the software doesn't think that the user is eligible for access. Don't translate username.
 #: TWLight/users/templates/users/editor_detail_data.html:72
 #, python-format
-msgid ""
-"%(username)s may still be eligible for access grants at the coordinators' "
-"discretion."
-msgstr ""
-"%(username)sさんはコーディネーターの特権により、アクセス権付与の資格を保有し"
-"ている可能性があります。"
+msgid "%(username)s may still be eligible for access grants at the coordinators' discretion."
+msgstr "%(username)sさんはコーディネーターの特権により、アクセス権付与の資格を保有している可能性があります。"
 
 #. Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this is the heading for a Yes/No ToU question.
 #: TWLight/users/templates/users/editor_detail_data.html:83
@@ -3090,14 +2437,8 @@ msgstr "（免除をを承認済み）"
 #. Translators: This message is shown on a user's profile if their Wikimedia account is blocked on one or more projects. They may still be granted access to the Library Bundle, but need to contact Wikipedia Library staff to verify.
 #: TWLight/users/templates/users/editor_detail_data.html:137
 #, python-format
-msgid ""
-"It looks like you have an active block on your account. If you meet the "
-"other criteria you may still be permitted access to the library - please <a "
-"class=\"twl-links\" href=\"%(contact_url)s\">contact us</a>."
-msgstr ""
-"あなたの登録アカウントは現在、ブロックを1件受けているようです。その他の要件を"
-"満たすなら、引き続き図書館バンドル制度の利用が承認される場合があります - ぜひ"
-"<a class=\"twl-links\" href=\"%(contact_url)s\">担当までご連絡ください</a>。"
+msgid "It looks like you have an active block on your account. If you meet the other criteria you may still be permitted access to the library - please <a class=\"twl-links\" href=\"%(contact_url)s\">contact us</a>."
+msgstr "あなたの登録アカウントは現在、ブロックを1件受けているようです。その他の要件を満たすなら、引き続き図書館バンドル制度の利用が承認される場合があります - ぜひ<a class=\"twl-links\" href=\"%(contact_url)s\">担当までご連絡ください</a>。"
 
 #. Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this is the heading for a Yes/No program eligibility question.
 #: TWLight/users/templates/users/editor_detail_data.html:153
@@ -3106,13 +2447,8 @@ msgstr "図書館バンドル制度のアクセス権は？"
 
 #. Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this question has a Yes or No answer.
 #: TWLight/users/templates/users/editor_detail_data.html:156
-msgid ""
-"At their last login, did this user meet the criteria set forth in the "
-"Library Bundle? Note that satisfying terms of use is a prerequisite to "
-"bundle eligibility."
-msgstr ""
-"直近のログイン時点で、この利用者は図書館バンドル制度の要件を満たしていました"
-"か？ バンドル制度の前提として、利用規約の要件に合致することが求められます。"
+msgid "At their last login, did this user meet the criteria set forth in the Library Bundle? Note that satisfying terms of use is a prerequisite to bundle eligibility."
+msgstr "直近のログイン時点で、この利用者は図書館バンドル制度の要件を満たしていましたか？ バンドル制度の前提として、利用規約の要件に合致することが求められます。"
 
 #. Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this is the heading for a Yes/No program eligibility question.
 #: TWLight/users/templates/users/editor_detail_data.html:177
@@ -3156,24 +2492,14 @@ msgstr "個人データ"
 
 #. Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this text is in the 'Personal data' section. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/users/templates/users/editor_detail_data.html:262
-msgid ""
-"The following information is visible only to you, site administrators, "
-"publishing partners (where required), and volunteer Wikipedia Library "
-"coordinators (who have signed a Non-Disclosure Agreement)."
-msgstr ""
-"以下の情報は利用者ご本人とサイト管理者、提携先出版社（必要な時のみ）ならびに"
-"ボランティアのウィキメディア図書館コーディネーター（秘密情報保持契約に署名済"
-"み）のみ閲覧できます。"
+msgid "The following information is visible only to you, site administrators, publishing partners (where required), and volunteer Wikipedia Library coordinators (who have signed a Non-Disclosure Agreement)."
+msgstr "以下の情報は利用者ご本人とサイト管理者、提携先出版社（必要な時のみ）ならびにボランティアのウィキメディア図書館コーディネーター（秘密情報保持契約に署名済み）のみ閲覧できます。"
 
 #. Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this labels a button which users can click to update or remove their personal information. Don't translate update_url.
 #: TWLight/users/templates/users/editor_detail_data.html:272
 #, python-format
-msgid ""
-"You may <a class=\"twl-links\" href=\"%(update_url)s\">update or delete</a> "
-"your data at any time."
-msgstr ""
-"ご自分の利用者データはいつでも<a class=\"twl-links\" href=\"%(update_url)s\">"
-"更新もしくは削除</a>ができます。"
+msgid "You may <a class=\"twl-links\" href=\"%(update_url)s\">update or delete</a> your data at any time."
+msgstr "ご自分の利用者データはいつでも<a class=\"twl-links\" href=\"%(update_url)s\">更新もしくは削除</a>ができます。"
 
 #. Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this labels the user's email. Don't remove the *.
 #: TWLight/users/templates/users/editor_detail_data.html:283
@@ -3192,37 +2518,24 @@ msgstr "利用者の所属機関"
 
 #. Translators: This message tells users that they are not eligible to access The Wikipedia Library content.
 #: TWLight/users/templates/users/eligibility_modal.html:7
-msgid ""
-"Sorry, your Wikipedia account doesn’t currently qualify to access The "
-"Wikipedia Library."
-msgstr ""
-"残念ですが、ご利用のウィキペディアのアカウントは現在、ウィキペディア図書館の"
-"アクセス要件を満たしていません。"
+msgid "Sorry, your Wikipedia account doesn’t currently qualify to access The Wikipedia Library."
+msgstr "残念ですが、ご利用のウィキペディアのアカウントは現在、ウィキペディア図書館のアクセス要件を満たしていません。"
 
 #. Translators: This message tells users that they have not agreed to the terms of use, therefore are ineligible to access the content in The Wikipedia Library.
 #: TWLight/users/templates/users/eligibility_modal.html:30
 #, python-format
-msgid ""
-"Agreed with <a href=\"%(terms)s\" class=\"text-danger\"> terms of use </a>"
+msgid "Agreed with <a href=\"%(terms)s\" class=\"text-danger\"> terms of use </a>"
 msgstr "<a href=\"%(terms)s\" class=\"text-danger\">利用規約</a>に同意しました"
 
 #: TWLight/users/templates/users/eligibility_modal.html:40
 #, python-format
-msgid ""
-"It looks like you have an active block on your account. If you meet the "
-"other criteria you may still be permitted access to the library - please <a "
-"href=\"%(contact_url)s\">contact us</a>."
-msgstr ""
-"あなたの登録アカウントは現在、ブロックを1件受けているようです。その他の要件を"
-"満たすなら、引き続き図書館バンドル制度の利用が承認される場合があります - ぜひ"
-"<a href=\"%(contact_url)s\">担当までご連絡ください</a>。"
+msgid "It looks like you have an active block on your account. If you meet the other criteria you may still be permitted access to the library - please <a href=\"%(contact_url)s\">contact us</a>."
+msgstr "あなたの登録アカウントは現在、ブロックを1件受けているようです。その他の要件を満たすなら、引き続き図書館バンドル制度の利用が承認される場合があります - ぜひ<a href=\"%(contact_url)s\">担当までご連絡ください</a>。"
 
 #. Translators: Instructions to refresh a user's data.
 #: TWLight/users/templates/users/eligibility_modal.html:50
 msgid "To refresh your data, please log out and back in."
-msgstr ""
-"最新の利用者データに更新するには、一度ログアウトの上、再度ログインしてくださ"
-"い。"
+msgstr "最新の利用者データに更新するには、一度ログアウトの上、再度ログインしてください。"
 
 #. Translators: A button that takes users to their profile.
 #: TWLight/users/templates/users/eligibility_modal.html:58
@@ -3256,14 +2569,8 @@ msgstr "言語を設定"
 
 #. Translators: This text on the user page helps users naviage to the TranslateWiki Wikipedia Library Card platform translation page.
 #: TWLight/users/templates/users/language_form.html:31
-msgid ""
-"You can help translate the tool at <a class=\"twl-links\" href=\"https://"
-"translatewiki.net/wiki/Translating:Wikipedia_Library_Card_Platform"
-"\">translatewiki.net</a>."
-msgstr ""
-"ツールの翻訳を<a class=\"twl-links\" href=\"https://translatewiki.net/wiki/"
-"Translating:Wikipedia_Library_Card_Platform\"></a>translatewiki.net</a>でお手"
-"伝いください。"
+msgid "You can help translate the tool at <a class=\"twl-links\" href=\"https://translatewiki.net/wiki/Translating:Wikipedia_Library_Card_Platform\">translatewiki.net</a>."
+msgstr "ツールの翻訳を<a class=\"twl-links\" href=\"https://translatewiki.net/wiki/Translating:Wikipedia_Library_Card_Platform\"></a>translatewiki.net</a>でお手伝いください。"
 
 #. Translators: When the user starts a new application and submits the application, the user can view the application and withdraw if need be. This changes the label for the Withdraw button.
 #: TWLight/users/templates/users/my_applications.html:65
@@ -3282,9 +2589,7 @@ msgstr "更新を申請"
 
 #. Translators: On the page listing applications, this text explains a user they cannot renew their application since they've already requested a renewal or there aren't any renewals available.
 #: TWLight/users/templates/users/my_applications.html:79
-msgid ""
-"Renewals are either not required, not available right now, or you have "
-"already requested a renewal."
+msgid "Renewals are either not required, not available right now, or you have already requested a renewal."
 msgstr "現在、更新が不要か申請できないか、すでに申請をしてあるかに該当します。"
 
 #. Translators: This text is the heading of a section in a user's profile where they can change their preferences.
@@ -3348,27 +2653,13 @@ msgstr "データ処理を制限"
 
 #. Translators: This message is displayed on the page where users can request we stop processing their data.
 #: TWLight/users/templates/users/restrict_data.html:15
-msgid ""
-"Checking this box and clicking “Restrict” will pause all processing of the "
-"data you have entered into this website. You will not be able to apply for "
-"access to resources, your applications will not be further processed, and "
-"none of your data will be altered, until you return to this page and uncheck "
-"the box. This is not the same as deleting your data."
-msgstr ""
-"このチェックボックスにレ点を入れて「制限」ボタンを押すと、このウェブサイトに"
-"利用者が入力したすべてのデータの処理を停止します。情報源へのアクセス権申請は"
-"できず、申請中の案件は処理が停止し、あなたのいかなる情報も改変されず、あなた"
-"がこのページに戻り、当該のチェックボックスのレ点を除去するまでそのまま保たれ"
-"ます。この処置は利用者データの削除とは異なります。"
+msgid "Checking this box and clicking “Restrict” will pause all processing of the data you have entered into this website. You will not be able to apply for access to resources, your applications will not be further processed, and none of your data will be altered, until you return to this page and uncheck the box. This is not the same as deleting your data."
+msgstr "このチェックボックスにレ点を入れて「制限」ボタンを押すと、このウェブサイトに利用者が入力したすべてのデータの処理を停止します。情報源へのアクセス権申請はできず、申請中の案件は処理が停止し、あなたのいかなる情報も改変されず、あなたがこのページに戻り、当該のチェックボックスのレ点を除去するまでそのまま保たれます。この処置は利用者データの削除とは異なります。"
 
 #. Translators: This warning message is shown to coordinators who view the data restriction page.
 #: TWLight/users/templates/users/restrict_data.html:26
-msgid ""
-"You are a coordinator on this site. If you restrict the processing of your "
-"data, your coordinator flag will be removed."
-msgstr ""
-"あなたはこのサイトのコーディネーターです。ご自分のデータの処理に制限をかける"
-"と、コーディネーターのフラッグは除去されます。"
+msgid "You are a coordinator on this site. If you restrict the processing of your data, your coordinator flag will be removed."
+msgstr "あなたはこのサイトのコーディネーターです。ご自分のデータの処理に制限をかけると、コーディネーターのフラッグは除去されます。"
 
 #. Translators: use the date *when you are translating*, in a language-appropriate format.
 #: TWLight/users/templates/users/terms.html:33
@@ -3387,35 +2678,13 @@ msgstr "ウィキペディア図書館カード利用規約と個人情報の声
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:51
-msgid ""
-"<a class=\"twl-links\" href=\"https://meta.wikimedia.org/wiki/"
-"The_Wikipedia_Library\"> The Wikipedia Library </a> has partnered with "
-"publishers around the world to allow users to access otherwise paywalled "
-"resources. This website allows Wikipedia editors to search and access these "
-"resources."
-msgstr ""
-"<a class=\"twl-links\" href=\"https://meta.wikimedia.org/wiki/"
-"The_Wikipedia_Library\"> ウィキペディア図書館 </a>は世界の出版社と提携関係を"
-"築き、利用者に本来なら有償（ペイウォール）の情報源の利用を提供します。利用者"
-"はこのウェブサイトから複数の出版社の素材に同時にアクセス権を申請できます。"
+msgid "<a class=\"twl-links\" href=\"https://meta.wikimedia.org/wiki/The_Wikipedia_Library\"> The Wikipedia Library </a> has partnered with publishers around the world to allow users to access otherwise paywalled resources. This website allows Wikipedia editors to search and access these resources."
+msgstr "<a class=\"twl-links\" href=\"https://meta.wikimedia.org/wiki/The_Wikipedia_Library\"> ウィキペディア図書館 </a>は世界の出版社と提携関係を築き、利用者に本来なら有償（ペイウォール）の情報源の利用を提供します。利用者はこのウェブサイトから複数の出版社の素材に同時にアクセス権を申請できます。"
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Wikimedia Foundation should not be translated. WMF should not be translated. Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:63
-msgid ""
-"This program is administered by the Wikimedia Foundation (WMF). These terms "
-"of use and privacy notice pertain to your application for access to "
-"resources through the Wikipedia Library, your use of this website, and your "
-"access to and use of those resources. They also describe our handling of the "
-"information you provide to us in order to create and administer your "
-"Wikipedia Library account. If we make material changes to the terms, we will "
-"notify users."
-msgstr ""
-"このプログラムの管理者はウィキメディア財団（WMF）です。利用者規約ならびに個人"
-"情報通知はウィキペディア図書館を経由した情報源へのアクセス権申請、このウェブ"
-"サイトの利用、当該の情報源へのアクセスならびに利用に適用されます。またそれら"
-"は皆さんがウィキペディア図書館アカウントの作成と管理をするために、皆さんから"
-"管理者に提供される情報の取り扱いを説明します。規約の情報を変更した場合は、利"
-"用者に通知します。"
+msgid "This program is administered by the Wikimedia Foundation (WMF). These terms of use and privacy notice pertain to your application for access to resources through the Wikipedia Library, your use of this website, and your access to and use of those resources. They also describe our handling of the information you provide to us in order to create and administer your Wikipedia Library account. If we make material changes to the terms, we will notify users."
+msgstr "このプログラムの管理者はウィキメディア財団（WMF）です。利用者規約ならびに個人情報通知はウィキペディア図書館を経由した情報源へのアクセス権申請、このウェブサイトの利用、当該の情報源へのアクセスならびに利用に適用されます。またそれらは皆さんがウィキペディア図書館アカウントの作成と管理をするために、皆さんから管理者に提供される情報の取り扱いを説明します。規約の情報を変更した場合は、利用者に通知します。"
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:74
@@ -3424,56 +2693,18 @@ msgstr "ウィキペディア図書館カードのアカウント要件"
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:78
-msgid ""
-"Access to resources via The Wikipedia Library is reserved for community "
-"members who have demonstrated their commitment to the Wikimedia projects, "
-"and who will use their access to these resources to improve project content. "
-"To that end, in order to be eligible for The Wikipedia Library, we require "
-"that you be registered for a user account on the projects, with at least 500 "
-"edits, six (6) months of activity, and 10+ edits in the last month. We ask "
-"that you do not request access to any publishers with a limited number of "
-"available accounts whose resources you can already access for free through "
-"your local library or university, or another institution or organization, in "
-"order to provide that opportunity to others."
-msgstr ""
-"ウィキペディア図書館経由の情報源へのアクセスを認可する利用者とは、ウィキメ"
-"ディアのプロジェクト群への貢献を裏付ける実績があり、なおかつ承認された情報源"
-"へのアクセスを活用してプロジェクトのコンテンツ改善に寄与することが条件です。"
-"その限りにおいてウィキペディア図書館プログラムの利用要件として、利用者はいず"
-"れかのプロジェクトにアカウントを登録済みであるものとします。また500回以上の編"
-"集と6ヵ月超の活動実績、加えてこの1ヵ月に10回超の編集をしていることが条件で"
-"す。ただし当該の情報源につき利用者が大学もしくは地域の図書館あるいはその他の"
-"機関や組織経由ですでに無料で利用可能な場合には申請を自粛され、他の人への利用"
-"権付与にご協力願います。"
+msgid "Access to resources via The Wikipedia Library is reserved for community members who have demonstrated their commitment to the Wikimedia projects, and who will use their access to these resources to improve project content. To that end, in order to be eligible for The Wikipedia Library, we require that you be registered for a user account on the projects, with at least 500 edits, six (6) months of activity, and 10+ edits in the last month. We ask that you do not request access to any publishers with a limited number of available accounts whose resources you can already access for free through your local library or university, or another institution or organization, in order to provide that opportunity to others."
+msgstr "ウィキペディア図書館経由の情報源へのアクセスを認可する利用者とは、ウィキメディアのプロジェクト群への貢献を裏付ける実績があり、なおかつ承認された情報源へのアクセスを活用してプロジェクトのコンテンツ改善に寄与することが条件です。その限りにおいてウィキペディア図書館プログラムの利用要件として、利用者はいずれかのプロジェクトにアカウントを登録済みであるものとします。また500回以上の編集と6ヵ月超の活動実績、加えてこの1ヵ月に10回超の編集をしていることが条件です。ただし当該の情報源につき利用者が大学もしくは地域の図書館あるいはその他の機関や組織経由ですでに無料で利用可能な場合には申請を自粛され、他の人への利用権付与にご協力願います。"
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:94
-msgid ""
-"Additionally, if you are currently blocked or banned from a Wikimedia "
-"project, applications to resources may be rejected or restricted. If you "
-"obtain a Wikipedia Library account, but a block or ban is subsequently "
-"instituted against you on one of the projects, you may lose access to your "
-"Wikipedia Library account."
-msgstr ""
-"前述に加え、現状で利用者が特定のウィキメディアのプロジェクトでブロックもしく"
-"は追放を受けている場合は、情報源への申請は却下もしくは制限の対象となる場合が"
-"あります。ウィキペディア図書館のアカウント保持者であっても、いずれかのプロ"
-"ジェクトにおいてその後、ブロックもしくは追放の対象となった場合、ウィキペディ"
-"ア図書館アカウントへのアクセス権が失効する場合があります。"
+msgid "Additionally, if you are currently blocked or banned from a Wikimedia project, applications to resources may be rejected or restricted. If you obtain a Wikipedia Library account, but a block or ban is subsequently instituted against you on one of the projects, you may lose access to your Wikipedia Library account."
+msgstr "前述に加え、現状で利用者が特定のウィキメディアのプロジェクトでブロックもしくは追放を受けている場合は、情報源への申請は却下もしくは制限の対象となる場合があります。ウィキペディア図書館のアカウント保持者であっても、いずれかのプロジェクトにおいてその後、ブロックもしくは追放の対象となった場合、ウィキペディア図書館アカウントへのアクセス権が失効する場合があります。"
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:104
-msgid ""
-"Your eligibility to access The Wikipedia Library is assessed at each login. "
-"While more than half of the library's content is provided via this automated "
-"eligibility check, access to other publisher's content may be time limited, "
-"typically lapsing after one year, after which you will usually need to apply "
-"for renewal."
-msgstr ""
-"ご利用者のログインのたびにウィキペディア図書館の利用要件を 確認しています。こ"
-"の自動チェックシステムで当ライブラリーのコンテンツの過半数をご利用いただけま"
-"すが、コンテンツの出版社によっては一般に1年の有効期間を設けており、通常は失効"
-"後に再応募が求められます。"
+msgid "Your eligibility to access The Wikipedia Library is assessed at each login. While more than half of the library's content is provided via this automated eligibility check, access to other publisher's content may be time limited, typically lapsing after one year, after which you will usually need to apply for renewal."
+msgstr "ご利用者のログインのたびにウィキペディア図書館の利用要件を 確認しています。この自動チェックシステムで当ライブラリーのコンテンツの過半数をご利用いただけますが、コンテンツの出版社によっては一般に1年の有効期間を設けており、通常は失効後に再応募が求められます。"
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:114
@@ -3482,65 +2713,28 @@ msgstr "ウィキペディア図書館カードのアカウントから申請"
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:118
-msgid ""
-"In order to apply for access to a partner resource, you must provide us with "
-"certain information, which we will use to evaluate your application. If your "
-"application is approved, we may transfer the information you have given us "
-"to the publishers whose resources you wish to access. They will either "
-"contact you with the account information directly or we will send access "
-"information to you ourselves."
-msgstr ""
-"提携組織の情報源にアクセス権を申請される利用者の皆さんには、申請の審査に向け"
-"ていくつかの情報提供をお願いしています。申請の承認後、提供いただいた情報はご"
-"利用を希望される情報源の出版社に転送する場合があります。アカウント情報に関す"
-"るご連絡は、出版社から直接送信されるか、もしくはウィキペディア図書館が行うも"
-"のとします。"
+msgid "In order to apply for access to a partner resource, you must provide us with certain information, which we will use to evaluate your application. If your application is approved, we may transfer the information you have given us to the publishers whose resources you wish to access. They will either contact you with the account information directly or we will send access information to you ourselves."
+msgstr "提携組織の情報源にアクセス権を申請される利用者の皆さんには、申請の審査に向けていくつかの情報提供をお願いしています。申請の承認後、提供いただいた情報はご利用を希望される情報源の出版社に転送する場合があります。アカウント情報に関するご連絡は、出版社から直接送信されるか、もしくはウィキペディア図書館が行うものとします。"
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:130
-msgid ""
-"In addition to the basic information you provide to us, our system will "
-"retrieve some information directly from the Wikimedia projects: your "
-"username, email address, edit count, registration date, user ID number, "
-"groups to which you belong, and any special user rights."
-msgstr ""
-"皆さんから提供される基本情報に加え、システムはウィキメディアのプロジェクト群"
-"から直接、複数の情報を抽出します。利用者名、メールアドレス、編集回数、登録"
-"日、利用者ID番号、所属するグループ名の他、特筆するべき利用者権限。"
+msgid "In addition to the basic information you provide to us, our system will retrieve some information directly from the Wikimedia projects: your username, email address, edit count, registration date, user ID number, groups to which you belong, and any special user rights."
+msgstr "皆さんから提供される基本情報に加え、システムはウィキメディアのプロジェクト群から直接、複数の情報を抽出します。利用者名、メールアドレス、編集回数、登録日、利用者ID番号、所属するグループ名の他、特筆するべき利用者権限。"
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:140
-msgid ""
-"Each time you log in to the Wikipedia Library Card Platform, this "
-"information will be automatically updated."
-msgstr ""
-"ウィキペディア図書館カードプラットフォームにログインするたび、この情報は自動"
-"更新されます。"
+msgid "Each time you log in to the Wikipedia Library Card Platform, this information will be automatically updated."
+msgstr "ウィキペディア図書館カードプラットフォームにログインするたび、この情報は自動更新されます。"
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:148
-msgid ""
-"We will ask you to provide us with some information about your history of "
-"contributions to the Wikimedia projects. Information on contribution history "
-"is optional, but will greatly assist us in evaluating your application."
-msgstr ""
-"利用者の皆さんにはウィキメディアのプロジェクト群における活動歴について、情報"
-"提供をお頼みします。もちろん活動歴の情報はオプションではありますが、申請の審"
-"査にたいへん役に立つものです。"
+msgid "We will ask you to provide us with some information about your history of contributions to the Wikimedia projects. Information on contribution history is optional, but will greatly assist us in evaluating your application."
+msgstr "利用者の皆さんにはウィキメディアのプロジェクト群における活動歴について、情報提供をお頼みします。もちろん活動歴の情報はオプションではありますが、申請の審査にたいへん役に立つものです。"
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). WMF should not be translated. Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:157
-msgid ""
-"The information you provide when creating your account will be visible to "
-"you while on the site but not to others unless they are approved Wikipedia "
-"Library Coordinators, WMF Staff, or WMF Contractors who need access to this "
-"data in order to carry out their work with the Wikipedia Library, all of "
-"whom are subject to non-disclosure obligations."
-msgstr ""
-"アカウント作成時に提供した情報は、当該利用者がサイトにログイン中は閲覧できる"
-"ものの、次の人を除き秘匿されます。承認を受けたウィキペディア図書館コーディ"
-"ネーター、WMF職員、WMF契約職員でウィキペディア図書館の業務遂行にこのデータの"
-"閲覧が必要な者とし、全員、秘密保持契約の対象です。"
+msgid "The information you provide when creating your account will be visible to you while on the site but not to others unless they are approved Wikipedia Library Coordinators, WMF Staff, or WMF Contractors who need access to this data in order to carry out their work with the Wikipedia Library, all of whom are subject to non-disclosure obligations."
+msgstr "アカウント作成時に提供した情報は、当該利用者がサイトにログイン中は閲覧できるものの、次の人を除き秘匿されます。承認を受けたウィキペディア図書館コーディネーター、WMF職員、WMF契約職員でウィキペディア図書館の業務遂行にこのデータの閲覧が必要な者とし、全員、秘密保持契約の対象です。"
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:167
@@ -3549,61 +2743,33 @@ msgstr "出版社の情報源の利用"
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:171
-msgid ""
-"In order to access an individual publisher’s resources, you must agree to "
-"that publisher’s terms of use and privacy policy. You agree that you will "
-"not violate such terms and policies in connection with your use of the "
-"Wikipedia Library. Additionally, the following activities are prohibited "
-"while accessing publisher resources through the Wikipedia Library."
-msgstr ""
-"個別の出版社の情報源にアクセスするには、出版社の利用規約ならびに個人情報方針"
-"に同意する必要があります。ウィキペディア図書館の利用に関連して利用者はそれら"
-"の規約や方針に違反しないことに同意します。さらに以下に述べる行動はウィキペ"
-"ディア図書館を経由して出版社の情報源にアクセスする場合は禁止されています。"
+msgid "In order to access an individual publisher’s resources, you must agree to that publisher’s terms of use and privacy policy. You agree that you will not violate such terms and policies in connection with your use of the Wikipedia Library. Additionally, the following activities are prohibited while accessing publisher resources through the Wikipedia Library."
+msgstr "個別の出版社の情報源にアクセスするには、出版社の利用規約ならびに個人情報方針に同意する必要があります。ウィキペディア図書館の利用に関連して利用者はそれらの規約や方針に違反しないことに同意します。さらに以下に述べる行動はウィキペディア図書館を経由して出版社の情報源にアクセスする場合は禁止されています。"
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:184
-msgid ""
-"Sharing your Wikipedia account, usernames, passwords, or any access codes "
-"for publisher resources with others;"
-msgstr ""
-"ウィキペディアのアカウント、利用者名、パスワードあるいは出版社の情報源のアク"
-"セスコードを他人と共有すること。"
+msgid "Sharing your Wikipedia account, usernames, passwords, or any access codes for publisher resources with others;"
+msgstr "ウィキペディアのアカウント、利用者名、パスワードあるいは出版社の情報源のアクセスコードを他人と共有すること。"
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:191
-msgid ""
-"Automatically scraping or downloading restricted content from publishers;"
-msgstr ""
-"出版社の制限付きのコンテンツを自動的に（無選別に）かき集めるもしくはダウン"
-"ロードする："
+msgid "Automatically scraping or downloading restricted content from publishers;"
+msgstr "出版社の制限付きのコンテンツを自動的に（無選別に）かき集めるもしくはダウンロードする："
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:197
-msgid ""
-"Systematically making printed or electronic copies of multiple extracts of "
-"restricted content available for any purpose;"
-msgstr ""
-"目的のいかんに関わらず、制限されたコンテンツから複数の抽出物を体系的に印刷物"
-"または電子コピーとして複製物を作成すること"
+msgid "Systematically making printed or electronic copies of multiple extracts of restricted content available for any purpose;"
+msgstr "目的のいかんに関わらず、制限されたコンテンツから複数の抽出物を体系的に印刷物または電子コピーとして複製物を作成すること"
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:204
-msgid ""
-"Data mining metadata without permission—for example, in order to use "
-"metadata for auto-created stub articles;"
-msgstr ""
-"許可を得ずにメタデータをデータマイニング—たとえばメタデータを利用しスタブ記事"
-"の自動作成に使用するため。"
+msgid "Data mining metadata without permission—for example, in order to use metadata for auto-created stub articles;"
+msgstr "許可を得ずにメタデータをデータマイニング—たとえばメタデータを利用しスタブ記事の自動作成に使用するため。"
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:211
-msgid ""
-"Using the access you receive through the Wikipedia Library for profit by "
-"selling access to your account or resources which you have through it."
-msgstr ""
-"ウィキペディア図書館を経由したアクセスを商用目的に利用し、利用者のアカウント"
-"へのアクセスもしくはそれを経由して入手した情報源を有償で他者に販売すること。"
+msgid "Using the access you receive through the Wikipedia Library for profit by selling access to your account or resources which you have through it."
+msgstr "ウィキペディア図書館を経由したアクセスを商用目的に利用し、利用者のアカウントへのアクセスもしくはそれを経由して入手した情報源を有償で他者に販売すること。"
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:220
@@ -3612,25 +2778,13 @@ msgstr "外部の検索およびプロキシサービス"
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:224
-msgid ""
-"Certain resources may only be accessed using an external search service, "
-"such as the EBSCO Discovery Service, or a proxy service, such as OCLC "
-"EZProxy. If you use such external search and/or proxy services, please "
-"review the applicable terms of use and privacy policies."
-msgstr ""
-"特定の情報源のアクセスには、たとえばEBSCO Discovery Serviceなど外部の検索サー"
-"ビス、もしくはOCLC EZProxyなどプロキシサービスを利用しないとアクセスできない"
-"場合があります。もしそれらの外部検索および/もしくはプロキシサービスを利用する"
-"場合は、当該の利用規約と個人情報方針を精査してください。"
+msgid "Certain resources may only be accessed using an external search service, such as the EBSCO Discovery Service, or a proxy service, such as OCLC EZProxy. If you use such external search and/or proxy services, please review the applicable terms of use and privacy policies."
+msgstr "特定の情報源のアクセスには、たとえばEBSCO Discovery Serviceなど外部の検索サービス、もしくはOCLC EZProxyなどプロキシサービスを利用しないとアクセスできない場合があります。もしそれらの外部検索および/もしくはプロキシサービスを利用する場合は、当該の利用規約と個人情報方針を精査してください。"
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:234
-msgid ""
-"In addition, if you use OCLC EZProxy, please note that you may not use it "
-"for commercial purposes."
-msgstr ""
-"前述に加え、OCLC EZProxyを使用する場合は、商用目的での使用は禁じられている点"
-"にご注意ください。"
+msgid "In addition, if you use OCLC EZProxy, please note that you may not use it for commercial purposes."
+msgstr "前述に加え、OCLC EZProxyを使用する場合は、商用目的での使用は禁じられている点にご注意ください。"
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:241
@@ -3639,182 +2793,50 @@ msgstr "データ保持と取り扱い"
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Wikimedia Foundation should not be translated. Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:245
-msgid ""
-"The Wikimedia Foundation and our service providers use your information for "
-"the legitimate purpose of providing Wikipedia Library services in support of "
-"our charitable mission. When you apply for a Wikipedia Library account, or "
-"use your Wikipedia Library account, we may routinely collect the following "
-"information: your username, email address, edit count, registration date, "
-"user ID number, groups to which you belong, and any special user rights; "
-"your name, country of residence, and/or affiliation, if required by a "
-"partner to which you are applying; your narrative description of your "
-"contributions and reasons for applying for access to partner resources; and "
-"the date you agree to these terms of use."
-msgstr ""
-"ウィキメディア財団と提携サービス提供者は申請者の個人情報の取り扱いにつき、公"
-"共的使命に資するウィキメディア図書館サービス提供の適法な目的にのみ用います。"
-"ウィキメディア図書館の利用権を申請する場合、もしくはウィキメディア図書館の利"
-"用権を行使する場合、私たちは定期的に次の情報を収集することがあります。利用者"
-"名、メールアドレス、編集回数、アカウント登録日、利用者識別番号（ID）、所属す"
-"るグループ、特別な利用者権限。利用者が申請した提携組織の求めに応じて、利用者"
-"名、居住国、職業および／もしくは所属を開示します。自己申告による利用者の貢献"
-"と提携先リソースを利用する理由。利用者がこれら利用規約に同意した日付。"
+msgid "The Wikimedia Foundation and our service providers use your information for the legitimate purpose of providing Wikipedia Library services in support of our charitable mission. When you apply for a Wikipedia Library account, or use your Wikipedia Library account, we may routinely collect the following information: your username, email address, edit count, registration date, user ID number, groups to which you belong, and any special user rights; your name, country of residence, and/or affiliation, if required by a partner to which you are applying; your narrative description of your contributions and reasons for applying for access to partner resources; and the date you agree to these terms of use."
+msgstr "ウィキメディア財団と提携サービス提供者は申請者の個人情報の取り扱いにつき、公共的使命に資するウィキメディア図書館サービス提供の適法な目的にのみ用います。ウィキメディア図書館の利用権を申請する場合、もしくはウィキメディア図書館の利用権を行使する場合、私たちは定期的に次の情報を収集することがあります。利用者名、メールアドレス、編集回数、アカウント登録日、利用者識別番号（ID）、所属するグループ、特別な利用者権限。利用者が申請した提携組織の求めに応じて、利用者名、居住国、職業および／もしくは所属を開示します。自己申告による利用者の貢献と提携先リソースを利用する理由。利用者がこれら利用規約に同意した日付。"
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:262
 #, python-format
-msgid ""
-"Each publisher who is a member of the Wikipedia Library program requires "
-"different specific information in the application. Some publishers may "
-"request only an email address, while others request more detailed data, such "
-"as your name, location, or institutional affiliation. When you complete your "
-"application, you will only be asked to supply information required by the "
-"publishers you have chosen, and each publisher will only receive the "
-"information they require for providing you with access. Please see our <a "
-"class=\"twl-links\" href=\"%(all_partners_url)s\">partner information</a> "
-"pages to learn what information is required by each publisher to gain access "
-"to their resources."
-msgstr ""
-"ウィキペディア図書館プログラムに加盟する出版社は、各社で個別にアクセス権申請"
-"の特定の情報の提出を求めます。出版社によってメールアドレスのみ必要なところ"
-"や、さらに詳細に氏名、所在地あるいは所属先の組織名を求めるところもあります。"
-"申請を完了するには申請先として選択した出版社が必須とする情報に限定して記入を"
-"求められ、個別の出版社はアクセス権提供にそれぞれが求める情報のみ受領します。"
-"情報源へのアクセス権供与の要件は<a class=\"twl-links\" href="
-"\"%(all_partners_url)s\">提携組織の情報</a>ページに出版社別に掲載しましたの"
-"で、ご参照ください。"
+msgid "Each publisher who is a member of the Wikipedia Library program requires different specific information in the application. Some publishers may request only an email address, while others request more detailed data, such as your name, location, or institutional affiliation. When you complete your application, you will only be asked to supply information required by the publishers you have chosen, and each publisher will only receive the information they require for providing you with access. Please see our <a class=\"twl-links\" href=\"%(all_partners_url)s\">partner information</a> pages to learn what information is required by each publisher to gain access to their resources."
+msgstr "ウィキペディア図書館プログラムに加盟する出版社は、各社で個別にアクセス権申請の特定の情報の提出を求めます。出版社によってメールアドレスのみ必要なところや、さらに詳細に氏名、所在地あるいは所属先の組織名を求めるところもあります。申請を完了するには申請先として選択した出版社が必須とする情報に限定して記入を求められ、個別の出版社はアクセス権提供にそれぞれが求める情報のみ受領します。情報源へのアクセス権供与の要件は<a class=\"twl-links\" href=\"%(all_partners_url)s\">提携組織の情報</a>ページに出版社別に掲載しましたので、ご参照ください。"
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Wikimedia Foundation should not be translated. Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:277
-msgid ""
-"Some Wikipedia Library pages are visible without logging in, but you will "
-"need to log in to apply or access proprietary partner resources. We use the "
-"data provided by you via OAuth and Wikimedia API calls to assess your "
-"application for access and to process approved requests."
-msgstr ""
-"ウィキペディア図書館サイトの特定のページの閲覧にはログインは不要ですが、知的"
-"所有権の存在する（プロプライエタリーな）提携組織の情報源のアクセス権申請もし"
-"くはアクセスには、ログインが必要です。一括ログインOAuthならびにウィキメディア"
-"API呼び出しに際して利用者から提供された情報を用いて、利用者のアクセス権申請を"
-"評価し、認可済みの申請の処理にあたります。"
+msgid "Some Wikipedia Library pages are visible without logging in, but you will need to log in to apply or access proprietary partner resources. We use the data provided by you via OAuth and Wikimedia API calls to assess your application for access and to process approved requests."
+msgstr "ウィキペディア図書館サイトの特定のページの閲覧にはログインは不要ですが、知的所有権の存在する（プロプライエタリーな）提携組織の情報源のアクセス権申請もしくはアクセスには、ログインが必要です。一括ログインOAuthならびにウィキメディアAPI呼び出しに際して利用者から提供された情報を用いて、利用者のアクセス権申請を評価し、認可済みの申請の処理にあたります。"
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:288
 #, python-format
-msgid ""
-"In order to administer the Wikipedia Library program, we will retain the "
-"application data we collect from you for three years after your most recent "
-"login, unless you delete your account, as described below. You can log in "
-"and go to <a class=\"twl-links\" href=\"%(profile_url)s\">your profile page</"
-"a> in order to see the information associated with your account, and can "
-"download it in JSON format. You may access, update, restrict, or delete this "
-"information at any time, except for the information that is automatically "
-"retrieved from the projects. If you have any questions or concerns about the "
-"handling of your data, please contact <a class=\"twl-links\" href=\"mailto:"
-"wikipedialibrary@wikimedia.org?Subject=Wikipedia%%20Library%%20Card"
-"%%20account%%20deactivation\"> wikipedialibrary@wikimedia.org </a>."
-msgstr ""
-"ウィキペディア図書館プログラムの管理上、利用者から収集した申請情報は利用者が"
-"下記の手続きに従ってアカウントを削除しない限り、利用者の直近のログインから3年"
-"にわたり保管します。ログイン後、<a class=\"twl-links\" href=\"%(profile_url)s"
-"\">ご自分のプロフィールページ</a>を開くと登録アカウントに紐付けされた情報の閲"
-"覧と、JSON形式でダウンロードができます。利用者はこの情報をいつでも閲覧、制"
-"限、削除できるものとし、プロジェクトから自動で取得した情報はこの限りではあり"
-"ません。ご自分のデータの取り扱いに疑問や懸念がある場合には、その旨を<a class="
-"\"twl-links\" href=\"mailto:wikipedialibrary@wikimedia.org?Subject=Wikipedia"
-"%%20Library%%20Card%%20account%%20deactivation\"> wikipedialibrary@wikimedia."
-"org </a>までご連絡ください。"
+msgid "In order to administer the Wikipedia Library program, we will retain the application data we collect from you for three years after your most recent login, unless you delete your account, as described below. You can log in and go to <a class=\"twl-links\" href=\"%(profile_url)s\">your profile page</a> in order to see the information associated with your account, and can download it in JSON format. You may access, update, restrict, or delete this information at any time, except for the information that is automatically retrieved from the projects. If you have any questions or concerns about the handling of your data, please contact <a class=\"twl-links\" href=\"mailto:wikipedialibrary@wikimedia.org?Subject=Wikipedia%%20Library%%20Card%%20account%%20deactivation\"> wikipedialibrary@wikimedia.org </a>."
+msgstr "ウィキペディア図書館プログラムの管理上、利用者から収集した申請情報は利用者が下記の手続きに従ってアカウントを削除しない限り、利用者の直近のログインから3年にわたり保管します。ログイン後、<a class=\"twl-links\" href=\"%(profile_url)s\">ご自分のプロフィールページ</a>を開くと登録アカウントに紐付けされた情報の閲覧と、JSON形式でダウンロードができます。利用者はこの情報をいつでも閲覧、制限、削除できるものとし、プロジェクトから自動で取得した情報はこの限りではありません。ご自分のデータの取り扱いに疑問や懸念がある場合には、その旨を<a class=\"twl-links\" href=\"mailto:wikipedialibrary@wikimedia.org?Subject=Wikipedia%%20Library%%20Card%%20account%%20deactivation\"> wikipedialibrary@wikimedia.org </a>までご連絡ください。"
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:305
-msgid ""
-"If you decide to disable your Wikipedia Library account, you can use the "
-"delete button on your profile to delete certain personal information "
-"associated with your account. We will delete your real name, institutional "
-"affiliation, and country of residence. Please note that the system will "
-"retain a record of your username, the publishers to which you applied or had "
-"access, and the dates of that access. Note that deletion is not reversible. "
-"Deletion of your Wikipedia Library account may also correspond with the "
-"removal of any resource access to which you were eligible or approved. If "
-"you request the deletion of account information and later wish to apply for "
-"a new account, you will need to provide the necessary information again."
-msgstr ""
-"Wikipedia ライブラリ アカウントを無効にする場合は、プロフィールの削除ボタンを"
-"使用して、アカウントに関連付けられている特定の個人情報を削除できます。本名、"
-"所属機関、居住国は削除されます。ユーザー名、申請またはアクセスした出版社、ア"
-"クセスした日付はシステムに保存されます。削除は元に戻せないことに注意してくだ"
-"さい。Wikipedia ライブラリ アカウントを削除すると、資格があった、または承認さ"
-"れたリソース アクセスも削除される可能性があります。アカウント情報の削除をリク"
-"エストし、後で新しいアカウントを申請する場合は、必要な情報を再度提供する必要"
-"があります。"
+msgid "If you decide to disable your Wikipedia Library account, you can use the delete button on your profile to delete certain personal information associated with your account. We will delete your real name, institutional affiliation, and country of residence. Please note that the system will retain a record of your username, the publishers to which you applied or had access, and the dates of that access. Note that deletion is not reversible. Deletion of your Wikipedia Library account may also correspond with the removal of any resource access to which you were eligible or approved. If you request the deletion of account information and later wish to apply for a new account, you will need to provide the necessary information again."
+msgstr "Wikipedia ライブラリ アカウントを無効にする場合は、プロフィールの削除ボタンを使用して、アカウントに関連付けられている特定の個人情報を削除できます。本名、所属機関、居住国は削除されます。ユーザー名、申請またはアクセスした出版社、アクセスした日付はシステムに保存されます。削除は元に戻せないことに注意してください。Wikipedia ライブラリ アカウントを削除すると、資格があった、または承認されたリソース アクセスも削除される可能性があります。アカウント情報の削除をリクエストし、後で新しいアカウントを申請する場合は、必要な情報を再度提供する必要があります。"
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). WMF should not be translated. Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:321
-msgid ""
-"The Wikipedia Library is run by WMF Staff, Contractors, and approved "
-"volunteer Coordinators. The data associated with your account will be shared "
-"with the WMF staff, contractors, service providers, and volunteer "
-"coordinators who need to process the information in connection with their "
-"work for the Wikipedia Library, and who are subject to confidentiality "
-"obligations. We will also use your data for internal Wikipedia Library "
-"purposes such as distributing user surveys and account notifications, and in "
-"a depersonalized or aggregated fashion for statistical analysis and "
-"administration. Finally, we will share your information with the publishers "
-"whom you specifically select in order to provide you with access to "
-"resources. Otherwise, your information will not be shared with third "
-"parties, with the exception of the circumstances described below."
-msgstr ""
-"ウィキペディア図書館の運営はWMF職員と契約職員ならびに承認を受けたボランティア"
-"のコーディネーターがおこないます。利用者に紐付けされた情報はWMF職員とけいやく"
-"しょくいん、サービス提供者ならびにボランティアのコーディネーターが共有し、そ"
-"れぞれのウィキペディア図書館に関連する業務において処理するものとし、個人情報"
-"保持義務の対象となります。利用者の情報は内部のウィキペディア図書館の目的とし"
-"て利用者調査の実施やアカウント通知などに使用し、非個人化もしくは抽象化して統"
-"計的分析ならびに管理業務にあてます。最後に、利用者が指定した出版社と利用者情"
-"報を共有し、その情報源へのアクセス権を設定します。それ以外については、利用者"
-"の情報は第三者と共有することなく、以下に説明する状況を例外とします。"
+msgid "The Wikipedia Library is run by WMF Staff, Contractors, and approved volunteer Coordinators. The data associated with your account will be shared with the WMF staff, contractors, service providers, and volunteer coordinators who need to process the information in connection with their work for the Wikipedia Library, and who are subject to confidentiality obligations. We will also use your data for internal Wikipedia Library purposes such as distributing user surveys and account notifications, and in a depersonalized or aggregated fashion for statistical analysis and administration. Finally, we will share your information with the publishers whom you specifically select in order to provide you with access to resources. Otherwise, your information will not be shared with third parties, with the exception of the circumstances described below."
+msgstr "ウィキペディア図書館の運営はWMF職員と契約職員ならびに承認を受けたボランティアのコーディネーターがおこないます。利用者に紐付けされた情報はWMF職員とけいやくしょくいん、サービス提供者ならびにボランティアのコーディネーターが共有し、それぞれのウィキペディア図書館に関連する業務において処理するものとし、個人情報保持義務の対象となります。利用者の情報は内部のウィキペディア図書館の目的として利用者調査の実施やアカウント通知などに使用し、非個人化もしくは抽象化して統計的分析ならびに管理業務にあてます。最後に、利用者が指定した出版社と利用者情報を共有し、その情報源へのアクセス権を設定します。それ以外については、利用者の情報は第三者と共有することなく、以下に説明する状況を例外とします。"
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). WMF should not be translated.
 #: TWLight/users/templates/users/terms.html:338
-msgid ""
-"We may disclose any collected information when required by law, when we have "
-"your permission, when needed to protect our rights, privacy, safety, users, "
-"or the general public, and when necessary to enforce these terms, WMF’s "
-"general <a class=\"twl-links\" href=\"https://foundation.wikimedia.org/wiki/"
-"Terms_of_Use\">Terms of Use</a>, or any other WMF policy."
-msgstr ""
-"収集したいずれの情報も必要なとき、すなわち法の求めに応じ、利用者の同意のある"
-"とき、（WMFの）権利や個人情報保護あるいは安全や利用者もしくは一般利用者の擁護"
-"に必要なとき、さらにこれらの規約ならびにWMFの全般的な<a class=\"twl-links\" "
-"href=\"https://foundation.wikimedia.org/wiki/Terms_of_Use\">利用規約</a>もし"
-"くはその他のいずれかのWMFの方針を徹底するため開示するものとします。"
+msgid "We may disclose any collected information when required by law, when we have your permission, when needed to protect our rights, privacy, safety, users, or the general public, and when necessary to enforce these terms, WMF’s general <a class=\"twl-links\" href=\"https://foundation.wikimedia.org/wiki/Terms_of_Use\">Terms of Use</a>, or any other WMF policy."
+msgstr "収集したいずれの情報も必要なとき、すなわち法の求めに応じ、利用者の同意のあるとき、（WMFの）権利や個人情報保護あるいは安全や利用者もしくは一般利用者の擁護に必要なとき、さらにこれらの規約ならびにWMFの全般的な<a class=\"twl-links\" href=\"https://foundation.wikimedia.org/wiki/Terms_of_Use\">利用規約</a>もしくはその他のいずれかのWMFの方針を徹底するため開示するものとします。"
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:349
-msgid ""
-"We take the security of your personal data seriously, and take reasonable "
-"precautions to ensure your data is protected. These precautions include "
-"access controls to limit who has access to your data and security "
-"technologies to protect data stored on the server. However, we cannot "
-"guarantee the safety of your data as it is transmitted and stored."
-msgstr ""
-"利用者の個人情報のセキュリティを非常に重視しており、利用者のデータ保護を確実"
-"にするため、合理的な予防策を講じます。その予防措置にはデータにアクセスできる"
-"利用者を制限するアクセス制御と、サーバに格納されたデータを保護するセキュリ"
-"ティ技術が含まれます。ただしデータの安全性はその送信および保存に際して保証で"
-"きません。"
+msgid "We take the security of your personal data seriously, and take reasonable precautions to ensure your data is protected. These precautions include access controls to limit who has access to your data and security technologies to protect data stored on the server. However, we cannot guarantee the safety of your data as it is transmitted and stored."
+msgstr "利用者の個人情報のセキュリティを非常に重視しており、利用者のデータ保護を確実にするため、合理的な予防策を講じます。その予防措置にはデータにアクセスできる利用者を制限するアクセス制御と、サーバに格納されたデータを保護するセキュリティ技術が含まれます。ただしデータの安全性はその送信および保存に際して保証できません。"
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:360
-msgid ""
-"Please note that these terms do not control the use and handling of your "
-"data by the publishers and service providers whose resources you access or "
-"apply to access. Please read their individual privacy policies for that "
-"information."
-msgstr ""
-"これらの規約は利用者がアクセスまたはアクセス権を申請する情報源の出版社ならび"
-"にサービス提供者による利用者のデータの使用と取り扱いを制御するものではありま"
-"せん。その情報は、先方の個別の個人情報方針をお読みください。"
+msgid "Please note that these terms do not control the use and handling of your data by the publishers and service providers whose resources you access or apply to access. Please read their individual privacy policies for that information."
+msgstr "これらの規約は利用者がアクセスまたはアクセス権を申請する情報源の出版社ならびにサービス提供者による利用者のデータの使用と取り扱いを制御するものではありません。その情報は、先方の個別の個人情報方針をお読みください。"
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:368
@@ -3823,49 +2845,18 @@ msgstr "重要なご注意："
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Wikimedia Foundation should not be translated. Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:373
-msgid ""
-"The Wikimedia Foundation is a nonprofit organization based in San Francisco, "
-"California. The Wikipedia Library program provides access to resources held "
-"by publishers in multiple countries. If you apply for a Wikipedia Library "
-"account (whether you are inside or outside of the United States), you "
-"understand that your personal data will be collected, transferred, stored, "
-"processed, disclosed and otherwise used in the U.S. as described in this "
-"privacy policy. You also understand that your information may be transferred "
-"by us from the U.S. to other countries, which may have different or less "
-"stringent data protection laws than your country, in connection with "
-"providing services to you, including evaluating your application and "
-"securing access to your chosen publishers (locations for each publisher are "
-"outlined on their respective partner information pages)."
-msgstr ""
-"ウィキメディア財団は米国カリフォルニア州サンフランシスコに本拠地を置く非営利"
-"活動団体です。ウィキメディア図書館制度は複数国の出版社が所有するリソースの利"
-"用券を提供します。ウィキメディア図書館のアカウント申請 (居住国が米国か外国か"
-"を問わず) 個人情報の収集、送信、保存、処理、開示その他の利用は、この個人情報"
-"方針に示すとおり、米国内で発生することに同意していただきます。さらに利用者情"
-"報は私たちがアメリカから外国へ送信する場合があり、送信先では利用者に提供する"
-"サービスに関して利用者の居住国とはデータ保護関連法が異なるもしくは規制がゆる"
-"い場合があり、その対象として利用者の申請の審査、利用者が選択した出版社への安"
-"全な接続を含みます (個別の出版社の所在地情報はそれぞれの当該情報ページに概説"
-"されます。)"
+msgid "The Wikimedia Foundation is a nonprofit organization based in San Francisco, California. The Wikipedia Library program provides access to resources held by publishers in multiple countries. If you apply for a Wikipedia Library account (whether you are inside or outside of the United States), you understand that your personal data will be collected, transferred, stored, processed, disclosed and otherwise used in the U.S. as described in this privacy policy. You also understand that your information may be transferred by us from the U.S. to other countries, which may have different or less stringent data protection laws than your country, in connection with providing services to you, including evaluating your application and securing access to your chosen publishers (locations for each publisher are outlined on their respective partner information pages)."
+msgstr "ウィキメディア財団は米国カリフォルニア州サンフランシスコに本拠地を置く非営利活動団体です。ウィキメディア図書館制度は複数国の出版社が所有するリソースの利用券を提供します。ウィキメディア図書館のアカウント申請 (居住国が米国か外国かを問わず) 個人情報の収集、送信、保存、処理、開示その他の利用は、この個人情報方針に示すとおり、米国内で発生することに同意していただきます。さらに利用者情報は私たちがアメリカから外国へ送信する場合があり、送信先では利用者に提供するサービスに関して利用者の居住国とはデータ保護関連法が異なるもしくは規制がゆるい場合があり、その対象として利用者の申請の審査、利用者が選択した出版社への安全な接続を含みます (個別の出版社の所在地情報はそれぞれの当該情報ページに概説されます。)"
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:392
-msgid ""
-"Please note that in the event of any differences in meaning or "
-"interpretation between the original English version of these terms and a "
-"translation, the original English version takes precedence."
-msgstr ""
-"もしこれらの規約の英語原文と翻訳文で意味もしくは解釈が異なる場合には、英語原"
-"文が優先される点にご注意ください。"
+msgid "Please note that in the event of any differences in meaning or interpretation between the original English version of these terms and a translation, the original English version takes precedence."
+msgstr "もしこれらの規約の英語原文と翻訳文で意味もしくは解釈が異なる場合には、英語原文が優先される点にご注意ください。"
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Wikimedia Foundation should not be translated.
 #: TWLight/users/templates/users/terms.html:403
-msgid ""
-"See also the <a class=\"twl-links\" href=\"https://wikimediafoundation.org/"
-"wiki/Privacy_policy\">Wikimedia Foundation Privacy Policy</a>."
-msgstr ""
-"合わせて<a class=\"twl-links\" href=\"https://wikimediafoundation.org/wiki/"
-"Privacy_policy\">ウィキメディア財団の個人情報方針</a>もご参照ください。"
+msgid "See also the <a class=\"twl-links\" href=\"https://wikimediafoundation.org/wiki/Privacy_policy\">Wikimedia Foundation Privacy Policy</a>."
+msgstr "合わせて<a class=\"twl-links\" href=\"https://wikimediafoundation.org/wiki/Privacy_policy\">ウィキメディア財団の個人情報方針</a>もご参照ください。"
 
 #. Translators: This is the second to last line of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:412
@@ -3884,16 +2875,8 @@ msgstr "ウィキメディア財団"
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:426
-msgid ""
-"By checking this box and clicking “Submit”, you agree that you have read the "
-"above terms and that you will adhere to the terms of use in your application "
-"to and use of the The Wikipedia Library, and the publishers’ services to "
-"which you gain access through The Wikipedia Library program."
-msgstr ""
-"このチェックボックスにレ点を記入し「提出」を押すと、利用者は上記の規約を通読"
-"したこと、なおかつご自分の利用申請およびその利用において、またウィキペディア"
-"図書館ならびに利用者がウィキペディア図書館プログラムを経由してアクセス権を得"
-"る出版社のサービスにおいて、それぞれの規約順守に同意することに賛成します。"
+msgid "By checking this box and clicking “Submit”, you agree that you have read the above terms and that you will adhere to the terms of use in your application to and use of the The Wikipedia Library, and the publishers’ services to which you gain access through The Wikipedia Library program."
+msgstr "このチェックボックスにレ点を記入し「提出」を押すと、利用者は上記の規約を通読したこと、なおかつご自分の利用申請およびその利用において、またウィキペディア図書館ならびに利用者がウィキペディア図書館プログラムを経由してアクセス権を得る出版社のサービスにおいて、それぞれの規約順守に同意することに賛成します。"
 
 #: TWLight/users/templates/users/user_collection_tile.html:32
 msgid "Remove this collection from favorites"
@@ -3945,41 +2928,19 @@ msgstr "すべてのデータを削除"
 
 #. Translators: This message is displayed on the page where users can request the deletion of their data.
 #: TWLight/users/templates/users/user_confirm_delete.html:17
-msgid ""
-"<b>Warning:</b> Performing this action will delete your Wikipedia Library "
-"Card user account and all associated applications. This process is not "
-"reversible. You may lose any partner accounts you were granted, and will not "
-"be able to renew those accounts or apply for new ones."
-msgstr ""
-"<b>警告：</b> この動作によりウィキペディア図書館カードの利用者アカウントなら"
-"びに関連の申請は削除されます。この手続きは取り消しができません。これまでに認"
-"可された提携組織のアカウントはすべて失効し、更新あるいは新規アカウントの申請"
-"は（訳注：このウェブサイト経由では）できなくなります。"
+msgid "<b>Warning:</b> Performing this action will delete your Wikipedia Library Card user account and all associated applications. This process is not reversible. You may lose any partner accounts you were granted, and will not be able to renew those accounts or apply for new ones."
+msgstr "<b>警告：</b> この動作によりウィキペディア図書館カードの利用者アカウントならびに関連の申請は削除されます。この手続きは取り消しができません。これまでに認可された提携組織のアカウントはすべて失効し、更新あるいは新規アカウントの申請は（訳注：このウェブサイト経由では）できなくなります。"
 
 #. Translators: this should show up for people who log in with a username/password and not OAuth, so we don't know what their Wikipedia identity is.
-#.
 #: TWLight/users/templates/users/user_detail.html:12
 #, python-format
-msgid ""
-"Hi, %(username)s! You don't have a Wikipedia editor profile attached to your "
-"account here, so you are probably a site administrator."
-msgstr ""
-"%(username)sさん、こんにちは。登録されたアカウントにウィキペディア編集者とし"
-"てのプロフィールが付いていないことから、もしかしてさいとの管理者を務めておら"
-"れませんか。"
+msgid "Hi, %(username)s! You don't have a Wikipedia editor profile attached to your account here, so you are probably a site administrator."
+msgstr "%(username)sさん、こんにちは。登録されたアカウントにウィキペディア編集者としてのプロフィールが付いていないことから、もしかしてさいとの管理者を務めておられませんか。"
 
 #. Translators: In the unlikely scenario that someone is able to register an account without using OAuth (thus leaving us without some of the information required for applications), users will see this message, encouraging them to re-register.
 #: TWLight/users/templates/users/user_detail.html:20
-msgid ""
-"If you aren't a site administrator, something weird has happened. You won't "
-"be able to apply for access without a Wikipedia editor profile. You should "
-"log out and create a new account by logging in via OAuth, or contact a site "
-"administrator for help."
-msgstr ""
-"あなたがサイトの管理者ではないとすると、何か正常ではないことが発生しました。"
-"ウィキペディアの編集者としてプロフィールがない場合、アクセス権の申請はできま"
-"せん。ログアウトして再度、OAuth経由でログインし新規アカウントを登録するか、サ"
-"イト管理者に連絡して支援を受けてください。"
+msgid "If you aren't a site administrator, something weird has happened. You won't be able to apply for access without a Wikipedia editor profile. You should log out and create a new account by logging in via OAuth, or contact a site administrator for help."
+msgstr "あなたがサイトの管理者ではないとすると、何か正常ではないことが発生しました。ウィキペディアの編集者としてプロフィールがない場合、アクセス権の申請はできません。ログアウトして再度、OAuth経由でログインし新規アカウントを登録するか、サイト管理者に連絡して支援を受けてください。"
 
 #. Translators: Labels a sections where coordinators can select their email preferences.
 #: TWLight/users/templates/users/user_email_preferences.html:15
@@ -3989,23 +2950,13 @@ msgstr "コーディネーター限定"
 #. Translators: This message is shown on user's own profile page, encouraging them to make sure their information is up to date, so that account coordinators can use the information to judge applications.
 #: TWLight/users/views.py:176
 #, python-brace-format
-msgid ""
-"Please <a class='twl-links' href='{url}'>update your contributions</a> to "
-"Wikipedia to help coordinators evaluate your applications."
-msgstr ""
-"申請の審査を担当するコーディネーターが参照できるよう、ぜひウィキペディアにお"
-"ける<a class='twl-links' href='{url}'>編集実績が最新かどうか確認</a>してくだ"
-"さい。"
+msgid "Please <a class='twl-links' href='{url}'>update your contributions</a> to Wikipedia to help coordinators evaluate your applications."
+msgstr "申請の審査を担当するコーディネーターが参照できるよう、ぜひウィキペディアにおける<a class='twl-links' href='{url}'>編集実績が最新かどうか確認</a>してください。"
 
 #. Translators: Coordinators are shown this message when they unselect all three types of reminder email options under preferences.
 #: TWLight/users/views.py:288
-msgid ""
-"You have chosen not to receive reminder emails. As a coordinator, you should "
-"receive at least one type of reminder emails, so consider changing your "
-"preferences."
-msgstr ""
-"確認メールが受信拒否に設定してあります。連絡係である以上、最低でも確認メール"
-"を1種類は受信する必要があり、ぜひ個人設定の変更をご検討ください。"
+msgid "You have chosen not to receive reminder emails. As a coordinator, you should receive at least one type of reminder emails, so consider changing your preferences."
+msgstr "確認メールが受信拒否に設定してあります。連絡係である以上、最低でも確認メールを1種類は受信する必要があり、ぜひ個人設定の変更をご検討ください。"
 
 #. Translators: Coordinators are shown this message when they make changes to their reminder email options under preferences.
 #: TWLight/users/views.py:296
@@ -4028,9 +2979,7 @@ msgstr "個人情報が更新されました。"
 #. Translators: If a user tries to save the 'email change form' without entering one and checking the 'use my Wikipedia email address' checkbox, this message is presented.
 #: TWLight/users/views.py:448
 msgid "Both the values cannot be blank. Either enter a email or check the box."
-msgstr ""
-"どちらの値も記入が必須です。メールアドレスを記入するかボックスを押して色を変"
-"えてください。"
+msgstr "どちらの値も記入が必須です。メールアドレスを記入するかボックスを押して色を変えてください。"
 
 #. Translators: Shown to users when they successfully modify their email. Don't translate {email}.
 #: TWLight/users/views.py:476
@@ -4040,12 +2989,8 @@ msgstr "メールアドレスが{email}に変更されました。"
 
 #. Translators: If the user has not filled out their email, they can browse the website but cannot apply for access to resources.
 #: TWLight/users/views.py:487
-msgid ""
-"Your email is blank. You can still explore the site, but you won't be able "
-"to apply for access to partner resources without an email."
-msgstr ""
-"メールアドレス欄が空欄です。サイト内を閲覧することはできても、メールアドレス"
-"の登録をするまで提携組織の情報源にアクセス権を申請できません。"
+msgid "Your email is blank. You can still explore the site, but you won't be able to apply for access to partner resources without an email."
+msgstr "メールアドレス欄が空欄です。サイト内を閲覧することはできても、メールアドレスの登録をするまで提携組織の情報源にアクセス権を申請できません。"
 
 #. Translators: This message is shown once the access to a partner has successfully been returned.
 #: TWLight/users/views.py:801
@@ -4077,31 +3022,3 @@ msgstr "現状でブロックを受けていないこと"
 msgid "10+ edits in the last 30 days"
 msgstr "直近30日間に10回以上の編集実績があること"
 
-#: tests/shunit/data/bad_i18n_comment_1.py:3
-#: tests/shunit/data/bad_i18n_newline_1.py:5
-msgid "1"
-msgstr ""
-
-#. Translators: Lorem ipsum dolor sit amet, consectetur adipiscing elit. Mauris vitae ipsum ut purus faucibus pretium. Proin tempus neque et aliquet consectetur. Ut egestas sapien in consectetur sagittis. Mauris neque lacus, dapibus non viverra vitae, interdum ut aenean ipsum.
-#. Translators: Lorem ipsum dolor sit amet, consectetur adipiscing elit. Mauris vitae ipsum ut purus faucibus pretium. Proin tempus neque et aliquet consectetur. Ut egestas sapien in consectetur sagittis. Mauris neque lacus, dapibus non.
-#: tests/shunit/data/bad_i18n_comment_2.py:4
-#: tests/shunit/data/bad_i18n_newline_2.py:5 tests/shunit/data/good_i18n_1.py:2
-#: tests/shunit/data/good_i18n_2.py:2
-msgid "2"
-msgstr ""
-
-#: tests/shunit/data/bad_i18n_newline_3.py:5
-msgid "3"
-msgstr ""
-
-#: tests/shunit/data/bad_i18n_newline_4.py:5
-msgid "4"
-msgstr ""
-
-#: tests/shunit/data/bad_i18n_newline_5.py:5
-msgid "5"
-msgstr ""
-
-#: tests/shunit/data/bad_i18n_newline_6.py:5
-msgid "6"
-msgstr ""

--- a/locale/ko/LC_MESSAGES/django.po
+++ b/locale/ko/LC_MESSAGES/django.po
@@ -14,10 +14,11 @@
 # Author: 아라
 msgid ""
 msgstr ""
+""
 "Project-Id-Version: Wikipedia Library Card Platform - Website\n"
-"Report-Msgid-Bugs-To: wikipedialibrary@wikimedia.org\n"
+"Report-Msgid-Bugs-To: translatewiki.net\n"
 "POT-Creation-Date: 2024-07-11 20:54+0000\n"
-"PO-Revision-Date: 2024-07-11 12:30:16+0000\n"
+"PO-Revision-Date: 2024-07-15 12:29:16+0000\n"
 "Language: ko\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
@@ -49,9 +50,7 @@ msgstr "내 정보"
 #. Translators: This note appears in a section of a form where we ask users to enter info (like country of residence) when applying for resource access.
 #: TWLight/applications/forms.py:179
 #, python-brace-format
-msgid ""
-"<p><small><i>Your personal data will be processed according to our <a "
-"class='twl-links' href='{terms_url}'> privacy policy</a>.</i></small></p>"
+msgid "<p><small><i>Your personal data will be processed according to our <a class='twl-links' href='{terms_url}'> privacy policy</a>.</i></small></p>"
 msgstr ""
 
 #. Translators: This is the title of the application form page, where users enter information required for the application. It lets the user know which partner application they are entering data for. {partner}
@@ -93,9 +92,7 @@ msgstr "파트너 웹사이트의 내 계정 이메일"
 #. Translators: This labels a choice field where users will have to select the number of months they wish to have their access for as part of the application renewal confirmation.
 #. Translators: When filling out an application, users may be required to enter the length of the account (expiry) they wish to have for proxy partners.
 #: TWLight/applications/forms.py:339 TWLight/applications/helpers.py:100
-msgid ""
-"The number of months you wish to have this access for before renewal is "
-"required"
+msgid "The number of months you wish to have this access for before renewal is required"
 msgstr ""
 
 #. Translators: When filling out an application, users may need to specify their name
@@ -184,9 +181,7 @@ msgstr "이메일"
 
 #. Translators: This comment is added to pending applications when our terms of use change.
 #: TWLight/applications/management/commands/notify_applicants_tou_changes.py:54
-msgid ""
-"Our terms of use have changed. Your applications will not be processed until "
-"you log in and agree to our updated terms."
+msgid "Our terms of use have changed. Your applications will not be processed until you log in and agree to our updated terms."
 msgstr ""
 
 #. Translators: This is the status of an application that has not yet been reviewed.
@@ -253,23 +248,17 @@ msgstr "접근 URL: {access_url}"
 
 #. Translators: This text goes into account approval emails in the case that we need to send the user's details to a publisher for manual account setup.
 #: TWLight/applications/models.py:331
-msgid ""
-"You can expect to receive access details within a week or two once it has "
-"been processed."
+msgid "You can expect to receive access details within a week or two once it has been processed."
 msgstr ""
 
 #. Translators: This comment is added to open applications when a partner joins the Library Bundle, which does not require applications.
 #: TWLight/applications/signals.py:247
-msgid ""
-"This partner joined the Library Bundle, which does not require applications. "
-"This application will be marked as invalid."
+msgid "This partner joined the Library Bundle, which does not require applications. This application will be marked as invalid."
 msgstr ""
 
 #. Translators: This is shown to users if the application is to a partner for which we have run out of available accounts. The application is therefore on a 'waitlist', and will be reviewed when more accounts are available.
 #: TWLight/applications/templates/applications/application_evaluation.html:29
-msgid ""
-"This application is on the waitlist because this partner does not have any "
-"access grants available at this time."
+msgid "This application is on the waitlist because this partner does not have any access grants available at this time."
 msgstr ""
 
 #. Translators: This message is shown on pages where coordinators can see personal information about applicants.
@@ -277,9 +266,7 @@ msgstr ""
 #: TWLight/applications/templates/applications/application_list_include.html:6
 #: TWLight/applications/templates/applications/send_partner.html:45
 #: TWLight/resources/templates/resources/partner_users.html:18
-msgid ""
-"Coordinators: This page may contain personal information such as real names "
-"and email addresses. Please remember that this information is confidential."
+msgid "Coordinators: This page may contain personal information such as real names and email addresses. Please remember that this information is confidential."
 msgstr ""
 
 #. Translators: This is the title of the application page shown to users who are a coordinator, and are able to accept or reject the application.
@@ -289,9 +276,7 @@ msgstr ""
 
 #. Translators: This text is shown to coordinators on application pages if the applicant has restricted processing of their data.
 #: TWLight/applications/templates/applications/application_evaluation.html:42
-msgid ""
-"This user has requested a restriction on the processing of their data, so "
-"you cannot change the status of their application."
+msgid "This user has requested a restriction on the processing of their data, so you cannot change the status of their application."
 msgstr ""
 
 #. Translators: This is the title of the application page shown to users who are not a coordinator.
@@ -365,9 +350,7 @@ msgstr "알 수 없음"
 
 #. Translators: This is the text displayed to coordinators when an applicant has no country of residence in their profile.
 #: TWLight/applications/templates/applications/application_evaluation.html:123
-msgid ""
-"Please request the applicant add their country of residence to their profile "
-"before proceeding further."
+msgid "Please request the applicant add their country of residence to their profile before proceeding further."
 msgstr ""
 
 #. Translators: This labels the section of an application showing the total number of accounts available for a partner or their collection.
@@ -378,12 +361,8 @@ msgstr "사용 가능한 계정"
 #. Translators: This labels the section of an application showing whether the user had agreed to the terms of use or not.
 #: TWLight/applications/templates/applications/application_evaluation.html:145
 #, python-format
-msgid ""
-"Has agreed to the site's <a class=\"twl-links\" href=\"%(terms_url)s\">terms "
-"of use</a>?"
-msgstr ""
-"사이트의 <a class=\"twl-links\" href=\"%(terms_url)s\">이용 약관</a>에 동의하"
-"셨나요?"
+msgid "Has agreed to the site's <a class=\"twl-links\" href=\"%(terms_url)s\">terms of use</a>?"
+msgstr "사이트의 <a class=\"twl-links\" href=\"%(terms_url)s\">이용 약관</a>에 동의하셨나요?"
 
 #. Translators: Displayed to coordinators when they've agreed to the terms of use.
 #. Translators: Displayed if the user has agreed to the terms of use.
@@ -418,9 +397,7 @@ msgstr "아니오"
 
 #. Translators: This is the text displayed to coordinators when an applicant has not agreed to the terms of use.
 #: TWLight/applications/templates/applications/application_evaluation.html:159
-msgid ""
-"Please request the applicant agree to the site's terms of use before "
-"approving this application."
+msgid "Please request the applicant agree to the site's terms of use before approving this application."
 msgstr ""
 
 #. Translators: This labels the section of an application containing the user's motivation for wanting access to this resource.
@@ -441,11 +418,8 @@ msgstr ""
 #. Translators: This message is shown next to the 'Renewal of existing access grant?' label if the application is a renewal. Don't translate HTML tags or parent_url.
 #: TWLight/applications/templates/applications/application_evaluation.html:195
 #, python-format
-msgid ""
-"Yes (<a class=\"twl-links\" href=\"%(parent_url)s\">previous application</a>)"
-msgstr ""
-"언제든지 데이터를 <a class=\"twl-links\" href=\"%(parent_url)s\">업데이트하거"
-"나 삭제</a>할 수 있습니다."
+msgid "Yes (<a class=\"twl-links\" href=\"%(parent_url)s\">previous application</a>)"
+msgstr "언제든지 데이터를 <a class=\"twl-links\" href=\"%(parent_url)s\">업데이트하거나 삭제</a>할 수 있습니다."
 
 #. Translators: This labels the section of the application showing the length of access remaining on the user's previous authorization.
 #: TWLight/applications/templates/applications/application_evaluation.html:208
@@ -479,9 +453,7 @@ msgstr "댓글 추가"
 
 #. Translators: On an application page, this text tells users that the comments posted on the application are visible to coordinators and the submitting user only.
 #: TWLight/applications/templates/applications/application_evaluation.html:297
-msgid ""
-"Comments are visible to all coordinators and to the editor who submitted "
-"this application."
+msgid "Comments are visible to all coordinators and to the editor who submitted this application."
 msgstr ""
 
 #. Translators: This is the title of the section of an application page which lists information about the user who submitted the application.
@@ -693,12 +665,7 @@ msgstr "상태 설정"
 
 #: TWLight/applications/templates/applications/apply.html:20
 #, python-format
-msgid ""
-"If your application is successful we may share your email address with "
-"%(partner)s. This is required to set up your access to their resources. By "
-"submitting this form you agree to allow your email address to be shared with "
-"%(partner)s if your application is successful, for the purposes of account "
-"setup."
+msgid "If your application is successful we may share your email address with %(partner)s. This is required to set up your access to their resources. By submitting this form you agree to allow your email address to be shared with %(partner)s if your application is successful, for the purposes of account setup."
 msgstr ""
 
 #. Translators: This message is displayed on the page where users can confirm their renewal. Please do not translate partner.
@@ -727,9 +694,7 @@ msgstr "어느 자원에 접근하시겠습니까?"
 
 #. Translators: This text explains that Library Bundle partners are not shown in this list.
 #: TWLight/applications/templates/applications/request_for_application.html:26
-msgid ""
-"Library Bundle partners are not shown as eligibility is determined "
-"automatically."
+msgid "Library Bundle partners are not shown as eligibility is determined automatically."
 msgstr ""
 
 #. Translators: On the page where users can apply for multiple partners, this message shows next to the partner name, taking them to the full application page when clicked.
@@ -744,10 +709,7 @@ msgstr ""
 
 #. Translators: the HTML is so that the word 'waitlisted' will look the same as it does in the page above; please translate 'waitlisted' the same way you did elsewhere in this file.
 #: TWLight/applications/templates/applications/request_for_application.html:74
-msgid ""
-"You can apply to <span class=\"badge badge-warning\">Waitlisted</span> "
-"partners, but they don't have access grants available right now. We will "
-"process those applications when access becomes available."
+msgid "You can apply to <span class=\"badge badge-warning\">Waitlisted</span> partners, but they don't have access grants available right now. We will process those applications when access becomes available."
 msgstr ""
 
 #. Translators: On the page where coordinators can see approved applications which have not had their details sent to the partner, this message shows when there are applications ready to be processed.
@@ -769,9 +731,7 @@ msgstr ""
 #. Translators: This message is shown when applications exceed the number of accounts available.
 #: TWLight/applications/templates/applications/send_partner.html:54
 #, python-format
-msgid ""
-"Application(s) for %(object)s, if sent, will exceed the total available "
-"accounts for the partner. Please proceed at your own discretion."
+msgid "Application(s) for %(object)s, if sent, will exceed the total available accounts for the partner. Please proceed at your own discretion."
 msgstr ""
 
 #. Translators: When viewing the list of applications ready to be sent for a particular partner, this is instructions for the coordinator to click the 'mark as sent' button after they have sent the information.
@@ -788,9 +748,7 @@ msgstr[0] "연락처"
 
 #. Translators: When viewing the list of applications ready to be sent for a particular partner, this message shows if there is no information about who the applications should be sent to. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/applications/templates/applications/send_partner.html:89
-msgid ""
-"Whoops, we don't have any listed contacts. Please notify Wikipedia Library "
-"administrators."
+msgid "Whoops, we don't have any listed contacts. Please notify Wikipedia Library administrators."
 msgstr ""
 
 #. Translators: When viewing the list of applications ready to be sent for a particular partner, this is the title of the section containing the information about those applications.
@@ -806,9 +764,7 @@ msgstr "보낸 것으로 표시"
 
 #. Translators: This text guides coordinators in using the code sending interface for approved applications.
 #: TWLight/applications/templates/applications/send_partner.html:152
-msgid ""
-"Use the dropdown menus to denote which editor will receive each code. Access "
-"codes will be sent to users automatically."
+msgid "Use the dropdown menus to denote which editor will receive each code. Access codes will be sent to users automatically."
 msgstr ""
 
 #. Translators: This labels a drop-down selection where staff can assign an access code to a user.
@@ -824,18 +780,13 @@ msgstr ""
 #. Translators: When a user applies for a set of resources, they receive this message if none are currently available. They are instead placed on a 'waitlist' for later approval.
 #. Translators: When a user renews their resource, they receive this message if none are currently available. They are instead placed on a 'waitlist' for later approval.
 #: TWLight/applications/views.py:140 TWLight/applications/views.py:1282
-msgid ""
-"This partner does not have any access grants available at this time. You may "
-"still apply for access; your application will be reviewed when access grants "
-"become available."
+msgid "This partner does not have any access grants available at this time. You may still apply for access; your application will be reviewed when access grants become available."
 msgstr ""
 
 #. Translators: This message is shown to users once they've successfully submitted their application for review.
 #: TWLight/applications/views.py:163
 #, python-brace-format
-msgid ""
-"Your application has been submitted for review. Head over to <a "
-"href='{applications_url}'>My Applications</a> to view the status."
+msgid "Your application has been submitted for review. Head over to <a href='{applications_url}'>My Applications</a> to view the status."
 msgstr ""
 
 #. Translators: This text is displayed to users when the user has chosen to restrict data and is trying to apply for multiple partners
@@ -884,16 +835,12 @@ msgstr ""
 
 #. Translators: After a coordinator has changed the status of an application to APPROVED, if the corresponding partner/collection is waitlisted this message appears.
 #: TWLight/applications/views.py:756
-msgid ""
-"Cannot approve application as partner with proxy authorization method is "
-"waitlisted."
+msgid "Cannot approve application as partner with proxy authorization method is waitlisted."
 msgstr ""
 
 #. Translators: After a coordinator has changed the status of an application to APPROVED, if the corresponding partner/collection has no accounts for distribution, this message appears.
 #: TWLight/applications/views.py:780
-msgid ""
-"Cannot approve application as partner with proxy authorization method is "
-"waitlisted and (or) has zero accounts available for distribution."
+msgid "Cannot approve application as partner with proxy authorization method is waitlisted and (or) has zero accounts available for distribution."
 msgstr ""
 
 #. Translators: This message appears on an "access denied" screen that stops users who attempt to authorize an editor to access a resource during a time period for which they are already authorized.
@@ -904,11 +851,7 @@ msgstr ""
 #. Translators: This message is shown to users when they access an application page of a now Bundle partner (new applications aren't allowed for Bundle partners and the status of old applications cannot be modified)
 #: TWLight/applications/views.py:857
 #, python-brace-format
-msgid ""
-"This application cannot be modified since this partner is now part of our <a "
-"href='{bundle}'>bundle access</a>. If you are eligible, you can access this "
-"resource from <a href='{library}'>your library</a>. <a "
-"href='{contact}'>Contact us</a> if you have any questions."
+msgid "This application cannot be modified since this partner is now part of our <a href='{bundle}'>bundle access</a>. If you are eligible, you can access this resource from <a href='{library}'>your library</a>. <a href='{contact}'>Contact us</a> if you have any questions."
 msgstr ""
 
 #. Translators: this lets a reviewer set the status of a single application.
@@ -918,9 +861,7 @@ msgstr ""
 
 #. Translators: This warning is message is shown to applicants when the number of pending applications is greater than the number of accounts available.
 #: TWLight/applications/views.py:891
-msgid ""
-"There are more pending applications than available accounts. Your "
-"application might get waitlisted."
+msgid "There are more pending applications than available accounts. Your application might get waitlisted."
 msgstr ""
 
 #. Translators: this message is shown to coordinators who attempt to change an application's Status from INVALID to any other Status.
@@ -940,11 +881,7 @@ msgstr "애플리케이션 {} 일괄 업데이트에 성공했습니다."
 
 #. Translators: After a coordinator has changed the status of a number of applications to APPROVED, if the corresponding partner(s) is/are waitlisted or has no accounts for distribution, this message appears.
 #: TWLight/applications/views.py:1051
-msgid ""
-"Cannot approve application(s) {} as partner(s) with proxy authorization "
-"method is/are waitlisted and (or) has/have not enough accounts available. If "
-"not enough accounts are available, prioritise the applications and then "
-"approve applications equal to the accounts available."
+msgid "Cannot approve application(s) {} as partner(s) with proxy authorization method is/are waitlisted and (or) has/have not enough accounts available. If not enough accounts are available, prioritise the applications and then approve applications equal to the accounts available."
 msgstr ""
 
 #. Translators: This message is shown to coordinators who attempt to assign the same access code to multiple users.
@@ -959,9 +896,7 @@ msgstr ""
 
 #. Translators: When a user tries to renew their resource, they receive this message if the partner is not available.
 #: TWLight/applications/views.py:1272
-msgid ""
-"Cannot renew application at this time as partner is not available. Please "
-"check back later, or contact us for more information."
+msgid "Cannot renew application at this time as partner is not available. Please check back later, or contact us for more information."
 msgstr ""
 
 #. Translators: This message is displayed when an attempt by a user to renew an application has been denied for some reason.
@@ -972,16 +907,12 @@ msgstr ""
 
 #. Translators: If a user requests the renewal of their account, but it wasn't renewed, this message is shown to them.
 #: TWLight/applications/views.py:1385
-msgid ""
-"This object cannot be renewed. (This probably means that you have already "
-"requested that it be renewed.)"
+msgid "This object cannot be renewed. (This probably means that you have already requested that it be renewed.)"
 msgstr ""
 
 #. Translators: If a user requests the renewal of their account, this message is shown to them.
 #: TWLight/applications/views.py:1395
-msgid ""
-"Your renewal request has been received. A coordinator will review your "
-"request."
+msgid "Your renewal request has been received. A coordinator will review your request."
 msgstr ""
 
 #. Translators: This labels a textfield where users can enter their email ID.
@@ -991,9 +922,7 @@ msgstr "내 이메일"
 
 #. Translators: This is the help text for the email field in the contact us form letting users know the field is updated by value pulled from their respective user profiles.
 #: TWLight/emails/forms.py:21
-msgid ""
-"This field is automatically updated with the email from your <a class='twl-"
-"links' href='{}'>user profile</a>."
+msgid "This field is automatically updated with the email from your <a class='twl-links' href='{}'>user profile</a>."
 msgstr ""
 
 #. Translators: This labels a textfield where users can enter their email message.
@@ -1017,19 +946,13 @@ msgstr "제출"
 #. Translators: This email is sent to users with their access code. Don't translate Jinja variables in curly braces like user or partner. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/access_code_email-body-html.html:5
 #, python-format
-msgid ""
-"<p>Your approved application to %(partner)s has now been finalised. Your "
-"access code or login details can be found below:</p> <p><b>%(access_code)s</"
-"b></p> <p>%(user_instructions)s</p>"
+msgid "<p>Your approved application to %(partner)s has now been finalised. Your access code or login details can be found below:</p> <p><b>%(access_code)s</b></p> <p>%(user_instructions)s</p>"
 msgstr ""
 
 #. Translators: This email is sent to users with their access code. Don't translate Jinja variables in curly braces like user or partner. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/access_code_email-body-text.html:3
 #, python-format
-msgid ""
-"Your approved application to %(partner)s has now been finalised. Your access "
-"code or login details can be found below: %(access_code)s "
-"%(user_instructions)s"
+msgid "Your approved application to %(partner)s has now been finalised. Your access code or login details can be found below: %(access_code)s %(user_instructions)s"
 msgstr ""
 
 #. Translators: This is the subject line of an email sent to users with their access code.
@@ -1040,23 +963,13 @@ msgstr "위키백과 도서관 접근 코드"
 #. Translators: This email is sent to users when their application is approved. Don't translate Jinja variables in curly braces like user or partner; don't translate html tags either. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/approval_notification-body-html.html:5
 #, python-format
-msgid ""
-"<p>Dear %(user)s,</p> <p>Thank you for applying for access to %(partner)s "
-"resources through The Wikipedia Library. We are happy to inform you that "
-"your application has been approved.</p> <p>%(user_instructions)s</p> <p>You "
-"can view the collections you're authorized to access at My Library: "
-"%(link)s</p> <p>Cheers!</p> <p>The Wikipedia Library</p>"
+msgid "<p>Dear %(user)s,</p> <p>Thank you for applying for access to %(partner)s resources through The Wikipedia Library. We are happy to inform you that your application has been approved.</p> <p>%(user_instructions)s</p> <p>You can view the collections you're authorized to access at My Library: %(link)s</p> <p>Cheers!</p> <p>The Wikipedia Library</p>"
 msgstr ""
 
 #. Translators: This email is sent to users when their application is approved. Don't translate Jinja variables in curly braces like user or partner. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/approval_notification-body-text.html:3
 #, python-format
-msgid ""
-"Dear %(user)s, Thank you for applying for access to %(partner)s resources "
-"through The Wikipedia Library. We are happy to inform you that your "
-"application has been approved. %(user_instructions)s You can view the "
-"collections you're authorized to access at My Library: %(link)s Cheers! The "
-"Wikipedia Library"
+msgid "Dear %(user)s, Thank you for applying for access to %(partner)s resources through The Wikipedia Library. We are happy to inform you that your application has been approved. %(user_instructions)s You can view the collections you're authorized to access at My Library: %(link)s Cheers! The Wikipedia Library"
 msgstr ""
 
 #. Translators: This is the subject of an email which is sent to users when their application has been approved. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
@@ -1067,19 +980,13 @@ msgstr ""
 #. Translators: This email is sent to coordinators when a comment is left on an application they are processing. Don't translate Jinja variables in curly braces like user or partner. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/comment_notification_coordinator-body-html.html:5
 #, python-format
-msgid ""
-"<p style=\"color: #500050\">%(submit_date)s - %(commenter)s</p> "
-"<blockquote><p>%(comment)s</p></blockquote> <p>Please reply to these at: <a "
-"href=\"%(app_url)s\">%(app_url)s</a></p> <p>Best,</p> <p>The Wikipedia "
-"Library</p>"
+msgid "<p style=\"color: #500050\">%(submit_date)s - %(commenter)s</p> <blockquote><p>%(comment)s</p></blockquote> <p>Please reply to these at: <a href=\"%(app_url)s\">%(app_url)s</a></p> <p>Best,</p> <p>The Wikipedia Library</p>"
 msgstr ""
 
 #. Translators: This email is sent to coordinators when a comment is left on an application they are processing. Don't translate Jinja variables in curly braces like user or partner. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/comment_notification_coordinator-body-text.html:3
 #, python-format
-msgid ""
-"%(submit_date)s - %(commenter)s %(comment)s Please reply to this at: "
-"%(app_url)s Best, The Wikipedia Library"
+msgid "%(submit_date)s - %(commenter)s %(comment)s Please reply to this at: %(app_url)s Best, The Wikipedia Library"
 msgstr ""
 
 #. Translators: This is the subject line of an email sent to coordinators when a comment is left on an application they processed.
@@ -1090,19 +997,13 @@ msgstr ""
 #. Translators: This email is sent to users when they receive a comment on their application. Don't translate Jinja variables in curly braces like user or partner; don't translate html tags either. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/comment_notification_editors-body-html.html:5
 #, python-format
-msgid ""
-"<p style=\"color: #500050\">%(submit_date)s - %(commenter)s</p> "
-"<blockquote><p>%(comment)s</p></blockquote> <p>Please reply to these at <a "
-"href=\"%(app_url)s\">%(app_url)s</a> so we can evaluate your application.</"
-"p> <p>Best,</p> <p>The Wikipedia Library</p>"
+msgid "<p style=\"color: #500050\">%(submit_date)s - %(commenter)s</p> <blockquote><p>%(comment)s</p></blockquote> <p>Please reply to these at <a href=\"%(app_url)s\">%(app_url)s</a> so we can evaluate your application.</p> <p>Best,</p> <p>The Wikipedia Library</p>"
 msgstr ""
 
 #. Translators: This email is sent to users when they receive a comment on their application. Don't translate Jinja variables in curly braces like user or partner. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/comment_notification_editors-body-text.html:3
 #, python-format
-msgid ""
-"%(submit_date)s - %(commenter)s %(comment)s Please reply to these at: "
-"%(app_url)s so we can evaluate your application. Best, The Wikipedia Library"
+msgid "%(submit_date)s - %(commenter)s %(comment)s Please reply to these at: %(app_url)s so we can evaluate your application. Best, The Wikipedia Library"
 msgstr ""
 
 #. Translators: This is the subject line of an email sent to users who have a comment added to one of their applications. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
@@ -1113,18 +1014,13 @@ msgstr "내 위키백과 도서관 애플리케이션에 새로운 댓글이 있
 #. Translators: This email is sent to users when an application they commented on receives another comment. Don't translate Jinja variables in curly braces like app_url; don't translate html tags either. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/comment_notification_others-body-html.html:5
 #, python-format
-msgid ""
-"<p style=\"color: #500050\">%(submit_date)s - %(commenter)s</p> "
-"<blockquote><p>%(comment)s</p></blockquote> See it at <a href=\"%(app_url)s"
-"\">%(app_url)s</a>. Thanks for helping review Wikipedia Library applications!"
+msgid "<p style=\"color: #500050\">%(submit_date)s - %(commenter)s</p> <blockquote><p>%(comment)s</p></blockquote> See it at <a href=\"%(app_url)s\">%(app_url)s</a>. Thanks for helping review Wikipedia Library applications!"
 msgstr ""
 
 #. Translators: This email is sent to users when an application they commented on receives another comment. Don't translate Jinja variables in curly braces like app_url. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/comment_notification_others-body-text.html:3
 #, python-format
-msgid ""
-"%(submit_date)s - %(commenter)s %(comment)s See it at: %(app_url)s Thanks "
-"for helping review Wikipedia Library applications!"
+msgid "%(submit_date)s - %(commenter)s %(comment)s See it at: %(app_url)s Thanks for helping review Wikipedia Library applications!"
 msgstr ""
 
 #. Translators: This is the subject line of an email sent to users who have a comment added to an application they also commented on. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
@@ -1135,13 +1031,8 @@ msgstr ""
 #. Translators: This text is part of a scheduled reminder email sent to coordinators who have applications requiring action. Don't translate Jinja variables in curly braces like total_apps, or user.
 #: TWLight/emails/templates/emails/coordinator_reminder_notification-body-html.html:5
 #, python-format
-msgid ""
-"<p>Dear %(user)s,</p> <p>Our records indicate that you are the designated "
-"coordinator for partners that have a total of %(total_apps)s applications.</"
-"p>"
-msgstr ""
-"<p>%(user)s님, </p> <p>저희의 기록에 따르면 귀하는 총 %(total_apps)s 응용 프"
-"로그램을 보유한 파트너의 지정된 조정자입니다.</p>"
+msgid "<p>Dear %(user)s,</p> <p>Our records indicate that you are the designated coordinator for partners that have a total of %(total_apps)s applications.</p>"
+msgstr "<p>%(user)s님, </p> <p>저희의 기록에 따르면 귀하는 총 %(total_apps)s 응용 프로그램을 보유한 파트너의 지정된 조정자입니다.</p>"
 
 #. Translators: Breakdown as in 'cost breakdown'; analysis.
 #: TWLight/emails/templates/emails/coordinator_reminder_notification-body-html.html:11
@@ -1176,31 +1067,19 @@ msgstr[0] "%(counter)s개의 승인된 신청."
 #. Translators: This text is part of a scheduled reminder email sent to coordinators who have applications requiring action. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library). Don't translate Jinja variables in curly braces like link; don't translate email addresses or html tags either.
 #: TWLight/emails/templates/emails/coordinator_reminder_notification-body-html.html:39
 #, python-format
-msgid ""
-"<p>This is a gentle reminder that you may review applications at <a href="
-"\"%(link)s\">%(link)s</a>.</p> <p>You can customise your reminders under "
-"'preferences' in your user profile.</p> <p>If you received this message in "
-"error, drop us a line at wikipedialibrary@wikimedia.org.</p> <p>Thanks for "
-"helping review Wikipedia Library applications!</p>"
+msgid "<p>This is a gentle reminder that you may review applications at <a href=\"%(link)s\">%(link)s</a>.</p> <p>You can customise your reminders under 'preferences' in your user profile.</p> <p>If you received this message in error, drop us a line at wikipedialibrary@wikimedia.org.</p> <p>Thanks for helping review Wikipedia Library applications!</p>"
 msgstr ""
 
 #. Translators: This text is part of a scheduled reminder email sent to coordinators who have applications requiring action. Don't translate Jinja variables in curly braces like total_apps, or user.
 #: TWLight/emails/templates/emails/coordinator_reminder_notification-body-text.html:3
 #, python-format
-msgid ""
-"Dear %(user)s, Our records indicate that you are the designated coordinator "
-"for partners that have a total of %(total_apps)s applications."
+msgid "Dear %(user)s, Our records indicate that you are the designated coordinator for partners that have a total of %(total_apps)s applications."
 msgstr ""
 
 #. Translators: This text is part of a scheduled reminder email sent to coordinators who have applications requiring action. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library). Don't translate Jinja variables in curly braces like link; don't translate the email address either.
 #: TWLight/emails/templates/emails/coordinator_reminder_notification-body-text.html:38
 #, python-format
-msgid ""
-"This is a gentle reminder that you may review applications at: %(link)s. You "
-"can customise your reminders under 'preferences' in your user profile. If "
-"you received this message in error, drop us a line at: "
-"wikipedialibrary@wikimedia.org Thanks for helping review Wikipedia Library "
-"applications!"
+msgid "This is a gentle reminder that you may review applications at: %(link)s. You can customise your reminders under 'preferences' in your user profile. If you received this message in error, drop us a line at: wikipedialibrary@wikimedia.org Thanks for helping review Wikipedia Library applications!"
 msgstr ""
 
 #. Translators: This is the subject line of a scheduled reminder email sent to coordinators who have applications to review. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library). Do not translate items in curly braces.
@@ -1211,22 +1090,13 @@ msgstr ""
 #. Translators: This email is sent to users when their application is rejected. Don't translate Jinja variables in curly braces like user or partner; don't translate html tags either. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/rejection_notification-body-html.html:5
 #, python-format
-msgid ""
-"<p>Dear %(user)s,</p> <p>Thank you for applying for access to %(partner)s "
-"resources through The Wikipedia Library. Unfortunately at this time your "
-"application has not been approved. You can view your application and review "
-"comments at <a href=\"%(app_url)s\">%(app_url)s</a>.</p> <p>Best,</p> <p>The "
-"Wikipedia Library</p>"
+msgid "<p>Dear %(user)s,</p> <p>Thank you for applying for access to %(partner)s resources through The Wikipedia Library. Unfortunately at this time your application has not been approved. You can view your application and review comments at <a href=\"%(app_url)s\">%(app_url)s</a>.</p> <p>Best,</p> <p>The Wikipedia Library</p>"
 msgstr ""
 
 #. Translators: This email is sent to users when their application is rejected. Don't translate Jinja variables in curly braces like user or partner. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/rejection_notification-body-text.html:3
 #, python-format
-msgid ""
-"Dear %(user)s, Thank you for applying for access to %(partner)s resources "
-"through The Wikipedia Library. Unfortunately at this time your application "
-"has not been approved. You can view your application and review comments at: "
-"%(app_url)s Best, The Wikipedia Library"
+msgid "Dear %(user)s, Thank you for applying for access to %(partner)s resources through The Wikipedia Library. Unfortunately at this time your application has not been approved. You can view your application and review comments at: %(app_url)s Best, The Wikipedia Library"
 msgstr ""
 
 #. Translators: This is the subject of an email which is sent to users when their application has been rejected. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
@@ -1237,25 +1107,13 @@ msgstr "내 위키백과 도서관 애플리케이션"
 #. Translators: This email is sent to users when they have an account that is soon to expire. Don't translate Jinja variables in curly braces like partner_name or partner_link; don't translate html tags either. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/user_renewal_notice-body-html.html:5
 #, python-format
-msgid ""
-"<p>Dear %(user)s,</p> <p>According to our records, your access to "
-"%(partner_name)s will soon expire and you may lose access. If you want to "
-"continue making use of your free account, you can request renewal of your "
-"account by clicking the 'Renew' or 'Extend' button at %(partner_link)s.</p> "
-"<p>Best,</p> <p>The Wikipedia Library</p> <p>You can disable these emails in "
-"your user page preferences: https://wikipedialibrary.wmflabs.org/users/</p>"
+msgid "<p>Dear %(user)s,</p> <p>According to our records, your access to %(partner_name)s will soon expire and you may lose access. If you want to continue making use of your free account, you can request renewal of your account by clicking the 'Renew' or 'Extend' button at %(partner_link)s.</p> <p>Best,</p> <p>The Wikipedia Library</p> <p>You can disable these emails in your user page preferences: https://wikipedialibrary.wmflabs.org/users/</p>"
 msgstr ""
 
 #. Translators: This email is sent to users when they have an account that is soon to expire. Don't translate Jinja variables in curly braces like partner_name or partner_link; don't translate html tags either. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/user_renewal_notice-body-text.html:3
 #, python-format
-msgid ""
-"Dear %(user)s, According to our records, your access to %(partner_name)s "
-"will soon expire and you may lose access. If you want to continue making use "
-"of your free account, you can request renewal of your account by clicking "
-"the Renew button at %(partner_link)s. Best, The Wikipedia Library You can "
-"disable these emails in your user page preferences: https://wikipedialibrary."
-"wmflabs.org/users/"
+msgid "Dear %(user)s, According to our records, your access to %(partner_name)s will soon expire and you may lose access. If you want to continue making use of your free account, you can request renewal of your account by clicking the Renew button at %(partner_link)s. Best, The Wikipedia Library You can disable these emails in your user page preferences: https://wikipedialibrary.wmflabs.org/users/"
 msgstr ""
 
 #. Translators: This is the subject of an email sent to users when they have an account that is soon to expire. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
@@ -1266,24 +1124,13 @@ msgstr "위키백과 도서관 접근 권한이 곧 만료됩니다"
 #. Translators: This email is sent to users when their application is waitlisted because there are no more accounts available. Don't translate Jinja variables in curly braces like user or partner; don't translate html tags either. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/waitlist_notification-body-html.html:5
 #, python-format
-msgid ""
-"<p>Dear %(user)s,</p> <p>Thank you for applying for access to %(partner)s "
-"resources through The Wikipedia Library. There are no accounts currently "
-"available so your application has been waitlisted. Your application will be "
-"evaluated if/when more accounts become available. You can see all available "
-"resources at <a href=\"%(link)s\">%(link)s</a>.</p> <p>Best,</p> <p>The "
-"Wikipedia Library</p>"
+msgid "<p>Dear %(user)s,</p> <p>Thank you for applying for access to %(partner)s resources through The Wikipedia Library. There are no accounts currently available so your application has been waitlisted. Your application will be evaluated if/when more accounts become available. You can see all available resources at <a href=\"%(link)s\">%(link)s</a>.</p> <p>Best,</p> <p>The Wikipedia Library</p>"
 msgstr ""
 
 #. Translators: This email is sent to users when their application is waitlisted because there are no more accounts available. Don't translate Jinja variables in curly braces like user or partner. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/waitlist_notification-body-text.html:3
 #, python-format
-msgid ""
-"Dear %(user)s, Thank you for applying for access to %(partner)s resources "
-"through The Wikipedia Library. There are no accounts currently available so "
-"your application has been waitlisted. Your application will be evaluated if/"
-"when more accounts become available. You can see all available resources at: "
-"%(link)s Best, The Wikipedia Library"
+msgid "Dear %(user)s, Thank you for applying for access to %(partner)s resources through The Wikipedia Library. There are no accounts currently available so your application has been waitlisted. Your application will be evaluated if/when more accounts become available. You can see all available resources at: %(link)s Best, The Wikipedia Library"
 msgstr ""
 
 #. Translators: This is the subject of an email sent to users when their application is waitlisted because there are no more accounts available. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
@@ -1449,17 +1296,14 @@ msgstr "사용할 수 없음"
 #: TWLight/resources/templates/resources/filter_section.html:14
 #: TWLight/templates/about.html:12
 #: TWLight/users/templates/users/filter_section.html:13
-msgid ""
-"The Wikipedia Library allows active editors to access a wide range of "
-"collections of paywalled reliable sources for free!"
+msgid "The Wikipedia Library allows active editors to access a wide range of collections of paywalled reliable sources for free!"
 msgstr ""
 
 #. Translators: On the Browse Partners page (https://wikipedialibrary.wmflabs.org/partners/), this introduces users to The Wikipedia Library.
 #. Translators: On the MyLibrary page (https://wikipedialibrary.wmflabs.org/users/my_library), this introduces users to The Wikipedia Library.
 #: TWLight/resources/templates/resources/filter_section.html:17
 #: TWLight/users/templates/users/filter_section.html:15
-msgid ""
-"Start with the search bar at the top or browse publisher websites directly."
+msgid "Start with the search bar at the top or browse publisher websites directly."
 msgstr ""
 
 #. Translators: On the Browse Partners page (https://wikipedialibrary.wmflabs.org/partners/), this appears below introductory text and links to the 'About' page (https://wikipedialibrary.wmflabs.org/about/)
@@ -1534,52 +1378,38 @@ msgstr "파트너로 돌아가기"
 #. Translators: If we have no available accounts for a partner, the coordinator can change the application system to a waiting list.
 #: TWLight/resources/templates/resources/partner_detail.html:36
 #: TWLight/resources/templates/resources/partner_detail_apply.html:17
-msgid ""
-"There are no access grants available for this partner at this time. You can "
-"still apply for access; applications will be processed when access is "
-"available."
+msgid "There are no access grants available for this partner at this time. You can still apply for access; applications will be processed when access is available."
 msgstr ""
 
 #. Translators: This text links to the minimum user requirements and terms of use on the partner page.
 #: TWLight/resources/templates/resources/partner_detail.html:48
 #: TWLight/resources/templates/resources/partner_detail_apply.html:29
 #, python-format
-msgid ""
-"Before applying, please review the <strong><a class=\"twl-links\" href="
-"\"%(about)s#req\">minimum requirements</a></strong> for access and our "
-"<strong><a class=\"twl-links\" href=\"%(terms)s\">terms of use</a></strong>."
+msgid "Before applying, please review the <strong><a class=\"twl-links\" href=\"%(about)s#req\">minimum requirements</a></strong> for access and our <strong><a class=\"twl-links\" href=\"%(terms)s\">terms of use</a></strong>."
 msgstr ""
 
 #. Translators: This text refers to the page containing the content a user is authorized to access.
 #: TWLight/resources/templates/resources/partner_detail.html:69
 #, python-format
-msgid ""
-"View the status of your access in <strong><a class=\"twl-links\" href="
-"\"%(library_url)s\">My Library</a></strong> page."
+msgid "View the status of your access in <strong><a class=\"twl-links\" href=\"%(library_url)s\">My Library</a></strong> page."
 msgstr ""
 
 #. Translators: This message is shown when a user has open applications, linking to their respective applications page.
 #: TWLight/resources/templates/resources/partner_detail.html:78
 #, python-format
-msgid ""
-"View the status of your application(s) on your <strong><a class=\"twl-links"
-"\" href=\"%(applications_url)s\">My Applications</a></strong> page."
+msgid "View the status of your application(s) on your <strong><a class=\"twl-links\" href=\"%(applications_url)s\">My Applications</a></strong> page."
 msgstr ""
 
 #. Translators: This message is shown when a user has authorizations, linking to their respective collections page.
 #: TWLight/resources/templates/resources/partner_detail_apply.html:50
 #, python-format
-msgid ""
-"View the status of your access on your <strong><a href=\"%(library_url)s\" "
-"class=\"twl-links\">My Library</a></strong> page."
+msgid "View the status of your access on your <strong><a href=\"%(library_url)s\" class=\"twl-links\">My Library</a></strong> page."
 msgstr ""
 
 #. Translators: This message is shown when a user has open applications, linking to their respective applications page.
 #: TWLight/resources/templates/resources/partner_detail_apply.html:60
 #, python-format
-msgid ""
-"View the status of your application(s) on your <strong><a href="
-"\"%(applications_url)s\">My Applications</a></strong> page."
+msgid "View the status of your application(s) on your <strong><a href=\"%(applications_url)s\">My Applications</a></strong> page."
 msgstr ""
 
 #. Translators: One the partner detail page, this text labels the button which coordinators can click to remove a partner from waitlisted status.
@@ -1609,10 +1439,7 @@ msgstr "특수:이메일보내기 문서"
 
 #. Translators: If no account coordinator is assigned to a partner, the Wikipedia Library team will coordinate signups. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/resources/templates/resources/partner_detail_apply.html:112
-msgid ""
-"The Wikipedia Library team will process this application. Want to help? <a "
-"class=\"twl-links\" href=\"https://en.wikipedia.org/wiki/Wikipedia:"
-"The_Wikipedia_Library/Coordinators/Signup\">Sign up as a coordinator.</a>"
+msgid "The Wikipedia Library team will process this application. Want to help? <a class=\"twl-links\" href=\"https://en.wikipedia.org/wiki/Wikipedia:The_Wikipedia_Library/Coordinators/Signup\">Sign up as a coordinator.</a>"
 msgstr ""
 
 #. Translators: This text labels a button coordinators can click to view a list of users who have applied for access for a particular partner
@@ -1643,18 +1470,13 @@ msgstr "라이브러리 번들 접근 권한"
 
 #. Translators: Text shown to authenticated, bundle eligible users when they visit a Bundle partner page.
 #: TWLight/resources/templates/resources/partner_detail_apply.html:138
-msgid ""
-"You are eligible to access Library Bundle partners. Click the button above "
-"to access the collection."
+msgid "You are eligible to access Library Bundle partners. Click the button above to access the collection."
 msgstr ""
 
 #. Translators: Text shown to authenticated, bundle ineligible users when they visit a Bundle partner page.
 #: TWLight/resources/templates/resources/partner_detail_apply.html:152
 #, python-format
-msgid ""
-"You are not eligible to access Library Bundle partners. Visit the <a class="
-"\"twl-links\" href=\"%(homepage)s\">homepage</a> to check the eligibility "
-"criteria."
+msgid "You are not eligible to access Library Bundle partners. Visit the <a class=\"twl-links\" href=\"%(homepage)s\">homepage</a> to check the eligibility criteria."
 msgstr ""
 
 #. Translators: Buttton prompting users to log in.
@@ -1666,10 +1488,7 @@ msgstr "로그인"
 #. Translators: Text shown to unauthenticated users when they visit a Bundle partner page.
 #: TWLight/resources/templates/resources/partner_detail_apply.html:168
 #, python-format
-msgid ""
-"This resource is part of our <a class=\"twl-links\" href=\"%(about)s"
-"\">Library Bundle</a>, which you can access if you meet our minimum "
-"eligibility criteria. Log in to find out if you are eligible."
+msgid "This resource is part of our <a class=\"twl-links\" href=\"%(about)s\">Library Bundle</a>, which you can access if you meet our minimum eligibility criteria. Log in to find out if you are eligible."
 msgstr ""
 
 #. Translators: This is the label for a number which shows the total active accounts for one partner. (e.g. https://wikipedialibrary.wmflabs.org/partners/8/).
@@ -1720,26 +1539,19 @@ msgstr ""
 #. Translators: If a partner has specified the excerpt limit both in words and percentage, this message will display the percentage of words and the number of words on the partner page.
 #: TWLight/resources/templates/resources/partner_detail_timeline.html:99
 #, python-format
-msgid ""
-"%(object)s allows a maximum of %(excerpt_limit)s words or "
-"%(excerpt_limit_percentage)s%% of an article be excerpted into a Wikipedia "
-"article."
+msgid "%(object)s allows a maximum of %(excerpt_limit)s words or %(excerpt_limit_percentage)s%% of an article be excerpted into a Wikipedia article."
 msgstr ""
 
 #. Translators: If a partner has specified the excerpt limit in words, this message will display the number of words on the partner page.
 #: TWLight/resources/templates/resources/partner_detail_timeline.html:106
 #, python-format
-msgid ""
-"%(object)s allows a maximum of %(excerpt_limit)s words be excerpted into a "
-"Wikipedia article."
+msgid "%(object)s allows a maximum of %(excerpt_limit)s words be excerpted into a Wikipedia article."
 msgstr ""
 
 #. Translators: If a partner has specified the excerpt limit in percentage, this message will display the percentage of words on the partner page.
 #: TWLight/resources/templates/resources/partner_detail_timeline.html:113
 #, python-format
-msgid ""
-"%(object)s allows a maximum of %(excerpt_limit_percentage)s%% of an article "
-"be excerpted into a Wikipedia article."
+msgid "%(object)s allows a maximum of %(excerpt_limit_percentage)s%% of an article be excerpted into a Wikipedia article."
 msgstr ""
 
 #. Translators: If a partner has other requirements for access, this text shows as the title for that information field. (e.g. https://wikipedialibrary.wmflabs.org/partners/10/).
@@ -1750,9 +1562,7 @@ msgstr ""
 #. Translators: If a user must agree to a Terms of Use document, they see this message, and must enter the name of the resource. Don't translate publisher or url.
 #: TWLight/resources/templates/resources/partner_detail_timeline.html:140
 #, python-format
-msgid ""
-"%(publisher)s requires that you agree with its <a href=\"%(url)s\">terms of "
-"use</a>."
+msgid "%(publisher)s requires that you agree with its <a href=\"%(url)s\">terms of use</a>."
 msgstr ""
 
 #. Translators: If a user must provide their real name to apply to a partner, they see this message, and must enter the name of the resource. Don't translate publisher.
@@ -1776,17 +1586,13 @@ msgstr ""
 #. Translators: If a user must select a specific resource to apply for, they see this message, and must enter the name of the resource. Don't translate publisher.
 #: TWLight/resources/templates/resources/partner_detail_timeline.html:177
 #, python-format
-msgid ""
-"%(publisher)s requires that you specify a particular title that you want to "
-"access."
+msgid "%(publisher)s requires that you specify a particular title that you want to access."
 msgstr ""
 
 #. Translators: If a user must register on the partner website before applying, they see this message. Don't translate partner.
 #: TWLight/resources/templates/resources/partner_detail_timeline.html:187
 #, python-format
-msgid ""
-"%(publisher)s requires that you sign up for an account before applying for "
-"access."
+msgid "%(publisher)s requires that you sign up for an account before applying for access."
 msgstr ""
 
 #. Translators: If a partner has their location listed, this message is a label for that location
@@ -1914,9 +1720,7 @@ msgstr "<b>%(object)s</b>을(를) 정말로 삭제하시겠습니까?"
 
 #. Translators: If multiple authorizations where returned for a collection, this message is shown to a user
 #: TWLight/resources/views.py:268
-msgid ""
-"Multiple authorizations were returned – something's wrong. Please contact us "
-"and don't forget to mention this message."
+msgid "Multiple authorizations were returned – something's wrong. Please contact us and don't forget to mention this message."
 msgstr ""
 
 #. Translators: This message is shown when user tries to access a NOT_AVAILABLE Partner
@@ -1957,14 +1761,7 @@ msgstr "죄송합니다. 해당 작업으로 무엇을 해야할지 모르겠습
 #. Translators: Shown on the website's 400 page, when a user sends a bad request. Don't translate path or Phabricator.
 #: TWLight/templates/400.html:20
 #, python-format
-msgid ""
-"If you think we should know what to do with that, please email us about this "
-"error at <a class=\"twl-links\" href=\"mailto:wikipedialibrary@wikimedia.org?"
-"Subject=Wikipedia%%20Library%%20%(path)s%%20Permission%%20denied"
-"\">wikipedialibrary@wikimedia.org</a> or report it to us on <a class=\"twl-"
-"links\" href=\"https://phabricator.wikimedia.org/maniphest/task/edit/form/1/?"
-"projectPHIDs=Library-Card-Platform&title=Wikipedia%%20Library%%20%(path)s"
-"%%20Bad%%20Request\">Phabricator</a>"
+msgid "If you think we should know what to do with that, please email us about this error at <a class=\"twl-links\" href=\"mailto:wikipedialibrary@wikimedia.org?Subject=Wikipedia%%20Library%%20%(path)s%%20Permission%%20denied\">wikipedialibrary@wikimedia.org</a> or report it to us on <a class=\"twl-links\" href=\"https://phabricator.wikimedia.org/maniphest/task/edit/form/1/?projectPHIDs=Library-Card-Platform&title=Wikipedia%%20Library%%20%(path)s%%20Bad%%20Request\">Phabricator</a>"
 msgstr ""
 
 #. Translators: Alt text for an image shown on the 400 error page.
@@ -1986,15 +1783,7 @@ msgstr "죄송합니다. 해당 작업을 수행할 권한이 없습니다."
 #. Translators: Shown on the website's 403 page, when a user attempts to navigate to a page they don't have permission to view. Don't translate path or Phabricator.
 #: TWLight/templates/403.html:20
 #, python-format
-msgid ""
-"If you think your account should be able to do that, please email us about "
-"this error at <a class=\"twl-links\" href=\"mailto:"
-"wikipedialibrary@wikimedia.org?Subject=Wikipedia%%20Library%%20%(path)s"
-"%%20Permission%%20denied\">wikipedialibrary@wikimedia.org</a> or report it "
-"to us on <a class=\"twl-links\" href=\"https://phabricator.wikimedia.org/"
-"maniphest/task/edit/form/1/?projectPHIDs=Library-Card-"
-"Platform&title=Wikipedia%%20Library%%20%(path)s%%20Permission%%20denied"
-"\">Phabricator</a>"
+msgid "If you think your account should be able to do that, please email us about this error at <a class=\"twl-links\" href=\"mailto:wikipedialibrary@wikimedia.org?Subject=Wikipedia%%20Library%%20%(path)s%%20Permission%%20denied\">wikipedialibrary@wikimedia.org</a> or report it to us on <a class=\"twl-links\" href=\"https://phabricator.wikimedia.org/maniphest/task/edit/form/1/?projectPHIDs=Library-Card-Platform&title=Wikipedia%%20Library%%20%(path)s%%20Permission%%20denied\">Phabricator</a>"
 msgstr ""
 
 #. Translators: Shown on the website's 404 page, when a user attempts to navigate to a page that doesn't exist.
@@ -2010,14 +1799,7 @@ msgstr "죄송합니다. 찾을 수 없습니다."
 #. Translators: Shown on the website's 404 page, when a user attempts to navigate to a page that doesn't exist. Don't translate path or Phabricator.
 #: TWLight/templates/404.html:19
 #, python-format
-msgid ""
-"If you are certain that something should be here, please email us about this "
-"error at <a class=\"twl-links\" href=\"mailto:wikipedialibrary@wikimedia.org?"
-"Subject=Wikipedia%%20Library%%20%(path)s%%20Not%%20found\"> "
-"wikipedialibrary@wikimedia.org</a> or report it to us on <a class=\"twl-links"
-"\" href=\"https://phabricator.wikimedia.org/maniphest/task/edit/form/1/?"
-"projectPHIDs=Library-Card-Platform&title=Wikipedia%%20Library%%20%(path)s"
-"%%20Not%%20found\">Phabricator</a>"
+msgid "If you are certain that something should be here, please email us about this error at <a class=\"twl-links\" href=\"mailto:wikipedialibrary@wikimedia.org?Subject=Wikipedia%%20Library%%20%(path)s%%20Not%%20found\"> wikipedialibrary@wikimedia.org</a> or report it to us on <a class=\"twl-links\" href=\"https://phabricator.wikimedia.org/maniphest/task/edit/form/1/?projectPHIDs=Library-Card-Platform&title=Wikipedia%%20Library%%20%(path)s%%20Not%%20found\">Phabricator</a>"
 msgstr ""
 
 #. Translators: Alt text for an image shown on the 404 error page.
@@ -2032,32 +1814,18 @@ msgstr "위키백과 도서관 정보"
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:20
-msgid ""
-"This platform is our central tool for facilitating access to our available "
-"collections. Here you can see which partnerships are available, search their "
-"contents, and apply for and access the ones you’re interested in."
+msgid "This platform is our central tool for facilitating access to our available collections. Here you can see which partnerships are available, search their contents, and apply for and access the ones you’re interested in."
 msgstr ""
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/). Wikimedia Foundation should not be translated.
 #: TWLight/templates/about.html:29
-msgid ""
-"All users receive immediate access to some collections, which can be browsed "
-"by clicking the 'Access collection' buttons or using the search bar at the "
-"top of the page. Other collections require an application before access is "
-"granted, and may be accessed directly or via an individual login or access "
-"code. Volunteer coordinators, who have signed non-disclosure agreements with "
-"the Wikimedia Foundation, review these applications and work with publishers "
-"to get you your free access."
+msgid "All users receive immediate access to some collections, which can be browsed by clicking the 'Access collection' buttons or using the search bar at the top of the page. Other collections require an application before access is granted, and may be accessed directly or via an individual login or access code. Volunteer coordinators, who have signed non-disclosure agreements with the Wikimedia Foundation, review these applications and work with publishers to get you your free access."
 msgstr ""
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/). Don't translate terms_url.
 #: TWLight/templates/about.html:43
 #, python-format
-msgid ""
-"For more information about how your information is stored and reviewed "
-"please see our <a class=\"twl-links\" href=\"%(terms_url)s\"> terms of use "
-"and privacy policy</a>. Accounts you apply for are also subject to the Terms "
-"of Use provided by each partner’s platform; please review them."
+msgid "For more information about how your information is stored and reviewed please see our <a class=\"twl-links\" href=\"%(terms_url)s\"> terms of use and privacy policy</a>. Accounts you apply for are also subject to the Terms of Use provided by each partner’s platform; please review them."
 msgstr ""
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
@@ -2067,12 +1835,7 @@ msgstr ""
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/). Wikimedia Foundation should not be translated.
 #: TWLight/templates/about.html:55
-msgid ""
-"Any active editor in good standing can receive access. For publishers with "
-"limited numbers of accounts, applications are reviewed based on the editor’s "
-"needs and contributions. If you think you could use access to one of our "
-"partner resources and are an active editor in any project supported by the "
-"Wikimedia Foundation, please apply."
+msgid "Any active editor in good standing can receive access. For publishers with limited numbers of accounts, applications are reviewed based on the editor’s needs and contributions. If you think you could use access to one of our partner resources and are an active editor in any project supported by the Wikimedia Foundation, please apply."
 msgstr ""
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
@@ -2102,23 +1865,12 @@ msgstr "현재 위키미디어 프로젝트 내 편집이 차단되어 있지 �
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/)
 #: TWLight/templates/about.html:89
-msgid ""
-"If you are applying for an available collection, please first check that you "
-"don't already have access through another library or institution. If you do, "
-"please consider using that access rather than taking up a seat for this "
-"resource in The Wikipedia Library."
+msgid "If you are applying for an available collection, please first check that you don't already have access through another library or institution. If you do, please consider using that access rather than taking up a seat for this resource in The Wikipedia Library."
 msgstr ""
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/)
 #: TWLight/templates/about.html:99
-msgid ""
-"If your account is blocked on one or more Wikimedia projects, you may still "
-"be granted access to The Wikipedia Library. You will need to contact the "
-"Wikipedia Library team, who will review your blocks. If you have been "
-"blocked for content issues, most notably copyright violations, or have "
-"multiple long-term blocks, we may decline your request. Additionally, if "
-"your block status changes after being approved, you will need to request "
-"another review."
+msgid "If your account is blocked on one or more Wikimedia projects, you may still be granted access to The Wikipedia Library. You will need to contact the Wikipedia Library team, who will review your blocks. If you have been blocked for content issues, most notably copyright violations, or have multiple long-term blocks, we may decline your request. Additionally, if your block status changes after being approved, you will need to request another review."
 msgstr ""
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
@@ -2153,9 +1905,7 @@ msgstr ""
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:136
-msgid ""
-"Share their account logins or passwords with others, or sell their access to "
-"other parties"
+msgid "Share their account logins or passwords with others, or sell their access to other parties"
 msgstr ""
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
@@ -2165,23 +1915,17 @@ msgstr ""
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:144
-msgid ""
-"Systematically make printed or electronic copies of multiple extracts of "
-"restricted content available for any purpose"
+msgid "Systematically make printed or electronic copies of multiple extracts of restricted content available for any purpose"
 msgstr ""
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/). Stub is a technical term for a short Wikipedia article, use the appropriate Wikipedia term in your language.
 #: TWLight/templates/about.html:148
-msgid ""
-"Datamine metadata without permission, in order, for instance, to use "
-"metadata for auto-created stub articles"
+msgid "Datamine metadata without permission, in order, for instance, to use metadata for auto-created stub articles"
 msgstr ""
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:154
-msgid ""
-"Respecting these agreements allows us to continue growing the partnerships "
-"available to the community."
+msgid "Respecting these agreements allows us to continue growing the partnerships available to the community."
 msgstr ""
 
 #. Translators: This is the heading for a section on the About page (https://wikipedialibrary.wmflabs.org/about/).
@@ -2191,41 +1935,22 @@ msgstr "EZProxy"
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:164
-msgid ""
-"EZProxy is a proxy server used to authenticate users for many Wikipedia "
-"Library partners. Users sign into EZProxy via the Library Card platform to "
-"verify that they are authorized users, and then the server accesses "
-"requested resources using its own IP address."
+msgid "EZProxy is a proxy server used to authenticate users for many Wikipedia Library partners. Users sign into EZProxy via the Library Card platform to verify that they are authorized users, and then the server accesses requested resources using its own IP address."
 msgstr ""
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:173
-msgid ""
-"You may notice that when accessing resources via EZProxy that URLs are "
-"dynamically rewritten. This is why we recommend logging in via the Library "
-"Card platform rather than going directly to the unproxied partner website. "
-"When in doubt, check the URL for ‘idm.oclc’. If it’s there, then you’re "
-"connected via EZProxy."
+msgid "You may notice that when accessing resources via EZProxy that URLs are dynamically rewritten. This is why we recommend logging in via the Library Card platform rather than going directly to the unproxied partner website. When in doubt, check the URL for ‘idm.oclc’. If it’s there, then you’re connected via EZProxy."
 msgstr ""
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:182
-msgid ""
-"Typically once you’ve logged in your session will remain active in your "
-"browser for up to two hours after you’ve finished searching. Note that use "
-"of EZProxy requires you to enable cookies. If you are having problems you "
-"should also try clearing your cache and restarting your browser."
+msgid "Typically once you’ve logged in your session will remain active in your browser for up to two hours after you’ve finished searching. Note that use of EZProxy requires you to enable cookies. If you are having problems you should also try clearing your cache and restarting your browser."
 msgstr ""
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/)
 #: TWLight/templates/about.html:193
-msgid ""
-"The Library Bundle is a collection of resources for which no application is "
-"required. If you meet the criteria laid out above, you will be authorized "
-"for access automatically upon logging in to the platform. Only some of our "
-"content is currently included in the Library Bundle, however we hope to "
-"expand the collection as more publishers become comfortable with "
-"participating. All Bundle content is accessed via EZProxy."
+msgid "The Library Bundle is a collection of resources for which no application is required. If you meet the criteria laid out above, you will be authorized for access automatically upon logging in to the platform. Only some of our content is currently included in the Library Bundle, however we hope to expand the collection as more publishers become comfortable with participating. All Bundle content is accessed via EZProxy."
 msgstr ""
 
 #. Translators: This is the heading for a section on the About page (https://wikipedialibrary.wmflabs.org/about/).
@@ -2235,12 +1960,7 @@ msgstr ""
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:206
-msgid ""
-"Citation practices vary by project and even by article. Generally, we "
-"support editors citing where they found information, in a form that allows "
-"others to check it for themselves. That often means providing both original "
-"source details as well as a link to the partner database in which the source "
-"was found."
+msgid "Citation practices vary by project and even by article. Generally, we support editors citing where they found information, in a form that allows others to check it for themselves. That often means providing both original source details as well as a link to the partner database in which the source was found."
 msgstr ""
 
 #. Translators: This is the heading for a section on the About page (https://wikipedialibrary.wmflabs.org/about/).
@@ -2252,12 +1972,8 @@ msgstr "문의하기"
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:218
 #, python-format
-msgid ""
-"If you have questions, need help, or want to volunteer to help, please see "
-"our <a class=\"twl-links\" href=\"%(contact_url)s\">contact page</a>."
-msgstr ""
-"질문이 있거나, 도움이 필요하거나, 자발적으로 도와주고 싶다면, 저희 <a class="
-"\"twl-links\" href=\"%(contact_url)s\">문의 페이지</a>를 참고해 주세요."
+msgid "If you have questions, need help, or want to volunteer to help, please see our <a class=\"twl-links\" href=\"%(contact_url)s\">contact page</a>."
+msgstr "질문이 있거나, 도움이 필요하거나, 자발적으로 도와주고 싶다면, 저희 <a class=\"twl-links\" href=\"%(contact_url)s\">문의 페이지</a>를 참고해 주세요."
 
 #. Translators: This is the title of the panel box detailing the contact information for the Wikipedia Library team.
 #: TWLight/templates/contact.html:14
@@ -2296,16 +2012,13 @@ msgstr "위키백과 도서관 트위터 페이지"
 #. Translators: This is the text that appears at the bottom of the contact us form directing users to the suggestions form.
 #: TWLight/templates/contact.html:48
 #, python-format
-msgid ""
-"(If you would like to suggest a partner, <a class=\"twl-links\" href="
-"\"%(suggest)s\"><strong>go here</strong></a>.)"
+msgid "(If you would like to suggest a partner, <a class=\"twl-links\" href=\"%(suggest)s\"><strong>go here</strong></a>.)"
 msgstr ""
 
 #. Translators: On a special 'link to search' page, this message is shown if JavaScript is disabled.
 #: TWLight/templates/eds_search_endpoint.html:7
 msgid "JavaScript is disabled; use the button below to continue."
-msgstr ""
-"자바스크립트가 비활성화되어 있습니다. 계속하려면 아래의 버튼을 사용하십시오."
+msgstr "자바스크립트가 비활성화되어 있습니다. 계속하려면 아래의 버튼을 사용하십시오."
 
 #. Translators: Alt text for the Wikipedia Library shown in the top left of all pages.
 #: TWLight/templates/header_partial_b4.html:14
@@ -2358,12 +2071,8 @@ msgstr "위키백과 도서관"
 #. Translators: Information about The Wikipedia Library.
 #: TWLight/templates/login_partial.html:53 TWLight/templates/new_base.html:21
 #, fuzzy, python-format
-msgid ""
-"More than 100 of the world's top subscription-only databases, with content "
-"in %(no_of_languages)s languages, free for Wikipedians of all backgrounds"
-msgstr ""
-"모든 위키백과 사용자가 무료로 이용하는, 세계 최고의 90개 이상의 구독 전용 데"
-"이터베이스"
+msgid "More than 100 of the world's top subscription-only databases, with content in %(no_of_languages)s languages, free for Wikipedians of all backgrounds"
+msgstr "모든 위키백과 사용자가 무료로 이용하는, 세계 최고의 90개 이상의 구독 전용 데이터베이스"
 
 #. Translators: Information about The Wikipedia Library.
 #: TWLight/templates/login_partial.html:64
@@ -2371,13 +2080,8 @@ msgid "Meet these criteria for automatic access"
 msgstr "자동 접근을 위해 이 기준을 충족하세요"
 
 #: TWLight/templates/login_partial.html:69
-msgid ""
-"These criteria grant you access to certain collections but not all. Some "
-"collections are accessible on a per application basis only."
-msgstr ""
-"이 기준은 특정 모음집의 접근 권한을 제공하는 것이지, 모든 모음집의 접근 권한"
-"을 제공하는 것이 아닙니다. 일부 모음집은 신청 기반을 통해서만 접근이 가능합니"
-"다."
+msgid "These criteria grant you access to certain collections but not all. Some collections are accessible on a per application basis only."
+msgstr "이 기준은 특정 모음집의 접근 권한을 제공하는 것이지, 모든 모음집의 접근 권한을 제공하는 것이 아닙니다. 일부 모음집은 신청 기반을 통해서만 접근이 가능합니다."
 
 #: TWLight/templates/login_partial.html:89
 msgid "Login via Wikipedia"
@@ -2386,29 +2090,19 @@ msgstr "위키백과로 로그인하기"
 #. Translators: Shown if the current user doesn't have a registered email on their account. Don't translate contact_us_url or email_url.
 #: TWLight/templates/message_partial.html:15
 #, python-format
-msgid ""
-"You don't have an email on file. We can't finalize your access to partner "
-"resources, and you won't be able to <a class=\"twl-links\" href="
-"\"%(contact_us_url)s\">contact us</a> without an email. Please <a class="
-"\"twl-links\" href=\"%(email_url)s\">update your email</a>."
+msgid "You don't have an email on file. We can't finalize your access to partner resources, and you won't be able to <a class=\"twl-links\" href=\"%(contact_us_url)s\">contact us</a> without an email. Please <a class=\"twl-links\" href=\"%(email_url)s\">update your email</a>."
 msgstr ""
 
 #. Translators: Shown if the current user has requested the processing of their data should be restricted.
 #: TWLight/templates/message_partial.html:26
 #, python-format
-msgid ""
-"You have requested a restriction on the processing of your data. Most site "
-"functionality will not be available to you until you <a class=\"twl-links\" "
-"href=\"%(restrict_url)s\">lift this restriction</a>."
+msgid "You have requested a restriction on the processing of your data. Most site functionality will not be available to you until you <a class=\"twl-links\" href=\"%(restrict_url)s\">lift this restriction</a>."
 msgstr ""
 
 #. Translators: Shown if the current user has not agreed to the terms of use.
 #: TWLight/templates/message_partial.html:37
 #, python-format
-msgid ""
-"You have not agreed to the <a class=\"twl-links\" href=\"%(terms_url)s"
-"\">terms of use</a> of this site. Your applications will not be processed "
-"and you won't be able to apply or access resources you are approved for."
+msgid "You have not agreed to the <a class=\"twl-links\" href=\"%(terms_url)s\">terms of use</a> of this site. Your applications will not be processed and you won't be able to apply or access resources you are approved for."
 msgstr ""
 
 #. Translators: This link is at the bottom of every page and links to the 'About' page (https://wikipedialibrary.wmflabs.org/about/)
@@ -2455,12 +2149,8 @@ msgstr "비밀번호 재설정"
 
 #. Translators: If a user goes to reset their password, this message asks them to enter their email to do so.
 #: TWLight/templates/registration/password_reset_form.html:13
-msgid ""
-"Forgot your password? Enter your email address below, and we'll email "
-"instructions for setting a new one."
-msgstr ""
-"비밀번호를 잊으셨나요? 아래에 이메일 주소를 입력하시면 저희가 새 비밀번호를 "
-"설정하는 방법을 이메일로 전달드리겠습니다."
+msgid "Forgot your password? Enter your email address below, and we'll email instructions for setting a new one."
+msgstr "비밀번호를 잊으셨나요? 아래에 이메일 주소를 입력하시면 저희가 새 비밀번호를 설정하는 방법을 이메일로 전달드리겠습니다."
 
 #. Translators: This is the label for a button that users click to update their public information.
 #: TWLight/users/forms.py:36
@@ -2504,19 +2194,12 @@ msgstr "이용 약관에 동의합니다"
 
 #. Translators: This text explains how to disagree to the site's terms of use and the restrictions that will come into effect when users disagree to the terms of use.
 #: TWLight/users/forms.py:185
-msgid ""
-"By unchecking this box and clicking “Update” you may explore the site, but "
-"you will not be able to apply for access to materials or evaluate "
-"applications unless you agree with the terms of use."
-msgstr ""
-"이 상자에 체크하지 않고 \"업데이트\"를 눌러도 사이트를 탐색할 수 있지만, 이"
-"용 약관에 동의하지 않는 한 자료에 대한 접근을 신청하거나 응용 프로그램을 평가"
-"할 수 없게 됩니다."
+msgid "By unchecking this box and clicking “Update” you may explore the site, but you will not be able to apply for access to materials or evaluate applications unless you agree with the terms of use."
+msgstr "이 상자에 체크하지 않고 \"업데이트\"를 눌러도 사이트를 탐색할 수 있지만, 이용 약관에 동의하지 않는 한 자료에 대한 접근을 신청하거나 응용 프로그램을 평가할 수 없게 됩니다."
 
 #. Translators: Users click this button to set their website email address to the one linked to their Wikipedia account.
 #: TWLight/users/forms.py:211
-msgid ""
-"Use my Wikipedia email address (will be updated the next time you login)."
+msgid "Use my Wikipedia email address (will be updated the next time you login)."
 msgstr "내 위키백과 이메일 주소를 사용합니다. (다음에 로그인할 때 반영됩니다)"
 
 #. Translators: This labels a button which users click to change their email.
@@ -2527,17 +2210,8 @@ msgstr "이메일 업데이트"
 #. Translators: Shown if the current user tried to 'favorite' a partner they can't access. Do not translate '{partner}'
 #: TWLight/users/models.py:201
 #, python-brace-format
-msgid ""
-"Cannot add partner {partner} to your favorites because you don't have access "
-"to it"
+msgid "Cannot add partner {partner} to your favorites because you don't have access to it"
 msgstr ""
-
-#. Translators: Do not translate.
-#: TWLight/users/models.py:869
-#, fuzzy, python-brace-format
-#| msgid "Username"
-msgid "{wp_username}"
-msgstr "사용자 이름"
 
 #. Translators: This error message is shown when there's a problem with the authenticated login process.
 #: TWLight/users/oauth.py:243
@@ -2557,12 +2231,8 @@ msgstr "핸드셰이커가 초기화되지 않았습니다. 로그인을 다시 
 
 #. Translators: this message is displayed to users that don't have accounts and clicked on a proxied link.
 #: TWLight/users/oauth.py:388
-msgid ""
-"To view this link you need to be an eligible library user. Please login to "
-"continue."
-msgstr ""
-"이 링크를 보려면 적법한 라이브러리 사용자가 필요합니다. 계속하려면 로그인해 "
-"주십시오."
+msgid "To view this link you need to be an eligible library user. Please login to continue."
+msgstr "이 링크를 보려면 적법한 라이브러리 사용자가 필요합니다. 계속하려면 로그인해 주십시오."
 
 #. Translators: This warning message is shown to users when the response received from Wikimedia OAuth servers is not a valid one.
 #: TWLight/users/oauth.py:430
@@ -2598,17 +2268,12 @@ msgstr "사용자 정보"
 
 #. Translators: If the user tries to log in, but their account does not meet certain requirements, they cannot login.
 #: TWLight/users/oauth.py:528
-msgid ""
-"Your Wikipedia account does not meet the eligibility criteria in the terms "
-"of use, so your Wikipedia Library Card Platform account cannot be activated."
+msgid "Your Wikipedia account does not meet the eligibility criteria in the terms of use, so your Wikipedia Library Card Platform account cannot be activated."
 msgstr ""
 
 #. Translators: If the user tries to log in, but their account does not meet certain requirements, they cannot login.
 #: TWLight/users/oauth.py:536
-msgid ""
-"Your Wikipedia account no longer meets the eligibility criteria in the terms "
-"of use, so you cannot be logged in. If you think you should be able to log "
-"in, please email wikipedialibrary@wikimedia.org."
+msgid "Your Wikipedia account no longer meets the eligibility criteria in the terms of use, so you cannot be logged in. If you think you should be able to log in, please email wikipedialibrary@wikimedia.org."
 msgstr ""
 
 #. Translators: this message is displayed to users with brand new accounts.
@@ -2619,10 +2284,7 @@ msgstr "환영합니다! 이용 약관에 동의해 주십시오."
 #. Translators: This message is displayed on the confirmation page where users can return their access to partner collections.
 #: TWLight/users/templates/users/authorization_confirm_return.html:13
 #, python-format
-msgid ""
-"You will no longer be able to access <b>%(partner)s's</b> resources via the "
-"Library Card platform, but can request access again by clicking 'renew', if "
-"you change your mind. Are you sure you want to return your access?"
+msgid "You will no longer be able to access <b>%(partner)s's</b> resources via the Library Card platform, but can request access again by clicking 'renew', if you change your mind. Are you sure you want to return your access?"
 msgstr ""
 
 #. Translators: On the MyLibrary page (https://wikipedialibrary.wmflabs.org/users/my_library), this tab shows all favorite collections a user has.
@@ -2692,10 +2354,7 @@ msgstr "편집자 데이터"
 
 #. Translators: This is shown on editor profiles, in their profile page or on applications.
 #: TWLight/users/templates/users/editor_detail.html:59
-msgid ""
-"Information with an * was retrieved from Wikipedia directly. Other "
-"information was entered directly by users or site admins, in their preferred "
-"language."
+msgid "Information with an * was retrieved from Wikipedia directly. Other information was entered directly by users or site admins, in their preferred language."
 msgstr ""
 
 #. Translators: This distinguishes users who have been flagged as account coordinators. Don't translate username.
@@ -2706,10 +2365,7 @@ msgstr ""
 
 #. Translators: This is shown on editor profiles, under the heading for Wikipedia editor data.
 #: TWLight/users/templates/users/editor_detail_data.html:5
-msgid ""
-"This information is updated automatically from your Wikimedia account each "
-"time you log in, except for the Contributions field, where you can describe "
-"your Wikimedia editing history."
+msgid "This information is updated automatically from your Wikimedia account each time you log in, except for the Contributions field, where you can describe your Wikimedia editing history."
 msgstr ""
 
 #. Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this labels the user's username.
@@ -2739,17 +2395,13 @@ msgstr "이용 약관에 동의하십니까?"
 
 #. Translators: when viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this question has a yes or no answer.
 #: TWLight/users/templates/users/editor_detail_data.html:57
-msgid ""
-"at their last login, did this user meet the criteria set forth in the terms "
-"of use?"
+msgid "at their last login, did this user meet the criteria set forth in the terms of use?"
 msgstr ""
 
 #. Translators: When viewing a user's profile in an application, this message shows if the software doesn't think that the user is eligible for access. Don't translate username.
 #: TWLight/users/templates/users/editor_detail_data.html:72
 #, python-format
-msgid ""
-"%(username)s may still be eligible for access grants at the coordinators' "
-"discretion."
+msgid "%(username)s may still be eligible for access grants at the coordinators' discretion."
 msgstr ""
 
 #. Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this is the heading for a Yes/No ToU question.
@@ -2784,10 +2436,7 @@ msgstr ""
 #. Translators: This message is shown on a user's profile if their Wikimedia account is blocked on one or more projects. They may still be granted access to the Library Bundle, but need to contact Wikipedia Library staff to verify.
 #: TWLight/users/templates/users/editor_detail_data.html:137
 #, python-format
-msgid ""
-"It looks like you have an active block on your account. If you meet the "
-"other criteria you may still be permitted access to the library - please <a "
-"class=\"twl-links\" href=\"%(contact_url)s\">contact us</a>."
+msgid "It looks like you have an active block on your account. If you meet the other criteria you may still be permitted access to the library - please <a class=\"twl-links\" href=\"%(contact_url)s\">contact us</a>."
 msgstr ""
 
 #. Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this is the heading for a Yes/No program eligibility question.
@@ -2797,10 +2446,7 @@ msgstr ""
 
 #. Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this question has a Yes or No answer.
 #: TWLight/users/templates/users/editor_detail_data.html:156
-msgid ""
-"At their last login, did this user meet the criteria set forth in the "
-"Library Bundle? Note that satisfying terms of use is a prerequisite to "
-"bundle eligibility."
+msgid "At their last login, did this user meet the criteria set forth in the Library Bundle? Note that satisfying terms of use is a prerequisite to bundle eligibility."
 msgstr ""
 
 #. Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this is the heading for a Yes/No program eligibility question.
@@ -2845,21 +2491,14 @@ msgstr "개인 데이터"
 
 #. Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this text is in the 'Personal data' section. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/users/templates/users/editor_detail_data.html:262
-msgid ""
-"The following information is visible only to you, site administrators, "
-"publishing partners (where required), and volunteer Wikipedia Library "
-"coordinators (who have signed a Non-Disclosure Agreement)."
+msgid "The following information is visible only to you, site administrators, publishing partners (where required), and volunteer Wikipedia Library coordinators (who have signed a Non-Disclosure Agreement)."
 msgstr ""
 
 #. Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this labels a button which users can click to update or remove their personal information. Don't translate update_url.
 #: TWLight/users/templates/users/editor_detail_data.html:272
 #, python-format
-msgid ""
-"You may <a class=\"twl-links\" href=\"%(update_url)s\">update or delete</a> "
-"your data at any time."
-msgstr ""
-"언제든지 데이터를 <a class=\"twl-links\" href=\"%(update_url)s\">업데이트하거"
-"나 삭제</a>할 수 있습니다."
+msgid "You may <a class=\"twl-links\" href=\"%(update_url)s\">update or delete</a> your data at any time."
+msgstr "언제든지 데이터를 <a class=\"twl-links\" href=\"%(update_url)s\">업데이트하거나 삭제</a>할 수 있습니다."
 
 #. Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this labels the user's email. Don't remove the *.
 #: TWLight/users/templates/users/editor_detail_data.html:283
@@ -2878,26 +2517,18 @@ msgstr ""
 
 #. Translators: This message tells users that they are not eligible to access The Wikipedia Library content.
 #: TWLight/users/templates/users/eligibility_modal.html:7
-msgid ""
-"Sorry, your Wikipedia account doesn’t currently qualify to access The "
-"Wikipedia Library."
+msgid "Sorry, your Wikipedia account doesn’t currently qualify to access The Wikipedia Library."
 msgstr ""
 
 #. Translators: This message tells users that they have not agreed to the terms of use, therefore are ineligible to access the content in The Wikipedia Library.
 #: TWLight/users/templates/users/eligibility_modal.html:30
 #, python-format
-msgid ""
-"Agreed with <a href=\"%(terms)s\" class=\"text-danger\"> terms of use </a>"
-msgstr ""
-"사이트의 <a href=\"%(terms)s\" class=\"text-danger\">이용 약관</a>에 동의하셨"
-"나요?"
+msgid "Agreed with <a href=\"%(terms)s\" class=\"text-danger\"> terms of use </a>"
+msgstr "사이트의 <a href=\"%(terms)s\" class=\"text-danger\">이용 약관</a>에 동의하셨나요?"
 
 #: TWLight/users/templates/users/eligibility_modal.html:40
 #, python-format
-msgid ""
-"It looks like you have an active block on your account. If you meet the "
-"other criteria you may still be permitted access to the library - please <a "
-"href=\"%(contact_url)s\">contact us</a>."
+msgid "It looks like you have an active block on your account. If you meet the other criteria you may still be permitted access to the library - please <a href=\"%(contact_url)s\">contact us</a>."
 msgstr ""
 
 #. Translators: Instructions to refresh a user's data.
@@ -2937,14 +2568,8 @@ msgstr "언어 설정"
 
 #. Translators: This text on the user page helps users naviage to the TranslateWiki Wikipedia Library Card platform translation page.
 #: TWLight/users/templates/users/language_form.html:31
-msgid ""
-"You can help translate the tool at <a class=\"twl-links\" href=\"https://"
-"translatewiki.net/wiki/Translating:Wikipedia_Library_Card_Platform"
-"\">translatewiki.net</a>."
-msgstr ""
-"<a class=\"twl-links\" href=\"https://translatewiki.net/wiki/Translating:"
-"Wikipedia_Library_Card_Platform\">translatewiki.net</a>에서 도구의 번역을 지"
-"원할 수 있습니다."
+msgid "You can help translate the tool at <a class=\"twl-links\" href=\"https://translatewiki.net/wiki/Translating:Wikipedia_Library_Card_Platform\">translatewiki.net</a>."
+msgstr "<a class=\"twl-links\" href=\"https://translatewiki.net/wiki/Translating:Wikipedia_Library_Card_Platform\">translatewiki.net</a>에서 도구의 번역을 지원할 수 있습니다."
 
 #. Translators: When the user starts a new application and submits the application, the user can view the application and withdraw if need be. This changes the label for the Withdraw button.
 #: TWLight/users/templates/users/my_applications.html:65
@@ -2963,9 +2588,7 @@ msgstr ""
 
 #. Translators: On the page listing applications, this text explains a user they cannot renew their application since they've already requested a renewal or there aren't any renewals available.
 #: TWLight/users/templates/users/my_applications.html:79
-msgid ""
-"Renewals are either not required, not available right now, or you have "
-"already requested a renewal."
+msgid "Renewals are either not required, not available right now, or you have already requested a renewal."
 msgstr ""
 
 #. Translators: This text is the heading of a section in a user's profile where they can change their preferences.
@@ -3029,19 +2652,12 @@ msgstr ""
 
 #. Translators: This message is displayed on the page where users can request we stop processing their data.
 #: TWLight/users/templates/users/restrict_data.html:15
-msgid ""
-"Checking this box and clicking “Restrict” will pause all processing of the "
-"data you have entered into this website. You will not be able to apply for "
-"access to resources, your applications will not be further processed, and "
-"none of your data will be altered, until you return to this page and uncheck "
-"the box. This is not the same as deleting your data."
+msgid "Checking this box and clicking “Restrict” will pause all processing of the data you have entered into this website. You will not be able to apply for access to resources, your applications will not be further processed, and none of your data will be altered, until you return to this page and uncheck the box. This is not the same as deleting your data."
 msgstr ""
 
 #. Translators: This warning message is shown to coordinators who view the data restriction page.
 #: TWLight/users/templates/users/restrict_data.html:26
-msgid ""
-"You are a coordinator on this site. If you restrict the processing of your "
-"data, your coordinator flag will be removed."
+msgid "You are a coordinator on this site. If you restrict the processing of your data, your coordinator flag will be removed."
 msgstr ""
 
 #. Translators: use the date *when you are translating*, in a language-appropriate format.
@@ -3061,24 +2677,12 @@ msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:51
-msgid ""
-"<a class=\"twl-links\" href=\"https://meta.wikimedia.org/wiki/"
-"The_Wikipedia_Library\"> The Wikipedia Library </a> has partnered with "
-"publishers around the world to allow users to access otherwise paywalled "
-"resources. This website allows Wikipedia editors to search and access these "
-"resources."
+msgid "<a class=\"twl-links\" href=\"https://meta.wikimedia.org/wiki/The_Wikipedia_Library\"> The Wikipedia Library </a> has partnered with publishers around the world to allow users to access otherwise paywalled resources. This website allows Wikipedia editors to search and access these resources."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Wikimedia Foundation should not be translated. WMF should not be translated. Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:63
-msgid ""
-"This program is administered by the Wikimedia Foundation (WMF). These terms "
-"of use and privacy notice pertain to your application for access to "
-"resources through the Wikipedia Library, your use of this website, and your "
-"access to and use of those resources. They also describe our handling of the "
-"information you provide to us in order to create and administer your "
-"Wikipedia Library account. If we make material changes to the terms, we will "
-"notify users."
+msgid "This program is administered by the Wikimedia Foundation (WMF). These terms of use and privacy notice pertain to your application for access to resources through the Wikipedia Library, your use of this website, and your access to and use of those resources. They also describe our handling of the information you provide to us in order to create and administer your Wikipedia Library account. If we make material changes to the terms, we will notify users."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
@@ -3088,37 +2692,17 @@ msgstr "위키백과 도서관 카드 계정의 요구사항"
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:78
-msgid ""
-"Access to resources via The Wikipedia Library is reserved for community "
-"members who have demonstrated their commitment to the Wikimedia projects, "
-"and who will use their access to these resources to improve project content. "
-"To that end, in order to be eligible for The Wikipedia Library, we require "
-"that you be registered for a user account on the projects, with at least 500 "
-"edits, six (6) months of activity, and 10+ edits in the last month. We ask "
-"that you do not request access to any publishers with a limited number of "
-"available accounts whose resources you can already access for free through "
-"your local library or university, or another institution or organization, in "
-"order to provide that opportunity to others."
+msgid "Access to resources via The Wikipedia Library is reserved for community members who have demonstrated their commitment to the Wikimedia projects, and who will use their access to these resources to improve project content. To that end, in order to be eligible for The Wikipedia Library, we require that you be registered for a user account on the projects, with at least 500 edits, six (6) months of activity, and 10+ edits in the last month. We ask that you do not request access to any publishers with a limited number of available accounts whose resources you can already access for free through your local library or university, or another institution or organization, in order to provide that opportunity to others."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:94
-msgid ""
-"Additionally, if you are currently blocked or banned from a Wikimedia "
-"project, applications to resources may be rejected or restricted. If you "
-"obtain a Wikipedia Library account, but a block or ban is subsequently "
-"instituted against you on one of the projects, you may lose access to your "
-"Wikipedia Library account."
+msgid "Additionally, if you are currently blocked or banned from a Wikimedia project, applications to resources may be rejected or restricted. If you obtain a Wikipedia Library account, but a block or ban is subsequently instituted against you on one of the projects, you may lose access to your Wikipedia Library account."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:104
-msgid ""
-"Your eligibility to access The Wikipedia Library is assessed at each login. "
-"While more than half of the library's content is provided via this automated "
-"eligibility check, access to other publisher's content may be time limited, "
-"typically lapsing after one year, after which you will usually need to apply "
-"for renewal."
+msgid "Your eligibility to access The Wikipedia Library is assessed at each login. While more than half of the library's content is provided via this automated eligibility check, access to other publisher's content may be time limited, typically lapsing after one year, after which you will usually need to apply for renewal."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
@@ -3129,47 +2713,27 @@ msgstr "위키백과 도서관 카드 계정 신청"
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:118
-msgid ""
-"In order to apply for access to a partner resource, you must provide us with "
-"certain information, which we will use to evaluate your application. If your "
-"application is approved, we may transfer the information you have given us "
-"to the publishers whose resources you wish to access. They will either "
-"contact you with the account information directly or we will send access "
-"information to you ourselves."
+msgid "In order to apply for access to a partner resource, you must provide us with certain information, which we will use to evaluate your application. If your application is approved, we may transfer the information you have given us to the publishers whose resources you wish to access. They will either contact you with the account information directly or we will send access information to you ourselves."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:130
-msgid ""
-"In addition to the basic information you provide to us, our system will "
-"retrieve some information directly from the Wikimedia projects: your "
-"username, email address, edit count, registration date, user ID number, "
-"groups to which you belong, and any special user rights."
+msgid "In addition to the basic information you provide to us, our system will retrieve some information directly from the Wikimedia projects: your username, email address, edit count, registration date, user ID number, groups to which you belong, and any special user rights."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:140
-msgid ""
-"Each time you log in to the Wikipedia Library Card Platform, this "
-"information will be automatically updated."
+msgid "Each time you log in to the Wikipedia Library Card Platform, this information will be automatically updated."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:148
-msgid ""
-"We will ask you to provide us with some information about your history of "
-"contributions to the Wikimedia projects. Information on contribution history "
-"is optional, but will greatly assist us in evaluating your application."
+msgid "We will ask you to provide us with some information about your history of contributions to the Wikimedia projects. Information on contribution history is optional, but will greatly assist us in evaluating your application."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). WMF should not be translated. Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:157
-msgid ""
-"The information you provide when creating your account will be visible to "
-"you while on the site but not to others unless they are approved Wikipedia "
-"Library Coordinators, WMF Staff, or WMF Contractors who need access to this "
-"data in order to carry out their work with the Wikipedia Library, all of "
-"whom are subject to non-disclosure obligations."
+msgid "The information you provide when creating your account will be visible to you while on the site but not to others unless they are approved Wikipedia Library Coordinators, WMF Staff, or WMF Contractors who need access to this data in order to carry out their work with the Wikipedia Library, all of whom are subject to non-disclosure obligations."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
@@ -3179,46 +2743,32 @@ msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:171
-msgid ""
-"In order to access an individual publisher’s resources, you must agree to "
-"that publisher’s terms of use and privacy policy. You agree that you will "
-"not violate such terms and policies in connection with your use of the "
-"Wikipedia Library. Additionally, the following activities are prohibited "
-"while accessing publisher resources through the Wikipedia Library."
+msgid "In order to access an individual publisher’s resources, you must agree to that publisher’s terms of use and privacy policy. You agree that you will not violate such terms and policies in connection with your use of the Wikipedia Library. Additionally, the following activities are prohibited while accessing publisher resources through the Wikipedia Library."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:184
-msgid ""
-"Sharing your Wikipedia account, usernames, passwords, or any access codes "
-"for publisher resources with others;"
+msgid "Sharing your Wikipedia account, usernames, passwords, or any access codes for publisher resources with others;"
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:191
-msgid ""
-"Automatically scraping or downloading restricted content from publishers;"
+msgid "Automatically scraping or downloading restricted content from publishers;"
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:197
-msgid ""
-"Systematically making printed or electronic copies of multiple extracts of "
-"restricted content available for any purpose;"
+msgid "Systematically making printed or electronic copies of multiple extracts of restricted content available for any purpose;"
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:204
-msgid ""
-"Data mining metadata without permission—for example, in order to use "
-"metadata for auto-created stub articles;"
+msgid "Data mining metadata without permission—for example, in order to use metadata for auto-created stub articles;"
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:211
-msgid ""
-"Using the access you receive through the Wikipedia Library for profit by "
-"selling access to your account or resources which you have through it."
+msgid "Using the access you receive through the Wikipedia Library for profit by selling access to your account or resources which you have through it."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
@@ -3228,18 +2778,12 @@ msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:224
-msgid ""
-"Certain resources may only be accessed using an external search service, "
-"such as the EBSCO Discovery Service, or a proxy service, such as OCLC "
-"EZProxy. If you use such external search and/or proxy services, please "
-"review the applicable terms of use and privacy policies."
+msgid "Certain resources may only be accessed using an external search service, such as the EBSCO Discovery Service, or a proxy service, such as OCLC EZProxy. If you use such external search and/or proxy services, please review the applicable terms of use and privacy policies."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:234
-msgid ""
-"In addition, if you use OCLC EZProxy, please note that you may not use it "
-"for commercial purposes."
+msgid "In addition, if you use OCLC EZProxy, please note that you may not use it for commercial purposes."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
@@ -3249,120 +2793,49 @@ msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Wikimedia Foundation should not be translated. Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:245
-msgid ""
-"The Wikimedia Foundation and our service providers use your information for "
-"the legitimate purpose of providing Wikipedia Library services in support of "
-"our charitable mission. When you apply for a Wikipedia Library account, or "
-"use your Wikipedia Library account, we may routinely collect the following "
-"information: your username, email address, edit count, registration date, "
-"user ID number, groups to which you belong, and any special user rights; "
-"your name, country of residence, and/or affiliation, if required by a "
-"partner to which you are applying; your narrative description of your "
-"contributions and reasons for applying for access to partner resources; and "
-"the date you agree to these terms of use."
+msgid "The Wikimedia Foundation and our service providers use your information for the legitimate purpose of providing Wikipedia Library services in support of our charitable mission. When you apply for a Wikipedia Library account, or use your Wikipedia Library account, we may routinely collect the following information: your username, email address, edit count, registration date, user ID number, groups to which you belong, and any special user rights; your name, country of residence, and/or affiliation, if required by a partner to which you are applying; your narrative description of your contributions and reasons for applying for access to partner resources; and the date you agree to these terms of use."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:262
 #, python-format
-msgid ""
-"Each publisher who is a member of the Wikipedia Library program requires "
-"different specific information in the application. Some publishers may "
-"request only an email address, while others request more detailed data, such "
-"as your name, location, or institutional affiliation. When you complete your "
-"application, you will only be asked to supply information required by the "
-"publishers you have chosen, and each publisher will only receive the "
-"information they require for providing you with access. Please see our <a "
-"class=\"twl-links\" href=\"%(all_partners_url)s\">partner information</a> "
-"pages to learn what information is required by each publisher to gain access "
-"to their resources."
+msgid "Each publisher who is a member of the Wikipedia Library program requires different specific information in the application. Some publishers may request only an email address, while others request more detailed data, such as your name, location, or institutional affiliation. When you complete your application, you will only be asked to supply information required by the publishers you have chosen, and each publisher will only receive the information they require for providing you with access. Please see our <a class=\"twl-links\" href=\"%(all_partners_url)s\">partner information</a> pages to learn what information is required by each publisher to gain access to their resources."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Wikimedia Foundation should not be translated. Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:277
-msgid ""
-"Some Wikipedia Library pages are visible without logging in, but you will "
-"need to log in to apply or access proprietary partner resources. We use the "
-"data provided by you via OAuth and Wikimedia API calls to assess your "
-"application for access and to process approved requests."
+msgid "Some Wikipedia Library pages are visible without logging in, but you will need to log in to apply or access proprietary partner resources. We use the data provided by you via OAuth and Wikimedia API calls to assess your application for access and to process approved requests."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:288
 #, python-format
-msgid ""
-"In order to administer the Wikipedia Library program, we will retain the "
-"application data we collect from you for three years after your most recent "
-"login, unless you delete your account, as described below. You can log in "
-"and go to <a class=\"twl-links\" href=\"%(profile_url)s\">your profile page</"
-"a> in order to see the information associated with your account, and can "
-"download it in JSON format. You may access, update, restrict, or delete this "
-"information at any time, except for the information that is automatically "
-"retrieved from the projects. If you have any questions or concerns about the "
-"handling of your data, please contact <a class=\"twl-links\" href=\"mailto:"
-"wikipedialibrary@wikimedia.org?Subject=Wikipedia%%20Library%%20Card"
-"%%20account%%20deactivation\"> wikipedialibrary@wikimedia.org </a>."
+msgid "In order to administer the Wikipedia Library program, we will retain the application data we collect from you for three years after your most recent login, unless you delete your account, as described below. You can log in and go to <a class=\"twl-links\" href=\"%(profile_url)s\">your profile page</a> in order to see the information associated with your account, and can download it in JSON format. You may access, update, restrict, or delete this information at any time, except for the information that is automatically retrieved from the projects. If you have any questions or concerns about the handling of your data, please contact <a class=\"twl-links\" href=\"mailto:wikipedialibrary@wikimedia.org?Subject=Wikipedia%%20Library%%20Card%%20account%%20deactivation\"> wikipedialibrary@wikimedia.org </a>."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:305
-msgid ""
-"If you decide to disable your Wikipedia Library account, you can use the "
-"delete button on your profile to delete certain personal information "
-"associated with your account. We will delete your real name, institutional "
-"affiliation, and country of residence. Please note that the system will "
-"retain a record of your username, the publishers to which you applied or had "
-"access, and the dates of that access. Note that deletion is not reversible. "
-"Deletion of your Wikipedia Library account may also correspond with the "
-"removal of any resource access to which you were eligible or approved. If "
-"you request the deletion of account information and later wish to apply for "
-"a new account, you will need to provide the necessary information again."
+msgid "If you decide to disable your Wikipedia Library account, you can use the delete button on your profile to delete certain personal information associated with your account. We will delete your real name, institutional affiliation, and country of residence. Please note that the system will retain a record of your username, the publishers to which you applied or had access, and the dates of that access. Note that deletion is not reversible. Deletion of your Wikipedia Library account may also correspond with the removal of any resource access to which you were eligible or approved. If you request the deletion of account information and later wish to apply for a new account, you will need to provide the necessary information again."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). WMF should not be translated. Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:321
-msgid ""
-"The Wikipedia Library is run by WMF Staff, Contractors, and approved "
-"volunteer Coordinators. The data associated with your account will be shared "
-"with the WMF staff, contractors, service providers, and volunteer "
-"coordinators who need to process the information in connection with their "
-"work for the Wikipedia Library, and who are subject to confidentiality "
-"obligations. We will also use your data for internal Wikipedia Library "
-"purposes such as distributing user surveys and account notifications, and in "
-"a depersonalized or aggregated fashion for statistical analysis and "
-"administration. Finally, we will share your information with the publishers "
-"whom you specifically select in order to provide you with access to "
-"resources. Otherwise, your information will not be shared with third "
-"parties, with the exception of the circumstances described below."
+msgid "The Wikipedia Library is run by WMF Staff, Contractors, and approved volunteer Coordinators. The data associated with your account will be shared with the WMF staff, contractors, service providers, and volunteer coordinators who need to process the information in connection with their work for the Wikipedia Library, and who are subject to confidentiality obligations. We will also use your data for internal Wikipedia Library purposes such as distributing user surveys and account notifications, and in a depersonalized or aggregated fashion for statistical analysis and administration. Finally, we will share your information with the publishers whom you specifically select in order to provide you with access to resources. Otherwise, your information will not be shared with third parties, with the exception of the circumstances described below."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). WMF should not be translated.
 #: TWLight/users/templates/users/terms.html:338
-msgid ""
-"We may disclose any collected information when required by law, when we have "
-"your permission, when needed to protect our rights, privacy, safety, users, "
-"or the general public, and when necessary to enforce these terms, WMF’s "
-"general <a class=\"twl-links\" href=\"https://foundation.wikimedia.org/wiki/"
-"Terms_of_Use\">Terms of Use</a>, or any other WMF policy."
+msgid "We may disclose any collected information when required by law, when we have your permission, when needed to protect our rights, privacy, safety, users, or the general public, and when necessary to enforce these terms, WMF’s general <a class=\"twl-links\" href=\"https://foundation.wikimedia.org/wiki/Terms_of_Use\">Terms of Use</a>, or any other WMF policy."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:349
-msgid ""
-"We take the security of your personal data seriously, and take reasonable "
-"precautions to ensure your data is protected. These precautions include "
-"access controls to limit who has access to your data and security "
-"technologies to protect data stored on the server. However, we cannot "
-"guarantee the safety of your data as it is transmitted and stored."
+msgid "We take the security of your personal data seriously, and take reasonable precautions to ensure your data is protected. These precautions include access controls to limit who has access to your data and security technologies to protect data stored on the server. However, we cannot guarantee the safety of your data as it is transmitted and stored."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:360
-msgid ""
-"Please note that these terms do not control the use and handling of your "
-"data by the publishers and service providers whose resources you access or "
-"apply to access. Please read their individual privacy policies for that "
-"information."
+msgid "Please note that these terms do not control the use and handling of your data by the publishers and service providers whose resources you access or apply to access. Please read their individual privacy policies for that information."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
@@ -3372,34 +2845,17 @@ msgstr "중요한 참고"
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Wikimedia Foundation should not be translated. Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:373
-msgid ""
-"The Wikimedia Foundation is a nonprofit organization based in San Francisco, "
-"California. The Wikipedia Library program provides access to resources held "
-"by publishers in multiple countries. If you apply for a Wikipedia Library "
-"account (whether you are inside or outside of the United States), you "
-"understand that your personal data will be collected, transferred, stored, "
-"processed, disclosed and otherwise used in the U.S. as described in this "
-"privacy policy. You also understand that your information may be transferred "
-"by us from the U.S. to other countries, which may have different or less "
-"stringent data protection laws than your country, in connection with "
-"providing services to you, including evaluating your application and "
-"securing access to your chosen publishers (locations for each publisher are "
-"outlined on their respective partner information pages)."
+msgid "The Wikimedia Foundation is a nonprofit organization based in San Francisco, California. The Wikipedia Library program provides access to resources held by publishers in multiple countries. If you apply for a Wikipedia Library account (whether you are inside or outside of the United States), you understand that your personal data will be collected, transferred, stored, processed, disclosed and otherwise used in the U.S. as described in this privacy policy. You also understand that your information may be transferred by us from the U.S. to other countries, which may have different or less stringent data protection laws than your country, in connection with providing services to you, including evaluating your application and securing access to your chosen publishers (locations for each publisher are outlined on their respective partner information pages)."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:392
-msgid ""
-"Please note that in the event of any differences in meaning or "
-"interpretation between the original English version of these terms and a "
-"translation, the original English version takes precedence."
+msgid "Please note that in the event of any differences in meaning or interpretation between the original English version of these terms and a translation, the original English version takes precedence."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Wikimedia Foundation should not be translated.
 #: TWLight/users/templates/users/terms.html:403
-msgid ""
-"See also the <a class=\"twl-links\" href=\"https://wikimediafoundation.org/"
-"wiki/Privacy_policy\">Wikimedia Foundation Privacy Policy</a>."
+msgid "See also the <a class=\"twl-links\" href=\"https://wikimediafoundation.org/wiki/Privacy_policy\">Wikimedia Foundation Privacy Policy</a>."
 msgstr ""
 
 #. Translators: This is the second to last line of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
@@ -3419,11 +2875,7 @@ msgstr "위키미디어 재단"
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:426
-msgid ""
-"By checking this box and clicking “Submit”, you agree that you have read the "
-"above terms and that you will adhere to the terms of use in your application "
-"to and use of the The Wikipedia Library, and the publishers’ services to "
-"which you gain access through The Wikipedia Library program."
+msgid "By checking this box and clicking “Submit”, you agree that you have read the above terms and that you will adhere to the terms of use in your application to and use of the The Wikipedia Library, and the publishers’ services to which you gain access through The Wikipedia Library program."
 msgstr ""
 
 #: TWLight/users/templates/users/user_collection_tile.html:32
@@ -3478,29 +2930,18 @@ msgstr "모든 데이터 삭제"
 
 #. Translators: This message is displayed on the page where users can request the deletion of their data.
 #: TWLight/users/templates/users/user_confirm_delete.html:17
-msgid ""
-"<b>Warning:</b> Performing this action will delete your Wikipedia Library "
-"Card user account and all associated applications. This process is not "
-"reversible. You may lose any partner accounts you were granted, and will not "
-"be able to renew those accounts or apply for new ones."
+msgid "<b>Warning:</b> Performing this action will delete your Wikipedia Library Card user account and all associated applications. This process is not reversible. You may lose any partner accounts you were granted, and will not be able to renew those accounts or apply for new ones."
 msgstr ""
 
 #. Translators: this should show up for people who log in with a username/password and not OAuth, so we don't know what their Wikipedia identity is.
-#.
 #: TWLight/users/templates/users/user_detail.html:12
 #, python-format
-msgid ""
-"Hi, %(username)s! You don't have a Wikipedia editor profile attached to your "
-"account here, so you are probably a site administrator."
+msgid "Hi, %(username)s! You don't have a Wikipedia editor profile attached to your account here, so you are probably a site administrator."
 msgstr ""
 
 #. Translators: In the unlikely scenario that someone is able to register an account without using OAuth (thus leaving us without some of the information required for applications), users will see this message, encouraging them to re-register.
 #: TWLight/users/templates/users/user_detail.html:20
-msgid ""
-"If you aren't a site administrator, something weird has happened. You won't "
-"be able to apply for access without a Wikipedia editor profile. You should "
-"log out and create a new account by logging in via OAuth, or contact a site "
-"administrator for help."
+msgid "If you aren't a site administrator, something weird has happened. You won't be able to apply for access without a Wikipedia editor profile. You should log out and create a new account by logging in via OAuth, or contact a site administrator for help."
 msgstr ""
 
 #. Translators: Labels a sections where coordinators can select their email preferences.
@@ -3511,17 +2952,12 @@ msgstr "조정자 전용"
 #. Translators: This message is shown on user's own profile page, encouraging them to make sure their information is up to date, so that account coordinators can use the information to judge applications.
 #: TWLight/users/views.py:176
 #, python-brace-format
-msgid ""
-"Please <a class='twl-links' href='{url}'>update your contributions</a> to "
-"Wikipedia to help coordinators evaluate your applications."
+msgid "Please <a class='twl-links' href='{url}'>update your contributions</a> to Wikipedia to help coordinators evaluate your applications."
 msgstr ""
 
 #. Translators: Coordinators are shown this message when they unselect all three types of reminder email options under preferences.
 #: TWLight/users/views.py:288
-msgid ""
-"You have chosen not to receive reminder emails. As a coordinator, you should "
-"receive at least one type of reminder emails, so consider changing your "
-"preferences."
+msgid "You have chosen not to receive reminder emails. As a coordinator, you should receive at least one type of reminder emails, so consider changing your preferences."
 msgstr ""
 
 #. Translators: Coordinators are shown this message when they make changes to their reminder email options under preferences.
@@ -3555,12 +2991,8 @@ msgstr "내 이메일이 {email}(으)로 변경되었습니다."
 
 #. Translators: If the user has not filled out their email, they can browse the website but cannot apply for access to resources.
 #: TWLight/users/views.py:487
-msgid ""
-"Your email is blank. You can still explore the site, but you won't be able "
-"to apply for access to partner resources without an email."
-msgstr ""
-"이메일이 비어있습니다. 그래도 사이트를 탐색할 수 있지만 이메일 없이는 파트너 "
-"리소스에 접근을 신청하지 못하게 됩니다."
+msgid "Your email is blank. You can still explore the site, but you won't be able to apply for access to partner resources without an email."
+msgstr "이메일이 비어있습니다. 그래도 사이트를 탐색할 수 있지만 이메일 없이는 파트너 리소스에 접근을 신청하지 못하게 됩니다."
 
 #. Translators: This message is shown once the access to a partner has successfully been returned.
 #: TWLight/users/views.py:801
@@ -3593,31 +3025,3 @@ msgstr "현재 차단되지 않은 상태"
 msgid "10+ edits in the last 30 days"
 msgstr "지난 달 편집 수 10건 이상"
 
-#: tests/shunit/data/bad_i18n_comment_1.py:3
-#: tests/shunit/data/bad_i18n_newline_1.py:5
-msgid "1"
-msgstr ""
-
-#. Translators: Lorem ipsum dolor sit amet, consectetur adipiscing elit. Mauris vitae ipsum ut purus faucibus pretium. Proin tempus neque et aliquet consectetur. Ut egestas sapien in consectetur sagittis. Mauris neque lacus, dapibus non viverra vitae, interdum ut aenean ipsum.
-#. Translators: Lorem ipsum dolor sit amet, consectetur adipiscing elit. Mauris vitae ipsum ut purus faucibus pretium. Proin tempus neque et aliquet consectetur. Ut egestas sapien in consectetur sagittis. Mauris neque lacus, dapibus non.
-#: tests/shunit/data/bad_i18n_comment_2.py:4
-#: tests/shunit/data/bad_i18n_newline_2.py:5 tests/shunit/data/good_i18n_1.py:2
-#: tests/shunit/data/good_i18n_2.py:2
-msgid "2"
-msgstr ""
-
-#: tests/shunit/data/bad_i18n_newline_3.py:5
-msgid "3"
-msgstr ""
-
-#: tests/shunit/data/bad_i18n_newline_4.py:5
-msgid "4"
-msgstr ""
-
-#: tests/shunit/data/bad_i18n_newline_5.py:5
-msgid "5"
-msgstr ""
-
-#: tests/shunit/data/bad_i18n_newline_6.py:5
-msgid "6"
-msgstr ""

--- a/locale/lb/LC_MESSAGES/django.po
+++ b/locale/lb/LC_MESSAGES/django.po
@@ -5,10 +5,11 @@
 # Author: Volvox
 msgid ""
 msgstr ""
+""
 "Project-Id-Version: Wikipedia Library Card Platform - Website\n"
-"Report-Msgid-Bugs-To: wikipedialibrary@wikimedia.org\n"
+"Report-Msgid-Bugs-To: translatewiki.net\n"
 "POT-Creation-Date: 2024-07-11 20:54+0000\n"
-"PO-Revision-Date: 2024-07-11 12:30:16+0000\n"
+"PO-Revision-Date: 2024-07-15 12:29:16+0000\n"
 "Language: lb\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
@@ -40,9 +41,7 @@ msgstr "Iwwer Iech"
 #. Translators: This note appears in a section of a form where we ask users to enter info (like country of residence) when applying for resource access.
 #: TWLight/applications/forms.py:179
 #, python-brace-format
-msgid ""
-"<p><small><i>Your personal data will be processed according to our <a "
-"class='twl-links' href='{terms_url}'> privacy policy</a>.</i></small></p>"
+msgid "<p><small><i>Your personal data will be processed according to our <a class='twl-links' href='{terms_url}'> privacy policy</a>.</i></small></p>"
 msgstr ""
 
 #. Translators: This is the title of the application form page, where users enter information required for the application. It lets the user know which partner application they are entering data for. {partner}
@@ -84,12 +83,8 @@ msgstr ""
 #. Translators: This labels a choice field where users will have to select the number of months they wish to have their access for as part of the application renewal confirmation.
 #. Translators: When filling out an application, users may be required to enter the length of the account (expiry) they wish to have for proxy partners.
 #: TWLight/applications/forms.py:339 TWLight/applications/helpers.py:100
-msgid ""
-"The number of months you wish to have this access for before renewal is "
-"required"
-msgstr ""
-"D'Zuel vu Méint, wärend deenen Dir dësen Zougang wëllt hunn, éier Dir en "
-"erneiere musst"
+msgid "The number of months you wish to have this access for before renewal is required"
+msgstr "D'Zuel vu Méint, wärend deenen Dir dësen Zougang wëllt hunn, éier Dir en erneiere musst"
 
 #. Translators: When filling out an application, users may need to specify their name
 #: TWLight/applications/helpers.py:81
@@ -177,9 +172,7 @@ msgstr "E-Mail"
 
 #. Translators: This comment is added to pending applications when our terms of use change.
 #: TWLight/applications/management/commands/notify_applicants_tou_changes.py:54
-msgid ""
-"Our terms of use have changed. Your applications will not be processed until "
-"you log in and agree to our updated terms."
+msgid "Our terms of use have changed. Your applications will not be processed until you log in and agree to our updated terms."
 msgstr ""
 
 #. Translators: This is the status of an application that has not yet been reviewed.
@@ -246,23 +239,17 @@ msgstr "Zougangs-URL: {access_url}"
 
 #. Translators: This text goes into account approval emails in the case that we need to send the user's details to a publisher for manual account setup.
 #: TWLight/applications/models.py:331
-msgid ""
-"You can expect to receive access details within a week or two once it has "
-"been processed."
+msgid "You can expect to receive access details within a week or two once it has been processed."
 msgstr ""
 
 #. Translators: This comment is added to open applications when a partner joins the Library Bundle, which does not require applications.
 #: TWLight/applications/signals.py:247
-msgid ""
-"This partner joined the Library Bundle, which does not require applications. "
-"This application will be marked as invalid."
+msgid "This partner joined the Library Bundle, which does not require applications. This application will be marked as invalid."
 msgstr ""
 
 #. Translators: This is shown to users if the application is to a partner for which we have run out of available accounts. The application is therefore on a 'waitlist', and will be reviewed when more accounts are available.
 #: TWLight/applications/templates/applications/application_evaluation.html:29
-msgid ""
-"This application is on the waitlist because this partner does not have any "
-"access grants available at this time."
+msgid "This application is on the waitlist because this partner does not have any access grants available at this time."
 msgstr ""
 
 #. Translators: This message is shown on pages where coordinators can see personal information about applicants.
@@ -270,9 +257,7 @@ msgstr ""
 #: TWLight/applications/templates/applications/application_list_include.html:6
 #: TWLight/applications/templates/applications/send_partner.html:45
 #: TWLight/resources/templates/resources/partner_users.html:18
-msgid ""
-"Coordinators: This page may contain personal information such as real names "
-"and email addresses. Please remember that this information is confidential."
+msgid "Coordinators: This page may contain personal information such as real names and email addresses. Please remember that this information is confidential."
 msgstr ""
 
 #. Translators: This is the title of the application page shown to users who are a coordinator, and are able to accept or reject the application.
@@ -282,9 +267,7 @@ msgstr ""
 
 #. Translators: This text is shown to coordinators on application pages if the applicant has restricted processing of their data.
 #: TWLight/applications/templates/applications/application_evaluation.html:42
-msgid ""
-"This user has requested a restriction on the processing of their data, so "
-"you cannot change the status of their application."
+msgid "This user has requested a restriction on the processing of their data, so you cannot change the status of their application."
 msgstr ""
 
 #. Translators: This is the title of the application page shown to users who are not a coordinator.
@@ -358,9 +341,7 @@ msgstr "Onbekannt"
 
 #. Translators: This is the text displayed to coordinators when an applicant has no country of residence in their profile.
 #: TWLight/applications/templates/applications/application_evaluation.html:123
-msgid ""
-"Please request the applicant add their country of residence to their profile "
-"before proceeding further."
+msgid "Please request the applicant add their country of residence to their profile before proceeding further."
 msgstr ""
 
 #. Translators: This labels the section of an application showing the total number of accounts available for a partner or their collection.
@@ -371,9 +352,7 @@ msgstr "Disponibel Benotzerkonten"
 #. Translators: This labels the section of an application showing whether the user had agreed to the terms of use or not.
 #: TWLight/applications/templates/applications/application_evaluation.html:145
 #, python-format
-msgid ""
-"Has agreed to the site's <a class=\"twl-links\" href=\"%(terms_url)s\">terms "
-"of use</a>?"
+msgid "Has agreed to the site's <a class=\"twl-links\" href=\"%(terms_url)s\">terms of use</a>?"
 msgstr ""
 
 #. Translators: Displayed to coordinators when they've agreed to the terms of use.
@@ -409,9 +388,7 @@ msgstr "Neen"
 
 #. Translators: This is the text displayed to coordinators when an applicant has not agreed to the terms of use.
 #: TWLight/applications/templates/applications/application_evaluation.html:159
-msgid ""
-"Please request the applicant agree to the site's terms of use before "
-"approving this application."
+msgid "Please request the applicant agree to the site's terms of use before approving this application."
 msgstr ""
 
 #. Translators: This labels the section of an application containing the user's motivation for wanting access to this resource.
@@ -432,8 +409,7 @@ msgstr ""
 #. Translators: This message is shown next to the 'Renewal of existing access grant?' label if the application is a renewal. Don't translate HTML tags or parent_url.
 #: TWLight/applications/templates/applications/application_evaluation.html:195
 #, python-format
-msgid ""
-"Yes (<a class=\"twl-links\" href=\"%(parent_url)s\">previous application</a>)"
+msgid "Yes (<a class=\"twl-links\" href=\"%(parent_url)s\">previous application</a>)"
 msgstr ""
 
 #. Translators: This labels the section of the application showing the length of access remaining on the user's previous authorization.
@@ -468,9 +444,7 @@ msgstr ""
 
 #. Translators: On an application page, this text tells users that the comments posted on the application are visible to coordinators and the submitting user only.
 #: TWLight/applications/templates/applications/application_evaluation.html:297
-msgid ""
-"Comments are visible to all coordinators and to the editor who submitted "
-"this application."
+msgid "Comments are visible to all coordinators and to the editor who submitted this application."
 msgstr ""
 
 #. Translators: This is the title of the section of an application page which lists information about the user who submitted the application.
@@ -682,12 +656,7 @@ msgstr ""
 
 #: TWLight/applications/templates/applications/apply.html:20
 #, python-format
-msgid ""
-"If your application is successful we may share your email address with "
-"%(partner)s. This is required to set up your access to their resources. By "
-"submitting this form you agree to allow your email address to be shared with "
-"%(partner)s if your application is successful, for the purposes of account "
-"setup."
+msgid "If your application is successful we may share your email address with %(partner)s. This is required to set up your access to their resources. By submitting this form you agree to allow your email address to be shared with %(partner)s if your application is successful, for the purposes of account setup."
 msgstr ""
 
 #. Translators: This message is displayed on the page where users can confirm their renewal. Please do not translate partner.
@@ -716,9 +685,7 @@ msgstr "Op wat fir Ressourcë wëllt Dir Zougang?"
 
 #. Translators: This text explains that Library Bundle partners are not shown in this list.
 #: TWLight/applications/templates/applications/request_for_application.html:26
-msgid ""
-"Library Bundle partners are not shown as eligibility is determined "
-"automatically."
+msgid "Library Bundle partners are not shown as eligibility is determined automatically."
 msgstr ""
 
 #. Translators: On the page where users can apply for multiple partners, this message shows next to the partner name, taking them to the full application page when clicked.
@@ -733,10 +700,7 @@ msgstr ""
 
 #. Translators: the HTML is so that the word 'waitlisted' will look the same as it does in the page above; please translate 'waitlisted' the same way you did elsewhere in this file.
 #: TWLight/applications/templates/applications/request_for_application.html:74
-msgid ""
-"You can apply to <span class=\"badge badge-warning\">Waitlisted</span> "
-"partners, but they don't have access grants available right now. We will "
-"process those applications when access becomes available."
+msgid "You can apply to <span class=\"badge badge-warning\">Waitlisted</span> partners, but they don't have access grants available right now. We will process those applications when access becomes available."
 msgstr ""
 
 #. Translators: On the page where coordinators can see approved applications which have not had their details sent to the partner, this message shows when there are applications ready to be processed.
@@ -758,9 +722,7 @@ msgstr ""
 #. Translators: This message is shown when applications exceed the number of accounts available.
 #: TWLight/applications/templates/applications/send_partner.html:54
 #, python-format
-msgid ""
-"Application(s) for %(object)s, if sent, will exceed the total available "
-"accounts for the partner. Please proceed at your own discretion."
+msgid "Application(s) for %(object)s, if sent, will exceed the total available accounts for the partner. Please proceed at your own discretion."
 msgstr ""
 
 #. Translators: When viewing the list of applications ready to be sent for a particular partner, this is instructions for the coordinator to click the 'mark as sent' button after they have sent the information.
@@ -777,9 +739,7 @@ msgstr[1] "Kontaktdaten"
 
 #. Translators: When viewing the list of applications ready to be sent for a particular partner, this message shows if there is no information about who the applications should be sent to. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/applications/templates/applications/send_partner.html:89
-msgid ""
-"Whoops, we don't have any listed contacts. Please notify Wikipedia Library "
-"administrators."
+msgid "Whoops, we don't have any listed contacts. Please notify Wikipedia Library administrators."
 msgstr ""
 
 #. Translators: When viewing the list of applications ready to be sent for a particular partner, this is the title of the section containing the information about those applications.
@@ -795,9 +755,7 @@ msgstr "Als geschéckt markéieren"
 
 #. Translators: This text guides coordinators in using the code sending interface for approved applications.
 #: TWLight/applications/templates/applications/send_partner.html:152
-msgid ""
-"Use the dropdown menus to denote which editor will receive each code. Access "
-"codes will be sent to users automatically."
+msgid "Use the dropdown menus to denote which editor will receive each code. Access codes will be sent to users automatically."
 msgstr ""
 
 #. Translators: This labels a drop-down selection where staff can assign an access code to a user.
@@ -813,18 +771,13 @@ msgstr ""
 #. Translators: When a user applies for a set of resources, they receive this message if none are currently available. They are instead placed on a 'waitlist' for later approval.
 #. Translators: When a user renews their resource, they receive this message if none are currently available. They are instead placed on a 'waitlist' for later approval.
 #: TWLight/applications/views.py:140 TWLight/applications/views.py:1282
-msgid ""
-"This partner does not have any access grants available at this time. You may "
-"still apply for access; your application will be reviewed when access grants "
-"become available."
+msgid "This partner does not have any access grants available at this time. You may still apply for access; your application will be reviewed when access grants become available."
 msgstr ""
 
 #. Translators: This message is shown to users once they've successfully submitted their application for review.
 #: TWLight/applications/views.py:163
 #, python-brace-format
-msgid ""
-"Your application has been submitted for review. Head over to <a "
-"href='{applications_url}'>My Applications</a> to view the status."
+msgid "Your application has been submitted for review. Head over to <a href='{applications_url}'>My Applications</a> to view the status."
 msgstr ""
 
 #. Translators: This text is displayed to users when the user has chosen to restrict data and is trying to apply for multiple partners
@@ -873,16 +826,12 @@ msgstr ""
 
 #. Translators: After a coordinator has changed the status of an application to APPROVED, if the corresponding partner/collection is waitlisted this message appears.
 #: TWLight/applications/views.py:756
-msgid ""
-"Cannot approve application as partner with proxy authorization method is "
-"waitlisted."
+msgid "Cannot approve application as partner with proxy authorization method is waitlisted."
 msgstr ""
 
 #. Translators: After a coordinator has changed the status of an application to APPROVED, if the corresponding partner/collection has no accounts for distribution, this message appears.
 #: TWLight/applications/views.py:780
-msgid ""
-"Cannot approve application as partner with proxy authorization method is "
-"waitlisted and (or) has zero accounts available for distribution."
+msgid "Cannot approve application as partner with proxy authorization method is waitlisted and (or) has zero accounts available for distribution."
 msgstr ""
 
 #. Translators: This message appears on an "access denied" screen that stops users who attempt to authorize an editor to access a resource during a time period for which they are already authorized.
@@ -893,11 +842,7 @@ msgstr ""
 #. Translators: This message is shown to users when they access an application page of a now Bundle partner (new applications aren't allowed for Bundle partners and the status of old applications cannot be modified)
 #: TWLight/applications/views.py:857
 #, python-brace-format
-msgid ""
-"This application cannot be modified since this partner is now part of our <a "
-"href='{bundle}'>bundle access</a>. If you are eligible, you can access this "
-"resource from <a href='{library}'>your library</a>. <a "
-"href='{contact}'>Contact us</a> if you have any questions."
+msgid "This application cannot be modified since this partner is now part of our <a href='{bundle}'>bundle access</a>. If you are eligible, you can access this resource from <a href='{library}'>your library</a>. <a href='{contact}'>Contact us</a> if you have any questions."
 msgstr ""
 
 #. Translators: this lets a reviewer set the status of a single application.
@@ -907,9 +852,7 @@ msgstr ""
 
 #. Translators: This warning is message is shown to applicants when the number of pending applications is greater than the number of accounts available.
 #: TWLight/applications/views.py:891
-msgid ""
-"There are more pending applications than available accounts. Your "
-"application might get waitlisted."
+msgid "There are more pending applications than available accounts. Your application might get waitlisted."
 msgstr ""
 
 #. Translators: this message is shown to coordinators who attempt to change an application's Status from INVALID to any other Status.
@@ -929,11 +872,7 @@ msgstr ""
 
 #. Translators: After a coordinator has changed the status of a number of applications to APPROVED, if the corresponding partner(s) is/are waitlisted or has no accounts for distribution, this message appears.
 #: TWLight/applications/views.py:1051
-msgid ""
-"Cannot approve application(s) {} as partner(s) with proxy authorization "
-"method is/are waitlisted and (or) has/have not enough accounts available. If "
-"not enough accounts are available, prioritise the applications and then "
-"approve applications equal to the accounts available."
+msgid "Cannot approve application(s) {} as partner(s) with proxy authorization method is/are waitlisted and (or) has/have not enough accounts available. If not enough accounts are available, prioritise the applications and then approve applications equal to the accounts available."
 msgstr ""
 
 #. Translators: This message is shown to coordinators who attempt to assign the same access code to multiple users.
@@ -948,9 +887,7 @@ msgstr ""
 
 #. Translators: When a user tries to renew their resource, they receive this message if the partner is not available.
 #: TWLight/applications/views.py:1272
-msgid ""
-"Cannot renew application at this time as partner is not available. Please "
-"check back later, or contact us for more information."
+msgid "Cannot renew application at this time as partner is not available. Please check back later, or contact us for more information."
 msgstr ""
 
 #. Translators: This message is displayed when an attempt by a user to renew an application has been denied for some reason.
@@ -961,16 +898,12 @@ msgstr ""
 
 #. Translators: If a user requests the renewal of their account, but it wasn't renewed, this message is shown to them.
 #: TWLight/applications/views.py:1385
-msgid ""
-"This object cannot be renewed. (This probably means that you have already "
-"requested that it be renewed.)"
+msgid "This object cannot be renewed. (This probably means that you have already requested that it be renewed.)"
 msgstr ""
 
 #. Translators: If a user requests the renewal of their account, this message is shown to them.
 #: TWLight/applications/views.py:1395
-msgid ""
-"Your renewal request has been received. A coordinator will review your "
-"request."
+msgid "Your renewal request has been received. A coordinator will review your request."
 msgstr ""
 
 #. Translators: This labels a textfield where users can enter their email ID.
@@ -980,9 +913,7 @@ msgstr "Äer E-Mail"
 
 #. Translators: This is the help text for the email field in the contact us form letting users know the field is updated by value pulled from their respective user profiles.
 #: TWLight/emails/forms.py:21
-msgid ""
-"This field is automatically updated with the email from your <a class='twl-"
-"links' href='{}'>user profile</a>."
+msgid "This field is automatically updated with the email from your <a class='twl-links' href='{}'>user profile</a>."
 msgstr ""
 
 #. Translators: This labels a textfield where users can enter their email message.
@@ -1006,19 +937,13 @@ msgstr "Schécken"
 #. Translators: This email is sent to users with their access code. Don't translate Jinja variables in curly braces like user or partner. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/access_code_email-body-html.html:5
 #, python-format
-msgid ""
-"<p>Your approved application to %(partner)s has now been finalised. Your "
-"access code or login details can be found below:</p> <p><b>%(access_code)s</"
-"b></p> <p>%(user_instructions)s</p>"
+msgid "<p>Your approved application to %(partner)s has now been finalised. Your access code or login details can be found below:</p> <p><b>%(access_code)s</b></p> <p>%(user_instructions)s</p>"
 msgstr ""
 
 #. Translators: This email is sent to users with their access code. Don't translate Jinja variables in curly braces like user or partner. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/access_code_email-body-text.html:3
 #, python-format
-msgid ""
-"Your approved application to %(partner)s has now been finalised. Your access "
-"code or login details can be found below: %(access_code)s "
-"%(user_instructions)s"
+msgid "Your approved application to %(partner)s has now been finalised. Your access code or login details can be found below: %(access_code)s %(user_instructions)s"
 msgstr ""
 
 #. Translators: This is the subject line of an email sent to users with their access code.
@@ -1029,23 +954,13 @@ msgstr ""
 #. Translators: This email is sent to users when their application is approved. Don't translate Jinja variables in curly braces like user or partner; don't translate html tags either. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/approval_notification-body-html.html:5
 #, python-format
-msgid ""
-"<p>Dear %(user)s,</p> <p>Thank you for applying for access to %(partner)s "
-"resources through The Wikipedia Library. We are happy to inform you that "
-"your application has been approved.</p> <p>%(user_instructions)s</p> <p>You "
-"can view the collections you're authorized to access at My Library: "
-"%(link)s</p> <p>Cheers!</p> <p>The Wikipedia Library</p>"
+msgid "<p>Dear %(user)s,</p> <p>Thank you for applying for access to %(partner)s resources through The Wikipedia Library. We are happy to inform you that your application has been approved.</p> <p>%(user_instructions)s</p> <p>You can view the collections you're authorized to access at My Library: %(link)s</p> <p>Cheers!</p> <p>The Wikipedia Library</p>"
 msgstr ""
 
 #. Translators: This email is sent to users when their application is approved. Don't translate Jinja variables in curly braces like user or partner. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/approval_notification-body-text.html:3
 #, python-format
-msgid ""
-"Dear %(user)s, Thank you for applying for access to %(partner)s resources "
-"through The Wikipedia Library. We are happy to inform you that your "
-"application has been approved. %(user_instructions)s You can view the "
-"collections you're authorized to access at My Library: %(link)s Cheers! The "
-"Wikipedia Library"
+msgid "Dear %(user)s, Thank you for applying for access to %(partner)s resources through The Wikipedia Library. We are happy to inform you that your application has been approved. %(user_instructions)s You can view the collections you're authorized to access at My Library: %(link)s Cheers! The Wikipedia Library"
 msgstr ""
 
 #. Translators: This is the subject of an email which is sent to users when their application has been approved. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
@@ -1056,19 +971,13 @@ msgstr ""
 #. Translators: This email is sent to coordinators when a comment is left on an application they are processing. Don't translate Jinja variables in curly braces like user or partner. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/comment_notification_coordinator-body-html.html:5
 #, python-format
-msgid ""
-"<p style=\"color: #500050\">%(submit_date)s - %(commenter)s</p> "
-"<blockquote><p>%(comment)s</p></blockquote> <p>Please reply to these at: <a "
-"href=\"%(app_url)s\">%(app_url)s</a></p> <p>Best,</p> <p>The Wikipedia "
-"Library</p>"
+msgid "<p style=\"color: #500050\">%(submit_date)s - %(commenter)s</p> <blockquote><p>%(comment)s</p></blockquote> <p>Please reply to these at: <a href=\"%(app_url)s\">%(app_url)s</a></p> <p>Best,</p> <p>The Wikipedia Library</p>"
 msgstr ""
 
 #. Translators: This email is sent to coordinators when a comment is left on an application they are processing. Don't translate Jinja variables in curly braces like user or partner. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/comment_notification_coordinator-body-text.html:3
 #, python-format
-msgid ""
-"%(submit_date)s - %(commenter)s %(comment)s Please reply to this at: "
-"%(app_url)s Best, The Wikipedia Library"
+msgid "%(submit_date)s - %(commenter)s %(comment)s Please reply to this at: %(app_url)s Best, The Wikipedia Library"
 msgstr ""
 
 #. Translators: This is the subject line of an email sent to coordinators when a comment is left on an application they processed.
@@ -1079,19 +988,13 @@ msgstr ""
 #. Translators: This email is sent to users when they receive a comment on their application. Don't translate Jinja variables in curly braces like user or partner; don't translate html tags either. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/comment_notification_editors-body-html.html:5
 #, python-format
-msgid ""
-"<p style=\"color: #500050\">%(submit_date)s - %(commenter)s</p> "
-"<blockquote><p>%(comment)s</p></blockquote> <p>Please reply to these at <a "
-"href=\"%(app_url)s\">%(app_url)s</a> so we can evaluate your application.</"
-"p> <p>Best,</p> <p>The Wikipedia Library</p>"
+msgid "<p style=\"color: #500050\">%(submit_date)s - %(commenter)s</p> <blockquote><p>%(comment)s</p></blockquote> <p>Please reply to these at <a href=\"%(app_url)s\">%(app_url)s</a> so we can evaluate your application.</p> <p>Best,</p> <p>The Wikipedia Library</p>"
 msgstr ""
 
 #. Translators: This email is sent to users when they receive a comment on their application. Don't translate Jinja variables in curly braces like user or partner. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/comment_notification_editors-body-text.html:3
 #, python-format
-msgid ""
-"%(submit_date)s - %(commenter)s %(comment)s Please reply to these at: "
-"%(app_url)s so we can evaluate your application. Best, The Wikipedia Library"
+msgid "%(submit_date)s - %(commenter)s %(comment)s Please reply to these at: %(app_url)s so we can evaluate your application. Best, The Wikipedia Library"
 msgstr ""
 
 #. Translators: This is the subject line of an email sent to users who have a comment added to one of their applications. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
@@ -1102,18 +1005,13 @@ msgstr ""
 #. Translators: This email is sent to users when an application they commented on receives another comment. Don't translate Jinja variables in curly braces like app_url; don't translate html tags either. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/comment_notification_others-body-html.html:5
 #, python-format
-msgid ""
-"<p style=\"color: #500050\">%(submit_date)s - %(commenter)s</p> "
-"<blockquote><p>%(comment)s</p></blockquote> See it at <a href=\"%(app_url)s"
-"\">%(app_url)s</a>. Thanks for helping review Wikipedia Library applications!"
+msgid "<p style=\"color: #500050\">%(submit_date)s - %(commenter)s</p> <blockquote><p>%(comment)s</p></blockquote> See it at <a href=\"%(app_url)s\">%(app_url)s</a>. Thanks for helping review Wikipedia Library applications!"
 msgstr ""
 
 #. Translators: This email is sent to users when an application they commented on receives another comment. Don't translate Jinja variables in curly braces like app_url. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/comment_notification_others-body-text.html:3
 #, python-format
-msgid ""
-"%(submit_date)s - %(commenter)s %(comment)s See it at: %(app_url)s Thanks "
-"for helping review Wikipedia Library applications!"
+msgid "%(submit_date)s - %(commenter)s %(comment)s See it at: %(app_url)s Thanks for helping review Wikipedia Library applications!"
 msgstr ""
 
 #. Translators: This is the subject line of an email sent to users who have a comment added to an application they also commented on. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
@@ -1124,10 +1022,7 @@ msgstr ""
 #. Translators: This text is part of a scheduled reminder email sent to coordinators who have applications requiring action. Don't translate Jinja variables in curly braces like total_apps, or user.
 #: TWLight/emails/templates/emails/coordinator_reminder_notification-body-html.html:5
 #, python-format
-msgid ""
-"<p>Dear %(user)s,</p> <p>Our records indicate that you are the designated "
-"coordinator for partners that have a total of %(total_apps)s applications.</"
-"p>"
+msgid "<p>Dear %(user)s,</p> <p>Our records indicate that you are the designated coordinator for partners that have a total of %(total_apps)s applications.</p>"
 msgstr ""
 
 #. Translators: Breakdown as in 'cost breakdown'; analysis.
@@ -1166,31 +1061,19 @@ msgstr[1] ""
 #. Translators: This text is part of a scheduled reminder email sent to coordinators who have applications requiring action. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library). Don't translate Jinja variables in curly braces like link; don't translate email addresses or html tags either.
 #: TWLight/emails/templates/emails/coordinator_reminder_notification-body-html.html:39
 #, python-format
-msgid ""
-"<p>This is a gentle reminder that you may review applications at <a href="
-"\"%(link)s\">%(link)s</a>.</p> <p>You can customise your reminders under "
-"'preferences' in your user profile.</p> <p>If you received this message in "
-"error, drop us a line at wikipedialibrary@wikimedia.org.</p> <p>Thanks for "
-"helping review Wikipedia Library applications!</p>"
+msgid "<p>This is a gentle reminder that you may review applications at <a href=\"%(link)s\">%(link)s</a>.</p> <p>You can customise your reminders under 'preferences' in your user profile.</p> <p>If you received this message in error, drop us a line at wikipedialibrary@wikimedia.org.</p> <p>Thanks for helping review Wikipedia Library applications!</p>"
 msgstr ""
 
 #. Translators: This text is part of a scheduled reminder email sent to coordinators who have applications requiring action. Don't translate Jinja variables in curly braces like total_apps, or user.
 #: TWLight/emails/templates/emails/coordinator_reminder_notification-body-text.html:3
 #, python-format
-msgid ""
-"Dear %(user)s, Our records indicate that you are the designated coordinator "
-"for partners that have a total of %(total_apps)s applications."
+msgid "Dear %(user)s, Our records indicate that you are the designated coordinator for partners that have a total of %(total_apps)s applications."
 msgstr ""
 
 #. Translators: This text is part of a scheduled reminder email sent to coordinators who have applications requiring action. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library). Don't translate Jinja variables in curly braces like link; don't translate the email address either.
 #: TWLight/emails/templates/emails/coordinator_reminder_notification-body-text.html:38
 #, python-format
-msgid ""
-"This is a gentle reminder that you may review applications at: %(link)s. You "
-"can customise your reminders under 'preferences' in your user profile. If "
-"you received this message in error, drop us a line at: "
-"wikipedialibrary@wikimedia.org Thanks for helping review Wikipedia Library "
-"applications!"
+msgid "This is a gentle reminder that you may review applications at: %(link)s. You can customise your reminders under 'preferences' in your user profile. If you received this message in error, drop us a line at: wikipedialibrary@wikimedia.org Thanks for helping review Wikipedia Library applications!"
 msgstr ""
 
 #. Translators: This is the subject line of a scheduled reminder email sent to coordinators who have applications to review. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library). Do not translate items in curly braces.
@@ -1201,22 +1084,13 @@ msgstr ""
 #. Translators: This email is sent to users when their application is rejected. Don't translate Jinja variables in curly braces like user or partner; don't translate html tags either. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/rejection_notification-body-html.html:5
 #, python-format
-msgid ""
-"<p>Dear %(user)s,</p> <p>Thank you for applying for access to %(partner)s "
-"resources through The Wikipedia Library. Unfortunately at this time your "
-"application has not been approved. You can view your application and review "
-"comments at <a href=\"%(app_url)s\">%(app_url)s</a>.</p> <p>Best,</p> <p>The "
-"Wikipedia Library</p>"
+msgid "<p>Dear %(user)s,</p> <p>Thank you for applying for access to %(partner)s resources through The Wikipedia Library. Unfortunately at this time your application has not been approved. You can view your application and review comments at <a href=\"%(app_url)s\">%(app_url)s</a>.</p> <p>Best,</p> <p>The Wikipedia Library</p>"
 msgstr ""
 
 #. Translators: This email is sent to users when their application is rejected. Don't translate Jinja variables in curly braces like user or partner. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/rejection_notification-body-text.html:3
 #, python-format
-msgid ""
-"Dear %(user)s, Thank you for applying for access to %(partner)s resources "
-"through The Wikipedia Library. Unfortunately at this time your application "
-"has not been approved. You can view your application and review comments at: "
-"%(app_url)s Best, The Wikipedia Library"
+msgid "Dear %(user)s, Thank you for applying for access to %(partner)s resources through The Wikipedia Library. Unfortunately at this time your application has not been approved. You can view your application and review comments at: %(app_url)s Best, The Wikipedia Library"
 msgstr ""
 
 #. Translators: This is the subject of an email which is sent to users when their application has been rejected. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
@@ -1227,25 +1101,13 @@ msgstr ""
 #. Translators: This email is sent to users when they have an account that is soon to expire. Don't translate Jinja variables in curly braces like partner_name or partner_link; don't translate html tags either. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/user_renewal_notice-body-html.html:5
 #, python-format
-msgid ""
-"<p>Dear %(user)s,</p> <p>According to our records, your access to "
-"%(partner_name)s will soon expire and you may lose access. If you want to "
-"continue making use of your free account, you can request renewal of your "
-"account by clicking the 'Renew' or 'Extend' button at %(partner_link)s.</p> "
-"<p>Best,</p> <p>The Wikipedia Library</p> <p>You can disable these emails in "
-"your user page preferences: https://wikipedialibrary.wmflabs.org/users/</p>"
+msgid "<p>Dear %(user)s,</p> <p>According to our records, your access to %(partner_name)s will soon expire and you may lose access. If you want to continue making use of your free account, you can request renewal of your account by clicking the 'Renew' or 'Extend' button at %(partner_link)s.</p> <p>Best,</p> <p>The Wikipedia Library</p> <p>You can disable these emails in your user page preferences: https://wikipedialibrary.wmflabs.org/users/</p>"
 msgstr ""
 
 #. Translators: This email is sent to users when they have an account that is soon to expire. Don't translate Jinja variables in curly braces like partner_name or partner_link; don't translate html tags either. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/user_renewal_notice-body-text.html:3
 #, python-format
-msgid ""
-"Dear %(user)s, According to our records, your access to %(partner_name)s "
-"will soon expire and you may lose access. If you want to continue making use "
-"of your free account, you can request renewal of your account by clicking "
-"the Renew button at %(partner_link)s. Best, The Wikipedia Library You can "
-"disable these emails in your user page preferences: https://wikipedialibrary."
-"wmflabs.org/users/"
+msgid "Dear %(user)s, According to our records, your access to %(partner_name)s will soon expire and you may lose access. If you want to continue making use of your free account, you can request renewal of your account by clicking the Renew button at %(partner_link)s. Best, The Wikipedia Library You can disable these emails in your user page preferences: https://wikipedialibrary.wmflabs.org/users/"
 msgstr ""
 
 #. Translators: This is the subject of an email sent to users when they have an account that is soon to expire. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
@@ -1256,24 +1118,13 @@ msgstr ""
 #. Translators: This email is sent to users when their application is waitlisted because there are no more accounts available. Don't translate Jinja variables in curly braces like user or partner; don't translate html tags either. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/waitlist_notification-body-html.html:5
 #, python-format
-msgid ""
-"<p>Dear %(user)s,</p> <p>Thank you for applying for access to %(partner)s "
-"resources through The Wikipedia Library. There are no accounts currently "
-"available so your application has been waitlisted. Your application will be "
-"evaluated if/when more accounts become available. You can see all available "
-"resources at <a href=\"%(link)s\">%(link)s</a>.</p> <p>Best,</p> <p>The "
-"Wikipedia Library</p>"
+msgid "<p>Dear %(user)s,</p> <p>Thank you for applying for access to %(partner)s resources through The Wikipedia Library. There are no accounts currently available so your application has been waitlisted. Your application will be evaluated if/when more accounts become available. You can see all available resources at <a href=\"%(link)s\">%(link)s</a>.</p> <p>Best,</p> <p>The Wikipedia Library</p>"
 msgstr ""
 
 #. Translators: This email is sent to users when their application is waitlisted because there are no more accounts available. Don't translate Jinja variables in curly braces like user or partner. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/waitlist_notification-body-text.html:3
 #, python-format
-msgid ""
-"Dear %(user)s, Thank you for applying for access to %(partner)s resources "
-"through The Wikipedia Library. There are no accounts currently available so "
-"your application has been waitlisted. Your application will be evaluated if/"
-"when more accounts become available. You can see all available resources at: "
-"%(link)s Best, The Wikipedia Library"
+msgid "Dear %(user)s, Thank you for applying for access to %(partner)s resources through The Wikipedia Library. There are no accounts currently available so your application has been waitlisted. Your application will be evaluated if/when more accounts become available. You can see all available resources at: %(link)s Best, The Wikipedia Library"
 msgstr ""
 
 #. Translators: This is the subject of an email sent to users when their application is waitlisted because there are no more accounts available. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
@@ -1435,17 +1286,14 @@ msgstr "Net disponibel"
 #: TWLight/resources/templates/resources/filter_section.html:14
 #: TWLight/templates/about.html:12
 #: TWLight/users/templates/users/filter_section.html:13
-msgid ""
-"The Wikipedia Library allows active editors to access a wide range of "
-"collections of paywalled reliable sources for free!"
+msgid "The Wikipedia Library allows active editors to access a wide range of collections of paywalled reliable sources for free!"
 msgstr ""
 
 #. Translators: On the Browse Partners page (https://wikipedialibrary.wmflabs.org/partners/), this introduces users to The Wikipedia Library.
 #. Translators: On the MyLibrary page (https://wikipedialibrary.wmflabs.org/users/my_library), this introduces users to The Wikipedia Library.
 #: TWLight/resources/templates/resources/filter_section.html:17
 #: TWLight/users/templates/users/filter_section.html:15
-msgid ""
-"Start with the search bar at the top or browse publisher websites directly."
+msgid "Start with the search bar at the top or browse publisher websites directly."
 msgstr ""
 
 #. Translators: On the Browse Partners page (https://wikipedialibrary.wmflabs.org/partners/), this appears below introductory text and links to the 'About' page (https://wikipedialibrary.wmflabs.org/about/)
@@ -1519,52 +1367,38 @@ msgstr ""
 #. Translators: If we have no available accounts for a partner, the coordinator can change the application system to a waiting list.
 #: TWLight/resources/templates/resources/partner_detail.html:36
 #: TWLight/resources/templates/resources/partner_detail_apply.html:17
-msgid ""
-"There are no access grants available for this partner at this time. You can "
-"still apply for access; applications will be processed when access is "
-"available."
+msgid "There are no access grants available for this partner at this time. You can still apply for access; applications will be processed when access is available."
 msgstr ""
 
 #. Translators: This text links to the minimum user requirements and terms of use on the partner page.
 #: TWLight/resources/templates/resources/partner_detail.html:48
 #: TWLight/resources/templates/resources/partner_detail_apply.html:29
 #, python-format
-msgid ""
-"Before applying, please review the <strong><a class=\"twl-links\" href="
-"\"%(about)s#req\">minimum requirements</a></strong> for access and our "
-"<strong><a class=\"twl-links\" href=\"%(terms)s\">terms of use</a></strong>."
+msgid "Before applying, please review the <strong><a class=\"twl-links\" href=\"%(about)s#req\">minimum requirements</a></strong> for access and our <strong><a class=\"twl-links\" href=\"%(terms)s\">terms of use</a></strong>."
 msgstr ""
 
 #. Translators: This text refers to the page containing the content a user is authorized to access.
 #: TWLight/resources/templates/resources/partner_detail.html:69
 #, python-format
-msgid ""
-"View the status of your access in <strong><a class=\"twl-links\" href="
-"\"%(library_url)s\">My Library</a></strong> page."
+msgid "View the status of your access in <strong><a class=\"twl-links\" href=\"%(library_url)s\">My Library</a></strong> page."
 msgstr ""
 
 #. Translators: This message is shown when a user has open applications, linking to their respective applications page.
 #: TWLight/resources/templates/resources/partner_detail.html:78
 #, python-format
-msgid ""
-"View the status of your application(s) on your <strong><a class=\"twl-links"
-"\" href=\"%(applications_url)s\">My Applications</a></strong> page."
+msgid "View the status of your application(s) on your <strong><a class=\"twl-links\" href=\"%(applications_url)s\">My Applications</a></strong> page."
 msgstr ""
 
 #. Translators: This message is shown when a user has authorizations, linking to their respective collections page.
 #: TWLight/resources/templates/resources/partner_detail_apply.html:50
 #, python-format
-msgid ""
-"View the status of your access on your <strong><a href=\"%(library_url)s\" "
-"class=\"twl-links\">My Library</a></strong> page."
+msgid "View the status of your access on your <strong><a href=\"%(library_url)s\" class=\"twl-links\">My Library</a></strong> page."
 msgstr ""
 
 #. Translators: This message is shown when a user has open applications, linking to their respective applications page.
 #: TWLight/resources/templates/resources/partner_detail_apply.html:60
 #, python-format
-msgid ""
-"View the status of your application(s) on your <strong><a href="
-"\"%(applications_url)s\">My Applications</a></strong> page."
+msgid "View the status of your application(s) on your <strong><a href=\"%(applications_url)s\">My Applications</a></strong> page."
 msgstr ""
 
 #. Translators: One the partner detail page, this text labels the button which coordinators can click to remove a partner from waitlisted status.
@@ -1594,10 +1428,7 @@ msgstr ""
 
 #. Translators: If no account coordinator is assigned to a partner, the Wikipedia Library team will coordinate signups. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/resources/templates/resources/partner_detail_apply.html:112
-msgid ""
-"The Wikipedia Library team will process this application. Want to help? <a "
-"class=\"twl-links\" href=\"https://en.wikipedia.org/wiki/Wikipedia:"
-"The_Wikipedia_Library/Coordinators/Signup\">Sign up as a coordinator.</a>"
+msgid "The Wikipedia Library team will process this application. Want to help? <a class=\"twl-links\" href=\"https://en.wikipedia.org/wiki/Wikipedia:The_Wikipedia_Library/Coordinators/Signup\">Sign up as a coordinator.</a>"
 msgstr ""
 
 #. Translators: This text labels a button coordinators can click to view a list of users who have applied for access for a particular partner
@@ -1627,18 +1458,13 @@ msgstr ""
 
 #. Translators: Text shown to authenticated, bundle eligible users when they visit a Bundle partner page.
 #: TWLight/resources/templates/resources/partner_detail_apply.html:138
-msgid ""
-"You are eligible to access Library Bundle partners. Click the button above "
-"to access the collection."
+msgid "You are eligible to access Library Bundle partners. Click the button above to access the collection."
 msgstr ""
 
 #. Translators: Text shown to authenticated, bundle ineligible users when they visit a Bundle partner page.
 #: TWLight/resources/templates/resources/partner_detail_apply.html:152
 #, python-format
-msgid ""
-"You are not eligible to access Library Bundle partners. Visit the <a class="
-"\"twl-links\" href=\"%(homepage)s\">homepage</a> to check the eligibility "
-"criteria."
+msgid "You are not eligible to access Library Bundle partners. Visit the <a class=\"twl-links\" href=\"%(homepage)s\">homepage</a> to check the eligibility criteria."
 msgstr ""
 
 #. Translators: Buttton prompting users to log in.
@@ -1650,10 +1476,7 @@ msgstr "Aloggen"
 #. Translators: Text shown to unauthenticated users when they visit a Bundle partner page.
 #: TWLight/resources/templates/resources/partner_detail_apply.html:168
 #, python-format
-msgid ""
-"This resource is part of our <a class=\"twl-links\" href=\"%(about)s"
-"\">Library Bundle</a>, which you can access if you meet our minimum "
-"eligibility criteria. Log in to find out if you are eligible."
+msgid "This resource is part of our <a class=\"twl-links\" href=\"%(about)s\">Library Bundle</a>, which you can access if you meet our minimum eligibility criteria. Log in to find out if you are eligible."
 msgstr ""
 
 #. Translators: This is the label for a number which shows the total active accounts for one partner. (e.g. https://wikipedialibrary.wmflabs.org/partners/8/).
@@ -1704,26 +1527,19 @@ msgstr ""
 #. Translators: If a partner has specified the excerpt limit both in words and percentage, this message will display the percentage of words and the number of words on the partner page.
 #: TWLight/resources/templates/resources/partner_detail_timeline.html:99
 #, python-format
-msgid ""
-"%(object)s allows a maximum of %(excerpt_limit)s words or "
-"%(excerpt_limit_percentage)s%% of an article be excerpted into a Wikipedia "
-"article."
+msgid "%(object)s allows a maximum of %(excerpt_limit)s words or %(excerpt_limit_percentage)s%% of an article be excerpted into a Wikipedia article."
 msgstr ""
 
 #. Translators: If a partner has specified the excerpt limit in words, this message will display the number of words on the partner page.
 #: TWLight/resources/templates/resources/partner_detail_timeline.html:106
 #, python-format
-msgid ""
-"%(object)s allows a maximum of %(excerpt_limit)s words be excerpted into a "
-"Wikipedia article."
+msgid "%(object)s allows a maximum of %(excerpt_limit)s words be excerpted into a Wikipedia article."
 msgstr ""
 
 #. Translators: If a partner has specified the excerpt limit in percentage, this message will display the percentage of words on the partner page.
 #: TWLight/resources/templates/resources/partner_detail_timeline.html:113
 #, python-format
-msgid ""
-"%(object)s allows a maximum of %(excerpt_limit_percentage)s%% of an article "
-"be excerpted into a Wikipedia article."
+msgid "%(object)s allows a maximum of %(excerpt_limit_percentage)s%% of an article be excerpted into a Wikipedia article."
 msgstr ""
 
 #. Translators: If a partner has other requirements for access, this text shows as the title for that information field. (e.g. https://wikipedialibrary.wmflabs.org/partners/10/).
@@ -1734,9 +1550,7 @@ msgstr ""
 #. Translators: If a user must agree to a Terms of Use document, they see this message, and must enter the name of the resource. Don't translate publisher or url.
 #: TWLight/resources/templates/resources/partner_detail_timeline.html:140
 #, python-format
-msgid ""
-"%(publisher)s requires that you agree with its <a href=\"%(url)s\">terms of "
-"use</a>."
+msgid "%(publisher)s requires that you agree with its <a href=\"%(url)s\">terms of use</a>."
 msgstr ""
 
 #. Translators: If a user must provide their real name to apply to a partner, they see this message, and must enter the name of the resource. Don't translate publisher.
@@ -1760,17 +1574,13 @@ msgstr ""
 #. Translators: If a user must select a specific resource to apply for, they see this message, and must enter the name of the resource. Don't translate publisher.
 #: TWLight/resources/templates/resources/partner_detail_timeline.html:177
 #, python-format
-msgid ""
-"%(publisher)s requires that you specify a particular title that you want to "
-"access."
+msgid "%(publisher)s requires that you specify a particular title that you want to access."
 msgstr ""
 
 #. Translators: If a user must register on the partner website before applying, they see this message. Don't translate partner.
 #: TWLight/resources/templates/resources/partner_detail_timeline.html:187
 #, python-format
-msgid ""
-"%(publisher)s requires that you sign up for an account before applying for "
-"access."
+msgid "%(publisher)s requires that you sign up for an account before applying for access."
 msgstr ""
 
 #. Translators: If a partner has their location listed, this message is a label for that location
@@ -1897,9 +1707,7 @@ msgstr "Sidd Dir sécher, datt Dir <b>%(object)s</b> läsche wëllt?"
 
 #. Translators: If multiple authorizations where returned for a collection, this message is shown to a user
 #: TWLight/resources/views.py:268
-msgid ""
-"Multiple authorizations were returned – something's wrong. Please contact us "
-"and don't forget to mention this message."
+msgid "Multiple authorizations were returned – something's wrong. Please contact us and don't forget to mention this message."
 msgstr ""
 
 #. Translators: This message is shown when user tries to access a NOT_AVAILABLE Partner
@@ -1940,14 +1748,7 @@ msgstr ""
 #. Translators: Shown on the website's 400 page, when a user sends a bad request. Don't translate path or Phabricator.
 #: TWLight/templates/400.html:20
 #, python-format
-msgid ""
-"If you think we should know what to do with that, please email us about this "
-"error at <a class=\"twl-links\" href=\"mailto:wikipedialibrary@wikimedia.org?"
-"Subject=Wikipedia%%20Library%%20%(path)s%%20Permission%%20denied"
-"\">wikipedialibrary@wikimedia.org</a> or report it to us on <a class=\"twl-"
-"links\" href=\"https://phabricator.wikimedia.org/maniphest/task/edit/form/1/?"
-"projectPHIDs=Library-Card-Platform&title=Wikipedia%%20Library%%20%(path)s"
-"%%20Bad%%20Request\">Phabricator</a>"
+msgid "If you think we should know what to do with that, please email us about this error at <a class=\"twl-links\" href=\"mailto:wikipedialibrary@wikimedia.org?Subject=Wikipedia%%20Library%%20%(path)s%%20Permission%%20denied\">wikipedialibrary@wikimedia.org</a> or report it to us on <a class=\"twl-links\" href=\"https://phabricator.wikimedia.org/maniphest/task/edit/form/1/?projectPHIDs=Library-Card-Platform&title=Wikipedia%%20Library%%20%(path)s%%20Bad%%20Request\">Phabricator</a>"
 msgstr ""
 
 #. Translators: Alt text for an image shown on the 400 error page.
@@ -1969,15 +1770,7 @@ msgstr ""
 #. Translators: Shown on the website's 403 page, when a user attempts to navigate to a page they don't have permission to view. Don't translate path or Phabricator.
 #: TWLight/templates/403.html:20
 #, python-format
-msgid ""
-"If you think your account should be able to do that, please email us about "
-"this error at <a class=\"twl-links\" href=\"mailto:"
-"wikipedialibrary@wikimedia.org?Subject=Wikipedia%%20Library%%20%(path)s"
-"%%20Permission%%20denied\">wikipedialibrary@wikimedia.org</a> or report it "
-"to us on <a class=\"twl-links\" href=\"https://phabricator.wikimedia.org/"
-"maniphest/task/edit/form/1/?projectPHIDs=Library-Card-"
-"Platform&title=Wikipedia%%20Library%%20%(path)s%%20Permission%%20denied"
-"\">Phabricator</a>"
+msgid "If you think your account should be able to do that, please email us about this error at <a class=\"twl-links\" href=\"mailto:wikipedialibrary@wikimedia.org?Subject=Wikipedia%%20Library%%20%(path)s%%20Permission%%20denied\">wikipedialibrary@wikimedia.org</a> or report it to us on <a class=\"twl-links\" href=\"https://phabricator.wikimedia.org/maniphest/task/edit/form/1/?projectPHIDs=Library-Card-Platform&title=Wikipedia%%20Library%%20%(path)s%%20Permission%%20denied\">Phabricator</a>"
 msgstr ""
 
 #. Translators: Shown on the website's 404 page, when a user attempts to navigate to a page that doesn't exist.
@@ -1993,14 +1786,7 @@ msgstr ""
 #. Translators: Shown on the website's 404 page, when a user attempts to navigate to a page that doesn't exist. Don't translate path or Phabricator.
 #: TWLight/templates/404.html:19
 #, python-format
-msgid ""
-"If you are certain that something should be here, please email us about this "
-"error at <a class=\"twl-links\" href=\"mailto:wikipedialibrary@wikimedia.org?"
-"Subject=Wikipedia%%20Library%%20%(path)s%%20Not%%20found\"> "
-"wikipedialibrary@wikimedia.org</a> or report it to us on <a class=\"twl-links"
-"\" href=\"https://phabricator.wikimedia.org/maniphest/task/edit/form/1/?"
-"projectPHIDs=Library-Card-Platform&title=Wikipedia%%20Library%%20%(path)s"
-"%%20Not%%20found\">Phabricator</a>"
+msgid "If you are certain that something should be here, please email us about this error at <a class=\"twl-links\" href=\"mailto:wikipedialibrary@wikimedia.org?Subject=Wikipedia%%20Library%%20%(path)s%%20Not%%20found\"> wikipedialibrary@wikimedia.org</a> or report it to us on <a class=\"twl-links\" href=\"https://phabricator.wikimedia.org/maniphest/task/edit/form/1/?projectPHIDs=Library-Card-Platform&title=Wikipedia%%20Library%%20%(path)s%%20Not%%20found\">Phabricator</a>"
 msgstr ""
 
 #. Translators: Alt text for an image shown on the 404 error page.
@@ -2015,32 +1801,18 @@ msgstr ""
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:20
-msgid ""
-"This platform is our central tool for facilitating access to our available "
-"collections. Here you can see which partnerships are available, search their "
-"contents, and apply for and access the ones you’re interested in."
+msgid "This platform is our central tool for facilitating access to our available collections. Here you can see which partnerships are available, search their contents, and apply for and access the ones you’re interested in."
 msgstr ""
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/). Wikimedia Foundation should not be translated.
 #: TWLight/templates/about.html:29
-msgid ""
-"All users receive immediate access to some collections, which can be browsed "
-"by clicking the 'Access collection' buttons or using the search bar at the "
-"top of the page. Other collections require an application before access is "
-"granted, and may be accessed directly or via an individual login or access "
-"code. Volunteer coordinators, who have signed non-disclosure agreements with "
-"the Wikimedia Foundation, review these applications and work with publishers "
-"to get you your free access."
+msgid "All users receive immediate access to some collections, which can be browsed by clicking the 'Access collection' buttons or using the search bar at the top of the page. Other collections require an application before access is granted, and may be accessed directly or via an individual login or access code. Volunteer coordinators, who have signed non-disclosure agreements with the Wikimedia Foundation, review these applications and work with publishers to get you your free access."
 msgstr ""
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/). Don't translate terms_url.
 #: TWLight/templates/about.html:43
 #, python-format
-msgid ""
-"For more information about how your information is stored and reviewed "
-"please see our <a class=\"twl-links\" href=\"%(terms_url)s\"> terms of use "
-"and privacy policy</a>. Accounts you apply for are also subject to the Terms "
-"of Use provided by each partner’s platform; please review them."
+msgid "For more information about how your information is stored and reviewed please see our <a class=\"twl-links\" href=\"%(terms_url)s\"> terms of use and privacy policy</a>. Accounts you apply for are also subject to the Terms of Use provided by each partner’s platform; please review them."
 msgstr ""
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
@@ -2050,12 +1822,7 @@ msgstr ""
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/). Wikimedia Foundation should not be translated.
 #: TWLight/templates/about.html:55
-msgid ""
-"Any active editor in good standing can receive access. For publishers with "
-"limited numbers of accounts, applications are reviewed based on the editor’s "
-"needs and contributions. If you think you could use access to one of our "
-"partner resources and are an active editor in any project supported by the "
-"Wikimedia Foundation, please apply."
+msgid "Any active editor in good standing can receive access. For publishers with limited numbers of accounts, applications are reviewed based on the editor’s needs and contributions. If you think you could use access to one of our partner resources and are an active editor in any project supported by the Wikimedia Foundation, please apply."
 msgstr ""
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
@@ -2085,23 +1852,12 @@ msgstr ""
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/)
 #: TWLight/templates/about.html:89
-msgid ""
-"If you are applying for an available collection, please first check that you "
-"don't already have access through another library or institution. If you do, "
-"please consider using that access rather than taking up a seat for this "
-"resource in The Wikipedia Library."
+msgid "If you are applying for an available collection, please first check that you don't already have access through another library or institution. If you do, please consider using that access rather than taking up a seat for this resource in The Wikipedia Library."
 msgstr ""
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/)
 #: TWLight/templates/about.html:99
-msgid ""
-"If your account is blocked on one or more Wikimedia projects, you may still "
-"be granted access to The Wikipedia Library. You will need to contact the "
-"Wikipedia Library team, who will review your blocks. If you have been "
-"blocked for content issues, most notably copyright violations, or have "
-"multiple long-term blocks, we may decline your request. Additionally, if "
-"your block status changes after being approved, you will need to request "
-"another review."
+msgid "If your account is blocked on one or more Wikimedia projects, you may still be granted access to The Wikipedia Library. You will need to contact the Wikipedia Library team, who will review your blocks. If you have been blocked for content issues, most notably copyright violations, or have multiple long-term blocks, we may decline your request. Additionally, if your block status changes after being approved, you will need to request another review."
 msgstr ""
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
@@ -2136,9 +1892,7 @@ msgstr ""
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:136
-msgid ""
-"Share their account logins or passwords with others, or sell their access to "
-"other parties"
+msgid "Share their account logins or passwords with others, or sell their access to other parties"
 msgstr ""
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
@@ -2148,23 +1902,17 @@ msgstr ""
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:144
-msgid ""
-"Systematically make printed or electronic copies of multiple extracts of "
-"restricted content available for any purpose"
+msgid "Systematically make printed or electronic copies of multiple extracts of restricted content available for any purpose"
 msgstr ""
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/). Stub is a technical term for a short Wikipedia article, use the appropriate Wikipedia term in your language.
 #: TWLight/templates/about.html:148
-msgid ""
-"Datamine metadata without permission, in order, for instance, to use "
-"metadata for auto-created stub articles"
+msgid "Datamine metadata without permission, in order, for instance, to use metadata for auto-created stub articles"
 msgstr ""
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:154
-msgid ""
-"Respecting these agreements allows us to continue growing the partnerships "
-"available to the community."
+msgid "Respecting these agreements allows us to continue growing the partnerships available to the community."
 msgstr ""
 
 #. Translators: This is the heading for a section on the About page (https://wikipedialibrary.wmflabs.org/about/).
@@ -2174,41 +1922,22 @@ msgstr "EZProxy"
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:164
-msgid ""
-"EZProxy is a proxy server used to authenticate users for many Wikipedia "
-"Library partners. Users sign into EZProxy via the Library Card platform to "
-"verify that they are authorized users, and then the server accesses "
-"requested resources using its own IP address."
+msgid "EZProxy is a proxy server used to authenticate users for many Wikipedia Library partners. Users sign into EZProxy via the Library Card platform to verify that they are authorized users, and then the server accesses requested resources using its own IP address."
 msgstr ""
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:173
-msgid ""
-"You may notice that when accessing resources via EZProxy that URLs are "
-"dynamically rewritten. This is why we recommend logging in via the Library "
-"Card platform rather than going directly to the unproxied partner website. "
-"When in doubt, check the URL for ‘idm.oclc’. If it’s there, then you’re "
-"connected via EZProxy."
+msgid "You may notice that when accessing resources via EZProxy that URLs are dynamically rewritten. This is why we recommend logging in via the Library Card platform rather than going directly to the unproxied partner website. When in doubt, check the URL for ‘idm.oclc’. If it’s there, then you’re connected via EZProxy."
 msgstr ""
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:182
-msgid ""
-"Typically once you’ve logged in your session will remain active in your "
-"browser for up to two hours after you’ve finished searching. Note that use "
-"of EZProxy requires you to enable cookies. If you are having problems you "
-"should also try clearing your cache and restarting your browser."
+msgid "Typically once you’ve logged in your session will remain active in your browser for up to two hours after you’ve finished searching. Note that use of EZProxy requires you to enable cookies. If you are having problems you should also try clearing your cache and restarting your browser."
 msgstr ""
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/)
 #: TWLight/templates/about.html:193
-msgid ""
-"The Library Bundle is a collection of resources for which no application is "
-"required. If you meet the criteria laid out above, you will be authorized "
-"for access automatically upon logging in to the platform. Only some of our "
-"content is currently included in the Library Bundle, however we hope to "
-"expand the collection as more publishers become comfortable with "
-"participating. All Bundle content is accessed via EZProxy."
+msgid "The Library Bundle is a collection of resources for which no application is required. If you meet the criteria laid out above, you will be authorized for access automatically upon logging in to the platform. Only some of our content is currently included in the Library Bundle, however we hope to expand the collection as more publishers become comfortable with participating. All Bundle content is accessed via EZProxy."
 msgstr ""
 
 #. Translators: This is the heading for a section on the About page (https://wikipedialibrary.wmflabs.org/about/).
@@ -2218,12 +1947,7 @@ msgstr ""
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:206
-msgid ""
-"Citation practices vary by project and even by article. Generally, we "
-"support editors citing where they found information, in a form that allows "
-"others to check it for themselves. That often means providing both original "
-"source details as well as a link to the partner database in which the source "
-"was found."
+msgid "Citation practices vary by project and even by article. Generally, we support editors citing where they found information, in a form that allows others to check it for themselves. That often means providing both original source details as well as a link to the partner database in which the source was found."
 msgstr ""
 
 #. Translators: This is the heading for a section on the About page (https://wikipedialibrary.wmflabs.org/about/).
@@ -2235,9 +1959,7 @@ msgstr "Kontaktéiert eis"
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:218
 #, python-format
-msgid ""
-"If you have questions, need help, or want to volunteer to help, please see "
-"our <a class=\"twl-links\" href=\"%(contact_url)s\">contact page</a>."
+msgid "If you have questions, need help, or want to volunteer to help, please see our <a class=\"twl-links\" href=\"%(contact_url)s\">contact page</a>."
 msgstr ""
 
 #. Translators: This is the title of the panel box detailing the contact information for the Wikipedia Library team.
@@ -2277,9 +1999,7 @@ msgstr "Wikipedia-Library-Twittersäit"
 #. Translators: This is the text that appears at the bottom of the contact us form directing users to the suggestions form.
 #: TWLight/templates/contact.html:48
 #, python-format
-msgid ""
-"(If you would like to suggest a partner, <a class=\"twl-links\" href="
-"\"%(suggest)s\"><strong>go here</strong></a>.)"
+msgid "(If you would like to suggest a partner, <a class=\"twl-links\" href=\"%(suggest)s\"><strong>go here</strong></a>.)"
 msgstr ""
 
 #. Translators: On a special 'link to search' page, this message is shown if JavaScript is disabled.
@@ -2336,9 +2056,7 @@ msgstr "D'Wikipedia-Bibliothéik"
 #. Translators: Information about The Wikipedia Library.
 #: TWLight/templates/login_partial.html:53 TWLight/templates/new_base.html:21
 #, python-format
-msgid ""
-"More than 100 of the world's top subscription-only databases, with content "
-"in %(no_of_languages)s languages, free for Wikipedians of all backgrounds"
+msgid "More than 100 of the world's top subscription-only databases, with content in %(no_of_languages)s languages, free for Wikipedians of all backgrounds"
 msgstr ""
 
 #. Translators: Information about The Wikipedia Library.
@@ -2347,9 +2065,7 @@ msgid "Meet these criteria for automatic access"
 msgstr ""
 
 #: TWLight/templates/login_partial.html:69
-msgid ""
-"These criteria grant you access to certain collections but not all. Some "
-"collections are accessible on a per application basis only."
+msgid "These criteria grant you access to certain collections but not all. Some collections are accessible on a per application basis only."
 msgstr ""
 
 #: TWLight/templates/login_partial.html:89
@@ -2359,29 +2075,19 @@ msgstr "Mat Wikipedia aloggen"
 #. Translators: Shown if the current user doesn't have a registered email on their account. Don't translate contact_us_url or email_url.
 #: TWLight/templates/message_partial.html:15
 #, python-format
-msgid ""
-"You don't have an email on file. We can't finalize your access to partner "
-"resources, and you won't be able to <a class=\"twl-links\" href="
-"\"%(contact_us_url)s\">contact us</a> without an email. Please <a class="
-"\"twl-links\" href=\"%(email_url)s\">update your email</a>."
+msgid "You don't have an email on file. We can't finalize your access to partner resources, and you won't be able to <a class=\"twl-links\" href=\"%(contact_us_url)s\">contact us</a> without an email. Please <a class=\"twl-links\" href=\"%(email_url)s\">update your email</a>."
 msgstr ""
 
 #. Translators: Shown if the current user has requested the processing of their data should be restricted.
 #: TWLight/templates/message_partial.html:26
 #, python-format
-msgid ""
-"You have requested a restriction on the processing of your data. Most site "
-"functionality will not be available to you until you <a class=\"twl-links\" "
-"href=\"%(restrict_url)s\">lift this restriction</a>."
+msgid "You have requested a restriction on the processing of your data. Most site functionality will not be available to you until you <a class=\"twl-links\" href=\"%(restrict_url)s\">lift this restriction</a>."
 msgstr ""
 
 #. Translators: Shown if the current user has not agreed to the terms of use.
 #: TWLight/templates/message_partial.html:37
 #, python-format
-msgid ""
-"You have not agreed to the <a class=\"twl-links\" href=\"%(terms_url)s"
-"\">terms of use</a> of this site. Your applications will not be processed "
-"and you won't be able to apply or access resources you are approved for."
+msgid "You have not agreed to the <a class=\"twl-links\" href=\"%(terms_url)s\">terms of use</a> of this site. Your applications will not be processed and you won't be able to apply or access resources you are approved for."
 msgstr ""
 
 #. Translators: This link is at the bottom of every page and links to the 'About' page (https://wikipedialibrary.wmflabs.org/about/)
@@ -2428,9 +2134,7 @@ msgstr "Passwuert zrécksetzen"
 
 #. Translators: If a user goes to reset their password, this message asks them to enter their email to do so.
 #: TWLight/templates/registration/password_reset_form.html:13
-msgid ""
-"Forgot your password? Enter your email address below, and we'll email "
-"instructions for setting a new one."
+msgid "Forgot your password? Enter your email address below, and we'll email instructions for setting a new one."
 msgstr ""
 
 #. Translators: This is the label for a button that users click to update their public information.
@@ -2475,16 +2179,12 @@ msgstr ""
 
 #. Translators: This text explains how to disagree to the site's terms of use and the restrictions that will come into effect when users disagree to the terms of use.
 #: TWLight/users/forms.py:185
-msgid ""
-"By unchecking this box and clicking “Update” you may explore the site, but "
-"you will not be able to apply for access to materials or evaluate "
-"applications unless you agree with the terms of use."
+msgid "By unchecking this box and clicking “Update” you may explore the site, but you will not be able to apply for access to materials or evaluate applications unless you agree with the terms of use."
 msgstr ""
 
 #. Translators: Users click this button to set their website email address to the one linked to their Wikipedia account.
 #: TWLight/users/forms.py:211
-msgid ""
-"Use my Wikipedia email address (will be updated the next time you login)."
+msgid "Use my Wikipedia email address (will be updated the next time you login)."
 msgstr ""
 
 #. Translators: This labels a button which users click to change their email.
@@ -2495,17 +2195,8 @@ msgstr "E-Mail-Adresse aktualiséieren"
 #. Translators: Shown if the current user tried to 'favorite' a partner they can't access. Do not translate '{partner}'
 #: TWLight/users/models.py:201
 #, python-brace-format
-msgid ""
-"Cannot add partner {partner} to your favorites because you don't have access "
-"to it"
+msgid "Cannot add partner {partner} to your favorites because you don't have access to it"
 msgstr ""
-
-#. Translators: Do not translate.
-#: TWLight/users/models.py:869
-#, fuzzy, python-brace-format
-#| msgid "Username"
-msgid "{wp_username}"
-msgstr "Benotzernumm"
 
 #. Translators: This error message is shown when there's a problem with the authenticated login process.
 #: TWLight/users/oauth.py:243
@@ -2525,9 +2216,7 @@ msgstr ""
 
 #. Translators: this message is displayed to users that don't have accounts and clicked on a proxied link.
 #: TWLight/users/oauth.py:388
-msgid ""
-"To view this link you need to be an eligible library user. Please login to "
-"continue."
+msgid "To view this link you need to be an eligible library user. Please login to continue."
 msgstr ""
 
 #. Translators: This warning message is shown to users when the response received from Wikimedia OAuth servers is not a valid one.
@@ -2563,17 +2252,12 @@ msgstr ""
 
 #. Translators: If the user tries to log in, but their account does not meet certain requirements, they cannot login.
 #: TWLight/users/oauth.py:528
-msgid ""
-"Your Wikipedia account does not meet the eligibility criteria in the terms "
-"of use, so your Wikipedia Library Card Platform account cannot be activated."
+msgid "Your Wikipedia account does not meet the eligibility criteria in the terms of use, so your Wikipedia Library Card Platform account cannot be activated."
 msgstr ""
 
 #. Translators: If the user tries to log in, but their account does not meet certain requirements, they cannot login.
 #: TWLight/users/oauth.py:536
-msgid ""
-"Your Wikipedia account no longer meets the eligibility criteria in the terms "
-"of use, so you cannot be logged in. If you think you should be able to log "
-"in, please email wikipedialibrary@wikimedia.org."
+msgid "Your Wikipedia account no longer meets the eligibility criteria in the terms of use, so you cannot be logged in. If you think you should be able to log in, please email wikipedialibrary@wikimedia.org."
 msgstr ""
 
 #. Translators: this message is displayed to users with brand new accounts.
@@ -2584,10 +2268,7 @@ msgstr ""
 #. Translators: This message is displayed on the confirmation page where users can return their access to partner collections.
 #: TWLight/users/templates/users/authorization_confirm_return.html:13
 #, python-format
-msgid ""
-"You will no longer be able to access <b>%(partner)s's</b> resources via the "
-"Library Card platform, but can request access again by clicking 'renew', if "
-"you change your mind. Are you sure you want to return your access?"
+msgid "You will no longer be able to access <b>%(partner)s's</b> resources via the Library Card platform, but can request access again by clicking 'renew', if you change your mind. Are you sure you want to return your access?"
 msgstr ""
 
 #. Translators: On the MyLibrary page (https://wikipedialibrary.wmflabs.org/users/my_library), this tab shows all favorite collections a user has.
@@ -2657,10 +2338,7 @@ msgstr ""
 
 #. Translators: This is shown on editor profiles, in their profile page or on applications.
 #: TWLight/users/templates/users/editor_detail.html:59
-msgid ""
-"Information with an * was retrieved from Wikipedia directly. Other "
-"information was entered directly by users or site admins, in their preferred "
-"language."
+msgid "Information with an * was retrieved from Wikipedia directly. Other information was entered directly by users or site admins, in their preferred language."
 msgstr ""
 
 #. Translators: This distinguishes users who have been flagged as account coordinators. Don't translate username.
@@ -2671,10 +2349,7 @@ msgstr ""
 
 #. Translators: This is shown on editor profiles, under the heading for Wikipedia editor data.
 #: TWLight/users/templates/users/editor_detail_data.html:5
-msgid ""
-"This information is updated automatically from your Wikimedia account each "
-"time you log in, except for the Contributions field, where you can describe "
-"your Wikimedia editing history."
+msgid "This information is updated automatically from your Wikimedia account each time you log in, except for the Contributions field, where you can describe your Wikimedia editing history."
 msgstr ""
 
 #. Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this labels the user's username.
@@ -2704,17 +2379,13 @@ msgstr ""
 
 #. Translators: when viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this question has a yes or no answer.
 #: TWLight/users/templates/users/editor_detail_data.html:57
-msgid ""
-"at their last login, did this user meet the criteria set forth in the terms "
-"of use?"
+msgid "at their last login, did this user meet the criteria set forth in the terms of use?"
 msgstr ""
 
 #. Translators: When viewing a user's profile in an application, this message shows if the software doesn't think that the user is eligible for access. Don't translate username.
 #: TWLight/users/templates/users/editor_detail_data.html:72
 #, python-format
-msgid ""
-"%(username)s may still be eligible for access grants at the coordinators' "
-"discretion."
+msgid "%(username)s may still be eligible for access grants at the coordinators' discretion."
 msgstr ""
 
 #. Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this is the heading for a Yes/No ToU question.
@@ -2749,10 +2420,7 @@ msgstr "(Ausnam accordéiert)"
 #. Translators: This message is shown on a user's profile if their Wikimedia account is blocked on one or more projects. They may still be granted access to the Library Bundle, but need to contact Wikipedia Library staff to verify.
 #: TWLight/users/templates/users/editor_detail_data.html:137
 #, python-format
-msgid ""
-"It looks like you have an active block on your account. If you meet the "
-"other criteria you may still be permitted access to the library - please <a "
-"class=\"twl-links\" href=\"%(contact_url)s\">contact us</a>."
+msgid "It looks like you have an active block on your account. If you meet the other criteria you may still be permitted access to the library - please <a class=\"twl-links\" href=\"%(contact_url)s\">contact us</a>."
 msgstr ""
 
 #. Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this is the heading for a Yes/No program eligibility question.
@@ -2762,10 +2430,7 @@ msgstr ""
 
 #. Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this question has a Yes or No answer.
 #: TWLight/users/templates/users/editor_detail_data.html:156
-msgid ""
-"At their last login, did this user meet the criteria set forth in the "
-"Library Bundle? Note that satisfying terms of use is a prerequisite to "
-"bundle eligibility."
+msgid "At their last login, did this user meet the criteria set forth in the Library Bundle? Note that satisfying terms of use is a prerequisite to bundle eligibility."
 msgstr ""
 
 #. Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this is the heading for a Yes/No program eligibility question.
@@ -2810,18 +2475,13 @@ msgstr "Perséinlech Daten"
 
 #. Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this text is in the 'Personal data' section. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/users/templates/users/editor_detail_data.html:262
-msgid ""
-"The following information is visible only to you, site administrators, "
-"publishing partners (where required), and volunteer Wikipedia Library "
-"coordinators (who have signed a Non-Disclosure Agreement)."
+msgid "The following information is visible only to you, site administrators, publishing partners (where required), and volunteer Wikipedia Library coordinators (who have signed a Non-Disclosure Agreement)."
 msgstr ""
 
 #. Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this labels a button which users can click to update or remove their personal information. Don't translate update_url.
 #: TWLight/users/templates/users/editor_detail_data.html:272
 #, python-format
-msgid ""
-"You may <a class=\"twl-links\" href=\"%(update_url)s\">update or delete</a> "
-"your data at any time."
+msgid "You may <a class=\"twl-links\" href=\"%(update_url)s\">update or delete</a> your data at any time."
 msgstr ""
 
 #. Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this labels the user's email. Don't remove the *.
@@ -2841,24 +2501,18 @@ msgstr ""
 
 #. Translators: This message tells users that they are not eligible to access The Wikipedia Library content.
 #: TWLight/users/templates/users/eligibility_modal.html:7
-msgid ""
-"Sorry, your Wikipedia account doesn’t currently qualify to access The "
-"Wikipedia Library."
+msgid "Sorry, your Wikipedia account doesn’t currently qualify to access The Wikipedia Library."
 msgstr ""
 
 #. Translators: This message tells users that they have not agreed to the terms of use, therefore are ineligible to access the content in The Wikipedia Library.
 #: TWLight/users/templates/users/eligibility_modal.html:30
 #, python-format
-msgid ""
-"Agreed with <a href=\"%(terms)s\" class=\"text-danger\"> terms of use </a>"
+msgid "Agreed with <a href=\"%(terms)s\" class=\"text-danger\"> terms of use </a>"
 msgstr ""
 
 #: TWLight/users/templates/users/eligibility_modal.html:40
 #, python-format
-msgid ""
-"It looks like you have an active block on your account. If you meet the "
-"other criteria you may still be permitted access to the library - please <a "
-"href=\"%(contact_url)s\">contact us</a>."
+msgid "It looks like you have an active block on your account. If you meet the other criteria you may still be permitted access to the library - please <a href=\"%(contact_url)s\">contact us</a>."
 msgstr ""
 
 #. Translators: Instructions to refresh a user's data.
@@ -2898,10 +2552,7 @@ msgstr "Sprooch eraussichen"
 
 #. Translators: This text on the user page helps users naviage to the TranslateWiki Wikipedia Library Card platform translation page.
 #: TWLight/users/templates/users/language_form.html:31
-msgid ""
-"You can help translate the tool at <a class=\"twl-links\" href=\"https://"
-"translatewiki.net/wiki/Translating:Wikipedia_Library_Card_Platform"
-"\">translatewiki.net</a>."
+msgid "You can help translate the tool at <a class=\"twl-links\" href=\"https://translatewiki.net/wiki/Translating:Wikipedia_Library_Card_Platform\">translatewiki.net</a>."
 msgstr ""
 
 #. Translators: When the user starts a new application and submits the application, the user can view the application and withdraw if need be. This changes the label for the Withdraw button.
@@ -2921,9 +2572,7 @@ msgstr ""
 
 #. Translators: On the page listing applications, this text explains a user they cannot renew their application since they've already requested a renewal or there aren't any renewals available.
 #: TWLight/users/templates/users/my_applications.html:79
-msgid ""
-"Renewals are either not required, not available right now, or you have "
-"already requested a renewal."
+msgid "Renewals are either not required, not available right now, or you have already requested a renewal."
 msgstr ""
 
 #. Translators: This text is the heading of a section in a user's profile where they can change their preferences.
@@ -2987,19 +2636,12 @@ msgstr ""
 
 #. Translators: This message is displayed on the page where users can request we stop processing their data.
 #: TWLight/users/templates/users/restrict_data.html:15
-msgid ""
-"Checking this box and clicking “Restrict” will pause all processing of the "
-"data you have entered into this website. You will not be able to apply for "
-"access to resources, your applications will not be further processed, and "
-"none of your data will be altered, until you return to this page and uncheck "
-"the box. This is not the same as deleting your data."
+msgid "Checking this box and clicking “Restrict” will pause all processing of the data you have entered into this website. You will not be able to apply for access to resources, your applications will not be further processed, and none of your data will be altered, until you return to this page and uncheck the box. This is not the same as deleting your data."
 msgstr ""
 
 #. Translators: This warning message is shown to coordinators who view the data restriction page.
 #: TWLight/users/templates/users/restrict_data.html:26
-msgid ""
-"You are a coordinator on this site. If you restrict the processing of your "
-"data, your coordinator flag will be removed."
+msgid "You are a coordinator on this site. If you restrict the processing of your data, your coordinator flag will be removed."
 msgstr ""
 
 #. Translators: use the date *when you are translating*, in a language-appropriate format.
@@ -3019,24 +2661,12 @@ msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:51
-msgid ""
-"<a class=\"twl-links\" href=\"https://meta.wikimedia.org/wiki/"
-"The_Wikipedia_Library\"> The Wikipedia Library </a> has partnered with "
-"publishers around the world to allow users to access otherwise paywalled "
-"resources. This website allows Wikipedia editors to search and access these "
-"resources."
+msgid "<a class=\"twl-links\" href=\"https://meta.wikimedia.org/wiki/The_Wikipedia_Library\"> The Wikipedia Library </a> has partnered with publishers around the world to allow users to access otherwise paywalled resources. This website allows Wikipedia editors to search and access these resources."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Wikimedia Foundation should not be translated. WMF should not be translated. Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:63
-msgid ""
-"This program is administered by the Wikimedia Foundation (WMF). These terms "
-"of use and privacy notice pertain to your application for access to "
-"resources through the Wikipedia Library, your use of this website, and your "
-"access to and use of those resources. They also describe our handling of the "
-"information you provide to us in order to create and administer your "
-"Wikipedia Library account. If we make material changes to the terms, we will "
-"notify users."
+msgid "This program is administered by the Wikimedia Foundation (WMF). These terms of use and privacy notice pertain to your application for access to resources through the Wikipedia Library, your use of this website, and your access to and use of those resources. They also describe our handling of the information you provide to us in order to create and administer your Wikipedia Library account. If we make material changes to the terms, we will notify users."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
@@ -3046,37 +2676,17 @@ msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:78
-msgid ""
-"Access to resources via The Wikipedia Library is reserved for community "
-"members who have demonstrated their commitment to the Wikimedia projects, "
-"and who will use their access to these resources to improve project content. "
-"To that end, in order to be eligible for The Wikipedia Library, we require "
-"that you be registered for a user account on the projects, with at least 500 "
-"edits, six (6) months of activity, and 10+ edits in the last month. We ask "
-"that you do not request access to any publishers with a limited number of "
-"available accounts whose resources you can already access for free through "
-"your local library or university, or another institution or organization, in "
-"order to provide that opportunity to others."
+msgid "Access to resources via The Wikipedia Library is reserved for community members who have demonstrated their commitment to the Wikimedia projects, and who will use their access to these resources to improve project content. To that end, in order to be eligible for The Wikipedia Library, we require that you be registered for a user account on the projects, with at least 500 edits, six (6) months of activity, and 10+ edits in the last month. We ask that you do not request access to any publishers with a limited number of available accounts whose resources you can already access for free through your local library or university, or another institution or organization, in order to provide that opportunity to others."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:94
-msgid ""
-"Additionally, if you are currently blocked or banned from a Wikimedia "
-"project, applications to resources may be rejected or restricted. If you "
-"obtain a Wikipedia Library account, but a block or ban is subsequently "
-"instituted against you on one of the projects, you may lose access to your "
-"Wikipedia Library account."
+msgid "Additionally, if you are currently blocked or banned from a Wikimedia project, applications to resources may be rejected or restricted. If you obtain a Wikipedia Library account, but a block or ban is subsequently instituted against you on one of the projects, you may lose access to your Wikipedia Library account."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:104
-msgid ""
-"Your eligibility to access The Wikipedia Library is assessed at each login. "
-"While more than half of the library's content is provided via this automated "
-"eligibility check, access to other publisher's content may be time limited, "
-"typically lapsing after one year, after which you will usually need to apply "
-"for renewal."
+msgid "Your eligibility to access The Wikipedia Library is assessed at each login. While more than half of the library's content is provided via this automated eligibility check, access to other publisher's content may be time limited, typically lapsing after one year, after which you will usually need to apply for renewal."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
@@ -3086,47 +2696,27 @@ msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:118
-msgid ""
-"In order to apply for access to a partner resource, you must provide us with "
-"certain information, which we will use to evaluate your application. If your "
-"application is approved, we may transfer the information you have given us "
-"to the publishers whose resources you wish to access. They will either "
-"contact you with the account information directly or we will send access "
-"information to you ourselves."
+msgid "In order to apply for access to a partner resource, you must provide us with certain information, which we will use to evaluate your application. If your application is approved, we may transfer the information you have given us to the publishers whose resources you wish to access. They will either contact you with the account information directly or we will send access information to you ourselves."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:130
-msgid ""
-"In addition to the basic information you provide to us, our system will "
-"retrieve some information directly from the Wikimedia projects: your "
-"username, email address, edit count, registration date, user ID number, "
-"groups to which you belong, and any special user rights."
+msgid "In addition to the basic information you provide to us, our system will retrieve some information directly from the Wikimedia projects: your username, email address, edit count, registration date, user ID number, groups to which you belong, and any special user rights."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:140
-msgid ""
-"Each time you log in to the Wikipedia Library Card Platform, this "
-"information will be automatically updated."
+msgid "Each time you log in to the Wikipedia Library Card Platform, this information will be automatically updated."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:148
-msgid ""
-"We will ask you to provide us with some information about your history of "
-"contributions to the Wikimedia projects. Information on contribution history "
-"is optional, but will greatly assist us in evaluating your application."
+msgid "We will ask you to provide us with some information about your history of contributions to the Wikimedia projects. Information on contribution history is optional, but will greatly assist us in evaluating your application."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). WMF should not be translated. Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:157
-msgid ""
-"The information you provide when creating your account will be visible to "
-"you while on the site but not to others unless they are approved Wikipedia "
-"Library Coordinators, WMF Staff, or WMF Contractors who need access to this "
-"data in order to carry out their work with the Wikipedia Library, all of "
-"whom are subject to non-disclosure obligations."
+msgid "The information you provide when creating your account will be visible to you while on the site but not to others unless they are approved Wikipedia Library Coordinators, WMF Staff, or WMF Contractors who need access to this data in order to carry out their work with the Wikipedia Library, all of whom are subject to non-disclosure obligations."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
@@ -3136,46 +2726,32 @@ msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:171
-msgid ""
-"In order to access an individual publisher’s resources, you must agree to "
-"that publisher’s terms of use and privacy policy. You agree that you will "
-"not violate such terms and policies in connection with your use of the "
-"Wikipedia Library. Additionally, the following activities are prohibited "
-"while accessing publisher resources through the Wikipedia Library."
+msgid "In order to access an individual publisher’s resources, you must agree to that publisher’s terms of use and privacy policy. You agree that you will not violate such terms and policies in connection with your use of the Wikipedia Library. Additionally, the following activities are prohibited while accessing publisher resources through the Wikipedia Library."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:184
-msgid ""
-"Sharing your Wikipedia account, usernames, passwords, or any access codes "
-"for publisher resources with others;"
+msgid "Sharing your Wikipedia account, usernames, passwords, or any access codes for publisher resources with others;"
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:191
-msgid ""
-"Automatically scraping or downloading restricted content from publishers;"
+msgid "Automatically scraping or downloading restricted content from publishers;"
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:197
-msgid ""
-"Systematically making printed or electronic copies of multiple extracts of "
-"restricted content available for any purpose;"
+msgid "Systematically making printed or electronic copies of multiple extracts of restricted content available for any purpose;"
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:204
-msgid ""
-"Data mining metadata without permission—for example, in order to use "
-"metadata for auto-created stub articles;"
+msgid "Data mining metadata without permission—for example, in order to use metadata for auto-created stub articles;"
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:211
-msgid ""
-"Using the access you receive through the Wikipedia Library for profit by "
-"selling access to your account or resources which you have through it."
+msgid "Using the access you receive through the Wikipedia Library for profit by selling access to your account or resources which you have through it."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
@@ -3185,18 +2761,12 @@ msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:224
-msgid ""
-"Certain resources may only be accessed using an external search service, "
-"such as the EBSCO Discovery Service, or a proxy service, such as OCLC "
-"EZProxy. If you use such external search and/or proxy services, please "
-"review the applicable terms of use and privacy policies."
+msgid "Certain resources may only be accessed using an external search service, such as the EBSCO Discovery Service, or a proxy service, such as OCLC EZProxy. If you use such external search and/or proxy services, please review the applicable terms of use and privacy policies."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:234
-msgid ""
-"In addition, if you use OCLC EZProxy, please note that you may not use it "
-"for commercial purposes."
+msgid "In addition, if you use OCLC EZProxy, please note that you may not use it for commercial purposes."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
@@ -3206,120 +2776,49 @@ msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Wikimedia Foundation should not be translated. Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:245
-msgid ""
-"The Wikimedia Foundation and our service providers use your information for "
-"the legitimate purpose of providing Wikipedia Library services in support of "
-"our charitable mission. When you apply for a Wikipedia Library account, or "
-"use your Wikipedia Library account, we may routinely collect the following "
-"information: your username, email address, edit count, registration date, "
-"user ID number, groups to which you belong, and any special user rights; "
-"your name, country of residence, and/or affiliation, if required by a "
-"partner to which you are applying; your narrative description of your "
-"contributions and reasons for applying for access to partner resources; and "
-"the date you agree to these terms of use."
+msgid "The Wikimedia Foundation and our service providers use your information for the legitimate purpose of providing Wikipedia Library services in support of our charitable mission. When you apply for a Wikipedia Library account, or use your Wikipedia Library account, we may routinely collect the following information: your username, email address, edit count, registration date, user ID number, groups to which you belong, and any special user rights; your name, country of residence, and/or affiliation, if required by a partner to which you are applying; your narrative description of your contributions and reasons for applying for access to partner resources; and the date you agree to these terms of use."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:262
 #, python-format
-msgid ""
-"Each publisher who is a member of the Wikipedia Library program requires "
-"different specific information in the application. Some publishers may "
-"request only an email address, while others request more detailed data, such "
-"as your name, location, or institutional affiliation. When you complete your "
-"application, you will only be asked to supply information required by the "
-"publishers you have chosen, and each publisher will only receive the "
-"information they require for providing you with access. Please see our <a "
-"class=\"twl-links\" href=\"%(all_partners_url)s\">partner information</a> "
-"pages to learn what information is required by each publisher to gain access "
-"to their resources."
+msgid "Each publisher who is a member of the Wikipedia Library program requires different specific information in the application. Some publishers may request only an email address, while others request more detailed data, such as your name, location, or institutional affiliation. When you complete your application, you will only be asked to supply information required by the publishers you have chosen, and each publisher will only receive the information they require for providing you with access. Please see our <a class=\"twl-links\" href=\"%(all_partners_url)s\">partner information</a> pages to learn what information is required by each publisher to gain access to their resources."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Wikimedia Foundation should not be translated. Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:277
-msgid ""
-"Some Wikipedia Library pages are visible without logging in, but you will "
-"need to log in to apply or access proprietary partner resources. We use the "
-"data provided by you via OAuth and Wikimedia API calls to assess your "
-"application for access and to process approved requests."
+msgid "Some Wikipedia Library pages are visible without logging in, but you will need to log in to apply or access proprietary partner resources. We use the data provided by you via OAuth and Wikimedia API calls to assess your application for access and to process approved requests."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:288
 #, python-format
-msgid ""
-"In order to administer the Wikipedia Library program, we will retain the "
-"application data we collect from you for three years after your most recent "
-"login, unless you delete your account, as described below. You can log in "
-"and go to <a class=\"twl-links\" href=\"%(profile_url)s\">your profile page</"
-"a> in order to see the information associated with your account, and can "
-"download it in JSON format. You may access, update, restrict, or delete this "
-"information at any time, except for the information that is automatically "
-"retrieved from the projects. If you have any questions or concerns about the "
-"handling of your data, please contact <a class=\"twl-links\" href=\"mailto:"
-"wikipedialibrary@wikimedia.org?Subject=Wikipedia%%20Library%%20Card"
-"%%20account%%20deactivation\"> wikipedialibrary@wikimedia.org </a>."
+msgid "In order to administer the Wikipedia Library program, we will retain the application data we collect from you for three years after your most recent login, unless you delete your account, as described below. You can log in and go to <a class=\"twl-links\" href=\"%(profile_url)s\">your profile page</a> in order to see the information associated with your account, and can download it in JSON format. You may access, update, restrict, or delete this information at any time, except for the information that is automatically retrieved from the projects. If you have any questions or concerns about the handling of your data, please contact <a class=\"twl-links\" href=\"mailto:wikipedialibrary@wikimedia.org?Subject=Wikipedia%%20Library%%20Card%%20account%%20deactivation\"> wikipedialibrary@wikimedia.org </a>."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:305
-msgid ""
-"If you decide to disable your Wikipedia Library account, you can use the "
-"delete button on your profile to delete certain personal information "
-"associated with your account. We will delete your real name, institutional "
-"affiliation, and country of residence. Please note that the system will "
-"retain a record of your username, the publishers to which you applied or had "
-"access, and the dates of that access. Note that deletion is not reversible. "
-"Deletion of your Wikipedia Library account may also correspond with the "
-"removal of any resource access to which you were eligible or approved. If "
-"you request the deletion of account information and later wish to apply for "
-"a new account, you will need to provide the necessary information again."
+msgid "If you decide to disable your Wikipedia Library account, you can use the delete button on your profile to delete certain personal information associated with your account. We will delete your real name, institutional affiliation, and country of residence. Please note that the system will retain a record of your username, the publishers to which you applied or had access, and the dates of that access. Note that deletion is not reversible. Deletion of your Wikipedia Library account may also correspond with the removal of any resource access to which you were eligible or approved. If you request the deletion of account information and later wish to apply for a new account, you will need to provide the necessary information again."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). WMF should not be translated. Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:321
-msgid ""
-"The Wikipedia Library is run by WMF Staff, Contractors, and approved "
-"volunteer Coordinators. The data associated with your account will be shared "
-"with the WMF staff, contractors, service providers, and volunteer "
-"coordinators who need to process the information in connection with their "
-"work for the Wikipedia Library, and who are subject to confidentiality "
-"obligations. We will also use your data for internal Wikipedia Library "
-"purposes such as distributing user surveys and account notifications, and in "
-"a depersonalized or aggregated fashion for statistical analysis and "
-"administration. Finally, we will share your information with the publishers "
-"whom you specifically select in order to provide you with access to "
-"resources. Otherwise, your information will not be shared with third "
-"parties, with the exception of the circumstances described below."
+msgid "The Wikipedia Library is run by WMF Staff, Contractors, and approved volunteer Coordinators. The data associated with your account will be shared with the WMF staff, contractors, service providers, and volunteer coordinators who need to process the information in connection with their work for the Wikipedia Library, and who are subject to confidentiality obligations. We will also use your data for internal Wikipedia Library purposes such as distributing user surveys and account notifications, and in a depersonalized or aggregated fashion for statistical analysis and administration. Finally, we will share your information with the publishers whom you specifically select in order to provide you with access to resources. Otherwise, your information will not be shared with third parties, with the exception of the circumstances described below."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). WMF should not be translated.
 #: TWLight/users/templates/users/terms.html:338
-msgid ""
-"We may disclose any collected information when required by law, when we have "
-"your permission, when needed to protect our rights, privacy, safety, users, "
-"or the general public, and when necessary to enforce these terms, WMF’s "
-"general <a class=\"twl-links\" href=\"https://foundation.wikimedia.org/wiki/"
-"Terms_of_Use\">Terms of Use</a>, or any other WMF policy."
+msgid "We may disclose any collected information when required by law, when we have your permission, when needed to protect our rights, privacy, safety, users, or the general public, and when necessary to enforce these terms, WMF’s general <a class=\"twl-links\" href=\"https://foundation.wikimedia.org/wiki/Terms_of_Use\">Terms of Use</a>, or any other WMF policy."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:349
-msgid ""
-"We take the security of your personal data seriously, and take reasonable "
-"precautions to ensure your data is protected. These precautions include "
-"access controls to limit who has access to your data and security "
-"technologies to protect data stored on the server. However, we cannot "
-"guarantee the safety of your data as it is transmitted and stored."
+msgid "We take the security of your personal data seriously, and take reasonable precautions to ensure your data is protected. These precautions include access controls to limit who has access to your data and security technologies to protect data stored on the server. However, we cannot guarantee the safety of your data as it is transmitted and stored."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:360
-msgid ""
-"Please note that these terms do not control the use and handling of your "
-"data by the publishers and service providers whose resources you access or "
-"apply to access. Please read their individual privacy policies for that "
-"information."
+msgid "Please note that these terms do not control the use and handling of your data by the publishers and service providers whose resources you access or apply to access. Please read their individual privacy policies for that information."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
@@ -3329,34 +2828,17 @@ msgstr "Wichteg Notiz"
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Wikimedia Foundation should not be translated. Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:373
-msgid ""
-"The Wikimedia Foundation is a nonprofit organization based in San Francisco, "
-"California. The Wikipedia Library program provides access to resources held "
-"by publishers in multiple countries. If you apply for a Wikipedia Library "
-"account (whether you are inside or outside of the United States), you "
-"understand that your personal data will be collected, transferred, stored, "
-"processed, disclosed and otherwise used in the U.S. as described in this "
-"privacy policy. You also understand that your information may be transferred "
-"by us from the U.S. to other countries, which may have different or less "
-"stringent data protection laws than your country, in connection with "
-"providing services to you, including evaluating your application and "
-"securing access to your chosen publishers (locations for each publisher are "
-"outlined on their respective partner information pages)."
+msgid "The Wikimedia Foundation is a nonprofit organization based in San Francisco, California. The Wikipedia Library program provides access to resources held by publishers in multiple countries. If you apply for a Wikipedia Library account (whether you are inside or outside of the United States), you understand that your personal data will be collected, transferred, stored, processed, disclosed and otherwise used in the U.S. as described in this privacy policy. You also understand that your information may be transferred by us from the U.S. to other countries, which may have different or less stringent data protection laws than your country, in connection with providing services to you, including evaluating your application and securing access to your chosen publishers (locations for each publisher are outlined on their respective partner information pages)."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:392
-msgid ""
-"Please note that in the event of any differences in meaning or "
-"interpretation between the original English version of these terms and a "
-"translation, the original English version takes precedence."
+msgid "Please note that in the event of any differences in meaning or interpretation between the original English version of these terms and a translation, the original English version takes precedence."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Wikimedia Foundation should not be translated.
 #: TWLight/users/templates/users/terms.html:403
-msgid ""
-"See also the <a class=\"twl-links\" href=\"https://wikimediafoundation.org/"
-"wiki/Privacy_policy\">Wikimedia Foundation Privacy Policy</a>."
+msgid "See also the <a class=\"twl-links\" href=\"https://wikimediafoundation.org/wiki/Privacy_policy\">Wikimedia Foundation Privacy Policy</a>."
 msgstr ""
 
 #. Translators: This is the second to last line of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
@@ -3376,11 +2858,7 @@ msgstr "Wikimedia Foundation"
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:426
-msgid ""
-"By checking this box and clicking “Submit”, you agree that you have read the "
-"above terms and that you will adhere to the terms of use in your application "
-"to and use of the The Wikipedia Library, and the publishers’ services to "
-"which you gain access through The Wikipedia Library program."
+msgid "By checking this box and clicking “Submit”, you agree that you have read the above terms and that you will adhere to the terms of use in your application to and use of the The Wikipedia Library, and the publishers’ services to which you gain access through The Wikipedia Library program."
 msgstr ""
 
 #: TWLight/users/templates/users/user_collection_tile.html:32
@@ -3433,29 +2911,18 @@ msgstr "All Donnéeë läschen"
 
 #. Translators: This message is displayed on the page where users can request the deletion of their data.
 #: TWLight/users/templates/users/user_confirm_delete.html:17
-msgid ""
-"<b>Warning:</b> Performing this action will delete your Wikipedia Library "
-"Card user account and all associated applications. This process is not "
-"reversible. You may lose any partner accounts you were granted, and will not "
-"be able to renew those accounts or apply for new ones."
+msgid "<b>Warning:</b> Performing this action will delete your Wikipedia Library Card user account and all associated applications. This process is not reversible. You may lose any partner accounts you were granted, and will not be able to renew those accounts or apply for new ones."
 msgstr ""
 
 #. Translators: this should show up for people who log in with a username/password and not OAuth, so we don't know what their Wikipedia identity is.
-#.
 #: TWLight/users/templates/users/user_detail.html:12
 #, python-format
-msgid ""
-"Hi, %(username)s! You don't have a Wikipedia editor profile attached to your "
-"account here, so you are probably a site administrator."
+msgid "Hi, %(username)s! You don't have a Wikipedia editor profile attached to your account here, so you are probably a site administrator."
 msgstr ""
 
 #. Translators: In the unlikely scenario that someone is able to register an account without using OAuth (thus leaving us without some of the information required for applications), users will see this message, encouraging them to re-register.
 #: TWLight/users/templates/users/user_detail.html:20
-msgid ""
-"If you aren't a site administrator, something weird has happened. You won't "
-"be able to apply for access without a Wikipedia editor profile. You should "
-"log out and create a new account by logging in via OAuth, or contact a site "
-"administrator for help."
+msgid "If you aren't a site administrator, something weird has happened. You won't be able to apply for access without a Wikipedia editor profile. You should log out and create a new account by logging in via OAuth, or contact a site administrator for help."
 msgstr ""
 
 #. Translators: Labels a sections where coordinators can select their email preferences.
@@ -3466,17 +2933,12 @@ msgstr ""
 #. Translators: This message is shown on user's own profile page, encouraging them to make sure their information is up to date, so that account coordinators can use the information to judge applications.
 #: TWLight/users/views.py:176
 #, python-brace-format
-msgid ""
-"Please <a class='twl-links' href='{url}'>update your contributions</a> to "
-"Wikipedia to help coordinators evaluate your applications."
+msgid "Please <a class='twl-links' href='{url}'>update your contributions</a> to Wikipedia to help coordinators evaluate your applications."
 msgstr ""
 
 #. Translators: Coordinators are shown this message when they unselect all three types of reminder email options under preferences.
 #: TWLight/users/views.py:288
-msgid ""
-"You have chosen not to receive reminder emails. As a coordinator, you should "
-"receive at least one type of reminder emails, so consider changing your "
-"preferences."
+msgid "You have chosen not to receive reminder emails. As a coordinator, you should receive at least one type of reminder emails, so consider changing your preferences."
 msgstr ""
 
 #. Translators: Coordinators are shown this message when they make changes to their reminder email options under preferences.
@@ -3510,9 +2972,7 @@ msgstr "Är E-Mail-Adress gouf op {email} geännert."
 
 #. Translators: If the user has not filled out their email, they can browse the website but cannot apply for access to resources.
 #: TWLight/users/views.py:487
-msgid ""
-"Your email is blank. You can still explore the site, but you won't be able "
-"to apply for access to partner resources without an email."
+msgid "Your email is blank. You can still explore the site, but you won't be able to apply for access to partner resources without an email."
 msgstr ""
 
 #. Translators: This message is shown once the access to a partner has successfully been returned.
@@ -3545,31 +3005,3 @@ msgstr "Keng aktiv Spären"
 msgid "10+ edits in the last 30 days"
 msgstr ""
 
-#: tests/shunit/data/bad_i18n_comment_1.py:3
-#: tests/shunit/data/bad_i18n_newline_1.py:5
-msgid "1"
-msgstr ""
-
-#. Translators: Lorem ipsum dolor sit amet, consectetur adipiscing elit. Mauris vitae ipsum ut purus faucibus pretium. Proin tempus neque et aliquet consectetur. Ut egestas sapien in consectetur sagittis. Mauris neque lacus, dapibus non viverra vitae, interdum ut aenean ipsum.
-#. Translators: Lorem ipsum dolor sit amet, consectetur adipiscing elit. Mauris vitae ipsum ut purus faucibus pretium. Proin tempus neque et aliquet consectetur. Ut egestas sapien in consectetur sagittis. Mauris neque lacus, dapibus non.
-#: tests/shunit/data/bad_i18n_comment_2.py:4
-#: tests/shunit/data/bad_i18n_newline_2.py:5 tests/shunit/data/good_i18n_1.py:2
-#: tests/shunit/data/good_i18n_2.py:2
-msgid "2"
-msgstr ""
-
-#: tests/shunit/data/bad_i18n_newline_3.py:5
-msgid "3"
-msgstr ""
-
-#: tests/shunit/data/bad_i18n_newline_4.py:5
-msgid "4"
-msgstr ""
-
-#: tests/shunit/data/bad_i18n_newline_5.py:5
-msgid "5"
-msgstr ""
-
-#: tests/shunit/data/bad_i18n_newline_6.py:5
-msgid "6"
-msgstr ""

--- a/locale/lt/LC_MESSAGES/django.po
+++ b/locale/lt/LC_MESSAGES/django.po
@@ -5,17 +5,17 @@
 # Author: Tomasdd
 msgid ""
 msgstr ""
+""
 "Project-Id-Version: Wikipedia Library Card Platform - Website\n"
-"Report-Msgid-Bugs-To: wikipedialibrary@wikimedia.org\n"
+"Report-Msgid-Bugs-To: translatewiki.net\n"
 "POT-Creation-Date: 2024-07-11 20:54+0000\n"
-"PO-Revision-Date: 2024-07-11 12:30:16+0000\n"
+"PO-Revision-Date: 2024-07-15 12:29:16+0000\n"
 "Language: lt\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "X-POT-Import-Date: 2024-06-25 18:44:08+0000\n"
 "X-Generator: MediaWiki 1.43.0-alpha; Translate 2024-07-16\n"
-"Plural-Forms: nplurals=3; plural=(n%10 == 1 && n%100 != 11) ? 0 : ( (n%10 >= "
-"2 && (n%100 < 10 || n%100 >= 20)) ? 1 : 2 );\n"
+"Plural-Forms: nplurals=3; plural=(n%10 == 1 && n%100 != 11) ? 0 : ( (n%10 >= 2 && (n%100 < 10 || n%100 >= 20)) ? 1 : 2 );\n"
 "X-Translation-Project: translatewiki.net <https://translatewiki.net>\n"
 
 #. Translators: Labels the button users click to apply for a partner's resources.
@@ -41,12 +41,8 @@ msgstr "Apie tave"
 #. Translators: This note appears in a section of a form where we ask users to enter info (like country of residence) when applying for resource access.
 #: TWLight/applications/forms.py:179
 #, python-brace-format
-msgid ""
-"<p><small><i>Your personal data will be processed according to our <a "
-"class='twl-links' href='{terms_url}'> privacy policy</a>.</i></small></p>"
-msgstr ""
-"<p><small><i>Jūsų asmens duomenis bus tvarkomi laikantis mūsų <a class='twl-"
-"links' href='{terms_url}'> privatumo politikos</a>.</i></small></p>"
+msgid "<p><small><i>Your personal data will be processed according to our <a class='twl-links' href='{terms_url}'> privacy policy</a>.</i></small></p>"
+msgstr "<p><small><i>Jūsų asmens duomenis bus tvarkomi laikantis mūsų <a class='twl-links' href='{terms_url}'> privatumo politikos</a>.</i></small></p>"
 
 #. Translators: This is the title of the application form page, where users enter information required for the application. It lets the user know which partner application they are entering data for. {partner}
 #: TWLight/applications/forms.py:189
@@ -87,11 +83,8 @@ msgstr "El. pašto adresas jūsų paskyrai partnerio interneto svetainėje"
 #. Translators: This labels a choice field where users will have to select the number of months they wish to have their access for as part of the application renewal confirmation.
 #. Translators: When filling out an application, users may be required to enter the length of the account (expiry) they wish to have for proxy partners.
 #: TWLight/applications/forms.py:339 TWLight/applications/helpers.py:100
-msgid ""
-"The number of months you wish to have this access for before renewal is "
-"required"
-msgstr ""
-"Kiek mėnesių norite turėti šią prieigą, iki kol bus reikalingas atnaujinimas"
+msgid "The number of months you wish to have this access for before renewal is required"
+msgstr "Kiek mėnesių norite turėti šią prieigą, iki kol bus reikalingas atnaujinimas"
 
 #. Translators: When filling out an application, users may need to specify their name
 #: TWLight/applications/helpers.py:81
@@ -179,12 +172,8 @@ msgstr "El. paštas"
 
 #. Translators: This comment is added to pending applications when our terms of use change.
 #: TWLight/applications/management/commands/notify_applicants_tou_changes.py:54
-msgid ""
-"Our terms of use have changed. Your applications will not be processed until "
-"you log in and agree to our updated terms."
-msgstr ""
-"Mūsų naudojimo sąlygos pasikeitė. Jūsų prašymas nebus apdorotos kol "
-"neprisijungsite ir nesutiksite su atnaujintomis sąlygomis."
+msgid "Our terms of use have changed. Your applications will not be processed until you log in and agree to our updated terms."
+msgstr "Mūsų naudojimo sąlygos pasikeitė. Jūsų prašymas nebus apdorotos kol neprisijungsite ir nesutiksite su atnaujintomis sąlygomis."
 
 #. Translators: This is the status of an application that has not yet been reviewed.
 #: TWLight/applications/models.py:54
@@ -250,40 +239,26 @@ msgstr "Prieigos URL: {access_url}"
 
 #. Translators: This text goes into account approval emails in the case that we need to send the user's details to a publisher for manual account setup.
 #: TWLight/applications/models.py:331
-msgid ""
-"You can expect to receive access details within a week or two once it has "
-"been processed."
-msgstr ""
-"Galite tikėtis gauti prieigos informaciją per savaitę ar dvi po apdorojimo."
+msgid "You can expect to receive access details within a week or two once it has been processed."
+msgstr "Galite tikėtis gauti prieigos informaciją per savaitę ar dvi po apdorojimo."
 
 #. Translators: This comment is added to open applications when a partner joins the Library Bundle, which does not require applications.
 #: TWLight/applications/signals.py:247
-msgid ""
-"This partner joined the Library Bundle, which does not require applications. "
-"This application will be marked as invalid."
-msgstr ""
-"Šis partneris prisijungė prie Bibliotekų paketo, kuris nereikalauja "
-"paraiškų. Ši paraiška bus pažymėta kaip negalima."
+msgid "This partner joined the Library Bundle, which does not require applications. This application will be marked as invalid."
+msgstr "Šis partneris prisijungė prie Bibliotekų paketo, kuris nereikalauja paraiškų. Ši paraiška bus pažymėta kaip negalima."
 
 #. Translators: This is shown to users if the application is to a partner for which we have run out of available accounts. The application is therefore on a 'waitlist', and will be reviewed when more accounts are available.
 #: TWLight/applications/templates/applications/application_evaluation.html:29
-msgid ""
-"This application is on the waitlist because this partner does not have any "
-"access grants available at this time."
-msgstr ""
-"Paraiška yra laukiančių sąraše, nes šis partneris šiuo metu neturi prieigų."
+msgid "This application is on the waitlist because this partner does not have any access grants available at this time."
+msgstr "Paraiška yra laukiančių sąraše, nes šis partneris šiuo metu neturi prieigų."
 
 #. Translators: This message is shown on pages where coordinators can see personal information about applicants.
 #: TWLight/applications/templates/applications/application_evaluation.html:36
 #: TWLight/applications/templates/applications/application_list_include.html:6
 #: TWLight/applications/templates/applications/send_partner.html:45
 #: TWLight/resources/templates/resources/partner_users.html:18
-msgid ""
-"Coordinators: This page may contain personal information such as real names "
-"and email addresses. Please remember that this information is confidential."
-msgstr ""
-"Koordinatoriai: šiame puslapyje gali būti asmens duomenų, pvz., tikrų vardų "
-"ar el. pašto adresų. Atminnkite, kad ši informacija konfidenciali."
+msgid "Coordinators: This page may contain personal information such as real names and email addresses. Please remember that this information is confidential."
+msgstr "Koordinatoriai: šiame puslapyje gali būti asmens duomenų, pvz., tikrų vardų ar el. pašto adresų. Atminnkite, kad ši informacija konfidenciali."
 
 #. Translators: This is the title of the application page shown to users who are a coordinator, and are able to accept or reject the application.
 #: TWLight/applications/templates/applications/application_evaluation.html:39
@@ -292,12 +267,8 @@ msgstr "Įvertinkite paraišką"
 
 #. Translators: This text is shown to coordinators on application pages if the applicant has restricted processing of their data.
 #: TWLight/applications/templates/applications/application_evaluation.html:42
-msgid ""
-"This user has requested a restriction on the processing of their data, so "
-"you cannot change the status of their application."
-msgstr ""
-"Šis naudotojas paprašė apriboti savo duomenų tvarkymą, tad negalite pakeisti "
-"jų prašymo būsenos."
+msgid "This user has requested a restriction on the processing of their data, so you cannot change the status of their application."
+msgstr "Šis naudotojas paprašė apriboti savo duomenų tvarkymą, tad negalite pakeisti jų prašymo būsenos."
 
 #. Translators: This is the title of the application page shown to users who are not a coordinator.
 #: TWLight/applications/templates/applications/application_evaluation.html:48
@@ -370,11 +341,8 @@ msgstr "Nežinoma"
 
 #. Translators: This is the text displayed to coordinators when an applicant has no country of residence in their profile.
 #: TWLight/applications/templates/applications/application_evaluation.html:123
-msgid ""
-"Please request the applicant add their country of residence to their profile "
-"before proceeding further."
-msgstr ""
-"Paprašykite pareiškėjo pridėti savo valstybę prie profilio prieš tęsiant."
+msgid "Please request the applicant add their country of residence to their profile before proceeding further."
+msgstr "Paprašykite pareiškėjo pridėti savo valstybę prie profilio prieš tęsiant."
 
 #. Translators: This labels the section of an application showing the total number of accounts available for a partner or their collection.
 #: TWLight/applications/templates/applications/application_evaluation.html:134
@@ -384,12 +352,8 @@ msgstr "Prieinama paskyrų"
 #. Translators: This labels the section of an application showing whether the user had agreed to the terms of use or not.
 #: TWLight/applications/templates/applications/application_evaluation.html:145
 #, python-format
-msgid ""
-"Has agreed to the site's <a class=\"twl-links\" href=\"%(terms_url)s\">terms "
-"of use</a>?"
-msgstr ""
-"Sutiko su svetainės <a class=\"twl-links\" href=\"%(terms_url)s\">naudojimo "
-"sąlygomis</a>?"
+msgid "Has agreed to the site's <a class=\"twl-links\" href=\"%(terms_url)s\">terms of use</a>?"
+msgstr "Sutiko su svetainės <a class=\"twl-links\" href=\"%(terms_url)s\">naudojimo sąlygomis</a>?"
 
 #. Translators: Displayed to coordinators when they've agreed to the terms of use.
 #. Translators: Displayed if the user has agreed to the terms of use.
@@ -424,12 +388,8 @@ msgstr "Ne"
 
 #. Translators: This is the text displayed to coordinators when an applicant has not agreed to the terms of use.
 #: TWLight/applications/templates/applications/application_evaluation.html:159
-msgid ""
-"Please request the applicant agree to the site's terms of use before "
-"approving this application."
-msgstr ""
-"Paprašykite pareiškėjo sutikti su naudojimo sąlygomis prieš patvirtinant "
-"paraišką."
+msgid "Please request the applicant agree to the site's terms of use before approving this application."
+msgstr "Paprašykite pareiškėjo sutikti su naudojimo sąlygomis prieš patvirtinant paraišką."
 
 #. Translators: This labels the section of an application containing the user's motivation for wanting access to this resource.
 #: TWLight/applications/templates/applications/application_evaluation.html:176
@@ -449,10 +409,8 @@ msgstr "Egzistuojančios prieigos atnaujinimas?"
 #. Translators: This message is shown next to the 'Renewal of existing access grant?' label if the application is a renewal. Don't translate HTML tags or parent_url.
 #: TWLight/applications/templates/applications/application_evaluation.html:195
 #, python-format
-msgid ""
-"Yes (<a class=\"twl-links\" href=\"%(parent_url)s\">previous application</a>)"
-msgstr ""
-"Taip (<a class=\"twl-links\" href=\"%(parent_url)s\">ankstesnė paraiška</a>)"
+msgid "Yes (<a class=\"twl-links\" href=\"%(parent_url)s\">previous application</a>)"
+msgstr "Taip (<a class=\"twl-links\" href=\"%(parent_url)s\">ankstesnė paraiška</a>)"
 
 #. Translators: This labels the section of the application showing the length of access remaining on the user's previous authorization.
 #: TWLight/applications/templates/applications/application_evaluation.html:208
@@ -486,9 +444,7 @@ msgstr "Pridėti komentarą"
 
 #. Translators: On an application page, this text tells users that the comments posted on the application are visible to coordinators and the submitting user only.
 #: TWLight/applications/templates/applications/application_evaluation.html:297
-msgid ""
-"Comments are visible to all coordinators and to the editor who submitted "
-"this application."
+msgid "Comments are visible to all coordinators and to the editor who submitted this application."
 msgstr "Komentarus mato visi koordinatoriai ir redaktorius, pateikęs paraišką."
 
 #. Translators: This is the title of the section of an application page which lists information about the user who submitted the application.
@@ -700,24 +656,14 @@ msgstr "Nustatyti būseną"
 
 #: TWLight/applications/templates/applications/apply.html:20
 #, python-format
-msgid ""
-"If your application is successful we may share your email address with "
-"%(partner)s. This is required to set up your access to their resources. By "
-"submitting this form you agree to allow your email address to be shared with "
-"%(partner)s if your application is successful, for the purposes of account "
-"setup."
-msgstr ""
-"Jei jūsų paraiška bus patvirtinta mes galime pasidalinti jūsų el. pašto "
-"adresu su %(partner)s. Tai reikalinga sukurti jums prieigą prie partnerio "
-"išteklių. Pateikiant šią formą sutinkate, kad jūsų el. paštu pasidalintume "
-"su %(partner)s, jei jūsų paraiška bus patvirtinta, paskyros sukūrimo tikslu."
+msgid "If your application is successful we may share your email address with %(partner)s. This is required to set up your access to their resources. By submitting this form you agree to allow your email address to be shared with %(partner)s if your application is successful, for the purposes of account setup."
+msgstr "Jei jūsų paraiška bus patvirtinta mes galime pasidalinti jūsų el. pašto adresu su %(partner)s. Tai reikalinga sukurti jums prieigą prie partnerio išteklių. Pateikiant šią formą sutinkate, kad jūsų el. paštu pasidalintume su %(partner)s, jei jūsų paraiška bus patvirtinta, paskyros sukūrimo tikslu."
 
 #. Translators: This message is displayed on the page where users can confirm their renewal. Please do not translate partner.
 #: TWLight/applications/templates/applications/confirm_renewal.html:23
 #, python-format
 msgid "Click 'confirm' to renew your application for %(partner)s"
-msgstr ""
-"Paspauskite „patvirtinti“, kad atnaujintumėte savo %(partner)s paraišką"
+msgstr "Paspauskite „patvirtinti“, kad atnaujintumėte savo %(partner)s paraišką"
 
 #. Translators: Labels the submit button requesting confirmation of application renewal.
 #. Translators: This is the button coordinators click to confirm deletion of a suggestion.
@@ -739,12 +685,8 @@ msgstr "Prie kokių išteklių norite prieiti?"
 
 #. Translators: This text explains that Library Bundle partners are not shown in this list.
 #: TWLight/applications/templates/applications/request_for_application.html:26
-msgid ""
-"Library Bundle partners are not shown as eligibility is determined "
-"automatically."
-msgstr ""
-"Bibliotekų paketo partneriai nerodomi, nes tinkamumas nustatomas "
-"automatiškai."
+msgid "Library Bundle partners are not shown as eligibility is determined automatically."
+msgstr "Bibliotekų paketo partneriai nerodomi, nes tinkamumas nustatomas automatiškai."
 
 #. Translators: On the page where users can apply for multiple partners, this message shows next to the partner name, taking them to the full application page when clicked.
 #: TWLight/applications/templates/applications/request_for_application.html:48
@@ -758,14 +700,8 @@ msgstr "Kol kas nepridėti jokie partnerio duomenys."
 
 #. Translators: the HTML is so that the word 'waitlisted' will look the same as it does in the page above; please translate 'waitlisted' the same way you did elsewhere in this file.
 #: TWLight/applications/templates/applications/request_for_application.html:74
-msgid ""
-"You can apply to <span class=\"badge badge-warning\">Waitlisted</span> "
-"partners, but they don't have access grants available right now. We will "
-"process those applications when access becomes available."
-msgstr ""
-"Galite teikti paraiškas dėl partnerių, esančių <span class=\"badge badge-"
-"warning\">laukiančių sąraše</span>, bet šiuo metu jie laisvų prieigų neturi. "
-"Peržiūrėsime šias paraiškas, kai prieigų bus."
+msgid "You can apply to <span class=\"badge badge-warning\">Waitlisted</span> partners, but they don't have access grants available right now. We will process those applications when access becomes available."
+msgstr "Galite teikti paraiškas dėl partnerių, esančių <span class=\"badge badge-warning\">laukiančių sąraše</span>, bet šiuo metu jie laisvų prieigų neturi. Peržiūrėsime šias paraiškas, kai prieigų bus."
 
 #. Translators: On the page where coordinators can see approved applications which have not had their details sent to the partner, this message shows when there are applications ready to be processed.
 #: TWLight/applications/templates/applications/send.html:10
@@ -786,19 +722,13 @@ msgstr "%(object)s paraiškos duomenys"
 #. Translators: This message is shown when applications exceed the number of accounts available.
 #: TWLight/applications/templates/applications/send_partner.html:54
 #, python-format
-msgid ""
-"Application(s) for %(object)s, if sent, will exceed the total available "
-"accounts for the partner. Please proceed at your own discretion."
-msgstr ""
-"%(object)s paraiška, jei bus išsiųsta, viršys visą prieinamų partnerio "
-"paskyrų skaičių. Tęsimas jūsų diskrecijoje."
+msgid "Application(s) for %(object)s, if sent, will exceed the total available accounts for the partner. Please proceed at your own discretion."
+msgstr "%(object)s paraiška, jei bus išsiųsta, viršys visą prieinamų partnerio paskyrų skaičių. Tęsimas jūsų diskrecijoje."
 
 #. Translators: When viewing the list of applications ready to be sent for a particular partner, this is instructions for the coordinator to click the 'mark as sent' button after they have sent the information.
 #: TWLight/applications/templates/applications/send_partner.html:65
 msgid "When you've processed the data below, click the 'mark as sent' button."
-msgstr ""
-"Kai peržiūrėsite žemiau esančius duomenis, spauskite „žymėti kaip išsiųstą“ "
-"mygtuką."
+msgstr "Kai peržiūrėsite žemiau esančius duomenis, spauskite „žymėti kaip išsiųstą“ mygtuką."
 
 #. Translators: When viewing the list of applications ready to be sent for a particular partner, this is the title of the section containing contact information for the people applications should be sent to.
 #: TWLight/applications/templates/applications/send_partner.html:71
@@ -810,12 +740,8 @@ msgstr[2] ""
 
 #. Translators: When viewing the list of applications ready to be sent for a particular partner, this message shows if there is no information about who the applications should be sent to. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/applications/templates/applications/send_partner.html:89
-msgid ""
-"Whoops, we don't have any listed contacts. Please notify Wikipedia Library "
-"administrators."
-msgstr ""
-"Oi, neturime nurodytų kontaktų. Praneškite Vikipedijos bibliotekos "
-"administratoriams."
+msgid "Whoops, we don't have any listed contacts. Please notify Wikipedia Library administrators."
+msgstr "Oi, neturime nurodytų kontaktų. Praneškite Vikipedijos bibliotekos administratoriams."
 
 #. Translators: When viewing the list of applications ready to be sent for a particular partner, this is the title of the section containing the information about those applications.
 #: TWLight/applications/templates/applications/send_partner.html:94
@@ -830,9 +756,7 @@ msgstr "Žymėti kaip išsiųstą"
 
 #. Translators: This text guides coordinators in using the code sending interface for approved applications.
 #: TWLight/applications/templates/applications/send_partner.html:152
-msgid ""
-"Use the dropdown menus to denote which editor will receive each code. Access "
-"codes will be sent to users automatically."
+msgid "Use the dropdown menus to denote which editor will receive each code. Access codes will be sent to users automatically."
 msgstr ""
 
 #. Translators: This labels a drop-down selection where staff can assign an access code to a user.
@@ -848,23 +772,14 @@ msgstr "Nėra patvirtintų, atsiimtų paraiškų."
 #. Translators: When a user applies for a set of resources, they receive this message if none are currently available. They are instead placed on a 'waitlist' for later approval.
 #. Translators: When a user renews their resource, they receive this message if none are currently available. They are instead placed on a 'waitlist' for later approval.
 #: TWLight/applications/views.py:140 TWLight/applications/views.py:1282
-msgid ""
-"This partner does not have any access grants available at this time. You may "
-"still apply for access; your application will be reviewed when access grants "
-"become available."
-msgstr ""
-"Šis partneris šiuo metu neturi galimų prieigų. Vis tiek galite teikti "
-"paraišką prieigai; jūsų paraiška bus peržiūrėta, kai prieigos bus galimos."
+msgid "This partner does not have any access grants available at this time. You may still apply for access; your application will be reviewed when access grants become available."
+msgstr "Šis partneris šiuo metu neturi galimų prieigų. Vis tiek galite teikti paraišką prieigai; jūsų paraiška bus peržiūrėta, kai prieigos bus galimos."
 
 #. Translators: This message is shown to users once they've successfully submitted their application for review.
 #: TWLight/applications/views.py:163
 #, python-brace-format
-msgid ""
-"Your application has been submitted for review. Head over to <a "
-"href='{applications_url}'>My Applications</a> to view the status."
-msgstr ""
-"Jūsų paraiška pateikta peržiūrai. Eikite į <a href='{applications_url}'>Mano "
-"paraiškas</a>, kad peržiūrėtumėte būseną."
+msgid "Your application has been submitted for review. Head over to <a href='{applications_url}'>My Applications</a> to view the status."
+msgstr "Jūsų paraiška pateikta peržiūrai. Eikite į <a href='{applications_url}'>Mano paraiškas</a>, kad peržiūrėtumėte būseną."
 
 #. Translators: This text is displayed to users when the user has chosen to restrict data and is trying to apply for multiple partners
 #: TWLight/applications/views.py:276
@@ -912,16 +827,12 @@ msgstr "Pateiktos paraiškos"
 
 #. Translators: After a coordinator has changed the status of an application to APPROVED, if the corresponding partner/collection is waitlisted this message appears.
 #: TWLight/applications/views.py:756
-msgid ""
-"Cannot approve application as partner with proxy authorization method is "
-"waitlisted."
+msgid "Cannot approve application as partner with proxy authorization method is waitlisted."
 msgstr ""
 
 #. Translators: After a coordinator has changed the status of an application to APPROVED, if the corresponding partner/collection has no accounts for distribution, this message appears.
 #: TWLight/applications/views.py:780
-msgid ""
-"Cannot approve application as partner with proxy authorization method is "
-"waitlisted and (or) has zero accounts available for distribution."
+msgid "Cannot approve application as partner with proxy authorization method is waitlisted and (or) has zero accounts available for distribution."
 msgstr ""
 
 #. Translators: This message appears on an "access denied" screen that stops users who attempt to authorize an editor to access a resource during a time period for which they are already authorized.
@@ -932,16 +843,8 @@ msgstr ""
 #. Translators: This message is shown to users when they access an application page of a now Bundle partner (new applications aren't allowed for Bundle partners and the status of old applications cannot be modified)
 #: TWLight/applications/views.py:857
 #, python-brace-format
-msgid ""
-"This application cannot be modified since this partner is now part of our <a "
-"href='{bundle}'>bundle access</a>. If you are eligible, you can access this "
-"resource from <a href='{library}'>your library</a>. <a "
-"href='{contact}'>Contact us</a> if you have any questions."
-msgstr ""
-"Paraiškos keisti negalima, nes šis partneris dabar yra mūsų <a "
-"href='{bundle}'>prieigos paketo</a> dalis. Jei atitinkate sąlygas, galite "
-"pasiekti išteklių per <a href='{library}'>savo biblioteką</a>. <a "
-"href='{contact}'>Susiekite su mumis</a>, jei turite klausimų."
+msgid "This application cannot be modified since this partner is now part of our <a href='{bundle}'>bundle access</a>. If you are eligible, you can access this resource from <a href='{library}'>your library</a>. <a href='{contact}'>Contact us</a> if you have any questions."
+msgstr "Paraiškos keisti negalima, nes šis partneris dabar yra mūsų <a href='{bundle}'>prieigos paketo</a> dalis. Jei atitinkate sąlygas, galite pasiekti išteklių per <a href='{library}'>savo biblioteką</a>. <a href='{contact}'>Susiekite su mumis</a>, jei turite klausimų."
 
 #. Translators: this lets a reviewer set the status of a single application.
 #: TWLight/applications/views.py:873
@@ -950,12 +853,8 @@ msgstr "Nustatyti paraiškos būseną"
 
 #. Translators: This warning is message is shown to applicants when the number of pending applications is greater than the number of accounts available.
 #: TWLight/applications/views.py:891
-msgid ""
-"There are more pending applications than available accounts. Your "
-"application might get waitlisted."
-msgstr ""
-"Yra daugiau laukiančių paraiškų, nei prieinamų paskyrų. Jūsų paraiška gali "
-"būti priskirta laukiančių sąrašui."
+msgid "There are more pending applications than available accounts. Your application might get waitlisted."
+msgstr "Yra daugiau laukiančių paraiškų, nei prieinamų paskyrų. Jūsų paraiška gali būti priskirta laukiančių sąrašui."
 
 #. Translators: this message is shown to coordinators who attempt to change an application's Status from INVALID to any other Status.
 #: TWLight/applications/views.py:904
@@ -974,11 +873,7 @@ msgstr ""
 
 #. Translators: After a coordinator has changed the status of a number of applications to APPROVED, if the corresponding partner(s) is/are waitlisted or has no accounts for distribution, this message appears.
 #: TWLight/applications/views.py:1051
-msgid ""
-"Cannot approve application(s) {} as partner(s) with proxy authorization "
-"method is/are waitlisted and (or) has/have not enough accounts available. If "
-"not enough accounts are available, prioritise the applications and then "
-"approve applications equal to the accounts available."
+msgid "Cannot approve application(s) {} as partner(s) with proxy authorization method is/are waitlisted and (or) has/have not enough accounts available. If not enough accounts are available, prioritise the applications and then approve applications equal to the accounts available."
 msgstr ""
 
 #. Translators: This message is shown to coordinators who attempt to assign the same access code to multiple users.
@@ -993,12 +888,8 @@ msgstr "Visos pasirinktos paraiškos pažymėtos kaip išsiųstos."
 
 #. Translators: When a user tries to renew their resource, they receive this message if the partner is not available.
 #: TWLight/applications/views.py:1272
-msgid ""
-"Cannot renew application at this time as partner is not available. Please "
-"check back later, or contact us for more information."
-msgstr ""
-"Negalima šiuo metu atnaujinti paraiškos, nes partneris neprieinamas. "
-"Patikrinkite vėliau arba susiekite su mumis dėl daugiau informacijos."
+msgid "Cannot renew application at this time as partner is not available. Please check back later, or contact us for more information."
+msgstr "Negalima šiuo metu atnaujinti paraiškos, nes partneris neprieinamas. Patikrinkite vėliau arba susiekite su mumis dėl daugiau informacijos."
 
 #. Translators: This message is displayed when an attempt by a user to renew an application has been denied for some reason.
 #: TWLight/applications/views.py:1308
@@ -1008,20 +899,13 @@ msgstr "Bandymas atnaujinti nepatvirtintą paraišką #{pk} atmestas"
 
 #. Translators: If a user requests the renewal of their account, but it wasn't renewed, this message is shown to them.
 #: TWLight/applications/views.py:1385
-msgid ""
-"This object cannot be renewed. (This probably means that you have already "
-"requested that it be renewed.)"
-msgstr ""
-"Objektas negali būti atnaujintas. (Tai tikriausiai reiškia, kad jūs jau "
-"paprašėte atnaujinimo.)"
+msgid "This object cannot be renewed. (This probably means that you have already requested that it be renewed.)"
+msgstr "Objektas negali būti atnaujintas. (Tai tikriausiai reiškia, kad jūs jau paprašėte atnaujinimo.)"
 
 #. Translators: If a user requests the renewal of their account, this message is shown to them.
 #: TWLight/applications/views.py:1395
-msgid ""
-"Your renewal request has been received. A coordinator will review your "
-"request."
-msgstr ""
-"Jūsų atnaujinimo prašymas gautas. Koordinatorius peržiūrės jūsų prašymą."
+msgid "Your renewal request has been received. A coordinator will review your request."
+msgstr "Jūsų atnaujinimo prašymas gautas. Koordinatorius peržiūrės jūsų prašymą."
 
 #. Translators: This labels a textfield where users can enter their email ID.
 #: TWLight/emails/forms.py:18
@@ -1030,12 +914,8 @@ msgstr "Jūsų el. paštas"
 
 #. Translators: This is the help text for the email field in the contact us form letting users know the field is updated by value pulled from their respective user profiles.
 #: TWLight/emails/forms.py:21
-msgid ""
-"This field is automatically updated with the email from your <a class='twl-"
-"links' href='{}'>user profile</a>."
-msgstr ""
-"Šis laukelis automatiškai atnaujinamas su jūsų el. paštu iš jūsų <a "
-"class='twl-links' href='{}'>naudotojo profilio</a>."
+msgid "This field is automatically updated with the email from your <a class='twl-links' href='{}'>user profile</a>."
+msgstr "Šis laukelis automatiškai atnaujinamas su jūsų el. paštu iš jūsų <a class='twl-links' href='{}'>naudotojo profilio</a>."
 
 #. Translators: This labels a textfield where users can enter their email message.
 #: TWLight/emails/forms.py:26
@@ -1058,25 +938,14 @@ msgstr "Siųsti"
 #. Translators: This email is sent to users with their access code. Don't translate Jinja variables in curly braces like user or partner. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/access_code_email-body-html.html:5
 #, python-format
-msgid ""
-"<p>Your approved application to %(partner)s has now been finalised. Your "
-"access code or login details can be found below:</p> <p><b>%(access_code)s</"
-"b></p> <p>%(user_instructions)s</p>"
-msgstr ""
-"<p>Jūsų patvirtinta %(partner)s paraiška užbaigta. Jūsų prieigos kodas ar "
-"prisijungimo duomenys pateikti žemiau:</p> <p><b>%(access_code)s</b></p> <p>"
-"%(user_instructions)s</p>"
+msgid "<p>Your approved application to %(partner)s has now been finalised. Your access code or login details can be found below:</p> <p><b>%(access_code)s</b></p> <p>%(user_instructions)s</p>"
+msgstr "<p>Jūsų patvirtinta %(partner)s paraiška užbaigta. Jūsų prieigos kodas ar prisijungimo duomenys pateikti žemiau:</p> <p><b>%(access_code)s</b></p> <p>%(user_instructions)s</p>"
 
 #. Translators: This email is sent to users with their access code. Don't translate Jinja variables in curly braces like user or partner. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/access_code_email-body-text.html:3
 #, python-format
-msgid ""
-"Your approved application to %(partner)s has now been finalised. Your access "
-"code or login details can be found below: %(access_code)s "
-"%(user_instructions)s"
-msgstr ""
-"Jūsų patvirtinta %(partner)s paraiška užbaigta. Jūsų prieigos kodas ar "
-"prisijungimo duomenys pateikti žemiau: %(access_code)s %(user_instructions)s"
+msgid "Your approved application to %(partner)s has now been finalised. Your access code or login details can be found below: %(access_code)s %(user_instructions)s"
+msgstr "Jūsų patvirtinta %(partner)s paraiška užbaigta. Jūsų prieigos kodas ar prisijungimo duomenys pateikti žemiau: %(access_code)s %(user_instructions)s"
 
 #. Translators: This is the subject line of an email sent to users with their access code.
 #: TWLight/emails/templates/emails/access_code_email-subject.html:3
@@ -1086,33 +955,14 @@ msgstr "Jūsų Vikipedijos bibliotekos prieigos kodas"
 #. Translators: This email is sent to users when their application is approved. Don't translate Jinja variables in curly braces like user or partner; don't translate html tags either. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/approval_notification-body-html.html:5
 #, python-format
-msgid ""
-"<p>Dear %(user)s,</p> <p>Thank you for applying for access to %(partner)s "
-"resources through The Wikipedia Library. We are happy to inform you that "
-"your application has been approved.</p> <p>%(user_instructions)s</p> <p>You "
-"can view the collections you're authorized to access at My Library: "
-"%(link)s</p> <p>Cheers!</p> <p>The Wikipedia Library</p>"
-msgstr ""
-"<p>%(user)s,</p> <p>Ačiū už jūsų paraišką dėl %(partner)s išteklių prieigos "
-"per Vikipedijos biblioteką. Džiaugiamės galėdami informuoti, kad jūsų "
-"paraiška patvirtinta.</p> <p>%(user_instructions)s</p> <p>Galite peržiūrėti "
-"kolekcijas, prie kurių galite prieiti, savo bibliotekoje: %(link)s</p> "
-"<p>Sėkmės!</p> <p>Vikipedijos biblioteka</p>"
+msgid "<p>Dear %(user)s,</p> <p>Thank you for applying for access to %(partner)s resources through The Wikipedia Library. We are happy to inform you that your application has been approved.</p> <p>%(user_instructions)s</p> <p>You can view the collections you're authorized to access at My Library: %(link)s</p> <p>Cheers!</p> <p>The Wikipedia Library</p>"
+msgstr "<p>%(user)s,</p> <p>Ačiū už jūsų paraišką dėl %(partner)s išteklių prieigos per Vikipedijos biblioteką. Džiaugiamės galėdami informuoti, kad jūsų paraiška patvirtinta.</p> <p>%(user_instructions)s</p> <p>Galite peržiūrėti kolekcijas, prie kurių galite prieiti, savo bibliotekoje: %(link)s</p> <p>Sėkmės!</p> <p>Vikipedijos biblioteka</p>"
 
 #. Translators: This email is sent to users when their application is approved. Don't translate Jinja variables in curly braces like user or partner. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/approval_notification-body-text.html:3
 #, python-format
-msgid ""
-"Dear %(user)s, Thank you for applying for access to %(partner)s resources "
-"through The Wikipedia Library. We are happy to inform you that your "
-"application has been approved. %(user_instructions)s You can view the "
-"collections you're authorized to access at My Library: %(link)s Cheers! The "
-"Wikipedia Library"
-msgstr ""
-"%(user)s, Ačiū už jūsų paraišką dėl %(partner)s išteklių prieigos per "
-"Vikipedijos biblioteką. Džiaugiamės galėdami informuoti, kad jūsų paraiška "
-"patvirtinta. %(user_instructions)s Galite peržiūrėti kolekcijas, prie kurių "
-"galite prieiti, savo bibliotekoje: %(link)s Sėkmės! Vikipedijos biblioteka"
+msgid "Dear %(user)s, Thank you for applying for access to %(partner)s resources through The Wikipedia Library. We are happy to inform you that your application has been approved. %(user_instructions)s You can view the collections you're authorized to access at My Library: %(link)s Cheers! The Wikipedia Library"
+msgstr "%(user)s, Ačiū už jūsų paraišką dėl %(partner)s išteklių prieigos per Vikipedijos biblioteką. Džiaugiamės galėdami informuoti, kad jūsų paraiška patvirtinta. %(user_instructions)s Galite peržiūrėti kolekcijas, prie kurių galite prieiti, savo bibliotekoje: %(link)s Sėkmės! Vikipedijos biblioteka"
 
 #. Translators: This is the subject of an email which is sent to users when their application has been approved. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/approval_notification-subject.html:4
@@ -1122,26 +972,14 @@ msgstr "Jūsų Vikipedijos bibliotekos paraiška patvirtinta"
 #. Translators: This email is sent to coordinators when a comment is left on an application they are processing. Don't translate Jinja variables in curly braces like user or partner. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/comment_notification_coordinator-body-html.html:5
 #, python-format
-msgid ""
-"<p style=\"color: #500050\">%(submit_date)s - %(commenter)s</p> "
-"<blockquote><p>%(comment)s</p></blockquote> <p>Please reply to these at: <a "
-"href=\"%(app_url)s\">%(app_url)s</a></p> <p>Best,</p> <p>The Wikipedia "
-"Library</p>"
-msgstr ""
-"<p style=\"color: #500050\">%(submit_date)s - %(commenter)s</p> "
-"<blockquote><p>%(comment)s</p></blockquote> <p>Prašome į juos atsakyti: <a "
-"href=\"%(app_url)s\">%(app_url)s</a></p> <p>Pagarbiai,</p> <p>Vikipedijos "
-"biblioteka</p>"
+msgid "<p style=\"color: #500050\">%(submit_date)s - %(commenter)s</p> <blockquote><p>%(comment)s</p></blockquote> <p>Please reply to these at: <a href=\"%(app_url)s\">%(app_url)s</a></p> <p>Best,</p> <p>The Wikipedia Library</p>"
+msgstr "<p style=\"color: #500050\">%(submit_date)s - %(commenter)s</p> <blockquote><p>%(comment)s</p></blockquote> <p>Prašome į juos atsakyti: <a href=\"%(app_url)s\">%(app_url)s</a></p> <p>Pagarbiai,</p> <p>Vikipedijos biblioteka</p>"
 
 #. Translators: This email is sent to coordinators when a comment is left on an application they are processing. Don't translate Jinja variables in curly braces like user or partner. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/comment_notification_coordinator-body-text.html:3
 #, python-format
-msgid ""
-"%(submit_date)s - %(commenter)s %(comment)s Please reply to this at: "
-"%(app_url)s Best, The Wikipedia Library"
-msgstr ""
-"%(submit_date)s - %(commenter)s %(comment)s Prašome į juos atsakyti: "
-"%(app_url)s Pagarbiai, Vikipedijos biblioteka"
+msgid "%(submit_date)s - %(commenter)s %(comment)s Please reply to this at: %(app_url)s Best, The Wikipedia Library"
+msgstr "%(submit_date)s - %(commenter)s %(comment)s Prašome į juos atsakyti: %(app_url)s Pagarbiai, Vikipedijos biblioteka"
 
 #. Translators: This is the subject line of an email sent to coordinators when a comment is left on an application they processed.
 #: TWLight/emails/templates/emails/comment_notification_coordinator-subject.html:3
@@ -1151,27 +989,14 @@ msgstr "Naujas komentaras jūsų tvarkytoje Vikipedijos bibliotekos paraiškoje"
 #. Translators: This email is sent to users when they receive a comment on their application. Don't translate Jinja variables in curly braces like user or partner; don't translate html tags either. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/comment_notification_editors-body-html.html:5
 #, python-format
-msgid ""
-"<p style=\"color: #500050\">%(submit_date)s - %(commenter)s</p> "
-"<blockquote><p>%(comment)s</p></blockquote> <p>Please reply to these at <a "
-"href=\"%(app_url)s\">%(app_url)s</a> so we can evaluate your application.</"
-"p> <p>Best,</p> <p>The Wikipedia Library</p>"
-msgstr ""
-"<p style=\"color: #500050\">%(submit_date)s - %(commenter)s</p> "
-"<blockquote><p>%(comment)s</p></blockquote> <p>Prašome į juos atsakyti <a "
-"href=\"%(app_url)s\">%(app_url)s</a>, kad galėtume įvertinti jūsų paraišką.</"
-"p> <p>Pagarbiai,</p> <p>Vikipedijos biblioteka</p>"
+msgid "<p style=\"color: #500050\">%(submit_date)s - %(commenter)s</p> <blockquote><p>%(comment)s</p></blockquote> <p>Please reply to these at <a href=\"%(app_url)s\">%(app_url)s</a> so we can evaluate your application.</p> <p>Best,</p> <p>The Wikipedia Library</p>"
+msgstr "<p style=\"color: #500050\">%(submit_date)s - %(commenter)s</p> <blockquote><p>%(comment)s</p></blockquote> <p>Prašome į juos atsakyti <a href=\"%(app_url)s\">%(app_url)s</a>, kad galėtume įvertinti jūsų paraišką.</p> <p>Pagarbiai,</p> <p>Vikipedijos biblioteka</p>"
 
 #. Translators: This email is sent to users when they receive a comment on their application. Don't translate Jinja variables in curly braces like user or partner. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/comment_notification_editors-body-text.html:3
 #, python-format
-msgid ""
-"%(submit_date)s - %(commenter)s %(comment)s Please reply to these at: "
-"%(app_url)s so we can evaluate your application. Best, The Wikipedia Library"
-msgstr ""
-"%(submit_date)s - %(commenter)s %(comment)s Prašome į juos atsakyti: "
-"%(app_url)s, kad galėtume įvertinti jūsų paraišką. Pagarbiai, Vikipedijos "
-"biblioteka"
+msgid "%(submit_date)s - %(commenter)s %(comment)s Please reply to these at: %(app_url)s so we can evaluate your application. Best, The Wikipedia Library"
+msgstr "%(submit_date)s - %(commenter)s %(comment)s Prašome į juos atsakyti: %(app_url)s, kad galėtume įvertinti jūsų paraišką. Pagarbiai, Vikipedijos biblioteka"
 
 #. Translators: This is the subject line of an email sent to users who have a comment added to one of their applications. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/comment_notification_editors-subject.html:3
@@ -1181,25 +1006,14 @@ msgstr "Naujas komentaras jūsų Vikipedijos bibliotekos paraiškoje"
 #. Translators: This email is sent to users when an application they commented on receives another comment. Don't translate Jinja variables in curly braces like app_url; don't translate html tags either. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/comment_notification_others-body-html.html:5
 #, python-format
-msgid ""
-"<p style=\"color: #500050\">%(submit_date)s - %(commenter)s</p> "
-"<blockquote><p>%(comment)s</p></blockquote> See it at <a href=\"%(app_url)s"
-"\">%(app_url)s</a>. Thanks for helping review Wikipedia Library applications!"
-msgstr ""
-"<p style=\"color: #500050\">%(submit_date)s - %(commenter)s</p> "
-"<blockquote><p>%(comment)s</p></blockquote> Peržiūrėkite <a href="
-"\"%(app_url)s\">%(app_url)s</a>. Ačiū, kad padedate peržiūrėti Vikipedijos "
-"bibliotekos paraiškas!"
+msgid "<p style=\"color: #500050\">%(submit_date)s - %(commenter)s</p> <blockquote><p>%(comment)s</p></blockquote> See it at <a href=\"%(app_url)s\">%(app_url)s</a>. Thanks for helping review Wikipedia Library applications!"
+msgstr "<p style=\"color: #500050\">%(submit_date)s - %(commenter)s</p> <blockquote><p>%(comment)s</p></blockquote> Peržiūrėkite <a href=\"%(app_url)s\">%(app_url)s</a>. Ačiū, kad padedate peržiūrėti Vikipedijos bibliotekos paraiškas!"
 
 #. Translators: This email is sent to users when an application they commented on receives another comment. Don't translate Jinja variables in curly braces like app_url. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/comment_notification_others-body-text.html:3
 #, python-format
-msgid ""
-"%(submit_date)s - %(commenter)s %(comment)s See it at: %(app_url)s Thanks "
-"for helping review Wikipedia Library applications!"
-msgstr ""
-"%(submit_date)s - %(commenter)s %(comment)s Peržiūrėkite: %(app_url)s Ačiū, "
-"kad padedate peržiūrėti Vikipedijos bibliotekos paraiškas!"
+msgid "%(submit_date)s - %(commenter)s %(comment)s See it at: %(app_url)s Thanks for helping review Wikipedia Library applications!"
+msgstr "%(submit_date)s - %(commenter)s %(comment)s Peržiūrėkite: %(app_url)s Ačiū, kad padedate peržiūrėti Vikipedijos bibliotekos paraiškas!"
 
 #. Translators: This is the subject line of an email sent to users who have a comment added to an application they also commented on. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/comment_notification_others-subject.html:4
@@ -1209,10 +1023,7 @@ msgstr "Naujas komentaras jūsų komentuotoje Vikipedijos bibliotekos paraiškoj
 #. Translators: This text is part of a scheduled reminder email sent to coordinators who have applications requiring action. Don't translate Jinja variables in curly braces like total_apps, or user.
 #: TWLight/emails/templates/emails/coordinator_reminder_notification-body-html.html:5
 #, python-format
-msgid ""
-"<p>Dear %(user)s,</p> <p>Our records indicate that you are the designated "
-"coordinator for partners that have a total of %(total_apps)s applications.</"
-"p>"
+msgid "<p>Dear %(user)s,</p> <p>Our records indicate that you are the designated coordinator for partners that have a total of %(total_apps)s applications.</p>"
 msgstr ""
 
 #. Translators: Breakdown as in 'cost breakdown'; analysis.
@@ -1254,41 +1065,20 @@ msgstr[2] ""
 #. Translators: This text is part of a scheduled reminder email sent to coordinators who have applications requiring action. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library). Don't translate Jinja variables in curly braces like link; don't translate email addresses or html tags either.
 #: TWLight/emails/templates/emails/coordinator_reminder_notification-body-html.html:39
 #, python-format
-msgid ""
-"<p>This is a gentle reminder that you may review applications at <a href="
-"\"%(link)s\">%(link)s</a>.</p> <p>You can customise your reminders under "
-"'preferences' in your user profile.</p> <p>If you received this message in "
-"error, drop us a line at wikipedialibrary@wikimedia.org.</p> <p>Thanks for "
-"helping review Wikipedia Library applications!</p>"
-msgstr ""
-"<p>Tai švelnus priminimas, kad galite peržiūrėti paraiškas <a href=\"%(link)s"
-"\">%(link)s</a>.</p> <p>Savo priminimus galite pritaikyti nustatymuose, savo "
-"naudotojo profilyje.</p> <p>Jei gavote šią žinutę per klaidą, parašykite "
-"mums wikipedialibrary@wikimedia.org.</p> <p>Ačiū, kad padedate peržiūrėti "
-"Vikipedijos bibliotekos paraiškas!</p>"
+msgid "<p>This is a gentle reminder that you may review applications at <a href=\"%(link)s\">%(link)s</a>.</p> <p>You can customise your reminders under 'preferences' in your user profile.</p> <p>If you received this message in error, drop us a line at wikipedialibrary@wikimedia.org.</p> <p>Thanks for helping review Wikipedia Library applications!</p>"
+msgstr "<p>Tai švelnus priminimas, kad galite peržiūrėti paraiškas <a href=\"%(link)s\">%(link)s</a>.</p> <p>Savo priminimus galite pritaikyti nustatymuose, savo naudotojo profilyje.</p> <p>Jei gavote šią žinutę per klaidą, parašykite mums wikipedialibrary@wikimedia.org.</p> <p>Ačiū, kad padedate peržiūrėti Vikipedijos bibliotekos paraiškas!</p>"
 
 #. Translators: This text is part of a scheduled reminder email sent to coordinators who have applications requiring action. Don't translate Jinja variables in curly braces like total_apps, or user.
 #: TWLight/emails/templates/emails/coordinator_reminder_notification-body-text.html:3
 #, python-format
-msgid ""
-"Dear %(user)s, Our records indicate that you are the designated coordinator "
-"for partners that have a total of %(total_apps)s applications."
+msgid "Dear %(user)s, Our records indicate that you are the designated coordinator for partners that have a total of %(total_apps)s applications."
 msgstr ""
 
 #. Translators: This text is part of a scheduled reminder email sent to coordinators who have applications requiring action. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library). Don't translate Jinja variables in curly braces like link; don't translate the email address either.
 #: TWLight/emails/templates/emails/coordinator_reminder_notification-body-text.html:38
 #, python-format
-msgid ""
-"This is a gentle reminder that you may review applications at: %(link)s. You "
-"can customise your reminders under 'preferences' in your user profile. If "
-"you received this message in error, drop us a line at: "
-"wikipedialibrary@wikimedia.org Thanks for helping review Wikipedia Library "
-"applications!"
-msgstr ""
-"Tai švelnus priminimas, kad galite peržiūrėti paraiškas %(link)s. Savo "
-"priminimus galite pritaikyti nustatymuose, savo naudotojo profilyje. Jei "
-"gavote šią žinutę per klaidą, parašykite mums wikipedialibrary@wikimedia."
-"org. Ačiū, kad padedate peržiūrėti Vikipedijos bibliotekos paraiškas!"
+msgid "This is a gentle reminder that you may review applications at: %(link)s. You can customise your reminders under 'preferences' in your user profile. If you received this message in error, drop us a line at: wikipedialibrary@wikimedia.org Thanks for helping review Wikipedia Library applications!"
+msgstr "Tai švelnus priminimas, kad galite peržiūrėti paraiškas %(link)s. Savo priminimus galite pritaikyti nustatymuose, savo naudotojo profilyje. Jei gavote šią žinutę per klaidą, parašykite mums wikipedialibrary@wikimedia.org. Ačiū, kad padedate peržiūrėti Vikipedijos bibliotekos paraiškas!"
 
 #. Translators: This is the subject line of a scheduled reminder email sent to coordinators who have applications to review. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library). Do not translate items in curly braces.
 #: TWLight/emails/templates/emails/coordinator_reminder_notification-subject.html:4
@@ -1298,30 +1088,14 @@ msgstr "Vikipedijos bibliotekos paraiškos laukia jūsų peržiūros"
 #. Translators: This email is sent to users when their application is rejected. Don't translate Jinja variables in curly braces like user or partner; don't translate html tags either. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/rejection_notification-body-html.html:5
 #, python-format
-msgid ""
-"<p>Dear %(user)s,</p> <p>Thank you for applying for access to %(partner)s "
-"resources through The Wikipedia Library. Unfortunately at this time your "
-"application has not been approved. You can view your application and review "
-"comments at <a href=\"%(app_url)s\">%(app_url)s</a>.</p> <p>Best,</p> <p>The "
-"Wikipedia Library</p>"
-msgstr ""
-"<p>%(user)s,</p> <p>Ačiū už jūsų paraišką dėl %(partner)s išteklių prieigos "
-"per Vikipedijos biblioteką. Deja, jūsų paraiška nepatvirtinta. Galite "
-"peržiūrėti savo paraišką ir komentarus <a href=\"%(app_url)s\">%(app_url)s</"
-"a>.</p> <p>Pagarbiai,</p> <p>Vikipedijos biblioteka</p>"
+msgid "<p>Dear %(user)s,</p> <p>Thank you for applying for access to %(partner)s resources through The Wikipedia Library. Unfortunately at this time your application has not been approved. You can view your application and review comments at <a href=\"%(app_url)s\">%(app_url)s</a>.</p> <p>Best,</p> <p>The Wikipedia Library</p>"
+msgstr "<p>%(user)s,</p> <p>Ačiū už jūsų paraišką dėl %(partner)s išteklių prieigos per Vikipedijos biblioteką. Deja, jūsų paraiška nepatvirtinta. Galite peržiūrėti savo paraišką ir komentarus <a href=\"%(app_url)s\">%(app_url)s</a>.</p> <p>Pagarbiai,</p> <p>Vikipedijos biblioteka</p>"
 
 #. Translators: This email is sent to users when their application is rejected. Don't translate Jinja variables in curly braces like user or partner. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/rejection_notification-body-text.html:3
 #, python-format
-msgid ""
-"Dear %(user)s, Thank you for applying for access to %(partner)s resources "
-"through The Wikipedia Library. Unfortunately at this time your application "
-"has not been approved. You can view your application and review comments at: "
-"%(app_url)s Best, The Wikipedia Library"
-msgstr ""
-"%(user)s, Ačiū už jūsų paraišką dėl %(partner)s išteklių prieigos per "
-"Vikipedijos biblioteką. Deja, jūsų paraiška nepatvirtinta. Galite peržiūrėti "
-"savo paraišką ir komentarus %(app_url)s. Pagarbiai, Vikipedijos biblioteka"
+msgid "Dear %(user)s, Thank you for applying for access to %(partner)s resources through The Wikipedia Library. Unfortunately at this time your application has not been approved. You can view your application and review comments at: %(app_url)s Best, The Wikipedia Library"
+msgstr "%(user)s, Ačiū už jūsų paraišką dėl %(partner)s išteklių prieigos per Vikipedijos biblioteką. Deja, jūsų paraiška nepatvirtinta. Galite peržiūrėti savo paraišką ir komentarus %(app_url)s. Pagarbiai, Vikipedijos biblioteka"
 
 #. Translators: This is the subject of an email which is sent to users when their application has been rejected. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/rejection_notification-subject.html:4
@@ -1331,39 +1105,14 @@ msgstr "Jūsų Vikipedijos bibliotekos paraiška"
 #. Translators: This email is sent to users when they have an account that is soon to expire. Don't translate Jinja variables in curly braces like partner_name or partner_link; don't translate html tags either. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/user_renewal_notice-body-html.html:5
 #, python-format
-msgid ""
-"<p>Dear %(user)s,</p> <p>According to our records, your access to "
-"%(partner_name)s will soon expire and you may lose access. If you want to "
-"continue making use of your free account, you can request renewal of your "
-"account by clicking the 'Renew' or 'Extend' button at %(partner_link)s.</p> "
-"<p>Best,</p> <p>The Wikipedia Library</p> <p>You can disable these emails in "
-"your user page preferences: https://wikipedialibrary.wmflabs.org/users/</p>"
-msgstr ""
-"<p>%(user)s,</p> <p>Pagal mūsų įrašus, jūsų prieiga prie %(partner_name)s "
-"greitai baigsis ir galite prarasti prieigą. Jei norite ir toliau naudotis "
-"savo nemokama paskyra, galite prašyti savo paskyros atnaujinimo paspaudžiant "
-"„Atnaujinti“ arba „Pratęsti“ mygtuką %(partner_link)s.</p> <p>Pagarbiai,</p> "
-"<p>Vikipedijos biblioteka</p> <p>Šiuos el. laiškus gali išjungti savo "
-"naudotojo puslapio nustatymuose: https://wikipedialibrary.wmflabs.org/users/"
-"</p>"
+msgid "<p>Dear %(user)s,</p> <p>According to our records, your access to %(partner_name)s will soon expire and you may lose access. If you want to continue making use of your free account, you can request renewal of your account by clicking the 'Renew' or 'Extend' button at %(partner_link)s.</p> <p>Best,</p> <p>The Wikipedia Library</p> <p>You can disable these emails in your user page preferences: https://wikipedialibrary.wmflabs.org/users/</p>"
+msgstr "<p>%(user)s,</p> <p>Pagal mūsų įrašus, jūsų prieiga prie %(partner_name)s greitai baigsis ir galite prarasti prieigą. Jei norite ir toliau naudotis savo nemokama paskyra, galite prašyti savo paskyros atnaujinimo paspaudžiant „Atnaujinti“ arba „Pratęsti“ mygtuką %(partner_link)s.</p> <p>Pagarbiai,</p> <p>Vikipedijos biblioteka</p> <p>Šiuos el. laiškus gali išjungti savo naudotojo puslapio nustatymuose: https://wikipedialibrary.wmflabs.org/users/</p>"
 
 #. Translators: This email is sent to users when they have an account that is soon to expire. Don't translate Jinja variables in curly braces like partner_name or partner_link; don't translate html tags either. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/user_renewal_notice-body-text.html:3
 #, python-format
-msgid ""
-"Dear %(user)s, According to our records, your access to %(partner_name)s "
-"will soon expire and you may lose access. If you want to continue making use "
-"of your free account, you can request renewal of your account by clicking "
-"the Renew button at %(partner_link)s. Best, The Wikipedia Library You can "
-"disable these emails in your user page preferences: https://wikipedialibrary."
-"wmflabs.org/users/"
-msgstr ""
-"%(user)s, Pagal mūsų įrašus, jūsų prieiga prie %(partner_name)s greitai "
-"baigsis ir galite prarasti prieigą. Jei norite ir toliau naudotis savo "
-"nemokama paskyra, galite prašyti savo paskyros atnaujinimo paspaudžiant "
-"„Atnaujinti“ arba „Pratęsti“ mygtuką %(partner_link)s. Pagarbiai, "
-"Vikipedijos biblioteka Šiuos el. laiškus gali išjungti savo naudotojo "
-"puslapio nustatymuose: https://wikipedialibrary.wmflabs.org/users/</p>"
+msgid "Dear %(user)s, According to our records, your access to %(partner_name)s will soon expire and you may lose access. If you want to continue making use of your free account, you can request renewal of your account by clicking the Renew button at %(partner_link)s. Best, The Wikipedia Library You can disable these emails in your user page preferences: https://wikipedialibrary.wmflabs.org/users/"
+msgstr "%(user)s, Pagal mūsų įrašus, jūsų prieiga prie %(partner_name)s greitai baigsis ir galite prarasti prieigą. Jei norite ir toliau naudotis savo nemokama paskyra, galite prašyti savo paskyros atnaujinimo paspaudžiant „Atnaujinti“ arba „Pratęsti“ mygtuką %(partner_link)s. Pagarbiai, Vikipedijos biblioteka Šiuos el. laiškus gali išjungti savo naudotojo puslapio nustatymuose: https://wikipedialibrary.wmflabs.org/users/</p>"
 
 #. Translators: This is the subject of an email sent to users when they have an account that is soon to expire. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/user_renewal_notice-subject.html:4
@@ -1373,36 +1122,14 @@ msgstr "Jūsų Vikipedijos bibliotekos prieiga greitai baigsis"
 #. Translators: This email is sent to users when their application is waitlisted because there are no more accounts available. Don't translate Jinja variables in curly braces like user or partner; don't translate html tags either. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/waitlist_notification-body-html.html:5
 #, python-format
-msgid ""
-"<p>Dear %(user)s,</p> <p>Thank you for applying for access to %(partner)s "
-"resources through The Wikipedia Library. There are no accounts currently "
-"available so your application has been waitlisted. Your application will be "
-"evaluated if/when more accounts become available. You can see all available "
-"resources at <a href=\"%(link)s\">%(link)s</a>.</p> <p>Best,</p> <p>The "
-"Wikipedia Library</p>"
-msgstr ""
-"<p>%(user)s,</p> <p>Ačiū už jūsų paraišką dėl prieigos prie %(partner)s "
-"išteklių per Vikipedijos biblioteką. Šiuo metu galimų paskyrų nėra, todėl "
-"jūsų paraiška įtraukta į laukiančių sąrašą. Jūsų paraiška bus įvertinta jei "
-"(kai) daugiau paskyrų taps prieinamomis. Galite peržiūrėti visus prieinamus "
-"išteklius <a href=\"%(link)s\">%(link)s</a>.</p> <p>Pagarbiai,</p> "
-"<p>Vikipedijos biblioteka</p>"
+msgid "<p>Dear %(user)s,</p> <p>Thank you for applying for access to %(partner)s resources through The Wikipedia Library. There are no accounts currently available so your application has been waitlisted. Your application will be evaluated if/when more accounts become available. You can see all available resources at <a href=\"%(link)s\">%(link)s</a>.</p> <p>Best,</p> <p>The Wikipedia Library</p>"
+msgstr "<p>%(user)s,</p> <p>Ačiū už jūsų paraišką dėl prieigos prie %(partner)s išteklių per Vikipedijos biblioteką. Šiuo metu galimų paskyrų nėra, todėl jūsų paraiška įtraukta į laukiančių sąrašą. Jūsų paraiška bus įvertinta jei (kai) daugiau paskyrų taps prieinamomis. Galite peržiūrėti visus prieinamus išteklius <a href=\"%(link)s\">%(link)s</a>.</p> <p>Pagarbiai,</p> <p>Vikipedijos biblioteka</p>"
 
 #. Translators: This email is sent to users when their application is waitlisted because there are no more accounts available. Don't translate Jinja variables in curly braces like user or partner. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/waitlist_notification-body-text.html:3
 #, python-format
-msgid ""
-"Dear %(user)s, Thank you for applying for access to %(partner)s resources "
-"through The Wikipedia Library. There are no accounts currently available so "
-"your application has been waitlisted. Your application will be evaluated if/"
-"when more accounts become available. You can see all available resources at: "
-"%(link)s Best, The Wikipedia Library"
-msgstr ""
-"%(user)s, Ačiū už jūsų paraišką dėl prieigos prie %(partner)s išteklių per "
-"Vikipedijos biblioteką. Šiuo metu galimų paskyrų nėra, todėl jūsų paraiška "
-"įtraukta į laukiančių sąrašą. Jūsų paraiška bus įvertinta jei (kai) daugiau "
-"paskyrų taps prieinamomis. Galite peržiūrėti visus prieinamus išteklius <a "
-"href=\"%(link)s\">%(link)s</a>. Pagarbiai, Vikipedijos biblioteka"
+msgid "Dear %(user)s, Thank you for applying for access to %(partner)s resources through The Wikipedia Library. There are no accounts currently available so your application has been waitlisted. Your application will be evaluated if/when more accounts become available. You can see all available resources at: %(link)s Best, The Wikipedia Library"
+msgstr "%(user)s, Ačiū už jūsų paraišką dėl prieigos prie %(partner)s išteklių per Vikipedijos biblioteką. Šiuo metu galimų paskyrų nėra, todėl jūsų paraiška įtraukta į laukiančių sąrašą. Jūsų paraiška bus įvertinta jei (kai) daugiau paskyrų taps prieinamomis. Galite peržiūrėti visus prieinamus išteklius <a href=\"%(link)s\">%(link)s</a>. Pagarbiai, Vikipedijos biblioteka"
 
 #. Translators: This is the subject of an email sent to users when their application is waitlisted because there are no more accounts available. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/waitlist_notification-subject.html:4
@@ -1563,22 +1290,15 @@ msgstr "Neprieinama"
 #: TWLight/resources/templates/resources/filter_section.html:14
 #: TWLight/templates/about.html:12
 #: TWLight/users/templates/users/filter_section.html:13
-msgid ""
-"The Wikipedia Library allows active editors to access a wide range of "
-"collections of paywalled reliable sources for free!"
-msgstr ""
-"Vikipedijos biblioteka leidžia aktyviems redaktoriams prieiti prie plačių "
-"mokamų patikimų išteklių kolekcijų nemokamai!"
+msgid "The Wikipedia Library allows active editors to access a wide range of collections of paywalled reliable sources for free!"
+msgstr "Vikipedijos biblioteka leidžia aktyviems redaktoriams prieiti prie plačių mokamų patikimų išteklių kolekcijų nemokamai!"
 
 #. Translators: On the Browse Partners page (https://wikipedialibrary.wmflabs.org/partners/), this introduces users to The Wikipedia Library.
 #. Translators: On the MyLibrary page (https://wikipedialibrary.wmflabs.org/users/my_library), this introduces users to The Wikipedia Library.
 #: TWLight/resources/templates/resources/filter_section.html:17
 #: TWLight/users/templates/users/filter_section.html:15
-msgid ""
-"Start with the search bar at the top or browse publisher websites directly."
-msgstr ""
-"Pradėkite nuo paieškos juostos viršuje arba naršykite platintojų tinklapius "
-"tiesiogiai."
+msgid "Start with the search bar at the top or browse publisher websites directly."
+msgstr "Pradėkite nuo paieškos juostos viršuje arba naršykite platintojų tinklapius tiesiogiai."
 
 #. Translators: On the Browse Partners page (https://wikipedialibrary.wmflabs.org/partners/), this appears below introductory text and links to the 'About' page (https://wikipedialibrary.wmflabs.org/about/)
 #. Translators: On the MyLibrary page (https://wikipedialibrary.wmflabs.org/users/my_library), this appears below introductory text and links to the 'About' page (https://wikipedialibrary.wmflabs.org/about/)
@@ -1651,67 +1371,39 @@ msgstr "Atgal į partnerius"
 #. Translators: If we have no available accounts for a partner, the coordinator can change the application system to a waiting list.
 #: TWLight/resources/templates/resources/partner_detail.html:36
 #: TWLight/resources/templates/resources/partner_detail_apply.html:17
-msgid ""
-"There are no access grants available for this partner at this time. You can "
-"still apply for access; applications will be processed when access is "
-"available."
-msgstr ""
-"Šiuo metu nėra galimų šio partnerio prieigų. Vis tiek galite pateikti "
-"paraišką prieigai; paraiškos bus išnagrinėtos, kai prieiga bus galima."
+msgid "There are no access grants available for this partner at this time. You can still apply for access; applications will be processed when access is available."
+msgstr "Šiuo metu nėra galimų šio partnerio prieigų. Vis tiek galite pateikti paraišką prieigai; paraiškos bus išnagrinėtos, kai prieiga bus galima."
 
 #. Translators: This text links to the minimum user requirements and terms of use on the partner page.
 #: TWLight/resources/templates/resources/partner_detail.html:48
 #: TWLight/resources/templates/resources/partner_detail_apply.html:29
 #, python-format
-msgid ""
-"Before applying, please review the <strong><a class=\"twl-links\" href="
-"\"%(about)s#req\">minimum requirements</a></strong> for access and our "
-"<strong><a class=\"twl-links\" href=\"%(terms)s\">terms of use</a></strong>."
-msgstr ""
-"Prieš teikiant paraišką, peržiūrėkite prieigos <strong><a class=\"twl-links"
-"\" href=\"%(about)s#req\">minimalius reikalavimus</a></strong> ir mūsų "
-"<strong><a class=\"twl-links\" href=\"%(terms)s\">naudojimo sąlygas</a></"
-"strong>."
+msgid "Before applying, please review the <strong><a class=\"twl-links\" href=\"%(about)s#req\">minimum requirements</a></strong> for access and our <strong><a class=\"twl-links\" href=\"%(terms)s\">terms of use</a></strong>."
+msgstr "Prieš teikiant paraišką, peržiūrėkite prieigos <strong><a class=\"twl-links\" href=\"%(about)s#req\">minimalius reikalavimus</a></strong> ir mūsų <strong><a class=\"twl-links\" href=\"%(terms)s\">naudojimo sąlygas</a></strong>."
 
 #. Translators: This text refers to the page containing the content a user is authorized to access.
 #: TWLight/resources/templates/resources/partner_detail.html:69
 #, python-format
-msgid ""
-"View the status of your access in <strong><a class=\"twl-links\" href="
-"\"%(library_url)s\">My Library</a></strong> page."
-msgstr ""
-"Peržiūrėkite savo prieigą <strong><a class=\"twl-links\" href="
-"\"%(library_url)s\">savo bibliotekos</a></strong> puslapyje."
+msgid "View the status of your access in <strong><a class=\"twl-links\" href=\"%(library_url)s\">My Library</a></strong> page."
+msgstr "Peržiūrėkite savo prieigą <strong><a class=\"twl-links\" href=\"%(library_url)s\">savo bibliotekos</a></strong> puslapyje."
 
 #. Translators: This message is shown when a user has open applications, linking to their respective applications page.
 #: TWLight/resources/templates/resources/partner_detail.html:78
 #, python-format
-msgid ""
-"View the status of your application(s) on your <strong><a class=\"twl-links"
-"\" href=\"%(applications_url)s\">My Applications</a></strong> page."
-msgstr ""
-"Peržiūrėkite savo paraiškos (-ų) būseną <strong><a class=\"twl-links\" href="
-"\"%(applications_url)s\">Mano paraiškos</a></strong> puslapyje."
+msgid "View the status of your application(s) on your <strong><a class=\"twl-links\" href=\"%(applications_url)s\">My Applications</a></strong> page."
+msgstr "Peržiūrėkite savo paraiškos (-ų) būseną <strong><a class=\"twl-links\" href=\"%(applications_url)s\">Mano paraiškos</a></strong> puslapyje."
 
 #. Translators: This message is shown when a user has authorizations, linking to their respective collections page.
 #: TWLight/resources/templates/resources/partner_detail_apply.html:50
 #, python-format
-msgid ""
-"View the status of your access on your <strong><a href=\"%(library_url)s\" "
-"class=\"twl-links\">My Library</a></strong> page."
-msgstr ""
-"Peržiūrėkite savo prieigos būseną <strong><a class=\"twl-links\" href="
-"\"%(library_url)s\">savo bibliotekos</a></strong> puslapyje."
+msgid "View the status of your access on your <strong><a href=\"%(library_url)s\" class=\"twl-links\">My Library</a></strong> page."
+msgstr "Peržiūrėkite savo prieigos būseną <strong><a class=\"twl-links\" href=\"%(library_url)s\">savo bibliotekos</a></strong> puslapyje."
 
 #. Translators: This message is shown when a user has open applications, linking to their respective applications page.
 #: TWLight/resources/templates/resources/partner_detail_apply.html:60
 #, python-format
-msgid ""
-"View the status of your application(s) on your <strong><a href="
-"\"%(applications_url)s\">My Applications</a></strong> page."
-msgstr ""
-"Peržiūrėkite savo paraiškos (-ų) būseną <strong><a class=\"twl-links\" href="
-"\"%(applications_url)s\">Mano paraiškos</a></strong> puslapyje."
+msgid "View the status of your application(s) on your <strong><a href=\"%(applications_url)s\">My Applications</a></strong> page."
+msgstr "Peržiūrėkite savo paraiškos (-ų) būseną <strong><a class=\"twl-links\" href=\"%(applications_url)s\">Mano paraiškos</a></strong> puslapyje."
 
 #. Translators: One the partner detail page, this text labels the button which coordinators can click to remove a partner from waitlisted status.
 #: TWLight/resources/templates/resources/partner_detail_apply.html:73
@@ -1740,14 +1432,8 @@ msgstr "Specialus:Rašyti_laišką"
 
 #. Translators: If no account coordinator is assigned to a partner, the Wikipedia Library team will coordinate signups. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/resources/templates/resources/partner_detail_apply.html:112
-msgid ""
-"The Wikipedia Library team will process this application. Want to help? <a "
-"class=\"twl-links\" href=\"https://en.wikipedia.org/wiki/Wikipedia:"
-"The_Wikipedia_Library/Coordinators/Signup\">Sign up as a coordinator.</a>"
-msgstr ""
-"Vikipedijos biblioteka peržiūrės šią paraišką. Norite padėti? <a class=\"twl-"
-"links\" href=\"https://en.wikipedia.org/wiki/Wikipedia:The_Wikipedia_Library/"
-"Coordinators/Signup\">Užsiregistruokite kaip koordinatorius.</a>"
+msgid "The Wikipedia Library team will process this application. Want to help? <a class=\"twl-links\" href=\"https://en.wikipedia.org/wiki/Wikipedia:The_Wikipedia_Library/Coordinators/Signup\">Sign up as a coordinator.</a>"
+msgstr "Vikipedijos biblioteka peržiūrės šią paraišką. Norite padėti? <a class=\"twl-links\" href=\"https://en.wikipedia.org/wiki/Wikipedia:The_Wikipedia_Library/Coordinators/Signup\">Užsiregistruokite kaip koordinatorius.</a>"
 
 #. Translators: This text labels a button coordinators can click to view a list of users who have applied for access for a particular partner
 #: TWLight/resources/templates/resources/partner_detail_apply.html:121
@@ -1776,24 +1462,14 @@ msgstr "Bibliotekos paketo prieiga"
 
 #. Translators: Text shown to authenticated, bundle eligible users when they visit a Bundle partner page.
 #: TWLight/resources/templates/resources/partner_detail_apply.html:138
-msgid ""
-"You are eligible to access Library Bundle partners. Click the button above "
-"to access the collection."
-msgstr ""
-"Jūs galite prieiti prie Bibliotekos paketo partnerių. Paspauskite mygtuką "
-"aukščiau, kad pasiektumėte kolekciją."
+msgid "You are eligible to access Library Bundle partners. Click the button above to access the collection."
+msgstr "Jūs galite prieiti prie Bibliotekos paketo partnerių. Paspauskite mygtuką aukščiau, kad pasiektumėte kolekciją."
 
 #. Translators: Text shown to authenticated, bundle ineligible users when they visit a Bundle partner page.
 #: TWLight/resources/templates/resources/partner_detail_apply.html:152
 #, python-format
-msgid ""
-"You are not eligible to access Library Bundle partners. Visit the <a class="
-"\"twl-links\" href=\"%(homepage)s\">homepage</a> to check the eligibility "
-"criteria."
-msgstr ""
-"Jūs negali prieiti prie Bibliotekos paketo partnerių. Apsilankykite <a class="
-"\"twl-links\" href=\"%(homepage)s\">pagrindiniame puslapyje</a>, kad "
-"patikrintumėte atitikimo kriterijus."
+msgid "You are not eligible to access Library Bundle partners. Visit the <a class=\"twl-links\" href=\"%(homepage)s\">homepage</a> to check the eligibility criteria."
+msgstr "Jūs negali prieiti prie Bibliotekos paketo partnerių. Apsilankykite <a class=\"twl-links\" href=\"%(homepage)s\">pagrindiniame puslapyje</a>, kad patikrintumėte atitikimo kriterijus."
 
 #. Translators: Buttton prompting users to log in.
 #: TWLight/resources/templates/resources/partner_detail_apply.html:160
@@ -1804,14 +1480,8 @@ msgstr "Prisijungti"
 #. Translators: Text shown to unauthenticated users when they visit a Bundle partner page.
 #: TWLight/resources/templates/resources/partner_detail_apply.html:168
 #, python-format
-msgid ""
-"This resource is part of our <a class=\"twl-links\" href=\"%(about)s"
-"\">Library Bundle</a>, which you can access if you meet our minimum "
-"eligibility criteria. Log in to find out if you are eligible."
-msgstr ""
-"Šis išteklius yra mūsų <a class=\"twl-links\" href=\"%(about)s\">Bibliotekos "
-"paketo</a>, kuris gali būti pasiekiamas, jei atitinkate minimalius "
-"kriterijus, dalis. Prisijunkite, kad sužinotumėte, ar atitinkate."
+msgid "This resource is part of our <a class=\"twl-links\" href=\"%(about)s\">Library Bundle</a>, which you can access if you meet our minimum eligibility criteria. Log in to find out if you are eligible."
+msgstr "Šis išteklius yra mūsų <a class=\"twl-links\" href=\"%(about)s\">Bibliotekos paketo</a>, kuris gali būti pasiekiamas, jei atitinkate minimalius kriterijus, dalis. Prisijunkite, kad sužinotumėte, ar atitinkate."
 
 #. Translators: This is the label for a number which shows the total active accounts for one partner. (e.g. https://wikipedialibrary.wmflabs.org/partners/8/).
 #: TWLight/resources/templates/resources/partner_detail_stats.html:21
@@ -1861,26 +1531,19 @@ msgstr "Ištraukų limitas"
 #. Translators: If a partner has specified the excerpt limit both in words and percentage, this message will display the percentage of words and the number of words on the partner page.
 #: TWLight/resources/templates/resources/partner_detail_timeline.html:99
 #, python-format
-msgid ""
-"%(object)s allows a maximum of %(excerpt_limit)s words or "
-"%(excerpt_limit_percentage)s%% of an article be excerpted into a Wikipedia "
-"article."
+msgid "%(object)s allows a maximum of %(excerpt_limit)s words or %(excerpt_limit_percentage)s%% of an article be excerpted into a Wikipedia article."
 msgstr ""
 
 #. Translators: If a partner has specified the excerpt limit in words, this message will display the number of words on the partner page.
 #: TWLight/resources/templates/resources/partner_detail_timeline.html:106
 #, python-format
-msgid ""
-"%(object)s allows a maximum of %(excerpt_limit)s words be excerpted into a "
-"Wikipedia article."
+msgid "%(object)s allows a maximum of %(excerpt_limit)s words be excerpted into a Wikipedia article."
 msgstr ""
 
 #. Translators: If a partner has specified the excerpt limit in percentage, this message will display the percentage of words on the partner page.
 #: TWLight/resources/templates/resources/partner_detail_timeline.html:113
 #, python-format
-msgid ""
-"%(object)s allows a maximum of %(excerpt_limit_percentage)s%% of an article "
-"be excerpted into a Wikipedia article."
+msgid "%(object)s allows a maximum of %(excerpt_limit_percentage)s%% of an article be excerpted into a Wikipedia article."
 msgstr ""
 
 #. Translators: If a partner has other requirements for access, this text shows as the title for that information field. (e.g. https://wikipedialibrary.wmflabs.org/partners/10/).
@@ -1891,12 +1554,8 @@ msgstr "Specialūs reikalavimai pretendentams"
 #. Translators: If a user must agree to a Terms of Use document, they see this message, and must enter the name of the resource. Don't translate publisher or url.
 #: TWLight/resources/templates/resources/partner_detail_timeline.html:140
 #, python-format
-msgid ""
-"%(publisher)s requires that you agree with its <a href=\"%(url)s\">terms of "
-"use</a>."
-msgstr ""
-"%(publisher)s reikalauja, kad sutiktumėte su <a href=\"%(url)s\">naudojimo "
-"sąlygomis</a>."
+msgid "%(publisher)s requires that you agree with its <a href=\"%(url)s\">terms of use</a>."
+msgstr "%(publisher)s reikalauja, kad sutiktumėte su <a href=\"%(url)s\">naudojimo sąlygomis</a>."
 
 #. Translators: If a user must provide their real name to apply to a partner, they see this message, and must enter the name of the resource. Don't translate publisher.
 #: TWLight/resources/templates/resources/partner_detail_timeline.html:150
@@ -1919,22 +1578,14 @@ msgstr "%(publisher)s reikalauja, kad nurodytumėte savo sąsają su institucija
 #. Translators: If a user must select a specific resource to apply for, they see this message, and must enter the name of the resource. Don't translate publisher.
 #: TWLight/resources/templates/resources/partner_detail_timeline.html:177
 #, python-format
-msgid ""
-"%(publisher)s requires that you specify a particular title that you want to "
-"access."
-msgstr ""
-"%(publisher)s reikalauja, kad nurodytumėte konkretaus objekto pavadinimą, "
-"kurį norite pasiekti."
+msgid "%(publisher)s requires that you specify a particular title that you want to access."
+msgstr "%(publisher)s reikalauja, kad nurodytumėte konkretaus objekto pavadinimą, kurį norite pasiekti."
 
 #. Translators: If a user must register on the partner website before applying, they see this message. Don't translate partner.
 #: TWLight/resources/templates/resources/partner_detail_timeline.html:187
 #, python-format
-msgid ""
-"%(publisher)s requires that you sign up for an account before applying for "
-"access."
-msgstr ""
-"%(publisher)s reikalauja, kad prieš pateikdami paraišką dėl prieigos "
-"prisiregistruotumėte."
+msgid "%(publisher)s requires that you sign up for an account before applying for access."
+msgstr "%(publisher)s reikalauja, kad prieš pateikdami paraišką dėl prieigos prisiregistruotumėte."
 
 #. Translators: If a partner has their location listed, this message is a label for that location
 #: TWLight/resources/templates/resources/partner_detail_timeline.html:206
@@ -2061,9 +1712,7 @@ msgstr "Ar tikrai norite ištrinti <b>%(object)s</b>?"
 
 #. Translators: If multiple authorizations where returned for a collection, this message is shown to a user
 #: TWLight/resources/views.py:268
-msgid ""
-"Multiple authorizations were returned – something's wrong. Please contact us "
-"and don't forget to mention this message."
+msgid "Multiple authorizations were returned – something's wrong. Please contact us and don't forget to mention this message."
 msgstr ""
 
 #. Translators: This message is shown when user tries to access a NOT_AVAILABLE Partner
@@ -2104,23 +1753,8 @@ msgstr "Atsiprašome; mes nežinome, ką su tuo daryti."
 #. Translators: Shown on the website's 400 page, when a user sends a bad request. Don't translate path or Phabricator.
 #: TWLight/templates/400.html:20
 #, python-format
-msgid ""
-"If you think we should know what to do with that, please email us about this "
-"error at <a class=\"twl-links\" href=\"mailto:wikipedialibrary@wikimedia.org?"
-"Subject=Wikipedia%%20Library%%20%(path)s%%20Permission%%20denied"
-"\">wikipedialibrary@wikimedia.org</a> or report it to us on <a class=\"twl-"
-"links\" href=\"https://phabricator.wikimedia.org/maniphest/task/edit/form/1/?"
-"projectPHIDs=Library-Card-Platform&title=Wikipedia%%20Library%%20%(path)s"
-"%%20Bad%%20Request\">Phabricator</a>"
-msgstr ""
-"Jei manote, kad turėtume žinoti ką su tuo daryti, atsiųskite mums el. laišką "
-"apie šią klaidą <a class=\"twl-links\" href=\"mailto:"
-"wikipedialibrary@wikimedia.org?Subject=Wikipedia%%20Library%%20%(path)s"
-"%%20Permission%%20denied\">wikipedialibrary@wikimedia.org</a> arba "
-"praneškite mums apie tai <a class=\"twl-links\" href=\"https://phabricator."
-"wikimedia.org/maniphest/task/edit/form/1/?projectPHIDs=Library-Card-"
-"Platform&title=Wikipedia%%20Library%%20%(path)s%%20Bad%%20Request"
-"\">Fabrikatoriuje</a>"
+msgid "If you think we should know what to do with that, please email us about this error at <a class=\"twl-links\" href=\"mailto:wikipedialibrary@wikimedia.org?Subject=Wikipedia%%20Library%%20%(path)s%%20Permission%%20denied\">wikipedialibrary@wikimedia.org</a> or report it to us on <a class=\"twl-links\" href=\"https://phabricator.wikimedia.org/maniphest/task/edit/form/1/?projectPHIDs=Library-Card-Platform&title=Wikipedia%%20Library%%20%(path)s%%20Bad%%20Request\">Phabricator</a>"
+msgstr "Jei manote, kad turėtume žinoti ką su tuo daryti, atsiųskite mums el. laišką apie šią klaidą <a class=\"twl-links\" href=\"mailto:wikipedialibrary@wikimedia.org?Subject=Wikipedia%%20Library%%20%(path)s%%20Permission%%20denied\">wikipedialibrary@wikimedia.org</a> arba praneškite mums apie tai <a class=\"twl-links\" href=\"https://phabricator.wikimedia.org/maniphest/task/edit/form/1/?projectPHIDs=Library-Card-Platform&title=Wikipedia%%20Library%%20%(path)s%%20Bad%%20Request\">Fabrikatoriuje</a>"
 
 #. Translators: Alt text for an image shown on the 400 error page.
 #. Translators: Alt text for an image shown on the 403 error page.
@@ -2141,24 +1775,8 @@ msgstr "Atsiprašome; jums neleidžiama to daryti."
 #. Translators: Shown on the website's 403 page, when a user attempts to navigate to a page they don't have permission to view. Don't translate path or Phabricator.
 #: TWLight/templates/403.html:20
 #, python-format
-msgid ""
-"If you think your account should be able to do that, please email us about "
-"this error at <a class=\"twl-links\" href=\"mailto:"
-"wikipedialibrary@wikimedia.org?Subject=Wikipedia%%20Library%%20%(path)s"
-"%%20Permission%%20denied\">wikipedialibrary@wikimedia.org</a> or report it "
-"to us on <a class=\"twl-links\" href=\"https://phabricator.wikimedia.org/"
-"maniphest/task/edit/form/1/?projectPHIDs=Library-Card-"
-"Platform&title=Wikipedia%%20Library%%20%(path)s%%20Permission%%20denied"
-"\">Phabricator</a>"
-msgstr ""
-"Jei manote, kad turėtume galėti tai padaryti, atsiųskite mums el. laišką "
-"apie šią klaidą <a class=\"twl-links\" href=\"mailto:"
-"wikipedialibrary@wikimedia.org?Subject=Wikipedia%%20Library%%20%(path)s"
-"%%20Permission%%20denied\">wikipedialibrary@wikimedia.org</a> arba "
-"praneškite mums apie tai <a class=\"twl-links\" href=\"https://phabricator."
-"wikimedia.org/maniphest/task/edit/form/1/?projectPHIDs=Library-Card-"
-"Platform&title=Wikipedia%%20Library%%20%(path)s%%20Permission%%20denied"
-"\">Fabrikatoriuje</a>"
+msgid "If you think your account should be able to do that, please email us about this error at <a class=\"twl-links\" href=\"mailto:wikipedialibrary@wikimedia.org?Subject=Wikipedia%%20Library%%20%(path)s%%20Permission%%20denied\">wikipedialibrary@wikimedia.org</a> or report it to us on <a class=\"twl-links\" href=\"https://phabricator.wikimedia.org/maniphest/task/edit/form/1/?projectPHIDs=Library-Card-Platform&title=Wikipedia%%20Library%%20%(path)s%%20Permission%%20denied\">Phabricator</a>"
+msgstr "Jei manote, kad turėtume galėti tai padaryti, atsiųskite mums el. laišką apie šią klaidą <a class=\"twl-links\" href=\"mailto:wikipedialibrary@wikimedia.org?Subject=Wikipedia%%20Library%%20%(path)s%%20Permission%%20denied\">wikipedialibrary@wikimedia.org</a> arba praneškite mums apie tai <a class=\"twl-links\" href=\"https://phabricator.wikimedia.org/maniphest/task/edit/form/1/?projectPHIDs=Library-Card-Platform&title=Wikipedia%%20Library%%20%(path)s%%20Permission%%20denied\">Fabrikatoriuje</a>"
 
 #. Translators: Shown on the website's 404 page, when a user attempts to navigate to a page that doesn't exist.
 #: TWLight/templates/404.html:11
@@ -2173,22 +1791,8 @@ msgstr "Atsiprašome; negalime to rasti."
 #. Translators: Shown on the website's 404 page, when a user attempts to navigate to a page that doesn't exist. Don't translate path or Phabricator.
 #: TWLight/templates/404.html:19
 #, python-format
-msgid ""
-"If you are certain that something should be here, please email us about this "
-"error at <a class=\"twl-links\" href=\"mailto:wikipedialibrary@wikimedia.org?"
-"Subject=Wikipedia%%20Library%%20%(path)s%%20Not%%20found\"> "
-"wikipedialibrary@wikimedia.org</a> or report it to us on <a class=\"twl-links"
-"\" href=\"https://phabricator.wikimedia.org/maniphest/task/edit/form/1/?"
-"projectPHIDs=Library-Card-Platform&title=Wikipedia%%20Library%%20%(path)s"
-"%%20Not%%20found\">Phabricator</a>"
-msgstr ""
-"Jei esate tikri, kad čia kažkas turėtų būti, atsiųskite mums el. laišką apie "
-"šią klaidą <a class=\"twl-links\" href=\"mailto:wikipedialibrary@wikimedia."
-"org?Subject=Wikipedia%%20Library%%20%(path)s%%20Not%%20found\"> "
-"wikipedialibrary@wikimedia.org</a> arba praneškite mums apie tai <a class="
-"\"twl-links\" href=\"https://phabricator.wikimedia.org/maniphest/task/edit/"
-"form/1/?projectPHIDs=Library-Card-Platform&title=Wikipedia%%20Library"
-"%%20%(path)s%%20Not%%20found\">Fabrikatoriuje</a>"
+msgid "If you are certain that something should be here, please email us about this error at <a class=\"twl-links\" href=\"mailto:wikipedialibrary@wikimedia.org?Subject=Wikipedia%%20Library%%20%(path)s%%20Not%%20found\"> wikipedialibrary@wikimedia.org</a> or report it to us on <a class=\"twl-links\" href=\"https://phabricator.wikimedia.org/maniphest/task/edit/form/1/?projectPHIDs=Library-Card-Platform&title=Wikipedia%%20Library%%20%(path)s%%20Not%%20found\">Phabricator</a>"
+msgstr "Jei esate tikri, kad čia kažkas turėtų būti, atsiųskite mums el. laišką apie šią klaidą <a class=\"twl-links\" href=\"mailto:wikipedialibrary@wikimedia.org?Subject=Wikipedia%%20Library%%20%(path)s%%20Not%%20found\"> wikipedialibrary@wikimedia.org</a> arba praneškite mums apie tai <a class=\"twl-links\" href=\"https://phabricator.wikimedia.org/maniphest/task/edit/form/1/?projectPHIDs=Library-Card-Platform&title=Wikipedia%%20Library%%20%(path)s%%20Not%%20found\">Fabrikatoriuje</a>"
 
 #. Translators: Alt text for an image shown on the 404 error page.
 #: TWLight/templates/404.html:32
@@ -2202,49 +1806,19 @@ msgstr "Apie Vikipedijos biblioteką"
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:20
-msgid ""
-"This platform is our central tool for facilitating access to our available "
-"collections. Here you can see which partnerships are available, search their "
-"contents, and apply for and access the ones you’re interested in."
-msgstr ""
-"Ši platforma yra mūsų pagrindinis įrankis, palengvinantis prieigą prie mūsų "
-"turimų kolekcijų. Čia galite pamatyti, kurios partnerystės yra prieinamos, "
-"ieškoti jų turinio, pateikti paraišką ir pasiekti jus dominančias "
-"partnerystes."
+msgid "This platform is our central tool for facilitating access to our available collections. Here you can see which partnerships are available, search their contents, and apply for and access the ones you’re interested in."
+msgstr "Ši platforma yra mūsų pagrindinis įrankis, palengvinantis prieigą prie mūsų turimų kolekcijų. Čia galite pamatyti, kurios partnerystės yra prieinamos, ieškoti jų turinio, pateikti paraišką ir pasiekti jus dominančias partnerystes."
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/). Wikimedia Foundation should not be translated.
 #: TWLight/templates/about.html:29
-msgid ""
-"All users receive immediate access to some collections, which can be browsed "
-"by clicking the 'Access collection' buttons or using the search bar at the "
-"top of the page. Other collections require an application before access is "
-"granted, and may be accessed directly or via an individual login or access "
-"code. Volunteer coordinators, who have signed non-disclosure agreements with "
-"the Wikimedia Foundation, review these applications and work with publishers "
-"to get you your free access."
-msgstr ""
-"Visi naudotojai iškart gauna prieigą prie kai kurių kolekcijų, kurias galima "
-"naršyti spustelėjus mygtukus „Atidaryti kolekciją“ arba naudojant puslapio "
-"viršuje esančią paieškos juostą. Kitų kolekcijų prieigai reikia pateikti "
-"paraišką ir jas galima pasiekti tiesiogiai arba naudojant individualų "
-"prisijungimo vardą arba prieigos kodą. Savanoriai koordinatoriai, pasirašę "
-"konfidencialumo sutartis su Vikimedijos fondu, peržiūri šias paraiškas ir "
-"bendradarbiauja su leidėjais, kad gautumėte nemokamą prieigą."
+msgid "All users receive immediate access to some collections, which can be browsed by clicking the 'Access collection' buttons or using the search bar at the top of the page. Other collections require an application before access is granted, and may be accessed directly or via an individual login or access code. Volunteer coordinators, who have signed non-disclosure agreements with the Wikimedia Foundation, review these applications and work with publishers to get you your free access."
+msgstr "Visi naudotojai iškart gauna prieigą prie kai kurių kolekcijų, kurias galima naršyti spustelėjus mygtukus „Atidaryti kolekciją“ arba naudojant puslapio viršuje esančią paieškos juostą. Kitų kolekcijų prieigai reikia pateikti paraišką ir jas galima pasiekti tiesiogiai arba naudojant individualų prisijungimo vardą arba prieigos kodą. Savanoriai koordinatoriai, pasirašę konfidencialumo sutartis su Vikimedijos fondu, peržiūri šias paraiškas ir bendradarbiauja su leidėjais, kad gautumėte nemokamą prieigą."
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/). Don't translate terms_url.
 #: TWLight/templates/about.html:43
 #, python-format
-msgid ""
-"For more information about how your information is stored and reviewed "
-"please see our <a class=\"twl-links\" href=\"%(terms_url)s\"> terms of use "
-"and privacy policy</a>. Accounts you apply for are also subject to the Terms "
-"of Use provided by each partner’s platform; please review them."
-msgstr ""
-"Norėdami gauti daugiau informacijos apie tai, kaip jūsų informacija saugoma "
-"ir peržiūrima, žiūrėkite mūsų <a class=\"twl-links\" href=\"%(terms_url)s\"> "
-"naudojimo sąlygas ir privatumo politiką</a>. Paskyroms, dėl kurių teikiate "
-"paraiškas, taip pat taikomos kiekvieno partnerio platformos pateiktos "
-"naudojimo sąlygos; prašome jas peržiūrėti."
+msgid "For more information about how your information is stored and reviewed please see our <a class=\"twl-links\" href=\"%(terms_url)s\"> terms of use and privacy policy</a>. Accounts you apply for are also subject to the Terms of Use provided by each partner’s platform; please review them."
+msgstr "Norėdami gauti daugiau informacijos apie tai, kaip jūsų informacija saugoma ir peržiūrima, žiūrėkite mūsų <a class=\"twl-links\" href=\"%(terms_url)s\"> naudojimo sąlygas ir privatumo politiką</a>. Paskyroms, dėl kurių teikiate paraiškas, taip pat taikomos kiekvieno partnerio platformos pateiktos naudojimo sąlygos; prašome jas peržiūrėti."
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:51
@@ -2253,25 +1827,13 @@ msgstr "Kas gali gauti prieigą?"
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/). Wikimedia Foundation should not be translated.
 #: TWLight/templates/about.html:55
-msgid ""
-"Any active editor in good standing can receive access. For publishers with "
-"limited numbers of accounts, applications are reviewed based on the editor’s "
-"needs and contributions. If you think you could use access to one of our "
-"partner resources and are an active editor in any project supported by the "
-"Wikimedia Foundation, please apply."
-msgstr ""
-"Bet kuris aktyvus, geros reputacijos redaktorius gali gauti prieigą. "
-"Leidėjų, turinčių ribotą paskyrų skaičių, paraiškos peržiūrimos "
-"atsižvelgiant į redaktoriaus poreikius ir indėlį. Jei manote, kad galėtumėte "
-"pasinaudoti prieiga prie vieno iš mūsų partnerių išteklių ir esate aktyvus "
-"bet kurio Vikimedijos fondo remiamo projekto redaktorius, pateikite paraišką."
+msgid "Any active editor in good standing can receive access. For publishers with limited numbers of accounts, applications are reviewed based on the editor’s needs and contributions. If you think you could use access to one of our partner resources and are an active editor in any project supported by the Wikimedia Foundation, please apply."
+msgstr "Bet kuris aktyvus, geros reputacijos redaktorius gali gauti prieigą. Leidėjų, turinčių ribotą paskyrų skaičių, paraiškos peržiūrimos atsižvelgiant į redaktoriaus poreikius ir indėlį. Jei manote, kad galėtumėte pasinaudoti prieiga prie vieno iš mūsų partnerių išteklių ir esate aktyvus bet kurio Vikimedijos fondo remiamo projekto redaktorius, pateikite paraišką."
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:65
 msgid "Any editor can use the library if they meet a few basic requirements:"
-msgstr ""
-"Bet kuris redaktorius gali naudoti biblioteką, jei atitinka kelis "
-"pagrindinius reikalavimus:"
+msgstr "Bet kuris redaktorius gali naudoti biblioteką, jei atitinka kelis pagrindinius reikalavimus:"
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:71
@@ -2286,8 +1848,7 @@ msgstr "Jūs atlikote mažiausiai 500 pakeitimų Vikimedijos projektuose"
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:79
 msgid "You have made at least 10 edits to Wikimedia projects in the last month"
-msgstr ""
-"Per pastarąjį mėnesį atlikote mažiausiai 10 Vikimedijos projektų pakeitimų"
+msgstr "Per pastarąjį mėnesį atlikote mažiausiai 10 Vikimedijos projektų pakeitimų"
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:83
@@ -2296,35 +1857,13 @@ msgstr "Šiuo metu nesate užblokuotas redaguoti Vikipedijos projekte"
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/)
 #: TWLight/templates/about.html:89
-msgid ""
-"If you are applying for an available collection, please first check that you "
-"don't already have access through another library or institution. If you do, "
-"please consider using that access rather than taking up a seat for this "
-"resource in The Wikipedia Library."
-msgstr ""
-"Jei kreipiatės dėl prieinamos kolekcijos, pirmiausia patikrinkite, ar dar "
-"neturite prieigos per kitą biblioteką ar instituciją. Jei turite, "
-"apsvarstykite galimybę pasinaudoti šia prieiga, o ne užimti vietą šiam "
-"ištekliui Vikipedijos bibliotekoje."
+msgid "If you are applying for an available collection, please first check that you don't already have access through another library or institution. If you do, please consider using that access rather than taking up a seat for this resource in The Wikipedia Library."
+msgstr "Jei kreipiatės dėl prieinamos kolekcijos, pirmiausia patikrinkite, ar dar neturite prieigos per kitą biblioteką ar instituciją. Jei turite, apsvarstykite galimybę pasinaudoti šia prieiga, o ne užimti vietą šiam ištekliui Vikipedijos bibliotekoje."
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/)
 #: TWLight/templates/about.html:99
-msgid ""
-"If your account is blocked on one or more Wikimedia projects, you may still "
-"be granted access to The Wikipedia Library. You will need to contact the "
-"Wikipedia Library team, who will review your blocks. If you have been "
-"blocked for content issues, most notably copyright violations, or have "
-"multiple long-term blocks, we may decline your request. Additionally, if "
-"your block status changes after being approved, you will need to request "
-"another review."
-msgstr ""
-"Jei jūsų paskyra užblokuota viename ar keliuose Vikimedijos projektuose, "
-"jums vis tiek gali būti suteikta prieiga prie Vikipedijos bibliotekos. "
-"Turėsite susisiekti su Vikipedijos bibliotekos komanda, kuri peržiūrės jūsų "
-"blokavimus. Jei buvote užblokuotas dėl turinio problemų, ypač dėl autorinių "
-"teisių pažeidimų, arba buvote užblokuoti kelis kartus, galime atmesti jūsų "
-"užklausą. Be to, jei blokavimo būsena pasikeis po patvirtinimo, turėsite "
-"pateikti užklausą dar kartą peržiūrai."
+msgid "If your account is blocked on one or more Wikimedia projects, you may still be granted access to The Wikipedia Library. You will need to contact the Wikipedia Library team, who will review your blocks. If you have been blocked for content issues, most notably copyright violations, or have multiple long-term blocks, we may decline your request. Additionally, if your block status changes after being approved, you will need to request another review."
+msgstr "Jei jūsų paskyra užblokuota viename ar keliuose Vikimedijos projektuose, jums vis tiek gali būti suteikta prieiga prie Vikipedijos bibliotekos. Turėsite susisiekti su Vikipedijos bibliotekos komanda, kuri peržiūrės jūsų blokavimus. Jei buvote užblokuotas dėl turinio problemų, ypač dėl autorinių teisių pažeidimų, arba buvote užblokuoti kelis kartus, galime atmesti jūsų užklausą. Be to, jei blokavimo būsena pasikeis po patvirtinimo, turėsite pateikti užklausą dar kartą peržiūrai."
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:110
@@ -2358,12 +1897,8 @@ msgstr "Patvirtinti redaktoriai <i>neturėtų</i>:"
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:136
-msgid ""
-"Share their account logins or passwords with others, or sell their access to "
-"other parties"
-msgstr ""
-"Bendrinti savo paskyros prisijungimo vardą ar slaptažodį su kitais arba "
-"parduoti jų prieigą kitoms šalims"
+msgid "Share their account logins or passwords with others, or sell their access to other parties"
+msgstr "Bendrinti savo paskyros prisijungimo vardą ar slaptažodį su kitais arba parduoti jų prieigą kitoms šalims"
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:140
@@ -2372,28 +1907,18 @@ msgstr "Masiškai nuskaityti ar masiškai atsisiųsti partnerio turinį"
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:144
-msgid ""
-"Systematically make printed or electronic copies of multiple extracts of "
-"restricted content available for any purpose"
-msgstr ""
-"Sistemingai daryti spausdintas arba elektronines riboto turinio ištraukų "
-"kopijas prieinamas bet kokiam tikslui"
+msgid "Systematically make printed or electronic copies of multiple extracts of restricted content available for any purpose"
+msgstr "Sistemingai daryti spausdintas arba elektronines riboto turinio ištraukų kopijas prieinamas bet kokiam tikslui"
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/). Stub is a technical term for a short Wikipedia article, use the appropriate Wikipedia term in your language.
 #: TWLight/templates/about.html:148
-msgid ""
-"Datamine metadata without permission, in order, for instance, to use "
-"metadata for auto-created stub articles"
+msgid "Datamine metadata without permission, in order, for instance, to use metadata for auto-created stub articles"
 msgstr ""
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:154
-msgid ""
-"Respecting these agreements allows us to continue growing the partnerships "
-"available to the community."
-msgstr ""
-"Šių susitarimų laikymasis leidžia mums toliau plėsti bendruomenei prieinamas "
-"partnerystes."
+msgid "Respecting these agreements allows us to continue growing the partnerships available to the community."
+msgstr "Šių susitarimų laikymasis leidžia mums toliau plėsti bendruomenei prieinamas partnerystes."
 
 #. Translators: This is the heading for a section on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:160
@@ -2402,48 +1927,23 @@ msgstr "EZProxy"
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:164
-msgid ""
-"EZProxy is a proxy server used to authenticate users for many Wikipedia "
-"Library partners. Users sign into EZProxy via the Library Card platform to "
-"verify that they are authorized users, and then the server accesses "
-"requested resources using its own IP address."
+msgid "EZProxy is a proxy server used to authenticate users for many Wikipedia Library partners. Users sign into EZProxy via the Library Card platform to verify that they are authorized users, and then the server accesses requested resources using its own IP address."
 msgstr ""
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:173
-msgid ""
-"You may notice that when accessing resources via EZProxy that URLs are "
-"dynamically rewritten. This is why we recommend logging in via the Library "
-"Card platform rather than going directly to the unproxied partner website. "
-"When in doubt, check the URL for ‘idm.oclc’. If it’s there, then you’re "
-"connected via EZProxy."
+msgid "You may notice that when accessing resources via EZProxy that URLs are dynamically rewritten. This is why we recommend logging in via the Library Card platform rather than going directly to the unproxied partner website. When in doubt, check the URL for ‘idm.oclc’. If it’s there, then you’re connected via EZProxy."
 msgstr ""
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:182
-msgid ""
-"Typically once you’ve logged in your session will remain active in your "
-"browser for up to two hours after you’ve finished searching. Note that use "
-"of EZProxy requires you to enable cookies. If you are having problems you "
-"should also try clearing your cache and restarting your browser."
+msgid "Typically once you’ve logged in your session will remain active in your browser for up to two hours after you’ve finished searching. Note that use of EZProxy requires you to enable cookies. If you are having problems you should also try clearing your cache and restarting your browser."
 msgstr ""
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/)
 #: TWLight/templates/about.html:193
-msgid ""
-"The Library Bundle is a collection of resources for which no application is "
-"required. If you meet the criteria laid out above, you will be authorized "
-"for access automatically upon logging in to the platform. Only some of our "
-"content is currently included in the Library Bundle, however we hope to "
-"expand the collection as more publishers become comfortable with "
-"participating. All Bundle content is accessed via EZProxy."
-msgstr ""
-"Bibliotekos paketas yra išteklių, kuriems nereikia jokių paraiškų, rinkinys. "
-"Jei atitinkate aukščiau nurodytus kriterijus, prisijungę prie platformos "
-"galėsite pasiekti šiuos išteklius automatiškai. Šiuo metu į Bibliotekos "
-"paketą įtraukta tik dalis mūsų turinio, tačiau tikimės išplėsti kolekciją, "
-"nes vis daugiau leidėjų jausis komfortabiliai dalyvaudami. Visas paketo "
-"turinys pasiekiamas per EZProxy."
+msgid "The Library Bundle is a collection of resources for which no application is required. If you meet the criteria laid out above, you will be authorized for access automatically upon logging in to the platform. Only some of our content is currently included in the Library Bundle, however we hope to expand the collection as more publishers become comfortable with participating. All Bundle content is accessed via EZProxy."
+msgstr "Bibliotekos paketas yra išteklių, kuriems nereikia jokių paraiškų, rinkinys. Jei atitinkate aukščiau nurodytus kriterijus, prisijungę prie platformos galėsite pasiekti šiuos išteklius automatiškai. Šiuo metu į Bibliotekos paketą įtraukta tik dalis mūsų turinio, tačiau tikimės išplėsti kolekciją, nes vis daugiau leidėjų jausis komfortabiliai dalyvaudami. Visas paketo turinys pasiekiamas per EZProxy."
 
 #. Translators: This is the heading for a section on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:202
@@ -2452,12 +1952,7 @@ msgstr "Citavimo praktika"
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:206
-msgid ""
-"Citation practices vary by project and even by article. Generally, we "
-"support editors citing where they found information, in a form that allows "
-"others to check it for themselves. That often means providing both original "
-"source details as well as a link to the partner database in which the source "
-"was found."
+msgid "Citation practices vary by project and even by article. Generally, we support editors citing where they found information, in a form that allows others to check it for themselves. That often means providing both original source details as well as a link to the partner database in which the source was found."
 msgstr ""
 
 #. Translators: This is the heading for a section on the About page (https://wikipedialibrary.wmflabs.org/about/).
@@ -2469,13 +1964,8 @@ msgstr "Susisiekite su mumis"
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:218
 #, python-format
-msgid ""
-"If you have questions, need help, or want to volunteer to help, please see "
-"our <a class=\"twl-links\" href=\"%(contact_url)s\">contact page</a>."
-msgstr ""
-"Jei turite klausimų, reikia pagalbos arba norite savanoriškai padėti, "
-"apsilankykite mūsų <a class=\"twl-links\" href=\"%(contact_url)s\">kontaktų "
-"puslapyje</a>."
+msgid "If you have questions, need help, or want to volunteer to help, please see our <a class=\"twl-links\" href=\"%(contact_url)s\">contact page</a>."
+msgstr "Jei turite klausimų, reikia pagalbos arba norite savanoriškai padėti, apsilankykite mūsų <a class=\"twl-links\" href=\"%(contact_url)s\">kontaktų puslapyje</a>."
 
 #. Translators: This is the title of the panel box detailing the contact information for the Wikipedia Library team.
 #: TWLight/templates/contact.html:14
@@ -2514,12 +2004,8 @@ msgstr "Vikipedijos bibliotekos Twitter puslapis"
 #. Translators: This is the text that appears at the bottom of the contact us form directing users to the suggestions form.
 #: TWLight/templates/contact.html:48
 #, python-format
-msgid ""
-"(If you would like to suggest a partner, <a class=\"twl-links\" href="
-"\"%(suggest)s\"><strong>go here</strong></a>.)"
-msgstr ""
-"(Jeigu norite pasiūlyti partnerį, <a class=\"twl-links\" href=\"%(suggest)s"
-"\"><strong>eikite čia</strong></a>.)"
+msgid "(If you would like to suggest a partner, <a class=\"twl-links\" href=\"%(suggest)s\"><strong>go here</strong></a>.)"
+msgstr "(Jeigu norite pasiūlyti partnerį, <a class=\"twl-links\" href=\"%(suggest)s\"><strong>eikite čia</strong></a>.)"
 
 #. Translators: On a special 'link to search' page, this message is shown if JavaScript is disabled.
 #: TWLight/templates/eds_search_endpoint.html:7
@@ -2576,12 +2062,8 @@ msgstr "Vikipedijos biblioteka"
 #. Translators: Information about The Wikipedia Library.
 #: TWLight/templates/login_partial.html:53 TWLight/templates/new_base.html:21
 #, fuzzy, python-format
-msgid ""
-"More than 100 of the world's top subscription-only databases, with content "
-"in %(no_of_languages)s languages, free for Wikipedians of all backgrounds"
-msgstr ""
-"Daugiau nei 90 populiariausių pasaulyje prenumeruojamų duomenų bazių, kurių "
-"turinys yra %(no_of_languages)s kalbomis, nemokamai Vikipedijos naudotojams"
+msgid "More than 100 of the world's top subscription-only databases, with content in %(no_of_languages)s languages, free for Wikipedians of all backgrounds"
+msgstr "Daugiau nei 90 populiariausių pasaulyje prenumeruojamų duomenų bazių, kurių turinys yra %(no_of_languages)s kalbomis, nemokamai Vikipedijos naudotojams"
 
 #. Translators: Information about The Wikipedia Library.
 #: TWLight/templates/login_partial.html:64
@@ -2589,12 +2071,8 @@ msgid "Meet these criteria for automatic access"
 msgstr "Automatinės prieigos kriterijai"
 
 #: TWLight/templates/login_partial.html:69
-msgid ""
-"These criteria grant you access to certain collections but not all. Some "
-"collections are accessible on a per application basis only."
-msgstr ""
-"Šie kriterijai suteikia prieigą prie tam tikrų kolekcijų, bet ne visų. Kai "
-"kurios kolekcijos pasiekiamos tik pagal paraišką."
+msgid "These criteria grant you access to certain collections but not all. Some collections are accessible on a per application basis only."
+msgstr "Šie kriterijai suteikia prieigą prie tam tikrų kolekcijų, bet ne visų. Kai kurios kolekcijos pasiekiamos tik pagal paraišką."
 
 #: TWLight/templates/login_partial.html:89
 msgid "Login via Wikipedia"
@@ -2603,41 +2081,20 @@ msgstr "Prisijungti su Vikipedija"
 #. Translators: Shown if the current user doesn't have a registered email on their account. Don't translate contact_us_url or email_url.
 #: TWLight/templates/message_partial.html:15
 #, python-format
-msgid ""
-"You don't have an email on file. We can't finalize your access to partner "
-"resources, and you won't be able to <a class=\"twl-links\" href="
-"\"%(contact_us_url)s\">contact us</a> without an email. Please <a class="
-"\"twl-links\" href=\"%(email_url)s\">update your email</a>."
-msgstr ""
-"Faile neturite el. pašto adreso. Negalime užbaigti jūsų prieigos prie "
-"partnerių išteklių ir negalėsite <a class=\"twl-links\" href="
-"\"%(contact_us_url)s\">su mumis susisiekti</a> be el. pašto. Prašome <a "
-"class=\"twl-links\" href=\"%(email_url)s\">atnaujinti savo el. paštą</a>."
+msgid "You don't have an email on file. We can't finalize your access to partner resources, and you won't be able to <a class=\"twl-links\" href=\"%(contact_us_url)s\">contact us</a> without an email. Please <a class=\"twl-links\" href=\"%(email_url)s\">update your email</a>."
+msgstr "Faile neturite el. pašto adreso. Negalime užbaigti jūsų prieigos prie partnerių išteklių ir negalėsite <a class=\"twl-links\" href=\"%(contact_us_url)s\">su mumis susisiekti</a> be el. pašto. Prašome <a class=\"twl-links\" href=\"%(email_url)s\">atnaujinti savo el. paštą</a>."
 
 #. Translators: Shown if the current user has requested the processing of their data should be restricted.
 #: TWLight/templates/message_partial.html:26
 #, python-format
-msgid ""
-"You have requested a restriction on the processing of your data. Most site "
-"functionality will not be available to you until you <a class=\"twl-links\" "
-"href=\"%(restrict_url)s\">lift this restriction</a>."
-msgstr ""
-"Paprašėte apriboti jūsų duomenų tvarkymą. Daugelis svetainės funkcijų nebus "
-"pasiekiamos, kol <a class=\"twl-links\" href=\"%(restrict_url)s"
-"\">nepanaikinsite šio apribojimo</a>."
+msgid "You have requested a restriction on the processing of your data. Most site functionality will not be available to you until you <a class=\"twl-links\" href=\"%(restrict_url)s\">lift this restriction</a>."
+msgstr "Paprašėte apriboti jūsų duomenų tvarkymą. Daugelis svetainės funkcijų nebus pasiekiamos, kol <a class=\"twl-links\" href=\"%(restrict_url)s\">nepanaikinsite šio apribojimo</a>."
 
 #. Translators: Shown if the current user has not agreed to the terms of use.
 #: TWLight/templates/message_partial.html:37
 #, python-format
-msgid ""
-"You have not agreed to the <a class=\"twl-links\" href=\"%(terms_url)s"
-"\">terms of use</a> of this site. Your applications will not be processed "
-"and you won't be able to apply or access resources you are approved for."
-msgstr ""
-"Jūs nesutikote su šios interneto svetainės <a class=\"twl-links\" href="
-"\"%(terms_url)s\">naudojimo sąlygomis</a>. Jūsų paraiškos nebus apdorojamos "
-"ir jūs negalėsite pateikti paraiškos arba pasiekti išteklių, kuriems esate "
-"patvirtinti."
+msgid "You have not agreed to the <a class=\"twl-links\" href=\"%(terms_url)s\">terms of use</a> of this site. Your applications will not be processed and you won't be able to apply or access resources you are approved for."
+msgstr "Jūs nesutikote su šios interneto svetainės <a class=\"twl-links\" href=\"%(terms_url)s\">naudojimo sąlygomis</a>. Jūsų paraiškos nebus apdorojamos ir jūs negalėsite pateikti paraiškos arba pasiekti išteklių, kuriems esate patvirtinti."
 
 #. Translators: This link is at the bottom of every page and links to the 'About' page (https://wikipedialibrary.wmflabs.org/about/)
 #: TWLight/templates/new_base.html:107
@@ -2683,12 +2140,8 @@ msgstr "Atstatyti slaptažodį"
 
 #. Translators: If a user goes to reset their password, this message asks them to enter their email to do so.
 #: TWLight/templates/registration/password_reset_form.html:13
-msgid ""
-"Forgot your password? Enter your email address below, and we'll email "
-"instructions for setting a new one."
-msgstr ""
-"Pamiršote savo slaptažodį? Toliau įveskite savo el. pašto adresą ir mes "
-"atsiųsime instrukcijas, kaip nustatyti naują."
+msgid "Forgot your password? Enter your email address below, and we'll email instructions for setting a new one."
+msgstr "Pamiršote savo slaptažodį? Toliau įveskite savo el. pašto adresą ir mes atsiųsime instrukcijas, kaip nustatyti naują."
 
 #. Translators: This is the label for a button that users click to update their public information.
 #: TWLight/users/forms.py:36
@@ -2732,23 +2185,13 @@ msgstr "Sutinku su naudojimo sąlygomis"
 
 #. Translators: This text explains how to disagree to the site's terms of use and the restrictions that will come into effect when users disagree to the terms of use.
 #: TWLight/users/forms.py:185
-msgid ""
-"By unchecking this box and clicking “Update” you may explore the site, but "
-"you will not be able to apply for access to materials or evaluate "
-"applications unless you agree with the terms of use."
-msgstr ""
-"Panaikindami šio langelio žymėjimą ir spustelėję „Atnaujinti“, galite "
-"naršyti interneto svetainėje, tačiau negalėsite pateikti paraiškos dėl "
-"prieigos prie medžiagos ar vertinti paraiškų, nebent sutiksite su naudojimo "
-"sąlygomis."
+msgid "By unchecking this box and clicking “Update” you may explore the site, but you will not be able to apply for access to materials or evaluate applications unless you agree with the terms of use."
+msgstr "Panaikindami šio langelio žymėjimą ir spustelėję „Atnaujinti“, galite naršyti interneto svetainėje, tačiau negalėsite pateikti paraiškos dėl prieigos prie medžiagos ar vertinti paraiškų, nebent sutiksite su naudojimo sąlygomis."
 
 #. Translators: Users click this button to set their website email address to the one linked to their Wikipedia account.
 #: TWLight/users/forms.py:211
-msgid ""
-"Use my Wikipedia email address (will be updated the next time you login)."
-msgstr ""
-"Naudoti mano Vikipedijos el. pašto adresą (bus atnaujintas kitą kartą "
-"prisijungus)."
+msgid "Use my Wikipedia email address (will be updated the next time you login)."
+msgstr "Naudoti mano Vikipedijos el. pašto adresą (bus atnaujintas kitą kartą prisijungus)."
 
 #. Translators: This labels a button which users click to change their email.
 #: TWLight/users/forms.py:232
@@ -2758,19 +2201,8 @@ msgstr "Atnaujinti el. pašto adresą"
 #. Translators: Shown if the current user tried to 'favorite' a partner they can't access. Do not translate '{partner}'
 #: TWLight/users/models.py:201
 #, python-brace-format
-msgid ""
-"Cannot add partner {partner} to your favorites because you don't have access "
-"to it"
-msgstr ""
-"Negalima pridėti partnerio {partner} prie mėgstamiausių, nes neturite "
-"prieigos"
-
-#. Translators: Do not translate.
-#: TWLight/users/models.py:869
-#, fuzzy, python-brace-format
-#| msgid "Username"
-msgid "{wp_username}"
-msgstr "Naudotojo vardas"
+msgid "Cannot add partner {partner} to your favorites because you don't have access to it"
+msgstr "Negalima pridėti partnerio {partner} prie mėgstamiausių, nes neturite prieigos"
 
 #. Translators: This error message is shown when there's a problem with the authenticated login process.
 #: TWLight/users/oauth.py:243
@@ -2790,12 +2222,8 @@ msgstr ""
 
 #. Translators: this message is displayed to users that don't have accounts and clicked on a proxied link.
 #: TWLight/users/oauth.py:388
-msgid ""
-"To view this link you need to be an eligible library user. Please login to "
-"continue."
-msgstr ""
-"Norėdami peržiūrėti šią nuorodą, turite būti tinkamas bibliotekos "
-"naudotojas. Prisijunkite, jei norite tęsti."
+msgid "To view this link you need to be an eligible library user. Please login to continue."
+msgstr "Norėdami peržiūrėti šią nuorodą, turite būti tinkamas bibliotekos naudotojas. Prisijunkite, jei norite tęsti."
 
 #. Translators: This warning message is shown to users when the response received from Wikimedia OAuth servers is not a valid one.
 #: TWLight/users/oauth.py:430
@@ -2830,25 +2258,13 @@ msgstr "Žiūrėkite {issue} dėl daugiau informacijos"
 
 #. Translators: If the user tries to log in, but their account does not meet certain requirements, they cannot login.
 #: TWLight/users/oauth.py:528
-msgid ""
-"Your Wikipedia account does not meet the eligibility criteria in the terms "
-"of use, so your Wikipedia Library Card Platform account cannot be activated."
-msgstr ""
-"Jūsų Vikipedijos paskyra neatitinka naudojimo sąlygose nustatytų tinkamumo "
-"kriterijų, todėl jūsų Vikipedijos bibliotekos kortelės platformos paskyros "
-"aktyvuoti negalima."
+msgid "Your Wikipedia account does not meet the eligibility criteria in the terms of use, so your Wikipedia Library Card Platform account cannot be activated."
+msgstr "Jūsų Vikipedijos paskyra neatitinka naudojimo sąlygose nustatytų tinkamumo kriterijų, todėl jūsų Vikipedijos bibliotekos kortelės platformos paskyros aktyvuoti negalima."
 
 #. Translators: If the user tries to log in, but their account does not meet certain requirements, they cannot login.
 #: TWLight/users/oauth.py:536
-msgid ""
-"Your Wikipedia account no longer meets the eligibility criteria in the terms "
-"of use, so you cannot be logged in. If you think you should be able to log "
-"in, please email wikipedialibrary@wikimedia.org."
-msgstr ""
-"Jūsų Vikipedijos paskyra nebeatitinka naudojimo sąlygose nurodytų tinkamumo "
-"kriterijų, todėl jūs negalite būti prisijungę. Jei manote, kad turėtumėte "
-"turėti galimybę prisijungti, rašykite el. paštu wikipedialibrary@wikimedia."
-"org."
+msgid "Your Wikipedia account no longer meets the eligibility criteria in the terms of use, so you cannot be logged in. If you think you should be able to log in, please email wikipedialibrary@wikimedia.org."
+msgstr "Jūsų Vikipedijos paskyra nebeatitinka naudojimo sąlygose nurodytų tinkamumo kriterijų, todėl jūs negalite būti prisijungę. Jei manote, kad turėtumėte turėti galimybę prisijungti, rašykite el. paštu wikipedialibrary@wikimedia.org."
 
 #. Translators: this message is displayed to users with brand new accounts.
 #: TWLight/users/oauth.py:549
@@ -2858,14 +2274,8 @@ msgstr "Sveiki! Prašome sutikti su naudojimo sąlygomis."
 #. Translators: This message is displayed on the confirmation page where users can return their access to partner collections.
 #: TWLight/users/templates/users/authorization_confirm_return.html:13
 #, python-format
-msgid ""
-"You will no longer be able to access <b>%(partner)s's</b> resources via the "
-"Library Card platform, but can request access again by clicking 'renew', if "
-"you change your mind. Are you sure you want to return your access?"
-msgstr ""
-"Nebegalėsite pasiekti <b>%(partner)s</b> išteklių per Bibliotekos kortelės "
-"platformą, bet vėl galėsite prašyti prieigos spustelėdami „atnaujinti“, jei "
-"apsigalvosite. Ar tikrai norite grąžinti prieigą?"
+msgid "You will no longer be able to access <b>%(partner)s's</b> resources via the Library Card platform, but can request access again by clicking 'renew', if you change your mind. Are you sure you want to return your access?"
+msgstr "Nebegalėsite pasiekti <b>%(partner)s</b> išteklių per Bibliotekos kortelės platformą, bet vėl galėsite prašyti prieigos spustelėdami „atnaujinti“, jei apsigalvosite. Ar tikrai norite grąžinti prieigą?"
 
 #. Translators: On the MyLibrary page (https://wikipedialibrary.wmflabs.org/users/my_library), this tab shows all favorite collections a user has.
 #: TWLight/users/templates/users/collections_section.html:9
@@ -2934,13 +2344,8 @@ msgstr "Redaktoriaus duomenys"
 
 #. Translators: This is shown on editor profiles, in their profile page or on applications.
 #: TWLight/users/templates/users/editor_detail.html:59
-msgid ""
-"Information with an * was retrieved from Wikipedia directly. Other "
-"information was entered directly by users or site admins, in their preferred "
-"language."
-msgstr ""
-"Informacija su * buvo gauta tiesiogiai iš Vikipedijos. Kitą informaciją "
-"naudotojai arba svetainės administratoriai įvedė tiesiogiai norima kalba."
+msgid "Information with an * was retrieved from Wikipedia directly. Other information was entered directly by users or site admins, in their preferred language."
+msgstr "Informacija su * buvo gauta tiesiogiai iš Vikipedijos. Kitą informaciją naudotojai arba svetainės administratoriai įvedė tiesiogiai norima kalba."
 
 #. Translators: This distinguishes users who have been flagged as account coordinators. Don't translate username.
 #: TWLight/users/templates/users/editor_detail.html:71
@@ -2950,14 +2355,8 @@ msgstr "%(username)s turi koordinatoriaus teises šioje interneto svetainėje."
 
 #. Translators: This is shown on editor profiles, under the heading for Wikipedia editor data.
 #: TWLight/users/templates/users/editor_detail_data.html:5
-msgid ""
-"This information is updated automatically from your Wikimedia account each "
-"time you log in, except for the Contributions field, where you can describe "
-"your Wikimedia editing history."
-msgstr ""
-"Ši informacija automatiškai atnaujinama iš jūsų Vikipedijos paskyros "
-"kiekvieną kartą, kai prisijungiate, išskyrus indėlio lauką, kuriame galite "
-"aprašyti savo Vikimedijos redagavimo istoriją."
+msgid "This information is updated automatically from your Wikimedia account each time you log in, except for the Contributions field, where you can describe your Wikimedia editing history."
+msgstr "Ši informacija automatiškai atnaujinama iš jūsų Vikipedijos paskyros kiekvieną kartą, kai prisijungiate, išskyrus indėlio lauką, kuriame galite aprašyti savo Vikimedijos redagavimo istoriją."
 
 #. Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this labels the user's username.
 #: TWLight/users/templates/users/editor_detail_data.html:17
@@ -2986,19 +2385,13 @@ msgstr "Atitinka naudojimo sąlygas?"
 
 #. Translators: when viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this question has a yes or no answer.
 #: TWLight/users/templates/users/editor_detail_data.html:57
-msgid ""
-"at their last login, did this user meet the criteria set forth in the terms "
-"of use?"
-msgstr ""
-"ar šis naudotojas paskutinio prisijungimo metu atitiko naudojimo sąlygose "
-"nurodytus kriterijus?"
+msgid "at their last login, did this user meet the criteria set forth in the terms of use?"
+msgstr "ar šis naudotojas paskutinio prisijungimo metu atitiko naudojimo sąlygose nurodytus kriterijus?"
 
 #. Translators: When viewing a user's profile in an application, this message shows if the software doesn't think that the user is eligible for access. Don't translate username.
 #: TWLight/users/templates/users/editor_detail_data.html:72
 #, python-format
-msgid ""
-"%(username)s may still be eligible for access grants at the coordinators' "
-"discretion."
+msgid "%(username)s may still be eligible for access grants at the coordinators' discretion."
 msgstr "%(username)s vis tiek gali gauti prieigą koordinatorių nuožiūra."
 
 #. Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this is the heading for a Yes/No ToU question.
@@ -3033,14 +2426,8 @@ msgstr ""
 #. Translators: This message is shown on a user's profile if their Wikimedia account is blocked on one or more projects. They may still be granted access to the Library Bundle, but need to contact Wikipedia Library staff to verify.
 #: TWLight/users/templates/users/editor_detail_data.html:137
 #, python-format
-msgid ""
-"It looks like you have an active block on your account. If you meet the "
-"other criteria you may still be permitted access to the library - please <a "
-"class=\"twl-links\" href=\"%(contact_url)s\">contact us</a>."
-msgstr ""
-"Panašu, kad jūsų paskyroje yra aktyvus blokavimas. Jei atitinkate kitus "
-"kriterijus, jums vis tiek gali būti leista patekti į biblioteką – prašome <a "
-"class=\"twl-links\" href=\"%(contact_url)s\">susisiekti su mumis</a>."
+msgid "It looks like you have an active block on your account. If you meet the other criteria you may still be permitted access to the library - please <a class=\"twl-links\" href=\"%(contact_url)s\">contact us</a>."
+msgstr "Panašu, kad jūsų paskyroje yra aktyvus blokavimas. Jei atitinkate kitus kriterijus, jums vis tiek gali būti leista patekti į biblioteką – prašome <a class=\"twl-links\" href=\"%(contact_url)s\">susisiekti su mumis</a>."
 
 #. Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this is the heading for a Yes/No program eligibility question.
 #: TWLight/users/templates/users/editor_detail_data.html:153
@@ -3049,14 +2436,8 @@ msgstr "Tinkamas Paketui?"
 
 #. Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this question has a Yes or No answer.
 #: TWLight/users/templates/users/editor_detail_data.html:156
-msgid ""
-"At their last login, did this user meet the criteria set forth in the "
-"Library Bundle? Note that satisfying terms of use is a prerequisite to "
-"bundle eligibility."
-msgstr ""
-"Ar šis naudotojas paskutinio prisijungimo metu atitiko kriterijus, nurodytus "
-"Bibliotekos pakete? Atminkite, kad atitiktis naudojimo sąlygoms yra būtina "
-"sąlyga, kad būtų galima naudoti paketą."
+msgid "At their last login, did this user meet the criteria set forth in the Library Bundle? Note that satisfying terms of use is a prerequisite to bundle eligibility."
+msgstr "Ar šis naudotojas paskutinio prisijungimo metu atitiko kriterijus, nurodytus Bibliotekos pakete? Atminkite, kad atitiktis naudojimo sąlygoms yra būtina sąlyga, kad būtų galima naudoti paketą."
 
 #. Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this is the heading for a Yes/No program eligibility question.
 #: TWLight/users/templates/users/editor_detail_data.html:177
@@ -3100,24 +2481,14 @@ msgstr "Asmens duomenys"
 
 #. Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this text is in the 'Personal data' section. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/users/templates/users/editor_detail_data.html:262
-msgid ""
-"The following information is visible only to you, site administrators, "
-"publishing partners (where required), and volunteer Wikipedia Library "
-"coordinators (who have signed a Non-Disclosure Agreement)."
-msgstr ""
-"Toliau pateikta informacija matoma tik jums, svetainės administratoriams, "
-"leidybos partneriams (jei reikia) ir Vikipedijos bibliotekos savanoriams "
-"koordinatoriams (sudariusiems konfidencialumo sutartį)."
+msgid "The following information is visible only to you, site administrators, publishing partners (where required), and volunteer Wikipedia Library coordinators (who have signed a Non-Disclosure Agreement)."
+msgstr "Toliau pateikta informacija matoma tik jums, svetainės administratoriams, leidybos partneriams (jei reikia) ir Vikipedijos bibliotekos savanoriams koordinatoriams (sudariusiems konfidencialumo sutartį)."
 
 #. Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this labels a button which users can click to update or remove their personal information. Don't translate update_url.
 #: TWLight/users/templates/users/editor_detail_data.html:272
 #, python-format
-msgid ""
-"You may <a class=\"twl-links\" href=\"%(update_url)s\">update or delete</a> "
-"your data at any time."
-msgstr ""
-"Savo duomenis galite <a class=\"twl-links\" href=\"%(update_url)s"
-"\">atnaujinti arba ištrinti</a> bet kuriuo metu."
+msgid "You may <a class=\"twl-links\" href=\"%(update_url)s\">update or delete</a> your data at any time."
+msgstr "Savo duomenis galite <a class=\"twl-links\" href=\"%(update_url)s\">atnaujinti arba ištrinti</a> bet kuriuo metu."
 
 #. Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this labels the user's email. Don't remove the *.
 #: TWLight/users/templates/users/editor_detail_data.html:283
@@ -3136,31 +2507,19 @@ msgstr "Institucinis ryšys"
 
 #. Translators: This message tells users that they are not eligible to access The Wikipedia Library content.
 #: TWLight/users/templates/users/eligibility_modal.html:7
-msgid ""
-"Sorry, your Wikipedia account doesn’t currently qualify to access The "
-"Wikipedia Library."
-msgstr ""
-"Atsiprašome, jūsų Vikipedijos paskyra šiuo metu neatitinka Vikipedijos "
-"bibliotekos reikalavimų."
+msgid "Sorry, your Wikipedia account doesn’t currently qualify to access The Wikipedia Library."
+msgstr "Atsiprašome, jūsų Vikipedijos paskyra šiuo metu neatitinka Vikipedijos bibliotekos reikalavimų."
 
 #. Translators: This message tells users that they have not agreed to the terms of use, therefore are ineligible to access the content in The Wikipedia Library.
 #: TWLight/users/templates/users/eligibility_modal.html:30
 #, python-format
-msgid ""
-"Agreed with <a href=\"%(terms)s\" class=\"text-danger\"> terms of use </a>"
-msgstr ""
-"Sutiko su <a href=\"%(terms)s\" class=\"text-danger\">naudojimo sąlygomis</a>"
+msgid "Agreed with <a href=\"%(terms)s\" class=\"text-danger\"> terms of use </a>"
+msgstr "Sutiko su <a href=\"%(terms)s\" class=\"text-danger\">naudojimo sąlygomis</a>"
 
 #: TWLight/users/templates/users/eligibility_modal.html:40
 #, python-format
-msgid ""
-"It looks like you have an active block on your account. If you meet the "
-"other criteria you may still be permitted access to the library - please <a "
-"href=\"%(contact_url)s\">contact us</a>."
-msgstr ""
-"Panašu, kad jūsų paskyroje yra aktyvus blokavimas. Jei atitinkate kitus "
-"kriterijus, jums vis tiek gali būti leista patekti į biblioteką – prašome <a "
-"href=\"%(contact_url)s\">susisiekti su mumis</a>."
+msgid "It looks like you have an active block on your account. If you meet the other criteria you may still be permitted access to the library - please <a href=\"%(contact_url)s\">contact us</a>."
+msgstr "Panašu, kad jūsų paskyroje yra aktyvus blokavimas. Jei atitinkate kitus kriterijus, jums vis tiek gali būti leista patekti į biblioteką – prašome <a href=\"%(contact_url)s\">susisiekti su mumis</a>."
 
 #. Translators: Instructions to refresh a user's data.
 #: TWLight/users/templates/users/eligibility_modal.html:50
@@ -3199,14 +2558,8 @@ msgstr "Nustatyti kalbą"
 
 #. Translators: This text on the user page helps users naviage to the TranslateWiki Wikipedia Library Card platform translation page.
 #: TWLight/users/templates/users/language_form.html:31
-msgid ""
-"You can help translate the tool at <a class=\"twl-links\" href=\"https://"
-"translatewiki.net/wiki/Translating:Wikipedia_Library_Card_Platform"
-"\">translatewiki.net</a>."
-msgstr ""
-"Galite padėti išversti įrankį adresu <a class=\"twl-links\" href=\"https://"
-"translatewiki.net/wiki/Translating:Wikipedia_Library_Card_Platform"
-"\">translatewiki.net</a>."
+msgid "You can help translate the tool at <a class=\"twl-links\" href=\"https://translatewiki.net/wiki/Translating:Wikipedia_Library_Card_Platform\">translatewiki.net</a>."
+msgstr "Galite padėti išversti įrankį adresu <a class=\"twl-links\" href=\"https://translatewiki.net/wiki/Translating:Wikipedia_Library_Card_Platform\">translatewiki.net</a>."
 
 #. Translators: When the user starts a new application and submits the application, the user can view the application and withdraw if need be. This changes the label for the Withdraw button.
 #: TWLight/users/templates/users/my_applications.html:65
@@ -3225,12 +2578,8 @@ msgstr "Prašyti atnaujinimo"
 
 #. Translators: On the page listing applications, this text explains a user they cannot renew their application since they've already requested a renewal or there aren't any renewals available.
 #: TWLight/users/templates/users/my_applications.html:79
-msgid ""
-"Renewals are either not required, not available right now, or you have "
-"already requested a renewal."
-msgstr ""
-"Atnaujinti nebūtina, atnaujinimas šiuo metu nepasiekiama arba jūs jau "
-"pateikėte atnaujinimo užklausą."
+msgid "Renewals are either not required, not available right now, or you have already requested a renewal."
+msgstr "Atnaujinti nebūtina, atnaujinimas šiuo metu nepasiekiama arba jūs jau pateikėte atnaujinimo užklausą."
 
 #. Translators: This text is the heading of a section in a user's profile where they can change their preferences.
 #: TWLight/users/templates/users/preferences.html:6
@@ -3293,27 +2642,13 @@ msgstr "Apriboti duomenų tvarkymą"
 
 #. Translators: This message is displayed on the page where users can request we stop processing their data.
 #: TWLight/users/templates/users/restrict_data.html:15
-msgid ""
-"Checking this box and clicking “Restrict” will pause all processing of the "
-"data you have entered into this website. You will not be able to apply for "
-"access to resources, your applications will not be further processed, and "
-"none of your data will be altered, until you return to this page and uncheck "
-"the box. This is not the same as deleting your data."
-msgstr ""
-"Pažymėjus šį langelį ir spustelėjus „Apriboti“, bus pristabdytas visas "
-"duomenų, kuriuos įvedėte į šią interneto svetainę, apdorojimas. Negalėsite "
-"pateikti paraiškos dėl prieigos prie išteklių, jūsų paraiškos nebus toliau "
-"peržiūrimos ir jokie jūsų duomenys nebus pakeisti, kol grįšite į šį puslapį "
-"ir nepažymėsite laukelio. Tai nėra tas pats, kas ištrinti savo duomenis."
+msgid "Checking this box and clicking “Restrict” will pause all processing of the data you have entered into this website. You will not be able to apply for access to resources, your applications will not be further processed, and none of your data will be altered, until you return to this page and uncheck the box. This is not the same as deleting your data."
+msgstr "Pažymėjus šį langelį ir spustelėjus „Apriboti“, bus pristabdytas visas duomenų, kuriuos įvedėte į šią interneto svetainę, apdorojimas. Negalėsite pateikti paraiškos dėl prieigos prie išteklių, jūsų paraiškos nebus toliau peržiūrimos ir jokie jūsų duomenys nebus pakeisti, kol grįšite į šį puslapį ir nepažymėsite laukelio. Tai nėra tas pats, kas ištrinti savo duomenis."
 
 #. Translators: This warning message is shown to coordinators who view the data restriction page.
 #: TWLight/users/templates/users/restrict_data.html:26
-msgid ""
-"You are a coordinator on this site. If you restrict the processing of your "
-"data, your coordinator flag will be removed."
-msgstr ""
-"Jūs esate šios interneto svetainės koordinatorius. Jei apribosite savo "
-"duomenų tvarkymą, jūsų koordinatoriaus vėliavėlė bus pašalinta."
+msgid "You are a coordinator on this site. If you restrict the processing of your data, your coordinator flag will be removed."
+msgstr "Jūs esate šios interneto svetainės koordinatorius. Jei apribosite savo duomenų tvarkymą, jūsų koordinatoriaus vėliavėlė bus pašalinta."
 
 #. Translators: use the date *when you are translating*, in a language-appropriate format.
 #: TWLight/users/templates/users/terms.html:33
@@ -3328,43 +2663,17 @@ msgstr "Vikimedijos fondo privatumo politika"
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:41
 msgid "Wikipedia Library Card Terms of Use and Privacy Statement"
-msgstr ""
-"Vikipedijos bibliotekos kortelės naudojimo sąlygos ir pareiškimas apie "
-"privatumą"
+msgstr "Vikipedijos bibliotekos kortelės naudojimo sąlygos ir pareiškimas apie privatumą"
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:51
-msgid ""
-"<a class=\"twl-links\" href=\"https://meta.wikimedia.org/wiki/"
-"The_Wikipedia_Library\"> The Wikipedia Library </a> has partnered with "
-"publishers around the world to allow users to access otherwise paywalled "
-"resources. This website allows Wikipedia editors to search and access these "
-"resources."
-msgstr ""
-"<a class=\"twl-links\" href=\"https://meta.wikimedia.org/wiki/"
-"The_Wikipedia_Library\">Vikipedijos biblioteka</a> bendradarbiauja su "
-"leidėjais visame pasaulyje, kad naudotojai galėtų pasiekti mokamus "
-"išteklius. Ši svetainė leidžia Vikipedijos redaktoriams ieškoti ir pasiekti "
-"šiuos išteklius."
+msgid "<a class=\"twl-links\" href=\"https://meta.wikimedia.org/wiki/The_Wikipedia_Library\"> The Wikipedia Library </a> has partnered with publishers around the world to allow users to access otherwise paywalled resources. This website allows Wikipedia editors to search and access these resources."
+msgstr "<a class=\"twl-links\" href=\"https://meta.wikimedia.org/wiki/The_Wikipedia_Library\">Vikipedijos biblioteka</a> bendradarbiauja su leidėjais visame pasaulyje, kad naudotojai galėtų pasiekti mokamus išteklius. Ši svetainė leidžia Vikipedijos redaktoriams ieškoti ir pasiekti šiuos išteklius."
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Wikimedia Foundation should not be translated. WMF should not be translated. Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:63
-msgid ""
-"This program is administered by the Wikimedia Foundation (WMF). These terms "
-"of use and privacy notice pertain to your application for access to "
-"resources through the Wikipedia Library, your use of this website, and your "
-"access to and use of those resources. They also describe our handling of the "
-"information you provide to us in order to create and administer your "
-"Wikipedia Library account. If we make material changes to the terms, we will "
-"notify users."
-msgstr ""
-"Šią programą administruoja Vikimedijos fondas (WMF). Šios naudojimo sąlygos "
-"ir privatumo pranešimas yra susiję su jūsų paraiška prieigai prie išteklių "
-"per Vikipedijos biblioteką, jūsų naudojimuisi šia svetaine ir jūsų prieiga "
-"prie tų išteklių bei jų naudojimu. Čia taip pat aprašoma, kaip elgiamės su "
-"informacija, kurią pateikiate mums, kad sukurtume ir administruotume jūsų "
-"Vikipedijos bibliotekos paskyrą. Jei atliksime esminių sąlygų pakeitimų, "
-"apie tai informuosime naudotojus."
+msgid "This program is administered by the Wikimedia Foundation (WMF). These terms of use and privacy notice pertain to your application for access to resources through the Wikipedia Library, your use of this website, and your access to and use of those resources. They also describe our handling of the information you provide to us in order to create and administer your Wikipedia Library account. If we make material changes to the terms, we will notify users."
+msgstr "Šią programą administruoja Vikimedijos fondas (WMF). Šios naudojimo sąlygos ir privatumo pranešimas yra susiję su jūsų paraiška prieigai prie išteklių per Vikipedijos biblioteką, jūsų naudojimuisi šia svetaine ir jūsų prieiga prie tų išteklių bei jų naudojimu. Čia taip pat aprašoma, kaip elgiamės su informacija, kurią pateikiate mums, kad sukurtume ir administruotume jūsų Vikipedijos bibliotekos paskyrą. Jei atliksime esminių sąlygų pakeitimų, apie tai informuosime naudotojus."
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:74
@@ -3373,57 +2682,18 @@ msgstr "Reikalavimai Vikipedijos bibliotekos kortelės paskyrai"
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:78
-msgid ""
-"Access to resources via The Wikipedia Library is reserved for community "
-"members who have demonstrated their commitment to the Wikimedia projects, "
-"and who will use their access to these resources to improve project content. "
-"To that end, in order to be eligible for The Wikipedia Library, we require "
-"that you be registered for a user account on the projects, with at least 500 "
-"edits, six (6) months of activity, and 10+ edits in the last month. We ask "
-"that you do not request access to any publishers with a limited number of "
-"available accounts whose resources you can already access for free through "
-"your local library or university, or another institution or organization, in "
-"order to provide that opportunity to others."
-msgstr ""
-"Prieiga prie išteklių per Vikipedijos biblioteką skirta bendruomenės "
-"nariams, kurie įrodė savo įsipareigojimą Vikimedijos projektams ir naudos "
-"savo prieigą prie šių išteklių projekto turiniui tobulinti. Tam, kad "
-"galėtumėte naudotis Vikipedijos biblioteka, reikalaujame, kad būtumėte "
-"užsiregistravę projektų naudotojo paskyrai su mažiausiai 500 pakeitimų, "
-"šešių (6) veiklos mėnesių ir 10+ pakeitimų per pastarąjį mėnesį. Prašome "
-"neteikti prieigos užklausos jokiems leidėjams, turintiems ribotą paskyrų "
-"skaičių, kurių išteklius jau galite nemokamai pasiekti per vietinę "
-"biblioteką, universitetą ar kitą instituciją ar organizaciją, kad "
-"suteiktumėte tokią galimybę kitiems."
+msgid "Access to resources via The Wikipedia Library is reserved for community members who have demonstrated their commitment to the Wikimedia projects, and who will use their access to these resources to improve project content. To that end, in order to be eligible for The Wikipedia Library, we require that you be registered for a user account on the projects, with at least 500 edits, six (6) months of activity, and 10+ edits in the last month. We ask that you do not request access to any publishers with a limited number of available accounts whose resources you can already access for free through your local library or university, or another institution or organization, in order to provide that opportunity to others."
+msgstr "Prieiga prie išteklių per Vikipedijos biblioteką skirta bendruomenės nariams, kurie įrodė savo įsipareigojimą Vikimedijos projektams ir naudos savo prieigą prie šių išteklių projekto turiniui tobulinti. Tam, kad galėtumėte naudotis Vikipedijos biblioteka, reikalaujame, kad būtumėte užsiregistravę projektų naudotojo paskyrai su mažiausiai 500 pakeitimų, šešių (6) veiklos mėnesių ir 10+ pakeitimų per pastarąjį mėnesį. Prašome neteikti prieigos užklausos jokiems leidėjams, turintiems ribotą paskyrų skaičių, kurių išteklius jau galite nemokamai pasiekti per vietinę biblioteką, universitetą ar kitą instituciją ar organizaciją, kad suteiktumėte tokią galimybę kitiems."
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:94
-msgid ""
-"Additionally, if you are currently blocked or banned from a Wikimedia "
-"project, applications to resources may be rejected or restricted. If you "
-"obtain a Wikipedia Library account, but a block or ban is subsequently "
-"instituted against you on one of the projects, you may lose access to your "
-"Wikipedia Library account."
-msgstr ""
-"Be to, jei šiuo metu esate užblokuotas Vikimedijos projekte, paraiškos "
-"ištekliams gali būti atmestos ar apribotos. Jei gausite Vikipedijos "
-"bibliotekos paskyrą, bet vėliau būsite užblokuotas viename iš projektų, "
-"galite prarasti prieigą prie savo Vikipedijos bibliotekos paskyros."
+msgid "Additionally, if you are currently blocked or banned from a Wikimedia project, applications to resources may be rejected or restricted. If you obtain a Wikipedia Library account, but a block or ban is subsequently instituted against you on one of the projects, you may lose access to your Wikipedia Library account."
+msgstr "Be to, jei šiuo metu esate užblokuotas Vikimedijos projekte, paraiškos ištekliams gali būti atmestos ar apribotos. Jei gausite Vikipedijos bibliotekos paskyrą, bet vėliau būsite užblokuotas viename iš projektų, galite prarasti prieigą prie savo Vikipedijos bibliotekos paskyros."
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:104
-msgid ""
-"Your eligibility to access The Wikipedia Library is assessed at each login. "
-"While more than half of the library's content is provided via this automated "
-"eligibility check, access to other publisher's content may be time limited, "
-"typically lapsing after one year, after which you will usually need to apply "
-"for renewal."
-msgstr ""
-"Jūsų tinkamumas pasiekti Vikipedijos biblioteką vertinamas kiekvieno "
-"prisijungimo metu. Nors daugiau nei pusė bibliotekos turinio pateikiama "
-"atliekant šį automatinį tinkamumo tikrinimą, prieiga prie kitų leidėjų "
-"turinio gali būti ribota, paprastai pasibaigia po vienerių metų, o po to "
-"paprastai turėsite pateikti paraišką dėl atnaujinimo."
+msgid "Your eligibility to access The Wikipedia Library is assessed at each login. While more than half of the library's content is provided via this automated eligibility check, access to other publisher's content may be time limited, typically lapsing after one year, after which you will usually need to apply for renewal."
+msgstr "Jūsų tinkamumas pasiekti Vikipedijos biblioteką vertinamas kiekvieno prisijungimo metu. Nors daugiau nei pusė bibliotekos turinio pateikiama atliekant šį automatinį tinkamumo tikrinimą, prieiga prie kitų leidėjų turinio gali būti ribota, paprastai pasibaigia po vienerių metų, o po to paprastai turėsite pateikti paraišką dėl atnaujinimo."
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:114
@@ -3432,68 +2702,28 @@ msgstr "Paraiška per Vikipedijos bibliotekos kortelės paskyrą"
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:118
-msgid ""
-"In order to apply for access to a partner resource, you must provide us with "
-"certain information, which we will use to evaluate your application. If your "
-"application is approved, we may transfer the information you have given us "
-"to the publishers whose resources you wish to access. They will either "
-"contact you with the account information directly or we will send access "
-"information to you ourselves."
-msgstr ""
-"Norėdami kreiptis dėl prieigos prie partnerių išteklių, turite pateikti mums "
-"tam tikrą informaciją, kurią naudosime vertindami jūsų paraišką. Jei jūsų "
-"paraiška bus patvirtinta, jūsų pateiktą informaciją galime perduoti "
-"leidėjams, kurių išteklius norite pasiekti. Jie arba susisieks su jumis "
-"tiesiogiai ir pateiks paskyros informaciją, arba mes patys atsiųsime jums "
-"prieigos informaciją."
+msgid "In order to apply for access to a partner resource, you must provide us with certain information, which we will use to evaluate your application. If your application is approved, we may transfer the information you have given us to the publishers whose resources you wish to access. They will either contact you with the account information directly or we will send access information to you ourselves."
+msgstr "Norėdami kreiptis dėl prieigos prie partnerių išteklių, turite pateikti mums tam tikrą informaciją, kurią naudosime vertindami jūsų paraišką. Jei jūsų paraiška bus patvirtinta, jūsų pateiktą informaciją galime perduoti leidėjams, kurių išteklius norite pasiekti. Jie arba susisieks su jumis tiesiogiai ir pateiks paskyros informaciją, arba mes patys atsiųsime jums prieigos informaciją."
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:130
-msgid ""
-"In addition to the basic information you provide to us, our system will "
-"retrieve some information directly from the Wikimedia projects: your "
-"username, email address, edit count, registration date, user ID number, "
-"groups to which you belong, and any special user rights."
-msgstr ""
-"Be pagrindinės informacijos, kurią mums pateikiate, mūsų sistema nuskaitys "
-"dalį informacijos tiesiai iš Vikimedijos projektų: jūsų naudotojo vardą, el. "
-"pašto adresą, keitimų skaičių, registracijos datą, naudotojo ID numerį, "
-"grupes, kurioms priklausote, ir visas specialias naudotojo teises."
+msgid "In addition to the basic information you provide to us, our system will retrieve some information directly from the Wikimedia projects: your username, email address, edit count, registration date, user ID number, groups to which you belong, and any special user rights."
+msgstr "Be pagrindinės informacijos, kurią mums pateikiate, mūsų sistema nuskaitys dalį informacijos tiesiai iš Vikimedijos projektų: jūsų naudotojo vardą, el. pašto adresą, keitimų skaičių, registracijos datą, naudotojo ID numerį, grupes, kurioms priklausote, ir visas specialias naudotojo teises."
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:140
-msgid ""
-"Each time you log in to the Wikipedia Library Card Platform, this "
-"information will be automatically updated."
-msgstr ""
-"Kiekvieną kartą prisijungus prie Vikipedijos bibliotekos kortelės platformos "
-"ši informacija bus automatiškai atnaujinama."
+msgid "Each time you log in to the Wikipedia Library Card Platform, this information will be automatically updated."
+msgstr "Kiekvieną kartą prisijungus prie Vikipedijos bibliotekos kortelės platformos ši informacija bus automatiškai atnaujinama."
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:148
-msgid ""
-"We will ask you to provide us with some information about your history of "
-"contributions to the Wikimedia projects. Information on contribution history "
-"is optional, but will greatly assist us in evaluating your application."
-msgstr ""
-"Mes paprašysime jūsų pateikti mums šiek tiek informacijos apie jūsų "
-"dalyvavimo Vikimedijos projektuose istoriją. Informacija apie indėlio "
-"istoriją yra neprivaloma, tačiau ji padės mums įvertinti jūsų paraišką."
+msgid "We will ask you to provide us with some information about your history of contributions to the Wikimedia projects. Information on contribution history is optional, but will greatly assist us in evaluating your application."
+msgstr "Mes paprašysime jūsų pateikti mums šiek tiek informacijos apie jūsų dalyvavimo Vikimedijos projektuose istoriją. Informacija apie indėlio istoriją yra neprivaloma, tačiau ji padės mums įvertinti jūsų paraišką."
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). WMF should not be translated. Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:157
-msgid ""
-"The information you provide when creating your account will be visible to "
-"you while on the site but not to others unless they are approved Wikipedia "
-"Library Coordinators, WMF Staff, or WMF Contractors who need access to this "
-"data in order to carry out their work with the Wikipedia Library, all of "
-"whom are subject to non-disclosure obligations."
-msgstr ""
-"Informacija, kurią pateikiate kurdami paskyrą, bus matoma jums būnant "
-"interneto svetainėje, bet ne kitiems, nebent jie bus patvirtinti Vikipedijos "
-"bibliotekos koordinatoriai, WMF darbuotojai arba WMF rangovai, kuriems "
-"reikia prieigos prie šių duomenų, kad galėtų atlikti savo darbą su "
-"Vikipedijos biblioteka - visiems jiems taikomi įsipareigojimai neatskleisti."
+msgid "The information you provide when creating your account will be visible to you while on the site but not to others unless they are approved Wikipedia Library Coordinators, WMF Staff, or WMF Contractors who need access to this data in order to carry out their work with the Wikipedia Library, all of whom are subject to non-disclosure obligations."
+msgstr "Informacija, kurią pateikiate kurdami paskyrą, bus matoma jums būnant interneto svetainėje, bet ne kitiems, nebent jie bus patvirtinti Vikipedijos bibliotekos koordinatoriai, WMF darbuotojai arba WMF rangovai, kuriems reikia prieigos prie šių duomenų, kad galėtų atlikti savo darbą su Vikipedijos biblioteka - visiems jiems taikomi įsipareigojimai neatskleisti."
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:167
@@ -3502,58 +2732,33 @@ msgstr "Jūsų naudojimasis leidėjų ištekliais"
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:171
-msgid ""
-"In order to access an individual publisher’s resources, you must agree to "
-"that publisher’s terms of use and privacy policy. You agree that you will "
-"not violate such terms and policies in connection with your use of the "
-"Wikipedia Library. Additionally, the following activities are prohibited "
-"while accessing publisher resources through the Wikipedia Library."
-msgstr ""
-"Kad galėtumėte pasiekti atskiro leidėjo išteklius, turite sutikti su to "
-"leidėjo naudojimo sąlygomis ir privatumo politika. Jūs sutinkate, kad "
-"nepažeisite tokių sąlygų ir politikos naudodamiesi Vikipedijos biblioteka. "
-"Be to, norint pasiekti leidėjo išteklius per Vikipedijos biblioteką, "
-"draudžiama atlikti toliau nurodytus veiksmus."
+msgid "In order to access an individual publisher’s resources, you must agree to that publisher’s terms of use and privacy policy. You agree that you will not violate such terms and policies in connection with your use of the Wikipedia Library. Additionally, the following activities are prohibited while accessing publisher resources through the Wikipedia Library."
+msgstr "Kad galėtumėte pasiekti atskiro leidėjo išteklius, turite sutikti su to leidėjo naudojimo sąlygomis ir privatumo politika. Jūs sutinkate, kad nepažeisite tokių sąlygų ir politikos naudodamiesi Vikipedijos biblioteka. Be to, norint pasiekti leidėjo išteklius per Vikipedijos biblioteką, draudžiama atlikti toliau nurodytus veiksmus."
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:184
-msgid ""
-"Sharing your Wikipedia account, usernames, passwords, or any access codes "
-"for publisher resources with others;"
-msgstr ""
-"Dalintis savo Vikipedijos paskyra, naudotojo vardais, slaptažodžiais ar bet "
-"kokiais leidėjo išteklių prieigos kodais su kitais;"
+msgid "Sharing your Wikipedia account, usernames, passwords, or any access codes for publisher resources with others;"
+msgstr "Dalintis savo Vikipedijos paskyra, naudotojo vardais, slaptažodžiais ar bet kokiais leidėjo išteklių prieigos kodais su kitais;"
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:191
-msgid ""
-"Automatically scraping or downloading restricted content from publishers;"
+msgid "Automatically scraping or downloading restricted content from publishers;"
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:197
-msgid ""
-"Systematically making printed or electronic copies of multiple extracts of "
-"restricted content available for any purpose;"
-msgstr ""
-"Sistemingai daryti spausdintas arba elektronines riboto turinio ištraukų "
-"kopijas prieinamas bet kokiam tikslui;"
+msgid "Systematically making printed or electronic copies of multiple extracts of restricted content available for any purpose;"
+msgstr "Sistemingai daryti spausdintas arba elektronines riboto turinio ištraukų kopijas prieinamas bet kokiam tikslui;"
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:204
-msgid ""
-"Data mining metadata without permission—for example, in order to use "
-"metadata for auto-created stub articles;"
+msgid "Data mining metadata without permission—for example, in order to use metadata for auto-created stub articles;"
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:211
-msgid ""
-"Using the access you receive through the Wikipedia Library for profit by "
-"selling access to your account or resources which you have through it."
-msgstr ""
-"Naudoti prieigą, kurią gaunate per Vikipedijos biblioteką, siekiant pelno, "
-"parduodant prieigą prie savo paskyros arba per ją turimų išteklių."
+msgid "Using the access you receive through the Wikipedia Library for profit by selling access to your account or resources which you have through it."
+msgstr "Naudoti prieigą, kurią gaunate per Vikipedijos biblioteką, siekiant pelno, parduodant prieigą prie savo paskyros arba per ją turimų išteklių."
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:220
@@ -3562,18 +2767,12 @@ msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:224
-msgid ""
-"Certain resources may only be accessed using an external search service, "
-"such as the EBSCO Discovery Service, or a proxy service, such as OCLC "
-"EZProxy. If you use such external search and/or proxy services, please "
-"review the applicable terms of use and privacy policies."
+msgid "Certain resources may only be accessed using an external search service, such as the EBSCO Discovery Service, or a proxy service, such as OCLC EZProxy. If you use such external search and/or proxy services, please review the applicable terms of use and privacy policies."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:234
-msgid ""
-"In addition, if you use OCLC EZProxy, please note that you may not use it "
-"for commercial purposes."
+msgid "In addition, if you use OCLC EZProxy, please note that you may not use it for commercial purposes."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
@@ -3584,193 +2783,51 @@ msgstr "Duomenų saugojimas ir tvarkymas"
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Wikimedia Foundation should not be translated. Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:245
 #, fuzzy
-msgid ""
-"The Wikimedia Foundation and our service providers use your information for "
-"the legitimate purpose of providing Wikipedia Library services in support of "
-"our charitable mission. When you apply for a Wikipedia Library account, or "
-"use your Wikipedia Library account, we may routinely collect the following "
-"information: your username, email address, edit count, registration date, "
-"user ID number, groups to which you belong, and any special user rights; "
-"your name, country of residence, and/or affiliation, if required by a "
-"partner to which you are applying; your narrative description of your "
-"contributions and reasons for applying for access to partner resources; and "
-"the date you agree to these terms of use."
-msgstr ""
-"Vikimedijos fondas ir mūsų paslaugų teikėjai naudoja jūsų informaciją "
-"teisėtam tikslui - teikti Vikipedijos bibliotekos paslaugas, remiant mūsų "
-"pelno nesiekiančią misiją. Kai pateikiate paraišką dėl Vikipedijos "
-"bibliotekos paskyros arba naudojate savo Vikipedijos bibliotekos paskyrą, "
-"mes galime reguliariai rinkti šią informaciją: jūsų naudotojo vardą, el. "
-"pašto adresą, keitimų skaičių, registracijos datą, naudotojo ID numerį, "
-"grupes, kurioms priklausote, ir bet kokias specialias naudotojo teises; jūsų "
-"vardą, pavardę, valstybę, kurioje gyvenate; profesiją ir (arba) institucinį "
-"ryšį, jei to reikalauja partneris, dėl kurio prieigos kreipėtės; jūsų "
-"indėlio aprašymas ir priežastys, kodėl kreipiatės dėl prieigos prie "
-"partnerių išteklių; ir data, kai sutinkate su šiomis naudojimo sąlygomis."
+msgid "The Wikimedia Foundation and our service providers use your information for the legitimate purpose of providing Wikipedia Library services in support of our charitable mission. When you apply for a Wikipedia Library account, or use your Wikipedia Library account, we may routinely collect the following information: your username, email address, edit count, registration date, user ID number, groups to which you belong, and any special user rights; your name, country of residence, and/or affiliation, if required by a partner to which you are applying; your narrative description of your contributions and reasons for applying for access to partner resources; and the date you agree to these terms of use."
+msgstr "Vikimedijos fondas ir mūsų paslaugų teikėjai naudoja jūsų informaciją teisėtam tikslui - teikti Vikipedijos bibliotekos paslaugas, remiant mūsų pelno nesiekiančią misiją. Kai pateikiate paraišką dėl Vikipedijos bibliotekos paskyros arba naudojate savo Vikipedijos bibliotekos paskyrą, mes galime reguliariai rinkti šią informaciją: jūsų naudotojo vardą, el. pašto adresą, keitimų skaičių, registracijos datą, naudotojo ID numerį, grupes, kurioms priklausote, ir bet kokias specialias naudotojo teises; jūsų vardą, pavardę, valstybę, kurioje gyvenate; profesiją ir (arba) institucinį ryšį, jei to reikalauja partneris, dėl kurio prieigos kreipėtės; jūsų indėlio aprašymas ir priežastys, kodėl kreipiatės dėl prieigos prie partnerių išteklių; ir data, kai sutinkate su šiomis naudojimo sąlygomis."
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:262
 #, fuzzy, python-format
-msgid ""
-"Each publisher who is a member of the Wikipedia Library program requires "
-"different specific information in the application. Some publishers may "
-"request only an email address, while others request more detailed data, such "
-"as your name, location, or institutional affiliation. When you complete your "
-"application, you will only be asked to supply information required by the "
-"publishers you have chosen, and each publisher will only receive the "
-"information they require for providing you with access. Please see our <a "
-"class=\"twl-links\" href=\"%(all_partners_url)s\">partner information</a> "
-"pages to learn what information is required by each publisher to gain access "
-"to their resources."
-msgstr ""
-"Kiekvienas leidėjas, kuris yra Vikipedijos bibliotekos programos narys, "
-"programoje reikalauja skirtingos konkrečios informacijos. Kai kurie leidėjai "
-"gali prašyti tik el. pašto adreso, o kiti – išsamesnių duomenų, pvz., jūsų "
-"vardo, vietos, profesijos ar institucinio ryšio. Kai užpildysite paraišką, "
-"jūsų bus paprašyta pateikti tik informaciją, kurios reikalauja jūsų "
-"pasirinkti leidėjai, o kiekvienas leidėjas gaus tik tą informaciją, kurios "
-"reikia norint suteikti jums prieigą. Žiūrėkite mūsų <a class=\"twl-links\" "
-"href=\"%(all_partners_url)s\">partnerių informacijos</a> puslapius, kad "
-"sužinotumėte, kokios informacijos kiekvienam leidėjui reikia, kad galėtumėte "
-"pasiekti jų išteklius."
+msgid "Each publisher who is a member of the Wikipedia Library program requires different specific information in the application. Some publishers may request only an email address, while others request more detailed data, such as your name, location, or institutional affiliation. When you complete your application, you will only be asked to supply information required by the publishers you have chosen, and each publisher will only receive the information they require for providing you with access. Please see our <a class=\"twl-links\" href=\"%(all_partners_url)s\">partner information</a> pages to learn what information is required by each publisher to gain access to their resources."
+msgstr "Kiekvienas leidėjas, kuris yra Vikipedijos bibliotekos programos narys, programoje reikalauja skirtingos konkrečios informacijos. Kai kurie leidėjai gali prašyti tik el. pašto adreso, o kiti – išsamesnių duomenų, pvz., jūsų vardo, vietos, profesijos ar institucinio ryšio. Kai užpildysite paraišką, jūsų bus paprašyta pateikti tik informaciją, kurios reikalauja jūsų pasirinkti leidėjai, o kiekvienas leidėjas gaus tik tą informaciją, kurios reikia norint suteikti jums prieigą. Žiūrėkite mūsų <a class=\"twl-links\" href=\"%(all_partners_url)s\">partnerių informacijos</a> puslapius, kad sužinotumėte, kokios informacijos kiekvienam leidėjui reikia, kad galėtumėte pasiekti jų išteklius."
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Wikimedia Foundation should not be translated. Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:277
-msgid ""
-"Some Wikipedia Library pages are visible without logging in, but you will "
-"need to log in to apply or access proprietary partner resources. We use the "
-"data provided by you via OAuth and Wikimedia API calls to assess your "
-"application for access and to process approved requests."
+msgid "Some Wikipedia Library pages are visible without logging in, but you will need to log in to apply or access proprietary partner resources. We use the data provided by you via OAuth and Wikimedia API calls to assess your application for access and to process approved requests."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:288
 #, python-format
-msgid ""
-"In order to administer the Wikipedia Library program, we will retain the "
-"application data we collect from you for three years after your most recent "
-"login, unless you delete your account, as described below. You can log in "
-"and go to <a class=\"twl-links\" href=\"%(profile_url)s\">your profile page</"
-"a> in order to see the information associated with your account, and can "
-"download it in JSON format. You may access, update, restrict, or delete this "
-"information at any time, except for the information that is automatically "
-"retrieved from the projects. If you have any questions or concerns about the "
-"handling of your data, please contact <a class=\"twl-links\" href=\"mailto:"
-"wikipedialibrary@wikimedia.org?Subject=Wikipedia%%20Library%%20Card"
-"%%20account%%20deactivation\"> wikipedialibrary@wikimedia.org </a>."
-msgstr ""
-"Siekdami administruoti Vikipedijos bibliotekos programą, iš jūsų surinktus "
-"paraiškos duomenis saugosime trejus metus po paskutinio prisijungimo, nebent "
-"ištrinsite savo paskyrą, kaip aprašyta toliau. Galite prisijungti ir eiti į "
-"<a class=\"twl-links\" href=\"%(profile_url)s\">savo profilio puslapį</a>, "
-"kad pamatytumėte su paskyra susietą informaciją, ir galite ją atsisiųsti "
-"JSON formatu. Šią informaciją galite pasiekti, atnaujinti, apriboti arba "
-"ištrinti bet kuriuo metu, išskyrus informaciją, kuri automatiškai gaunama iš "
-"projektų. Jei turite klausimų dėl jūsų duomenų tvarkymo, susisiekite su <a "
-"class=\"twl-links\" href=\"mailto:wikipedialibrary@wikimedia.org?"
-"Subject=Wikipedia%%20Library%%20Card%%20account%%20deactivation\"> "
-"wikipedialibrary@wikimedia.org </a>."
+msgid "In order to administer the Wikipedia Library program, we will retain the application data we collect from you for three years after your most recent login, unless you delete your account, as described below. You can log in and go to <a class=\"twl-links\" href=\"%(profile_url)s\">your profile page</a> in order to see the information associated with your account, and can download it in JSON format. You may access, update, restrict, or delete this information at any time, except for the information that is automatically retrieved from the projects. If you have any questions or concerns about the handling of your data, please contact <a class=\"twl-links\" href=\"mailto:wikipedialibrary@wikimedia.org?Subject=Wikipedia%%20Library%%20Card%%20account%%20deactivation\"> wikipedialibrary@wikimedia.org </a>."
+msgstr "Siekdami administruoti Vikipedijos bibliotekos programą, iš jūsų surinktus paraiškos duomenis saugosime trejus metus po paskutinio prisijungimo, nebent ištrinsite savo paskyrą, kaip aprašyta toliau. Galite prisijungti ir eiti į <a class=\"twl-links\" href=\"%(profile_url)s\">savo profilio puslapį</a>, kad pamatytumėte su paskyra susietą informaciją, ir galite ją atsisiųsti JSON formatu. Šią informaciją galite pasiekti, atnaujinti, apriboti arba ištrinti bet kuriuo metu, išskyrus informaciją, kuri automatiškai gaunama iš projektų. Jei turite klausimų dėl jūsų duomenų tvarkymo, susisiekite su <a class=\"twl-links\" href=\"mailto:wikipedialibrary@wikimedia.org?Subject=Wikipedia%%20Library%%20Card%%20account%%20deactivation\"> wikipedialibrary@wikimedia.org </a>."
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:305
 #, fuzzy
-msgid ""
-"If you decide to disable your Wikipedia Library account, you can use the "
-"delete button on your profile to delete certain personal information "
-"associated with your account. We will delete your real name, institutional "
-"affiliation, and country of residence. Please note that the system will "
-"retain a record of your username, the publishers to which you applied or had "
-"access, and the dates of that access. Note that deletion is not reversible. "
-"Deletion of your Wikipedia Library account may also correspond with the "
-"removal of any resource access to which you were eligible or approved. If "
-"you request the deletion of account information and later wish to apply for "
-"a new account, you will need to provide the necessary information again."
-msgstr ""
-"Jei nuspręsite išjungti Vikipedijos bibliotekos paskyrą, galite naudoti savo "
-"profilyje esantį trynimo mygtuką, kad ištrintumėte tam tikrą asmeninę "
-"informaciją, susietą su jūsų paskyra. Ištrinsime jūsų tikrąjį vardą, "
-"profesiją, institucinį ryšį ir valstybę, kurioje gyvenate. Atminkite, kad "
-"sistema išsaugos jūsų naudotojo vardą, leidėjus, dėl kurių kreipėtės arba "
-"prie kurių turėjote prieigą, ir prieigos datų įrašus. Atminkite, kad "
-"ištrynimas negrįžtamas. Vikipedijos bibliotekos paskyros ištrynimas taip pat "
-"gali reikšti bet kokios prieigos prie išteklių, prie kurių turėjote teisę "
-"prieiti arba patvirtinimą prieiti, pašalinimą. Jei paprašysite ištrinti "
-"paskyros informaciją ir vėliau norėsite pateikti paraišką dėl naujos "
-"paskyros, reikiamą informaciją turėsite pateikti dar kartą."
+msgid "If you decide to disable your Wikipedia Library account, you can use the delete button on your profile to delete certain personal information associated with your account. We will delete your real name, institutional affiliation, and country of residence. Please note that the system will retain a record of your username, the publishers to which you applied or had access, and the dates of that access. Note that deletion is not reversible. Deletion of your Wikipedia Library account may also correspond with the removal of any resource access to which you were eligible or approved. If you request the deletion of account information and later wish to apply for a new account, you will need to provide the necessary information again."
+msgstr "Jei nuspręsite išjungti Vikipedijos bibliotekos paskyrą, galite naudoti savo profilyje esantį trynimo mygtuką, kad ištrintumėte tam tikrą asmeninę informaciją, susietą su jūsų paskyra. Ištrinsime jūsų tikrąjį vardą, profesiją, institucinį ryšį ir valstybę, kurioje gyvenate. Atminkite, kad sistema išsaugos jūsų naudotojo vardą, leidėjus, dėl kurių kreipėtės arba prie kurių turėjote prieigą, ir prieigos datų įrašus. Atminkite, kad ištrynimas negrįžtamas. Vikipedijos bibliotekos paskyros ištrynimas taip pat gali reikšti bet kokios prieigos prie išteklių, prie kurių turėjote teisę prieiti arba patvirtinimą prieiti, pašalinimą. Jei paprašysite ištrinti paskyros informaciją ir vėliau norėsite pateikti paraišką dėl naujos paskyros, reikiamą informaciją turėsite pateikti dar kartą."
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). WMF should not be translated. Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:321
-msgid ""
-"The Wikipedia Library is run by WMF Staff, Contractors, and approved "
-"volunteer Coordinators. The data associated with your account will be shared "
-"with the WMF staff, contractors, service providers, and volunteer "
-"coordinators who need to process the information in connection with their "
-"work for the Wikipedia Library, and who are subject to confidentiality "
-"obligations. We will also use your data for internal Wikipedia Library "
-"purposes such as distributing user surveys and account notifications, and in "
-"a depersonalized or aggregated fashion for statistical analysis and "
-"administration. Finally, we will share your information with the publishers "
-"whom you specifically select in order to provide you with access to "
-"resources. Otherwise, your information will not be shared with third "
-"parties, with the exception of the circumstances described below."
-msgstr ""
-"Vikipedijos biblioteką tvarko WMF darbuotojai, rangovai ir patvirtinti "
-"savanoriai koordinatoriai. Su jūsų paskyra susiję duomenys bus bendrinami su "
-"WMF darbuotojais, rangovais, paslaugų teikėjais ir savanoriais "
-"koordinatoriais, kuriems reikia apdoroti informaciją, susijusią su jų darbu "
-"Vikipedijos bibliotekoje, ir kuriems taikomi konfidencialumo "
-"įsipareigojimai. Jūsų duomenis taip pat naudosime vidiniais Vikipedijos "
-"bibliotekos tikslais, pvz., platindami naudotojų apklausas ir paskyros, taip "
-"pat nuasmenintu arba apibendrintu būdu statistinei analizei ir "
-"administravimui. Galiausiai, mes pasidalinsime jūsų informacija su "
-"leidėjais, kuriuos konkrečiai pasirinkote, kad suteiktume jums prieigą prie "
-"išteklių. Priešingu atveju jūsų informacija nebus bendrinama su trečiosiomis "
-"šalimis, išskyrus toliau aprašytas aplinkybes."
+msgid "The Wikipedia Library is run by WMF Staff, Contractors, and approved volunteer Coordinators. The data associated with your account will be shared with the WMF staff, contractors, service providers, and volunteer coordinators who need to process the information in connection with their work for the Wikipedia Library, and who are subject to confidentiality obligations. We will also use your data for internal Wikipedia Library purposes such as distributing user surveys and account notifications, and in a depersonalized or aggregated fashion for statistical analysis and administration. Finally, we will share your information with the publishers whom you specifically select in order to provide you with access to resources. Otherwise, your information will not be shared with third parties, with the exception of the circumstances described below."
+msgstr "Vikipedijos biblioteką tvarko WMF darbuotojai, rangovai ir patvirtinti savanoriai koordinatoriai. Su jūsų paskyra susiję duomenys bus bendrinami su WMF darbuotojais, rangovais, paslaugų teikėjais ir savanoriais koordinatoriais, kuriems reikia apdoroti informaciją, susijusią su jų darbu Vikipedijos bibliotekoje, ir kuriems taikomi konfidencialumo įsipareigojimai. Jūsų duomenis taip pat naudosime vidiniais Vikipedijos bibliotekos tikslais, pvz., platindami naudotojų apklausas ir paskyros, taip pat nuasmenintu arba apibendrintu būdu statistinei analizei ir administravimui. Galiausiai, mes pasidalinsime jūsų informacija su leidėjais, kuriuos konkrečiai pasirinkote, kad suteiktume jums prieigą prie išteklių. Priešingu atveju jūsų informacija nebus bendrinama su trečiosiomis šalimis, išskyrus toliau aprašytas aplinkybes."
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). WMF should not be translated.
 #: TWLight/users/templates/users/terms.html:338
-msgid ""
-"We may disclose any collected information when required by law, when we have "
-"your permission, when needed to protect our rights, privacy, safety, users, "
-"or the general public, and when necessary to enforce these terms, WMF’s "
-"general <a class=\"twl-links\" href=\"https://foundation.wikimedia.org/wiki/"
-"Terms_of_Use\">Terms of Use</a>, or any other WMF policy."
-msgstr ""
-"Galime atskleisti bet kokią surinktą informaciją, kai to reikalauja teisės "
-"aktai, kai turime jūsų leidimą, kai to reikia siekiant apsaugoti mūsų "
-"teises, privatumą, saugumą, naudotojus ar plačiąją visuomenę, ir kai reikia "
-"šių sąlygų, WMF bendrųjų <a class=\"twl-links\" href=\"https://foundation."
-"wikimedia.org/wiki/Terms_of_Use\">naudojimo sąlygų</a> arba bet kokios kitos "
-"WMF politikos vykdymui."
+msgid "We may disclose any collected information when required by law, when we have your permission, when needed to protect our rights, privacy, safety, users, or the general public, and when necessary to enforce these terms, WMF’s general <a class=\"twl-links\" href=\"https://foundation.wikimedia.org/wiki/Terms_of_Use\">Terms of Use</a>, or any other WMF policy."
+msgstr "Galime atskleisti bet kokią surinktą informaciją, kai to reikalauja teisės aktai, kai turime jūsų leidimą, kai to reikia siekiant apsaugoti mūsų teises, privatumą, saugumą, naudotojus ar plačiąją visuomenę, ir kai reikia šių sąlygų, WMF bendrųjų <a class=\"twl-links\" href=\"https://foundation.wikimedia.org/wiki/Terms_of_Use\">naudojimo sąlygų</a> arba bet kokios kitos WMF politikos vykdymui."
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:349
-msgid ""
-"We take the security of your personal data seriously, and take reasonable "
-"precautions to ensure your data is protected. These precautions include "
-"access controls to limit who has access to your data and security "
-"technologies to protect data stored on the server. However, we cannot "
-"guarantee the safety of your data as it is transmitted and stored."
-msgstr ""
-"Mes rimtai žiūrime į jūsų asmens duomenų saugumą ir imamės pagrįstų "
-"atsargumo priemonių, kad užtikrintume jūsų duomenų apsaugą. Šios atsargumo "
-"priemonės apima prieigos kontrolę, skirtą apriboti, kas turi prieigą prie "
-"jūsų duomenų, ir saugos technologijas, skirtas apsaugoti serveryje saugomus "
-"duomenis. Tačiau mes negalime garantuoti jūsų duomenų saugumo, kai jie yra "
-"perduodami ir saugomi."
+msgid "We take the security of your personal data seriously, and take reasonable precautions to ensure your data is protected. These precautions include access controls to limit who has access to your data and security technologies to protect data stored on the server. However, we cannot guarantee the safety of your data as it is transmitted and stored."
+msgstr "Mes rimtai žiūrime į jūsų asmens duomenų saugumą ir imamės pagrįstų atsargumo priemonių, kad užtikrintume jūsų duomenų apsaugą. Šios atsargumo priemonės apima prieigos kontrolę, skirtą apriboti, kas turi prieigą prie jūsų duomenų, ir saugos technologijas, skirtas apsaugoti serveryje saugomus duomenis. Tačiau mes negalime garantuoti jūsų duomenų saugumo, kai jie yra perduodami ir saugomi."
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:360
-msgid ""
-"Please note that these terms do not control the use and handling of your "
-"data by the publishers and service providers whose resources you access or "
-"apply to access. Please read their individual privacy policies for that "
-"information."
-msgstr ""
-"Atminkite, kad šios sąlygos nekontroliuoja, kaip leidėjai ir paslaugų "
-"teikėjai, kurių išteklius pasiekiate arba kreipiatės dėl prieigos, naudoja "
-"ir tvarko jūsų duomenis. Norėdami gauti šią informaciją, perskaitykite jų "
-"individualias privatumo politikas."
+msgid "Please note that these terms do not control the use and handling of your data by the publishers and service providers whose resources you access or apply to access. Please read their individual privacy policies for that information."
+msgstr "Atminkite, kad šios sąlygos nekontroliuoja, kaip leidėjai ir paslaugų teikėjai, kurių išteklius pasiekiate arba kreipiatės dėl prieigos, naudoja ir tvarko jūsų duomenis. Norėdami gauti šią informaciją, perskaitykite jų individualias privatumo politikas."
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:368
@@ -3779,52 +2836,18 @@ msgstr "Svarbi pastaba"
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Wikimedia Foundation should not be translated. Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:373
-msgid ""
-"The Wikimedia Foundation is a nonprofit organization based in San Francisco, "
-"California. The Wikipedia Library program provides access to resources held "
-"by publishers in multiple countries. If you apply for a Wikipedia Library "
-"account (whether you are inside or outside of the United States), you "
-"understand that your personal data will be collected, transferred, stored, "
-"processed, disclosed and otherwise used in the U.S. as described in this "
-"privacy policy. You also understand that your information may be transferred "
-"by us from the U.S. to other countries, which may have different or less "
-"stringent data protection laws than your country, in connection with "
-"providing services to you, including evaluating your application and "
-"securing access to your chosen publishers (locations for each publisher are "
-"outlined on their respective partner information pages)."
-msgstr ""
-"Vikimedijos fondas yra ne pelno siekianti organizacija, įsikūrusi San "
-"Franciske, Kalifornijoje. Vikipedijos bibliotekos programa suteikia prieigą "
-"prie išteklių, kuriuos turi leidėjai keliose valstybėse. Jei kreipiatės dėl "
-"Vikipedijos bibliotekos paskyros (nesvarbu, ar esate JAV, ar už jos ribų), "
-"suprantate, kad jūsų asmens duomenys bus renkami, perduodami, saugomi, "
-"tvarkomi, atskleidžiami ir kitaip naudojami JAV, kaip aprašyta šioje "
-"privatumo politikoje. Taip pat suprantate, kad mes galime perduoti jūsų "
-"informaciją iš JAV į kitas valstybes, kuriose gali būti taikomi kitokie arba "
-"ne tokie griežti duomenų apsaugos teisės aktai kaip jūsų valstybėje, "
-"teikdami jums paslaugas, įskaitant jūsų paraiškų vertinimą ir prieigos prie "
-"jūsų pasirinktos leidėjų informacijos užtikrinimą (kiekvieno leidėjo vietos "
-"nurodytos atitinkamuose partnerių informacijos puslapiuose)."
+msgid "The Wikimedia Foundation is a nonprofit organization based in San Francisco, California. The Wikipedia Library program provides access to resources held by publishers in multiple countries. If you apply for a Wikipedia Library account (whether you are inside or outside of the United States), you understand that your personal data will be collected, transferred, stored, processed, disclosed and otherwise used in the U.S. as described in this privacy policy. You also understand that your information may be transferred by us from the U.S. to other countries, which may have different or less stringent data protection laws than your country, in connection with providing services to you, including evaluating your application and securing access to your chosen publishers (locations for each publisher are outlined on their respective partner information pages)."
+msgstr "Vikimedijos fondas yra ne pelno siekianti organizacija, įsikūrusi San Franciske, Kalifornijoje. Vikipedijos bibliotekos programa suteikia prieigą prie išteklių, kuriuos turi leidėjai keliose valstybėse. Jei kreipiatės dėl Vikipedijos bibliotekos paskyros (nesvarbu, ar esate JAV, ar už jos ribų), suprantate, kad jūsų asmens duomenys bus renkami, perduodami, saugomi, tvarkomi, atskleidžiami ir kitaip naudojami JAV, kaip aprašyta šioje privatumo politikoje. Taip pat suprantate, kad mes galime perduoti jūsų informaciją iš JAV į kitas valstybes, kuriose gali būti taikomi kitokie arba ne tokie griežti duomenų apsaugos teisės aktai kaip jūsų valstybėje, teikdami jums paslaugas, įskaitant jūsų paraiškų vertinimą ir prieigos prie jūsų pasirinktos leidėjų informacijos užtikrinimą (kiekvieno leidėjo vietos nurodytos atitinkamuose partnerių informacijos puslapiuose)."
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:392
-msgid ""
-"Please note that in the event of any differences in meaning or "
-"interpretation between the original English version of these terms and a "
-"translation, the original English version takes precedence."
-msgstr ""
-"Atkreipkite dėmesį, kad esant bet kokiems prasmės ar interpretavimo "
-"skirtumams tarp šių terminų originalios versijos anglų kalba ir vertimo, "
-"pirmenybė teikiama originalui anglų kalba."
+msgid "Please note that in the event of any differences in meaning or interpretation between the original English version of these terms and a translation, the original English version takes precedence."
+msgstr "Atkreipkite dėmesį, kad esant bet kokiems prasmės ar interpretavimo skirtumams tarp šių terminų originalios versijos anglų kalba ir vertimo, pirmenybė teikiama originalui anglų kalba."
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Wikimedia Foundation should not be translated.
 #: TWLight/users/templates/users/terms.html:403
-msgid ""
-"See also the <a class=\"twl-links\" href=\"https://wikimediafoundation.org/"
-"wiki/Privacy_policy\">Wikimedia Foundation Privacy Policy</a>."
-msgstr ""
-"Taip pat žiūrėkite <a class=\"twl-links\" href=\"https://wikimediafoundation."
-"org/wiki/Privacy_policy\">Vikimedijos fondo privatumo politiką</a>."
+msgid "See also the <a class=\"twl-links\" href=\"https://wikimediafoundation.org/wiki/Privacy_policy\">Wikimedia Foundation Privacy Policy</a>."
+msgstr "Taip pat žiūrėkite <a class=\"twl-links\" href=\"https://wikimediafoundation.org/wiki/Privacy_policy\">Vikimedijos fondo privatumo politiką</a>."
 
 #. Translators: This is the second to last line of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:412
@@ -3843,16 +2866,8 @@ msgstr "Vikimedijos fondas"
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:426
-msgid ""
-"By checking this box and clicking “Submit”, you agree that you have read the "
-"above terms and that you will adhere to the terms of use in your application "
-"to and use of the The Wikipedia Library, and the publishers’ services to "
-"which you gain access through The Wikipedia Library program."
-msgstr ""
-"Pažymėdami šį laukelį ir spustelėdami „Siųsti“, sutinkate, kad perskaitėte "
-"aukščiau pateiktas sąlygas ir kad laikysitės naudojimo sąlygų, pateiktų savo "
-"paraiškoje ir naudodamiesi Vikipedijos biblioteka bei leidėjų paslaugomis, "
-"kurias gaunate per Vikipedijos bibliotekos programą."
+msgid "By checking this box and clicking “Submit”, you agree that you have read the above terms and that you will adhere to the terms of use in your application to and use of the The Wikipedia Library, and the publishers’ services to which you gain access through The Wikipedia Library program."
+msgstr "Pažymėdami šį laukelį ir spustelėdami „Siųsti“, sutinkate, kad perskaitėte aukščiau pateiktas sąlygas ir kad laikysitės naudojimo sąlygų, pateiktų savo paraiškoje ir naudodamiesi Vikipedijos biblioteka bei leidėjų paslaugomis, kurias gaunate per Vikipedijos bibliotekos programą."
 
 #: TWLight/users/templates/users/user_collection_tile.html:32
 msgid "Remove this collection from favorites"
@@ -3904,40 +2919,19 @@ msgstr "Ištrinti visus duomenis"
 
 #. Translators: This message is displayed on the page where users can request the deletion of their data.
 #: TWLight/users/templates/users/user_confirm_delete.html:17
-msgid ""
-"<b>Warning:</b> Performing this action will delete your Wikipedia Library "
-"Card user account and all associated applications. This process is not "
-"reversible. You may lose any partner accounts you were granted, and will not "
-"be able to renew those accounts or apply for new ones."
-msgstr ""
-"<b>Įspėjimas:</b> atlikus šį veiksmą bus ištrinta jūsų Vikipedijos "
-"bibliotekos kortelės naudotojo paskyra ir visos susijusios paraiškos. Šis "
-"procesas negrįžtamas. Galite prarasti visas jums suteiktas partnerių "
-"paskyras ir negalėsite tų paskyrų atnaujinti ar prašyti naujų."
+msgid "<b>Warning:</b> Performing this action will delete your Wikipedia Library Card user account and all associated applications. This process is not reversible. You may lose any partner accounts you were granted, and will not be able to renew those accounts or apply for new ones."
+msgstr "<b>Įspėjimas:</b> atlikus šį veiksmą bus ištrinta jūsų Vikipedijos bibliotekos kortelės naudotojo paskyra ir visos susijusios paraiškos. Šis procesas negrįžtamas. Galite prarasti visas jums suteiktas partnerių paskyras ir negalėsite tų paskyrų atnaujinti ar prašyti naujų."
 
 #. Translators: this should show up for people who log in with a username/password and not OAuth, so we don't know what their Wikipedia identity is.
-#.
 #: TWLight/users/templates/users/user_detail.html:12
 #, python-format
-msgid ""
-"Hi, %(username)s! You don't have a Wikipedia editor profile attached to your "
-"account here, so you are probably a site administrator."
-msgstr ""
-"Sveiki, %(username)s! Čia prie paskyros nėra prijungtas jūsų Vikipedijos "
-"redaktoriaus profilis, todėl tikriausiai esate svetainės administratorius."
+msgid "Hi, %(username)s! You don't have a Wikipedia editor profile attached to your account here, so you are probably a site administrator."
+msgstr "Sveiki, %(username)s! Čia prie paskyros nėra prijungtas jūsų Vikipedijos redaktoriaus profilis, todėl tikriausiai esate svetainės administratorius."
 
 #. Translators: In the unlikely scenario that someone is able to register an account without using OAuth (thus leaving us without some of the information required for applications), users will see this message, encouraging them to re-register.
 #: TWLight/users/templates/users/user_detail.html:20
-msgid ""
-"If you aren't a site administrator, something weird has happened. You won't "
-"be able to apply for access without a Wikipedia editor profile. You should "
-"log out and create a new account by logging in via OAuth, or contact a site "
-"administrator for help."
-msgstr ""
-"Jei nesate svetainės administratorius, nutiko kažkas keisto. Negalėsite "
-"pateikti paraiškos dėl prieigos be Vikipedijos redaktoriaus profilio. "
-"Turėtumėte atsijungti ir susikurti naują paskyrą prisijungiant per „OAuth“ "
-"arba kreiptis pagalbos į svetainės administratorių."
+msgid "If you aren't a site administrator, something weird has happened. You won't be able to apply for access without a Wikipedia editor profile. You should log out and create a new account by logging in via OAuth, or contact a site administrator for help."
+msgstr "Jei nesate svetainės administratorius, nutiko kažkas keisto. Negalėsite pateikti paraiškos dėl prieigos be Vikipedijos redaktoriaus profilio. Turėtumėte atsijungti ir susikurti naują paskyrą prisijungiant per „OAuth“ arba kreiptis pagalbos į svetainės administratorių."
 
 #. Translators: Labels a sections where coordinators can select their email preferences.
 #: TWLight/users/templates/users/user_email_preferences.html:15
@@ -3947,23 +2941,13 @@ msgstr "Tik koordinatoriai"
 #. Translators: This message is shown on user's own profile page, encouraging them to make sure their information is up to date, so that account coordinators can use the information to judge applications.
 #: TWLight/users/views.py:176
 #, python-brace-format
-msgid ""
-"Please <a class='twl-links' href='{url}'>update your contributions</a> to "
-"Wikipedia to help coordinators evaluate your applications."
-msgstr ""
-"<a class='twl-links' href='{url}'>Atnaujinkite savo indėlį</a> į Vikipediją, "
-"kad padėtumėte koordinatoriams įvertinti jūsų paraiškas."
+msgid "Please <a class='twl-links' href='{url}'>update your contributions</a> to Wikipedia to help coordinators evaluate your applications."
+msgstr "<a class='twl-links' href='{url}'>Atnaujinkite savo indėlį</a> į Vikipediją, kad padėtumėte koordinatoriams įvertinti jūsų paraiškas."
 
 #. Translators: Coordinators are shown this message when they unselect all three types of reminder email options under preferences.
 #: TWLight/users/views.py:288
-msgid ""
-"You have chosen not to receive reminder emails. As a coordinator, you should "
-"receive at least one type of reminder emails, so consider changing your "
-"preferences."
-msgstr ""
-"Pasirinkote negauti priminimų el. laiškų. Kaip koordinatorius turėtumėte "
-"gauti bent vieno tipo priminimo el. laiškus, todėl apsvarstykite galimybę "
-"pakeisti savo nuostatas."
+msgid "You have chosen not to receive reminder emails. As a coordinator, you should receive at least one type of reminder emails, so consider changing your preferences."
+msgstr "Pasirinkote negauti priminimų el. laiškų. Kaip koordinatorius turėtumėte gauti bent vieno tipo priminimo el. laiškus, todėl apsvarstykite galimybę pakeisti savo nuostatas."
 
 #. Translators: Coordinators are shown this message when they make changes to their reminder email options under preferences.
 #: TWLight/users/views.py:296
@@ -3986,9 +2970,7 @@ msgstr "Jūsų informacija buvo atnaujinta."
 #. Translators: If a user tries to save the 'email change form' without entering one and checking the 'use my Wikipedia email address' checkbox, this message is presented.
 #: TWLight/users/views.py:448
 msgid "Both the values cannot be blank. Either enter a email or check the box."
-msgstr ""
-"Abi reikšmės negali būti tuščios. Įveskite el. pašto adresą arba pažymėkite "
-"laukelį."
+msgstr "Abi reikšmės negali būti tuščios. Įveskite el. pašto adresą arba pažymėkite laukelį."
 
 #. Translators: Shown to users when they successfully modify their email. Don't translate {email}.
 #: TWLight/users/views.py:476
@@ -3998,13 +2980,8 @@ msgstr "Jūsų el. paštas pakeistas į {email}."
 
 #. Translators: If the user has not filled out their email, they can browse the website but cannot apply for access to resources.
 #: TWLight/users/views.py:487
-msgid ""
-"Your email is blank. You can still explore the site, but you won't be able "
-"to apply for access to partner resources without an email."
-msgstr ""
-"Jūsų el. pašto adresas yra tuščias. Vis tiek galite naršyti svetainę, bet "
-"negalėsite pateikti paraiškos dėl prieigos prie partnerių išteklių be el. "
-"pašto."
+msgid "Your email is blank. You can still explore the site, but you won't be able to apply for access to partner resources without an email."
+msgstr "Jūsų el. pašto adresas yra tuščias. Vis tiek galite naršyti svetainę, bet negalėsite pateikti paraiškos dėl prieigos prie partnerių išteklių be el. pašto."
 
 #. Translators: This message is shown once the access to a partner has successfully been returned.
 #: TWLight/users/views.py:801
@@ -4037,31 +3014,3 @@ msgstr "Nėra aktyvaus blokavimo"
 msgid "10+ edits in the last 30 days"
 msgstr "10+ pakeitimų per pastarąjį mėnesį"
 
-#: tests/shunit/data/bad_i18n_comment_1.py:3
-#: tests/shunit/data/bad_i18n_newline_1.py:5
-msgid "1"
-msgstr ""
-
-#. Translators: Lorem ipsum dolor sit amet, consectetur adipiscing elit. Mauris vitae ipsum ut purus faucibus pretium. Proin tempus neque et aliquet consectetur. Ut egestas sapien in consectetur sagittis. Mauris neque lacus, dapibus non viverra vitae, interdum ut aenean ipsum.
-#. Translators: Lorem ipsum dolor sit amet, consectetur adipiscing elit. Mauris vitae ipsum ut purus faucibus pretium. Proin tempus neque et aliquet consectetur. Ut egestas sapien in consectetur sagittis. Mauris neque lacus, dapibus non.
-#: tests/shunit/data/bad_i18n_comment_2.py:4
-#: tests/shunit/data/bad_i18n_newline_2.py:5 tests/shunit/data/good_i18n_1.py:2
-#: tests/shunit/data/good_i18n_2.py:2
-msgid "2"
-msgstr ""
-
-#: tests/shunit/data/bad_i18n_newline_3.py:5
-msgid "3"
-msgstr ""
-
-#: tests/shunit/data/bad_i18n_newline_4.py:5
-msgid "4"
-msgstr ""
-
-#: tests/shunit/data/bad_i18n_newline_5.py:5
-msgid "5"
-msgstr ""
-
-#: tests/shunit/data/bad_i18n_newline_6.py:5
-msgid "6"
-msgstr ""

--- a/locale/lv/LC_MESSAGES/django.po
+++ b/locale/lv/LC_MESSAGES/django.po
@@ -5,18 +5,18 @@
 # Author: Peridot Nation
 msgid ""
 msgstr ""
+""
 "Project-Id-Version: Wikipedia Library Card Platform - Website\n"
-"Report-Msgid-Bugs-To: wikipedialibrary@wikimedia.org\n"
+"Report-Msgid-Bugs-To: translatewiki.net\n"
 "POT-Creation-Date: 2024-07-11 20:54+0000\n"
-"PO-Revision-Date: 2024-07-11 12:30:16+0000\n"
+"PO-Revision-Date: 2024-07-15 12:29:17+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
 "Language: lv\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=3; plural=(n%10 == 1 && n%100 != 11) ? 0 : ( (n != "
-"0) ? 1 : 2 );\n"
+"Plural-Forms: nplurals=3; plural=(n%10 == 1 && n%100 != 11) ? 0 : ( (n != 0) ? 1 : 2 );\n"
 "X-POT-Import-Date: 2024-06-25 18:44:08+0000\n"
 "X-Generator: MediaWiki 1.43.0-alpha; Translate 2024-07-16\n"
 "X-Translation-Project: translatewiki.net <https://translatewiki.net>\n"
@@ -44,9 +44,7 @@ msgstr ""
 #. Translators: This note appears in a section of a form where we ask users to enter info (like country of residence) when applying for resource access.
 #: TWLight/applications/forms.py:179
 #, python-brace-format
-msgid ""
-"<p><small><i>Your personal data will be processed according to our <a "
-"class='twl-links' href='{terms_url}'> privacy policy</a>.</i></small></p>"
+msgid "<p><small><i>Your personal data will be processed according to our <a class='twl-links' href='{terms_url}'> privacy policy</a>.</i></small></p>"
 msgstr ""
 
 #. Translators: This is the title of the application form page, where users enter information required for the application. It lets the user know which partner application they are entering data for. {partner}
@@ -88,9 +86,7 @@ msgstr ""
 #. Translators: This labels a choice field where users will have to select the number of months they wish to have their access for as part of the application renewal confirmation.
 #. Translators: When filling out an application, users may be required to enter the length of the account (expiry) they wish to have for proxy partners.
 #: TWLight/applications/forms.py:339 TWLight/applications/helpers.py:100
-msgid ""
-"The number of months you wish to have this access for before renewal is "
-"required"
+msgid "The number of months you wish to have this access for before renewal is required"
 msgstr ""
 
 #. Translators: When filling out an application, users may need to specify their name
@@ -179,9 +175,7 @@ msgstr ""
 
 #. Translators: This comment is added to pending applications when our terms of use change.
 #: TWLight/applications/management/commands/notify_applicants_tou_changes.py:54
-msgid ""
-"Our terms of use have changed. Your applications will not be processed until "
-"you log in and agree to our updated terms."
+msgid "Our terms of use have changed. Your applications will not be processed until you log in and agree to our updated terms."
 msgstr ""
 
 #. Translators: This is the status of an application that has not yet been reviewed.
@@ -248,23 +242,17 @@ msgstr ""
 
 #. Translators: This text goes into account approval emails in the case that we need to send the user's details to a publisher for manual account setup.
 #: TWLight/applications/models.py:331
-msgid ""
-"You can expect to receive access details within a week or two once it has "
-"been processed."
+msgid "You can expect to receive access details within a week or two once it has been processed."
 msgstr ""
 
 #. Translators: This comment is added to open applications when a partner joins the Library Bundle, which does not require applications.
 #: TWLight/applications/signals.py:247
-msgid ""
-"This partner joined the Library Bundle, which does not require applications. "
-"This application will be marked as invalid."
+msgid "This partner joined the Library Bundle, which does not require applications. This application will be marked as invalid."
 msgstr ""
 
 #. Translators: This is shown to users if the application is to a partner for which we have run out of available accounts. The application is therefore on a 'waitlist', and will be reviewed when more accounts are available.
 #: TWLight/applications/templates/applications/application_evaluation.html:29
-msgid ""
-"This application is on the waitlist because this partner does not have any "
-"access grants available at this time."
+msgid "This application is on the waitlist because this partner does not have any access grants available at this time."
 msgstr ""
 
 #. Translators: This message is shown on pages where coordinators can see personal information about applicants.
@@ -272,9 +260,7 @@ msgstr ""
 #: TWLight/applications/templates/applications/application_list_include.html:6
 #: TWLight/applications/templates/applications/send_partner.html:45
 #: TWLight/resources/templates/resources/partner_users.html:18
-msgid ""
-"Coordinators: This page may contain personal information such as real names "
-"and email addresses. Please remember that this information is confidential."
+msgid "Coordinators: This page may contain personal information such as real names and email addresses. Please remember that this information is confidential."
 msgstr ""
 
 #. Translators: This is the title of the application page shown to users who are a coordinator, and are able to accept or reject the application.
@@ -284,9 +270,7 @@ msgstr ""
 
 #. Translators: This text is shown to coordinators on application pages if the applicant has restricted processing of their data.
 #: TWLight/applications/templates/applications/application_evaluation.html:42
-msgid ""
-"This user has requested a restriction on the processing of their data, so "
-"you cannot change the status of their application."
+msgid "This user has requested a restriction on the processing of their data, so you cannot change the status of their application."
 msgstr ""
 
 #. Translators: This is the title of the application page shown to users who are not a coordinator.
@@ -360,9 +344,7 @@ msgstr ""
 
 #. Translators: This is the text displayed to coordinators when an applicant has no country of residence in their profile.
 #: TWLight/applications/templates/applications/application_evaluation.html:123
-msgid ""
-"Please request the applicant add their country of residence to their profile "
-"before proceeding further."
+msgid "Please request the applicant add their country of residence to their profile before proceeding further."
 msgstr ""
 
 #. Translators: This labels the section of an application showing the total number of accounts available for a partner or their collection.
@@ -373,9 +355,7 @@ msgstr "Pieejamie konti"
 #. Translators: This labels the section of an application showing whether the user had agreed to the terms of use or not.
 #: TWLight/applications/templates/applications/application_evaluation.html:145
 #, python-format
-msgid ""
-"Has agreed to the site's <a class=\"twl-links\" href=\"%(terms_url)s\">terms "
-"of use</a>?"
+msgid "Has agreed to the site's <a class=\"twl-links\" href=\"%(terms_url)s\">terms of use</a>?"
 msgstr ""
 
 #. Translators: Displayed to coordinators when they've agreed to the terms of use.
@@ -411,9 +391,7 @@ msgstr ""
 
 #. Translators: This is the text displayed to coordinators when an applicant has not agreed to the terms of use.
 #: TWLight/applications/templates/applications/application_evaluation.html:159
-msgid ""
-"Please request the applicant agree to the site's terms of use before "
-"approving this application."
+msgid "Please request the applicant agree to the site's terms of use before approving this application."
 msgstr ""
 
 #. Translators: This labels the section of an application containing the user's motivation for wanting access to this resource.
@@ -434,8 +412,7 @@ msgstr ""
 #. Translators: This message is shown next to the 'Renewal of existing access grant?' label if the application is a renewal. Don't translate HTML tags or parent_url.
 #: TWLight/applications/templates/applications/application_evaluation.html:195
 #, python-format
-msgid ""
-"Yes (<a class=\"twl-links\" href=\"%(parent_url)s\">previous application</a>)"
+msgid "Yes (<a class=\"twl-links\" href=\"%(parent_url)s\">previous application</a>)"
 msgstr ""
 
 #. Translators: This labels the section of the application showing the length of access remaining on the user's previous authorization.
@@ -470,9 +447,7 @@ msgstr ""
 
 #. Translators: On an application page, this text tells users that the comments posted on the application are visible to coordinators and the submitting user only.
 #: TWLight/applications/templates/applications/application_evaluation.html:297
-msgid ""
-"Comments are visible to all coordinators and to the editor who submitted "
-"this application."
+msgid "Comments are visible to all coordinators and to the editor who submitted this application."
 msgstr ""
 
 #. Translators: This is the title of the section of an application page which lists information about the user who submitted the application.
@@ -684,12 +659,7 @@ msgstr ""
 
 #: TWLight/applications/templates/applications/apply.html:20
 #, python-format
-msgid ""
-"If your application is successful we may share your email address with "
-"%(partner)s. This is required to set up your access to their resources. By "
-"submitting this form you agree to allow your email address to be shared with "
-"%(partner)s if your application is successful, for the purposes of account "
-"setup."
+msgid "If your application is successful we may share your email address with %(partner)s. This is required to set up your access to their resources. By submitting this form you agree to allow your email address to be shared with %(partner)s if your application is successful, for the purposes of account setup."
 msgstr ""
 
 #. Translators: This message is displayed on the page where users can confirm their renewal. Please do not translate partner.
@@ -718,9 +688,7 @@ msgstr ""
 
 #. Translators: This text explains that Library Bundle partners are not shown in this list.
 #: TWLight/applications/templates/applications/request_for_application.html:26
-msgid ""
-"Library Bundle partners are not shown as eligibility is determined "
-"automatically."
+msgid "Library Bundle partners are not shown as eligibility is determined automatically."
 msgstr ""
 
 #. Translators: On the page where users can apply for multiple partners, this message shows next to the partner name, taking them to the full application page when clicked.
@@ -735,10 +703,7 @@ msgstr ""
 
 #. Translators: the HTML is so that the word 'waitlisted' will look the same as it does in the page above; please translate 'waitlisted' the same way you did elsewhere in this file.
 #: TWLight/applications/templates/applications/request_for_application.html:74
-msgid ""
-"You can apply to <span class=\"badge badge-warning\">Waitlisted</span> "
-"partners, but they don't have access grants available right now. We will "
-"process those applications when access becomes available."
+msgid "You can apply to <span class=\"badge badge-warning\">Waitlisted</span> partners, but they don't have access grants available right now. We will process those applications when access becomes available."
 msgstr ""
 
 #. Translators: On the page where coordinators can see approved applications which have not had their details sent to the partner, this message shows when there are applications ready to be processed.
@@ -760,9 +725,7 @@ msgstr ""
 #. Translators: This message is shown when applications exceed the number of accounts available.
 #: TWLight/applications/templates/applications/send_partner.html:54
 #, python-format
-msgid ""
-"Application(s) for %(object)s, if sent, will exceed the total available "
-"accounts for the partner. Please proceed at your own discretion."
+msgid "Application(s) for %(object)s, if sent, will exceed the total available accounts for the partner. Please proceed at your own discretion."
 msgstr ""
 
 #. Translators: When viewing the list of applications ready to be sent for a particular partner, this is instructions for the coordinator to click the 'mark as sent' button after they have sent the information.
@@ -780,9 +743,7 @@ msgstr[2] ""
 
 #. Translators: When viewing the list of applications ready to be sent for a particular partner, this message shows if there is no information about who the applications should be sent to. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/applications/templates/applications/send_partner.html:89
-msgid ""
-"Whoops, we don't have any listed contacts. Please notify Wikipedia Library "
-"administrators."
+msgid "Whoops, we don't have any listed contacts. Please notify Wikipedia Library administrators."
 msgstr ""
 
 #. Translators: When viewing the list of applications ready to be sent for a particular partner, this is the title of the section containing the information about those applications.
@@ -798,9 +759,7 @@ msgstr ""
 
 #. Translators: This text guides coordinators in using the code sending interface for approved applications.
 #: TWLight/applications/templates/applications/send_partner.html:152
-msgid ""
-"Use the dropdown menus to denote which editor will receive each code. Access "
-"codes will be sent to users automatically."
+msgid "Use the dropdown menus to denote which editor will receive each code. Access codes will be sent to users automatically."
 msgstr ""
 
 #. Translators: This labels a drop-down selection where staff can assign an access code to a user.
@@ -816,18 +775,13 @@ msgstr ""
 #. Translators: When a user applies for a set of resources, they receive this message if none are currently available. They are instead placed on a 'waitlist' for later approval.
 #. Translators: When a user renews their resource, they receive this message if none are currently available. They are instead placed on a 'waitlist' for later approval.
 #: TWLight/applications/views.py:140 TWLight/applications/views.py:1282
-msgid ""
-"This partner does not have any access grants available at this time. You may "
-"still apply for access; your application will be reviewed when access grants "
-"become available."
+msgid "This partner does not have any access grants available at this time. You may still apply for access; your application will be reviewed when access grants become available."
 msgstr ""
 
 #. Translators: This message is shown to users once they've successfully submitted their application for review.
 #: TWLight/applications/views.py:163
 #, python-brace-format
-msgid ""
-"Your application has been submitted for review. Head over to <a "
-"href='{applications_url}'>My Applications</a> to view the status."
+msgid "Your application has been submitted for review. Head over to <a href='{applications_url}'>My Applications</a> to view the status."
 msgstr ""
 
 #. Translators: This text is displayed to users when the user has chosen to restrict data and is trying to apply for multiple partners
@@ -876,16 +830,12 @@ msgstr ""
 
 #. Translators: After a coordinator has changed the status of an application to APPROVED, if the corresponding partner/collection is waitlisted this message appears.
 #: TWLight/applications/views.py:756
-msgid ""
-"Cannot approve application as partner with proxy authorization method is "
-"waitlisted."
+msgid "Cannot approve application as partner with proxy authorization method is waitlisted."
 msgstr ""
 
 #. Translators: After a coordinator has changed the status of an application to APPROVED, if the corresponding partner/collection has no accounts for distribution, this message appears.
 #: TWLight/applications/views.py:780
-msgid ""
-"Cannot approve application as partner with proxy authorization method is "
-"waitlisted and (or) has zero accounts available for distribution."
+msgid "Cannot approve application as partner with proxy authorization method is waitlisted and (or) has zero accounts available for distribution."
 msgstr ""
 
 #. Translators: This message appears on an "access denied" screen that stops users who attempt to authorize an editor to access a resource during a time period for which they are already authorized.
@@ -896,11 +846,7 @@ msgstr ""
 #. Translators: This message is shown to users when they access an application page of a now Bundle partner (new applications aren't allowed for Bundle partners and the status of old applications cannot be modified)
 #: TWLight/applications/views.py:857
 #, python-brace-format
-msgid ""
-"This application cannot be modified since this partner is now part of our <a "
-"href='{bundle}'>bundle access</a>. If you are eligible, you can access this "
-"resource from <a href='{library}'>your library</a>. <a "
-"href='{contact}'>Contact us</a> if you have any questions."
+msgid "This application cannot be modified since this partner is now part of our <a href='{bundle}'>bundle access</a>. If you are eligible, you can access this resource from <a href='{library}'>your library</a>. <a href='{contact}'>Contact us</a> if you have any questions."
 msgstr ""
 
 #. Translators: this lets a reviewer set the status of a single application.
@@ -910,9 +856,7 @@ msgstr ""
 
 #. Translators: This warning is message is shown to applicants when the number of pending applications is greater than the number of accounts available.
 #: TWLight/applications/views.py:891
-msgid ""
-"There are more pending applications than available accounts. Your "
-"application might get waitlisted."
+msgid "There are more pending applications than available accounts. Your application might get waitlisted."
 msgstr ""
 
 #. Translators: this message is shown to coordinators who attempt to change an application's Status from INVALID to any other Status.
@@ -932,11 +876,7 @@ msgstr ""
 
 #. Translators: After a coordinator has changed the status of a number of applications to APPROVED, if the corresponding partner(s) is/are waitlisted or has no accounts for distribution, this message appears.
 #: TWLight/applications/views.py:1051
-msgid ""
-"Cannot approve application(s) {} as partner(s) with proxy authorization "
-"method is/are waitlisted and (or) has/have not enough accounts available. If "
-"not enough accounts are available, prioritise the applications and then "
-"approve applications equal to the accounts available."
+msgid "Cannot approve application(s) {} as partner(s) with proxy authorization method is/are waitlisted and (or) has/have not enough accounts available. If not enough accounts are available, prioritise the applications and then approve applications equal to the accounts available."
 msgstr ""
 
 #. Translators: This message is shown to coordinators who attempt to assign the same access code to multiple users.
@@ -951,9 +891,7 @@ msgstr ""
 
 #. Translators: When a user tries to renew their resource, they receive this message if the partner is not available.
 #: TWLight/applications/views.py:1272
-msgid ""
-"Cannot renew application at this time as partner is not available. Please "
-"check back later, or contact us for more information."
+msgid "Cannot renew application at this time as partner is not available. Please check back later, or contact us for more information."
 msgstr ""
 
 #. Translators: This message is displayed when an attempt by a user to renew an application has been denied for some reason.
@@ -964,16 +902,12 @@ msgstr ""
 
 #. Translators: If a user requests the renewal of their account, but it wasn't renewed, this message is shown to them.
 #: TWLight/applications/views.py:1385
-msgid ""
-"This object cannot be renewed. (This probably means that you have already "
-"requested that it be renewed.)"
+msgid "This object cannot be renewed. (This probably means that you have already requested that it be renewed.)"
 msgstr ""
 
 #. Translators: If a user requests the renewal of their account, this message is shown to them.
 #: TWLight/applications/views.py:1395
-msgid ""
-"Your renewal request has been received. A coordinator will review your "
-"request."
+msgid "Your renewal request has been received. A coordinator will review your request."
 msgstr ""
 
 #. Translators: This labels a textfield where users can enter their email ID.
@@ -983,9 +917,7 @@ msgstr ""
 
 #. Translators: This is the help text for the email field in the contact us form letting users know the field is updated by value pulled from their respective user profiles.
 #: TWLight/emails/forms.py:21
-msgid ""
-"This field is automatically updated with the email from your <a class='twl-"
-"links' href='{}'>user profile</a>."
+msgid "This field is automatically updated with the email from your <a class='twl-links' href='{}'>user profile</a>."
 msgstr ""
 
 #. Translators: This labels a textfield where users can enter their email message.
@@ -1009,19 +941,13 @@ msgstr "Iesniegt"
 #. Translators: This email is sent to users with their access code. Don't translate Jinja variables in curly braces like user or partner. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/access_code_email-body-html.html:5
 #, python-format
-msgid ""
-"<p>Your approved application to %(partner)s has now been finalised. Your "
-"access code or login details can be found below:</p> <p><b>%(access_code)s</"
-"b></p> <p>%(user_instructions)s</p>"
+msgid "<p>Your approved application to %(partner)s has now been finalised. Your access code or login details can be found below:</p> <p><b>%(access_code)s</b></p> <p>%(user_instructions)s</p>"
 msgstr ""
 
 #. Translators: This email is sent to users with their access code. Don't translate Jinja variables in curly braces like user or partner. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/access_code_email-body-text.html:3
 #, python-format
-msgid ""
-"Your approved application to %(partner)s has now been finalised. Your access "
-"code or login details can be found below: %(access_code)s "
-"%(user_instructions)s"
+msgid "Your approved application to %(partner)s has now been finalised. Your access code or login details can be found below: %(access_code)s %(user_instructions)s"
 msgstr ""
 
 #. Translators: This is the subject line of an email sent to users with their access code.
@@ -1032,23 +958,13 @@ msgstr ""
 #. Translators: This email is sent to users when their application is approved. Don't translate Jinja variables in curly braces like user or partner; don't translate html tags either. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/approval_notification-body-html.html:5
 #, python-format
-msgid ""
-"<p>Dear %(user)s,</p> <p>Thank you for applying for access to %(partner)s "
-"resources through The Wikipedia Library. We are happy to inform you that "
-"your application has been approved.</p> <p>%(user_instructions)s</p> <p>You "
-"can view the collections you're authorized to access at My Library: "
-"%(link)s</p> <p>Cheers!</p> <p>The Wikipedia Library</p>"
+msgid "<p>Dear %(user)s,</p> <p>Thank you for applying for access to %(partner)s resources through The Wikipedia Library. We are happy to inform you that your application has been approved.</p> <p>%(user_instructions)s</p> <p>You can view the collections you're authorized to access at My Library: %(link)s</p> <p>Cheers!</p> <p>The Wikipedia Library</p>"
 msgstr ""
 
 #. Translators: This email is sent to users when their application is approved. Don't translate Jinja variables in curly braces like user or partner. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/approval_notification-body-text.html:3
 #, python-format
-msgid ""
-"Dear %(user)s, Thank you for applying for access to %(partner)s resources "
-"through The Wikipedia Library. We are happy to inform you that your "
-"application has been approved. %(user_instructions)s You can view the "
-"collections you're authorized to access at My Library: %(link)s Cheers! The "
-"Wikipedia Library"
+msgid "Dear %(user)s, Thank you for applying for access to %(partner)s resources through The Wikipedia Library. We are happy to inform you that your application has been approved. %(user_instructions)s You can view the collections you're authorized to access at My Library: %(link)s Cheers! The Wikipedia Library"
 msgstr ""
 
 #. Translators: This is the subject of an email which is sent to users when their application has been approved. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
@@ -1059,19 +975,13 @@ msgstr ""
 #. Translators: This email is sent to coordinators when a comment is left on an application they are processing. Don't translate Jinja variables in curly braces like user or partner. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/comment_notification_coordinator-body-html.html:5
 #, python-format
-msgid ""
-"<p style=\"color: #500050\">%(submit_date)s - %(commenter)s</p> "
-"<blockquote><p>%(comment)s</p></blockquote> <p>Please reply to these at: <a "
-"href=\"%(app_url)s\">%(app_url)s</a></p> <p>Best,</p> <p>The Wikipedia "
-"Library</p>"
+msgid "<p style=\"color: #500050\">%(submit_date)s - %(commenter)s</p> <blockquote><p>%(comment)s</p></blockquote> <p>Please reply to these at: <a href=\"%(app_url)s\">%(app_url)s</a></p> <p>Best,</p> <p>The Wikipedia Library</p>"
 msgstr ""
 
 #. Translators: This email is sent to coordinators when a comment is left on an application they are processing. Don't translate Jinja variables in curly braces like user or partner. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/comment_notification_coordinator-body-text.html:3
 #, python-format
-msgid ""
-"%(submit_date)s - %(commenter)s %(comment)s Please reply to this at: "
-"%(app_url)s Best, The Wikipedia Library"
+msgid "%(submit_date)s - %(commenter)s %(comment)s Please reply to this at: %(app_url)s Best, The Wikipedia Library"
 msgstr ""
 
 #. Translators: This is the subject line of an email sent to coordinators when a comment is left on an application they processed.
@@ -1082,19 +992,13 @@ msgstr ""
 #. Translators: This email is sent to users when they receive a comment on their application. Don't translate Jinja variables in curly braces like user or partner; don't translate html tags either. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/comment_notification_editors-body-html.html:5
 #, python-format
-msgid ""
-"<p style=\"color: #500050\">%(submit_date)s - %(commenter)s</p> "
-"<blockquote><p>%(comment)s</p></blockquote> <p>Please reply to these at <a "
-"href=\"%(app_url)s\">%(app_url)s</a> so we can evaluate your application.</"
-"p> <p>Best,</p> <p>The Wikipedia Library</p>"
+msgid "<p style=\"color: #500050\">%(submit_date)s - %(commenter)s</p> <blockquote><p>%(comment)s</p></blockquote> <p>Please reply to these at <a href=\"%(app_url)s\">%(app_url)s</a> so we can evaluate your application.</p> <p>Best,</p> <p>The Wikipedia Library</p>"
 msgstr ""
 
 #. Translators: This email is sent to users when they receive a comment on their application. Don't translate Jinja variables in curly braces like user or partner. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/comment_notification_editors-body-text.html:3
 #, python-format
-msgid ""
-"%(submit_date)s - %(commenter)s %(comment)s Please reply to these at: "
-"%(app_url)s so we can evaluate your application. Best, The Wikipedia Library"
+msgid "%(submit_date)s - %(commenter)s %(comment)s Please reply to these at: %(app_url)s so we can evaluate your application. Best, The Wikipedia Library"
 msgstr ""
 
 #. Translators: This is the subject line of an email sent to users who have a comment added to one of their applications. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
@@ -1105,18 +1009,13 @@ msgstr ""
 #. Translators: This email is sent to users when an application they commented on receives another comment. Don't translate Jinja variables in curly braces like app_url; don't translate html tags either. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/comment_notification_others-body-html.html:5
 #, python-format
-msgid ""
-"<p style=\"color: #500050\">%(submit_date)s - %(commenter)s</p> "
-"<blockquote><p>%(comment)s</p></blockquote> See it at <a href=\"%(app_url)s"
-"\">%(app_url)s</a>. Thanks for helping review Wikipedia Library applications!"
+msgid "<p style=\"color: #500050\">%(submit_date)s - %(commenter)s</p> <blockquote><p>%(comment)s</p></blockquote> See it at <a href=\"%(app_url)s\">%(app_url)s</a>. Thanks for helping review Wikipedia Library applications!"
 msgstr ""
 
 #. Translators: This email is sent to users when an application they commented on receives another comment. Don't translate Jinja variables in curly braces like app_url. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/comment_notification_others-body-text.html:3
 #, python-format
-msgid ""
-"%(submit_date)s - %(commenter)s %(comment)s See it at: %(app_url)s Thanks "
-"for helping review Wikipedia Library applications!"
+msgid "%(submit_date)s - %(commenter)s %(comment)s See it at: %(app_url)s Thanks for helping review Wikipedia Library applications!"
 msgstr ""
 
 #. Translators: This is the subject line of an email sent to users who have a comment added to an application they also commented on. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
@@ -1127,10 +1026,7 @@ msgstr ""
 #. Translators: This text is part of a scheduled reminder email sent to coordinators who have applications requiring action. Don't translate Jinja variables in curly braces like total_apps, or user.
 #: TWLight/emails/templates/emails/coordinator_reminder_notification-body-html.html:5
 #, python-format
-msgid ""
-"<p>Dear %(user)s,</p> <p>Our records indicate that you are the designated "
-"coordinator for partners that have a total of %(total_apps)s applications.</"
-"p>"
+msgid "<p>Dear %(user)s,</p> <p>Our records indicate that you are the designated coordinator for partners that have a total of %(total_apps)s applications.</p>"
 msgstr ""
 
 #. Translators: Breakdown as in 'cost breakdown'; analysis.
@@ -1172,31 +1068,19 @@ msgstr[2] ""
 #. Translators: This text is part of a scheduled reminder email sent to coordinators who have applications requiring action. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library). Don't translate Jinja variables in curly braces like link; don't translate email addresses or html tags either.
 #: TWLight/emails/templates/emails/coordinator_reminder_notification-body-html.html:39
 #, python-format
-msgid ""
-"<p>This is a gentle reminder that you may review applications at <a href="
-"\"%(link)s\">%(link)s</a>.</p> <p>You can customise your reminders under "
-"'preferences' in your user profile.</p> <p>If you received this message in "
-"error, drop us a line at wikipedialibrary@wikimedia.org.</p> <p>Thanks for "
-"helping review Wikipedia Library applications!</p>"
+msgid "<p>This is a gentle reminder that you may review applications at <a href=\"%(link)s\">%(link)s</a>.</p> <p>You can customise your reminders under 'preferences' in your user profile.</p> <p>If you received this message in error, drop us a line at wikipedialibrary@wikimedia.org.</p> <p>Thanks for helping review Wikipedia Library applications!</p>"
 msgstr ""
 
 #. Translators: This text is part of a scheduled reminder email sent to coordinators who have applications requiring action. Don't translate Jinja variables in curly braces like total_apps, or user.
 #: TWLight/emails/templates/emails/coordinator_reminder_notification-body-text.html:3
 #, python-format
-msgid ""
-"Dear %(user)s, Our records indicate that you are the designated coordinator "
-"for partners that have a total of %(total_apps)s applications."
+msgid "Dear %(user)s, Our records indicate that you are the designated coordinator for partners that have a total of %(total_apps)s applications."
 msgstr ""
 
 #. Translators: This text is part of a scheduled reminder email sent to coordinators who have applications requiring action. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library). Don't translate Jinja variables in curly braces like link; don't translate the email address either.
 #: TWLight/emails/templates/emails/coordinator_reminder_notification-body-text.html:38
 #, python-format
-msgid ""
-"This is a gentle reminder that you may review applications at: %(link)s. You "
-"can customise your reminders under 'preferences' in your user profile. If "
-"you received this message in error, drop us a line at: "
-"wikipedialibrary@wikimedia.org Thanks for helping review Wikipedia Library "
-"applications!"
+msgid "This is a gentle reminder that you may review applications at: %(link)s. You can customise your reminders under 'preferences' in your user profile. If you received this message in error, drop us a line at: wikipedialibrary@wikimedia.org Thanks for helping review Wikipedia Library applications!"
 msgstr ""
 
 #. Translators: This is the subject line of a scheduled reminder email sent to coordinators who have applications to review. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library). Do not translate items in curly braces.
@@ -1207,22 +1091,13 @@ msgstr ""
 #. Translators: This email is sent to users when their application is rejected. Don't translate Jinja variables in curly braces like user or partner; don't translate html tags either. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/rejection_notification-body-html.html:5
 #, python-format
-msgid ""
-"<p>Dear %(user)s,</p> <p>Thank you for applying for access to %(partner)s "
-"resources through The Wikipedia Library. Unfortunately at this time your "
-"application has not been approved. You can view your application and review "
-"comments at <a href=\"%(app_url)s\">%(app_url)s</a>.</p> <p>Best,</p> <p>The "
-"Wikipedia Library</p>"
+msgid "<p>Dear %(user)s,</p> <p>Thank you for applying for access to %(partner)s resources through The Wikipedia Library. Unfortunately at this time your application has not been approved. You can view your application and review comments at <a href=\"%(app_url)s\">%(app_url)s</a>.</p> <p>Best,</p> <p>The Wikipedia Library</p>"
 msgstr ""
 
 #. Translators: This email is sent to users when their application is rejected. Don't translate Jinja variables in curly braces like user or partner. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/rejection_notification-body-text.html:3
 #, python-format
-msgid ""
-"Dear %(user)s, Thank you for applying for access to %(partner)s resources "
-"through The Wikipedia Library. Unfortunately at this time your application "
-"has not been approved. You can view your application and review comments at: "
-"%(app_url)s Best, The Wikipedia Library"
+msgid "Dear %(user)s, Thank you for applying for access to %(partner)s resources through The Wikipedia Library. Unfortunately at this time your application has not been approved. You can view your application and review comments at: %(app_url)s Best, The Wikipedia Library"
 msgstr ""
 
 #. Translators: This is the subject of an email which is sent to users when their application has been rejected. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
@@ -1233,25 +1108,13 @@ msgstr ""
 #. Translators: This email is sent to users when they have an account that is soon to expire. Don't translate Jinja variables in curly braces like partner_name or partner_link; don't translate html tags either. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/user_renewal_notice-body-html.html:5
 #, python-format
-msgid ""
-"<p>Dear %(user)s,</p> <p>According to our records, your access to "
-"%(partner_name)s will soon expire and you may lose access. If you want to "
-"continue making use of your free account, you can request renewal of your "
-"account by clicking the 'Renew' or 'Extend' button at %(partner_link)s.</p> "
-"<p>Best,</p> <p>The Wikipedia Library</p> <p>You can disable these emails in "
-"your user page preferences: https://wikipedialibrary.wmflabs.org/users/</p>"
+msgid "<p>Dear %(user)s,</p> <p>According to our records, your access to %(partner_name)s will soon expire and you may lose access. If you want to continue making use of your free account, you can request renewal of your account by clicking the 'Renew' or 'Extend' button at %(partner_link)s.</p> <p>Best,</p> <p>The Wikipedia Library</p> <p>You can disable these emails in your user page preferences: https://wikipedialibrary.wmflabs.org/users/</p>"
 msgstr ""
 
 #. Translators: This email is sent to users when they have an account that is soon to expire. Don't translate Jinja variables in curly braces like partner_name or partner_link; don't translate html tags either. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/user_renewal_notice-body-text.html:3
 #, python-format
-msgid ""
-"Dear %(user)s, According to our records, your access to %(partner_name)s "
-"will soon expire and you may lose access. If you want to continue making use "
-"of your free account, you can request renewal of your account by clicking "
-"the Renew button at %(partner_link)s. Best, The Wikipedia Library You can "
-"disable these emails in your user page preferences: https://wikipedialibrary."
-"wmflabs.org/users/"
+msgid "Dear %(user)s, According to our records, your access to %(partner_name)s will soon expire and you may lose access. If you want to continue making use of your free account, you can request renewal of your account by clicking the Renew button at %(partner_link)s. Best, The Wikipedia Library You can disable these emails in your user page preferences: https://wikipedialibrary.wmflabs.org/users/"
 msgstr ""
 
 #. Translators: This is the subject of an email sent to users when they have an account that is soon to expire. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
@@ -1262,24 +1125,13 @@ msgstr ""
 #. Translators: This email is sent to users when their application is waitlisted because there are no more accounts available. Don't translate Jinja variables in curly braces like user or partner; don't translate html tags either. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/waitlist_notification-body-html.html:5
 #, python-format
-msgid ""
-"<p>Dear %(user)s,</p> <p>Thank you for applying for access to %(partner)s "
-"resources through The Wikipedia Library. There are no accounts currently "
-"available so your application has been waitlisted. Your application will be "
-"evaluated if/when more accounts become available. You can see all available "
-"resources at <a href=\"%(link)s\">%(link)s</a>.</p> <p>Best,</p> <p>The "
-"Wikipedia Library</p>"
+msgid "<p>Dear %(user)s,</p> <p>Thank you for applying for access to %(partner)s resources through The Wikipedia Library. There are no accounts currently available so your application has been waitlisted. Your application will be evaluated if/when more accounts become available. You can see all available resources at <a href=\"%(link)s\">%(link)s</a>.</p> <p>Best,</p> <p>The Wikipedia Library</p>"
 msgstr ""
 
 #. Translators: This email is sent to users when their application is waitlisted because there are no more accounts available. Don't translate Jinja variables in curly braces like user or partner. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/waitlist_notification-body-text.html:3
 #, python-format
-msgid ""
-"Dear %(user)s, Thank you for applying for access to %(partner)s resources "
-"through The Wikipedia Library. There are no accounts currently available so "
-"your application has been waitlisted. Your application will be evaluated if/"
-"when more accounts become available. You can see all available resources at: "
-"%(link)s Best, The Wikipedia Library"
+msgid "Dear %(user)s, Thank you for applying for access to %(partner)s resources through The Wikipedia Library. There are no accounts currently available so your application has been waitlisted. Your application will be evaluated if/when more accounts become available. You can see all available resources at: %(link)s Best, The Wikipedia Library"
 msgstr ""
 
 #. Translators: This is the subject of an email sent to users when their application is waitlisted because there are no more accounts available. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
@@ -1444,17 +1296,14 @@ msgstr "Pieejamie konti"
 #: TWLight/resources/templates/resources/filter_section.html:14
 #: TWLight/templates/about.html:12
 #: TWLight/users/templates/users/filter_section.html:13
-msgid ""
-"The Wikipedia Library allows active editors to access a wide range of "
-"collections of paywalled reliable sources for free!"
+msgid "The Wikipedia Library allows active editors to access a wide range of collections of paywalled reliable sources for free!"
 msgstr ""
 
 #. Translators: On the Browse Partners page (https://wikipedialibrary.wmflabs.org/partners/), this introduces users to The Wikipedia Library.
 #. Translators: On the MyLibrary page (https://wikipedialibrary.wmflabs.org/users/my_library), this introduces users to The Wikipedia Library.
 #: TWLight/resources/templates/resources/filter_section.html:17
 #: TWLight/users/templates/users/filter_section.html:15
-msgid ""
-"Start with the search bar at the top or browse publisher websites directly."
+msgid "Start with the search bar at the top or browse publisher websites directly."
 msgstr ""
 
 #. Translators: On the Browse Partners page (https://wikipedialibrary.wmflabs.org/partners/), this appears below introductory text and links to the 'About' page (https://wikipedialibrary.wmflabs.org/about/)
@@ -1529,52 +1378,38 @@ msgstr ""
 #. Translators: If we have no available accounts for a partner, the coordinator can change the application system to a waiting list.
 #: TWLight/resources/templates/resources/partner_detail.html:36
 #: TWLight/resources/templates/resources/partner_detail_apply.html:17
-msgid ""
-"There are no access grants available for this partner at this time. You can "
-"still apply for access; applications will be processed when access is "
-"available."
+msgid "There are no access grants available for this partner at this time. You can still apply for access; applications will be processed when access is available."
 msgstr ""
 
 #. Translators: This text links to the minimum user requirements and terms of use on the partner page.
 #: TWLight/resources/templates/resources/partner_detail.html:48
 #: TWLight/resources/templates/resources/partner_detail_apply.html:29
 #, python-format
-msgid ""
-"Before applying, please review the <strong><a class=\"twl-links\" href="
-"\"%(about)s#req\">minimum requirements</a></strong> for access and our "
-"<strong><a class=\"twl-links\" href=\"%(terms)s\">terms of use</a></strong>."
+msgid "Before applying, please review the <strong><a class=\"twl-links\" href=\"%(about)s#req\">minimum requirements</a></strong> for access and our <strong><a class=\"twl-links\" href=\"%(terms)s\">terms of use</a></strong>."
 msgstr ""
 
 #. Translators: This text refers to the page containing the content a user is authorized to access.
 #: TWLight/resources/templates/resources/partner_detail.html:69
 #, python-format
-msgid ""
-"View the status of your access in <strong><a class=\"twl-links\" href="
-"\"%(library_url)s\">My Library</a></strong> page."
+msgid "View the status of your access in <strong><a class=\"twl-links\" href=\"%(library_url)s\">My Library</a></strong> page."
 msgstr ""
 
 #. Translators: This message is shown when a user has open applications, linking to their respective applications page.
 #: TWLight/resources/templates/resources/partner_detail.html:78
 #, python-format
-msgid ""
-"View the status of your application(s) on your <strong><a class=\"twl-links"
-"\" href=\"%(applications_url)s\">My Applications</a></strong> page."
+msgid "View the status of your application(s) on your <strong><a class=\"twl-links\" href=\"%(applications_url)s\">My Applications</a></strong> page."
 msgstr ""
 
 #. Translators: This message is shown when a user has authorizations, linking to their respective collections page.
 #: TWLight/resources/templates/resources/partner_detail_apply.html:50
 #, python-format
-msgid ""
-"View the status of your access on your <strong><a href=\"%(library_url)s\" "
-"class=\"twl-links\">My Library</a></strong> page."
+msgid "View the status of your access on your <strong><a href=\"%(library_url)s\" class=\"twl-links\">My Library</a></strong> page."
 msgstr ""
 
 #. Translators: This message is shown when a user has open applications, linking to their respective applications page.
 #: TWLight/resources/templates/resources/partner_detail_apply.html:60
 #, python-format
-msgid ""
-"View the status of your application(s) on your <strong><a href="
-"\"%(applications_url)s\">My Applications</a></strong> page."
+msgid "View the status of your application(s) on your <strong><a href=\"%(applications_url)s\">My Applications</a></strong> page."
 msgstr ""
 
 #. Translators: One the partner detail page, this text labels the button which coordinators can click to remove a partner from waitlisted status.
@@ -1604,10 +1439,7 @@ msgstr ""
 
 #. Translators: If no account coordinator is assigned to a partner, the Wikipedia Library team will coordinate signups. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/resources/templates/resources/partner_detail_apply.html:112
-msgid ""
-"The Wikipedia Library team will process this application. Want to help? <a "
-"class=\"twl-links\" href=\"https://en.wikipedia.org/wiki/Wikipedia:"
-"The_Wikipedia_Library/Coordinators/Signup\">Sign up as a coordinator.</a>"
+msgid "The Wikipedia Library team will process this application. Want to help? <a class=\"twl-links\" href=\"https://en.wikipedia.org/wiki/Wikipedia:The_Wikipedia_Library/Coordinators/Signup\">Sign up as a coordinator.</a>"
 msgstr ""
 
 #. Translators: This text labels a button coordinators can click to view a list of users who have applied for access for a particular partner
@@ -1637,18 +1469,13 @@ msgstr ""
 
 #. Translators: Text shown to authenticated, bundle eligible users when they visit a Bundle partner page.
 #: TWLight/resources/templates/resources/partner_detail_apply.html:138
-msgid ""
-"You are eligible to access Library Bundle partners. Click the button above "
-"to access the collection."
+msgid "You are eligible to access Library Bundle partners. Click the button above to access the collection."
 msgstr ""
 
 #. Translators: Text shown to authenticated, bundle ineligible users when they visit a Bundle partner page.
 #: TWLight/resources/templates/resources/partner_detail_apply.html:152
 #, python-format
-msgid ""
-"You are not eligible to access Library Bundle partners. Visit the <a class="
-"\"twl-links\" href=\"%(homepage)s\">homepage</a> to check the eligibility "
-"criteria."
+msgid "You are not eligible to access Library Bundle partners. Visit the <a class=\"twl-links\" href=\"%(homepage)s\">homepage</a> to check the eligibility criteria."
 msgstr ""
 
 #. Translators: Buttton prompting users to log in.
@@ -1660,10 +1487,7 @@ msgstr ""
 #. Translators: Text shown to unauthenticated users when they visit a Bundle partner page.
 #: TWLight/resources/templates/resources/partner_detail_apply.html:168
 #, python-format
-msgid ""
-"This resource is part of our <a class=\"twl-links\" href=\"%(about)s"
-"\">Library Bundle</a>, which you can access if you meet our minimum "
-"eligibility criteria. Log in to find out if you are eligible."
+msgid "This resource is part of our <a class=\"twl-links\" href=\"%(about)s\">Library Bundle</a>, which you can access if you meet our minimum eligibility criteria. Log in to find out if you are eligible."
 msgstr ""
 
 #. Translators: This is the label for a number which shows the total active accounts for one partner. (e.g. https://wikipedialibrary.wmflabs.org/partners/8/).
@@ -1714,26 +1538,19 @@ msgstr ""
 #. Translators: If a partner has specified the excerpt limit both in words and percentage, this message will display the percentage of words and the number of words on the partner page.
 #: TWLight/resources/templates/resources/partner_detail_timeline.html:99
 #, python-format
-msgid ""
-"%(object)s allows a maximum of %(excerpt_limit)s words or "
-"%(excerpt_limit_percentage)s%% of an article be excerpted into a Wikipedia "
-"article."
+msgid "%(object)s allows a maximum of %(excerpt_limit)s words or %(excerpt_limit_percentage)s%% of an article be excerpted into a Wikipedia article."
 msgstr ""
 
 #. Translators: If a partner has specified the excerpt limit in words, this message will display the number of words on the partner page.
 #: TWLight/resources/templates/resources/partner_detail_timeline.html:106
 #, python-format
-msgid ""
-"%(object)s allows a maximum of %(excerpt_limit)s words be excerpted into a "
-"Wikipedia article."
+msgid "%(object)s allows a maximum of %(excerpt_limit)s words be excerpted into a Wikipedia article."
 msgstr ""
 
 #. Translators: If a partner has specified the excerpt limit in percentage, this message will display the percentage of words on the partner page.
 #: TWLight/resources/templates/resources/partner_detail_timeline.html:113
 #, python-format
-msgid ""
-"%(object)s allows a maximum of %(excerpt_limit_percentage)s%% of an article "
-"be excerpted into a Wikipedia article."
+msgid "%(object)s allows a maximum of %(excerpt_limit_percentage)s%% of an article be excerpted into a Wikipedia article."
 msgstr ""
 
 #. Translators: If a partner has other requirements for access, this text shows as the title for that information field. (e.g. https://wikipedialibrary.wmflabs.org/partners/10/).
@@ -1744,9 +1561,7 @@ msgstr ""
 #. Translators: If a user must agree to a Terms of Use document, they see this message, and must enter the name of the resource. Don't translate publisher or url.
 #: TWLight/resources/templates/resources/partner_detail_timeline.html:140
 #, python-format
-msgid ""
-"%(publisher)s requires that you agree with its <a href=\"%(url)s\">terms of "
-"use</a>."
+msgid "%(publisher)s requires that you agree with its <a href=\"%(url)s\">terms of use</a>."
 msgstr ""
 
 #. Translators: If a user must provide their real name to apply to a partner, they see this message, and must enter the name of the resource. Don't translate publisher.
@@ -1770,17 +1585,13 @@ msgstr ""
 #. Translators: If a user must select a specific resource to apply for, they see this message, and must enter the name of the resource. Don't translate publisher.
 #: TWLight/resources/templates/resources/partner_detail_timeline.html:177
 #, python-format
-msgid ""
-"%(publisher)s requires that you specify a particular title that you want to "
-"access."
+msgid "%(publisher)s requires that you specify a particular title that you want to access."
 msgstr ""
 
 #. Translators: If a user must register on the partner website before applying, they see this message. Don't translate partner.
 #: TWLight/resources/templates/resources/partner_detail_timeline.html:187
 #, python-format
-msgid ""
-"%(publisher)s requires that you sign up for an account before applying for "
-"access."
+msgid "%(publisher)s requires that you sign up for an account before applying for access."
 msgstr ""
 
 #. Translators: If a partner has their location listed, this message is a label for that location
@@ -1908,9 +1719,7 @@ msgstr ""
 
 #. Translators: If multiple authorizations where returned for a collection, this message is shown to a user
 #: TWLight/resources/views.py:268
-msgid ""
-"Multiple authorizations were returned – something's wrong. Please contact us "
-"and don't forget to mention this message."
+msgid "Multiple authorizations were returned – something's wrong. Please contact us and don't forget to mention this message."
 msgstr ""
 
 #. Translators: This message is shown when user tries to access a NOT_AVAILABLE Partner
@@ -1951,14 +1760,7 @@ msgstr ""
 #. Translators: Shown on the website's 400 page, when a user sends a bad request. Don't translate path or Phabricator.
 #: TWLight/templates/400.html:20
 #, python-format
-msgid ""
-"If you think we should know what to do with that, please email us about this "
-"error at <a class=\"twl-links\" href=\"mailto:wikipedialibrary@wikimedia.org?"
-"Subject=Wikipedia%%20Library%%20%(path)s%%20Permission%%20denied"
-"\">wikipedialibrary@wikimedia.org</a> or report it to us on <a class=\"twl-"
-"links\" href=\"https://phabricator.wikimedia.org/maniphest/task/edit/form/1/?"
-"projectPHIDs=Library-Card-Platform&title=Wikipedia%%20Library%%20%(path)s"
-"%%20Bad%%20Request\">Phabricator</a>"
+msgid "If you think we should know what to do with that, please email us about this error at <a class=\"twl-links\" href=\"mailto:wikipedialibrary@wikimedia.org?Subject=Wikipedia%%20Library%%20%(path)s%%20Permission%%20denied\">wikipedialibrary@wikimedia.org</a> or report it to us on <a class=\"twl-links\" href=\"https://phabricator.wikimedia.org/maniphest/task/edit/form/1/?projectPHIDs=Library-Card-Platform&title=Wikipedia%%20Library%%20%(path)s%%20Bad%%20Request\">Phabricator</a>"
 msgstr ""
 
 #. Translators: Alt text for an image shown on the 400 error page.
@@ -1980,15 +1782,7 @@ msgstr ""
 #. Translators: Shown on the website's 403 page, when a user attempts to navigate to a page they don't have permission to view. Don't translate path or Phabricator.
 #: TWLight/templates/403.html:20
 #, python-format
-msgid ""
-"If you think your account should be able to do that, please email us about "
-"this error at <a class=\"twl-links\" href=\"mailto:"
-"wikipedialibrary@wikimedia.org?Subject=Wikipedia%%20Library%%20%(path)s"
-"%%20Permission%%20denied\">wikipedialibrary@wikimedia.org</a> or report it "
-"to us on <a class=\"twl-links\" href=\"https://phabricator.wikimedia.org/"
-"maniphest/task/edit/form/1/?projectPHIDs=Library-Card-"
-"Platform&title=Wikipedia%%20Library%%20%(path)s%%20Permission%%20denied"
-"\">Phabricator</a>"
+msgid "If you think your account should be able to do that, please email us about this error at <a class=\"twl-links\" href=\"mailto:wikipedialibrary@wikimedia.org?Subject=Wikipedia%%20Library%%20%(path)s%%20Permission%%20denied\">wikipedialibrary@wikimedia.org</a> or report it to us on <a class=\"twl-links\" href=\"https://phabricator.wikimedia.org/maniphest/task/edit/form/1/?projectPHIDs=Library-Card-Platform&title=Wikipedia%%20Library%%20%(path)s%%20Permission%%20denied\">Phabricator</a>"
 msgstr ""
 
 #. Translators: Shown on the website's 404 page, when a user attempts to navigate to a page that doesn't exist.
@@ -2004,14 +1798,7 @@ msgstr ""
 #. Translators: Shown on the website's 404 page, when a user attempts to navigate to a page that doesn't exist. Don't translate path or Phabricator.
 #: TWLight/templates/404.html:19
 #, python-format
-msgid ""
-"If you are certain that something should be here, please email us about this "
-"error at <a class=\"twl-links\" href=\"mailto:wikipedialibrary@wikimedia.org?"
-"Subject=Wikipedia%%20Library%%20%(path)s%%20Not%%20found\"> "
-"wikipedialibrary@wikimedia.org</a> or report it to us on <a class=\"twl-links"
-"\" href=\"https://phabricator.wikimedia.org/maniphest/task/edit/form/1/?"
-"projectPHIDs=Library-Card-Platform&title=Wikipedia%%20Library%%20%(path)s"
-"%%20Not%%20found\">Phabricator</a>"
+msgid "If you are certain that something should be here, please email us about this error at <a class=\"twl-links\" href=\"mailto:wikipedialibrary@wikimedia.org?Subject=Wikipedia%%20Library%%20%(path)s%%20Not%%20found\"> wikipedialibrary@wikimedia.org</a> or report it to us on <a class=\"twl-links\" href=\"https://phabricator.wikimedia.org/maniphest/task/edit/form/1/?projectPHIDs=Library-Card-Platform&title=Wikipedia%%20Library%%20%(path)s%%20Not%%20found\">Phabricator</a>"
 msgstr ""
 
 #. Translators: Alt text for an image shown on the 404 error page.
@@ -2026,32 +1813,18 @@ msgstr ""
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:20
-msgid ""
-"This platform is our central tool for facilitating access to our available "
-"collections. Here you can see which partnerships are available, search their "
-"contents, and apply for and access the ones you’re interested in."
+msgid "This platform is our central tool for facilitating access to our available collections. Here you can see which partnerships are available, search their contents, and apply for and access the ones you’re interested in."
 msgstr ""
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/). Wikimedia Foundation should not be translated.
 #: TWLight/templates/about.html:29
-msgid ""
-"All users receive immediate access to some collections, which can be browsed "
-"by clicking the 'Access collection' buttons or using the search bar at the "
-"top of the page. Other collections require an application before access is "
-"granted, and may be accessed directly or via an individual login or access "
-"code. Volunteer coordinators, who have signed non-disclosure agreements with "
-"the Wikimedia Foundation, review these applications and work with publishers "
-"to get you your free access."
+msgid "All users receive immediate access to some collections, which can be browsed by clicking the 'Access collection' buttons or using the search bar at the top of the page. Other collections require an application before access is granted, and may be accessed directly or via an individual login or access code. Volunteer coordinators, who have signed non-disclosure agreements with the Wikimedia Foundation, review these applications and work with publishers to get you your free access."
 msgstr ""
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/). Don't translate terms_url.
 #: TWLight/templates/about.html:43
 #, python-format
-msgid ""
-"For more information about how your information is stored and reviewed "
-"please see our <a class=\"twl-links\" href=\"%(terms_url)s\"> terms of use "
-"and privacy policy</a>. Accounts you apply for are also subject to the Terms "
-"of Use provided by each partner’s platform; please review them."
+msgid "For more information about how your information is stored and reviewed please see our <a class=\"twl-links\" href=\"%(terms_url)s\"> terms of use and privacy policy</a>. Accounts you apply for are also subject to the Terms of Use provided by each partner’s platform; please review them."
 msgstr ""
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
@@ -2061,12 +1834,7 @@ msgstr ""
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/). Wikimedia Foundation should not be translated.
 #: TWLight/templates/about.html:55
-msgid ""
-"Any active editor in good standing can receive access. For publishers with "
-"limited numbers of accounts, applications are reviewed based on the editor’s "
-"needs and contributions. If you think you could use access to one of our "
-"partner resources and are an active editor in any project supported by the "
-"Wikimedia Foundation, please apply."
+msgid "Any active editor in good standing can receive access. For publishers with limited numbers of accounts, applications are reviewed based on the editor’s needs and contributions. If you think you could use access to one of our partner resources and are an active editor in any project supported by the Wikimedia Foundation, please apply."
 msgstr ""
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
@@ -2096,23 +1864,12 @@ msgstr ""
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/)
 #: TWLight/templates/about.html:89
-msgid ""
-"If you are applying for an available collection, please first check that you "
-"don't already have access through another library or institution. If you do, "
-"please consider using that access rather than taking up a seat for this "
-"resource in The Wikipedia Library."
+msgid "If you are applying for an available collection, please first check that you don't already have access through another library or institution. If you do, please consider using that access rather than taking up a seat for this resource in The Wikipedia Library."
 msgstr ""
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/)
 #: TWLight/templates/about.html:99
-msgid ""
-"If your account is blocked on one or more Wikimedia projects, you may still "
-"be granted access to The Wikipedia Library. You will need to contact the "
-"Wikipedia Library team, who will review your blocks. If you have been "
-"blocked for content issues, most notably copyright violations, or have "
-"multiple long-term blocks, we may decline your request. Additionally, if "
-"your block status changes after being approved, you will need to request "
-"another review."
+msgid "If your account is blocked on one or more Wikimedia projects, you may still be granted access to The Wikipedia Library. You will need to contact the Wikipedia Library team, who will review your blocks. If you have been blocked for content issues, most notably copyright violations, or have multiple long-term blocks, we may decline your request. Additionally, if your block status changes after being approved, you will need to request another review."
 msgstr ""
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
@@ -2147,9 +1904,7 @@ msgstr ""
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:136
-msgid ""
-"Share their account logins or passwords with others, or sell their access to "
-"other parties"
+msgid "Share their account logins or passwords with others, or sell their access to other parties"
 msgstr ""
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
@@ -2159,23 +1914,17 @@ msgstr ""
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:144
-msgid ""
-"Systematically make printed or electronic copies of multiple extracts of "
-"restricted content available for any purpose"
+msgid "Systematically make printed or electronic copies of multiple extracts of restricted content available for any purpose"
 msgstr ""
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/). Stub is a technical term for a short Wikipedia article, use the appropriate Wikipedia term in your language.
 #: TWLight/templates/about.html:148
-msgid ""
-"Datamine metadata without permission, in order, for instance, to use "
-"metadata for auto-created stub articles"
+msgid "Datamine metadata without permission, in order, for instance, to use metadata for auto-created stub articles"
 msgstr ""
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:154
-msgid ""
-"Respecting these agreements allows us to continue growing the partnerships "
-"available to the community."
+msgid "Respecting these agreements allows us to continue growing the partnerships available to the community."
 msgstr ""
 
 #. Translators: This is the heading for a section on the About page (https://wikipedialibrary.wmflabs.org/about/).
@@ -2185,41 +1934,22 @@ msgstr "EZProxy"
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:164
-msgid ""
-"EZProxy is a proxy server used to authenticate users for many Wikipedia "
-"Library partners. Users sign into EZProxy via the Library Card platform to "
-"verify that they are authorized users, and then the server accesses "
-"requested resources using its own IP address."
+msgid "EZProxy is a proxy server used to authenticate users for many Wikipedia Library partners. Users sign into EZProxy via the Library Card platform to verify that they are authorized users, and then the server accesses requested resources using its own IP address."
 msgstr ""
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:173
-msgid ""
-"You may notice that when accessing resources via EZProxy that URLs are "
-"dynamically rewritten. This is why we recommend logging in via the Library "
-"Card platform rather than going directly to the unproxied partner website. "
-"When in doubt, check the URL for ‘idm.oclc’. If it’s there, then you’re "
-"connected via EZProxy."
+msgid "You may notice that when accessing resources via EZProxy that URLs are dynamically rewritten. This is why we recommend logging in via the Library Card platform rather than going directly to the unproxied partner website. When in doubt, check the URL for ‘idm.oclc’. If it’s there, then you’re connected via EZProxy."
 msgstr ""
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:182
-msgid ""
-"Typically once you’ve logged in your session will remain active in your "
-"browser for up to two hours after you’ve finished searching. Note that use "
-"of EZProxy requires you to enable cookies. If you are having problems you "
-"should also try clearing your cache and restarting your browser."
+msgid "Typically once you’ve logged in your session will remain active in your browser for up to two hours after you’ve finished searching. Note that use of EZProxy requires you to enable cookies. If you are having problems you should also try clearing your cache and restarting your browser."
 msgstr ""
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/)
 #: TWLight/templates/about.html:193
-msgid ""
-"The Library Bundle is a collection of resources for which no application is "
-"required. If you meet the criteria laid out above, you will be authorized "
-"for access automatically upon logging in to the platform. Only some of our "
-"content is currently included in the Library Bundle, however we hope to "
-"expand the collection as more publishers become comfortable with "
-"participating. All Bundle content is accessed via EZProxy."
+msgid "The Library Bundle is a collection of resources for which no application is required. If you meet the criteria laid out above, you will be authorized for access automatically upon logging in to the platform. Only some of our content is currently included in the Library Bundle, however we hope to expand the collection as more publishers become comfortable with participating. All Bundle content is accessed via EZProxy."
 msgstr ""
 
 #. Translators: This is the heading for a section on the About page (https://wikipedialibrary.wmflabs.org/about/).
@@ -2229,12 +1959,7 @@ msgstr ""
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:206
-msgid ""
-"Citation practices vary by project and even by article. Generally, we "
-"support editors citing where they found information, in a form that allows "
-"others to check it for themselves. That often means providing both original "
-"source details as well as a link to the partner database in which the source "
-"was found."
+msgid "Citation practices vary by project and even by article. Generally, we support editors citing where they found information, in a form that allows others to check it for themselves. That often means providing both original source details as well as a link to the partner database in which the source was found."
 msgstr ""
 
 #. Translators: This is the heading for a section on the About page (https://wikipedialibrary.wmflabs.org/about/).
@@ -2246,9 +1971,7 @@ msgstr ""
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:218
 #, python-format
-msgid ""
-"If you have questions, need help, or want to volunteer to help, please see "
-"our <a class=\"twl-links\" href=\"%(contact_url)s\">contact page</a>."
+msgid "If you have questions, need help, or want to volunteer to help, please see our <a class=\"twl-links\" href=\"%(contact_url)s\">contact page</a>."
 msgstr ""
 
 #. Translators: This is the title of the panel box detailing the contact information for the Wikipedia Library team.
@@ -2288,9 +2011,7 @@ msgstr "Vikipēdijas bibliotēkas Twitter konts"
 #. Translators: This is the text that appears at the bottom of the contact us form directing users to the suggestions form.
 #: TWLight/templates/contact.html:48
 #, python-format
-msgid ""
-"(If you would like to suggest a partner, <a class=\"twl-links\" href="
-"\"%(suggest)s\"><strong>go here</strong></a>.)"
+msgid "(If you would like to suggest a partner, <a class=\"twl-links\" href=\"%(suggest)s\"><strong>go here</strong></a>.)"
 msgstr ""
 
 #. Translators: On a special 'link to search' page, this message is shown if JavaScript is disabled.
@@ -2350,9 +2071,7 @@ msgstr "Vikipēdijas bibliotēkas Twitter konts"
 #. Translators: Information about The Wikipedia Library.
 #: TWLight/templates/login_partial.html:53 TWLight/templates/new_base.html:21
 #, python-format
-msgid ""
-"More than 100 of the world's top subscription-only databases, with content "
-"in %(no_of_languages)s languages, free for Wikipedians of all backgrounds"
+msgid "More than 100 of the world's top subscription-only databases, with content in %(no_of_languages)s languages, free for Wikipedians of all backgrounds"
 msgstr ""
 
 #. Translators: Information about The Wikipedia Library.
@@ -2361,9 +2080,7 @@ msgid "Meet these criteria for automatic access"
 msgstr ""
 
 #: TWLight/templates/login_partial.html:69
-msgid ""
-"These criteria grant you access to certain collections but not all. Some "
-"collections are accessible on a per application basis only."
+msgid "These criteria grant you access to certain collections but not all. Some collections are accessible on a per application basis only."
 msgstr ""
 
 #: TWLight/templates/login_partial.html:89
@@ -2373,29 +2090,19 @@ msgstr ""
 #. Translators: Shown if the current user doesn't have a registered email on their account. Don't translate contact_us_url or email_url.
 #: TWLight/templates/message_partial.html:15
 #, python-format
-msgid ""
-"You don't have an email on file. We can't finalize your access to partner "
-"resources, and you won't be able to <a class=\"twl-links\" href="
-"\"%(contact_us_url)s\">contact us</a> without an email. Please <a class="
-"\"twl-links\" href=\"%(email_url)s\">update your email</a>."
+msgid "You don't have an email on file. We can't finalize your access to partner resources, and you won't be able to <a class=\"twl-links\" href=\"%(contact_us_url)s\">contact us</a> without an email. Please <a class=\"twl-links\" href=\"%(email_url)s\">update your email</a>."
 msgstr ""
 
 #. Translators: Shown if the current user has requested the processing of their data should be restricted.
 #: TWLight/templates/message_partial.html:26
 #, python-format
-msgid ""
-"You have requested a restriction on the processing of your data. Most site "
-"functionality will not be available to you until you <a class=\"twl-links\" "
-"href=\"%(restrict_url)s\">lift this restriction</a>."
+msgid "You have requested a restriction on the processing of your data. Most site functionality will not be available to you until you <a class=\"twl-links\" href=\"%(restrict_url)s\">lift this restriction</a>."
 msgstr ""
 
 #. Translators: Shown if the current user has not agreed to the terms of use.
 #: TWLight/templates/message_partial.html:37
 #, python-format
-msgid ""
-"You have not agreed to the <a class=\"twl-links\" href=\"%(terms_url)s"
-"\">terms of use</a> of this site. Your applications will not be processed "
-"and you won't be able to apply or access resources you are approved for."
+msgid "You have not agreed to the <a class=\"twl-links\" href=\"%(terms_url)s\">terms of use</a> of this site. Your applications will not be processed and you won't be able to apply or access resources you are approved for."
 msgstr ""
 
 #. Translators: This link is at the bottom of every page and links to the 'About' page (https://wikipedialibrary.wmflabs.org/about/)
@@ -2442,9 +2149,7 @@ msgstr ""
 
 #. Translators: If a user goes to reset their password, this message asks them to enter their email to do so.
 #: TWLight/templates/registration/password_reset_form.html:13
-msgid ""
-"Forgot your password? Enter your email address below, and we'll email "
-"instructions for setting a new one."
+msgid "Forgot your password? Enter your email address below, and we'll email instructions for setting a new one."
 msgstr ""
 
 #. Translators: This is the label for a button that users click to update their public information.
@@ -2489,16 +2194,12 @@ msgstr ""
 
 #. Translators: This text explains how to disagree to the site's terms of use and the restrictions that will come into effect when users disagree to the terms of use.
 #: TWLight/users/forms.py:185
-msgid ""
-"By unchecking this box and clicking “Update” you may explore the site, but "
-"you will not be able to apply for access to materials or evaluate "
-"applications unless you agree with the terms of use."
+msgid "By unchecking this box and clicking “Update” you may explore the site, but you will not be able to apply for access to materials or evaluate applications unless you agree with the terms of use."
 msgstr ""
 
 #. Translators: Users click this button to set their website email address to the one linked to their Wikipedia account.
 #: TWLight/users/forms.py:211
-msgid ""
-"Use my Wikipedia email address (will be updated the next time you login)."
+msgid "Use my Wikipedia email address (will be updated the next time you login)."
 msgstr ""
 
 #. Translators: This labels a button which users click to change their email.
@@ -2509,15 +2210,7 @@ msgstr ""
 #. Translators: Shown if the current user tried to 'favorite' a partner they can't access. Do not translate '{partner}'
 #: TWLight/users/models.py:201
 #, python-brace-format
-msgid ""
-"Cannot add partner {partner} to your favorites because you don't have access "
-"to it"
-msgstr ""
-
-#. Translators: Do not translate.
-#: TWLight/users/models.py:869
-#, python-brace-format
-msgid "{wp_username}"
+msgid "Cannot add partner {partner} to your favorites because you don't have access to it"
 msgstr ""
 
 #. Translators: This error message is shown when there's a problem with the authenticated login process.
@@ -2538,9 +2231,7 @@ msgstr ""
 
 #. Translators: this message is displayed to users that don't have accounts and clicked on a proxied link.
 #: TWLight/users/oauth.py:388
-msgid ""
-"To view this link you need to be an eligible library user. Please login to "
-"continue."
+msgid "To view this link you need to be an eligible library user. Please login to continue."
 msgstr ""
 
 #. Translators: This warning message is shown to users when the response received from Wikimedia OAuth servers is not a valid one.
@@ -2576,17 +2267,12 @@ msgstr ""
 
 #. Translators: If the user tries to log in, but their account does not meet certain requirements, they cannot login.
 #: TWLight/users/oauth.py:528
-msgid ""
-"Your Wikipedia account does not meet the eligibility criteria in the terms "
-"of use, so your Wikipedia Library Card Platform account cannot be activated."
+msgid "Your Wikipedia account does not meet the eligibility criteria in the terms of use, so your Wikipedia Library Card Platform account cannot be activated."
 msgstr ""
 
 #. Translators: If the user tries to log in, but their account does not meet certain requirements, they cannot login.
 #: TWLight/users/oauth.py:536
-msgid ""
-"Your Wikipedia account no longer meets the eligibility criteria in the terms "
-"of use, so you cannot be logged in. If you think you should be able to log "
-"in, please email wikipedialibrary@wikimedia.org."
+msgid "Your Wikipedia account no longer meets the eligibility criteria in the terms of use, so you cannot be logged in. If you think you should be able to log in, please email wikipedialibrary@wikimedia.org."
 msgstr ""
 
 #. Translators: this message is displayed to users with brand new accounts.
@@ -2597,10 +2283,7 @@ msgstr ""
 #. Translators: This message is displayed on the confirmation page where users can return their access to partner collections.
 #: TWLight/users/templates/users/authorization_confirm_return.html:13
 #, python-format
-msgid ""
-"You will no longer be able to access <b>%(partner)s's</b> resources via the "
-"Library Card platform, but can request access again by clicking 'renew', if "
-"you change your mind. Are you sure you want to return your access?"
+msgid "You will no longer be able to access <b>%(partner)s's</b> resources via the Library Card platform, but can request access again by clicking 'renew', if you change your mind. Are you sure you want to return your access?"
 msgstr ""
 
 #. Translators: On the MyLibrary page (https://wikipedialibrary.wmflabs.org/users/my_library), this tab shows all favorite collections a user has.
@@ -2674,10 +2357,7 @@ msgstr ""
 
 #. Translators: This is shown on editor profiles, in their profile page or on applications.
 #: TWLight/users/templates/users/editor_detail.html:59
-msgid ""
-"Information with an * was retrieved from Wikipedia directly. Other "
-"information was entered directly by users or site admins, in their preferred "
-"language."
+msgid "Information with an * was retrieved from Wikipedia directly. Other information was entered directly by users or site admins, in their preferred language."
 msgstr ""
 
 #. Translators: This distinguishes users who have been flagged as account coordinators. Don't translate username.
@@ -2688,10 +2368,7 @@ msgstr ""
 
 #. Translators: This is shown on editor profiles, under the heading for Wikipedia editor data.
 #: TWLight/users/templates/users/editor_detail_data.html:5
-msgid ""
-"This information is updated automatically from your Wikimedia account each "
-"time you log in, except for the Contributions field, where you can describe "
-"your Wikimedia editing history."
+msgid "This information is updated automatically from your Wikimedia account each time you log in, except for the Contributions field, where you can describe your Wikimedia editing history."
 msgstr ""
 
 #. Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this labels the user's username.
@@ -2721,17 +2398,13 @@ msgstr ""
 
 #. Translators: when viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this question has a yes or no answer.
 #: TWLight/users/templates/users/editor_detail_data.html:57
-msgid ""
-"at their last login, did this user meet the criteria set forth in the terms "
-"of use?"
+msgid "at their last login, did this user meet the criteria set forth in the terms of use?"
 msgstr ""
 
 #. Translators: When viewing a user's profile in an application, this message shows if the software doesn't think that the user is eligible for access. Don't translate username.
 #: TWLight/users/templates/users/editor_detail_data.html:72
 #, python-format
-msgid ""
-"%(username)s may still be eligible for access grants at the coordinators' "
-"discretion."
+msgid "%(username)s may still be eligible for access grants at the coordinators' discretion."
 msgstr ""
 
 #. Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this is the heading for a Yes/No ToU question.
@@ -2766,10 +2439,7 @@ msgstr ""
 #. Translators: This message is shown on a user's profile if their Wikimedia account is blocked on one or more projects. They may still be granted access to the Library Bundle, but need to contact Wikipedia Library staff to verify.
 #: TWLight/users/templates/users/editor_detail_data.html:137
 #, python-format
-msgid ""
-"It looks like you have an active block on your account. If you meet the "
-"other criteria you may still be permitted access to the library - please <a "
-"class=\"twl-links\" href=\"%(contact_url)s\">contact us</a>."
+msgid "It looks like you have an active block on your account. If you meet the other criteria you may still be permitted access to the library - please <a class=\"twl-links\" href=\"%(contact_url)s\">contact us</a>."
 msgstr ""
 
 #. Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this is the heading for a Yes/No program eligibility question.
@@ -2779,10 +2449,7 @@ msgstr ""
 
 #. Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this question has a Yes or No answer.
 #: TWLight/users/templates/users/editor_detail_data.html:156
-msgid ""
-"At their last login, did this user meet the criteria set forth in the "
-"Library Bundle? Note that satisfying terms of use is a prerequisite to "
-"bundle eligibility."
+msgid "At their last login, did this user meet the criteria set forth in the Library Bundle? Note that satisfying terms of use is a prerequisite to bundle eligibility."
 msgstr ""
 
 #. Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this is the heading for a Yes/No program eligibility question.
@@ -2827,18 +2494,13 @@ msgstr ""
 
 #. Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this text is in the 'Personal data' section. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/users/templates/users/editor_detail_data.html:262
-msgid ""
-"The following information is visible only to you, site administrators, "
-"publishing partners (where required), and volunteer Wikipedia Library "
-"coordinators (who have signed a Non-Disclosure Agreement)."
+msgid "The following information is visible only to you, site administrators, publishing partners (where required), and volunteer Wikipedia Library coordinators (who have signed a Non-Disclosure Agreement)."
 msgstr ""
 
 #. Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this labels a button which users can click to update or remove their personal information. Don't translate update_url.
 #: TWLight/users/templates/users/editor_detail_data.html:272
 #, python-format
-msgid ""
-"You may <a class=\"twl-links\" href=\"%(update_url)s\">update or delete</a> "
-"your data at any time."
+msgid "You may <a class=\"twl-links\" href=\"%(update_url)s\">update or delete</a> your data at any time."
 msgstr ""
 
 #. Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this labels the user's email. Don't remove the *.
@@ -2858,24 +2520,18 @@ msgstr ""
 
 #. Translators: This message tells users that they are not eligible to access The Wikipedia Library content.
 #: TWLight/users/templates/users/eligibility_modal.html:7
-msgid ""
-"Sorry, your Wikipedia account doesn’t currently qualify to access The "
-"Wikipedia Library."
+msgid "Sorry, your Wikipedia account doesn’t currently qualify to access The Wikipedia Library."
 msgstr ""
 
 #. Translators: This message tells users that they have not agreed to the terms of use, therefore are ineligible to access the content in The Wikipedia Library.
 #: TWLight/users/templates/users/eligibility_modal.html:30
 #, python-format
-msgid ""
-"Agreed with <a href=\"%(terms)s\" class=\"text-danger\"> terms of use </a>"
+msgid "Agreed with <a href=\"%(terms)s\" class=\"text-danger\"> terms of use </a>"
 msgstr ""
 
 #: TWLight/users/templates/users/eligibility_modal.html:40
 #, python-format
-msgid ""
-"It looks like you have an active block on your account. If you meet the "
-"other criteria you may still be permitted access to the library - please <a "
-"href=\"%(contact_url)s\">contact us</a>."
+msgid "It looks like you have an active block on your account. If you meet the other criteria you may still be permitted access to the library - please <a href=\"%(contact_url)s\">contact us</a>."
 msgstr ""
 
 #. Translators: Instructions to refresh a user's data.
@@ -2915,10 +2571,7 @@ msgstr ""
 
 #. Translators: This text on the user page helps users naviage to the TranslateWiki Wikipedia Library Card platform translation page.
 #: TWLight/users/templates/users/language_form.html:31
-msgid ""
-"You can help translate the tool at <a class=\"twl-links\" href=\"https://"
-"translatewiki.net/wiki/Translating:Wikipedia_Library_Card_Platform"
-"\">translatewiki.net</a>."
+msgid "You can help translate the tool at <a class=\"twl-links\" href=\"https://translatewiki.net/wiki/Translating:Wikipedia_Library_Card_Platform\">translatewiki.net</a>."
 msgstr ""
 
 #. Translators: When the user starts a new application and submits the application, the user can view the application and withdraw if need be. This changes the label for the Withdraw button.
@@ -2938,9 +2591,7 @@ msgstr ""
 
 #. Translators: On the page listing applications, this text explains a user they cannot renew their application since they've already requested a renewal or there aren't any renewals available.
 #: TWLight/users/templates/users/my_applications.html:79
-msgid ""
-"Renewals are either not required, not available right now, or you have "
-"already requested a renewal."
+msgid "Renewals are either not required, not available right now, or you have already requested a renewal."
 msgstr ""
 
 #. Translators: This text is the heading of a section in a user's profile where they can change their preferences.
@@ -3004,19 +2655,12 @@ msgstr ""
 
 #. Translators: This message is displayed on the page where users can request we stop processing their data.
 #: TWLight/users/templates/users/restrict_data.html:15
-msgid ""
-"Checking this box and clicking “Restrict” will pause all processing of the "
-"data you have entered into this website. You will not be able to apply for "
-"access to resources, your applications will not be further processed, and "
-"none of your data will be altered, until you return to this page and uncheck "
-"the box. This is not the same as deleting your data."
+msgid "Checking this box and clicking “Restrict” will pause all processing of the data you have entered into this website. You will not be able to apply for access to resources, your applications will not be further processed, and none of your data will be altered, until you return to this page and uncheck the box. This is not the same as deleting your data."
 msgstr ""
 
 #. Translators: This warning message is shown to coordinators who view the data restriction page.
 #: TWLight/users/templates/users/restrict_data.html:26
-msgid ""
-"You are a coordinator on this site. If you restrict the processing of your "
-"data, your coordinator flag will be removed."
+msgid "You are a coordinator on this site. If you restrict the processing of your data, your coordinator flag will be removed."
 msgstr ""
 
 #. Translators: use the date *when you are translating*, in a language-appropriate format.
@@ -3036,24 +2680,12 @@ msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:51
-msgid ""
-"<a class=\"twl-links\" href=\"https://meta.wikimedia.org/wiki/"
-"The_Wikipedia_Library\"> The Wikipedia Library </a> has partnered with "
-"publishers around the world to allow users to access otherwise paywalled "
-"resources. This website allows Wikipedia editors to search and access these "
-"resources."
+msgid "<a class=\"twl-links\" href=\"https://meta.wikimedia.org/wiki/The_Wikipedia_Library\"> The Wikipedia Library </a> has partnered with publishers around the world to allow users to access otherwise paywalled resources. This website allows Wikipedia editors to search and access these resources."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Wikimedia Foundation should not be translated. WMF should not be translated. Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:63
-msgid ""
-"This program is administered by the Wikimedia Foundation (WMF). These terms "
-"of use and privacy notice pertain to your application for access to "
-"resources through the Wikipedia Library, your use of this website, and your "
-"access to and use of those resources. They also describe our handling of the "
-"information you provide to us in order to create and administer your "
-"Wikipedia Library account. If we make material changes to the terms, we will "
-"notify users."
+msgid "This program is administered by the Wikimedia Foundation (WMF). These terms of use and privacy notice pertain to your application for access to resources through the Wikipedia Library, your use of this website, and your access to and use of those resources. They also describe our handling of the information you provide to us in order to create and administer your Wikipedia Library account. If we make material changes to the terms, we will notify users."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
@@ -3063,37 +2695,17 @@ msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:78
-msgid ""
-"Access to resources via The Wikipedia Library is reserved for community "
-"members who have demonstrated their commitment to the Wikimedia projects, "
-"and who will use their access to these resources to improve project content. "
-"To that end, in order to be eligible for The Wikipedia Library, we require "
-"that you be registered for a user account on the projects, with at least 500 "
-"edits, six (6) months of activity, and 10+ edits in the last month. We ask "
-"that you do not request access to any publishers with a limited number of "
-"available accounts whose resources you can already access for free through "
-"your local library or university, or another institution or organization, in "
-"order to provide that opportunity to others."
+msgid "Access to resources via The Wikipedia Library is reserved for community members who have demonstrated their commitment to the Wikimedia projects, and who will use their access to these resources to improve project content. To that end, in order to be eligible for The Wikipedia Library, we require that you be registered for a user account on the projects, with at least 500 edits, six (6) months of activity, and 10+ edits in the last month. We ask that you do not request access to any publishers with a limited number of available accounts whose resources you can already access for free through your local library or university, or another institution or organization, in order to provide that opportunity to others."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:94
-msgid ""
-"Additionally, if you are currently blocked or banned from a Wikimedia "
-"project, applications to resources may be rejected or restricted. If you "
-"obtain a Wikipedia Library account, but a block or ban is subsequently "
-"instituted against you on one of the projects, you may lose access to your "
-"Wikipedia Library account."
+msgid "Additionally, if you are currently blocked or banned from a Wikimedia project, applications to resources may be rejected or restricted. If you obtain a Wikipedia Library account, but a block or ban is subsequently instituted against you on one of the projects, you may lose access to your Wikipedia Library account."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:104
-msgid ""
-"Your eligibility to access The Wikipedia Library is assessed at each login. "
-"While more than half of the library's content is provided via this automated "
-"eligibility check, access to other publisher's content may be time limited, "
-"typically lapsing after one year, after which you will usually need to apply "
-"for renewal."
+msgid "Your eligibility to access The Wikipedia Library is assessed at each login. While more than half of the library's content is provided via this automated eligibility check, access to other publisher's content may be time limited, typically lapsing after one year, after which you will usually need to apply for renewal."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
@@ -3103,47 +2715,27 @@ msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:118
-msgid ""
-"In order to apply for access to a partner resource, you must provide us with "
-"certain information, which we will use to evaluate your application. If your "
-"application is approved, we may transfer the information you have given us "
-"to the publishers whose resources you wish to access. They will either "
-"contact you with the account information directly or we will send access "
-"information to you ourselves."
+msgid "In order to apply for access to a partner resource, you must provide us with certain information, which we will use to evaluate your application. If your application is approved, we may transfer the information you have given us to the publishers whose resources you wish to access. They will either contact you with the account information directly or we will send access information to you ourselves."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:130
-msgid ""
-"In addition to the basic information you provide to us, our system will "
-"retrieve some information directly from the Wikimedia projects: your "
-"username, email address, edit count, registration date, user ID number, "
-"groups to which you belong, and any special user rights."
+msgid "In addition to the basic information you provide to us, our system will retrieve some information directly from the Wikimedia projects: your username, email address, edit count, registration date, user ID number, groups to which you belong, and any special user rights."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:140
-msgid ""
-"Each time you log in to the Wikipedia Library Card Platform, this "
-"information will be automatically updated."
+msgid "Each time you log in to the Wikipedia Library Card Platform, this information will be automatically updated."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:148
-msgid ""
-"We will ask you to provide us with some information about your history of "
-"contributions to the Wikimedia projects. Information on contribution history "
-"is optional, but will greatly assist us in evaluating your application."
+msgid "We will ask you to provide us with some information about your history of contributions to the Wikimedia projects. Information on contribution history is optional, but will greatly assist us in evaluating your application."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). WMF should not be translated. Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:157
-msgid ""
-"The information you provide when creating your account will be visible to "
-"you while on the site but not to others unless they are approved Wikipedia "
-"Library Coordinators, WMF Staff, or WMF Contractors who need access to this "
-"data in order to carry out their work with the Wikipedia Library, all of "
-"whom are subject to non-disclosure obligations."
+msgid "The information you provide when creating your account will be visible to you while on the site but not to others unless they are approved Wikipedia Library Coordinators, WMF Staff, or WMF Contractors who need access to this data in order to carry out their work with the Wikipedia Library, all of whom are subject to non-disclosure obligations."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
@@ -3153,46 +2745,32 @@ msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:171
-msgid ""
-"In order to access an individual publisher’s resources, you must agree to "
-"that publisher’s terms of use and privacy policy. You agree that you will "
-"not violate such terms and policies in connection with your use of the "
-"Wikipedia Library. Additionally, the following activities are prohibited "
-"while accessing publisher resources through the Wikipedia Library."
+msgid "In order to access an individual publisher’s resources, you must agree to that publisher’s terms of use and privacy policy. You agree that you will not violate such terms and policies in connection with your use of the Wikipedia Library. Additionally, the following activities are prohibited while accessing publisher resources through the Wikipedia Library."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:184
-msgid ""
-"Sharing your Wikipedia account, usernames, passwords, or any access codes "
-"for publisher resources with others;"
+msgid "Sharing your Wikipedia account, usernames, passwords, or any access codes for publisher resources with others;"
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:191
-msgid ""
-"Automatically scraping or downloading restricted content from publishers;"
+msgid "Automatically scraping or downloading restricted content from publishers;"
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:197
-msgid ""
-"Systematically making printed or electronic copies of multiple extracts of "
-"restricted content available for any purpose;"
+msgid "Systematically making printed or electronic copies of multiple extracts of restricted content available for any purpose;"
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:204
-msgid ""
-"Data mining metadata without permission—for example, in order to use "
-"metadata for auto-created stub articles;"
+msgid "Data mining metadata without permission—for example, in order to use metadata for auto-created stub articles;"
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:211
-msgid ""
-"Using the access you receive through the Wikipedia Library for profit by "
-"selling access to your account or resources which you have through it."
+msgid "Using the access you receive through the Wikipedia Library for profit by selling access to your account or resources which you have through it."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
@@ -3202,18 +2780,12 @@ msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:224
-msgid ""
-"Certain resources may only be accessed using an external search service, "
-"such as the EBSCO Discovery Service, or a proxy service, such as OCLC "
-"EZProxy. If you use such external search and/or proxy services, please "
-"review the applicable terms of use and privacy policies."
+msgid "Certain resources may only be accessed using an external search service, such as the EBSCO Discovery Service, or a proxy service, such as OCLC EZProxy. If you use such external search and/or proxy services, please review the applicable terms of use and privacy policies."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:234
-msgid ""
-"In addition, if you use OCLC EZProxy, please note that you may not use it "
-"for commercial purposes."
+msgid "In addition, if you use OCLC EZProxy, please note that you may not use it for commercial purposes."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
@@ -3223,120 +2795,49 @@ msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Wikimedia Foundation should not be translated. Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:245
-msgid ""
-"The Wikimedia Foundation and our service providers use your information for "
-"the legitimate purpose of providing Wikipedia Library services in support of "
-"our charitable mission. When you apply for a Wikipedia Library account, or "
-"use your Wikipedia Library account, we may routinely collect the following "
-"information: your username, email address, edit count, registration date, "
-"user ID number, groups to which you belong, and any special user rights; "
-"your name, country of residence, and/or affiliation, if required by a "
-"partner to which you are applying; your narrative description of your "
-"contributions and reasons for applying for access to partner resources; and "
-"the date you agree to these terms of use."
+msgid "The Wikimedia Foundation and our service providers use your information for the legitimate purpose of providing Wikipedia Library services in support of our charitable mission. When you apply for a Wikipedia Library account, or use your Wikipedia Library account, we may routinely collect the following information: your username, email address, edit count, registration date, user ID number, groups to which you belong, and any special user rights; your name, country of residence, and/or affiliation, if required by a partner to which you are applying; your narrative description of your contributions and reasons for applying for access to partner resources; and the date you agree to these terms of use."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:262
 #, python-format
-msgid ""
-"Each publisher who is a member of the Wikipedia Library program requires "
-"different specific information in the application. Some publishers may "
-"request only an email address, while others request more detailed data, such "
-"as your name, location, or institutional affiliation. When you complete your "
-"application, you will only be asked to supply information required by the "
-"publishers you have chosen, and each publisher will only receive the "
-"information they require for providing you with access. Please see our <a "
-"class=\"twl-links\" href=\"%(all_partners_url)s\">partner information</a> "
-"pages to learn what information is required by each publisher to gain access "
-"to their resources."
+msgid "Each publisher who is a member of the Wikipedia Library program requires different specific information in the application. Some publishers may request only an email address, while others request more detailed data, such as your name, location, or institutional affiliation. When you complete your application, you will only be asked to supply information required by the publishers you have chosen, and each publisher will only receive the information they require for providing you with access. Please see our <a class=\"twl-links\" href=\"%(all_partners_url)s\">partner information</a> pages to learn what information is required by each publisher to gain access to their resources."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Wikimedia Foundation should not be translated. Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:277
-msgid ""
-"Some Wikipedia Library pages are visible without logging in, but you will "
-"need to log in to apply or access proprietary partner resources. We use the "
-"data provided by you via OAuth and Wikimedia API calls to assess your "
-"application for access and to process approved requests."
+msgid "Some Wikipedia Library pages are visible without logging in, but you will need to log in to apply or access proprietary partner resources. We use the data provided by you via OAuth and Wikimedia API calls to assess your application for access and to process approved requests."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:288
 #, python-format
-msgid ""
-"In order to administer the Wikipedia Library program, we will retain the "
-"application data we collect from you for three years after your most recent "
-"login, unless you delete your account, as described below. You can log in "
-"and go to <a class=\"twl-links\" href=\"%(profile_url)s\">your profile page</"
-"a> in order to see the information associated with your account, and can "
-"download it in JSON format. You may access, update, restrict, or delete this "
-"information at any time, except for the information that is automatically "
-"retrieved from the projects. If you have any questions or concerns about the "
-"handling of your data, please contact <a class=\"twl-links\" href=\"mailto:"
-"wikipedialibrary@wikimedia.org?Subject=Wikipedia%%20Library%%20Card"
-"%%20account%%20deactivation\"> wikipedialibrary@wikimedia.org </a>."
+msgid "In order to administer the Wikipedia Library program, we will retain the application data we collect from you for three years after your most recent login, unless you delete your account, as described below. You can log in and go to <a class=\"twl-links\" href=\"%(profile_url)s\">your profile page</a> in order to see the information associated with your account, and can download it in JSON format. You may access, update, restrict, or delete this information at any time, except for the information that is automatically retrieved from the projects. If you have any questions or concerns about the handling of your data, please contact <a class=\"twl-links\" href=\"mailto:wikipedialibrary@wikimedia.org?Subject=Wikipedia%%20Library%%20Card%%20account%%20deactivation\"> wikipedialibrary@wikimedia.org </a>."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:305
-msgid ""
-"If you decide to disable your Wikipedia Library account, you can use the "
-"delete button on your profile to delete certain personal information "
-"associated with your account. We will delete your real name, institutional "
-"affiliation, and country of residence. Please note that the system will "
-"retain a record of your username, the publishers to which you applied or had "
-"access, and the dates of that access. Note that deletion is not reversible. "
-"Deletion of your Wikipedia Library account may also correspond with the "
-"removal of any resource access to which you were eligible or approved. If "
-"you request the deletion of account information and later wish to apply for "
-"a new account, you will need to provide the necessary information again."
+msgid "If you decide to disable your Wikipedia Library account, you can use the delete button on your profile to delete certain personal information associated with your account. We will delete your real name, institutional affiliation, and country of residence. Please note that the system will retain a record of your username, the publishers to which you applied or had access, and the dates of that access. Note that deletion is not reversible. Deletion of your Wikipedia Library account may also correspond with the removal of any resource access to which you were eligible or approved. If you request the deletion of account information and later wish to apply for a new account, you will need to provide the necessary information again."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). WMF should not be translated. Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:321
-msgid ""
-"The Wikipedia Library is run by WMF Staff, Contractors, and approved "
-"volunteer Coordinators. The data associated with your account will be shared "
-"with the WMF staff, contractors, service providers, and volunteer "
-"coordinators who need to process the information in connection with their "
-"work for the Wikipedia Library, and who are subject to confidentiality "
-"obligations. We will also use your data for internal Wikipedia Library "
-"purposes such as distributing user surveys and account notifications, and in "
-"a depersonalized or aggregated fashion for statistical analysis and "
-"administration. Finally, we will share your information with the publishers "
-"whom you specifically select in order to provide you with access to "
-"resources. Otherwise, your information will not be shared with third "
-"parties, with the exception of the circumstances described below."
+msgid "The Wikipedia Library is run by WMF Staff, Contractors, and approved volunteer Coordinators. The data associated with your account will be shared with the WMF staff, contractors, service providers, and volunteer coordinators who need to process the information in connection with their work for the Wikipedia Library, and who are subject to confidentiality obligations. We will also use your data for internal Wikipedia Library purposes such as distributing user surveys and account notifications, and in a depersonalized or aggregated fashion for statistical analysis and administration. Finally, we will share your information with the publishers whom you specifically select in order to provide you with access to resources. Otherwise, your information will not be shared with third parties, with the exception of the circumstances described below."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). WMF should not be translated.
 #: TWLight/users/templates/users/terms.html:338
-msgid ""
-"We may disclose any collected information when required by law, when we have "
-"your permission, when needed to protect our rights, privacy, safety, users, "
-"or the general public, and when necessary to enforce these terms, WMF’s "
-"general <a class=\"twl-links\" href=\"https://foundation.wikimedia.org/wiki/"
-"Terms_of_Use\">Terms of Use</a>, or any other WMF policy."
+msgid "We may disclose any collected information when required by law, when we have your permission, when needed to protect our rights, privacy, safety, users, or the general public, and when necessary to enforce these terms, WMF’s general <a class=\"twl-links\" href=\"https://foundation.wikimedia.org/wiki/Terms_of_Use\">Terms of Use</a>, or any other WMF policy."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:349
-msgid ""
-"We take the security of your personal data seriously, and take reasonable "
-"precautions to ensure your data is protected. These precautions include "
-"access controls to limit who has access to your data and security "
-"technologies to protect data stored on the server. However, we cannot "
-"guarantee the safety of your data as it is transmitted and stored."
+msgid "We take the security of your personal data seriously, and take reasonable precautions to ensure your data is protected. These precautions include access controls to limit who has access to your data and security technologies to protect data stored on the server. However, we cannot guarantee the safety of your data as it is transmitted and stored."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:360
-msgid ""
-"Please note that these terms do not control the use and handling of your "
-"data by the publishers and service providers whose resources you access or "
-"apply to access. Please read their individual privacy policies for that "
-"information."
+msgid "Please note that these terms do not control the use and handling of your data by the publishers and service providers whose resources you access or apply to access. Please read their individual privacy policies for that information."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
@@ -3346,34 +2847,17 @@ msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Wikimedia Foundation should not be translated. Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:373
-msgid ""
-"The Wikimedia Foundation is a nonprofit organization based in San Francisco, "
-"California. The Wikipedia Library program provides access to resources held "
-"by publishers in multiple countries. If you apply for a Wikipedia Library "
-"account (whether you are inside or outside of the United States), you "
-"understand that your personal data will be collected, transferred, stored, "
-"processed, disclosed and otherwise used in the U.S. as described in this "
-"privacy policy. You also understand that your information may be transferred "
-"by us from the U.S. to other countries, which may have different or less "
-"stringent data protection laws than your country, in connection with "
-"providing services to you, including evaluating your application and "
-"securing access to your chosen publishers (locations for each publisher are "
-"outlined on their respective partner information pages)."
+msgid "The Wikimedia Foundation is a nonprofit organization based in San Francisco, California. The Wikipedia Library program provides access to resources held by publishers in multiple countries. If you apply for a Wikipedia Library account (whether you are inside or outside of the United States), you understand that your personal data will be collected, transferred, stored, processed, disclosed and otherwise used in the U.S. as described in this privacy policy. You also understand that your information may be transferred by us from the U.S. to other countries, which may have different or less stringent data protection laws than your country, in connection with providing services to you, including evaluating your application and securing access to your chosen publishers (locations for each publisher are outlined on their respective partner information pages)."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:392
-msgid ""
-"Please note that in the event of any differences in meaning or "
-"interpretation between the original English version of these terms and a "
-"translation, the original English version takes precedence."
+msgid "Please note that in the event of any differences in meaning or interpretation between the original English version of these terms and a translation, the original English version takes precedence."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Wikimedia Foundation should not be translated.
 #: TWLight/users/templates/users/terms.html:403
-msgid ""
-"See also the <a class=\"twl-links\" href=\"https://wikimediafoundation.org/"
-"wiki/Privacy_policy\">Wikimedia Foundation Privacy Policy</a>."
+msgid "See also the <a class=\"twl-links\" href=\"https://wikimediafoundation.org/wiki/Privacy_policy\">Wikimedia Foundation Privacy Policy</a>."
 msgstr ""
 
 #. Translators: This is the second to last line of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
@@ -3393,11 +2877,7 @@ msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:426
-msgid ""
-"By checking this box and clicking “Submit”, you agree that you have read the "
-"above terms and that you will adhere to the terms of use in your application "
-"to and use of the The Wikipedia Library, and the publishers’ services to "
-"which you gain access through The Wikipedia Library program."
+msgid "By checking this box and clicking “Submit”, you agree that you have read the above terms and that you will adhere to the terms of use in your application to and use of the The Wikipedia Library, and the publishers’ services to which you gain access through The Wikipedia Library program."
 msgstr ""
 
 #: TWLight/users/templates/users/user_collection_tile.html:32
@@ -3451,29 +2931,18 @@ msgstr ""
 
 #. Translators: This message is displayed on the page where users can request the deletion of their data.
 #: TWLight/users/templates/users/user_confirm_delete.html:17
-msgid ""
-"<b>Warning:</b> Performing this action will delete your Wikipedia Library "
-"Card user account and all associated applications. This process is not "
-"reversible. You may lose any partner accounts you were granted, and will not "
-"be able to renew those accounts or apply for new ones."
+msgid "<b>Warning:</b> Performing this action will delete your Wikipedia Library Card user account and all associated applications. This process is not reversible. You may lose any partner accounts you were granted, and will not be able to renew those accounts or apply for new ones."
 msgstr ""
 
 #. Translators: this should show up for people who log in with a username/password and not OAuth, so we don't know what their Wikipedia identity is.
-#.
 #: TWLight/users/templates/users/user_detail.html:12
 #, python-format
-msgid ""
-"Hi, %(username)s! You don't have a Wikipedia editor profile attached to your "
-"account here, so you are probably a site administrator."
+msgid "Hi, %(username)s! You don't have a Wikipedia editor profile attached to your account here, so you are probably a site administrator."
 msgstr ""
 
 #. Translators: In the unlikely scenario that someone is able to register an account without using OAuth (thus leaving us without some of the information required for applications), users will see this message, encouraging them to re-register.
 #: TWLight/users/templates/users/user_detail.html:20
-msgid ""
-"If you aren't a site administrator, something weird has happened. You won't "
-"be able to apply for access without a Wikipedia editor profile. You should "
-"log out and create a new account by logging in via OAuth, or contact a site "
-"administrator for help."
+msgid "If you aren't a site administrator, something weird has happened. You won't be able to apply for access without a Wikipedia editor profile. You should log out and create a new account by logging in via OAuth, or contact a site administrator for help."
 msgstr ""
 
 #. Translators: Labels a sections where coordinators can select their email preferences.
@@ -3484,17 +2953,12 @@ msgstr ""
 #. Translators: This message is shown on user's own profile page, encouraging them to make sure their information is up to date, so that account coordinators can use the information to judge applications.
 #: TWLight/users/views.py:176
 #, python-brace-format
-msgid ""
-"Please <a class='twl-links' href='{url}'>update your contributions</a> to "
-"Wikipedia to help coordinators evaluate your applications."
+msgid "Please <a class='twl-links' href='{url}'>update your contributions</a> to Wikipedia to help coordinators evaluate your applications."
 msgstr ""
 
 #. Translators: Coordinators are shown this message when they unselect all three types of reminder email options under preferences.
 #: TWLight/users/views.py:288
-msgid ""
-"You have chosen not to receive reminder emails. As a coordinator, you should "
-"receive at least one type of reminder emails, so consider changing your "
-"preferences."
+msgid "You have chosen not to receive reminder emails. As a coordinator, you should receive at least one type of reminder emails, so consider changing your preferences."
 msgstr ""
 
 #. Translators: Coordinators are shown this message when they make changes to their reminder email options under preferences.
@@ -3528,9 +2992,7 @@ msgstr ""
 
 #. Translators: If the user has not filled out their email, they can browse the website but cannot apply for access to resources.
 #: TWLight/users/views.py:487
-msgid ""
-"Your email is blank. You can still explore the site, but you won't be able "
-"to apply for access to partner resources without an email."
+msgid "Your email is blank. You can still explore the site, but you won't be able to apply for access to partner resources without an email."
 msgstr ""
 
 #. Translators: This message is shown once the access to a partner has successfully been returned.
@@ -3563,31 +3025,3 @@ msgstr ""
 msgid "10+ edits in the last 30 days"
 msgstr ""
 
-#: tests/shunit/data/bad_i18n_comment_1.py:3
-#: tests/shunit/data/bad_i18n_newline_1.py:5
-msgid "1"
-msgstr ""
-
-#. Translators: Lorem ipsum dolor sit amet, consectetur adipiscing elit. Mauris vitae ipsum ut purus faucibus pretium. Proin tempus neque et aliquet consectetur. Ut egestas sapien in consectetur sagittis. Mauris neque lacus, dapibus non viverra vitae, interdum ut aenean ipsum.
-#. Translators: Lorem ipsum dolor sit amet, consectetur adipiscing elit. Mauris vitae ipsum ut purus faucibus pretium. Proin tempus neque et aliquet consectetur. Ut egestas sapien in consectetur sagittis. Mauris neque lacus, dapibus non.
-#: tests/shunit/data/bad_i18n_comment_2.py:4
-#: tests/shunit/data/bad_i18n_newline_2.py:5 tests/shunit/data/good_i18n_1.py:2
-#: tests/shunit/data/good_i18n_2.py:2
-msgid "2"
-msgstr ""
-
-#: tests/shunit/data/bad_i18n_newline_3.py:5
-msgid "3"
-msgstr ""
-
-#: tests/shunit/data/bad_i18n_newline_4.py:5
-msgid "4"
-msgstr ""
-
-#: tests/shunit/data/bad_i18n_newline_5.py:5
-msgid "5"
-msgstr ""
-
-#: tests/shunit/data/bad_i18n_newline_6.py:5
-msgid "6"
-msgstr ""

--- a/locale/mk/LC_MESSAGES/django.po
+++ b/locale/mk/LC_MESSAGES/django.po
@@ -9,10 +9,11 @@
 # Author: Vlad5250
 msgid ""
 msgstr ""
+""
 "Project-Id-Version: Wikipedia Library Card Platform - Website\n"
-"Report-Msgid-Bugs-To: wikipedialibrary@wikimedia.org\n"
+"Report-Msgid-Bugs-To: translatewiki.net\n"
 "POT-Creation-Date: 2024-07-11 20:54+0000\n"
-"PO-Revision-Date: 2024-07-11 12:30:17+0000\n"
+"PO-Revision-Date: 2024-07-15 12:29:17+0000\n"
 "Language: mk\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
@@ -44,13 +45,8 @@ msgstr "За вас"
 #. Translators: This note appears in a section of a form where we ask users to enter info (like country of residence) when applying for resource access.
 #: TWLight/applications/forms.py:179
 #, python-brace-format
-msgid ""
-"<p><small><i>Your personal data will be processed according to our <a "
-"class='twl-links' href='{terms_url}'> privacy policy</a>.</i></small></p>"
-msgstr ""
-"<p><small><i>Вашите лични податоци ќе се обработат во склад со нашите <a "
-"class='twl-links' href='{terms_url}'>правила за заштита на личните податоци</"
-"a>.</i></small></p>"
+msgid "<p><small><i>Your personal data will be processed according to our <a class='twl-links' href='{terms_url}'> privacy policy</a>.</i></small></p>"
+msgstr "<p><small><i>Вашите лични податоци ќе се обработат во склад со нашите <a class='twl-links' href='{terms_url}'>правила за заштита на личните податоци</a>.</i></small></p>"
 
 #. Translators: This is the title of the application form page, where users enter information required for the application. It lets the user know which partner application they are entering data for. {partner}
 #: TWLight/applications/forms.py:189
@@ -91,12 +87,8 @@ msgstr "Е-пошта за вашата сметка на мрежното ме�
 #. Translators: This labels a choice field where users will have to select the number of months they wish to have their access for as part of the application renewal confirmation.
 #. Translators: When filling out an application, users may be required to enter the length of the account (expiry) they wish to have for proxy partners.
 #: TWLight/applications/forms.py:339 TWLight/applications/helpers.py:100
-msgid ""
-"The number of months you wish to have this access for before renewal is "
-"required"
-msgstr ""
-"Бројот на месеци за кои сакате да го имате овој пристап пред да е потребно "
-"обновувањето"
+msgid "The number of months you wish to have this access for before renewal is required"
+msgstr "Бројот на месеци за кои сакате да го имате овој пристап пред да е потребно обновувањето"
 
 #. Translators: When filling out an application, users may need to specify their name
 #: TWLight/applications/helpers.py:81
@@ -184,12 +176,8 @@ msgstr "Е-пошта"
 
 #. Translators: This comment is added to pending applications when our terms of use change.
 #: TWLight/applications/management/commands/notify_applicants_tou_changes.py:54
-msgid ""
-"Our terms of use have changed. Your applications will not be processed until "
-"you log in and agree to our updated terms."
-msgstr ""
-"Нашите услови на употреба се сменија. Вашите барања нема да се обработуваат "
-"сè додека не се согласите со новите услови."
+msgid "Our terms of use have changed. Your applications will not be processed until you log in and agree to our updated terms."
+msgstr "Нашите услови на употреба се сменија. Вашите барања нема да се обработуваат сè додека не се согласите со новите услови."
 
 #. Translators: This is the status of an application that has not yet been reviewed.
 #: TWLight/applications/models.py:54
@@ -258,39 +246,25 @@ msgstr "URL на пристап: {access_url}"
 
 #. Translators: This text goes into account approval emails in the case that we need to send the user's details to a publisher for manual account setup.
 #: TWLight/applications/models.py:331
-msgid ""
-"You can expect to receive access details within a week or two once it has "
-"been processed."
-msgstr ""
-"Очекувајте да ги добиете пристапните податоци за една-две недели или штом ќе "
-"бидат обработени."
+msgid "You can expect to receive access details within a week or two once it has been processed."
+msgstr "Очекувајте да ги добиете пристапните податоци за една-две недели или штом ќе бидат обработени."
 
 #. Translators: This comment is added to open applications when a partner joins the Library Bundle, which does not require applications.
 #: TWLight/applications/signals.py:247
-msgid ""
-"This partner joined the Library Bundle, which does not require applications. "
-"This application will be marked as invalid."
-msgstr ""
-"Овој партнер се приклучи кон Библиотечниот пакет, кој не бара поднесување на "
-"барања. Ова барање ќе биде означено како неважечко."
+msgid "This partner joined the Library Bundle, which does not require applications. This application will be marked as invalid."
+msgstr "Овој партнер се приклучи кон Библиотечниот пакет, кој не бара поднесување на барања. Ова барање ќе биде означено како неважечко."
 
 #. Translators: This is shown to users if the application is to a partner for which we have run out of available accounts. The application is therefore on a 'waitlist', and will be reviewed when more accounts are available.
 #: TWLight/applications/templates/applications/application_evaluation.html:29
-msgid ""
-"This application is on the waitlist because this partner does not have any "
-"access grants available at this time."
-msgstr ""
-"Ова барање е во чекалница бидејќи соработникот тековно нема расположливи "
-"дозволи за пристап."
+msgid "This application is on the waitlist because this partner does not have any access grants available at this time."
+msgstr "Ова барање е во чекалница бидејќи соработникот тековно нема расположливи дозволи за пристап."
 
 #. Translators: This message is shown on pages where coordinators can see personal information about applicants.
 #: TWLight/applications/templates/applications/application_evaluation.html:36
 #: TWLight/applications/templates/applications/application_list_include.html:6
 #: TWLight/applications/templates/applications/send_partner.html:45
 #: TWLight/resources/templates/resources/partner_users.html:18
-msgid ""
-"Coordinators: This page may contain personal information such as real names "
-"and email addresses. Please remember that this information is confidential."
+msgid "Coordinators: This page may contain personal information such as real names and email addresses. Please remember that this information is confidential."
 msgstr ""
 
 #. Translators: This is the title of the application page shown to users who are a coordinator, and are able to accept or reject the application.
@@ -300,12 +274,8 @@ msgstr "Оцени барање"
 
 #. Translators: This text is shown to coordinators on application pages if the applicant has restricted processing of their data.
 #: TWLight/applications/templates/applications/application_evaluation.html:42
-msgid ""
-"This user has requested a restriction on the processing of their data, so "
-"you cannot change the status of their application."
-msgstr ""
-"Овој корисник побарал ограничување на обработката на неговите податоци. "
-"Затоа, не можете да ја смените состојбата на неговото барање."
+msgid "This user has requested a restriction on the processing of their data, so you cannot change the status of their application."
+msgstr "Овој корисник побарал ограничување на обработката на неговите податоци. Затоа, не можете да ја смените состојбата на неговото барање."
 
 #. Translators: This is the title of the application page shown to users who are not a coordinator.
 #: TWLight/applications/templates/applications/application_evaluation.html:48
@@ -380,9 +350,7 @@ msgstr "Непознато"
 
 #. Translators: This is the text displayed to coordinators when an applicant has no country of residence in their profile.
 #: TWLight/applications/templates/applications/application_evaluation.html:123
-msgid ""
-"Please request the applicant add their country of residence to their profile "
-"before proceeding further."
+msgid "Please request the applicant add their country of residence to their profile before proceeding further."
 msgstr ""
 
 #. Translators: This labels the section of an application showing the total number of accounts available for a partner or their collection.
@@ -393,12 +361,8 @@ msgstr "Расположливи сметки"
 #. Translators: This labels the section of an application showing whether the user had agreed to the terms of use or not.
 #: TWLight/applications/templates/applications/application_evaluation.html:145
 #, python-format
-msgid ""
-"Has agreed to the site's <a class=\"twl-links\" href=\"%(terms_url)s\">terms "
-"of use</a>?"
-msgstr ""
-"Се согласил со <a class=\"twl-links\" href=\"%(terms_url)s\">условите ба "
-"употреба</a> на мрежното место?"
+msgid "Has agreed to the site's <a class=\"twl-links\" href=\"%(terms_url)s\">terms of use</a>?"
+msgstr "Се согласил со <a class=\"twl-links\" href=\"%(terms_url)s\">условите ба употреба</a> на мрежното место?"
 
 #. Translators: Displayed to coordinators when they've agreed to the terms of use.
 #. Translators: Displayed if the user has agreed to the terms of use.
@@ -433,9 +397,7 @@ msgstr "Не"
 
 #. Translators: This is the text displayed to coordinators when an applicant has not agreed to the terms of use.
 #: TWLight/applications/templates/applications/application_evaluation.html:159
-msgid ""
-"Please request the applicant agree to the site's terms of use before "
-"approving this application."
+msgid "Please request the applicant agree to the site's terms of use before approving this application."
 msgstr ""
 
 #. Translators: This labels the section of an application containing the user's motivation for wanting access to this resource.
@@ -456,8 +418,7 @@ msgstr "Да ја обновам постоечката дозвола за пр
 #. Translators: This message is shown next to the 'Renewal of existing access grant?' label if the application is a renewal. Don't translate HTML tags or parent_url.
 #: TWLight/applications/templates/applications/application_evaluation.html:195
 #, python-format
-msgid ""
-"Yes (<a class=\"twl-links\" href=\"%(parent_url)s\">previous application</a>)"
+msgid "Yes (<a class=\"twl-links\" href=\"%(parent_url)s\">previous application</a>)"
 msgstr ""
 
 #. Translators: This labels the section of the application showing the length of access remaining on the user's previous authorization.
@@ -492,9 +453,7 @@ msgstr "Додај коментар"
 
 #. Translators: On an application page, this text tells users that the comments posted on the application are visible to coordinators and the submitting user only.
 #: TWLight/applications/templates/applications/application_evaluation.html:297
-msgid ""
-"Comments are visible to all coordinators and to the editor who submitted "
-"this application."
+msgid "Comments are visible to all coordinators and to the editor who submitted this application."
 msgstr ""
 
 #. Translators: This is the title of the section of an application page which lists information about the user who submitted the application.
@@ -708,12 +667,7 @@ msgstr "Задај состојба"
 
 #: TWLight/applications/templates/applications/apply.html:20
 #, python-format
-msgid ""
-"If your application is successful we may share your email address with "
-"%(partner)s. This is required to set up your access to their resources. By "
-"submitting this form you agree to allow your email address to be shared with "
-"%(partner)s if your application is successful, for the purposes of account "
-"setup."
+msgid "If your application is successful we may share your email address with %(partner)s. This is required to set up your access to their resources. By submitting this form you agree to allow your email address to be shared with %(partner)s if your application is successful, for the purposes of account setup."
 msgstr ""
 
 #. Translators: This message is displayed on the page where users can confirm their renewal. Please do not translate partner.
@@ -742,12 +696,8 @@ msgstr "До кои извори сакате да пристапите?"
 
 #. Translators: This text explains that Library Bundle partners are not shown in this list.
 #: TWLight/applications/templates/applications/request_for_application.html:26
-msgid ""
-"Library Bundle partners are not shown as eligibility is determined "
-"automatically."
-msgstr ""
-"Партнерите на Библиотечен пакет не се прикажуваат бидејќи подобноста се "
-"одредува автоматски."
+msgid "Library Bundle partners are not shown as eligibility is determined automatically."
+msgstr "Партнерите на Библиотечен пакет не се прикажуваат бидејќи подобноста се одредува автоматски."
 
 #. Translators: On the page where users can apply for multiple partners, this message shows next to the partner name, taking them to the full application page when clicked.
 #: TWLight/applications/templates/applications/request_for_application.html:48
@@ -761,14 +711,8 @@ msgstr ""
 
 #. Translators: the HTML is so that the word 'waitlisted' will look the same as it does in the page above; please translate 'waitlisted' the same way you did elsewhere in this file.
 #: TWLight/applications/templates/applications/request_for_application.html:74
-msgid ""
-"You can apply to <span class=\"badge badge-warning\">Waitlisted</span> "
-"partners, but they don't have access grants available right now. We will "
-"process those applications when access becomes available."
-msgstr ""
-"Можете да доставите барање до соработници <span class=\"badge badge-warning"
-"\">во чекалницата</span>, но тие тековно немаат расположливи дозволи за "
-"пристап. Таквите барања ќе се разгледаат кога ќе се појават дозволи."
+msgid "You can apply to <span class=\"badge badge-warning\">Waitlisted</span> partners, but they don't have access grants available right now. We will process those applications when access becomes available."
+msgstr "Можете да доставите барање до соработници <span class=\"badge badge-warning\">во чекалницата</span>, но тие тековно немаат расположливи дозволи за пристап. Таквите барања ќе се разгледаат кога ќе се појават дозволи."
 
 #. Translators: On the page where coordinators can see approved applications which have not had their details sent to the partner, this message shows when there are applications ready to be processed.
 #: TWLight/applications/templates/applications/send.html:10
@@ -789,9 +733,7 @@ msgstr ""
 #. Translators: This message is shown when applications exceed the number of accounts available.
 #: TWLight/applications/templates/applications/send_partner.html:54
 #, python-format
-msgid ""
-"Application(s) for %(object)s, if sent, will exceed the total available "
-"accounts for the partner. Please proceed at your own discretion."
+msgid "Application(s) for %(object)s, if sent, will exceed the total available accounts for the partner. Please proceed at your own discretion."
 msgstr ""
 
 #. Translators: When viewing the list of applications ready to be sent for a particular partner, this is instructions for the coordinator to click the 'mark as sent' button after they have sent the information.
@@ -808,9 +750,7 @@ msgstr[1] "Контакти"
 
 #. Translators: When viewing the list of applications ready to be sent for a particular partner, this message shows if there is no information about who the applications should be sent to. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/applications/templates/applications/send_partner.html:89
-msgid ""
-"Whoops, we don't have any listed contacts. Please notify Wikipedia Library "
-"administrators."
+msgid "Whoops, we don't have any listed contacts. Please notify Wikipedia Library administrators."
 msgstr ""
 
 #. Translators: When viewing the list of applications ready to be sent for a particular partner, this is the title of the section containing the information about those applications.
@@ -826,9 +766,7 @@ msgstr "Означи како испратено"
 
 #. Translators: This text guides coordinators in using the code sending interface for approved applications.
 #: TWLight/applications/templates/applications/send_partner.html:152
-msgid ""
-"Use the dropdown menus to denote which editor will receive each code. Access "
-"codes will be sent to users automatically."
+msgid "Use the dropdown menus to denote which editor will receive each code. Access codes will be sent to users automatically."
 msgstr ""
 
 #. Translators: This labels a drop-down selection where staff can assign an access code to a user.
@@ -844,24 +782,14 @@ msgstr ""
 #. Translators: When a user applies for a set of resources, they receive this message if none are currently available. They are instead placed on a 'waitlist' for later approval.
 #. Translators: When a user renews their resource, they receive this message if none are currently available. They are instead placed on a 'waitlist' for later approval.
 #: TWLight/applications/views.py:140 TWLight/applications/views.py:1282
-msgid ""
-"This partner does not have any access grants available at this time. You may "
-"still apply for access; your application will be reviewed when access grants "
-"become available."
-msgstr ""
-"Овој соработник тековно нема расположливи дозволи за пристап. Можете сепак "
-"да доставите барање, но тоа ќе се разгледа откако ќе се појават достапни "
-"дозволи."
+msgid "This partner does not have any access grants available at this time. You may still apply for access; your application will be reviewed when access grants become available."
+msgstr "Овој соработник тековно нема расположливи дозволи за пристап. Можете сепак да доставите барање, но тоа ќе се разгледа откако ќе се појават достапни дозволи."
 
 #. Translators: This message is shown to users once they've successfully submitted their application for review.
 #: TWLight/applications/views.py:163
 #, python-brace-format
-msgid ""
-"Your application has been submitted for review. Head over to <a "
-"href='{applications_url}'>My Applications</a> to view the status."
-msgstr ""
-"Вашето барање е поднесено на разгледување. Појдет на <a "
-"href='{applications_url}'>Мои барања</a> за да го видите статусот."
+msgid "Your application has been submitted for review. Head over to <a href='{applications_url}'>My Applications</a> to view the status."
+msgstr "Вашето барање е поднесено на разгледување. Појдет на <a href='{applications_url}'>Мои барања</a> за да го видите статусот."
 
 #. Translators: This text is displayed to users when the user has chosen to restrict data and is trying to apply for multiple partners
 #: TWLight/applications/views.py:276
@@ -909,16 +837,12 @@ msgstr "Испратени барања"
 
 #. Translators: After a coordinator has changed the status of an application to APPROVED, if the corresponding partner/collection is waitlisted this message appears.
 #: TWLight/applications/views.py:756
-msgid ""
-"Cannot approve application as partner with proxy authorization method is "
-"waitlisted."
+msgid "Cannot approve application as partner with proxy authorization method is waitlisted."
 msgstr ""
 
 #. Translators: After a coordinator has changed the status of an application to APPROVED, if the corresponding partner/collection has no accounts for distribution, this message appears.
 #: TWLight/applications/views.py:780
-msgid ""
-"Cannot approve application as partner with proxy authorization method is "
-"waitlisted and (or) has zero accounts available for distribution."
+msgid "Cannot approve application as partner with proxy authorization method is waitlisted and (or) has zero accounts available for distribution."
 msgstr ""
 
 #. Translators: This message appears on an "access denied" screen that stops users who attempt to authorize an editor to access a resource during a time period for which they are already authorized.
@@ -929,11 +853,7 @@ msgstr ""
 #. Translators: This message is shown to users when they access an application page of a now Bundle partner (new applications aren't allowed for Bundle partners and the status of old applications cannot be modified)
 #: TWLight/applications/views.py:857
 #, python-brace-format
-msgid ""
-"This application cannot be modified since this partner is now part of our <a "
-"href='{bundle}'>bundle access</a>. If you are eligible, you can access this "
-"resource from <a href='{library}'>your library</a>. <a "
-"href='{contact}'>Contact us</a> if you have any questions."
+msgid "This application cannot be modified since this partner is now part of our <a href='{bundle}'>bundle access</a>. If you are eligible, you can access this resource from <a href='{library}'>your library</a>. <a href='{contact}'>Contact us</a> if you have any questions."
 msgstr ""
 
 #. Translators: this lets a reviewer set the status of a single application.
@@ -943,12 +863,8 @@ msgstr "Задај состојба на барања"
 
 #. Translators: This warning is message is shown to applicants when the number of pending applications is greater than the number of accounts available.
 #: TWLight/applications/views.py:891
-msgid ""
-"There are more pending applications than available accounts. Your "
-"application might get waitlisted."
-msgstr ""
-"Има повеќе необработени барања отколку расположливи сметки. Вашето барање "
-"може да биде ставено на чекање."
+msgid "There are more pending applications than available accounts. Your application might get waitlisted."
+msgstr "Има повеќе необработени барања отколку расположливи сметки. Вашето барање може да биде ставено на чекање."
 
 #. Translators: this message is shown to coordinators who attempt to change an application's Status from INVALID to any other Status.
 #: TWLight/applications/views.py:904
@@ -967,11 +883,7 @@ msgstr ""
 
 #. Translators: After a coordinator has changed the status of a number of applications to APPROVED, if the corresponding partner(s) is/are waitlisted or has no accounts for distribution, this message appears.
 #: TWLight/applications/views.py:1051
-msgid ""
-"Cannot approve application(s) {} as partner(s) with proxy authorization "
-"method is/are waitlisted and (or) has/have not enough accounts available. If "
-"not enough accounts are available, prioritise the applications and then "
-"approve applications equal to the accounts available."
+msgid "Cannot approve application(s) {} as partner(s) with proxy authorization method is/are waitlisted and (or) has/have not enough accounts available. If not enough accounts are available, prioritise the applications and then approve applications equal to the accounts available."
 msgstr ""
 
 #. Translators: This message is shown to coordinators who attempt to assign the same access code to multiple users.
@@ -986,9 +898,7 @@ msgstr ""
 
 #. Translators: When a user tries to renew their resource, they receive this message if the partner is not available.
 #: TWLight/applications/views.py:1272
-msgid ""
-"Cannot renew application at this time as partner is not available. Please "
-"check back later, or contact us for more information."
+msgid "Cannot renew application at this time as partner is not available. Please check back later, or contact us for more information."
 msgstr ""
 
 #. Translators: This message is displayed when an attempt by a user to renew an application has been denied for some reason.
@@ -999,16 +909,12 @@ msgstr ""
 
 #. Translators: If a user requests the renewal of their account, but it wasn't renewed, this message is shown to them.
 #: TWLight/applications/views.py:1385
-msgid ""
-"This object cannot be renewed. (This probably means that you have already "
-"requested that it be renewed.)"
+msgid "This object cannot be renewed. (This probably means that you have already requested that it be renewed.)"
 msgstr ""
 
 #. Translators: If a user requests the renewal of their account, this message is shown to them.
 #: TWLight/applications/views.py:1395
-msgid ""
-"Your renewal request has been received. A coordinator will review your "
-"request."
+msgid "Your renewal request has been received. A coordinator will review your request."
 msgstr ""
 
 #. Translators: This labels a textfield where users can enter their email ID.
@@ -1018,9 +924,7 @@ msgstr "Ваша е-пошта"
 
 #. Translators: This is the help text for the email field in the contact us form letting users know the field is updated by value pulled from their respective user profiles.
 #: TWLight/emails/forms.py:21
-msgid ""
-"This field is automatically updated with the email from your <a class='twl-"
-"links' href='{}'>user profile</a>."
+msgid "This field is automatically updated with the email from your <a class='twl-links' href='{}'>user profile</a>."
 msgstr ""
 
 #. Translators: This labels a textfield where users can enter their email message.
@@ -1044,19 +948,13 @@ msgstr "Поднеси"
 #. Translators: This email is sent to users with their access code. Don't translate Jinja variables in curly braces like user or partner. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/access_code_email-body-html.html:5
 #, python-format
-msgid ""
-"<p>Your approved application to %(partner)s has now been finalised. Your "
-"access code or login details can be found below:</p> <p><b>%(access_code)s</"
-"b></p> <p>%(user_instructions)s</p>"
+msgid "<p>Your approved application to %(partner)s has now been finalised. Your access code or login details can be found below:</p> <p><b>%(access_code)s</b></p> <p>%(user_instructions)s</p>"
 msgstr ""
 
 #. Translators: This email is sent to users with their access code. Don't translate Jinja variables in curly braces like user or partner. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/access_code_email-body-text.html:3
 #, python-format
-msgid ""
-"Your approved application to %(partner)s has now been finalised. Your access "
-"code or login details can be found below: %(access_code)s "
-"%(user_instructions)s"
+msgid "Your approved application to %(partner)s has now been finalised. Your access code or login details can be found below: %(access_code)s %(user_instructions)s"
 msgstr ""
 
 #. Translators: This is the subject line of an email sent to users with their access code.
@@ -1067,23 +965,13 @@ msgstr "Вашиот пристапен код за Викимедиината �
 #. Translators: This email is sent to users when their application is approved. Don't translate Jinja variables in curly braces like user or partner; don't translate html tags either. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/approval_notification-body-html.html:5
 #, python-format
-msgid ""
-"<p>Dear %(user)s,</p> <p>Thank you for applying for access to %(partner)s "
-"resources through The Wikipedia Library. We are happy to inform you that "
-"your application has been approved.</p> <p>%(user_instructions)s</p> <p>You "
-"can view the collections you're authorized to access at My Library: "
-"%(link)s</p> <p>Cheers!</p> <p>The Wikipedia Library</p>"
+msgid "<p>Dear %(user)s,</p> <p>Thank you for applying for access to %(partner)s resources through The Wikipedia Library. We are happy to inform you that your application has been approved.</p> <p>%(user_instructions)s</p> <p>You can view the collections you're authorized to access at My Library: %(link)s</p> <p>Cheers!</p> <p>The Wikipedia Library</p>"
 msgstr ""
 
 #. Translators: This email is sent to users when their application is approved. Don't translate Jinja variables in curly braces like user or partner. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/approval_notification-body-text.html:3
 #, python-format
-msgid ""
-"Dear %(user)s, Thank you for applying for access to %(partner)s resources "
-"through The Wikipedia Library. We are happy to inform you that your "
-"application has been approved. %(user_instructions)s You can view the "
-"collections you're authorized to access at My Library: %(link)s Cheers! The "
-"Wikipedia Library"
+msgid "Dear %(user)s, Thank you for applying for access to %(partner)s resources through The Wikipedia Library. We are happy to inform you that your application has been approved. %(user_instructions)s You can view the collections you're authorized to access at My Library: %(link)s Cheers! The Wikipedia Library"
 msgstr ""
 
 #. Translators: This is the subject of an email which is sent to users when their application has been approved. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
@@ -1094,19 +982,13 @@ msgstr ""
 #. Translators: This email is sent to coordinators when a comment is left on an application they are processing. Don't translate Jinja variables in curly braces like user or partner. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/comment_notification_coordinator-body-html.html:5
 #, python-format
-msgid ""
-"<p style=\"color: #500050\">%(submit_date)s - %(commenter)s</p> "
-"<blockquote><p>%(comment)s</p></blockquote> <p>Please reply to these at: <a "
-"href=\"%(app_url)s\">%(app_url)s</a></p> <p>Best,</p> <p>The Wikipedia "
-"Library</p>"
+msgid "<p style=\"color: #500050\">%(submit_date)s - %(commenter)s</p> <blockquote><p>%(comment)s</p></blockquote> <p>Please reply to these at: <a href=\"%(app_url)s\">%(app_url)s</a></p> <p>Best,</p> <p>The Wikipedia Library</p>"
 msgstr ""
 
 #. Translators: This email is sent to coordinators when a comment is left on an application they are processing. Don't translate Jinja variables in curly braces like user or partner. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/comment_notification_coordinator-body-text.html:3
 #, python-format
-msgid ""
-"%(submit_date)s - %(commenter)s %(comment)s Please reply to this at: "
-"%(app_url)s Best, The Wikipedia Library"
+msgid "%(submit_date)s - %(commenter)s %(comment)s Please reply to this at: %(app_url)s Best, The Wikipedia Library"
 msgstr ""
 
 #. Translators: This is the subject line of an email sent to coordinators when a comment is left on an application they processed.
@@ -1117,19 +999,13 @@ msgstr ""
 #. Translators: This email is sent to users when they receive a comment on their application. Don't translate Jinja variables in curly braces like user or partner; don't translate html tags either. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/comment_notification_editors-body-html.html:5
 #, python-format
-msgid ""
-"<p style=\"color: #500050\">%(submit_date)s - %(commenter)s</p> "
-"<blockquote><p>%(comment)s</p></blockquote> <p>Please reply to these at <a "
-"href=\"%(app_url)s\">%(app_url)s</a> so we can evaluate your application.</"
-"p> <p>Best,</p> <p>The Wikipedia Library</p>"
+msgid "<p style=\"color: #500050\">%(submit_date)s - %(commenter)s</p> <blockquote><p>%(comment)s</p></blockquote> <p>Please reply to these at <a href=\"%(app_url)s\">%(app_url)s</a> so we can evaluate your application.</p> <p>Best,</p> <p>The Wikipedia Library</p>"
 msgstr ""
 
 #. Translators: This email is sent to users when they receive a comment on their application. Don't translate Jinja variables in curly braces like user or partner. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/comment_notification_editors-body-text.html:3
 #, python-format
-msgid ""
-"%(submit_date)s - %(commenter)s %(comment)s Please reply to these at: "
-"%(app_url)s so we can evaluate your application. Best, The Wikipedia Library"
+msgid "%(submit_date)s - %(commenter)s %(comment)s Please reply to these at: %(app_url)s so we can evaluate your application. Best, The Wikipedia Library"
 msgstr ""
 
 #. Translators: This is the subject line of an email sent to users who have a comment added to one of their applications. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
@@ -1140,18 +1016,13 @@ msgstr ""
 #. Translators: This email is sent to users when an application they commented on receives another comment. Don't translate Jinja variables in curly braces like app_url; don't translate html tags either. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/comment_notification_others-body-html.html:5
 #, python-format
-msgid ""
-"<p style=\"color: #500050\">%(submit_date)s - %(commenter)s</p> "
-"<blockquote><p>%(comment)s</p></blockquote> See it at <a href=\"%(app_url)s"
-"\">%(app_url)s</a>. Thanks for helping review Wikipedia Library applications!"
+msgid "<p style=\"color: #500050\">%(submit_date)s - %(commenter)s</p> <blockquote><p>%(comment)s</p></blockquote> See it at <a href=\"%(app_url)s\">%(app_url)s</a>. Thanks for helping review Wikipedia Library applications!"
 msgstr ""
 
 #. Translators: This email is sent to users when an application they commented on receives another comment. Don't translate Jinja variables in curly braces like app_url. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/comment_notification_others-body-text.html:3
 #, python-format
-msgid ""
-"%(submit_date)s - %(commenter)s %(comment)s See it at: %(app_url)s Thanks "
-"for helping review Wikipedia Library applications!"
+msgid "%(submit_date)s - %(commenter)s %(comment)s See it at: %(app_url)s Thanks for helping review Wikipedia Library applications!"
 msgstr ""
 
 #. Translators: This is the subject line of an email sent to users who have a comment added to an application they also commented on. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
@@ -1162,10 +1033,7 @@ msgstr ""
 #. Translators: This text is part of a scheduled reminder email sent to coordinators who have applications requiring action. Don't translate Jinja variables in curly braces like total_apps, or user.
 #: TWLight/emails/templates/emails/coordinator_reminder_notification-body-html.html:5
 #, python-format
-msgid ""
-"<p>Dear %(user)s,</p> <p>Our records indicate that you are the designated "
-"coordinator for partners that have a total of %(total_apps)s applications.</"
-"p>"
+msgid "<p>Dear %(user)s,</p> <p>Our records indicate that you are the designated coordinator for partners that have a total of %(total_apps)s applications.</p>"
 msgstr ""
 
 #. Translators: Breakdown as in 'cost breakdown'; analysis.
@@ -1204,31 +1072,19 @@ msgstr[1] "%(counter)s одобрени барања."
 #. Translators: This text is part of a scheduled reminder email sent to coordinators who have applications requiring action. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library). Don't translate Jinja variables in curly braces like link; don't translate email addresses or html tags either.
 #: TWLight/emails/templates/emails/coordinator_reminder_notification-body-html.html:39
 #, python-format
-msgid ""
-"<p>This is a gentle reminder that you may review applications at <a href="
-"\"%(link)s\">%(link)s</a>.</p> <p>You can customise your reminders under "
-"'preferences' in your user profile.</p> <p>If you received this message in "
-"error, drop us a line at wikipedialibrary@wikimedia.org.</p> <p>Thanks for "
-"helping review Wikipedia Library applications!</p>"
+msgid "<p>This is a gentle reminder that you may review applications at <a href=\"%(link)s\">%(link)s</a>.</p> <p>You can customise your reminders under 'preferences' in your user profile.</p> <p>If you received this message in error, drop us a line at wikipedialibrary@wikimedia.org.</p> <p>Thanks for helping review Wikipedia Library applications!</p>"
 msgstr ""
 
 #. Translators: This text is part of a scheduled reminder email sent to coordinators who have applications requiring action. Don't translate Jinja variables in curly braces like total_apps, or user.
 #: TWLight/emails/templates/emails/coordinator_reminder_notification-body-text.html:3
 #, python-format
-msgid ""
-"Dear %(user)s, Our records indicate that you are the designated coordinator "
-"for partners that have a total of %(total_apps)s applications."
+msgid "Dear %(user)s, Our records indicate that you are the designated coordinator for partners that have a total of %(total_apps)s applications."
 msgstr ""
 
 #. Translators: This text is part of a scheduled reminder email sent to coordinators who have applications requiring action. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library). Don't translate Jinja variables in curly braces like link; don't translate the email address either.
 #: TWLight/emails/templates/emails/coordinator_reminder_notification-body-text.html:38
 #, python-format
-msgid ""
-"This is a gentle reminder that you may review applications at: %(link)s. You "
-"can customise your reminders under 'preferences' in your user profile. If "
-"you received this message in error, drop us a line at: "
-"wikipedialibrary@wikimedia.org Thanks for helping review Wikipedia Library "
-"applications!"
+msgid "This is a gentle reminder that you may review applications at: %(link)s. You can customise your reminders under 'preferences' in your user profile. If you received this message in error, drop us a line at: wikipedialibrary@wikimedia.org Thanks for helping review Wikipedia Library applications!"
 msgstr ""
 
 #. Translators: This is the subject line of a scheduled reminder email sent to coordinators who have applications to review. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library). Do not translate items in curly braces.
@@ -1239,22 +1095,13 @@ msgstr ""
 #. Translators: This email is sent to users when their application is rejected. Don't translate Jinja variables in curly braces like user or partner; don't translate html tags either. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/rejection_notification-body-html.html:5
 #, python-format
-msgid ""
-"<p>Dear %(user)s,</p> <p>Thank you for applying for access to %(partner)s "
-"resources through The Wikipedia Library. Unfortunately at this time your "
-"application has not been approved. You can view your application and review "
-"comments at <a href=\"%(app_url)s\">%(app_url)s</a>.</p> <p>Best,</p> <p>The "
-"Wikipedia Library</p>"
+msgid "<p>Dear %(user)s,</p> <p>Thank you for applying for access to %(partner)s resources through The Wikipedia Library. Unfortunately at this time your application has not been approved. You can view your application and review comments at <a href=\"%(app_url)s\">%(app_url)s</a>.</p> <p>Best,</p> <p>The Wikipedia Library</p>"
 msgstr ""
 
 #. Translators: This email is sent to users when their application is rejected. Don't translate Jinja variables in curly braces like user or partner. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/rejection_notification-body-text.html:3
 #, python-format
-msgid ""
-"Dear %(user)s, Thank you for applying for access to %(partner)s resources "
-"through The Wikipedia Library. Unfortunately at this time your application "
-"has not been approved. You can view your application and review comments at: "
-"%(app_url)s Best, The Wikipedia Library"
+msgid "Dear %(user)s, Thank you for applying for access to %(partner)s resources through The Wikipedia Library. Unfortunately at this time your application has not been approved. You can view your application and review comments at: %(app_url)s Best, The Wikipedia Library"
 msgstr ""
 
 #. Translators: This is the subject of an email which is sent to users when their application has been rejected. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
@@ -1265,25 +1112,13 @@ msgstr "Вашето барање во Википедиината библиот
 #. Translators: This email is sent to users when they have an account that is soon to expire. Don't translate Jinja variables in curly braces like partner_name or partner_link; don't translate html tags either. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/user_renewal_notice-body-html.html:5
 #, python-format
-msgid ""
-"<p>Dear %(user)s,</p> <p>According to our records, your access to "
-"%(partner_name)s will soon expire and you may lose access. If you want to "
-"continue making use of your free account, you can request renewal of your "
-"account by clicking the 'Renew' or 'Extend' button at %(partner_link)s.</p> "
-"<p>Best,</p> <p>The Wikipedia Library</p> <p>You can disable these emails in "
-"your user page preferences: https://wikipedialibrary.wmflabs.org/users/</p>"
+msgid "<p>Dear %(user)s,</p> <p>According to our records, your access to %(partner_name)s will soon expire and you may lose access. If you want to continue making use of your free account, you can request renewal of your account by clicking the 'Renew' or 'Extend' button at %(partner_link)s.</p> <p>Best,</p> <p>The Wikipedia Library</p> <p>You can disable these emails in your user page preferences: https://wikipedialibrary.wmflabs.org/users/</p>"
 msgstr ""
 
 #. Translators: This email is sent to users when they have an account that is soon to expire. Don't translate Jinja variables in curly braces like partner_name or partner_link; don't translate html tags either. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/user_renewal_notice-body-text.html:3
 #, python-format
-msgid ""
-"Dear %(user)s, According to our records, your access to %(partner_name)s "
-"will soon expire and you may lose access. If you want to continue making use "
-"of your free account, you can request renewal of your account by clicking "
-"the Renew button at %(partner_link)s. Best, The Wikipedia Library You can "
-"disable these emails in your user page preferences: https://wikipedialibrary."
-"wmflabs.org/users/"
+msgid "Dear %(user)s, According to our records, your access to %(partner_name)s will soon expire and you may lose access. If you want to continue making use of your free account, you can request renewal of your account by clicking the Renew button at %(partner_link)s. Best, The Wikipedia Library You can disable these emails in your user page preferences: https://wikipedialibrary.wmflabs.org/users/"
 msgstr ""
 
 #. Translators: This is the subject of an email sent to users when they have an account that is soon to expire. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
@@ -1294,24 +1129,13 @@ msgstr "Вашиот пристап до Википедиината библио
 #. Translators: This email is sent to users when their application is waitlisted because there are no more accounts available. Don't translate Jinja variables in curly braces like user or partner; don't translate html tags either. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/waitlist_notification-body-html.html:5
 #, python-format
-msgid ""
-"<p>Dear %(user)s,</p> <p>Thank you for applying for access to %(partner)s "
-"resources through The Wikipedia Library. There are no accounts currently "
-"available so your application has been waitlisted. Your application will be "
-"evaluated if/when more accounts become available. You can see all available "
-"resources at <a href=\"%(link)s\">%(link)s</a>.</p> <p>Best,</p> <p>The "
-"Wikipedia Library</p>"
+msgid "<p>Dear %(user)s,</p> <p>Thank you for applying for access to %(partner)s resources through The Wikipedia Library. There are no accounts currently available so your application has been waitlisted. Your application will be evaluated if/when more accounts become available. You can see all available resources at <a href=\"%(link)s\">%(link)s</a>.</p> <p>Best,</p> <p>The Wikipedia Library</p>"
 msgstr ""
 
 #. Translators: This email is sent to users when their application is waitlisted because there are no more accounts available. Don't translate Jinja variables in curly braces like user or partner. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/waitlist_notification-body-text.html:3
 #, python-format
-msgid ""
-"Dear %(user)s, Thank you for applying for access to %(partner)s resources "
-"through The Wikipedia Library. There are no accounts currently available so "
-"your application has been waitlisted. Your application will be evaluated if/"
-"when more accounts become available. You can see all available resources at: "
-"%(link)s Best, The Wikipedia Library"
+msgid "Dear %(user)s, Thank you for applying for access to %(partner)s resources through The Wikipedia Library. There are no accounts currently available so your application has been waitlisted. Your application will be evaluated if/when more accounts become available. You can see all available resources at: %(link)s Best, The Wikipedia Library"
 msgstr ""
 
 #. Translators: This is the subject of an email sent to users when their application is waitlisted because there are no more accounts available. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
@@ -1473,22 +1297,15 @@ msgstr "Недостапно"
 #: TWLight/resources/templates/resources/filter_section.html:14
 #: TWLight/templates/about.html:12
 #: TWLight/users/templates/users/filter_section.html:13
-msgid ""
-"The Wikipedia Library allows active editors to access a wide range of "
-"collections of paywalled reliable sources for free!"
-msgstr ""
-"Википедиината библиотека им овозможува на активните уредници пристап до "
-"широк опсег на збирки на платни доверливи извори!"
+msgid "The Wikipedia Library allows active editors to access a wide range of collections of paywalled reliable sources for free!"
+msgstr "Википедиината библиотека им овозможува на активните уредници пристап до широк опсег на збирки на платни доверливи извори!"
 
 #. Translators: On the Browse Partners page (https://wikipedialibrary.wmflabs.org/partners/), this introduces users to The Wikipedia Library.
 #. Translators: On the MyLibrary page (https://wikipedialibrary.wmflabs.org/users/my_library), this introduces users to The Wikipedia Library.
 #: TWLight/resources/templates/resources/filter_section.html:17
 #: TWLight/users/templates/users/filter_section.html:15
-msgid ""
-"Start with the search bar at the top or browse publisher websites directly."
-msgstr ""
-"Почнете со полето за пребарување на врвот од страницата или непосредно "
-"прелистајте ги мрежните места на издавачите."
+msgid "Start with the search bar at the top or browse publisher websites directly."
+msgstr "Почнете со полето за пребарување на врвот од страницата или непосредно прелистајте ги мрежните места на издавачите."
 
 #. Translators: On the Browse Partners page (https://wikipedialibrary.wmflabs.org/partners/), this appears below introductory text and links to the 'About' page (https://wikipedialibrary.wmflabs.org/about/)
 #. Translators: On the MyLibrary page (https://wikipedialibrary.wmflabs.org/users/my_library), this appears below introductory text and links to the 'About' page (https://wikipedialibrary.wmflabs.org/about/)
@@ -1561,55 +1378,38 @@ msgstr "Назад кон партнерите"
 #. Translators: If we have no available accounts for a partner, the coordinator can change the application system to a waiting list.
 #: TWLight/resources/templates/resources/partner_detail.html:36
 #: TWLight/resources/templates/resources/partner_detail_apply.html:17
-msgid ""
-"There are no access grants available for this partner at this time. You can "
-"still apply for access; applications will be processed when access is "
-"available."
-msgstr ""
-"Тековно соработникот нема расположливи дозволи за пристап. Можете сепак да "
-"доставите барање, но тоа ќе се разгледа откако ќе се појават достапни "
-"дозволи."
+msgid "There are no access grants available for this partner at this time. You can still apply for access; applications will be processed when access is available."
+msgstr "Тековно соработникот нема расположливи дозволи за пристап. Можете сепак да доставите барање, но тоа ќе се разгледа откако ќе се појават достапни дозволи."
 
 #. Translators: This text links to the minimum user requirements and terms of use on the partner page.
 #: TWLight/resources/templates/resources/partner_detail.html:48
 #: TWLight/resources/templates/resources/partner_detail_apply.html:29
 #, python-format
-msgid ""
-"Before applying, please review the <strong><a class=\"twl-links\" href="
-"\"%(about)s#req\">minimum requirements</a></strong> for access and our "
-"<strong><a class=\"twl-links\" href=\"%(terms)s\">terms of use</a></strong>."
+msgid "Before applying, please review the <strong><a class=\"twl-links\" href=\"%(about)s#req\">minimum requirements</a></strong> for access and our <strong><a class=\"twl-links\" href=\"%(terms)s\">terms of use</a></strong>."
 msgstr ""
 
 #. Translators: This text refers to the page containing the content a user is authorized to access.
 #: TWLight/resources/templates/resources/partner_detail.html:69
 #, python-format
-msgid ""
-"View the status of your access in <strong><a class=\"twl-links\" href="
-"\"%(library_url)s\">My Library</a></strong> page."
+msgid "View the status of your access in <strong><a class=\"twl-links\" href=\"%(library_url)s\">My Library</a></strong> page."
 msgstr ""
 
 #. Translators: This message is shown when a user has open applications, linking to their respective applications page.
 #: TWLight/resources/templates/resources/partner_detail.html:78
 #, python-format
-msgid ""
-"View the status of your application(s) on your <strong><a class=\"twl-links"
-"\" href=\"%(applications_url)s\">My Applications</a></strong> page."
+msgid "View the status of your application(s) on your <strong><a class=\"twl-links\" href=\"%(applications_url)s\">My Applications</a></strong> page."
 msgstr ""
 
 #. Translators: This message is shown when a user has authorizations, linking to their respective collections page.
 #: TWLight/resources/templates/resources/partner_detail_apply.html:50
 #, python-format
-msgid ""
-"View the status of your access on your <strong><a href=\"%(library_url)s\" "
-"class=\"twl-links\">My Library</a></strong> page."
+msgid "View the status of your access on your <strong><a href=\"%(library_url)s\" class=\"twl-links\">My Library</a></strong> page."
 msgstr ""
 
 #. Translators: This message is shown when a user has open applications, linking to their respective applications page.
 #: TWLight/resources/templates/resources/partner_detail_apply.html:60
 #, python-format
-msgid ""
-"View the status of your application(s) on your <strong><a href="
-"\"%(applications_url)s\">My Applications</a></strong> page."
+msgid "View the status of your application(s) on your <strong><a href=\"%(applications_url)s\">My Applications</a></strong> page."
 msgstr ""
 
 #. Translators: One the partner detail page, this text labels the button which coordinators can click to remove a partner from waitlisted status.
@@ -1639,10 +1439,7 @@ msgstr "Службена:Е-пошта за корисникот"
 
 #. Translators: If no account coordinator is assigned to a partner, the Wikipedia Library team will coordinate signups. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/resources/templates/resources/partner_detail_apply.html:112
-msgid ""
-"The Wikipedia Library team will process this application. Want to help? <a "
-"class=\"twl-links\" href=\"https://en.wikipedia.org/wiki/Wikipedia:"
-"The_Wikipedia_Library/Coordinators/Signup\">Sign up as a coordinator.</a>"
+msgid "The Wikipedia Library team will process this application. Want to help? <a class=\"twl-links\" href=\"https://en.wikipedia.org/wiki/Wikipedia:The_Wikipedia_Library/Coordinators/Signup\">Sign up as a coordinator.</a>"
 msgstr ""
 
 #. Translators: This text labels a button coordinators can click to view a list of users who have applied for access for a particular partner
@@ -1672,24 +1469,14 @@ msgstr "Пристап до библиотечниот пакет"
 
 #. Translators: Text shown to authenticated, bundle eligible users when they visit a Bundle partner page.
 #: TWLight/resources/templates/resources/partner_detail_apply.html:138
-msgid ""
-"You are eligible to access Library Bundle partners. Click the button above "
-"to access the collection."
-msgstr ""
-"Ги исполнувате условите за пристап до партнерите на Библиотечен пакет. "
-"Стиснете на копчето погоре за да дојдете до збирката."
+msgid "You are eligible to access Library Bundle partners. Click the button above to access the collection."
+msgstr "Ги исполнувате условите за пристап до партнерите на Библиотечен пакет. Стиснете на копчето погоре за да дојдете до збирката."
 
 #. Translators: Text shown to authenticated, bundle ineligible users when they visit a Bundle partner page.
 #: TWLight/resources/templates/resources/partner_detail_apply.html:152
 #, python-format
-msgid ""
-"You are not eligible to access Library Bundle partners. Visit the <a class="
-"\"twl-links\" href=\"%(homepage)s\">homepage</a> to check the eligibility "
-"criteria."
-msgstr ""
-"Не ги исполнувате условите за пристап до партнерите на Библиотечен пакет. "
-"Посетете ја <a class=\"twl-links\" href=\"%(homepage)s\">почетната страница</"
-"a> и погледајте ги критериумите за пободност."
+msgid "You are not eligible to access Library Bundle partners. Visit the <a class=\"twl-links\" href=\"%(homepage)s\">homepage</a> to check the eligibility criteria."
+msgstr "Не ги исполнувате условите за пристап до партнерите на Библиотечен пакет. Посетете ја <a class=\"twl-links\" href=\"%(homepage)s\">почетната страница</a> и погледајте ги критериумите за пободност."
 
 #. Translators: Buttton prompting users to log in.
 #: TWLight/resources/templates/resources/partner_detail_apply.html:160
@@ -1700,14 +1487,8 @@ msgstr "Најава"
 #. Translators: Text shown to unauthenticated users when they visit a Bundle partner page.
 #: TWLight/resources/templates/resources/partner_detail_apply.html:168
 #, python-format
-msgid ""
-"This resource is part of our <a class=\"twl-links\" href=\"%(about)s"
-"\">Library Bundle</a>, which you can access if you meet our minimum "
-"eligibility criteria. Log in to find out if you are eligible."
-msgstr ""
-"Овој ресурс е дел од нашиот <a class=\"twl-links\" href=\"%(about)s"
-"\">Библиотечен пакет</a>, кој можете да го користите ако ги исполнуватете "
-"условите за подобност. Најавете се за да дознаете дали сте подобни."
+msgid "This resource is part of our <a class=\"twl-links\" href=\"%(about)s\">Library Bundle</a>, which you can access if you meet our minimum eligibility criteria. Log in to find out if you are eligible."
+msgstr "Овој ресурс е дел од нашиот <a class=\"twl-links\" href=\"%(about)s\">Библиотечен пакет</a>, кој можете да го користите ако ги исполнуватете условите за подобност. Најавете се за да дознаете дали сте подобни."
 
 #. Translators: This is the label for a number which shows the total active accounts for one partner. (e.g. https://wikipedialibrary.wmflabs.org/partners/8/).
 #: TWLight/resources/templates/resources/partner_detail_stats.html:21
@@ -1757,34 +1538,20 @@ msgstr "Ограничување на извадокот"
 #. Translators: If a partner has specified the excerpt limit both in words and percentage, this message will display the percentage of words and the number of words on the partner page.
 #: TWLight/resources/templates/resources/partner_detail_timeline.html:99
 #, python-format
-msgid ""
-"%(object)s allows a maximum of %(excerpt_limit)s words or "
-"%(excerpt_limit_percentage)s%% of an article be excerpted into a Wikipedia "
-"article."
-msgstr ""
-"%(object)s допушта највеќе %(excerpt_limit)s зборови или "
-"%(excerpt_limit_percentage)s%% од статија да бидат ставени како извадок во "
-"статија на Википедија."
+msgid "%(object)s allows a maximum of %(excerpt_limit)s words or %(excerpt_limit_percentage)s%% of an article be excerpted into a Wikipedia article."
+msgstr "%(object)s допушта највеќе %(excerpt_limit)s зборови или %(excerpt_limit_percentage)s%% од статија да бидат ставени како извадок во статија на Википедија."
 
 #. Translators: If a partner has specified the excerpt limit in words, this message will display the number of words on the partner page.
 #: TWLight/resources/templates/resources/partner_detail_timeline.html:106
 #, python-format
-msgid ""
-"%(object)s allows a maximum of %(excerpt_limit)s words be excerpted into a "
-"Wikipedia article."
-msgstr ""
-"%(object)s допушта највеќе %(excerpt_limit)s зборови да бидат ставени како "
-"извадок во статија на Википедија."
+msgid "%(object)s allows a maximum of %(excerpt_limit)s words be excerpted into a Wikipedia article."
+msgstr "%(object)s допушта највеќе %(excerpt_limit)s зборови да бидат ставени како извадок во статија на Википедија."
 
 #. Translators: If a partner has specified the excerpt limit in percentage, this message will display the percentage of words on the partner page.
 #: TWLight/resources/templates/resources/partner_detail_timeline.html:113
 #, python-format
-msgid ""
-"%(object)s allows a maximum of %(excerpt_limit_percentage)s%% of an article "
-"be excerpted into a Wikipedia article."
-msgstr ""
-"%(object)s допушта највеќе %(excerpt_limit_percentage)s%% од статија да "
-"бидат ставени како извадок во статија на Википедија."
+msgid "%(object)s allows a maximum of %(excerpt_limit_percentage)s%% of an article be excerpted into a Wikipedia article."
+msgstr "%(object)s допушта највеќе %(excerpt_limit_percentage)s%% од статија да бидат ставени како извадок во статија на Википедија."
 
 #. Translators: If a partner has other requirements for access, this text shows as the title for that information field. (e.g. https://wikipedialibrary.wmflabs.org/partners/10/).
 #: TWLight/resources/templates/resources/partner_detail_timeline.html:132
@@ -1794,12 +1561,8 @@ msgstr "Посебни услови за баратели"
 #. Translators: If a user must agree to a Terms of Use document, they see this message, and must enter the name of the resource. Don't translate publisher or url.
 #: TWLight/resources/templates/resources/partner_detail_timeline.html:140
 #, python-format
-msgid ""
-"%(publisher)s requires that you agree with its <a href=\"%(url)s\">terms of "
-"use</a>."
-msgstr ""
-"%(publisher)s бара да се согласите со нивните <a href=\"%(url)s\">услови на "
-"употреба</a>."
+msgid "%(publisher)s requires that you agree with its <a href=\"%(url)s\">terms of use</a>."
+msgstr "%(publisher)s бара да се согласите со нивните <a href=\"%(url)s\">услови на употреба</a>."
 
 #. Translators: If a user must provide their real name to apply to a partner, they see this message, and must enter the name of the resource. Don't translate publisher.
 #: TWLight/resources/templates/resources/partner_detail_timeline.html:150
@@ -1822,18 +1585,13 @@ msgstr "%(publisher)s бара да внесете на која установ�
 #. Translators: If a user must select a specific resource to apply for, they see this message, and must enter the name of the resource. Don't translate publisher.
 #: TWLight/resources/templates/resources/partner_detail_timeline.html:177
 #, python-format
-msgid ""
-"%(publisher)s requires that you specify a particular title that you want to "
-"access."
-msgstr ""
-"%(publisher)s бара да укажете конкретен наслов што сакате да го пристапите."
+msgid "%(publisher)s requires that you specify a particular title that you want to access."
+msgstr "%(publisher)s бара да укажете конкретен наслов што сакате да го пристапите."
 
 #. Translators: If a user must register on the partner website before applying, they see this message. Don't translate partner.
 #: TWLight/resources/templates/resources/partner_detail_timeline.html:187
 #, python-format
-msgid ""
-"%(publisher)s requires that you sign up for an account before applying for "
-"access."
+msgid "%(publisher)s requires that you sign up for an account before applying for access."
 msgstr "%(publisher)s бара да направите сметка пред да побарате пристап."
 
 #. Translators: If a partner has their location listed, this message is a label for that location
@@ -1960,9 +1718,7 @@ msgstr "Сигурно сакате да избришете <b>%(object)s</b>?"
 
 #. Translators: If multiple authorizations where returned for a collection, this message is shown to a user
 #: TWLight/resources/views.py:268
-msgid ""
-"Multiple authorizations were returned – something's wrong. Please contact us "
-"and don't forget to mention this message."
+msgid "Multiple authorizations were returned – something's wrong. Please contact us and don't forget to mention this message."
 msgstr ""
 
 #. Translators: This message is shown when user tries to access a NOT_AVAILABLE Partner
@@ -2003,14 +1759,7 @@ msgstr ""
 #. Translators: Shown on the website's 400 page, when a user sends a bad request. Don't translate path or Phabricator.
 #: TWLight/templates/400.html:20
 #, python-format
-msgid ""
-"If you think we should know what to do with that, please email us about this "
-"error at <a class=\"twl-links\" href=\"mailto:wikipedialibrary@wikimedia.org?"
-"Subject=Wikipedia%%20Library%%20%(path)s%%20Permission%%20denied"
-"\">wikipedialibrary@wikimedia.org</a> or report it to us on <a class=\"twl-"
-"links\" href=\"https://phabricator.wikimedia.org/maniphest/task/edit/form/1/?"
-"projectPHIDs=Library-Card-Platform&title=Wikipedia%%20Library%%20%(path)s"
-"%%20Bad%%20Request\">Phabricator</a>"
+msgid "If you think we should know what to do with that, please email us about this error at <a class=\"twl-links\" href=\"mailto:wikipedialibrary@wikimedia.org?Subject=Wikipedia%%20Library%%20%(path)s%%20Permission%%20denied\">wikipedialibrary@wikimedia.org</a> or report it to us on <a class=\"twl-links\" href=\"https://phabricator.wikimedia.org/maniphest/task/edit/form/1/?projectPHIDs=Library-Card-Platform&title=Wikipedia%%20Library%%20%(path)s%%20Bad%%20Request\">Phabricator</a>"
 msgstr ""
 
 #. Translators: Alt text for an image shown on the 400 error page.
@@ -2032,15 +1781,7 @@ msgstr ""
 #. Translators: Shown on the website's 403 page, when a user attempts to navigate to a page they don't have permission to view. Don't translate path or Phabricator.
 #: TWLight/templates/403.html:20
 #, python-format
-msgid ""
-"If you think your account should be able to do that, please email us about "
-"this error at <a class=\"twl-links\" href=\"mailto:"
-"wikipedialibrary@wikimedia.org?Subject=Wikipedia%%20Library%%20%(path)s"
-"%%20Permission%%20denied\">wikipedialibrary@wikimedia.org</a> or report it "
-"to us on <a class=\"twl-links\" href=\"https://phabricator.wikimedia.org/"
-"maniphest/task/edit/form/1/?projectPHIDs=Library-Card-"
-"Platform&title=Wikipedia%%20Library%%20%(path)s%%20Permission%%20denied"
-"\">Phabricator</a>"
+msgid "If you think your account should be able to do that, please email us about this error at <a class=\"twl-links\" href=\"mailto:wikipedialibrary@wikimedia.org?Subject=Wikipedia%%20Library%%20%(path)s%%20Permission%%20denied\">wikipedialibrary@wikimedia.org</a> or report it to us on <a class=\"twl-links\" href=\"https://phabricator.wikimedia.org/maniphest/task/edit/form/1/?projectPHIDs=Library-Card-Platform&title=Wikipedia%%20Library%%20%(path)s%%20Permission%%20denied\">Phabricator</a>"
 msgstr ""
 
 #. Translators: Shown on the website's 404 page, when a user attempts to navigate to a page that doesn't exist.
@@ -2056,14 +1797,7 @@ msgstr ""
 #. Translators: Shown on the website's 404 page, when a user attempts to navigate to a page that doesn't exist. Don't translate path or Phabricator.
 #: TWLight/templates/404.html:19
 #, python-format
-msgid ""
-"If you are certain that something should be here, please email us about this "
-"error at <a class=\"twl-links\" href=\"mailto:wikipedialibrary@wikimedia.org?"
-"Subject=Wikipedia%%20Library%%20%(path)s%%20Not%%20found\"> "
-"wikipedialibrary@wikimedia.org</a> or report it to us on <a class=\"twl-links"
-"\" href=\"https://phabricator.wikimedia.org/maniphest/task/edit/form/1/?"
-"projectPHIDs=Library-Card-Platform&title=Wikipedia%%20Library%%20%(path)s"
-"%%20Not%%20found\">Phabricator</a>"
+msgid "If you are certain that something should be here, please email us about this error at <a class=\"twl-links\" href=\"mailto:wikipedialibrary@wikimedia.org?Subject=Wikipedia%%20Library%%20%(path)s%%20Not%%20found\"> wikipedialibrary@wikimedia.org</a> or report it to us on <a class=\"twl-links\" href=\"https://phabricator.wikimedia.org/maniphest/task/edit/form/1/?projectPHIDs=Library-Card-Platform&title=Wikipedia%%20Library%%20%(path)s%%20Not%%20found\">Phabricator</a>"
 msgstr ""
 
 #. Translators: Alt text for an image shown on the 404 error page.
@@ -2078,44 +1812,18 @@ msgstr "За Википедиината библиотека"
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:20
-msgid ""
-"This platform is our central tool for facilitating access to our available "
-"collections. Here you can see which partnerships are available, search their "
-"contents, and apply for and access the ones you’re interested in."
-msgstr ""
-"Оваа подлога е нашата централна алатка за овозможување на пристап до нашите "
-"расположливи збирки. Тука можете да видите кои партнерства се достапни, да "
-"ги пребарувате нивните содржини и да поднесете барање за пристап до оние кои "
-"ве интересираат."
+msgid "This platform is our central tool for facilitating access to our available collections. Here you can see which partnerships are available, search their contents, and apply for and access the ones you’re interested in."
+msgstr "Оваа подлога е нашата централна алатка за овозможување на пристап до нашите расположливи збирки. Тука можете да видите кои партнерства се достапни, да ги пребарувате нивните содржини и да поднесете барање за пристап до оние кои ве интересираат."
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/). Wikimedia Foundation should not be translated.
 #: TWLight/templates/about.html:29
-msgid ""
-"All users receive immediate access to some collections, which can be browsed "
-"by clicking the 'Access collection' buttons or using the search bar at the "
-"top of the page. Other collections require an application before access is "
-"granted, and may be accessed directly or via an individual login or access "
-"code. Volunteer coordinators, who have signed non-disclosure agreements with "
-"the Wikimedia Foundation, review these applications and work with publishers "
-"to get you your free access."
-msgstr ""
-"Сите корисници веднаш добиваат непосреден пристап до некои збирки кои можат "
-"да се прелистуваат стискајќи на копчињата „Пристап до збирката“ или со "
-"полето за пребарување на врвот од страницата. За други збирки ќе треба да "
-"поднесете барање пред да ви се даде пристап, и може да бидат достапни "
-"непосредно или преку поединечна најава или со пристапен код. Доброволечките "
-"координатори, кои имаат потпишано договор за неразоткривање со Фондацијата "
-"Викимедија, ги разгледуваат овие барања и работат со издавачите за да ви "
-"обезбедат слободен пристап."
+msgid "All users receive immediate access to some collections, which can be browsed by clicking the 'Access collection' buttons or using the search bar at the top of the page. Other collections require an application before access is granted, and may be accessed directly or via an individual login or access code. Volunteer coordinators, who have signed non-disclosure agreements with the Wikimedia Foundation, review these applications and work with publishers to get you your free access."
+msgstr "Сите корисници веднаш добиваат непосреден пристап до некои збирки кои можат да се прелистуваат стискајќи на копчињата „Пристап до збирката“ или со полето за пребарување на врвот од страницата. За други збирки ќе треба да поднесете барање пред да ви се даде пристап, и може да бидат достапни непосредно или преку поединечна најава или со пристапен код. Доброволечките координатори, кои имаат потпишано договор за неразоткривање со Фондацијата Викимедија, ги разгледуваат овие барања и работат со издавачите за да ви обезбедат слободен пристап."
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/). Don't translate terms_url.
 #: TWLight/templates/about.html:43
 #, python-format
-msgid ""
-"For more information about how your information is stored and reviewed "
-"please see our <a class=\"twl-links\" href=\"%(terms_url)s\"> terms of use "
-"and privacy policy</a>. Accounts you apply for are also subject to the Terms "
-"of Use provided by each partner’s platform; please review them."
+msgid "For more information about how your information is stored and reviewed please see our <a class=\"twl-links\" href=\"%(terms_url)s\"> terms of use and privacy policy</a>. Accounts you apply for are also subject to the Terms of Use provided by each partner’s platform; please review them."
 msgstr ""
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
@@ -2125,25 +1833,13 @@ msgstr "Кој може да добие пристап?"
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/). Wikimedia Foundation should not be translated.
 #: TWLight/templates/about.html:55
-msgid ""
-"Any active editor in good standing can receive access. For publishers with "
-"limited numbers of accounts, applications are reviewed based on the editor’s "
-"needs and contributions. If you think you could use access to one of our "
-"partner resources and are an active editor in any project supported by the "
-"Wikimedia Foundation, please apply."
-msgstr ""
-"Секој добростоечки активен корисник може да добие пристап. За издавачи со "
-"ограничен број на сметки, барањата треба да се разгледуваат врз основа на "
-"потребите и придонесите на уредникот. Ако сметате дека ќе ви користи пристпа "
-"до еден од нашите партнерски ресурси и сте активен уредник на било кој "
-"поддржан проект на Фондацијата Викимедија, тогаш повелете, поднесете барање."
+msgid "Any active editor in good standing can receive access. For publishers with limited numbers of accounts, applications are reviewed based on the editor’s needs and contributions. If you think you could use access to one of our partner resources and are an active editor in any project supported by the Wikimedia Foundation, please apply."
+msgstr "Секој добростоечки активен корисник може да добие пристап. За издавачи со ограничен број на сметки, барањата треба да се разгледуваат врз основа на потребите и придонесите на уредникот. Ако сметате дека ќе ви користи пристпа до еден од нашите партнерски ресурси и сте активен уредник на било кој поддржан проект на Фондацијата Викимедија, тогаш повелете, поднесете барање."
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:65
 msgid "Any editor can use the library if they meet a few basic requirements:"
-msgstr ""
-"Секој уредник може да ја користи библиотеката ако задоволува неколку основни "
-"услови:"
+msgstr "Секој уредник може да ја користи библиотеката ако задоволува неколку основни услови:"
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:71
@@ -2158,9 +1854,7 @@ msgstr "Имате најмалку 500 уредувања на Викимеди
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:79
 msgid "You have made at least 10 edits to Wikimedia projects in the last month"
-msgstr ""
-"Имате направено барем 10 уредувања на Викимедиините проекти во последниот "
-"месец."
+msgstr "Имате направено барем 10 уредувања на Викимедиините проекти во последниот месец."
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:83
@@ -2169,23 +1863,12 @@ msgstr "Моментално не ви е забрането да уредува
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/)
 #: TWLight/templates/about.html:89
-msgid ""
-"If you are applying for an available collection, please first check that you "
-"don't already have access through another library or institution. If you do, "
-"please consider using that access rather than taking up a seat for this "
-"resource in The Wikipedia Library."
+msgid "If you are applying for an available collection, please first check that you don't already have access through another library or institution. If you do, please consider using that access rather than taking up a seat for this resource in The Wikipedia Library."
 msgstr ""
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/)
 #: TWLight/templates/about.html:99
-msgid ""
-"If your account is blocked on one or more Wikimedia projects, you may still "
-"be granted access to The Wikipedia Library. You will need to contact the "
-"Wikipedia Library team, who will review your blocks. If you have been "
-"blocked for content issues, most notably copyright violations, or have "
-"multiple long-term blocks, we may decline your request. Additionally, if "
-"your block status changes after being approved, you will need to request "
-"another review."
+msgid "If your account is blocked on one or more Wikimedia projects, you may still be granted access to The Wikipedia Library. You will need to contact the Wikipedia Library team, who will review your blocks. If you have been blocked for content issues, most notably copyright violations, or have multiple long-term blocks, we may decline your request. Additionally, if your block status changes after being approved, you will need to request another review."
 msgstr ""
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
@@ -2220,9 +1903,7 @@ msgstr ""
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:136
-msgid ""
-"Share their account logins or passwords with others, or sell their access to "
-"other parties"
+msgid "Share their account logins or passwords with others, or sell their access to other parties"
 msgstr ""
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
@@ -2232,23 +1913,17 @@ msgstr ""
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:144
-msgid ""
-"Systematically make printed or electronic copies of multiple extracts of "
-"restricted content available for any purpose"
+msgid "Systematically make printed or electronic copies of multiple extracts of restricted content available for any purpose"
 msgstr ""
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/). Stub is a technical term for a short Wikipedia article, use the appropriate Wikipedia term in your language.
 #: TWLight/templates/about.html:148
-msgid ""
-"Datamine metadata without permission, in order, for instance, to use "
-"metadata for auto-created stub articles"
+msgid "Datamine metadata without permission, in order, for instance, to use metadata for auto-created stub articles"
 msgstr ""
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:154
-msgid ""
-"Respecting these agreements allows us to continue growing the partnerships "
-"available to the community."
+msgid "Respecting these agreements allows us to continue growing the partnerships available to the community."
 msgstr ""
 
 #. Translators: This is the heading for a section on the About page (https://wikipedialibrary.wmflabs.org/about/).
@@ -2258,48 +1933,23 @@ msgstr "EZProxy"
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:164
-msgid ""
-"EZProxy is a proxy server used to authenticate users for many Wikipedia "
-"Library partners. Users sign into EZProxy via the Library Card platform to "
-"verify that they are authorized users, and then the server accesses "
-"requested resources using its own IP address."
+msgid "EZProxy is a proxy server used to authenticate users for many Wikipedia Library partners. Users sign into EZProxy via the Library Card platform to verify that they are authorized users, and then the server accesses requested resources using its own IP address."
 msgstr ""
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:173
-msgid ""
-"You may notice that when accessing resources via EZProxy that URLs are "
-"dynamically rewritten. This is why we recommend logging in via the Library "
-"Card platform rather than going directly to the unproxied partner website. "
-"When in doubt, check the URL for ‘idm.oclc’. If it’s there, then you’re "
-"connected via EZProxy."
+msgid "You may notice that when accessing resources via EZProxy that URLs are dynamically rewritten. This is why we recommend logging in via the Library Card platform rather than going directly to the unproxied partner website. When in doubt, check the URL for ‘idm.oclc’. If it’s there, then you’re connected via EZProxy."
 msgstr ""
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:182
-msgid ""
-"Typically once you’ve logged in your session will remain active in your "
-"browser for up to two hours after you’ve finished searching. Note that use "
-"of EZProxy requires you to enable cookies. If you are having problems you "
-"should also try clearing your cache and restarting your browser."
+msgid "Typically once you’ve logged in your session will remain active in your browser for up to two hours after you’ve finished searching. Note that use of EZProxy requires you to enable cookies. If you are having problems you should also try clearing your cache and restarting your browser."
 msgstr ""
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/)
 #: TWLight/templates/about.html:193
-msgid ""
-"The Library Bundle is a collection of resources for which no application is "
-"required. If you meet the criteria laid out above, you will be authorized "
-"for access automatically upon logging in to the platform. Only some of our "
-"content is currently included in the Library Bundle, however we hope to "
-"expand the collection as more publishers become comfortable with "
-"participating. All Bundle content is accessed via EZProxy."
-msgstr ""
-"Библиотечниот пакет е збирка на ресурси за кои не треба да се поднесуваат "
-"барања. Ако ги задоволувате горенаведените услови, имате автоматско право на "
-"пристап кога ќе се најавите на подлогата. Само извесни делови од нашата "
-"содржина се тековно достапни во Библиотечниот пакет. Сепак, се надеваме да "
-"ја прошириме збирката кога повеќе издавачи ќе се решат да учествуваат. Сета "
-"содржина на пакетот се пристапува преку EZProxy."
+msgid "The Library Bundle is a collection of resources for which no application is required. If you meet the criteria laid out above, you will be authorized for access automatically upon logging in to the platform. Only some of our content is currently included in the Library Bundle, however we hope to expand the collection as more publishers become comfortable with participating. All Bundle content is accessed via EZProxy."
+msgstr "Библиотечниот пакет е збирка на ресурси за кои не треба да се поднесуваат барања. Ако ги задоволувате горенаведените услови, имате автоматско право на пристап кога ќе се најавите на подлогата. Само извесни делови од нашата содржина се тековно достапни во Библиотечниот пакет. Сепак, се надеваме да ја прошириме збирката кога повеќе издавачи ќе се решат да учествуваат. Сета содржина на пакетот се пристапува преку EZProxy."
 
 #. Translators: This is the heading for a section on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:202
@@ -2308,12 +1958,7 @@ msgstr "Напатствија за наведување"
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:206
-msgid ""
-"Citation practices vary by project and even by article. Generally, we "
-"support editors citing where they found information, in a form that allows "
-"others to check it for themselves. That often means providing both original "
-"source details as well as a link to the partner database in which the source "
-"was found."
+msgid "Citation practices vary by project and even by article. Generally, we support editors citing where they found information, in a form that allows others to check it for themselves. That often means providing both original source details as well as a link to the partner database in which the source was found."
 msgstr ""
 
 #. Translators: This is the heading for a section on the About page (https://wikipedialibrary.wmflabs.org/about/).
@@ -2325,9 +1970,7 @@ msgstr "Контактирајте нè"
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:218
 #, python-format
-msgid ""
-"If you have questions, need help, or want to volunteer to help, please see "
-"our <a class=\"twl-links\" href=\"%(contact_url)s\">contact page</a>."
+msgid "If you have questions, need help, or want to volunteer to help, please see our <a class=\"twl-links\" href=\"%(contact_url)s\">contact page</a>."
 msgstr ""
 
 #. Translators: This is the title of the panel box detailing the contact information for the Wikipedia Library team.
@@ -2367,9 +2010,7 @@ msgstr "Википедиината библиотека на Твитер"
 #. Translators: This is the text that appears at the bottom of the contact us form directing users to the suggestions form.
 #: TWLight/templates/contact.html:48
 #, python-format
-msgid ""
-"(If you would like to suggest a partner, <a class=\"twl-links\" href="
-"\"%(suggest)s\"><strong>go here</strong></a>.)"
+msgid "(If you would like to suggest a partner, <a class=\"twl-links\" href=\"%(suggest)s\"><strong>go here</strong></a>.)"
 msgstr ""
 
 #. Translators: On a special 'link to search' page, this message is shown if JavaScript is disabled.
@@ -2427,12 +2068,8 @@ msgstr "Википедиина библиотека"
 #. Translators: Information about The Wikipedia Library.
 #: TWLight/templates/login_partial.html:53 TWLight/templates/new_base.html:21
 #, fuzzy, python-format
-msgid ""
-"More than 100 of the world's top subscription-only databases, with content "
-"in %(no_of_languages)s languages, free for Wikipedians of all backgrounds"
-msgstr ""
-"Преку 90 од најдобрите претплатни бази на податоци со содржини на "
-"%(no_of_languages)s јазици, бесплатни за википедијанци од сите профили"
+msgid "More than 100 of the world's top subscription-only databases, with content in %(no_of_languages)s languages, free for Wikipedians of all backgrounds"
+msgstr "Преку 90 од најдобрите претплатни бази на податоци со содржини на %(no_of_languages)s јазици, бесплатни за википедијанци од сите профили"
 
 #. Translators: Information about The Wikipedia Library.
 #: TWLight/templates/login_partial.html:64
@@ -2440,9 +2077,7 @@ msgid "Meet these criteria for automatic access"
 msgstr "Исполнете ги овие услови за автоматски пристап"
 
 #: TWLight/templates/login_partial.html:69
-msgid ""
-"These criteria grant you access to certain collections but not all. Some "
-"collections are accessible on a per application basis only."
+msgid "These criteria grant you access to certain collections but not all. Some collections are accessible on a per application basis only."
 msgstr ""
 
 #: TWLight/templates/login_partial.html:89
@@ -2452,34 +2087,20 @@ msgstr "Најавете се преку Википедија"
 #. Translators: Shown if the current user doesn't have a registered email on their account. Don't translate contact_us_url or email_url.
 #: TWLight/templates/message_partial.html:15
 #, python-format
-msgid ""
-"You don't have an email on file. We can't finalize your access to partner "
-"resources, and you won't be able to <a class=\"twl-links\" href="
-"\"%(contact_us_url)s\">contact us</a> without an email. Please <a class="
-"\"twl-links\" href=\"%(email_url)s\">update your email</a>."
+msgid "You don't have an email on file. We can't finalize your access to partner resources, and you won't be able to <a class=\"twl-links\" href=\"%(contact_us_url)s\">contact us</a> without an email. Please <a class=\"twl-links\" href=\"%(email_url)s\">update your email</a>."
 msgstr ""
 
 #. Translators: Shown if the current user has requested the processing of their data should be restricted.
 #: TWLight/templates/message_partial.html:26
 #, python-format
-msgid ""
-"You have requested a restriction on the processing of your data. Most site "
-"functionality will not be available to you until you <a class=\"twl-links\" "
-"href=\"%(restrict_url)s\">lift this restriction</a>."
+msgid "You have requested a restriction on the processing of your data. Most site functionality will not be available to you until you <a class=\"twl-links\" href=\"%(restrict_url)s\">lift this restriction</a>."
 msgstr ""
 
 #. Translators: Shown if the current user has not agreed to the terms of use.
 #: TWLight/templates/message_partial.html:37
 #, python-format
-msgid ""
-"You have not agreed to the <a class=\"twl-links\" href=\"%(terms_url)s"
-"\">terms of use</a> of this site. Your applications will not be processed "
-"and you won't be able to apply or access resources you are approved for."
-msgstr ""
-"Не се имате согласено со <a class=\"twl-links\" href=\"%(terms_url)s"
-"\">условите на употреба</a> на ова мрежно место. Вашите барања нема да се "
-"обработат и нема да можете да поднесувате нови барања или да ги користите "
-"ресурсите кои ви се одобрени."
+msgid "You have not agreed to the <a class=\"twl-links\" href=\"%(terms_url)s\">terms of use</a> of this site. Your applications will not be processed and you won't be able to apply or access resources you are approved for."
+msgstr "Не се имате согласено со <a class=\"twl-links\" href=\"%(terms_url)s\">условите на употреба</a> на ова мрежно место. Вашите барања нема да се обработат и нема да можете да поднесувате нови барања или да ги користите ресурсите кои ви се одобрени."
 
 #. Translators: This link is at the bottom of every page and links to the 'About' page (https://wikipedialibrary.wmflabs.org/about/)
 #: TWLight/templates/new_base.html:107
@@ -2525,9 +2146,7 @@ msgstr "Смени лозинка"
 
 #. Translators: If a user goes to reset their password, this message asks them to enter their email to do so.
 #: TWLight/templates/registration/password_reset_form.html:13
-msgid ""
-"Forgot your password? Enter your email address below, and we'll email "
-"instructions for setting a new one."
+msgid "Forgot your password? Enter your email address below, and we'll email instructions for setting a new one."
 msgstr ""
 
 #. Translators: This is the label for a button that users click to update their public information.
@@ -2572,20 +2191,12 @@ msgstr "Се согласувам со условите на употреба"
 
 #. Translators: This text explains how to disagree to the site's terms of use and the restrictions that will come into effect when users disagree to the terms of use.
 #: TWLight/users/forms.py:185
-msgid ""
-"By unchecking this box and clicking “Update” you may explore the site, but "
-"you will not be able to apply for access to materials or evaluate "
-"applications unless you agree with the terms of use."
-msgstr ""
-"Отштиклирајќи го ова кутивче и стискајќи на „Поднови“, можете да го "
-"истражувате мрежното место, но нема да можете да поднесувате барања за "
-"пристап до материјали или да оценувате барања освен ако не се согласите со "
-"условите на употреба."
+msgid "By unchecking this box and clicking “Update” you may explore the site, but you will not be able to apply for access to materials or evaluate applications unless you agree with the terms of use."
+msgstr "Отштиклирајќи го ова кутивче и стискајќи на „Поднови“, можете да го истражувате мрежното место, но нема да можете да поднесувате барања за пристап до материјали или да оценувате барања освен ако не се согласите со условите на употреба."
 
 #. Translators: Users click this button to set their website email address to the one linked to their Wikipedia account.
 #: TWLight/users/forms.py:211
-msgid ""
-"Use my Wikipedia email address (will be updated the next time you login)."
+msgid "Use my Wikipedia email address (will be updated the next time you login)."
 msgstr ""
 
 #. Translators: This labels a button which users click to change their email.
@@ -2596,17 +2207,8 @@ msgstr "Поднови е-пошта"
 #. Translators: Shown if the current user tried to 'favorite' a partner they can't access. Do not translate '{partner}'
 #: TWLight/users/models.py:201
 #, python-brace-format
-msgid ""
-"Cannot add partner {partner} to your favorites because you don't have access "
-"to it"
+msgid "Cannot add partner {partner} to your favorites because you don't have access to it"
 msgstr ""
-
-#. Translators: Do not translate.
-#: TWLight/users/models.py:869
-#, fuzzy, python-brace-format
-#| msgid "Username"
-msgid "{wp_username}"
-msgstr "Корисничко име"
 
 #. Translators: This error message is shown when there's a problem with the authenticated login process.
 #: TWLight/users/oauth.py:243
@@ -2626,12 +2228,8 @@ msgstr "Ракувањето не е започнато. Најавете се �
 
 #. Translators: this message is displayed to users that don't have accounts and clicked on a proxied link.
 #: TWLight/users/oauth.py:388
-msgid ""
-"To view this link you need to be an eligible library user. Please login to "
-"continue."
-msgstr ""
-"За да ја погледате оваа врска треба да сте подобен корисник на библиотеката. "
-"Најавете се за да продолжите."
+msgid "To view this link you need to be an eligible library user. Please login to continue."
+msgstr "За да ја погледате оваа врска треба да сте подобен корисник на библиотеката. Најавете се за да продолжите."
 
 #. Translators: This warning message is shown to users when the response received from Wikimedia OAuth servers is not a valid one.
 #: TWLight/users/oauth.py:430
@@ -2666,20 +2264,12 @@ msgstr "За повеќе информации, погледајте {issue}"
 
 #. Translators: If the user tries to log in, but their account does not meet certain requirements, they cannot login.
 #: TWLight/users/oauth.py:528
-msgid ""
-"Your Wikipedia account does not meet the eligibility criteria in the terms "
-"of use, so your Wikipedia Library Card Platform account cannot be activated."
-msgstr ""
-"Вашата сметка на Википедија не ги задоволува критериумите во условите за "
-"употреба. Затоа, вашата подлога на членство во Википедиината библиотека не "
-"може да се активира."
+msgid "Your Wikipedia account does not meet the eligibility criteria in the terms of use, so your Wikipedia Library Card Platform account cannot be activated."
+msgstr "Вашата сметка на Википедија не ги задоволува критериумите во условите за употреба. Затоа, вашата подлога на членство во Википедиината библиотека не може да се активира."
 
 #. Translators: If the user tries to log in, but their account does not meet certain requirements, they cannot login.
 #: TWLight/users/oauth.py:536
-msgid ""
-"Your Wikipedia account no longer meets the eligibility criteria in the terms "
-"of use, so you cannot be logged in. If you think you should be able to log "
-"in, please email wikipedialibrary@wikimedia.org."
+msgid "Your Wikipedia account no longer meets the eligibility criteria in the terms of use, so you cannot be logged in. If you think you should be able to log in, please email wikipedialibrary@wikimedia.org."
 msgstr ""
 
 #. Translators: this message is displayed to users with brand new accounts.
@@ -2690,10 +2280,7 @@ msgstr "Добре дојдовте! Ве молиме, согласете се 
 #. Translators: This message is displayed on the confirmation page where users can return their access to partner collections.
 #: TWLight/users/templates/users/authorization_confirm_return.html:13
 #, python-format
-msgid ""
-"You will no longer be able to access <b>%(partner)s's</b> resources via the "
-"Library Card platform, but can request access again by clicking 'renew', if "
-"you change your mind. Are you sure you want to return your access?"
+msgid "You will no longer be able to access <b>%(partner)s's</b> resources via the Library Card platform, but can request access again by clicking 'renew', if you change your mind. Are you sure you want to return your access?"
 msgstr ""
 
 #. Translators: On the MyLibrary page (https://wikipedialibrary.wmflabs.org/users/my_library), this tab shows all favorite collections a user has.
@@ -2763,14 +2350,8 @@ msgstr "Податоци за уредникот"
 
 #. Translators: This is shown on editor profiles, in their profile page or on applications.
 #: TWLight/users/templates/users/editor_detail.html:59
-msgid ""
-"Information with an * was retrieved from Wikipedia directly. Other "
-"information was entered directly by users or site admins, in their preferred "
-"language."
-msgstr ""
-"Информациите со * се непосредно извлечени од Википедија. Другите информации "
-"се внесуваат право од корисниците или администраторите, на нивниот "
-"претпочитан јазик."
+msgid "Information with an * was retrieved from Wikipedia directly. Other information was entered directly by users or site admins, in their preferred language."
+msgstr "Информациите со * се непосредно извлечени од Википедија. Другите информации се внесуваат право од корисниците или администраторите, на нивниот претпочитан јазик."
 
 #. Translators: This distinguishes users who have been flagged as account coordinators. Don't translate username.
 #: TWLight/users/templates/users/editor_detail.html:71
@@ -2780,14 +2361,8 @@ msgstr "%(username)s има координаторски права на ова 
 
 #. Translators: This is shown on editor profiles, under the heading for Wikipedia editor data.
 #: TWLight/users/templates/users/editor_detail_data.html:5
-msgid ""
-"This information is updated automatically from your Wikimedia account each "
-"time you log in, except for the Contributions field, where you can describe "
-"your Wikimedia editing history."
-msgstr ""
-"Овие информации се подновуваат автоматски од вашата сметка на Викимедија "
-"секојпат кога ќе се најавите, со исклучок на полето Придонеси, каде можете "
-"да ја опишете вашата уредувачка историја на Викимедија."
+msgid "This information is updated automatically from your Wikimedia account each time you log in, except for the Contributions field, where you can describe your Wikimedia editing history."
+msgstr "Овие информации се подновуваат автоматски од вашата сметка на Викимедија секојпат кога ќе се најавите, со исклучок на полето Придонеси, каде можете да ја опишете вашата уредувачка историја на Викимедија."
 
 #. Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this labels the user's username.
 #: TWLight/users/templates/users/editor_detail_data.html:17
@@ -2816,20 +2391,14 @@ msgstr "Дали ги задоволува условите за употреб�
 
 #. Translators: when viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this question has a yes or no answer.
 #: TWLight/users/templates/users/editor_detail_data.html:57
-msgid ""
-"at their last login, did this user meet the criteria set forth in the terms "
-"of use?"
+msgid "at their last login, did this user meet the criteria set forth in the terms of use?"
 msgstr ""
 
 #. Translators: When viewing a user's profile in an application, this message shows if the software doesn't think that the user is eligible for access. Don't translate username.
 #: TWLight/users/templates/users/editor_detail_data.html:72
 #, python-format
-msgid ""
-"%(username)s may still be eligible for access grants at the coordinators' "
-"discretion."
-msgstr ""
-"%(username)s може сепак да е подобен за дозвола за пристап, по лична одлука "
-"на координаторот."
+msgid "%(username)s may still be eligible for access grants at the coordinators' discretion."
+msgstr "%(username)s може сепак да е подобен за дозвола за пристап, по лична одлука на координаторот."
 
 #. Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this is the heading for a Yes/No ToU question.
 #: TWLight/users/templates/users/editor_detail_data.html:83
@@ -2863,10 +2432,7 @@ msgstr "(доделено изземање)"
 #. Translators: This message is shown on a user's profile if their Wikimedia account is blocked on one or more projects. They may still be granted access to the Library Bundle, but need to contact Wikipedia Library staff to verify.
 #: TWLight/users/templates/users/editor_detail_data.html:137
 #, python-format
-msgid ""
-"It looks like you have an active block on your account. If you meet the "
-"other criteria you may still be permitted access to the library - please <a "
-"class=\"twl-links\" href=\"%(contact_url)s\">contact us</a>."
+msgid "It looks like you have an active block on your account. If you meet the other criteria you may still be permitted access to the library - please <a class=\"twl-links\" href=\"%(contact_url)s\">contact us</a>."
 msgstr ""
 
 #. Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this is the heading for a Yes/No program eligibility question.
@@ -2876,14 +2442,8 @@ msgstr ""
 
 #. Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this question has a Yes or No answer.
 #: TWLight/users/templates/users/editor_detail_data.html:156
-msgid ""
-"At their last login, did this user meet the criteria set forth in the "
-"Library Bundle? Note that satisfying terms of use is a prerequisite to "
-"bundle eligibility."
-msgstr ""
-"При последната најава, дали овој корисник ги задоволувал условите поставени "
-"во Библиотечниот пакет? Имајте на ум дека задоволувањето на овие барања е "
-"предуслов за пристап до пакетот"
+msgid "At their last login, did this user meet the criteria set forth in the Library Bundle? Note that satisfying terms of use is a prerequisite to bundle eligibility."
+msgstr "При последната најава, дали овој корисник ги задоволувал условите поставени во Библиотечниот пакет? Имајте на ум дека задоволувањето на овие барања е предуслов за пристап до пакетот"
 
 #. Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this is the heading for a Yes/No program eligibility question.
 #: TWLight/users/templates/users/editor_detail_data.html:177
@@ -2927,24 +2487,14 @@ msgstr "Лични податоци"
 
 #. Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this text is in the 'Personal data' section. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/users/templates/users/editor_detail_data.html:262
-msgid ""
-"The following information is visible only to you, site administrators, "
-"publishing partners (where required), and volunteer Wikipedia Library "
-"coordinators (who have signed a Non-Disclosure Agreement)."
-msgstr ""
-"Следниве информации се видливи само за вас, администраторите на мрежното "
-"место, издавачите-партнери и доброволечките координатори на Википедиината "
-"библиотека (кои имаат потпишано договор за неразоткривање)."
+msgid "The following information is visible only to you, site administrators, publishing partners (where required), and volunteer Wikipedia Library coordinators (who have signed a Non-Disclosure Agreement)."
+msgstr "Следниве информации се видливи само за вас, администраторите на мрежното место, издавачите-партнери и доброволечките координатори на Википедиината библиотека (кои имаат потпишано договор за неразоткривање)."
 
 #. Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this labels a button which users can click to update or remove their personal information. Don't translate update_url.
 #: TWLight/users/templates/users/editor_detail_data.html:272
 #, python-format
-msgid ""
-"You may <a class=\"twl-links\" href=\"%(update_url)s\">update or delete</a> "
-"your data at any time."
-msgstr ""
-"Можете да ги <a class=\"twl-links\" href=\"%(update_url)s\">измените или "
-"бришете</a> вашите податоци во секое време."
+msgid "You may <a class=\"twl-links\" href=\"%(update_url)s\">update or delete</a> your data at any time."
+msgstr "Можете да ги <a class=\"twl-links\" href=\"%(update_url)s\">измените или бришете</a> вашите податоци во секое време."
 
 #. Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this labels the user's email. Don't remove the *.
 #: TWLight/users/templates/users/editor_detail_data.html:283
@@ -2963,24 +2513,18 @@ msgstr "Припадност кон установа"
 
 #. Translators: This message tells users that they are not eligible to access The Wikipedia Library content.
 #: TWLight/users/templates/users/eligibility_modal.html:7
-msgid ""
-"Sorry, your Wikipedia account doesn’t currently qualify to access The "
-"Wikipedia Library."
+msgid "Sorry, your Wikipedia account doesn’t currently qualify to access The Wikipedia Library."
 msgstr ""
 
 #. Translators: This message tells users that they have not agreed to the terms of use, therefore are ineligible to access the content in The Wikipedia Library.
 #: TWLight/users/templates/users/eligibility_modal.html:30
 #, python-format
-msgid ""
-"Agreed with <a href=\"%(terms)s\" class=\"text-danger\"> terms of use </a>"
+msgid "Agreed with <a href=\"%(terms)s\" class=\"text-danger\"> terms of use </a>"
 msgstr ""
 
 #: TWLight/users/templates/users/eligibility_modal.html:40
 #, python-format
-msgid ""
-"It looks like you have an active block on your account. If you meet the "
-"other criteria you may still be permitted access to the library - please <a "
-"href=\"%(contact_url)s\">contact us</a>."
+msgid "It looks like you have an active block on your account. If you meet the other criteria you may still be permitted access to the library - please <a href=\"%(contact_url)s\">contact us</a>."
 msgstr ""
 
 #. Translators: Instructions to refresh a user's data.
@@ -3020,14 +2564,8 @@ msgstr "Задај јазик"
 
 #. Translators: This text on the user page helps users naviage to the TranslateWiki Wikipedia Library Card platform translation page.
 #: TWLight/users/templates/users/language_form.html:31
-msgid ""
-"You can help translate the tool at <a class=\"twl-links\" href=\"https://"
-"translatewiki.net/wiki/Translating:Wikipedia_Library_Card_Platform"
-"\">translatewiki.net</a>."
-msgstr ""
-"Можете да помогнете во преведувањето на алатката на <a class=\"twl-links\" "
-"href=\"https://translatewiki.net/wiki/Translating:"
-"Wikipedia_Library_Card_Platform\">translatewiki.net</a>."
+msgid "You can help translate the tool at <a class=\"twl-links\" href=\"https://translatewiki.net/wiki/Translating:Wikipedia_Library_Card_Platform\">translatewiki.net</a>."
+msgstr "Можете да помогнете во преведувањето на алатката на <a class=\"twl-links\" href=\"https://translatewiki.net/wiki/Translating:Wikipedia_Library_Card_Platform\">translatewiki.net</a>."
 
 #. Translators: When the user starts a new application and submits the application, the user can view the application and withdraw if need be. This changes the label for the Withdraw button.
 #: TWLight/users/templates/users/my_applications.html:65
@@ -3046,9 +2584,7 @@ msgstr ""
 
 #. Translators: On the page listing applications, this text explains a user they cannot renew their application since they've already requested a renewal or there aren't any renewals available.
 #: TWLight/users/templates/users/my_applications.html:79
-msgid ""
-"Renewals are either not required, not available right now, or you have "
-"already requested a renewal."
+msgid "Renewals are either not required, not available right now, or you have already requested a renewal."
 msgstr ""
 
 #. Translators: This text is the heading of a section in a user's profile where they can change their preferences.
@@ -3112,19 +2648,12 @@ msgstr "Ограничи обработка на податоци"
 
 #. Translators: This message is displayed on the page where users can request we stop processing their data.
 #: TWLight/users/templates/users/restrict_data.html:15
-msgid ""
-"Checking this box and clicking “Restrict” will pause all processing of the "
-"data you have entered into this website. You will not be able to apply for "
-"access to resources, your applications will not be further processed, and "
-"none of your data will be altered, until you return to this page and uncheck "
-"the box. This is not the same as deleting your data."
+msgid "Checking this box and clicking “Restrict” will pause all processing of the data you have entered into this website. You will not be able to apply for access to resources, your applications will not be further processed, and none of your data will be altered, until you return to this page and uncheck the box. This is not the same as deleting your data."
 msgstr ""
 
 #. Translators: This warning message is shown to coordinators who view the data restriction page.
 #: TWLight/users/templates/users/restrict_data.html:26
-msgid ""
-"You are a coordinator on this site. If you restrict the processing of your "
-"data, your coordinator flag will be removed."
+msgid "You are a coordinator on this site. If you restrict the processing of your data, your coordinator flag will be removed."
 msgstr ""
 
 #. Translators: use the date *when you are translating*, in a language-appropriate format.
@@ -3140,30 +2669,16 @@ msgstr "Заштита на личните податоци на Фондаци�
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:41
 msgid "Wikipedia Library Card Terms of Use and Privacy Statement"
-msgstr ""
-"Услови на употреба и изјава за личните податоци на членство во Википедиината "
-"библиотека"
+msgstr "Услови на употреба и изјава за личните податоци на членство во Википедиината библиотека"
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:51
-msgid ""
-"<a class=\"twl-links\" href=\"https://meta.wikimedia.org/wiki/"
-"The_Wikipedia_Library\"> The Wikipedia Library </a> has partnered with "
-"publishers around the world to allow users to access otherwise paywalled "
-"resources. This website allows Wikipedia editors to search and access these "
-"resources."
+msgid "<a class=\"twl-links\" href=\"https://meta.wikimedia.org/wiki/The_Wikipedia_Library\"> The Wikipedia Library </a> has partnered with publishers around the world to allow users to access otherwise paywalled resources. This website allows Wikipedia editors to search and access these resources."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Wikimedia Foundation should not be translated. WMF should not be translated. Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:63
-msgid ""
-"This program is administered by the Wikimedia Foundation (WMF). These terms "
-"of use and privacy notice pertain to your application for access to "
-"resources through the Wikipedia Library, your use of this website, and your "
-"access to and use of those resources. They also describe our handling of the "
-"information you provide to us in order to create and administer your "
-"Wikipedia Library account. If we make material changes to the terms, we will "
-"notify users."
+msgid "This program is administered by the Wikimedia Foundation (WMF). These terms of use and privacy notice pertain to your application for access to resources through the Wikipedia Library, your use of this website, and your access to and use of those resources. They also describe our handling of the information you provide to us in order to create and administer your Wikipedia Library account. If we make material changes to the terms, we will notify users."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
@@ -3173,37 +2688,17 @@ msgstr "Услови за сметка на членство во Википед
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:78
-msgid ""
-"Access to resources via The Wikipedia Library is reserved for community "
-"members who have demonstrated their commitment to the Wikimedia projects, "
-"and who will use their access to these resources to improve project content. "
-"To that end, in order to be eligible for The Wikipedia Library, we require "
-"that you be registered for a user account on the projects, with at least 500 "
-"edits, six (6) months of activity, and 10+ edits in the last month. We ask "
-"that you do not request access to any publishers with a limited number of "
-"available accounts whose resources you can already access for free through "
-"your local library or university, or another institution or organization, in "
-"order to provide that opportunity to others."
+msgid "Access to resources via The Wikipedia Library is reserved for community members who have demonstrated their commitment to the Wikimedia projects, and who will use their access to these resources to improve project content. To that end, in order to be eligible for The Wikipedia Library, we require that you be registered for a user account on the projects, with at least 500 edits, six (6) months of activity, and 10+ edits in the last month. We ask that you do not request access to any publishers with a limited number of available accounts whose resources you can already access for free through your local library or university, or another institution or organization, in order to provide that opportunity to others."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:94
-msgid ""
-"Additionally, if you are currently blocked or banned from a Wikimedia "
-"project, applications to resources may be rejected or restricted. If you "
-"obtain a Wikipedia Library account, but a block or ban is subsequently "
-"instituted against you on one of the projects, you may lose access to your "
-"Wikipedia Library account."
+msgid "Additionally, if you are currently blocked or banned from a Wikimedia project, applications to resources may be rejected or restricted. If you obtain a Wikipedia Library account, but a block or ban is subsequently instituted against you on one of the projects, you may lose access to your Wikipedia Library account."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:104
-msgid ""
-"Your eligibility to access The Wikipedia Library is assessed at each login. "
-"While more than half of the library's content is provided via this automated "
-"eligibility check, access to other publisher's content may be time limited, "
-"typically lapsing after one year, after which you will usually need to apply "
-"for renewal."
+msgid "Your eligibility to access The Wikipedia Library is assessed at each login. While more than half of the library's content is provided via this automated eligibility check, access to other publisher's content may be time limited, typically lapsing after one year, after which you will usually need to apply for renewal."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
@@ -3214,51 +2709,27 @@ msgstr "Барање за сметка во Википедиината библ�
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:118
-msgid ""
-"In order to apply for access to a partner resource, you must provide us with "
-"certain information, which we will use to evaluate your application. If your "
-"application is approved, we may transfer the information you have given us "
-"to the publishers whose resources you wish to access. They will either "
-"contact you with the account information directly or we will send access "
-"information to you ourselves."
+msgid "In order to apply for access to a partner resource, you must provide us with certain information, which we will use to evaluate your application. If your application is approved, we may transfer the information you have given us to the publishers whose resources you wish to access. They will either contact you with the account information directly or we will send access information to you ourselves."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:130
-msgid ""
-"In addition to the basic information you provide to us, our system will "
-"retrieve some information directly from the Wikimedia projects: your "
-"username, email address, edit count, registration date, user ID number, "
-"groups to which you belong, and any special user rights."
-msgstr ""
-"Покрај основните податоци што ни ги доставате, самиот наш систем ќе преземе "
-"извесни информации непосредно од Викимедиините проекти: вашето корисничко "
-"име, е-пошта, број на уредувања, датум на зачленување, корисничка назнака, "
-"во кои групи членувате и било кои посебни кориснички права."
+msgid "In addition to the basic information you provide to us, our system will retrieve some information directly from the Wikimedia projects: your username, email address, edit count, registration date, user ID number, groups to which you belong, and any special user rights."
+msgstr "Покрај основните податоци што ни ги доставате, самиот наш систем ќе преземе извесни информации непосредно од Викимедиините проекти: вашето корисничко име, е-пошта, број на уредувања, датум на зачленување, корисничка назнака, во кои групи членувате и било кои посебни кориснички права."
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:140
-msgid ""
-"Each time you log in to the Wikipedia Library Card Platform, this "
-"information will be automatically updated."
+msgid "Each time you log in to the Wikipedia Library Card Platform, this information will be automatically updated."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:148
-msgid ""
-"We will ask you to provide us with some information about your history of "
-"contributions to the Wikimedia projects. Information on contribution history "
-"is optional, but will greatly assist us in evaluating your application."
+msgid "We will ask you to provide us with some information about your history of contributions to the Wikimedia projects. Information on contribution history is optional, but will greatly assist us in evaluating your application."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). WMF should not be translated. Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:157
-msgid ""
-"The information you provide when creating your account will be visible to "
-"you while on the site but not to others unless they are approved Wikipedia "
-"Library Coordinators, WMF Staff, or WMF Contractors who need access to this "
-"data in order to carry out their work with the Wikipedia Library, all of "
-"whom are subject to non-disclosure obligations."
+msgid "The information you provide when creating your account will be visible to you while on the site but not to others unless they are approved Wikipedia Library Coordinators, WMF Staff, or WMF Contractors who need access to this data in order to carry out their work with the Wikipedia Library, all of whom are subject to non-disclosure obligations."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
@@ -3268,46 +2739,32 @@ msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:171
-msgid ""
-"In order to access an individual publisher’s resources, you must agree to "
-"that publisher’s terms of use and privacy policy. You agree that you will "
-"not violate such terms and policies in connection with your use of the "
-"Wikipedia Library. Additionally, the following activities are prohibited "
-"while accessing publisher resources through the Wikipedia Library."
+msgid "In order to access an individual publisher’s resources, you must agree to that publisher’s terms of use and privacy policy. You agree that you will not violate such terms and policies in connection with your use of the Wikipedia Library. Additionally, the following activities are prohibited while accessing publisher resources through the Wikipedia Library."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:184
-msgid ""
-"Sharing your Wikipedia account, usernames, passwords, or any access codes "
-"for publisher resources with others;"
+msgid "Sharing your Wikipedia account, usernames, passwords, or any access codes for publisher resources with others;"
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:191
-msgid ""
-"Automatically scraping or downloading restricted content from publishers;"
+msgid "Automatically scraping or downloading restricted content from publishers;"
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:197
-msgid ""
-"Systematically making printed or electronic copies of multiple extracts of "
-"restricted content available for any purpose;"
+msgid "Systematically making printed or electronic copies of multiple extracts of restricted content available for any purpose;"
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:204
-msgid ""
-"Data mining metadata without permission—for example, in order to use "
-"metadata for auto-created stub articles;"
+msgid "Data mining metadata without permission—for example, in order to use metadata for auto-created stub articles;"
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:211
-msgid ""
-"Using the access you receive through the Wikipedia Library for profit by "
-"selling access to your account or resources which you have through it."
+msgid "Using the access you receive through the Wikipedia Library for profit by selling access to your account or resources which you have through it."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
@@ -3317,18 +2774,12 @@ msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:224
-msgid ""
-"Certain resources may only be accessed using an external search service, "
-"such as the EBSCO Discovery Service, or a proxy service, such as OCLC "
-"EZProxy. If you use such external search and/or proxy services, please "
-"review the applicable terms of use and privacy policies."
+msgid "Certain resources may only be accessed using an external search service, such as the EBSCO Discovery Service, or a proxy service, such as OCLC EZProxy. If you use such external search and/or proxy services, please review the applicable terms of use and privacy policies."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:234
-msgid ""
-"In addition, if you use OCLC EZProxy, please note that you may not use it "
-"for commercial purposes."
+msgid "In addition, if you use OCLC EZProxy, please note that you may not use it for commercial purposes."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
@@ -3338,120 +2789,49 @@ msgstr "Задршка на и работа со податоци"
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Wikimedia Foundation should not be translated. Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:245
-msgid ""
-"The Wikimedia Foundation and our service providers use your information for "
-"the legitimate purpose of providing Wikipedia Library services in support of "
-"our charitable mission. When you apply for a Wikipedia Library account, or "
-"use your Wikipedia Library account, we may routinely collect the following "
-"information: your username, email address, edit count, registration date, "
-"user ID number, groups to which you belong, and any special user rights; "
-"your name, country of residence, and/or affiliation, if required by a "
-"partner to which you are applying; your narrative description of your "
-"contributions and reasons for applying for access to partner resources; and "
-"the date you agree to these terms of use."
+msgid "The Wikimedia Foundation and our service providers use your information for the legitimate purpose of providing Wikipedia Library services in support of our charitable mission. When you apply for a Wikipedia Library account, or use your Wikipedia Library account, we may routinely collect the following information: your username, email address, edit count, registration date, user ID number, groups to which you belong, and any special user rights; your name, country of residence, and/or affiliation, if required by a partner to which you are applying; your narrative description of your contributions and reasons for applying for access to partner resources; and the date you agree to these terms of use."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:262
 #, python-format
-msgid ""
-"Each publisher who is a member of the Wikipedia Library program requires "
-"different specific information in the application. Some publishers may "
-"request only an email address, while others request more detailed data, such "
-"as your name, location, or institutional affiliation. When you complete your "
-"application, you will only be asked to supply information required by the "
-"publishers you have chosen, and each publisher will only receive the "
-"information they require for providing you with access. Please see our <a "
-"class=\"twl-links\" href=\"%(all_partners_url)s\">partner information</a> "
-"pages to learn what information is required by each publisher to gain access "
-"to their resources."
+msgid "Each publisher who is a member of the Wikipedia Library program requires different specific information in the application. Some publishers may request only an email address, while others request more detailed data, such as your name, location, or institutional affiliation. When you complete your application, you will only be asked to supply information required by the publishers you have chosen, and each publisher will only receive the information they require for providing you with access. Please see our <a class=\"twl-links\" href=\"%(all_partners_url)s\">partner information</a> pages to learn what information is required by each publisher to gain access to their resources."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Wikimedia Foundation should not be translated. Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:277
-msgid ""
-"Some Wikipedia Library pages are visible without logging in, but you will "
-"need to log in to apply or access proprietary partner resources. We use the "
-"data provided by you via OAuth and Wikimedia API calls to assess your "
-"application for access and to process approved requests."
+msgid "Some Wikipedia Library pages are visible without logging in, but you will need to log in to apply or access proprietary partner resources. We use the data provided by you via OAuth and Wikimedia API calls to assess your application for access and to process approved requests."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:288
 #, python-format
-msgid ""
-"In order to administer the Wikipedia Library program, we will retain the "
-"application data we collect from you for three years after your most recent "
-"login, unless you delete your account, as described below. You can log in "
-"and go to <a class=\"twl-links\" href=\"%(profile_url)s\">your profile page</"
-"a> in order to see the information associated with your account, and can "
-"download it in JSON format. You may access, update, restrict, or delete this "
-"information at any time, except for the information that is automatically "
-"retrieved from the projects. If you have any questions or concerns about the "
-"handling of your data, please contact <a class=\"twl-links\" href=\"mailto:"
-"wikipedialibrary@wikimedia.org?Subject=Wikipedia%%20Library%%20Card"
-"%%20account%%20deactivation\"> wikipedialibrary@wikimedia.org </a>."
+msgid "In order to administer the Wikipedia Library program, we will retain the application data we collect from you for three years after your most recent login, unless you delete your account, as described below. You can log in and go to <a class=\"twl-links\" href=\"%(profile_url)s\">your profile page</a> in order to see the information associated with your account, and can download it in JSON format. You may access, update, restrict, or delete this information at any time, except for the information that is automatically retrieved from the projects. If you have any questions or concerns about the handling of your data, please contact <a class=\"twl-links\" href=\"mailto:wikipedialibrary@wikimedia.org?Subject=Wikipedia%%20Library%%20Card%%20account%%20deactivation\"> wikipedialibrary@wikimedia.org </a>."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:305
-msgid ""
-"If you decide to disable your Wikipedia Library account, you can use the "
-"delete button on your profile to delete certain personal information "
-"associated with your account. We will delete your real name, institutional "
-"affiliation, and country of residence. Please note that the system will "
-"retain a record of your username, the publishers to which you applied or had "
-"access, and the dates of that access. Note that deletion is not reversible. "
-"Deletion of your Wikipedia Library account may also correspond with the "
-"removal of any resource access to which you were eligible or approved. If "
-"you request the deletion of account information and later wish to apply for "
-"a new account, you will need to provide the necessary information again."
+msgid "If you decide to disable your Wikipedia Library account, you can use the delete button on your profile to delete certain personal information associated with your account. We will delete your real name, institutional affiliation, and country of residence. Please note that the system will retain a record of your username, the publishers to which you applied or had access, and the dates of that access. Note that deletion is not reversible. Deletion of your Wikipedia Library account may also correspond with the removal of any resource access to which you were eligible or approved. If you request the deletion of account information and later wish to apply for a new account, you will need to provide the necessary information again."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). WMF should not be translated. Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:321
-msgid ""
-"The Wikipedia Library is run by WMF Staff, Contractors, and approved "
-"volunteer Coordinators. The data associated with your account will be shared "
-"with the WMF staff, contractors, service providers, and volunteer "
-"coordinators who need to process the information in connection with their "
-"work for the Wikipedia Library, and who are subject to confidentiality "
-"obligations. We will also use your data for internal Wikipedia Library "
-"purposes such as distributing user surveys and account notifications, and in "
-"a depersonalized or aggregated fashion for statistical analysis and "
-"administration. Finally, we will share your information with the publishers "
-"whom you specifically select in order to provide you with access to "
-"resources. Otherwise, your information will not be shared with third "
-"parties, with the exception of the circumstances described below."
+msgid "The Wikipedia Library is run by WMF Staff, Contractors, and approved volunteer Coordinators. The data associated with your account will be shared with the WMF staff, contractors, service providers, and volunteer coordinators who need to process the information in connection with their work for the Wikipedia Library, and who are subject to confidentiality obligations. We will also use your data for internal Wikipedia Library purposes such as distributing user surveys and account notifications, and in a depersonalized or aggregated fashion for statistical analysis and administration. Finally, we will share your information with the publishers whom you specifically select in order to provide you with access to resources. Otherwise, your information will not be shared with third parties, with the exception of the circumstances described below."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). WMF should not be translated.
 #: TWLight/users/templates/users/terms.html:338
-msgid ""
-"We may disclose any collected information when required by law, when we have "
-"your permission, when needed to protect our rights, privacy, safety, users, "
-"or the general public, and when necessary to enforce these terms, WMF’s "
-"general <a class=\"twl-links\" href=\"https://foundation.wikimedia.org/wiki/"
-"Terms_of_Use\">Terms of Use</a>, or any other WMF policy."
+msgid "We may disclose any collected information when required by law, when we have your permission, when needed to protect our rights, privacy, safety, users, or the general public, and when necessary to enforce these terms, WMF’s general <a class=\"twl-links\" href=\"https://foundation.wikimedia.org/wiki/Terms_of_Use\">Terms of Use</a>, or any other WMF policy."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:349
-msgid ""
-"We take the security of your personal data seriously, and take reasonable "
-"precautions to ensure your data is protected. These precautions include "
-"access controls to limit who has access to your data and security "
-"technologies to protect data stored on the server. However, we cannot "
-"guarantee the safety of your data as it is transmitted and stored."
+msgid "We take the security of your personal data seriously, and take reasonable precautions to ensure your data is protected. These precautions include access controls to limit who has access to your data and security technologies to protect data stored on the server. However, we cannot guarantee the safety of your data as it is transmitted and stored."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:360
-msgid ""
-"Please note that these terms do not control the use and handling of your "
-"data by the publishers and service providers whose resources you access or "
-"apply to access. Please read their individual privacy policies for that "
-"information."
+msgid "Please note that these terms do not control the use and handling of your data by the publishers and service providers whose resources you access or apply to access. Please read their individual privacy policies for that information."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
@@ -3462,34 +2842,17 @@ msgstr "Увезено"
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Wikimedia Foundation should not be translated. Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:373
-msgid ""
-"The Wikimedia Foundation is a nonprofit organization based in San Francisco, "
-"California. The Wikipedia Library program provides access to resources held "
-"by publishers in multiple countries. If you apply for a Wikipedia Library "
-"account (whether you are inside or outside of the United States), you "
-"understand that your personal data will be collected, transferred, stored, "
-"processed, disclosed and otherwise used in the U.S. as described in this "
-"privacy policy. You also understand that your information may be transferred "
-"by us from the U.S. to other countries, which may have different or less "
-"stringent data protection laws than your country, in connection with "
-"providing services to you, including evaluating your application and "
-"securing access to your chosen publishers (locations for each publisher are "
-"outlined on their respective partner information pages)."
+msgid "The Wikimedia Foundation is a nonprofit organization based in San Francisco, California. The Wikipedia Library program provides access to resources held by publishers in multiple countries. If you apply for a Wikipedia Library account (whether you are inside or outside of the United States), you understand that your personal data will be collected, transferred, stored, processed, disclosed and otherwise used in the U.S. as described in this privacy policy. You also understand that your information may be transferred by us from the U.S. to other countries, which may have different or less stringent data protection laws than your country, in connection with providing services to you, including evaluating your application and securing access to your chosen publishers (locations for each publisher are outlined on their respective partner information pages)."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:392
-msgid ""
-"Please note that in the event of any differences in meaning or "
-"interpretation between the original English version of these terms and a "
-"translation, the original English version takes precedence."
+msgid "Please note that in the event of any differences in meaning or interpretation between the original English version of these terms and a translation, the original English version takes precedence."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Wikimedia Foundation should not be translated.
 #: TWLight/users/templates/users/terms.html:403
-msgid ""
-"See also the <a class=\"twl-links\" href=\"https://wikimediafoundation.org/"
-"wiki/Privacy_policy\">Wikimedia Foundation Privacy Policy</a>."
+msgid "See also the <a class=\"twl-links\" href=\"https://wikimediafoundation.org/wiki/Privacy_policy\">Wikimedia Foundation Privacy Policy</a>."
 msgstr ""
 
 #. Translators: This is the second to last line of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
@@ -3510,11 +2873,7 @@ msgstr "Заштита на личните податоци на Фондаци�
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:426
-msgid ""
-"By checking this box and clicking “Submit”, you agree that you have read the "
-"above terms and that you will adhere to the terms of use in your application "
-"to and use of the The Wikipedia Library, and the publishers’ services to "
-"which you gain access through The Wikipedia Library program."
+msgid "By checking this box and clicking “Submit”, you agree that you have read the above terms and that you will adhere to the terms of use in your application to and use of the The Wikipedia Library, and the publishers’ services to which you gain access through The Wikipedia Library program."
 msgstr ""
 
 #: TWLight/users/templates/users/user_collection_tile.html:32
@@ -3567,33 +2926,18 @@ msgstr "Избриши ги сите податоци"
 
 #. Translators: This message is displayed on the page where users can request the deletion of their data.
 #: TWLight/users/templates/users/user_confirm_delete.html:17
-msgid ""
-"<b>Warning:</b> Performing this action will delete your Wikipedia Library "
-"Card user account and all associated applications. This process is not "
-"reversible. You may lose any partner accounts you were granted, and will not "
-"be able to renew those accounts or apply for new ones."
-msgstr ""
-"<b>Предупредување:</b> Извршувајќи го ова дејство ќе ја избришете вашата "
-"корисничка сметка на Википедиината библиотека и сите поврзани прилози. Оваа "
-"постапка е неповратна. Може да ги изгубите доделените сметки од "
-"соработниците, и нема да можете да ги обновите или да побарате нови."
+msgid "<b>Warning:</b> Performing this action will delete your Wikipedia Library Card user account and all associated applications. This process is not reversible. You may lose any partner accounts you were granted, and will not be able to renew those accounts or apply for new ones."
+msgstr "<b>Предупредување:</b> Извршувајќи го ова дејство ќе ја избришете вашата корисничка сметка на Википедиината библиотека и сите поврзани прилози. Оваа постапка е неповратна. Може да ги изгубите доделените сметки од соработниците, и нема да можете да ги обновите или да побарате нови."
 
 #. Translators: this should show up for people who log in with a username/password and not OAuth, so we don't know what their Wikipedia identity is.
-#.
 #: TWLight/users/templates/users/user_detail.html:12
 #, python-format
-msgid ""
-"Hi, %(username)s! You don't have a Wikipedia editor profile attached to your "
-"account here, so you are probably a site administrator."
+msgid "Hi, %(username)s! You don't have a Wikipedia editor profile attached to your account here, so you are probably a site administrator."
 msgstr ""
 
 #. Translators: In the unlikely scenario that someone is able to register an account without using OAuth (thus leaving us without some of the information required for applications), users will see this message, encouraging them to re-register.
 #: TWLight/users/templates/users/user_detail.html:20
-msgid ""
-"If you aren't a site administrator, something weird has happened. You won't "
-"be able to apply for access without a Wikipedia editor profile. You should "
-"log out and create a new account by logging in via OAuth, or contact a site "
-"administrator for help."
+msgid "If you aren't a site administrator, something weird has happened. You won't be able to apply for access without a Wikipedia editor profile. You should log out and create a new account by logging in via OAuth, or contact a site administrator for help."
 msgstr ""
 
 #. Translators: Labels a sections where coordinators can select their email preferences.
@@ -3604,17 +2948,12 @@ msgstr "Само координатори"
 #. Translators: This message is shown on user's own profile page, encouraging them to make sure their information is up to date, so that account coordinators can use the information to judge applications.
 #: TWLight/users/views.py:176
 #, python-brace-format
-msgid ""
-"Please <a class='twl-links' href='{url}'>update your contributions</a> to "
-"Wikipedia to help coordinators evaluate your applications."
+msgid "Please <a class='twl-links' href='{url}'>update your contributions</a> to Wikipedia to help coordinators evaluate your applications."
 msgstr ""
 
 #. Translators: Coordinators are shown this message when they unselect all three types of reminder email options under preferences.
 #: TWLight/users/views.py:288
-msgid ""
-"You have chosen not to receive reminder emails. As a coordinator, you should "
-"receive at least one type of reminder emails, so consider changing your "
-"preferences."
+msgid "You have chosen not to receive reminder emails. As a coordinator, you should receive at least one type of reminder emails, so consider changing your preferences."
 msgstr ""
 
 #. Translators: Coordinators are shown this message when they make changes to their reminder email options under preferences.
@@ -3648,9 +2987,7 @@ msgstr ""
 
 #. Translators: If the user has not filled out their email, they can browse the website but cannot apply for access to resources.
 #: TWLight/users/views.py:487
-msgid ""
-"Your email is blank. You can still explore the site, but you won't be able "
-"to apply for access to partner resources without an email."
+msgid "Your email is blank. You can still explore the site, but you won't be able to apply for access to partner resources without an email."
 msgstr ""
 
 #. Translators: This message is shown once the access to a partner has successfully been returned.
@@ -3684,31 +3021,3 @@ msgstr "Без активни блокови"
 msgid "10+ edits in the last 30 days"
 msgstr "10+ уредувања во последниве 30 дена"
 
-#: tests/shunit/data/bad_i18n_comment_1.py:3
-#: tests/shunit/data/bad_i18n_newline_1.py:5
-msgid "1"
-msgstr ""
-
-#. Translators: Lorem ipsum dolor sit amet, consectetur adipiscing elit. Mauris vitae ipsum ut purus faucibus pretium. Proin tempus neque et aliquet consectetur. Ut egestas sapien in consectetur sagittis. Mauris neque lacus, dapibus non viverra vitae, interdum ut aenean ipsum.
-#. Translators: Lorem ipsum dolor sit amet, consectetur adipiscing elit. Mauris vitae ipsum ut purus faucibus pretium. Proin tempus neque et aliquet consectetur. Ut egestas sapien in consectetur sagittis. Mauris neque lacus, dapibus non.
-#: tests/shunit/data/bad_i18n_comment_2.py:4
-#: tests/shunit/data/bad_i18n_newline_2.py:5 tests/shunit/data/good_i18n_1.py:2
-#: tests/shunit/data/good_i18n_2.py:2
-msgid "2"
-msgstr ""
-
-#: tests/shunit/data/bad_i18n_newline_3.py:5
-msgid "3"
-msgstr ""
-
-#: tests/shunit/data/bad_i18n_newline_4.py:5
-msgid "4"
-msgstr ""
-
-#: tests/shunit/data/bad_i18n_newline_5.py:5
-msgid "5"
-msgstr ""
-
-#: tests/shunit/data/bad_i18n_newline_6.py:5
-msgid "6"
-msgstr ""

--- a/locale/mnw/LC_MESSAGES/django.po
+++ b/locale/mnw/LC_MESSAGES/django.po
@@ -8,10 +8,11 @@
 # Author: 咽頭べさ
 msgid ""
 msgstr ""
+""
 "Project-Id-Version: Wikipedia Library Card Platform - Website\n"
-"Report-Msgid-Bugs-To: wikipedialibrary@wikimedia.org\n"
+"Report-Msgid-Bugs-To: translatewiki.net\n"
 "POT-Creation-Date: 2024-07-11 20:54+0000\n"
-"PO-Revision-Date: 2024-07-11 12:30:17+0000\n"
+"PO-Revision-Date: 2024-07-15 12:29:17+0000\n"
 "Language: mnw\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
@@ -43,12 +44,8 @@ msgstr "ပရူ ညးလွပ်"
 #. Translators: This note appears in a section of a form where we ask users to enter info (like country of residence) when applying for resource access.
 #: TWLight/applications/forms.py:179
 #, python-brace-format
-msgid ""
-"<p><small><i>Your personal data will be processed according to our <a "
-"class='twl-links' href='{terms_url}'> privacy policy</a>.</i></small></p>"
-msgstr ""
-"<p><small><i> တၚ်နၚ်ပူဂိုလ်မၞးဂှ် သီဗ္ၜေဝ်ကေတ် ဗွဲအစောန် ပိုယ် <a class='twl-links' "
-"href='{terms_url}'>မူဝါဒ မဒှ်ပူဂိုလ် </a>.</i></small></p>"
+msgid "<p><small><i>Your personal data will be processed according to our <a class='twl-links' href='{terms_url}'> privacy policy</a>.</i></small></p>"
+msgstr "<p><small><i> တၚ်နၚ်ပူဂိုလ်မၞးဂှ် သီဗ္ၜေဝ်ကေတ် ဗွဲအစောန် ပိုယ် <a class='twl-links' href='{terms_url}'>မူဝါဒ မဒှ်ပူဂိုလ် </a>.</i></small></p>"
 
 #. Translators: This is the title of the application form page, where users enter information required for the application. It lets the user know which partner application they are entering data for. {partner}
 #: TWLight/applications/forms.py:189
@@ -89,9 +86,7 @@ msgstr "အဳမေလ်သွက်အကံက်မၞးပ္ဍဲမု
 #. Translators: This labels a choice field where users will have to select the number of months they wish to have their access for as part of the application renewal confirmation.
 #. Translators: When filling out an application, users may be required to enter the length of the account (expiry) they wish to have for proxy partners.
 #: TWLight/applications/forms.py:339 TWLight/applications/helpers.py:100
-msgid ""
-"The number of months you wish to have this access for before renewal is "
-"required"
+msgid "The number of months you wish to have this access for before renewal is required"
 msgstr ""
 
 #. Translators: When filling out an application, users may need to specify their name
@@ -180,9 +175,7 @@ msgstr "အဳမေလ်"
 
 #. Translators: This comment is added to pending applications when our terms of use change.
 #: TWLight/applications/management/commands/notify_applicants_tou_changes.py:54
-msgid ""
-"Our terms of use have changed. Your applications will not be processed until "
-"you log in and agree to our updated terms."
+msgid "Our terms of use have changed. Your applications will not be processed until you log in and agree to our updated terms."
 msgstr ""
 
 #. Translators: This is the status of an application that has not yet been reviewed.
@@ -249,23 +242,17 @@ msgstr ""
 
 #. Translators: This text goes into account approval emails in the case that we need to send the user's details to a publisher for manual account setup.
 #: TWLight/applications/models.py:331
-msgid ""
-"You can expect to receive access details within a week or two once it has "
-"been processed."
+msgid "You can expect to receive access details within a week or two once it has been processed."
 msgstr ""
 
 #. Translators: This comment is added to open applications when a partner joins the Library Bundle, which does not require applications.
 #: TWLight/applications/signals.py:247
-msgid ""
-"This partner joined the Library Bundle, which does not require applications. "
-"This application will be marked as invalid."
+msgid "This partner joined the Library Bundle, which does not require applications. This application will be marked as invalid."
 msgstr ""
 
 #. Translators: This is shown to users if the application is to a partner for which we have run out of available accounts. The application is therefore on a 'waitlist', and will be reviewed when more accounts are available.
 #: TWLight/applications/templates/applications/application_evaluation.html:29
-msgid ""
-"This application is on the waitlist because this partner does not have any "
-"access grants available at this time."
+msgid "This application is on the waitlist because this partner does not have any access grants available at this time."
 msgstr "လိက်ဂရၚ်ပတီဝွံ သှ်ေဒၟံၚ် ပ္ဍဲဒၞာဲစရင်မမၚ် ဟိုတ်နူ သကအ်ညး ဟွံကလိဂွံအခေါၚ် မသၟဟ်အစောံဏီ ပ္ဍဲအခိၚ်လၟုဟ်၊၊"
 
 #. Translators: This message is shown on pages where coordinators can see personal information about applicants.
@@ -273,12 +260,8 @@ msgstr "လိက်ဂရၚ်ပတီဝွံ သှ်ေဒၟံၚ် �
 #: TWLight/applications/templates/applications/application_list_include.html:6
 #: TWLight/applications/templates/applications/send_partner.html:45
 #: TWLight/resources/templates/resources/partner_users.html:18
-msgid ""
-"Coordinators: This page may contain personal information such as real names "
-"and email addresses. Please remember that this information is confidential."
-msgstr ""
-"ညးမဆက်စၠောအ်ဂမၠိုၚ် - မုက်လိက်ဏအ် နွံဒၟံၚ် ကုပရိုၚ်တၚ်ဂၞၚ်ပူဂိုလ် မပ္တံ ကု ယၟုညး ကေုာံ အဳမေလ် ညးတအ်ဇေတ်တ် ဒှ်မာန်ရ၊၊ "
-"ဟိုတ်ဂှ်ရ ပရိုၚ်တၚ်ဂၞၚ်တအ်ဂှ် ဒှ် အရာမဒးပၞုက်လဝ်ရောင်၊၊"
+msgid "Coordinators: This page may contain personal information such as real names and email addresses. Please remember that this information is confidential."
+msgstr "ညးမဆက်စၠောအ်ဂမၠိုၚ် - မုက်လိက်ဏအ် နွံဒၟံၚ် ကုပရိုၚ်တၚ်ဂၞၚ်ပူဂိုလ် မပ္တံ ကု ယၟုညး ကေုာံ အဳမေလ် ညးတအ်ဇေတ်တ် ဒှ်မာန်ရ၊၊ ဟိုတ်ဂှ်ရ ပရိုၚ်တၚ်ဂၞၚ်တအ်ဂှ် ဒှ် အရာမဒးပၞုက်လဝ်ရောင်၊၊"
 
 #. Translators: This is the title of the application page shown to users who are a coordinator, and are able to accept or reject the application.
 #: TWLight/applications/templates/applications/application_evaluation.html:39
@@ -287,12 +270,8 @@ msgstr "စၚ်ခြၚ်ၜတ်ကၞာတ်မံၚ် ပွမဂ�
 
 #. Translators: This text is shown to coordinators on application pages if the applicant has restricted processing of their data.
 #: TWLight/applications/templates/applications/application_evaluation.html:42
-msgid ""
-"This user has requested a restriction on the processing of their data, so "
-"you cannot change the status of their application."
-msgstr ""
-"မၞိဟ်လွပ်တအ်ဏအ်ဝွံ မဒးဒုၚ် စၟတ်သမ္တီလဝ် နဒဒှ် မၞုံအခေါၚ်အပိုၚ်အခြာ မစပ်ကဵု မပတိုန် တၚ်ဂၞင်ညးတအ်ရ၊ ဟိုတ်ဂှ်ရ "
-"မၞးပလေဝ်ထောအ် ဒတန်ကဆံၚ် လိက်ဂရၚ််ပတီညးတအ် ဟွံဂွံ၊၊"
+msgid "This user has requested a restriction on the processing of their data, so you cannot change the status of their application."
+msgstr "မၞိဟ်လွပ်တအ်ဏအ်ဝွံ မဒးဒုၚ် စၟတ်သမ္တီလဝ် နဒဒှ် မၞုံအခေါၚ်အပိုၚ်အခြာ မစပ်ကဵု မပတိုန် တၚ်ဂၞင်ညးတအ်ရ၊ ဟိုတ်ဂှ်ရ မၞးပလေဝ်ထောအ် ဒတန်ကဆံၚ် လိက်ဂရၚ််ပတီညးတအ် ဟွံဂွံ၊၊"
 
 #. Translators: This is the title of the application page shown to users who are not a coordinator.
 #: TWLight/applications/templates/applications/application_evaluation.html:48
@@ -365,9 +344,7 @@ msgstr ""
 
 #. Translators: This is the text displayed to coordinators when an applicant has no country of residence in their profile.
 #: TWLight/applications/templates/applications/application_evaluation.html:123
-msgid ""
-"Please request the applicant add their country of residence to their profile "
-"before proceeding further."
+msgid "Please request the applicant add their country of residence to their profile before proceeding further."
 msgstr ""
 
 #. Translators: This labels the section of an application showing the total number of accounts available for a partner or their collection.
@@ -378,9 +355,7 @@ msgstr ""
 #. Translators: This labels the section of an application showing whether the user had agreed to the terms of use or not.
 #: TWLight/applications/templates/applications/application_evaluation.html:145
 #, python-format
-msgid ""
-"Has agreed to the site's <a class=\"twl-links\" href=\"%(terms_url)s\">terms "
-"of use</a>?"
+msgid "Has agreed to the site's <a class=\"twl-links\" href=\"%(terms_url)s\">terms of use</a>?"
 msgstr ""
 
 #. Translators: Displayed to coordinators when they've agreed to the terms of use.
@@ -416,9 +391,7 @@ msgstr "ဟအှ်ေ"
 
 #. Translators: This is the text displayed to coordinators when an applicant has not agreed to the terms of use.
 #: TWLight/applications/templates/applications/application_evaluation.html:159
-msgid ""
-"Please request the applicant agree to the site's terms of use before "
-"approving this application."
+msgid "Please request the applicant agree to the site's terms of use before approving this application."
 msgstr ""
 
 #. Translators: This labels the section of an application containing the user's motivation for wanting access to this resource.
@@ -439,10 +412,8 @@ msgstr "ကလေၚ်တၟိပတိုန် အခေါင်အရာ �
 #. Translators: This message is shown next to the 'Renewal of existing access grant?' label if the application is a renewal. Don't translate HTML tags or parent_url.
 #: TWLight/applications/templates/applications/application_evaluation.html:195
 #, python-format
-msgid ""
-"Yes (<a class=\"twl-links\" href=\"%(parent_url)s\">previous application</a>)"
-msgstr ""
-"ယွံ (<a class=\"twl-links\" href=\"%(parent_url)s\">ပွမဂရၚ်အာတ်မိက် မတုဲကၠုၚ်ဂမၠိုၚ်</a>)"
+msgid "Yes (<a class=\"twl-links\" href=\"%(parent_url)s\">previous application</a>)"
+msgstr "ယွံ (<a class=\"twl-links\" href=\"%(parent_url)s\">ပွမဂရၚ်အာတ်မိက် မတုဲကၠုၚ်ဂမၠိုၚ်</a>)"
 
 #. Translators: This labels the section of the application showing the length of access remaining on the user's previous authorization.
 #: TWLight/applications/templates/applications/application_evaluation.html:208
@@ -476,12 +447,8 @@ msgstr "စုတ် ဂလာန်ဗကန်"
 
 #. Translators: On an application page, this text tells users that the comments posted on the application are visible to coordinators and the submitting user only.
 #: TWLight/applications/templates/applications/application_evaluation.html:297
-msgid ""
-"Comments are visible to all coordinators and to the editor who submitted "
-"this application."
-msgstr ""
-"ကမ္မောန်မပတိုန်လဝ်တအ်ဂှ် ညးမဆက်စၠောအ်တအ် သီုဖအိုတ် ဂွံဆဵုကေတ်မာန် တုဲပၠန် ညးမပလေဝ်ဒါန်တအ်လေဝ် ပလေဝ်ဒါန် "
-"ဂရၚ်ပတီဏအ်ဂွံရ၊၊"
+msgid "Comments are visible to all coordinators and to the editor who submitted this application."
+msgstr "ကမ္မောန်မပတိုန်လဝ်တအ်ဂှ် ညးမဆက်စၠောအ်တအ် သီုဖအိုတ် ဂွံဆဵုကေတ်မာန် တုဲပၠန် ညးမပလေဝ်ဒါန်တအ်လေဝ် ပလေဝ်ဒါန် ဂရၚ်ပတီဏအ်ဂွံရ၊၊"
 
 #. Translators: This is the title of the section of an application page which lists information about the user who submitted the application.
 #. Translators: On the page where coordinators can view data on applications to a partner they coordinate, this is a table column heading for the username.
@@ -693,12 +660,7 @@ msgstr "ဖျေဟ် ဒၞာဲကဆံၚ်"
 
 #: TWLight/applications/templates/applications/apply.html:20
 #, python-format
-msgid ""
-"If your application is successful we may share your email address with "
-"%(partner)s. This is required to set up your access to their resources. By "
-"submitting this form you agree to allow your email address to be shared with "
-"%(partner)s if your application is successful, for the purposes of account "
-"setup."
+msgid "If your application is successful we may share your email address with %(partner)s. This is required to set up your access to their resources. By submitting this form you agree to allow your email address to be shared with %(partner)s if your application is successful, for the purposes of account setup."
 msgstr ""
 
 #. Translators: This message is displayed on the page where users can confirm their renewal. Please do not translate partner.
@@ -727,9 +689,7 @@ msgstr "မုတမ်ရိုဟ် မၞး မိက်ဂွံလုပ�
 
 #. Translators: This text explains that Library Bundle partners are not shown in this list.
 #: TWLight/applications/templates/applications/request_for_application.html:26
-msgid ""
-"Library Bundle partners are not shown as eligibility is determined "
-"automatically."
+msgid "Library Bundle partners are not shown as eligibility is determined automatically."
 msgstr ""
 
 #. Translators: On the page where users can apply for multiple partners, this message shows next to the partner name, taking them to the full application page when clicked.
@@ -744,14 +704,8 @@ msgstr "တၚ်ဂၞၚ် သကအ်လဵုလေဝ် ဟွံဂွ�
 
 #. Translators: the HTML is so that the word 'waitlisted' will look the same as it does in the page above; please translate 'waitlisted' the same way you did elsewhere in this file.
 #: TWLight/applications/templates/applications/request_for_application.html:74
-msgid ""
-"You can apply to <span class=\"badge badge-warning\">Waitlisted</span> "
-"partners, but they don't have access grants available right now. We will "
-"process those applications when access becomes available."
-msgstr ""
-"မၞး ဂရင်အာတ်ကေတ် ဇရေင် <span class=\"badge badge-warning\">စရင်မမင်ဒၟံင်</span> "
-"သကအ်ဂမၠိုင်ဂွံရ၊၊ ဆဂး ညးတအ် ဟွံကလိဂွံ အခေါင်မသၟဟ်အစောံဏီ ပြဟ်ဟ်ဏအ်၊၊ လိက်ဂရၚ်ပတီဏအ် ပိုဲပၠောပ်ကဵုရောင် "
-"ကာလမပၠောပ် သၟဟ်အစောံမ္ဂး၊၊"
+msgid "You can apply to <span class=\"badge badge-warning\">Waitlisted</span> partners, but they don't have access grants available right now. We will process those applications when access becomes available."
+msgstr "မၞး ဂရင်အာတ်ကေတ် ဇရေင် <span class=\"badge badge-warning\">စရင်မမင်ဒၟံင်</span> သကအ်ဂမၠိုင်ဂွံရ၊၊ ဆဂး ညးတအ် ဟွံကလိဂွံ အခေါင်မသၟဟ်အစောံဏီ ပြဟ်ဟ်ဏအ်၊၊ လိက်ဂရၚ်ပတီဏအ် ပိုဲပၠောပ်ကဵုရောင် ကာလမပၠောပ် သၟဟ်အစောံမ္ဂး၊၊"
 
 #. Translators: On the page where coordinators can see approved applications which have not had their details sent to the partner, this message shows when there are applications ready to be processed.
 #: TWLight/applications/templates/applications/send.html:10
@@ -772,9 +726,7 @@ msgstr "တၚ်ဂၞၚ် မဂရၚ်အာတ်မိက် သွက�
 #. Translators: This message is shown when applications exceed the number of accounts available.
 #: TWLight/applications/templates/applications/send_partner.html:54
 #, python-format
-msgid ""
-"Application(s) for %(object)s, if sent, will exceed the total available "
-"accounts for the partner. Please proceed at your own discretion."
+msgid "Application(s) for %(object)s, if sent, will exceed the total available accounts for the partner. Please proceed at your own discretion."
 msgstr ""
 
 #. Translators: When viewing the list of applications ready to be sent for a particular partner, this is instructions for the coordinator to click the 'mark as sent' button after they have sent the information.
@@ -791,9 +743,7 @@ msgstr[1] ""
 
 #. Translators: When viewing the list of applications ready to be sent for a particular partner, this message shows if there is no information about who the applications should be sent to. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/applications/templates/applications/send_partner.html:89
-msgid ""
-"Whoops, we don't have any listed contacts. Please notify Wikipedia Library "
-"administrators."
+msgid "Whoops, we don't have any listed contacts. Please notify Wikipedia Library administrators."
 msgstr ""
 
 #. Translators: When viewing the list of applications ready to be sent for a particular partner, this is the title of the section containing the information about those applications.
@@ -809,9 +759,7 @@ msgstr "သမ္တီဒဒှ်မပြၚ်တုဲ"
 
 #. Translators: This text guides coordinators in using the code sending interface for approved applications.
 #: TWLight/applications/templates/applications/send_partner.html:152
-msgid ""
-"Use the dropdown menus to denote which editor will receive each code. Access "
-"codes will be sent to users automatically."
+msgid "Use the dropdown menus to denote which editor will receive each code. Access codes will be sent to users automatically."
 msgstr ""
 
 #. Translators: This labels a drop-down selection where staff can assign an access code to a user.
@@ -827,18 +775,13 @@ msgstr ""
 #. Translators: When a user applies for a set of resources, they receive this message if none are currently available. They are instead placed on a 'waitlist' for later approval.
 #. Translators: When a user renews their resource, they receive this message if none are currently available. They are instead placed on a 'waitlist' for later approval.
 #: TWLight/applications/views.py:140 TWLight/applications/views.py:1282
-msgid ""
-"This partner does not have any access grants available at this time. You may "
-"still apply for access; your application will be reviewed when access grants "
-"become available."
+msgid "This partner does not have any access grants available at this time. You may still apply for access; your application will be reviewed when access grants become available."
 msgstr ""
 
 #. Translators: This message is shown to users once they've successfully submitted their application for review.
 #: TWLight/applications/views.py:163
 #, python-brace-format
-msgid ""
-"Your application has been submitted for review. Head over to <a "
-"href='{applications_url}'>My Applications</a> to view the status."
+msgid "Your application has been submitted for review. Head over to <a href='{applications_url}'>My Applications</a> to view the status."
 msgstr ""
 
 #. Translators: This text is displayed to users when the user has chosen to restrict data and is trying to apply for multiple partners
@@ -887,16 +830,12 @@ msgstr "ပြၚ်လဝ် မဂရၚ်အာတ်မိက် ဂမၠ�
 
 #. Translators: After a coordinator has changed the status of an application to APPROVED, if the corresponding partner/collection is waitlisted this message appears.
 #: TWLight/applications/views.py:756
-msgid ""
-"Cannot approve application as partner with proxy authorization method is "
-"waitlisted."
+msgid "Cannot approve application as partner with proxy authorization method is waitlisted."
 msgstr ""
 
 #. Translators: After a coordinator has changed the status of an application to APPROVED, if the corresponding partner/collection has no accounts for distribution, this message appears.
 #: TWLight/applications/views.py:780
-msgid ""
-"Cannot approve application as partner with proxy authorization method is "
-"waitlisted and (or) has zero accounts available for distribution."
+msgid "Cannot approve application as partner with proxy authorization method is waitlisted and (or) has zero accounts available for distribution."
 msgstr ""
 
 #. Translators: This message appears on an "access denied" screen that stops users who attempt to authorize an editor to access a resource during a time period for which they are already authorized.
@@ -907,11 +846,7 @@ msgstr ""
 #. Translators: This message is shown to users when they access an application page of a now Bundle partner (new applications aren't allowed for Bundle partners and the status of old applications cannot be modified)
 #: TWLight/applications/views.py:857
 #, python-brace-format
-msgid ""
-"This application cannot be modified since this partner is now part of our <a "
-"href='{bundle}'>bundle access</a>. If you are eligible, you can access this "
-"resource from <a href='{library}'>your library</a>. <a "
-"href='{contact}'>Contact us</a> if you have any questions."
+msgid "This application cannot be modified since this partner is now part of our <a href='{bundle}'>bundle access</a>. If you are eligible, you can access this resource from <a href='{library}'>your library</a>. <a href='{contact}'>Contact us</a> if you have any questions."
 msgstr ""
 
 #. Translators: this lets a reviewer set the status of a single application.
@@ -921,9 +856,7 @@ msgstr "ဖျေအ်ဒၞဲါကဆံၚ်မဂရၚ်အာတ်မ
 
 #. Translators: This warning is message is shown to applicants when the number of pending applications is greater than the number of accounts available.
 #: TWLight/applications/views.py:891
-msgid ""
-"There are more pending applications than available accounts. Your "
-"application might get waitlisted."
+msgid "There are more pending applications than available accounts. Your application might get waitlisted."
 msgstr ""
 
 #. Translators: this message is shown to coordinators who attempt to change an application's Status from INVALID to any other Status.
@@ -943,11 +876,7 @@ msgstr ""
 
 #. Translators: After a coordinator has changed the status of a number of applications to APPROVED, if the corresponding partner(s) is/are waitlisted or has no accounts for distribution, this message appears.
 #: TWLight/applications/views.py:1051
-msgid ""
-"Cannot approve application(s) {} as partner(s) with proxy authorization "
-"method is/are waitlisted and (or) has/have not enough accounts available. If "
-"not enough accounts are available, prioritise the applications and then "
-"approve applications equal to the accounts available."
+msgid "Cannot approve application(s) {} as partner(s) with proxy authorization method is/are waitlisted and (or) has/have not enough accounts available. If not enough accounts are available, prioritise the applications and then approve applications equal to the accounts available."
 msgstr ""
 
 #. Translators: This message is shown to coordinators who attempt to assign the same access code to multiple users.
@@ -962,9 +891,7 @@ msgstr ""
 
 #. Translators: When a user tries to renew their resource, they receive this message if the partner is not available.
 #: TWLight/applications/views.py:1272
-msgid ""
-"Cannot renew application at this time as partner is not available. Please "
-"check back later, or contact us for more information."
+msgid "Cannot renew application at this time as partner is not available. Please check back later, or contact us for more information."
 msgstr ""
 
 #. Translators: This message is displayed when an attempt by a user to renew an application has been denied for some reason.
@@ -975,16 +902,12 @@ msgstr ""
 
 #. Translators: If a user requests the renewal of their account, but it wasn't renewed, this message is shown to them.
 #: TWLight/applications/views.py:1385
-msgid ""
-"This object cannot be renewed. (This probably means that you have already "
-"requested that it be renewed.)"
+msgid "This object cannot be renewed. (This probably means that you have already requested that it be renewed.)"
 msgstr ""
 
 #. Translators: If a user requests the renewal of their account, this message is shown to them.
 #: TWLight/applications/views.py:1395
-msgid ""
-"Your renewal request has been received. A coordinator will review your "
-"request."
+msgid "Your renewal request has been received. A coordinator will review your request."
 msgstr ""
 
 #. Translators: This labels a textfield where users can enter their email ID.
@@ -994,9 +917,7 @@ msgstr ""
 
 #. Translators: This is the help text for the email field in the contact us form letting users know the field is updated by value pulled from their respective user profiles.
 #: TWLight/emails/forms.py:21
-msgid ""
-"This field is automatically updated with the email from your <a class='twl-"
-"links' href='{}'>user profile</a>."
+msgid "This field is automatically updated with the email from your <a class='twl-links' href='{}'>user profile</a>."
 msgstr ""
 
 #. Translators: This labels a textfield where users can enter their email message.
@@ -1020,19 +941,13 @@ msgstr ""
 #. Translators: This email is sent to users with their access code. Don't translate Jinja variables in curly braces like user or partner. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/access_code_email-body-html.html:5
 #, python-format
-msgid ""
-"<p>Your approved application to %(partner)s has now been finalised. Your "
-"access code or login details can be found below:</p> <p><b>%(access_code)s</"
-"b></p> <p>%(user_instructions)s</p>"
+msgid "<p>Your approved application to %(partner)s has now been finalised. Your access code or login details can be found below:</p> <p><b>%(access_code)s</b></p> <p>%(user_instructions)s</p>"
 msgstr ""
 
 #. Translators: This email is sent to users with their access code. Don't translate Jinja variables in curly braces like user or partner. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/access_code_email-body-text.html:3
 #, python-format
-msgid ""
-"Your approved application to %(partner)s has now been finalised. Your access "
-"code or login details can be found below: %(access_code)s "
-"%(user_instructions)s"
+msgid "Your approved application to %(partner)s has now been finalised. Your access code or login details can be found below: %(access_code)s %(user_instructions)s"
 msgstr ""
 
 #. Translators: This is the subject line of an email sent to users with their access code.
@@ -1043,23 +958,13 @@ msgstr ""
 #. Translators: This email is sent to users when their application is approved. Don't translate Jinja variables in curly braces like user or partner; don't translate html tags either. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/approval_notification-body-html.html:5
 #, python-format
-msgid ""
-"<p>Dear %(user)s,</p> <p>Thank you for applying for access to %(partner)s "
-"resources through The Wikipedia Library. We are happy to inform you that "
-"your application has been approved.</p> <p>%(user_instructions)s</p> <p>You "
-"can view the collections you're authorized to access at My Library: "
-"%(link)s</p> <p>Cheers!</p> <p>The Wikipedia Library</p>"
+msgid "<p>Dear %(user)s,</p> <p>Thank you for applying for access to %(partner)s resources through The Wikipedia Library. We are happy to inform you that your application has been approved.</p> <p>%(user_instructions)s</p> <p>You can view the collections you're authorized to access at My Library: %(link)s</p> <p>Cheers!</p> <p>The Wikipedia Library</p>"
 msgstr ""
 
 #. Translators: This email is sent to users when their application is approved. Don't translate Jinja variables in curly braces like user or partner. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/approval_notification-body-text.html:3
 #, python-format
-msgid ""
-"Dear %(user)s, Thank you for applying for access to %(partner)s resources "
-"through The Wikipedia Library. We are happy to inform you that your "
-"application has been approved. %(user_instructions)s You can view the "
-"collections you're authorized to access at My Library: %(link)s Cheers! The "
-"Wikipedia Library"
+msgid "Dear %(user)s, Thank you for applying for access to %(partner)s resources through The Wikipedia Library. We are happy to inform you that your application has been approved. %(user_instructions)s You can view the collections you're authorized to access at My Library: %(link)s Cheers! The Wikipedia Library"
 msgstr ""
 
 #. Translators: This is the subject of an email which is sent to users when their application has been approved. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
@@ -1070,19 +975,13 @@ msgstr ""
 #. Translators: This email is sent to coordinators when a comment is left on an application they are processing. Don't translate Jinja variables in curly braces like user or partner. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/comment_notification_coordinator-body-html.html:5
 #, python-format
-msgid ""
-"<p style=\"color: #500050\">%(submit_date)s - %(commenter)s</p> "
-"<blockquote><p>%(comment)s</p></blockquote> <p>Please reply to these at: <a "
-"href=\"%(app_url)s\">%(app_url)s</a></p> <p>Best,</p> <p>The Wikipedia "
-"Library</p>"
+msgid "<p style=\"color: #500050\">%(submit_date)s - %(commenter)s</p> <blockquote><p>%(comment)s</p></blockquote> <p>Please reply to these at: <a href=\"%(app_url)s\">%(app_url)s</a></p> <p>Best,</p> <p>The Wikipedia Library</p>"
 msgstr ""
 
 #. Translators: This email is sent to coordinators when a comment is left on an application they are processing. Don't translate Jinja variables in curly braces like user or partner. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/comment_notification_coordinator-body-text.html:3
 #, python-format
-msgid ""
-"%(submit_date)s - %(commenter)s %(comment)s Please reply to this at: "
-"%(app_url)s Best, The Wikipedia Library"
+msgid "%(submit_date)s - %(commenter)s %(comment)s Please reply to this at: %(app_url)s Best, The Wikipedia Library"
 msgstr ""
 
 #. Translators: This is the subject line of an email sent to coordinators when a comment is left on an application they processed.
@@ -1093,19 +992,13 @@ msgstr ""
 #. Translators: This email is sent to users when they receive a comment on their application. Don't translate Jinja variables in curly braces like user or partner; don't translate html tags either. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/comment_notification_editors-body-html.html:5
 #, python-format
-msgid ""
-"<p style=\"color: #500050\">%(submit_date)s - %(commenter)s</p> "
-"<blockquote><p>%(comment)s</p></blockquote> <p>Please reply to these at <a "
-"href=\"%(app_url)s\">%(app_url)s</a> so we can evaluate your application.</"
-"p> <p>Best,</p> <p>The Wikipedia Library</p>"
+msgid "<p style=\"color: #500050\">%(submit_date)s - %(commenter)s</p> <blockquote><p>%(comment)s</p></blockquote> <p>Please reply to these at <a href=\"%(app_url)s\">%(app_url)s</a> so we can evaluate your application.</p> <p>Best,</p> <p>The Wikipedia Library</p>"
 msgstr ""
 
 #. Translators: This email is sent to users when they receive a comment on their application. Don't translate Jinja variables in curly braces like user or partner. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/comment_notification_editors-body-text.html:3
 #, python-format
-msgid ""
-"%(submit_date)s - %(commenter)s %(comment)s Please reply to these at: "
-"%(app_url)s so we can evaluate your application. Best, The Wikipedia Library"
+msgid "%(submit_date)s - %(commenter)s %(comment)s Please reply to these at: %(app_url)s so we can evaluate your application. Best, The Wikipedia Library"
 msgstr ""
 
 #. Translators: This is the subject line of an email sent to users who have a comment added to one of their applications. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
@@ -1116,18 +1009,13 @@ msgstr ""
 #. Translators: This email is sent to users when an application they commented on receives another comment. Don't translate Jinja variables in curly braces like app_url; don't translate html tags either. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/comment_notification_others-body-html.html:5
 #, python-format
-msgid ""
-"<p style=\"color: #500050\">%(submit_date)s - %(commenter)s</p> "
-"<blockquote><p>%(comment)s</p></blockquote> See it at <a href=\"%(app_url)s"
-"\">%(app_url)s</a>. Thanks for helping review Wikipedia Library applications!"
+msgid "<p style=\"color: #500050\">%(submit_date)s - %(commenter)s</p> <blockquote><p>%(comment)s</p></blockquote> See it at <a href=\"%(app_url)s\">%(app_url)s</a>. Thanks for helping review Wikipedia Library applications!"
 msgstr ""
 
 #. Translators: This email is sent to users when an application they commented on receives another comment. Don't translate Jinja variables in curly braces like app_url. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/comment_notification_others-body-text.html:3
 #, python-format
-msgid ""
-"%(submit_date)s - %(commenter)s %(comment)s See it at: %(app_url)s Thanks "
-"for helping review Wikipedia Library applications!"
+msgid "%(submit_date)s - %(commenter)s %(comment)s See it at: %(app_url)s Thanks for helping review Wikipedia Library applications!"
 msgstr ""
 
 #. Translators: This is the subject line of an email sent to users who have a comment added to an application they also commented on. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
@@ -1138,10 +1026,7 @@ msgstr ""
 #. Translators: This text is part of a scheduled reminder email sent to coordinators who have applications requiring action. Don't translate Jinja variables in curly braces like total_apps, or user.
 #: TWLight/emails/templates/emails/coordinator_reminder_notification-body-html.html:5
 #, python-format
-msgid ""
-"<p>Dear %(user)s,</p> <p>Our records indicate that you are the designated "
-"coordinator for partners that have a total of %(total_apps)s applications.</"
-"p>"
+msgid "<p>Dear %(user)s,</p> <p>Our records indicate that you are the designated coordinator for partners that have a total of %(total_apps)s applications.</p>"
 msgstr ""
 
 #. Translators: Breakdown as in 'cost breakdown'; analysis.
@@ -1180,31 +1065,19 @@ msgstr[1] "လၟိုဟ် ဂရၚ်အာတ်မိက်မဒဒ္�
 #. Translators: This text is part of a scheduled reminder email sent to coordinators who have applications requiring action. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library). Don't translate Jinja variables in curly braces like link; don't translate email addresses or html tags either.
 #: TWLight/emails/templates/emails/coordinator_reminder_notification-body-html.html:39
 #, python-format
-msgid ""
-"<p>This is a gentle reminder that you may review applications at <a href="
-"\"%(link)s\">%(link)s</a>.</p> <p>You can customise your reminders under "
-"'preferences' in your user profile.</p> <p>If you received this message in "
-"error, drop us a line at wikipedialibrary@wikimedia.org.</p> <p>Thanks for "
-"helping review Wikipedia Library applications!</p>"
+msgid "<p>This is a gentle reminder that you may review applications at <a href=\"%(link)s\">%(link)s</a>.</p> <p>You can customise your reminders under 'preferences' in your user profile.</p> <p>If you received this message in error, drop us a line at wikipedialibrary@wikimedia.org.</p> <p>Thanks for helping review Wikipedia Library applications!</p>"
 msgstr ""
 
 #. Translators: This text is part of a scheduled reminder email sent to coordinators who have applications requiring action. Don't translate Jinja variables in curly braces like total_apps, or user.
 #: TWLight/emails/templates/emails/coordinator_reminder_notification-body-text.html:3
 #, python-format
-msgid ""
-"Dear %(user)s, Our records indicate that you are the designated coordinator "
-"for partners that have a total of %(total_apps)s applications."
+msgid "Dear %(user)s, Our records indicate that you are the designated coordinator for partners that have a total of %(total_apps)s applications."
 msgstr ""
 
 #. Translators: This text is part of a scheduled reminder email sent to coordinators who have applications requiring action. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library). Don't translate Jinja variables in curly braces like link; don't translate the email address either.
 #: TWLight/emails/templates/emails/coordinator_reminder_notification-body-text.html:38
 #, python-format
-msgid ""
-"This is a gentle reminder that you may review applications at: %(link)s. You "
-"can customise your reminders under 'preferences' in your user profile. If "
-"you received this message in error, drop us a line at: "
-"wikipedialibrary@wikimedia.org Thanks for helping review Wikipedia Library "
-"applications!"
+msgid "This is a gentle reminder that you may review applications at: %(link)s. You can customise your reminders under 'preferences' in your user profile. If you received this message in error, drop us a line at: wikipedialibrary@wikimedia.org Thanks for helping review Wikipedia Library applications!"
 msgstr ""
 
 #. Translators: This is the subject line of a scheduled reminder email sent to coordinators who have applications to review. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library). Do not translate items in curly braces.
@@ -1215,22 +1088,13 @@ msgstr ""
 #. Translators: This email is sent to users when their application is rejected. Don't translate Jinja variables in curly braces like user or partner; don't translate html tags either. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/rejection_notification-body-html.html:5
 #, python-format
-msgid ""
-"<p>Dear %(user)s,</p> <p>Thank you for applying for access to %(partner)s "
-"resources through The Wikipedia Library. Unfortunately at this time your "
-"application has not been approved. You can view your application and review "
-"comments at <a href=\"%(app_url)s\">%(app_url)s</a>.</p> <p>Best,</p> <p>The "
-"Wikipedia Library</p>"
+msgid "<p>Dear %(user)s,</p> <p>Thank you for applying for access to %(partner)s resources through The Wikipedia Library. Unfortunately at this time your application has not been approved. You can view your application and review comments at <a href=\"%(app_url)s\">%(app_url)s</a>.</p> <p>Best,</p> <p>The Wikipedia Library</p>"
 msgstr ""
 
 #. Translators: This email is sent to users when their application is rejected. Don't translate Jinja variables in curly braces like user or partner. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/rejection_notification-body-text.html:3
 #, python-format
-msgid ""
-"Dear %(user)s, Thank you for applying for access to %(partner)s resources "
-"through The Wikipedia Library. Unfortunately at this time your application "
-"has not been approved. You can view your application and review comments at: "
-"%(app_url)s Best, The Wikipedia Library"
+msgid "Dear %(user)s, Thank you for applying for access to %(partner)s resources through The Wikipedia Library. Unfortunately at this time your application has not been approved. You can view your application and review comments at: %(app_url)s Best, The Wikipedia Library"
 msgstr ""
 
 #. Translators: This is the subject of an email which is sent to users when their application has been rejected. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
@@ -1241,25 +1105,13 @@ msgstr ""
 #. Translators: This email is sent to users when they have an account that is soon to expire. Don't translate Jinja variables in curly braces like partner_name or partner_link; don't translate html tags either. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/user_renewal_notice-body-html.html:5
 #, python-format
-msgid ""
-"<p>Dear %(user)s,</p> <p>According to our records, your access to "
-"%(partner_name)s will soon expire and you may lose access. If you want to "
-"continue making use of your free account, you can request renewal of your "
-"account by clicking the 'Renew' or 'Extend' button at %(partner_link)s.</p> "
-"<p>Best,</p> <p>The Wikipedia Library</p> <p>You can disable these emails in "
-"your user page preferences: https://wikipedialibrary.wmflabs.org/users/</p>"
+msgid "<p>Dear %(user)s,</p> <p>According to our records, your access to %(partner_name)s will soon expire and you may lose access. If you want to continue making use of your free account, you can request renewal of your account by clicking the 'Renew' or 'Extend' button at %(partner_link)s.</p> <p>Best,</p> <p>The Wikipedia Library</p> <p>You can disable these emails in your user page preferences: https://wikipedialibrary.wmflabs.org/users/</p>"
 msgstr ""
 
 #. Translators: This email is sent to users when they have an account that is soon to expire. Don't translate Jinja variables in curly braces like partner_name or partner_link; don't translate html tags either. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/user_renewal_notice-body-text.html:3
 #, python-format
-msgid ""
-"Dear %(user)s, According to our records, your access to %(partner_name)s "
-"will soon expire and you may lose access. If you want to continue making use "
-"of your free account, you can request renewal of your account by clicking "
-"the Renew button at %(partner_link)s. Best, The Wikipedia Library You can "
-"disable these emails in your user page preferences: https://wikipedialibrary."
-"wmflabs.org/users/"
+msgid "Dear %(user)s, According to our records, your access to %(partner_name)s will soon expire and you may lose access. If you want to continue making use of your free account, you can request renewal of your account by clicking the Renew button at %(partner_link)s. Best, The Wikipedia Library You can disable these emails in your user page preferences: https://wikipedialibrary.wmflabs.org/users/"
 msgstr ""
 
 #. Translators: This is the subject of an email sent to users when they have an account that is soon to expire. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
@@ -1270,24 +1122,13 @@ msgstr ""
 #. Translators: This email is sent to users when their application is waitlisted because there are no more accounts available. Don't translate Jinja variables in curly braces like user or partner; don't translate html tags either. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/waitlist_notification-body-html.html:5
 #, python-format
-msgid ""
-"<p>Dear %(user)s,</p> <p>Thank you for applying for access to %(partner)s "
-"resources through The Wikipedia Library. There are no accounts currently "
-"available so your application has been waitlisted. Your application will be "
-"evaluated if/when more accounts become available. You can see all available "
-"resources at <a href=\"%(link)s\">%(link)s</a>.</p> <p>Best,</p> <p>The "
-"Wikipedia Library</p>"
+msgid "<p>Dear %(user)s,</p> <p>Thank you for applying for access to %(partner)s resources through The Wikipedia Library. There are no accounts currently available so your application has been waitlisted. Your application will be evaluated if/when more accounts become available. You can see all available resources at <a href=\"%(link)s\">%(link)s</a>.</p> <p>Best,</p> <p>The Wikipedia Library</p>"
 msgstr ""
 
 #. Translators: This email is sent to users when their application is waitlisted because there are no more accounts available. Don't translate Jinja variables in curly braces like user or partner. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/waitlist_notification-body-text.html:3
 #, python-format
-msgid ""
-"Dear %(user)s, Thank you for applying for access to %(partner)s resources "
-"through The Wikipedia Library. There are no accounts currently available so "
-"your application has been waitlisted. Your application will be evaluated if/"
-"when more accounts become available. You can see all available resources at: "
-"%(link)s Best, The Wikipedia Library"
+msgid "Dear %(user)s, Thank you for applying for access to %(partner)s resources through The Wikipedia Library. There are no accounts currently available so your application has been waitlisted. Your application will be evaluated if/when more accounts become available. You can see all available resources at: %(link)s Best, The Wikipedia Library"
 msgstr ""
 
 #. Translators: This is the subject of an email sent to users when their application is waitlisted because there are no more accounts available. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
@@ -1453,17 +1294,14 @@ msgstr "မကလိဂွံ ဟွံမာန်"
 #: TWLight/resources/templates/resources/filter_section.html:14
 #: TWLight/templates/about.html:12
 #: TWLight/users/templates/users/filter_section.html:13
-msgid ""
-"The Wikipedia Library allows active editors to access a wide range of "
-"collections of paywalled reliable sources for free!"
+msgid "The Wikipedia Library allows active editors to access a wide range of collections of paywalled reliable sources for free!"
 msgstr ""
 
 #. Translators: On the Browse Partners page (https://wikipedialibrary.wmflabs.org/partners/), this introduces users to The Wikipedia Library.
 #. Translators: On the MyLibrary page (https://wikipedialibrary.wmflabs.org/users/my_library), this introduces users to The Wikipedia Library.
 #: TWLight/resources/templates/resources/filter_section.html:17
 #: TWLight/users/templates/users/filter_section.html:15
-msgid ""
-"Start with the search bar at the top or browse publisher websites directly."
+msgid "Start with the search bar at the top or browse publisher websites directly."
 msgstr ""
 
 #. Translators: On the Browse Partners page (https://wikipedialibrary.wmflabs.org/partners/), this appears below introductory text and links to the 'About' page (https://wikipedialibrary.wmflabs.org/about/)
@@ -1543,52 +1381,38 @@ msgstr ""
 #. Translators: If we have no available accounts for a partner, the coordinator can change the application system to a waiting list.
 #: TWLight/resources/templates/resources/partner_detail.html:36
 #: TWLight/resources/templates/resources/partner_detail_apply.html:17
-msgid ""
-"There are no access grants available for this partner at this time. You can "
-"still apply for access; applications will be processed when access is "
-"available."
+msgid "There are no access grants available for this partner at this time. You can still apply for access; applications will be processed when access is available."
 msgstr ""
 
 #. Translators: This text links to the minimum user requirements and terms of use on the partner page.
 #: TWLight/resources/templates/resources/partner_detail.html:48
 #: TWLight/resources/templates/resources/partner_detail_apply.html:29
 #, python-format
-msgid ""
-"Before applying, please review the <strong><a class=\"twl-links\" href="
-"\"%(about)s#req\">minimum requirements</a></strong> for access and our "
-"<strong><a class=\"twl-links\" href=\"%(terms)s\">terms of use</a></strong>."
+msgid "Before applying, please review the <strong><a class=\"twl-links\" href=\"%(about)s#req\">minimum requirements</a></strong> for access and our <strong><a class=\"twl-links\" href=\"%(terms)s\">terms of use</a></strong>."
 msgstr ""
 
 #. Translators: This text refers to the page containing the content a user is authorized to access.
 #: TWLight/resources/templates/resources/partner_detail.html:69
 #, python-format
-msgid ""
-"View the status of your access in <strong><a class=\"twl-links\" href="
-"\"%(library_url)s\">My Library</a></strong> page."
+msgid "View the status of your access in <strong><a class=\"twl-links\" href=\"%(library_url)s\">My Library</a></strong> page."
 msgstr ""
 
 #. Translators: This message is shown when a user has open applications, linking to their respective applications page.
 #: TWLight/resources/templates/resources/partner_detail.html:78
 #, python-format
-msgid ""
-"View the status of your application(s) on your <strong><a class=\"twl-links"
-"\" href=\"%(applications_url)s\">My Applications</a></strong> page."
+msgid "View the status of your application(s) on your <strong><a class=\"twl-links\" href=\"%(applications_url)s\">My Applications</a></strong> page."
 msgstr ""
 
 #. Translators: This message is shown when a user has authorizations, linking to their respective collections page.
 #: TWLight/resources/templates/resources/partner_detail_apply.html:50
 #, python-format
-msgid ""
-"View the status of your access on your <strong><a href=\"%(library_url)s\" "
-"class=\"twl-links\">My Library</a></strong> page."
+msgid "View the status of your access on your <strong><a href=\"%(library_url)s\" class=\"twl-links\">My Library</a></strong> page."
 msgstr ""
 
 #. Translators: This message is shown when a user has open applications, linking to their respective applications page.
 #: TWLight/resources/templates/resources/partner_detail_apply.html:60
 #, python-format
-msgid ""
-"View the status of your application(s) on your <strong><a href="
-"\"%(applications_url)s\">My Applications</a></strong> page."
+msgid "View the status of your application(s) on your <strong><a href=\"%(applications_url)s\">My Applications</a></strong> page."
 msgstr ""
 
 #. Translators: One the partner detail page, this text labels the button which coordinators can click to remove a partner from waitlisted status.
@@ -1618,10 +1442,7 @@ msgstr ""
 
 #. Translators: If no account coordinator is assigned to a partner, the Wikipedia Library team will coordinate signups. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/resources/templates/resources/partner_detail_apply.html:112
-msgid ""
-"The Wikipedia Library team will process this application. Want to help? <a "
-"class=\"twl-links\" href=\"https://en.wikipedia.org/wiki/Wikipedia:"
-"The_Wikipedia_Library/Coordinators/Signup\">Sign up as a coordinator.</a>"
+msgid "The Wikipedia Library team will process this application. Want to help? <a class=\"twl-links\" href=\"https://en.wikipedia.org/wiki/Wikipedia:The_Wikipedia_Library/Coordinators/Signup\">Sign up as a coordinator.</a>"
 msgstr ""
 
 #. Translators: This text labels a button coordinators can click to view a list of users who have applied for access for a particular partner
@@ -1651,18 +1472,13 @@ msgstr ""
 
 #. Translators: Text shown to authenticated, bundle eligible users when they visit a Bundle partner page.
 #: TWLight/resources/templates/resources/partner_detail_apply.html:138
-msgid ""
-"You are eligible to access Library Bundle partners. Click the button above "
-"to access the collection."
+msgid "You are eligible to access Library Bundle partners. Click the button above to access the collection."
 msgstr ""
 
 #. Translators: Text shown to authenticated, bundle ineligible users when they visit a Bundle partner page.
 #: TWLight/resources/templates/resources/partner_detail_apply.html:152
 #, python-format
-msgid ""
-"You are not eligible to access Library Bundle partners. Visit the <a class="
-"\"twl-links\" href=\"%(homepage)s\">homepage</a> to check the eligibility "
-"criteria."
+msgid "You are not eligible to access Library Bundle partners. Visit the <a class=\"twl-links\" href=\"%(homepage)s\">homepage</a> to check the eligibility criteria."
 msgstr ""
 
 #. Translators: Buttton prompting users to log in.
@@ -1674,10 +1490,7 @@ msgstr "လုပ်လံက်အေန်"
 #. Translators: Text shown to unauthenticated users when they visit a Bundle partner page.
 #: TWLight/resources/templates/resources/partner_detail_apply.html:168
 #, python-format
-msgid ""
-"This resource is part of our <a class=\"twl-links\" href=\"%(about)s"
-"\">Library Bundle</a>, which you can access if you meet our minimum "
-"eligibility criteria. Log in to find out if you are eligible."
+msgid "This resource is part of our <a class=\"twl-links\" href=\"%(about)s\">Library Bundle</a>, which you can access if you meet our minimum eligibility criteria. Log in to find out if you are eligible."
 msgstr ""
 
 #. Translators: This is the label for a number which shows the total active accounts for one partner. (e.g. https://wikipedialibrary.wmflabs.org/partners/8/).
@@ -1728,26 +1541,19 @@ msgstr ""
 #. Translators: If a partner has specified the excerpt limit both in words and percentage, this message will display the percentage of words and the number of words on the partner page.
 #: TWLight/resources/templates/resources/partner_detail_timeline.html:99
 #, python-format
-msgid ""
-"%(object)s allows a maximum of %(excerpt_limit)s words or "
-"%(excerpt_limit_percentage)s%% of an article be excerpted into a Wikipedia "
-"article."
+msgid "%(object)s allows a maximum of %(excerpt_limit)s words or %(excerpt_limit_percentage)s%% of an article be excerpted into a Wikipedia article."
 msgstr ""
 
 #. Translators: If a partner has specified the excerpt limit in words, this message will display the number of words on the partner page.
 #: TWLight/resources/templates/resources/partner_detail_timeline.html:106
 #, python-format
-msgid ""
-"%(object)s allows a maximum of %(excerpt_limit)s words be excerpted into a "
-"Wikipedia article."
+msgid "%(object)s allows a maximum of %(excerpt_limit)s words be excerpted into a Wikipedia article."
 msgstr ""
 
 #. Translators: If a partner has specified the excerpt limit in percentage, this message will display the percentage of words on the partner page.
 #: TWLight/resources/templates/resources/partner_detail_timeline.html:113
 #, python-format
-msgid ""
-"%(object)s allows a maximum of %(excerpt_limit_percentage)s%% of an article "
-"be excerpted into a Wikipedia article."
+msgid "%(object)s allows a maximum of %(excerpt_limit_percentage)s%% of an article be excerpted into a Wikipedia article."
 msgstr ""
 
 #. Translators: If a partner has other requirements for access, this text shows as the title for that information field. (e.g. https://wikipedialibrary.wmflabs.org/partners/10/).
@@ -1758,9 +1564,7 @@ msgstr ""
 #. Translators: If a user must agree to a Terms of Use document, they see this message, and must enter the name of the resource. Don't translate publisher or url.
 #: TWLight/resources/templates/resources/partner_detail_timeline.html:140
 #, python-format
-msgid ""
-"%(publisher)s requires that you agree with its <a href=\"%(url)s\">terms of "
-"use</a>."
+msgid "%(publisher)s requires that you agree with its <a href=\"%(url)s\">terms of use</a>."
 msgstr ""
 
 #. Translators: If a user must provide their real name to apply to a partner, they see this message, and must enter the name of the resource. Don't translate publisher.
@@ -1784,17 +1588,13 @@ msgstr ""
 #. Translators: If a user must select a specific resource to apply for, they see this message, and must enter the name of the resource. Don't translate publisher.
 #: TWLight/resources/templates/resources/partner_detail_timeline.html:177
 #, python-format
-msgid ""
-"%(publisher)s requires that you specify a particular title that you want to "
-"access."
+msgid "%(publisher)s requires that you specify a particular title that you want to access."
 msgstr ""
 
 #. Translators: If a user must register on the partner website before applying, they see this message. Don't translate partner.
 #: TWLight/resources/templates/resources/partner_detail_timeline.html:187
 #, python-format
-msgid ""
-"%(publisher)s requires that you sign up for an account before applying for "
-"access."
+msgid "%(publisher)s requires that you sign up for an account before applying for access."
 msgstr ""
 
 #. Translators: If a partner has their location listed, this message is a label for that location
@@ -1922,9 +1722,7 @@ msgstr ""
 
 #. Translators: If multiple authorizations where returned for a collection, this message is shown to a user
 #: TWLight/resources/views.py:268
-msgid ""
-"Multiple authorizations were returned – something's wrong. Please contact us "
-"and don't forget to mention this message."
+msgid "Multiple authorizations were returned – something's wrong. Please contact us and don't forget to mention this message."
 msgstr ""
 
 #. Translators: This message is shown when user tries to access a NOT_AVAILABLE Partner
@@ -1965,14 +1763,7 @@ msgstr "သၠးအခေါၚ် - အရာဏအ် မုဂွံပဂ�
 #. Translators: Shown on the website's 400 page, when a user sends a bad request. Don't translate path or Phabricator.
 #: TWLight/templates/400.html:20
 #, python-format
-msgid ""
-"If you think we should know what to do with that, please email us about this "
-"error at <a class=\"twl-links\" href=\"mailto:wikipedialibrary@wikimedia.org?"
-"Subject=Wikipedia%%20Library%%20%(path)s%%20Permission%%20denied"
-"\">wikipedialibrary@wikimedia.org</a> or report it to us on <a class=\"twl-"
-"links\" href=\"https://phabricator.wikimedia.org/maniphest/task/edit/form/1/?"
-"projectPHIDs=Library-Card-Platform&title=Wikipedia%%20Library%%20%(path)s"
-"%%20Bad%%20Request\">Phabricator</a>"
+msgid "If you think we should know what to do with that, please email us about this error at <a class=\"twl-links\" href=\"mailto:wikipedialibrary@wikimedia.org?Subject=Wikipedia%%20Library%%20%(path)s%%20Permission%%20denied\">wikipedialibrary@wikimedia.org</a> or report it to us on <a class=\"twl-links\" href=\"https://phabricator.wikimedia.org/maniphest/task/edit/form/1/?projectPHIDs=Library-Card-Platform&title=Wikipedia%%20Library%%20%(path)s%%20Bad%%20Request\">Phabricator</a>"
 msgstr ""
 
 #. Translators: Alt text for an image shown on the 400 error page.
@@ -1994,15 +1785,7 @@ msgstr ""
 #. Translators: Shown on the website's 403 page, when a user attempts to navigate to a page they don't have permission to view. Don't translate path or Phabricator.
 #: TWLight/templates/403.html:20
 #, python-format
-msgid ""
-"If you think your account should be able to do that, please email us about "
-"this error at <a class=\"twl-links\" href=\"mailto:"
-"wikipedialibrary@wikimedia.org?Subject=Wikipedia%%20Library%%20%(path)s"
-"%%20Permission%%20denied\">wikipedialibrary@wikimedia.org</a> or report it "
-"to us on <a class=\"twl-links\" href=\"https://phabricator.wikimedia.org/"
-"maniphest/task/edit/form/1/?projectPHIDs=Library-Card-"
-"Platform&title=Wikipedia%%20Library%%20%(path)s%%20Permission%%20denied"
-"\">Phabricator</a>"
+msgid "If you think your account should be able to do that, please email us about this error at <a class=\"twl-links\" href=\"mailto:wikipedialibrary@wikimedia.org?Subject=Wikipedia%%20Library%%20%(path)s%%20Permission%%20denied\">wikipedialibrary@wikimedia.org</a> or report it to us on <a class=\"twl-links\" href=\"https://phabricator.wikimedia.org/maniphest/task/edit/form/1/?projectPHIDs=Library-Card-Platform&title=Wikipedia%%20Library%%20%(path)s%%20Permission%%20denied\">Phabricator</a>"
 msgstr ""
 
 #. Translators: Shown on the website's 404 page, when a user attempts to navigate to a page that doesn't exist.
@@ -2018,14 +1801,7 @@ msgstr "သၠးအခေါၚ်: ပိုယ်ဆဵုကေတ်ဟွ�
 #. Translators: Shown on the website's 404 page, when a user attempts to navigate to a page that doesn't exist. Don't translate path or Phabricator.
 #: TWLight/templates/404.html:19
 #, python-format
-msgid ""
-"If you are certain that something should be here, please email us about this "
-"error at <a class=\"twl-links\" href=\"mailto:wikipedialibrary@wikimedia.org?"
-"Subject=Wikipedia%%20Library%%20%(path)s%%20Not%%20found\"> "
-"wikipedialibrary@wikimedia.org</a> or report it to us on <a class=\"twl-links"
-"\" href=\"https://phabricator.wikimedia.org/maniphest/task/edit/form/1/?"
-"projectPHIDs=Library-Card-Platform&title=Wikipedia%%20Library%%20%(path)s"
-"%%20Not%%20found\">Phabricator</a>"
+msgid "If you are certain that something should be here, please email us about this error at <a class=\"twl-links\" href=\"mailto:wikipedialibrary@wikimedia.org?Subject=Wikipedia%%20Library%%20%(path)s%%20Not%%20found\"> wikipedialibrary@wikimedia.org</a> or report it to us on <a class=\"twl-links\" href=\"https://phabricator.wikimedia.org/maniphest/task/edit/form/1/?projectPHIDs=Library-Card-Platform&title=Wikipedia%%20Library%%20%(path)s%%20Not%%20found\">Phabricator</a>"
 msgstr ""
 
 #. Translators: Alt text for an image shown on the 404 error page.
@@ -2040,32 +1816,18 @@ msgstr ""
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:20
-msgid ""
-"This platform is our central tool for facilitating access to our available "
-"collections. Here you can see which partnerships are available, search their "
-"contents, and apply for and access the ones you’re interested in."
+msgid "This platform is our central tool for facilitating access to our available collections. Here you can see which partnerships are available, search their contents, and apply for and access the ones you’re interested in."
 msgstr ""
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/). Wikimedia Foundation should not be translated.
 #: TWLight/templates/about.html:29
-msgid ""
-"All users receive immediate access to some collections, which can be browsed "
-"by clicking the 'Access collection' buttons or using the search bar at the "
-"top of the page. Other collections require an application before access is "
-"granted, and may be accessed directly or via an individual login or access "
-"code. Volunteer coordinators, who have signed non-disclosure agreements with "
-"the Wikimedia Foundation, review these applications and work with publishers "
-"to get you your free access."
+msgid "All users receive immediate access to some collections, which can be browsed by clicking the 'Access collection' buttons or using the search bar at the top of the page. Other collections require an application before access is granted, and may be accessed directly or via an individual login or access code. Volunteer coordinators, who have signed non-disclosure agreements with the Wikimedia Foundation, review these applications and work with publishers to get you your free access."
 msgstr ""
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/). Don't translate terms_url.
 #: TWLight/templates/about.html:43
 #, python-format
-msgid ""
-"For more information about how your information is stored and reviewed "
-"please see our <a class=\"twl-links\" href=\"%(terms_url)s\"> terms of use "
-"and privacy policy</a>. Accounts you apply for are also subject to the Terms "
-"of Use provided by each partner’s platform; please review them."
+msgid "For more information about how your information is stored and reviewed please see our <a class=\"twl-links\" href=\"%(terms_url)s\"> terms of use and privacy policy</a>. Accounts you apply for are also subject to the Terms of Use provided by each partner’s platform; please review them."
 msgstr ""
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
@@ -2075,12 +1837,7 @@ msgstr ""
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/). Wikimedia Foundation should not be translated.
 #: TWLight/templates/about.html:55
-msgid ""
-"Any active editor in good standing can receive access. For publishers with "
-"limited numbers of accounts, applications are reviewed based on the editor’s "
-"needs and contributions. If you think you could use access to one of our "
-"partner resources and are an active editor in any project supported by the "
-"Wikimedia Foundation, please apply."
+msgid "Any active editor in good standing can receive access. For publishers with limited numbers of accounts, applications are reviewed based on the editor’s needs and contributions. If you think you could use access to one of our partner resources and are an active editor in any project supported by the Wikimedia Foundation, please apply."
 msgstr ""
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
@@ -2110,23 +1867,12 @@ msgstr ""
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/)
 #: TWLight/templates/about.html:89
-msgid ""
-"If you are applying for an available collection, please first check that you "
-"don't already have access through another library or institution. If you do, "
-"please consider using that access rather than taking up a seat for this "
-"resource in The Wikipedia Library."
+msgid "If you are applying for an available collection, please first check that you don't already have access through another library or institution. If you do, please consider using that access rather than taking up a seat for this resource in The Wikipedia Library."
 msgstr ""
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/)
 #: TWLight/templates/about.html:99
-msgid ""
-"If your account is blocked on one or more Wikimedia projects, you may still "
-"be granted access to The Wikipedia Library. You will need to contact the "
-"Wikipedia Library team, who will review your blocks. If you have been "
-"blocked for content issues, most notably copyright violations, or have "
-"multiple long-term blocks, we may decline your request. Additionally, if "
-"your block status changes after being approved, you will need to request "
-"another review."
+msgid "If your account is blocked on one or more Wikimedia projects, you may still be granted access to The Wikipedia Library. You will need to contact the Wikipedia Library team, who will review your blocks. If you have been blocked for content issues, most notably copyright violations, or have multiple long-term blocks, we may decline your request. Additionally, if your block status changes after being approved, you will need to request another review."
 msgstr ""
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
@@ -2161,9 +1907,7 @@ msgstr "ညးဒါန်ပလေဝ်မသ္ပဒတန်တုဲ <i>�
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:136
-msgid ""
-"Share their account logins or passwords with others, or sell their access to "
-"other parties"
+msgid "Share their account logins or passwords with others, or sell their access to other parties"
 msgstr ""
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
@@ -2173,23 +1917,17 @@ msgstr ""
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:144
-msgid ""
-"Systematically make printed or electronic copies of multiple extracts of "
-"restricted content available for any purpose"
+msgid "Systematically make printed or electronic copies of multiple extracts of restricted content available for any purpose"
 msgstr ""
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/). Stub is a technical term for a short Wikipedia article, use the appropriate Wikipedia term in your language.
 #: TWLight/templates/about.html:148
-msgid ""
-"Datamine metadata without permission, in order, for instance, to use "
-"metadata for auto-created stub articles"
+msgid "Datamine metadata without permission, in order, for instance, to use metadata for auto-created stub articles"
 msgstr ""
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:154
-msgid ""
-"Respecting these agreements allows us to continue growing the partnerships "
-"available to the community."
+msgid "Respecting these agreements allows us to continue growing the partnerships available to the community."
 msgstr ""
 
 #. Translators: This is the heading for a section on the About page (https://wikipedialibrary.wmflabs.org/about/).
@@ -2199,41 +1937,22 @@ msgstr ""
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:164
-msgid ""
-"EZProxy is a proxy server used to authenticate users for many Wikipedia "
-"Library partners. Users sign into EZProxy via the Library Card platform to "
-"verify that they are authorized users, and then the server accesses "
-"requested resources using its own IP address."
+msgid "EZProxy is a proxy server used to authenticate users for many Wikipedia Library partners. Users sign into EZProxy via the Library Card platform to verify that they are authorized users, and then the server accesses requested resources using its own IP address."
 msgstr ""
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:173
-msgid ""
-"You may notice that when accessing resources via EZProxy that URLs are "
-"dynamically rewritten. This is why we recommend logging in via the Library "
-"Card platform rather than going directly to the unproxied partner website. "
-"When in doubt, check the URL for ‘idm.oclc’. If it’s there, then you’re "
-"connected via EZProxy."
+msgid "You may notice that when accessing resources via EZProxy that URLs are dynamically rewritten. This is why we recommend logging in via the Library Card platform rather than going directly to the unproxied partner website. When in doubt, check the URL for ‘idm.oclc’. If it’s there, then you’re connected via EZProxy."
 msgstr ""
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:182
-msgid ""
-"Typically once you’ve logged in your session will remain active in your "
-"browser for up to two hours after you’ve finished searching. Note that use "
-"of EZProxy requires you to enable cookies. If you are having problems you "
-"should also try clearing your cache and restarting your browser."
+msgid "Typically once you’ve logged in your session will remain active in your browser for up to two hours after you’ve finished searching. Note that use of EZProxy requires you to enable cookies. If you are having problems you should also try clearing your cache and restarting your browser."
 msgstr ""
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/)
 #: TWLight/templates/about.html:193
-msgid ""
-"The Library Bundle is a collection of resources for which no application is "
-"required. If you meet the criteria laid out above, you will be authorized "
-"for access automatically upon logging in to the platform. Only some of our "
-"content is currently included in the Library Bundle, however we hope to "
-"expand the collection as more publishers become comfortable with "
-"participating. All Bundle content is accessed via EZProxy."
+msgid "The Library Bundle is a collection of resources for which no application is required. If you meet the criteria laid out above, you will be authorized for access automatically upon logging in to the platform. Only some of our content is currently included in the Library Bundle, however we hope to expand the collection as more publishers become comfortable with participating. All Bundle content is accessed via EZProxy."
 msgstr ""
 
 #. Translators: This is the heading for a section on the About page (https://wikipedialibrary.wmflabs.org/about/).
@@ -2243,12 +1962,7 @@ msgstr ""
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:206
-msgid ""
-"Citation practices vary by project and even by article. Generally, we "
-"support editors citing where they found information, in a form that allows "
-"others to check it for themselves. That often means providing both original "
-"source details as well as a link to the partner database in which the source "
-"was found."
+msgid "Citation practices vary by project and even by article. Generally, we support editors citing where they found information, in a form that allows others to check it for themselves. That often means providing both original source details as well as a link to the partner database in which the source was found."
 msgstr ""
 
 #. Translators: This is the heading for a section on the About page (https://wikipedialibrary.wmflabs.org/about/).
@@ -2260,9 +1974,7 @@ msgstr "ကေတ်အဆက်ကု ပိုယ်"
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:218
 #, python-format
-msgid ""
-"If you have questions, need help, or want to volunteer to help, please see "
-"our <a class=\"twl-links\" href=\"%(contact_url)s\">contact page</a>."
+msgid "If you have questions, need help, or want to volunteer to help, please see our <a class=\"twl-links\" href=\"%(contact_url)s\">contact page</a>."
 msgstr ""
 
 #. Translators: This is the title of the panel box detailing the contact information for the Wikipedia Library team.
@@ -2302,9 +2014,7 @@ msgstr ""
 #. Translators: This is the text that appears at the bottom of the contact us form directing users to the suggestions form.
 #: TWLight/templates/contact.html:48
 #, python-format
-msgid ""
-"(If you would like to suggest a partner, <a class=\"twl-links\" href="
-"\"%(suggest)s\"><strong>go here</strong></a>.)"
+msgid "(If you would like to suggest a partner, <a class=\"twl-links\" href=\"%(suggest)s\"><strong>go here</strong></a>.)"
 msgstr ""
 
 #. Translators: On a special 'link to search' page, this message is shown if JavaScript is disabled.
@@ -2362,9 +2072,7 @@ msgstr ""
 #. Translators: Information about The Wikipedia Library.
 #: TWLight/templates/login_partial.html:53 TWLight/templates/new_base.html:21
 #, python-format
-msgid ""
-"More than 100 of the world's top subscription-only databases, with content "
-"in %(no_of_languages)s languages, free for Wikipedians of all backgrounds"
+msgid "More than 100 of the world's top subscription-only databases, with content in %(no_of_languages)s languages, free for Wikipedians of all backgrounds"
 msgstr ""
 
 #. Translators: Information about The Wikipedia Library.
@@ -2373,9 +2081,7 @@ msgid "Meet these criteria for automatic access"
 msgstr ""
 
 #: TWLight/templates/login_partial.html:69
-msgid ""
-"These criteria grant you access to certain collections but not all. Some "
-"collections are accessible on a per application basis only."
+msgid "These criteria grant you access to certain collections but not all. Some collections are accessible on a per application basis only."
 msgstr ""
 
 #: TWLight/templates/login_partial.html:89
@@ -2385,29 +2091,19 @@ msgstr ""
 #. Translators: Shown if the current user doesn't have a registered email on their account. Don't translate contact_us_url or email_url.
 #: TWLight/templates/message_partial.html:15
 #, python-format
-msgid ""
-"You don't have an email on file. We can't finalize your access to partner "
-"resources, and you won't be able to <a class=\"twl-links\" href="
-"\"%(contact_us_url)s\">contact us</a> without an email. Please <a class="
-"\"twl-links\" href=\"%(email_url)s\">update your email</a>."
+msgid "You don't have an email on file. We can't finalize your access to partner resources, and you won't be able to <a class=\"twl-links\" href=\"%(contact_us_url)s\">contact us</a> without an email. Please <a class=\"twl-links\" href=\"%(email_url)s\">update your email</a>."
 msgstr ""
 
 #. Translators: Shown if the current user has requested the processing of their data should be restricted.
 #: TWLight/templates/message_partial.html:26
 #, python-format
-msgid ""
-"You have requested a restriction on the processing of your data. Most site "
-"functionality will not be available to you until you <a class=\"twl-links\" "
-"href=\"%(restrict_url)s\">lift this restriction</a>."
+msgid "You have requested a restriction on the processing of your data. Most site functionality will not be available to you until you <a class=\"twl-links\" href=\"%(restrict_url)s\">lift this restriction</a>."
 msgstr ""
 
 #. Translators: Shown if the current user has not agreed to the terms of use.
 #: TWLight/templates/message_partial.html:37
 #, python-format
-msgid ""
-"You have not agreed to the <a class=\"twl-links\" href=\"%(terms_url)s"
-"\">terms of use</a> of this site. Your applications will not be processed "
-"and you won't be able to apply or access resources you are approved for."
+msgid "You have not agreed to the <a class=\"twl-links\" href=\"%(terms_url)s\">terms of use</a> of this site. Your applications will not be processed and you won't be able to apply or access resources you are approved for."
 msgstr ""
 
 #. Translators: This link is at the bottom of every page and links to the 'About' page (https://wikipedialibrary.wmflabs.org/about/)
@@ -2455,9 +2151,7 @@ msgstr "ကလေင်ချိၚ် မအက္ခရ်ပၞုက်"
 
 #. Translators: If a user goes to reset their password, this message asks them to enter their email to do so.
 #: TWLight/templates/registration/password_reset_form.html:13
-msgid ""
-"Forgot your password? Enter your email address below, and we'll email "
-"instructions for setting a new one."
+msgid "Forgot your password? Enter your email address below, and we'll email instructions for setting a new one."
 msgstr ""
 
 #. Translators: This is the label for a button that users click to update their public information.
@@ -2502,16 +2196,12 @@ msgstr ""
 
 #. Translators: This text explains how to disagree to the site's terms of use and the restrictions that will come into effect when users disagree to the terms of use.
 #: TWLight/users/forms.py:185
-msgid ""
-"By unchecking this box and clicking “Update” you may explore the site, but "
-"you will not be able to apply for access to materials or evaluate "
-"applications unless you agree with the terms of use."
+msgid "By unchecking this box and clicking “Update” you may explore the site, but you will not be able to apply for access to materials or evaluate applications unless you agree with the terms of use."
 msgstr ""
 
 #. Translators: Users click this button to set their website email address to the one linked to their Wikipedia account.
 #: TWLight/users/forms.py:211
-msgid ""
-"Use my Wikipedia email address (will be updated the next time you login)."
+msgid "Use my Wikipedia email address (will be updated the next time you login)."
 msgstr ""
 
 #. Translators: This labels a button which users click to change their email.
@@ -2522,17 +2212,8 @@ msgstr "ပခိုဟ်လဟဵု အီမေလ်"
 #. Translators: Shown if the current user tried to 'favorite' a partner they can't access. Do not translate '{partner}'
 #: TWLight/users/models.py:201
 #, python-brace-format
-msgid ""
-"Cannot add partner {partner} to your favorites because you don't have access "
-"to it"
+msgid "Cannot add partner {partner} to your favorites because you don't have access to it"
 msgstr ""
-
-#. Translators: Do not translate.
-#: TWLight/users/models.py:869
-#, fuzzy, python-brace-format
-#| msgid "Username"
-msgid "{wp_username}"
-msgstr "ယၟုညးလွပ်"
 
 #. Translators: This error message is shown when there's a problem with the authenticated login process.
 #: TWLight/users/oauth.py:243
@@ -2552,9 +2233,7 @@ msgstr ""
 
 #. Translators: this message is displayed to users that don't have accounts and clicked on a proxied link.
 #: TWLight/users/oauth.py:388
-msgid ""
-"To view this link you need to be an eligible library user. Please login to "
-"continue."
+msgid "To view this link you need to be an eligible library user. Please login to continue."
 msgstr ""
 
 #. Translators: This warning message is shown to users when the response received from Wikimedia OAuth servers is not a valid one.
@@ -2590,17 +2269,12 @@ msgstr "ပရိုင်တင်ဂၞင် ညးလွပ်"
 
 #. Translators: If the user tries to log in, but their account does not meet certain requirements, they cannot login.
 #: TWLight/users/oauth.py:528
-msgid ""
-"Your Wikipedia account does not meet the eligibility criteria in the terms "
-"of use, so your Wikipedia Library Card Platform account cannot be activated."
+msgid "Your Wikipedia account does not meet the eligibility criteria in the terms of use, so your Wikipedia Library Card Platform account cannot be activated."
 msgstr ""
 
 #. Translators: If the user tries to log in, but their account does not meet certain requirements, they cannot login.
 #: TWLight/users/oauth.py:536
-msgid ""
-"Your Wikipedia account no longer meets the eligibility criteria in the terms "
-"of use, so you cannot be logged in. If you think you should be able to log "
-"in, please email wikipedialibrary@wikimedia.org."
+msgid "Your Wikipedia account no longer meets the eligibility criteria in the terms of use, so you cannot be logged in. If you think you should be able to log in, please email wikipedialibrary@wikimedia.org."
 msgstr ""
 
 #. Translators: this message is displayed to users with brand new accounts.
@@ -2611,10 +2285,7 @@ msgstr ""
 #. Translators: This message is displayed on the confirmation page where users can return their access to partner collections.
 #: TWLight/users/templates/users/authorization_confirm_return.html:13
 #, python-format
-msgid ""
-"You will no longer be able to access <b>%(partner)s's</b> resources via the "
-"Library Card platform, but can request access again by clicking 'renew', if "
-"you change your mind. Are you sure you want to return your access?"
+msgid "You will no longer be able to access <b>%(partner)s's</b> resources via the Library Card platform, but can request access again by clicking 'renew', if you change your mind. Are you sure you want to return your access?"
 msgstr ""
 
 #. Translators: On the MyLibrary page (https://wikipedialibrary.wmflabs.org/users/my_library), this tab shows all favorite collections a user has.
@@ -2687,10 +2358,7 @@ msgstr ""
 
 #. Translators: This is shown on editor profiles, in their profile page or on applications.
 #: TWLight/users/templates/users/editor_detail.html:59
-msgid ""
-"Information with an * was retrieved from Wikipedia directly. Other "
-"information was entered directly by users or site admins, in their preferred "
-"language."
+msgid "Information with an * was retrieved from Wikipedia directly. Other information was entered directly by users or site admins, in their preferred language."
 msgstr ""
 
 #. Translators: This distinguishes users who have been flagged as account coordinators. Don't translate username.
@@ -2701,10 +2369,7 @@ msgstr ""
 
 #. Translators: This is shown on editor profiles, under the heading for Wikipedia editor data.
 #: TWLight/users/templates/users/editor_detail_data.html:5
-msgid ""
-"This information is updated automatically from your Wikimedia account each "
-"time you log in, except for the Contributions field, where you can describe "
-"your Wikimedia editing history."
+msgid "This information is updated automatically from your Wikimedia account each time you log in, except for the Contributions field, where you can describe your Wikimedia editing history."
 msgstr ""
 
 #. Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this labels the user's username.
@@ -2734,17 +2399,13 @@ msgstr ""
 
 #. Translators: when viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this question has a yes or no answer.
 #: TWLight/users/templates/users/editor_detail_data.html:57
-msgid ""
-"at their last login, did this user meet the criteria set forth in the terms "
-"of use?"
+msgid "at their last login, did this user meet the criteria set forth in the terms of use?"
 msgstr ""
 
 #. Translators: When viewing a user's profile in an application, this message shows if the software doesn't think that the user is eligible for access. Don't translate username.
 #: TWLight/users/templates/users/editor_detail_data.html:72
 #, python-format
-msgid ""
-"%(username)s may still be eligible for access grants at the coordinators' "
-"discretion."
+msgid "%(username)s may still be eligible for access grants at the coordinators' discretion."
 msgstr ""
 
 #. Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this is the heading for a Yes/No ToU question.
@@ -2779,10 +2440,7 @@ msgstr ""
 #. Translators: This message is shown on a user's profile if their Wikimedia account is blocked on one or more projects. They may still be granted access to the Library Bundle, but need to contact Wikipedia Library staff to verify.
 #: TWLight/users/templates/users/editor_detail_data.html:137
 #, python-format
-msgid ""
-"It looks like you have an active block on your account. If you meet the "
-"other criteria you may still be permitted access to the library - please <a "
-"class=\"twl-links\" href=\"%(contact_url)s\">contact us</a>."
+msgid "It looks like you have an active block on your account. If you meet the other criteria you may still be permitted access to the library - please <a class=\"twl-links\" href=\"%(contact_url)s\">contact us</a>."
 msgstr ""
 
 #. Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this is the heading for a Yes/No program eligibility question.
@@ -2792,10 +2450,7 @@ msgstr ""
 
 #. Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this question has a Yes or No answer.
 #: TWLight/users/templates/users/editor_detail_data.html:156
-msgid ""
-"At their last login, did this user meet the criteria set forth in the "
-"Library Bundle? Note that satisfying terms of use is a prerequisite to "
-"bundle eligibility."
+msgid "At their last login, did this user meet the criteria set forth in the Library Bundle? Note that satisfying terms of use is a prerequisite to bundle eligibility."
 msgstr ""
 
 #. Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this is the heading for a Yes/No program eligibility question.
@@ -2840,18 +2495,13 @@ msgstr ""
 
 #. Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this text is in the 'Personal data' section. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/users/templates/users/editor_detail_data.html:262
-msgid ""
-"The following information is visible only to you, site administrators, "
-"publishing partners (where required), and volunteer Wikipedia Library "
-"coordinators (who have signed a Non-Disclosure Agreement)."
+msgid "The following information is visible only to you, site administrators, publishing partners (where required), and volunteer Wikipedia Library coordinators (who have signed a Non-Disclosure Agreement)."
 msgstr ""
 
 #. Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this labels a button which users can click to update or remove their personal information. Don't translate update_url.
 #: TWLight/users/templates/users/editor_detail_data.html:272
 #, python-format
-msgid ""
-"You may <a class=\"twl-links\" href=\"%(update_url)s\">update or delete</a> "
-"your data at any time."
+msgid "You may <a class=\"twl-links\" href=\"%(update_url)s\">update or delete</a> your data at any time."
 msgstr ""
 
 #. Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this labels the user's email. Don't remove the *.
@@ -2871,24 +2521,18 @@ msgstr ""
 
 #. Translators: This message tells users that they are not eligible to access The Wikipedia Library content.
 #: TWLight/users/templates/users/eligibility_modal.html:7
-msgid ""
-"Sorry, your Wikipedia account doesn’t currently qualify to access The "
-"Wikipedia Library."
+msgid "Sorry, your Wikipedia account doesn’t currently qualify to access The Wikipedia Library."
 msgstr ""
 
 #. Translators: This message tells users that they have not agreed to the terms of use, therefore are ineligible to access the content in The Wikipedia Library.
 #: TWLight/users/templates/users/eligibility_modal.html:30
 #, python-format
-msgid ""
-"Agreed with <a href=\"%(terms)s\" class=\"text-danger\"> terms of use </a>"
+msgid "Agreed with <a href=\"%(terms)s\" class=\"text-danger\"> terms of use </a>"
 msgstr ""
 
 #: TWLight/users/templates/users/eligibility_modal.html:40
 #, python-format
-msgid ""
-"It looks like you have an active block on your account. If you meet the "
-"other criteria you may still be permitted access to the library - please <a "
-"href=\"%(contact_url)s\">contact us</a>."
+msgid "It looks like you have an active block on your account. If you meet the other criteria you may still be permitted access to the library - please <a href=\"%(contact_url)s\">contact us</a>."
 msgstr ""
 
 #. Translators: Instructions to refresh a user's data.
@@ -2928,10 +2572,7 @@ msgstr "ချိၚ်ကၞာတ် အရေဝ်ဘာသာ"
 
 #. Translators: This text on the user page helps users naviage to the TranslateWiki Wikipedia Library Card platform translation page.
 #: TWLight/users/templates/users/language_form.html:31
-msgid ""
-"You can help translate the tool at <a class=\"twl-links\" href=\"https://"
-"translatewiki.net/wiki/Translating:Wikipedia_Library_Card_Platform"
-"\">translatewiki.net</a>."
+msgid "You can help translate the tool at <a class=\"twl-links\" href=\"https://translatewiki.net/wiki/Translating:Wikipedia_Library_Card_Platform\">translatewiki.net</a>."
 msgstr ""
 
 #. Translators: When the user starts a new application and submits the application, the user can view the application and withdraw if need be. This changes the label for the Withdraw button.
@@ -2951,12 +2592,8 @@ msgstr "အာတ်အခေါၚ်မဆက်စပ်မကလေၚ်က
 
 #. Translators: On the page listing applications, this text explains a user they cannot renew their application since they've already requested a renewal or there aren't any renewals available.
 #: TWLight/users/templates/users/my_applications.html:79
-msgid ""
-"Renewals are either not required, not available right now, or you have "
-"already requested a renewal."
-msgstr ""
-"မကလေင်တၟိပတိုန်ဂှ် ဟွံဂွံဂရၚ်ပတီဏီ ဟွံသၟဟ်အစောံဏီ ပြဟ်ဟ်ဏအ်၊ သာ်ဂှ်ဟွံသေင် မၞးဂရၚ်ပတီလဝ် သွက်ဂွံ ကလေၚ်တၟိပတိုန်ပၠန် တုဲတုဲလေဝ် "
-"ဒှ်မာန်၊၊"
+msgid "Renewals are either not required, not available right now, or you have already requested a renewal."
+msgstr "မကလေင်တၟိပတိုန်ဂှ် ဟွံဂွံဂရၚ်ပတီဏီ ဟွံသၟဟ်အစောံဏီ ပြဟ်ဟ်ဏအ်၊ သာ်ဂှ်ဟွံသေင် မၞးဂရၚ်ပတီလဝ် သွက်ဂွံ ကလေၚ်တၟိပတိုန်ပၠန် တုဲတုဲလေဝ် ဒှ်မာန်၊၊"
 
 #. Translators: This text is the heading of a section in a user's profile where they can change their preferences.
 #: TWLight/users/templates/users/preferences.html:6
@@ -3019,19 +2656,12 @@ msgstr ""
 
 #. Translators: This message is displayed on the page where users can request we stop processing their data.
 #: TWLight/users/templates/users/restrict_data.html:15
-msgid ""
-"Checking this box and clicking “Restrict” will pause all processing of the "
-"data you have entered into this website. You will not be able to apply for "
-"access to resources, your applications will not be further processed, and "
-"none of your data will be altered, until you return to this page and uncheck "
-"the box. This is not the same as deleting your data."
+msgid "Checking this box and clicking “Restrict” will pause all processing of the data you have entered into this website. You will not be able to apply for access to resources, your applications will not be further processed, and none of your data will be altered, until you return to this page and uncheck the box. This is not the same as deleting your data."
 msgstr ""
 
 #. Translators: This warning message is shown to coordinators who view the data restriction page.
 #: TWLight/users/templates/users/restrict_data.html:26
-msgid ""
-"You are a coordinator on this site. If you restrict the processing of your "
-"data, your coordinator flag will be removed."
+msgid "You are a coordinator on this site. If you restrict the processing of your data, your coordinator flag will be removed."
 msgstr ""
 
 #. Translators: use the date *when you are translating*, in a language-appropriate format.
@@ -3051,24 +2681,12 @@ msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:51
-msgid ""
-"<a class=\"twl-links\" href=\"https://meta.wikimedia.org/wiki/"
-"The_Wikipedia_Library\"> The Wikipedia Library </a> has partnered with "
-"publishers around the world to allow users to access otherwise paywalled "
-"resources. This website allows Wikipedia editors to search and access these "
-"resources."
+msgid "<a class=\"twl-links\" href=\"https://meta.wikimedia.org/wiki/The_Wikipedia_Library\"> The Wikipedia Library </a> has partnered with publishers around the world to allow users to access otherwise paywalled resources. This website allows Wikipedia editors to search and access these resources."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Wikimedia Foundation should not be translated. WMF should not be translated. Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:63
-msgid ""
-"This program is administered by the Wikimedia Foundation (WMF). These terms "
-"of use and privacy notice pertain to your application for access to "
-"resources through the Wikipedia Library, your use of this website, and your "
-"access to and use of those resources. They also describe our handling of the "
-"information you provide to us in order to create and administer your "
-"Wikipedia Library account. If we make material changes to the terms, we will "
-"notify users."
+msgid "This program is administered by the Wikimedia Foundation (WMF). These terms of use and privacy notice pertain to your application for access to resources through the Wikipedia Library, your use of this website, and your access to and use of those resources. They also describe our handling of the information you provide to us in order to create and administer your Wikipedia Library account. If we make material changes to the terms, we will notify users."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
@@ -3078,37 +2696,17 @@ msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:78
-msgid ""
-"Access to resources via The Wikipedia Library is reserved for community "
-"members who have demonstrated their commitment to the Wikimedia projects, "
-"and who will use their access to these resources to improve project content. "
-"To that end, in order to be eligible for The Wikipedia Library, we require "
-"that you be registered for a user account on the projects, with at least 500 "
-"edits, six (6) months of activity, and 10+ edits in the last month. We ask "
-"that you do not request access to any publishers with a limited number of "
-"available accounts whose resources you can already access for free through "
-"your local library or university, or another institution or organization, in "
-"order to provide that opportunity to others."
+msgid "Access to resources via The Wikipedia Library is reserved for community members who have demonstrated their commitment to the Wikimedia projects, and who will use their access to these resources to improve project content. To that end, in order to be eligible for The Wikipedia Library, we require that you be registered for a user account on the projects, with at least 500 edits, six (6) months of activity, and 10+ edits in the last month. We ask that you do not request access to any publishers with a limited number of available accounts whose resources you can already access for free through your local library or university, or another institution or organization, in order to provide that opportunity to others."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:94
-msgid ""
-"Additionally, if you are currently blocked or banned from a Wikimedia "
-"project, applications to resources may be rejected or restricted. If you "
-"obtain a Wikipedia Library account, but a block or ban is subsequently "
-"instituted against you on one of the projects, you may lose access to your "
-"Wikipedia Library account."
+msgid "Additionally, if you are currently blocked or banned from a Wikimedia project, applications to resources may be rejected or restricted. If you obtain a Wikipedia Library account, but a block or ban is subsequently instituted against you on one of the projects, you may lose access to your Wikipedia Library account."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:104
-msgid ""
-"Your eligibility to access The Wikipedia Library is assessed at each login. "
-"While more than half of the library's content is provided via this automated "
-"eligibility check, access to other publisher's content may be time limited, "
-"typically lapsing after one year, after which you will usually need to apply "
-"for renewal."
+msgid "Your eligibility to access The Wikipedia Library is assessed at each login. While more than half of the library's content is provided via this automated eligibility check, access to other publisher's content may be time limited, typically lapsing after one year, after which you will usually need to apply for renewal."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
@@ -3118,47 +2716,27 @@ msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:118
-msgid ""
-"In order to apply for access to a partner resource, you must provide us with "
-"certain information, which we will use to evaluate your application. If your "
-"application is approved, we may transfer the information you have given us "
-"to the publishers whose resources you wish to access. They will either "
-"contact you with the account information directly or we will send access "
-"information to you ourselves."
+msgid "In order to apply for access to a partner resource, you must provide us with certain information, which we will use to evaluate your application. If your application is approved, we may transfer the information you have given us to the publishers whose resources you wish to access. They will either contact you with the account information directly or we will send access information to you ourselves."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:130
-msgid ""
-"In addition to the basic information you provide to us, our system will "
-"retrieve some information directly from the Wikimedia projects: your "
-"username, email address, edit count, registration date, user ID number, "
-"groups to which you belong, and any special user rights."
+msgid "In addition to the basic information you provide to us, our system will retrieve some information directly from the Wikimedia projects: your username, email address, edit count, registration date, user ID number, groups to which you belong, and any special user rights."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:140
-msgid ""
-"Each time you log in to the Wikipedia Library Card Platform, this "
-"information will be automatically updated."
+msgid "Each time you log in to the Wikipedia Library Card Platform, this information will be automatically updated."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:148
-msgid ""
-"We will ask you to provide us with some information about your history of "
-"contributions to the Wikimedia projects. Information on contribution history "
-"is optional, but will greatly assist us in evaluating your application."
+msgid "We will ask you to provide us with some information about your history of contributions to the Wikimedia projects. Information on contribution history is optional, but will greatly assist us in evaluating your application."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). WMF should not be translated. Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:157
-msgid ""
-"The information you provide when creating your account will be visible to "
-"you while on the site but not to others unless they are approved Wikipedia "
-"Library Coordinators, WMF Staff, or WMF Contractors who need access to this "
-"data in order to carry out their work with the Wikipedia Library, all of "
-"whom are subject to non-disclosure obligations."
+msgid "The information you provide when creating your account will be visible to you while on the site but not to others unless they are approved Wikipedia Library Coordinators, WMF Staff, or WMF Contractors who need access to this data in order to carry out their work with the Wikipedia Library, all of whom are subject to non-disclosure obligations."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
@@ -3168,46 +2746,32 @@ msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:171
-msgid ""
-"In order to access an individual publisher’s resources, you must agree to "
-"that publisher’s terms of use and privacy policy. You agree that you will "
-"not violate such terms and policies in connection with your use of the "
-"Wikipedia Library. Additionally, the following activities are prohibited "
-"while accessing publisher resources through the Wikipedia Library."
+msgid "In order to access an individual publisher’s resources, you must agree to that publisher’s terms of use and privacy policy. You agree that you will not violate such terms and policies in connection with your use of the Wikipedia Library. Additionally, the following activities are prohibited while accessing publisher resources through the Wikipedia Library."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:184
-msgid ""
-"Sharing your Wikipedia account, usernames, passwords, or any access codes "
-"for publisher resources with others;"
+msgid "Sharing your Wikipedia account, usernames, passwords, or any access codes for publisher resources with others;"
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:191
-msgid ""
-"Automatically scraping or downloading restricted content from publishers;"
+msgid "Automatically scraping or downloading restricted content from publishers;"
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:197
-msgid ""
-"Systematically making printed or electronic copies of multiple extracts of "
-"restricted content available for any purpose;"
+msgid "Systematically making printed or electronic copies of multiple extracts of restricted content available for any purpose;"
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:204
-msgid ""
-"Data mining metadata without permission—for example, in order to use "
-"metadata for auto-created stub articles;"
+msgid "Data mining metadata without permission—for example, in order to use metadata for auto-created stub articles;"
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:211
-msgid ""
-"Using the access you receive through the Wikipedia Library for profit by "
-"selling access to your account or resources which you have through it."
+msgid "Using the access you receive through the Wikipedia Library for profit by selling access to your account or resources which you have through it."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
@@ -3217,18 +2781,12 @@ msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:224
-msgid ""
-"Certain resources may only be accessed using an external search service, "
-"such as the EBSCO Discovery Service, or a proxy service, such as OCLC "
-"EZProxy. If you use such external search and/or proxy services, please "
-"review the applicable terms of use and privacy policies."
+msgid "Certain resources may only be accessed using an external search service, such as the EBSCO Discovery Service, or a proxy service, such as OCLC EZProxy. If you use such external search and/or proxy services, please review the applicable terms of use and privacy policies."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:234
-msgid ""
-"In addition, if you use OCLC EZProxy, please note that you may not use it "
-"for commercial purposes."
+msgid "In addition, if you use OCLC EZProxy, please note that you may not use it for commercial purposes."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
@@ -3238,120 +2796,49 @@ msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Wikimedia Foundation should not be translated. Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:245
-msgid ""
-"The Wikimedia Foundation and our service providers use your information for "
-"the legitimate purpose of providing Wikipedia Library services in support of "
-"our charitable mission. When you apply for a Wikipedia Library account, or "
-"use your Wikipedia Library account, we may routinely collect the following "
-"information: your username, email address, edit count, registration date, "
-"user ID number, groups to which you belong, and any special user rights; "
-"your name, country of residence, and/or affiliation, if required by a "
-"partner to which you are applying; your narrative description of your "
-"contributions and reasons for applying for access to partner resources; and "
-"the date you agree to these terms of use."
+msgid "The Wikimedia Foundation and our service providers use your information for the legitimate purpose of providing Wikipedia Library services in support of our charitable mission. When you apply for a Wikipedia Library account, or use your Wikipedia Library account, we may routinely collect the following information: your username, email address, edit count, registration date, user ID number, groups to which you belong, and any special user rights; your name, country of residence, and/or affiliation, if required by a partner to which you are applying; your narrative description of your contributions and reasons for applying for access to partner resources; and the date you agree to these terms of use."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:262
 #, python-format
-msgid ""
-"Each publisher who is a member of the Wikipedia Library program requires "
-"different specific information in the application. Some publishers may "
-"request only an email address, while others request more detailed data, such "
-"as your name, location, or institutional affiliation. When you complete your "
-"application, you will only be asked to supply information required by the "
-"publishers you have chosen, and each publisher will only receive the "
-"information they require for providing you with access. Please see our <a "
-"class=\"twl-links\" href=\"%(all_partners_url)s\">partner information</a> "
-"pages to learn what information is required by each publisher to gain access "
-"to their resources."
+msgid "Each publisher who is a member of the Wikipedia Library program requires different specific information in the application. Some publishers may request only an email address, while others request more detailed data, such as your name, location, or institutional affiliation. When you complete your application, you will only be asked to supply information required by the publishers you have chosen, and each publisher will only receive the information they require for providing you with access. Please see our <a class=\"twl-links\" href=\"%(all_partners_url)s\">partner information</a> pages to learn what information is required by each publisher to gain access to their resources."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Wikimedia Foundation should not be translated. Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:277
-msgid ""
-"Some Wikipedia Library pages are visible without logging in, but you will "
-"need to log in to apply or access proprietary partner resources. We use the "
-"data provided by you via OAuth and Wikimedia API calls to assess your "
-"application for access and to process approved requests."
+msgid "Some Wikipedia Library pages are visible without logging in, but you will need to log in to apply or access proprietary partner resources. We use the data provided by you via OAuth and Wikimedia API calls to assess your application for access and to process approved requests."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:288
 #, python-format
-msgid ""
-"In order to administer the Wikipedia Library program, we will retain the "
-"application data we collect from you for three years after your most recent "
-"login, unless you delete your account, as described below. You can log in "
-"and go to <a class=\"twl-links\" href=\"%(profile_url)s\">your profile page</"
-"a> in order to see the information associated with your account, and can "
-"download it in JSON format. You may access, update, restrict, or delete this "
-"information at any time, except for the information that is automatically "
-"retrieved from the projects. If you have any questions or concerns about the "
-"handling of your data, please contact <a class=\"twl-links\" href=\"mailto:"
-"wikipedialibrary@wikimedia.org?Subject=Wikipedia%%20Library%%20Card"
-"%%20account%%20deactivation\"> wikipedialibrary@wikimedia.org </a>."
+msgid "In order to administer the Wikipedia Library program, we will retain the application data we collect from you for three years after your most recent login, unless you delete your account, as described below. You can log in and go to <a class=\"twl-links\" href=\"%(profile_url)s\">your profile page</a> in order to see the information associated with your account, and can download it in JSON format. You may access, update, restrict, or delete this information at any time, except for the information that is automatically retrieved from the projects. If you have any questions or concerns about the handling of your data, please contact <a class=\"twl-links\" href=\"mailto:wikipedialibrary@wikimedia.org?Subject=Wikipedia%%20Library%%20Card%%20account%%20deactivation\"> wikipedialibrary@wikimedia.org </a>."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:305
-msgid ""
-"If you decide to disable your Wikipedia Library account, you can use the "
-"delete button on your profile to delete certain personal information "
-"associated with your account. We will delete your real name, institutional "
-"affiliation, and country of residence. Please note that the system will "
-"retain a record of your username, the publishers to which you applied or had "
-"access, and the dates of that access. Note that deletion is not reversible. "
-"Deletion of your Wikipedia Library account may also correspond with the "
-"removal of any resource access to which you were eligible or approved. If "
-"you request the deletion of account information and later wish to apply for "
-"a new account, you will need to provide the necessary information again."
+msgid "If you decide to disable your Wikipedia Library account, you can use the delete button on your profile to delete certain personal information associated with your account. We will delete your real name, institutional affiliation, and country of residence. Please note that the system will retain a record of your username, the publishers to which you applied or had access, and the dates of that access. Note that deletion is not reversible. Deletion of your Wikipedia Library account may also correspond with the removal of any resource access to which you were eligible or approved. If you request the deletion of account information and later wish to apply for a new account, you will need to provide the necessary information again."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). WMF should not be translated. Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:321
-msgid ""
-"The Wikipedia Library is run by WMF Staff, Contractors, and approved "
-"volunteer Coordinators. The data associated with your account will be shared "
-"with the WMF staff, contractors, service providers, and volunteer "
-"coordinators who need to process the information in connection with their "
-"work for the Wikipedia Library, and who are subject to confidentiality "
-"obligations. We will also use your data for internal Wikipedia Library "
-"purposes such as distributing user surveys and account notifications, and in "
-"a depersonalized or aggregated fashion for statistical analysis and "
-"administration. Finally, we will share your information with the publishers "
-"whom you specifically select in order to provide you with access to "
-"resources. Otherwise, your information will not be shared with third "
-"parties, with the exception of the circumstances described below."
+msgid "The Wikipedia Library is run by WMF Staff, Contractors, and approved volunteer Coordinators. The data associated with your account will be shared with the WMF staff, contractors, service providers, and volunteer coordinators who need to process the information in connection with their work for the Wikipedia Library, and who are subject to confidentiality obligations. We will also use your data for internal Wikipedia Library purposes such as distributing user surveys and account notifications, and in a depersonalized or aggregated fashion for statistical analysis and administration. Finally, we will share your information with the publishers whom you specifically select in order to provide you with access to resources. Otherwise, your information will not be shared with third parties, with the exception of the circumstances described below."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). WMF should not be translated.
 #: TWLight/users/templates/users/terms.html:338
-msgid ""
-"We may disclose any collected information when required by law, when we have "
-"your permission, when needed to protect our rights, privacy, safety, users, "
-"or the general public, and when necessary to enforce these terms, WMF’s "
-"general <a class=\"twl-links\" href=\"https://foundation.wikimedia.org/wiki/"
-"Terms_of_Use\">Terms of Use</a>, or any other WMF policy."
+msgid "We may disclose any collected information when required by law, when we have your permission, when needed to protect our rights, privacy, safety, users, or the general public, and when necessary to enforce these terms, WMF’s general <a class=\"twl-links\" href=\"https://foundation.wikimedia.org/wiki/Terms_of_Use\">Terms of Use</a>, or any other WMF policy."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:349
-msgid ""
-"We take the security of your personal data seriously, and take reasonable "
-"precautions to ensure your data is protected. These precautions include "
-"access controls to limit who has access to your data and security "
-"technologies to protect data stored on the server. However, we cannot "
-"guarantee the safety of your data as it is transmitted and stored."
+msgid "We take the security of your personal data seriously, and take reasonable precautions to ensure your data is protected. These precautions include access controls to limit who has access to your data and security technologies to protect data stored on the server. However, we cannot guarantee the safety of your data as it is transmitted and stored."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:360
-msgid ""
-"Please note that these terms do not control the use and handling of your "
-"data by the publishers and service providers whose resources you access or "
-"apply to access. Please read their individual privacy policies for that "
-"information."
+msgid "Please note that these terms do not control the use and handling of your data by the publishers and service providers whose resources you access or apply to access. Please read their individual privacy policies for that information."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
@@ -3361,34 +2848,17 @@ msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Wikimedia Foundation should not be translated. Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:373
-msgid ""
-"The Wikimedia Foundation is a nonprofit organization based in San Francisco, "
-"California. The Wikipedia Library program provides access to resources held "
-"by publishers in multiple countries. If you apply for a Wikipedia Library "
-"account (whether you are inside or outside of the United States), you "
-"understand that your personal data will be collected, transferred, stored, "
-"processed, disclosed and otherwise used in the U.S. as described in this "
-"privacy policy. You also understand that your information may be transferred "
-"by us from the U.S. to other countries, which may have different or less "
-"stringent data protection laws than your country, in connection with "
-"providing services to you, including evaluating your application and "
-"securing access to your chosen publishers (locations for each publisher are "
-"outlined on their respective partner information pages)."
+msgid "The Wikimedia Foundation is a nonprofit organization based in San Francisco, California. The Wikipedia Library program provides access to resources held by publishers in multiple countries. If you apply for a Wikipedia Library account (whether you are inside or outside of the United States), you understand that your personal data will be collected, transferred, stored, processed, disclosed and otherwise used in the U.S. as described in this privacy policy. You also understand that your information may be transferred by us from the U.S. to other countries, which may have different or less stringent data protection laws than your country, in connection with providing services to you, including evaluating your application and securing access to your chosen publishers (locations for each publisher are outlined on their respective partner information pages)."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:392
-msgid ""
-"Please note that in the event of any differences in meaning or "
-"interpretation between the original English version of these terms and a "
-"translation, the original English version takes precedence."
+msgid "Please note that in the event of any differences in meaning or interpretation between the original English version of these terms and a translation, the original English version takes precedence."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Wikimedia Foundation should not be translated.
 #: TWLight/users/templates/users/terms.html:403
-msgid ""
-"See also the <a class=\"twl-links\" href=\"https://wikimediafoundation.org/"
-"wiki/Privacy_policy\">Wikimedia Foundation Privacy Policy</a>."
+msgid "See also the <a class=\"twl-links\" href=\"https://wikimediafoundation.org/wiki/Privacy_policy\">Wikimedia Foundation Privacy Policy</a>."
 msgstr ""
 
 #. Translators: This is the second to last line of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
@@ -3408,11 +2878,7 @@ msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:426
-msgid ""
-"By checking this box and clicking “Submit”, you agree that you have read the "
-"above terms and that you will adhere to the terms of use in your application "
-"to and use of the The Wikipedia Library, and the publishers’ services to "
-"which you gain access through The Wikipedia Library program."
+msgid "By checking this box and clicking “Submit”, you agree that you have read the above terms and that you will adhere to the terms of use in your application to and use of the The Wikipedia Library, and the publishers’ services to which you gain access through The Wikipedia Library program."
 msgstr ""
 
 #: TWLight/users/templates/users/user_collection_tile.html:32
@@ -3466,29 +2932,18 @@ msgstr "ပလီု တၚ်ဂၞၚ်သီုဖအိုတ်"
 
 #. Translators: This message is displayed on the page where users can request the deletion of their data.
 #: TWLight/users/templates/users/user_confirm_delete.html:17
-msgid ""
-"<b>Warning:</b> Performing this action will delete your Wikipedia Library "
-"Card user account and all associated applications. This process is not "
-"reversible. You may lose any partner accounts you were granted, and will not "
-"be able to renew those accounts or apply for new ones."
+msgid "<b>Warning:</b> Performing this action will delete your Wikipedia Library Card user account and all associated applications. This process is not reversible. You may lose any partner accounts you were granted, and will not be able to renew those accounts or apply for new ones."
 msgstr ""
 
 #. Translators: this should show up for people who log in with a username/password and not OAuth, so we don't know what their Wikipedia identity is.
-#.
 #: TWLight/users/templates/users/user_detail.html:12
 #, python-format
-msgid ""
-"Hi, %(username)s! You don't have a Wikipedia editor profile attached to your "
-"account here, so you are probably a site administrator."
+msgid "Hi, %(username)s! You don't have a Wikipedia editor profile attached to your account here, so you are probably a site administrator."
 msgstr ""
 
 #. Translators: In the unlikely scenario that someone is able to register an account without using OAuth (thus leaving us without some of the information required for applications), users will see this message, encouraging them to re-register.
 #: TWLight/users/templates/users/user_detail.html:20
-msgid ""
-"If you aren't a site administrator, something weird has happened. You won't "
-"be able to apply for access without a Wikipedia editor profile. You should "
-"log out and create a new account by logging in via OAuth, or contact a site "
-"administrator for help."
+msgid "If you aren't a site administrator, something weird has happened. You won't be able to apply for access without a Wikipedia editor profile. You should log out and create a new account by logging in via OAuth, or contact a site administrator for help."
 msgstr ""
 
 #. Translators: Labels a sections where coordinators can select their email preferences.
@@ -3499,17 +2954,12 @@ msgstr ""
 #. Translators: This message is shown on user's own profile page, encouraging them to make sure their information is up to date, so that account coordinators can use the information to judge applications.
 #: TWLight/users/views.py:176
 #, python-brace-format
-msgid ""
-"Please <a class='twl-links' href='{url}'>update your contributions</a> to "
-"Wikipedia to help coordinators evaluate your applications."
+msgid "Please <a class='twl-links' href='{url}'>update your contributions</a> to Wikipedia to help coordinators evaluate your applications."
 msgstr ""
 
 #. Translators: Coordinators are shown this message when they unselect all three types of reminder email options under preferences.
 #: TWLight/users/views.py:288
-msgid ""
-"You have chosen not to receive reminder emails. As a coordinator, you should "
-"receive at least one type of reminder emails, so consider changing your "
-"preferences."
+msgid "You have chosen not to receive reminder emails. As a coordinator, you should receive at least one type of reminder emails, so consider changing your preferences."
 msgstr ""
 
 #. Translators: Coordinators are shown this message when they make changes to their reminder email options under preferences.
@@ -3543,9 +2993,7 @@ msgstr ""
 
 #. Translators: If the user has not filled out their email, they can browse the website but cannot apply for access to resources.
 #: TWLight/users/views.py:487
-msgid ""
-"Your email is blank. You can still explore the site, but you won't be able "
-"to apply for access to partner resources without an email."
+msgid "Your email is blank. You can still explore the site, but you won't be able to apply for access to partner resources without an email."
 msgstr ""
 
 #. Translators: This message is shown once the access to a partner has successfully been returned.
@@ -3578,31 +3026,3 @@ msgstr ""
 msgid "10+ edits in the last 30 days"
 msgstr ""
 
-#: tests/shunit/data/bad_i18n_comment_1.py:3
-#: tests/shunit/data/bad_i18n_newline_1.py:5
-msgid "1"
-msgstr ""
-
-#. Translators: Lorem ipsum dolor sit amet, consectetur adipiscing elit. Mauris vitae ipsum ut purus faucibus pretium. Proin tempus neque et aliquet consectetur. Ut egestas sapien in consectetur sagittis. Mauris neque lacus, dapibus non viverra vitae, interdum ut aenean ipsum.
-#. Translators: Lorem ipsum dolor sit amet, consectetur adipiscing elit. Mauris vitae ipsum ut purus faucibus pretium. Proin tempus neque et aliquet consectetur. Ut egestas sapien in consectetur sagittis. Mauris neque lacus, dapibus non.
-#: tests/shunit/data/bad_i18n_comment_2.py:4
-#: tests/shunit/data/bad_i18n_newline_2.py:5 tests/shunit/data/good_i18n_1.py:2
-#: tests/shunit/data/good_i18n_2.py:2
-msgid "2"
-msgstr ""
-
-#: tests/shunit/data/bad_i18n_newline_3.py:5
-msgid "3"
-msgstr ""
-
-#: tests/shunit/data/bad_i18n_newline_4.py:5
-msgid "4"
-msgstr ""
-
-#: tests/shunit/data/bad_i18n_newline_5.py:5
-msgid "5"
-msgstr ""
-
-#: tests/shunit/data/bad_i18n_newline_6.py:5
-msgid "6"
-msgstr ""

--- a/locale/mr/LC_MESSAGES/django.po
+++ b/locale/mr/LC_MESSAGES/django.po
@@ -6,10 +6,11 @@
 # Author: Sureshkhole
 msgid ""
 msgstr ""
+""
 "Project-Id-Version: Wikipedia Library Card Platform - Website\n"
-"Report-Msgid-Bugs-To: wikipedialibrary@wikimedia.org\n"
+"Report-Msgid-Bugs-To: translatewiki.net\n"
 "POT-Creation-Date: 2024-07-11 20:54+0000\n"
-"PO-Revision-Date: 2024-07-11 12:30:17+0000\n"
+"PO-Revision-Date: 2024-07-15 12:29:17+0000\n"
 "Language: mr\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
@@ -41,12 +42,8 @@ msgstr "तुमच्याबद्दल लिहा"
 #. Translators: This note appears in a section of a form where we ask users to enter info (like country of residence) when applying for resource access.
 #: TWLight/applications/forms.py:179
 #, python-brace-format
-msgid ""
-"<p><small><i>Your personal data will be processed according to our <a "
-"class='twl-links' href='{terms_url}'> privacy policy</a>.</i></small></p>"
-msgstr ""
-"<p><small><i>आपल्या खाजगी माहितीवर आमच्या <a class='twl-links' "
-"href='{terms_url}'>गोपनियता धोरणांनूसार प्रक्रिया केली‌ जाईल</a>.</i></small></p>"
+msgid "<p><small><i>Your personal data will be processed according to our <a class='twl-links' href='{terms_url}'> privacy policy</a>.</i></small></p>"
+msgstr "<p><small><i>आपल्या खाजगी माहितीवर आमच्या <a class='twl-links' href='{terms_url}'>गोपनियता धोरणांनूसार प्रक्रिया केली‌ जाईल</a>.</i></small></p>"
 
 #. Translators: This is the title of the application form page, where users enter information required for the application. It lets the user know which partner application they are entering data for. {partner}
 #: TWLight/applications/forms.py:189
@@ -87,9 +84,7 @@ msgstr "आमच्या भागीदाराच्या संकेत�
 #. Translators: This labels a choice field where users will have to select the number of months they wish to have their access for as part of the application renewal confirmation.
 #. Translators: When filling out an application, users may be required to enter the length of the account (expiry) they wish to have for proxy partners.
 #: TWLight/applications/forms.py:339 TWLight/applications/helpers.py:100
-msgid ""
-"The number of months you wish to have this access for before renewal is "
-"required"
+msgid "The number of months you wish to have this access for before renewal is required"
 msgstr ""
 
 #. Translators: When filling out an application, users may need to specify their name
@@ -178,9 +173,7 @@ msgstr "ई-मेल"
 
 #. Translators: This comment is added to pending applications when our terms of use change.
 #: TWLight/applications/management/commands/notify_applicants_tou_changes.py:54
-msgid ""
-"Our terms of use have changed. Your applications will not be processed until "
-"you log in and agree to our updated terms."
+msgid "Our terms of use have changed. Your applications will not be processed until you log in and agree to our updated terms."
 msgstr ""
 
 #. Translators: This is the status of an application that has not yet been reviewed.
@@ -247,23 +240,17 @@ msgstr ""
 
 #. Translators: This text goes into account approval emails in the case that we need to send the user's details to a publisher for manual account setup.
 #: TWLight/applications/models.py:331
-msgid ""
-"You can expect to receive access details within a week or two once it has "
-"been processed."
+msgid "You can expect to receive access details within a week or two once it has been processed."
 msgstr ""
 
 #. Translators: This comment is added to open applications when a partner joins the Library Bundle, which does not require applications.
 #: TWLight/applications/signals.py:247
-msgid ""
-"This partner joined the Library Bundle, which does not require applications. "
-"This application will be marked as invalid."
+msgid "This partner joined the Library Bundle, which does not require applications. This application will be marked as invalid."
 msgstr ""
 
 #. Translators: This is shown to users if the application is to a partner for which we have run out of available accounts. The application is therefore on a 'waitlist', and will be reviewed when more accounts are available.
 #: TWLight/applications/templates/applications/application_evaluation.html:29
-msgid ""
-"This application is on the waitlist because this partner does not have any "
-"access grants available at this time."
+msgid "This application is on the waitlist because this partner does not have any access grants available at this time."
 msgstr "आपल्या साथीदार संस्थेकडे सध्या खाती उपलब्ध नसल्याने आपला अर्ज रांगेत ठेवला गेला आहे."
 
 #. Translators: This message is shown on pages where coordinators can see personal information about applicants.
@@ -271,12 +258,8 @@ msgstr "आपल्या साथीदार संस्थेकडे स
 #: TWLight/applications/templates/applications/application_list_include.html:6
 #: TWLight/applications/templates/applications/send_partner.html:45
 #: TWLight/resources/templates/resources/partner_users.html:18
-msgid ""
-"Coordinators: This page may contain personal information such as real names "
-"and email addresses. Please remember that this information is confidential."
-msgstr ""
-"संचालक मंडळ : लक्षात ठेवा ह्या पानावरील माहिती गोपनिय असू शकते, त्यामध्ये व्यक्तींची नावे "
-"आणि ई-पत्ते यांचा समावेश असू शकतो."
+msgid "Coordinators: This page may contain personal information such as real names and email addresses. Please remember that this information is confidential."
+msgstr "संचालक मंडळ : लक्षात ठेवा ह्या पानावरील माहिती गोपनिय असू शकते, त्यामध्ये व्यक्तींची नावे आणि ई-पत्ते यांचा समावेश असू शकतो."
 
 #. Translators: This is the title of the application page shown to users who are a coordinator, and are able to accept or reject the application.
 #: TWLight/applications/templates/applications/application_evaluation.html:39
@@ -285,12 +268,8 @@ msgstr "अर्जाची तपासणी करा"
 
 #. Translators: This text is shown to coordinators on application pages if the applicant has restricted processing of their data.
 #: TWLight/applications/templates/applications/application_evaluation.html:42
-msgid ""
-"This user has requested a restriction on the processing of their data, so "
-"you cannot change the status of their application."
-msgstr ""
-"या सदस्यानेत्यांच्या माहितीवर प्रक्रिया करण्यास मनाई घातलेली आहे तेव्हा आपण त्यांच्या "
-"अर्जाची स्थिती बदलू शकत नाहीत"
+msgid "This user has requested a restriction on the processing of their data, so you cannot change the status of their application."
+msgstr "या सदस्यानेत्यांच्या माहितीवर प्रक्रिया करण्यास मनाई घातलेली आहे तेव्हा आपण त्यांच्या अर्जाची स्थिती बदलू शकत नाहीत"
 
 #. Translators: This is the title of the application page shown to users who are not a coordinator.
 #: TWLight/applications/templates/applications/application_evaluation.html:48
@@ -364,9 +343,7 @@ msgstr ""
 
 #. Translators: This is the text displayed to coordinators when an applicant has no country of residence in their profile.
 #: TWLight/applications/templates/applications/application_evaluation.html:123
-msgid ""
-"Please request the applicant add their country of residence to their profile "
-"before proceeding further."
+msgid "Please request the applicant add their country of residence to their profile before proceeding further."
 msgstr ""
 
 #. Translators: This labels the section of an application showing the total number of accounts available for a partner or their collection.
@@ -378,9 +355,7 @@ msgstr "ई-मेल खाते"
 #. Translators: This labels the section of an application showing whether the user had agreed to the terms of use or not.
 #: TWLight/applications/templates/applications/application_evaluation.html:145
 #, python-format
-msgid ""
-"Has agreed to the site's <a class=\"twl-links\" href=\"%(terms_url)s\">terms "
-"of use</a>?"
+msgid "Has agreed to the site's <a class=\"twl-links\" href=\"%(terms_url)s\">terms of use</a>?"
 msgstr ""
 
 #. Translators: Displayed to coordinators when they've agreed to the terms of use.
@@ -416,9 +391,7 @@ msgstr "नाही"
 
 #. Translators: This is the text displayed to coordinators when an applicant has not agreed to the terms of use.
 #: TWLight/applications/templates/applications/application_evaluation.html:159
-msgid ""
-"Please request the applicant agree to the site's terms of use before "
-"approving this application."
+msgid "Please request the applicant agree to the site's terms of use before approving this application."
 msgstr ""
 
 #. Translators: This labels the section of an application containing the user's motivation for wanting access to this resource.
@@ -439,8 +412,7 @@ msgstr "सध्या चालू असलेल्या वर्गणी
 #. Translators: This message is shown next to the 'Renewal of existing access grant?' label if the application is a renewal. Don't translate HTML tags or parent_url.
 #: TWLight/applications/templates/applications/application_evaluation.html:195
 #, python-format
-msgid ""
-"Yes (<a class=\"twl-links\" href=\"%(parent_url)s\">previous application</a>)"
+msgid "Yes (<a class=\"twl-links\" href=\"%(parent_url)s\">previous application</a>)"
 msgstr "हो (<a class=\"twl-links\" href=\"%(parent_url)s\">ह्या आधीचा अर्ज</a>)"
 
 #. Translators: This labels the section of the application showing the length of access remaining on the user's previous authorization.
@@ -477,9 +449,7 @@ msgstr "मजकुर जोडा"
 
 #. Translators: On an application page, this text tells users that the comments posted on the application are visible to coordinators and the submitting user only.
 #: TWLight/applications/templates/applications/application_evaluation.html:297
-msgid ""
-"Comments are visible to all coordinators and to the editor who submitted "
-"this application."
+msgid "Comments are visible to all coordinators and to the editor who submitted this application."
 msgstr "येथील टिपा सर्व संचालक मंडळास आणि अर्ज भरलेल्या सदस्यांना दिसतील."
 
 #. Translators: This is the title of the section of an application page which lists information about the user who submitted the application.
@@ -695,12 +665,7 @@ msgstr "नविन दर्जा द्या"
 
 #: TWLight/applications/templates/applications/apply.html:20
 #, python-format
-msgid ""
-"If your application is successful we may share your email address with "
-"%(partner)s. This is required to set up your access to their resources. By "
-"submitting this form you agree to allow your email address to be shared with "
-"%(partner)s if your application is successful, for the purposes of account "
-"setup."
+msgid "If your application is successful we may share your email address with %(partner)s. This is required to set up your access to their resources. By submitting this form you agree to allow your email address to be shared with %(partner)s if your application is successful, for the purposes of account setup."
 msgstr ""
 
 #. Translators: This message is displayed on the page where users can confirm their renewal. Please do not translate partner.
@@ -729,9 +694,7 @@ msgstr "कोणत्या संशोधन साहित्यास त
 
 #. Translators: This text explains that Library Bundle partners are not shown in this list.
 #: TWLight/applications/templates/applications/request_for_application.html:26
-msgid ""
-"Library Bundle partners are not shown as eligibility is determined "
-"automatically."
+msgid "Library Bundle partners are not shown as eligibility is determined automatically."
 msgstr ""
 
 #. Translators: On the page where users can apply for multiple partners, this message shows next to the partner name, taking them to the full application page when clicked.
@@ -746,10 +709,7 @@ msgstr "ह्या जोडीदाराविषयीची माहि�
 
 #. Translators: the HTML is so that the word 'waitlisted' will look the same as it does in the page above; please translate 'waitlisted' the same way you did elsewhere in this file.
 #: TWLight/applications/templates/applications/request_for_application.html:74
-msgid ""
-"You can apply to <span class=\"badge badge-warning\">Waitlisted</span> "
-"partners, but they don't have access grants available right now. We will "
-"process those applications when access becomes available."
+msgid "You can apply to <span class=\"badge badge-warning\">Waitlisted</span> partners, but they don't have access grants available right now. We will process those applications when access becomes available."
 msgstr ""
 
 #. Translators: On the page where coordinators can see approved applications which have not had their details sent to the partner, this message shows when there are applications ready to be processed.
@@ -771,9 +731,7 @@ msgstr "%(object)s यांबद्दल अर्जांविषयीच
 #. Translators: This message is shown when applications exceed the number of accounts available.
 #: TWLight/applications/templates/applications/send_partner.html:54
 #, python-format
-msgid ""
-"Application(s) for %(object)s, if sent, will exceed the total available "
-"accounts for the partner. Please proceed at your own discretion."
+msgid "Application(s) for %(object)s, if sent, will exceed the total available accounts for the partner. Please proceed at your own discretion."
 msgstr ""
 
 #. Translators: When viewing the list of applications ready to be sent for a particular partner, this is instructions for the coordinator to click the 'mark as sent' button after they have sent the information.
@@ -790,11 +748,8 @@ msgstr[1] ""
 
 #. Translators: When viewing the list of applications ready to be sent for a particular partner, this message shows if there is no information about who the applications should be sent to. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/applications/templates/applications/send_partner.html:89
-msgid ""
-"Whoops, we don't have any listed contacts. Please notify Wikipedia Library "
-"administrators."
-msgstr ""
-"अरे रे, आमच्याकडे यांचा संपर्क नाही, कृपया विकिपीडिया ग्रंथालय प्रचालकांना संपर्क करा."
+msgid "Whoops, we don't have any listed contacts. Please notify Wikipedia Library administrators."
+msgstr "अरे रे, आमच्याकडे यांचा संपर्क नाही, कृपया विकिपीडिया ग्रंथालय प्रचालकांना संपर्क करा."
 
 #. Translators: When viewing the list of applications ready to be sent for a particular partner, this is the title of the section containing the information about those applications.
 #: TWLight/applications/templates/applications/send_partner.html:94
@@ -809,9 +764,7 @@ msgstr "पाठवले अशी खूण"
 
 #. Translators: This text guides coordinators in using the code sending interface for approved applications.
 #: TWLight/applications/templates/applications/send_partner.html:152
-msgid ""
-"Use the dropdown menus to denote which editor will receive each code. Access "
-"codes will be sent to users automatically."
+msgid "Use the dropdown menus to denote which editor will receive each code. Access codes will be sent to users automatically."
 msgstr ""
 
 #. Translators: This labels a drop-down selection where staff can assign an access code to a user.
@@ -827,18 +780,13 @@ msgstr "मंजूर झालेले आणि पुढे न पाठ�
 #. Translators: When a user applies for a set of resources, they receive this message if none are currently available. They are instead placed on a 'waitlist' for later approval.
 #. Translators: When a user renews their resource, they receive this message if none are currently available. They are instead placed on a 'waitlist' for later approval.
 #: TWLight/applications/views.py:140 TWLight/applications/views.py:1282
-msgid ""
-"This partner does not have any access grants available at this time. You may "
-"still apply for access; your application will be reviewed when access grants "
-"become available."
+msgid "This partner does not have any access grants available at this time. You may still apply for access; your application will be reviewed when access grants become available."
 msgstr ""
 
 #. Translators: This message is shown to users once they've successfully submitted their application for review.
 #: TWLight/applications/views.py:163
 #, python-brace-format
-msgid ""
-"Your application has been submitted for review. Head over to <a "
-"href='{applications_url}'>My Applications</a> to view the status."
+msgid "Your application has been submitted for review. Head over to <a href='{applications_url}'>My Applications</a> to view the status."
 msgstr ""
 
 #. Translators: This text is displayed to users when the user has chosen to restrict data and is trying to apply for multiple partners
@@ -888,16 +836,12 @@ msgstr "पुढे पाठवलेले अर्ज"
 
 #. Translators: After a coordinator has changed the status of an application to APPROVED, if the corresponding partner/collection is waitlisted this message appears.
 #: TWLight/applications/views.py:756
-msgid ""
-"Cannot approve application as partner with proxy authorization method is "
-"waitlisted."
+msgid "Cannot approve application as partner with proxy authorization method is waitlisted."
 msgstr ""
 
 #. Translators: After a coordinator has changed the status of an application to APPROVED, if the corresponding partner/collection has no accounts for distribution, this message appears.
 #: TWLight/applications/views.py:780
-msgid ""
-"Cannot approve application as partner with proxy authorization method is "
-"waitlisted and (or) has zero accounts available for distribution."
+msgid "Cannot approve application as partner with proxy authorization method is waitlisted and (or) has zero accounts available for distribution."
 msgstr ""
 
 #. Translators: This message appears on an "access denied" screen that stops users who attempt to authorize an editor to access a resource during a time period for which they are already authorized.
@@ -908,11 +852,7 @@ msgstr ""
 #. Translators: This message is shown to users when they access an application page of a now Bundle partner (new applications aren't allowed for Bundle partners and the status of old applications cannot be modified)
 #: TWLight/applications/views.py:857
 #, python-brace-format
-msgid ""
-"This application cannot be modified since this partner is now part of our <a "
-"href='{bundle}'>bundle access</a>. If you are eligible, you can access this "
-"resource from <a href='{library}'>your library</a>. <a "
-"href='{contact}'>Contact us</a> if you have any questions."
+msgid "This application cannot be modified since this partner is now part of our <a href='{bundle}'>bundle access</a>. If you are eligible, you can access this resource from <a href='{library}'>your library</a>. <a href='{contact}'>Contact us</a> if you have any questions."
 msgstr ""
 
 #. Translators: this lets a reviewer set the status of a single application.
@@ -922,9 +862,7 @@ msgstr "अर्जाची स्थिती निश्चित करा
 
 #. Translators: This warning is message is shown to applicants when the number of pending applications is greater than the number of accounts available.
 #: TWLight/applications/views.py:891
-msgid ""
-"There are more pending applications than available accounts. Your "
-"application might get waitlisted."
+msgid "There are more pending applications than available accounts. Your application might get waitlisted."
 msgstr ""
 
 #. Translators: this message is shown to coordinators who attempt to change an application's Status from INVALID to any other Status.
@@ -945,11 +883,7 @@ msgstr "गटाला ताजेतवाने केले गेले."
 
 #. Translators: After a coordinator has changed the status of a number of applications to APPROVED, if the corresponding partner(s) is/are waitlisted or has no accounts for distribution, this message appears.
 #: TWLight/applications/views.py:1051
-msgid ""
-"Cannot approve application(s) {} as partner(s) with proxy authorization "
-"method is/are waitlisted and (or) has/have not enough accounts available. If "
-"not enough accounts are available, prioritise the applications and then "
-"approve applications equal to the accounts available."
+msgid "Cannot approve application(s) {} as partner(s) with proxy authorization method is/are waitlisted and (or) has/have not enough accounts available. If not enough accounts are available, prioritise the applications and then approve applications equal to the accounts available."
 msgstr ""
 
 #. Translators: This message is shown to coordinators who attempt to assign the same access code to multiple users.
@@ -964,9 +898,7 @@ msgstr "निवडलेले सर्व अर्ज पुढे पा�
 
 #. Translators: When a user tries to renew their resource, they receive this message if the partner is not available.
 #: TWLight/applications/views.py:1272
-msgid ""
-"Cannot renew application at this time as partner is not available. Please "
-"check back later, or contact us for more information."
+msgid "Cannot renew application at this time as partner is not available. Please check back later, or contact us for more information."
 msgstr ""
 
 #. Translators: This message is displayed when an attempt by a user to renew an application has been denied for some reason.
@@ -977,20 +909,13 @@ msgstr ""
 
 #. Translators: If a user requests the renewal of their account, but it wasn't renewed, this message is shown to them.
 #: TWLight/applications/views.py:1385
-msgid ""
-"This object cannot be renewed. (This probably means that you have already "
-"requested that it be renewed.)"
-msgstr ""
-"ह्या साहित्याची वर्गणी पुन्हा भरली जाऊ शकत नाही. (कदाचित तुम्ही आधीच ते केलेले असावे.)"
+msgid "This object cannot be renewed. (This probably means that you have already requested that it be renewed.)"
+msgstr "ह्या साहित्याची वर्गणी पुन्हा भरली जाऊ शकत नाही. (कदाचित तुम्ही आधीच ते केलेले असावे.)"
 
 #. Translators: If a user requests the renewal of their account, this message is shown to them.
 #: TWLight/applications/views.py:1395
-msgid ""
-"Your renewal request has been received. A coordinator will review your "
-"request."
-msgstr ""
-"तुमचा पुन्हा वर्गणीदार होण्याचा अर्ज स्वीकारला गेला आहे, तो लवकरच तपासला जाईल आणि "
-"त्यावर योग्य ती कारवाई होईल."
+msgid "Your renewal request has been received. A coordinator will review your request."
+msgstr "तुमचा पुन्हा वर्गणीदार होण्याचा अर्ज स्वीकारला गेला आहे, तो लवकरच तपासला जाईल आणि त्यावर योग्य ती कारवाई होईल."
 
 #. Translators: This labels a textfield where users can enter their email ID.
 #: TWLight/emails/forms.py:18
@@ -1000,9 +925,7 @@ msgstr "ई-मेल खाते"
 
 #. Translators: This is the help text for the email field in the contact us form letting users know the field is updated by value pulled from their respective user profiles.
 #: TWLight/emails/forms.py:21
-msgid ""
-"This field is automatically updated with the email from your <a class='twl-"
-"links' href='{}'>user profile</a>."
+msgid "This field is automatically updated with the email from your <a class='twl-links' href='{}'>user profile</a>."
 msgstr ""
 
 #. Translators: This labels a textfield where users can enter their email message.
@@ -1026,19 +949,13 @@ msgstr ""
 #. Translators: This email is sent to users with their access code. Don't translate Jinja variables in curly braces like user or partner. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/access_code_email-body-html.html:5
 #, python-format
-msgid ""
-"<p>Your approved application to %(partner)s has now been finalised. Your "
-"access code or login details can be found below:</p> <p><b>%(access_code)s</"
-"b></p> <p>%(user_instructions)s</p>"
+msgid "<p>Your approved application to %(partner)s has now been finalised. Your access code or login details can be found below:</p> <p><b>%(access_code)s</b></p> <p>%(user_instructions)s</p>"
 msgstr ""
 
 #. Translators: This email is sent to users with their access code. Don't translate Jinja variables in curly braces like user or partner. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/access_code_email-body-text.html:3
 #, python-format
-msgid ""
-"Your approved application to %(partner)s has now been finalised. Your access "
-"code or login details can be found below: %(access_code)s "
-"%(user_instructions)s"
+msgid "Your approved application to %(partner)s has now been finalised. Your access code or login details can be found below: %(access_code)s %(user_instructions)s"
 msgstr ""
 
 #. Translators: This is the subject line of an email sent to users with their access code.
@@ -1050,23 +967,13 @@ msgstr "खालील विकिपिडीया ग्रंथालय 
 #. Translators: This email is sent to users when their application is approved. Don't translate Jinja variables in curly braces like user or partner; don't translate html tags either. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/approval_notification-body-html.html:5
 #, python-format
-msgid ""
-"<p>Dear %(user)s,</p> <p>Thank you for applying for access to %(partner)s "
-"resources through The Wikipedia Library. We are happy to inform you that "
-"your application has been approved.</p> <p>%(user_instructions)s</p> <p>You "
-"can view the collections you're authorized to access at My Library: "
-"%(link)s</p> <p>Cheers!</p> <p>The Wikipedia Library</p>"
+msgid "<p>Dear %(user)s,</p> <p>Thank you for applying for access to %(partner)s resources through The Wikipedia Library. We are happy to inform you that your application has been approved.</p> <p>%(user_instructions)s</p> <p>You can view the collections you're authorized to access at My Library: %(link)s</p> <p>Cheers!</p> <p>The Wikipedia Library</p>"
 msgstr ""
 
 #. Translators: This email is sent to users when their application is approved. Don't translate Jinja variables in curly braces like user or partner. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/approval_notification-body-text.html:3
 #, python-format
-msgid ""
-"Dear %(user)s, Thank you for applying for access to %(partner)s resources "
-"through The Wikipedia Library. We are happy to inform you that your "
-"application has been approved. %(user_instructions)s You can view the "
-"collections you're authorized to access at My Library: %(link)s Cheers! The "
-"Wikipedia Library"
+msgid "Dear %(user)s, Thank you for applying for access to %(partner)s resources through The Wikipedia Library. We are happy to inform you that your application has been approved. %(user_instructions)s You can view the collections you're authorized to access at My Library: %(link)s Cheers! The Wikipedia Library"
 msgstr ""
 
 #. Translators: This is the subject of an email which is sent to users when their application has been approved. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
@@ -1077,19 +984,13 @@ msgstr "तुमचा विकिपीडीया ग्रंथालय�
 #. Translators: This email is sent to coordinators when a comment is left on an application they are processing. Don't translate Jinja variables in curly braces like user or partner. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/comment_notification_coordinator-body-html.html:5
 #, python-format
-msgid ""
-"<p style=\"color: #500050\">%(submit_date)s - %(commenter)s</p> "
-"<blockquote><p>%(comment)s</p></blockquote> <p>Please reply to these at: <a "
-"href=\"%(app_url)s\">%(app_url)s</a></p> <p>Best,</p> <p>The Wikipedia "
-"Library</p>"
+msgid "<p style=\"color: #500050\">%(submit_date)s - %(commenter)s</p> <blockquote><p>%(comment)s</p></blockquote> <p>Please reply to these at: <a href=\"%(app_url)s\">%(app_url)s</a></p> <p>Best,</p> <p>The Wikipedia Library</p>"
 msgstr ""
 
 #. Translators: This email is sent to coordinators when a comment is left on an application they are processing. Don't translate Jinja variables in curly braces like user or partner. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/comment_notification_coordinator-body-text.html:3
 #, python-format
-msgid ""
-"%(submit_date)s - %(commenter)s %(comment)s Please reply to this at: "
-"%(app_url)s Best, The Wikipedia Library"
+msgid "%(submit_date)s - %(commenter)s %(comment)s Please reply to this at: %(app_url)s Best, The Wikipedia Library"
 msgstr ""
 
 #. Translators: This is the subject line of an email sent to coordinators when a comment is left on an application they processed.
@@ -1100,19 +1001,13 @@ msgstr "तुम्ही मंजूर केलेल्या विकि
 #. Translators: This email is sent to users when they receive a comment on their application. Don't translate Jinja variables in curly braces like user or partner; don't translate html tags either. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/comment_notification_editors-body-html.html:5
 #, python-format
-msgid ""
-"<p style=\"color: #500050\">%(submit_date)s - %(commenter)s</p> "
-"<blockquote><p>%(comment)s</p></blockquote> <p>Please reply to these at <a "
-"href=\"%(app_url)s\">%(app_url)s</a> so we can evaluate your application.</"
-"p> <p>Best,</p> <p>The Wikipedia Library</p>"
+msgid "<p style=\"color: #500050\">%(submit_date)s - %(commenter)s</p> <blockquote><p>%(comment)s</p></blockquote> <p>Please reply to these at <a href=\"%(app_url)s\">%(app_url)s</a> so we can evaluate your application.</p> <p>Best,</p> <p>The Wikipedia Library</p>"
 msgstr ""
 
 #. Translators: This email is sent to users when they receive a comment on their application. Don't translate Jinja variables in curly braces like user or partner. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/comment_notification_editors-body-text.html:3
 #, python-format
-msgid ""
-"%(submit_date)s - %(commenter)s %(comment)s Please reply to these at: "
-"%(app_url)s so we can evaluate your application. Best, The Wikipedia Library"
+msgid "%(submit_date)s - %(commenter)s %(comment)s Please reply to these at: %(app_url)s so we can evaluate your application. Best, The Wikipedia Library"
 msgstr ""
 
 #. Translators: This is the subject line of an email sent to users who have a comment added to one of their applications. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
@@ -1123,33 +1018,24 @@ msgstr "तुम्ही मंजूर केलेल्या विकि
 #. Translators: This email is sent to users when an application they commented on receives another comment. Don't translate Jinja variables in curly braces like app_url; don't translate html tags either. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/comment_notification_others-body-html.html:5
 #, python-format
-msgid ""
-"<p style=\"color: #500050\">%(submit_date)s - %(commenter)s</p> "
-"<blockquote><p>%(comment)s</p></blockquote> See it at <a href=\"%(app_url)s"
-"\">%(app_url)s</a>. Thanks for helping review Wikipedia Library applications!"
+msgid "<p style=\"color: #500050\">%(submit_date)s - %(commenter)s</p> <blockquote><p>%(comment)s</p></blockquote> See it at <a href=\"%(app_url)s\">%(app_url)s</a>. Thanks for helping review Wikipedia Library applications!"
 msgstr ""
 
 #. Translators: This email is sent to users when an application they commented on receives another comment. Don't translate Jinja variables in curly braces like app_url. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/comment_notification_others-body-text.html:3
 #, python-format
-msgid ""
-"%(submit_date)s - %(commenter)s %(comment)s See it at: %(app_url)s Thanks "
-"for helping review Wikipedia Library applications!"
+msgid "%(submit_date)s - %(commenter)s %(comment)s See it at: %(app_url)s Thanks for helping review Wikipedia Library applications!"
 msgstr ""
 
 #. Translators: This is the subject line of an email sent to users who have a comment added to an application they also commented on. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/comment_notification_others-subject.html:4
 msgid "New comment on a Wikipedia Library application you commented on"
-msgstr ""
-"तुम्ही मंजूर केलेल्या आणि टिपणी केलेल्या विकिपीडिया ग्रंथालय अर्जावर एक टिपणी आली आहे."
+msgstr "तुम्ही मंजूर केलेल्या आणि टिपणी केलेल्या विकिपीडिया ग्रंथालय अर्जावर एक टिपणी आली आहे."
 
 #. Translators: This text is part of a scheduled reminder email sent to coordinators who have applications requiring action. Don't translate Jinja variables in curly braces like total_apps, or user.
 #: TWLight/emails/templates/emails/coordinator_reminder_notification-body-html.html:5
 #, python-format
-msgid ""
-"<p>Dear %(user)s,</p> <p>Our records indicate that you are the designated "
-"coordinator for partners that have a total of %(total_apps)s applications.</"
-"p>"
+msgid "<p>Dear %(user)s,</p> <p>Our records indicate that you are the designated coordinator for partners that have a total of %(total_apps)s applications.</p>"
 msgstr ""
 
 #. Translators: Breakdown as in 'cost breakdown'; analysis.
@@ -1188,31 +1074,19 @@ msgstr[1] "मंजूर झालेले अर्ज"
 #. Translators: This text is part of a scheduled reminder email sent to coordinators who have applications requiring action. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library). Don't translate Jinja variables in curly braces like link; don't translate email addresses or html tags either.
 #: TWLight/emails/templates/emails/coordinator_reminder_notification-body-html.html:39
 #, python-format
-msgid ""
-"<p>This is a gentle reminder that you may review applications at <a href="
-"\"%(link)s\">%(link)s</a>.</p> <p>You can customise your reminders under "
-"'preferences' in your user profile.</p> <p>If you received this message in "
-"error, drop us a line at wikipedialibrary@wikimedia.org.</p> <p>Thanks for "
-"helping review Wikipedia Library applications!</p>"
+msgid "<p>This is a gentle reminder that you may review applications at <a href=\"%(link)s\">%(link)s</a>.</p> <p>You can customise your reminders under 'preferences' in your user profile.</p> <p>If you received this message in error, drop us a line at wikipedialibrary@wikimedia.org.</p> <p>Thanks for helping review Wikipedia Library applications!</p>"
 msgstr ""
 
 #. Translators: This text is part of a scheduled reminder email sent to coordinators who have applications requiring action. Don't translate Jinja variables in curly braces like total_apps, or user.
 #: TWLight/emails/templates/emails/coordinator_reminder_notification-body-text.html:3
 #, python-format
-msgid ""
-"Dear %(user)s, Our records indicate that you are the designated coordinator "
-"for partners that have a total of %(total_apps)s applications."
+msgid "Dear %(user)s, Our records indicate that you are the designated coordinator for partners that have a total of %(total_apps)s applications."
 msgstr ""
 
 #. Translators: This text is part of a scheduled reminder email sent to coordinators who have applications requiring action. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library). Don't translate Jinja variables in curly braces like link; don't translate the email address either.
 #: TWLight/emails/templates/emails/coordinator_reminder_notification-body-text.html:38
 #, python-format
-msgid ""
-"This is a gentle reminder that you may review applications at: %(link)s. You "
-"can customise your reminders under 'preferences' in your user profile. If "
-"you received this message in error, drop us a line at: "
-"wikipedialibrary@wikimedia.org Thanks for helping review Wikipedia Library "
-"applications!"
+msgid "This is a gentle reminder that you may review applications at: %(link)s. You can customise your reminders under 'preferences' in your user profile. If you received this message in error, drop us a line at: wikipedialibrary@wikimedia.org Thanks for helping review Wikipedia Library applications!"
 msgstr ""
 
 #. Translators: This is the subject line of a scheduled reminder email sent to coordinators who have applications to review. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library). Do not translate items in curly braces.
@@ -1223,22 +1097,13 @@ msgstr "खालील विकिपिडीया ग्रंथालय 
 #. Translators: This email is sent to users when their application is rejected. Don't translate Jinja variables in curly braces like user or partner; don't translate html tags either. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/rejection_notification-body-html.html:5
 #, python-format
-msgid ""
-"<p>Dear %(user)s,</p> <p>Thank you for applying for access to %(partner)s "
-"resources through The Wikipedia Library. Unfortunately at this time your "
-"application has not been approved. You can view your application and review "
-"comments at <a href=\"%(app_url)s\">%(app_url)s</a>.</p> <p>Best,</p> <p>The "
-"Wikipedia Library</p>"
+msgid "<p>Dear %(user)s,</p> <p>Thank you for applying for access to %(partner)s resources through The Wikipedia Library. Unfortunately at this time your application has not been approved. You can view your application and review comments at <a href=\"%(app_url)s\">%(app_url)s</a>.</p> <p>Best,</p> <p>The Wikipedia Library</p>"
 msgstr ""
 
 #. Translators: This email is sent to users when their application is rejected. Don't translate Jinja variables in curly braces like user or partner. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/rejection_notification-body-text.html:3
 #, python-format
-msgid ""
-"Dear %(user)s, Thank you for applying for access to %(partner)s resources "
-"through The Wikipedia Library. Unfortunately at this time your application "
-"has not been approved. You can view your application and review comments at: "
-"%(app_url)s Best, The Wikipedia Library"
+msgid "Dear %(user)s, Thank you for applying for access to %(partner)s resources through The Wikipedia Library. Unfortunately at this time your application has not been approved. You can view your application and review comments at: %(app_url)s Best, The Wikipedia Library"
 msgstr ""
 
 #. Translators: This is the subject of an email which is sent to users when their application has been rejected. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
@@ -1250,25 +1115,13 @@ msgstr "तुमचा विकिपीडिया ग्रंथालय 
 #. Translators: This email is sent to users when they have an account that is soon to expire. Don't translate Jinja variables in curly braces like partner_name or partner_link; don't translate html tags either. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/user_renewal_notice-body-html.html:5
 #, python-format
-msgid ""
-"<p>Dear %(user)s,</p> <p>According to our records, your access to "
-"%(partner_name)s will soon expire and you may lose access. If you want to "
-"continue making use of your free account, you can request renewal of your "
-"account by clicking the 'Renew' or 'Extend' button at %(partner_link)s.</p> "
-"<p>Best,</p> <p>The Wikipedia Library</p> <p>You can disable these emails in "
-"your user page preferences: https://wikipedialibrary.wmflabs.org/users/</p>"
+msgid "<p>Dear %(user)s,</p> <p>According to our records, your access to %(partner_name)s will soon expire and you may lose access. If you want to continue making use of your free account, you can request renewal of your account by clicking the 'Renew' or 'Extend' button at %(partner_link)s.</p> <p>Best,</p> <p>The Wikipedia Library</p> <p>You can disable these emails in your user page preferences: https://wikipedialibrary.wmflabs.org/users/</p>"
 msgstr ""
 
 #. Translators: This email is sent to users when they have an account that is soon to expire. Don't translate Jinja variables in curly braces like partner_name or partner_link; don't translate html tags either. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/user_renewal_notice-body-text.html:3
 #, python-format
-msgid ""
-"Dear %(user)s, According to our records, your access to %(partner_name)s "
-"will soon expire and you may lose access. If you want to continue making use "
-"of your free account, you can request renewal of your account by clicking "
-"the Renew button at %(partner_link)s. Best, The Wikipedia Library You can "
-"disable these emails in your user page preferences: https://wikipedialibrary."
-"wmflabs.org/users/"
+msgid "Dear %(user)s, According to our records, your access to %(partner_name)s will soon expire and you may lose access. If you want to continue making use of your free account, you can request renewal of your account by clicking the Renew button at %(partner_link)s. Best, The Wikipedia Library You can disable these emails in your user page preferences: https://wikipedialibrary.wmflabs.org/users/"
 msgstr ""
 
 #. Translators: This is the subject of an email sent to users when they have an account that is soon to expire. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
@@ -1280,24 +1133,13 @@ msgstr "खालील विकिपिडीया ग्रंथालय 
 #. Translators: This email is sent to users when their application is waitlisted because there are no more accounts available. Don't translate Jinja variables in curly braces like user or partner; don't translate html tags either. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/waitlist_notification-body-html.html:5
 #, python-format
-msgid ""
-"<p>Dear %(user)s,</p> <p>Thank you for applying for access to %(partner)s "
-"resources through The Wikipedia Library. There are no accounts currently "
-"available so your application has been waitlisted. Your application will be "
-"evaluated if/when more accounts become available. You can see all available "
-"resources at <a href=\"%(link)s\">%(link)s</a>.</p> <p>Best,</p> <p>The "
-"Wikipedia Library</p>"
+msgid "<p>Dear %(user)s,</p> <p>Thank you for applying for access to %(partner)s resources through The Wikipedia Library. There are no accounts currently available so your application has been waitlisted. Your application will be evaluated if/when more accounts become available. You can see all available resources at <a href=\"%(link)s\">%(link)s</a>.</p> <p>Best,</p> <p>The Wikipedia Library</p>"
 msgstr ""
 
 #. Translators: This email is sent to users when their application is waitlisted because there are no more accounts available. Don't translate Jinja variables in curly braces like user or partner. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/waitlist_notification-body-text.html:3
 #, python-format
-msgid ""
-"Dear %(user)s, Thank you for applying for access to %(partner)s resources "
-"through The Wikipedia Library. There are no accounts currently available so "
-"your application has been waitlisted. Your application will be evaluated if/"
-"when more accounts become available. You can see all available resources at: "
-"%(link)s Best, The Wikipedia Library"
+msgid "Dear %(user)s, Thank you for applying for access to %(partner)s resources through The Wikipedia Library. There are no accounts currently available so your application has been waitlisted. Your application will be evaluated if/when more accounts become available. You can see all available resources at: %(link)s Best, The Wikipedia Library"
 msgstr ""
 
 #. Translators: This is the subject of an email sent to users when their application is waitlisted because there are no more accounts available. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
@@ -1462,17 +1304,14 @@ msgstr "ई-मेल खाते"
 #: TWLight/resources/templates/resources/filter_section.html:14
 #: TWLight/templates/about.html:12
 #: TWLight/users/templates/users/filter_section.html:13
-msgid ""
-"The Wikipedia Library allows active editors to access a wide range of "
-"collections of paywalled reliable sources for free!"
+msgid "The Wikipedia Library allows active editors to access a wide range of collections of paywalled reliable sources for free!"
 msgstr ""
 
 #. Translators: On the Browse Partners page (https://wikipedialibrary.wmflabs.org/partners/), this introduces users to The Wikipedia Library.
 #. Translators: On the MyLibrary page (https://wikipedialibrary.wmflabs.org/users/my_library), this introduces users to The Wikipedia Library.
 #: TWLight/resources/templates/resources/filter_section.html:17
 #: TWLight/users/templates/users/filter_section.html:15
-msgid ""
-"Start with the search bar at the top or browse publisher websites directly."
+msgid "Start with the search bar at the top or browse publisher websites directly."
 msgstr ""
 
 #. Translators: On the Browse Partners page (https://wikipedialibrary.wmflabs.org/partners/), this appears below introductory text and links to the 'About' page (https://wikipedialibrary.wmflabs.org/about/)
@@ -1552,52 +1391,38 @@ msgstr "साथीदारांना पाठवले आहे"
 #. Translators: If we have no available accounts for a partner, the coordinator can change the application system to a waiting list.
 #: TWLight/resources/templates/resources/partner_detail.html:36
 #: TWLight/resources/templates/resources/partner_detail_apply.html:17
-msgid ""
-"There are no access grants available for this partner at this time. You can "
-"still apply for access; applications will be processed when access is "
-"available."
+msgid "There are no access grants available for this partner at this time. You can still apply for access; applications will be processed when access is available."
 msgstr ""
 
 #. Translators: This text links to the minimum user requirements and terms of use on the partner page.
 #: TWLight/resources/templates/resources/partner_detail.html:48
 #: TWLight/resources/templates/resources/partner_detail_apply.html:29
 #, python-format
-msgid ""
-"Before applying, please review the <strong><a class=\"twl-links\" href="
-"\"%(about)s#req\">minimum requirements</a></strong> for access and our "
-"<strong><a class=\"twl-links\" href=\"%(terms)s\">terms of use</a></strong>."
+msgid "Before applying, please review the <strong><a class=\"twl-links\" href=\"%(about)s#req\">minimum requirements</a></strong> for access and our <strong><a class=\"twl-links\" href=\"%(terms)s\">terms of use</a></strong>."
 msgstr ""
 
 #. Translators: This text refers to the page containing the content a user is authorized to access.
 #: TWLight/resources/templates/resources/partner_detail.html:69
 #, python-format
-msgid ""
-"View the status of your access in <strong><a class=\"twl-links\" href="
-"\"%(library_url)s\">My Library</a></strong> page."
+msgid "View the status of your access in <strong><a class=\"twl-links\" href=\"%(library_url)s\">My Library</a></strong> page."
 msgstr ""
 
 #. Translators: This message is shown when a user has open applications, linking to their respective applications page.
 #: TWLight/resources/templates/resources/partner_detail.html:78
 #, python-format
-msgid ""
-"View the status of your application(s) on your <strong><a class=\"twl-links"
-"\" href=\"%(applications_url)s\">My Applications</a></strong> page."
+msgid "View the status of your application(s) on your <strong><a class=\"twl-links\" href=\"%(applications_url)s\">My Applications</a></strong> page."
 msgstr ""
 
 #. Translators: This message is shown when a user has authorizations, linking to their respective collections page.
 #: TWLight/resources/templates/resources/partner_detail_apply.html:50
 #, python-format
-msgid ""
-"View the status of your access on your <strong><a href=\"%(library_url)s\" "
-"class=\"twl-links\">My Library</a></strong> page."
+msgid "View the status of your access on your <strong><a href=\"%(library_url)s\" class=\"twl-links\">My Library</a></strong> page."
 msgstr ""
 
 #. Translators: This message is shown when a user has open applications, linking to their respective applications page.
 #: TWLight/resources/templates/resources/partner_detail_apply.html:60
 #, python-format
-msgid ""
-"View the status of your application(s) on your <strong><a href="
-"\"%(applications_url)s\">My Applications</a></strong> page."
+msgid "View the status of your application(s) on your <strong><a href=\"%(applications_url)s\">My Applications</a></strong> page."
 msgstr ""
 
 #. Translators: One the partner detail page, this text labels the button which coordinators can click to remove a partner from waitlisted status.
@@ -1627,10 +1452,7 @@ msgstr ""
 
 #. Translators: If no account coordinator is assigned to a partner, the Wikipedia Library team will coordinate signups. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/resources/templates/resources/partner_detail_apply.html:112
-msgid ""
-"The Wikipedia Library team will process this application. Want to help? <a "
-"class=\"twl-links\" href=\"https://en.wikipedia.org/wiki/Wikipedia:"
-"The_Wikipedia_Library/Coordinators/Signup\">Sign up as a coordinator.</a>"
+msgid "The Wikipedia Library team will process this application. Want to help? <a class=\"twl-links\" href=\"https://en.wikipedia.org/wiki/Wikipedia:The_Wikipedia_Library/Coordinators/Signup\">Sign up as a coordinator.</a>"
 msgstr ""
 
 #. Translators: This text labels a button coordinators can click to view a list of users who have applied for access for a particular partner
@@ -1661,18 +1483,13 @@ msgstr ""
 
 #. Translators: Text shown to authenticated, bundle eligible users when they visit a Bundle partner page.
 #: TWLight/resources/templates/resources/partner_detail_apply.html:138
-msgid ""
-"You are eligible to access Library Bundle partners. Click the button above "
-"to access the collection."
+msgid "You are eligible to access Library Bundle partners. Click the button above to access the collection."
 msgstr ""
 
 #. Translators: Text shown to authenticated, bundle ineligible users when they visit a Bundle partner page.
 #: TWLight/resources/templates/resources/partner_detail_apply.html:152
 #, python-format
-msgid ""
-"You are not eligible to access Library Bundle partners. Visit the <a class="
-"\"twl-links\" href=\"%(homepage)s\">homepage</a> to check the eligibility "
-"criteria."
+msgid "You are not eligible to access Library Bundle partners. Visit the <a class=\"twl-links\" href=\"%(homepage)s\">homepage</a> to check the eligibility criteria."
 msgstr ""
 
 #. Translators: Buttton prompting users to log in.
@@ -1684,10 +1501,7 @@ msgstr ""
 #. Translators: Text shown to unauthenticated users when they visit a Bundle partner page.
 #: TWLight/resources/templates/resources/partner_detail_apply.html:168
 #, python-format
-msgid ""
-"This resource is part of our <a class=\"twl-links\" href=\"%(about)s"
-"\">Library Bundle</a>, which you can access if you meet our minimum "
-"eligibility criteria. Log in to find out if you are eligible."
+msgid "This resource is part of our <a class=\"twl-links\" href=\"%(about)s\">Library Bundle</a>, which you can access if you meet our minimum eligibility criteria. Log in to find out if you are eligible."
 msgstr ""
 
 #. Translators: This is the label for a number which shows the total active accounts for one partner. (e.g. https://wikipedialibrary.wmflabs.org/partners/8/).
@@ -1738,26 +1552,19 @@ msgstr ""
 #. Translators: If a partner has specified the excerpt limit both in words and percentage, this message will display the percentage of words and the number of words on the partner page.
 #: TWLight/resources/templates/resources/partner_detail_timeline.html:99
 #, python-format
-msgid ""
-"%(object)s allows a maximum of %(excerpt_limit)s words or "
-"%(excerpt_limit_percentage)s%% of an article be excerpted into a Wikipedia "
-"article."
+msgid "%(object)s allows a maximum of %(excerpt_limit)s words or %(excerpt_limit_percentage)s%% of an article be excerpted into a Wikipedia article."
 msgstr ""
 
 #. Translators: If a partner has specified the excerpt limit in words, this message will display the number of words on the partner page.
 #: TWLight/resources/templates/resources/partner_detail_timeline.html:106
 #, python-format
-msgid ""
-"%(object)s allows a maximum of %(excerpt_limit)s words be excerpted into a "
-"Wikipedia article."
+msgid "%(object)s allows a maximum of %(excerpt_limit)s words be excerpted into a Wikipedia article."
 msgstr ""
 
 #. Translators: If a partner has specified the excerpt limit in percentage, this message will display the percentage of words on the partner page.
 #: TWLight/resources/templates/resources/partner_detail_timeline.html:113
 #, python-format
-msgid ""
-"%(object)s allows a maximum of %(excerpt_limit_percentage)s%% of an article "
-"be excerpted into a Wikipedia article."
+msgid "%(object)s allows a maximum of %(excerpt_limit_percentage)s%% of an article be excerpted into a Wikipedia article."
 msgstr ""
 
 #. Translators: If a partner has other requirements for access, this text shows as the title for that information field. (e.g. https://wikipedialibrary.wmflabs.org/partners/10/).
@@ -1768,9 +1575,7 @@ msgstr ""
 #. Translators: If a user must agree to a Terms of Use document, they see this message, and must enter the name of the resource. Don't translate publisher or url.
 #: TWLight/resources/templates/resources/partner_detail_timeline.html:140
 #, python-format
-msgid ""
-"%(publisher)s requires that you agree with its <a href=\"%(url)s\">terms of "
-"use</a>."
+msgid "%(publisher)s requires that you agree with its <a href=\"%(url)s\">terms of use</a>."
 msgstr ""
 
 #. Translators: If a user must provide their real name to apply to a partner, they see this message, and must enter the name of the resource. Don't translate publisher.
@@ -1794,17 +1599,13 @@ msgstr ""
 #. Translators: If a user must select a specific resource to apply for, they see this message, and must enter the name of the resource. Don't translate publisher.
 #: TWLight/resources/templates/resources/partner_detail_timeline.html:177
 #, python-format
-msgid ""
-"%(publisher)s requires that you specify a particular title that you want to "
-"access."
+msgid "%(publisher)s requires that you specify a particular title that you want to access."
 msgstr ""
 
 #. Translators: If a user must register on the partner website before applying, they see this message. Don't translate partner.
 #: TWLight/resources/templates/resources/partner_detail_timeline.html:187
 #, python-format
-msgid ""
-"%(publisher)s requires that you sign up for an account before applying for "
-"access."
+msgid "%(publisher)s requires that you sign up for an account before applying for access."
 msgstr ""
 
 #. Translators: If a partner has their location listed, this message is a label for that location
@@ -1933,9 +1734,7 @@ msgstr ""
 
 #. Translators: If multiple authorizations where returned for a collection, this message is shown to a user
 #: TWLight/resources/views.py:268
-msgid ""
-"Multiple authorizations were returned – something's wrong. Please contact us "
-"and don't forget to mention this message."
+msgid "Multiple authorizations were returned – something's wrong. Please contact us and don't forget to mention this message."
 msgstr ""
 
 #. Translators: This message is shown when user tries to access a NOT_AVAILABLE Partner
@@ -1976,14 +1775,7 @@ msgstr ""
 #. Translators: Shown on the website's 400 page, when a user sends a bad request. Don't translate path or Phabricator.
 #: TWLight/templates/400.html:20
 #, python-format
-msgid ""
-"If you think we should know what to do with that, please email us about this "
-"error at <a class=\"twl-links\" href=\"mailto:wikipedialibrary@wikimedia.org?"
-"Subject=Wikipedia%%20Library%%20%(path)s%%20Permission%%20denied"
-"\">wikipedialibrary@wikimedia.org</a> or report it to us on <a class=\"twl-"
-"links\" href=\"https://phabricator.wikimedia.org/maniphest/task/edit/form/1/?"
-"projectPHIDs=Library-Card-Platform&title=Wikipedia%%20Library%%20%(path)s"
-"%%20Bad%%20Request\">Phabricator</a>"
+msgid "If you think we should know what to do with that, please email us about this error at <a class=\"twl-links\" href=\"mailto:wikipedialibrary@wikimedia.org?Subject=Wikipedia%%20Library%%20%(path)s%%20Permission%%20denied\">wikipedialibrary@wikimedia.org</a> or report it to us on <a class=\"twl-links\" href=\"https://phabricator.wikimedia.org/maniphest/task/edit/form/1/?projectPHIDs=Library-Card-Platform&title=Wikipedia%%20Library%%20%(path)s%%20Bad%%20Request\">Phabricator</a>"
 msgstr ""
 
 #. Translators: Alt text for an image shown on the 400 error page.
@@ -2005,15 +1797,7 @@ msgstr ""
 #. Translators: Shown on the website's 403 page, when a user attempts to navigate to a page they don't have permission to view. Don't translate path or Phabricator.
 #: TWLight/templates/403.html:20
 #, python-format
-msgid ""
-"If you think your account should be able to do that, please email us about "
-"this error at <a class=\"twl-links\" href=\"mailto:"
-"wikipedialibrary@wikimedia.org?Subject=Wikipedia%%20Library%%20%(path)s"
-"%%20Permission%%20denied\">wikipedialibrary@wikimedia.org</a> or report it "
-"to us on <a class=\"twl-links\" href=\"https://phabricator.wikimedia.org/"
-"maniphest/task/edit/form/1/?projectPHIDs=Library-Card-"
-"Platform&title=Wikipedia%%20Library%%20%(path)s%%20Permission%%20denied"
-"\">Phabricator</a>"
+msgid "If you think your account should be able to do that, please email us about this error at <a class=\"twl-links\" href=\"mailto:wikipedialibrary@wikimedia.org?Subject=Wikipedia%%20Library%%20%(path)s%%20Permission%%20denied\">wikipedialibrary@wikimedia.org</a> or report it to us on <a class=\"twl-links\" href=\"https://phabricator.wikimedia.org/maniphest/task/edit/form/1/?projectPHIDs=Library-Card-Platform&title=Wikipedia%%20Library%%20%(path)s%%20Permission%%20denied\">Phabricator</a>"
 msgstr ""
 
 #. Translators: Shown on the website's 404 page, when a user attempts to navigate to a page that doesn't exist.
@@ -2029,14 +1813,7 @@ msgstr ""
 #. Translators: Shown on the website's 404 page, when a user attempts to navigate to a page that doesn't exist. Don't translate path or Phabricator.
 #: TWLight/templates/404.html:19
 #, python-format
-msgid ""
-"If you are certain that something should be here, please email us about this "
-"error at <a class=\"twl-links\" href=\"mailto:wikipedialibrary@wikimedia.org?"
-"Subject=Wikipedia%%20Library%%20%(path)s%%20Not%%20found\"> "
-"wikipedialibrary@wikimedia.org</a> or report it to us on <a class=\"twl-links"
-"\" href=\"https://phabricator.wikimedia.org/maniphest/task/edit/form/1/?"
-"projectPHIDs=Library-Card-Platform&title=Wikipedia%%20Library%%20%(path)s"
-"%%20Not%%20found\">Phabricator</a>"
+msgid "If you are certain that something should be here, please email us about this error at <a class=\"twl-links\" href=\"mailto:wikipedialibrary@wikimedia.org?Subject=Wikipedia%%20Library%%20%(path)s%%20Not%%20found\"> wikipedialibrary@wikimedia.org</a> or report it to us on <a class=\"twl-links\" href=\"https://phabricator.wikimedia.org/maniphest/task/edit/form/1/?projectPHIDs=Library-Card-Platform&title=Wikipedia%%20Library%%20%(path)s%%20Not%%20found\">Phabricator</a>"
 msgstr ""
 
 #. Translators: Alt text for an image shown on the 404 error page.
@@ -2051,32 +1828,18 @@ msgstr ""
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:20
-msgid ""
-"This platform is our central tool for facilitating access to our available "
-"collections. Here you can see which partnerships are available, search their "
-"contents, and apply for and access the ones you’re interested in."
+msgid "This platform is our central tool for facilitating access to our available collections. Here you can see which partnerships are available, search their contents, and apply for and access the ones you’re interested in."
 msgstr ""
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/). Wikimedia Foundation should not be translated.
 #: TWLight/templates/about.html:29
-msgid ""
-"All users receive immediate access to some collections, which can be browsed "
-"by clicking the 'Access collection' buttons or using the search bar at the "
-"top of the page. Other collections require an application before access is "
-"granted, and may be accessed directly or via an individual login or access "
-"code. Volunteer coordinators, who have signed non-disclosure agreements with "
-"the Wikimedia Foundation, review these applications and work with publishers "
-"to get you your free access."
+msgid "All users receive immediate access to some collections, which can be browsed by clicking the 'Access collection' buttons or using the search bar at the top of the page. Other collections require an application before access is granted, and may be accessed directly or via an individual login or access code. Volunteer coordinators, who have signed non-disclosure agreements with the Wikimedia Foundation, review these applications and work with publishers to get you your free access."
 msgstr ""
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/). Don't translate terms_url.
 #: TWLight/templates/about.html:43
 #, python-format
-msgid ""
-"For more information about how your information is stored and reviewed "
-"please see our <a class=\"twl-links\" href=\"%(terms_url)s\"> terms of use "
-"and privacy policy</a>. Accounts you apply for are also subject to the Terms "
-"of Use provided by each partner’s platform; please review them."
+msgid "For more information about how your information is stored and reviewed please see our <a class=\"twl-links\" href=\"%(terms_url)s\"> terms of use and privacy policy</a>. Accounts you apply for are also subject to the Terms of Use provided by each partner’s platform; please review them."
 msgstr ""
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
@@ -2086,12 +1849,7 @@ msgstr ""
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/). Wikimedia Foundation should not be translated.
 #: TWLight/templates/about.html:55
-msgid ""
-"Any active editor in good standing can receive access. For publishers with "
-"limited numbers of accounts, applications are reviewed based on the editor’s "
-"needs and contributions. If you think you could use access to one of our "
-"partner resources and are an active editor in any project supported by the "
-"Wikimedia Foundation, please apply."
+msgid "Any active editor in good standing can receive access. For publishers with limited numbers of accounts, applications are reviewed based on the editor’s needs and contributions. If you think you could use access to one of our partner resources and are an active editor in any project supported by the Wikimedia Foundation, please apply."
 msgstr ""
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
@@ -2121,23 +1879,12 @@ msgstr ""
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/)
 #: TWLight/templates/about.html:89
-msgid ""
-"If you are applying for an available collection, please first check that you "
-"don't already have access through another library or institution. If you do, "
-"please consider using that access rather than taking up a seat for this "
-"resource in The Wikipedia Library."
+msgid "If you are applying for an available collection, please first check that you don't already have access through another library or institution. If you do, please consider using that access rather than taking up a seat for this resource in The Wikipedia Library."
 msgstr ""
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/)
 #: TWLight/templates/about.html:99
-msgid ""
-"If your account is blocked on one or more Wikimedia projects, you may still "
-"be granted access to The Wikipedia Library. You will need to contact the "
-"Wikipedia Library team, who will review your blocks. If you have been "
-"blocked for content issues, most notably copyright violations, or have "
-"multiple long-term blocks, we may decline your request. Additionally, if "
-"your block status changes after being approved, you will need to request "
-"another review."
+msgid "If your account is blocked on one or more Wikimedia projects, you may still be granted access to The Wikipedia Library. You will need to contact the Wikipedia Library team, who will review your blocks. If you have been blocked for content issues, most notably copyright violations, or have multiple long-term blocks, we may decline your request. Additionally, if your block status changes after being approved, you will need to request another review."
 msgstr ""
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
@@ -2172,9 +1919,7 @@ msgstr ""
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:136
-msgid ""
-"Share their account logins or passwords with others, or sell their access to "
-"other parties"
+msgid "Share their account logins or passwords with others, or sell their access to other parties"
 msgstr ""
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
@@ -2184,23 +1929,17 @@ msgstr ""
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:144
-msgid ""
-"Systematically make printed or electronic copies of multiple extracts of "
-"restricted content available for any purpose"
+msgid "Systematically make printed or electronic copies of multiple extracts of restricted content available for any purpose"
 msgstr ""
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/). Stub is a technical term for a short Wikipedia article, use the appropriate Wikipedia term in your language.
 #: TWLight/templates/about.html:148
-msgid ""
-"Datamine metadata without permission, in order, for instance, to use "
-"metadata for auto-created stub articles"
+msgid "Datamine metadata without permission, in order, for instance, to use metadata for auto-created stub articles"
 msgstr ""
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:154
-msgid ""
-"Respecting these agreements allows us to continue growing the partnerships "
-"available to the community."
+msgid "Respecting these agreements allows us to continue growing the partnerships available to the community."
 msgstr ""
 
 #. Translators: This is the heading for a section on the About page (https://wikipedialibrary.wmflabs.org/about/).
@@ -2210,41 +1949,22 @@ msgstr ""
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:164
-msgid ""
-"EZProxy is a proxy server used to authenticate users for many Wikipedia "
-"Library partners. Users sign into EZProxy via the Library Card platform to "
-"verify that they are authorized users, and then the server accesses "
-"requested resources using its own IP address."
+msgid "EZProxy is a proxy server used to authenticate users for many Wikipedia Library partners. Users sign into EZProxy via the Library Card platform to verify that they are authorized users, and then the server accesses requested resources using its own IP address."
 msgstr ""
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:173
-msgid ""
-"You may notice that when accessing resources via EZProxy that URLs are "
-"dynamically rewritten. This is why we recommend logging in via the Library "
-"Card platform rather than going directly to the unproxied partner website. "
-"When in doubt, check the URL for ‘idm.oclc’. If it’s there, then you’re "
-"connected via EZProxy."
+msgid "You may notice that when accessing resources via EZProxy that URLs are dynamically rewritten. This is why we recommend logging in via the Library Card platform rather than going directly to the unproxied partner website. When in doubt, check the URL for ‘idm.oclc’. If it’s there, then you’re connected via EZProxy."
 msgstr ""
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:182
-msgid ""
-"Typically once you’ve logged in your session will remain active in your "
-"browser for up to two hours after you’ve finished searching. Note that use "
-"of EZProxy requires you to enable cookies. If you are having problems you "
-"should also try clearing your cache and restarting your browser."
+msgid "Typically once you’ve logged in your session will remain active in your browser for up to two hours after you’ve finished searching. Note that use of EZProxy requires you to enable cookies. If you are having problems you should also try clearing your cache and restarting your browser."
 msgstr ""
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/)
 #: TWLight/templates/about.html:193
-msgid ""
-"The Library Bundle is a collection of resources for which no application is "
-"required. If you meet the criteria laid out above, you will be authorized "
-"for access automatically upon logging in to the platform. Only some of our "
-"content is currently included in the Library Bundle, however we hope to "
-"expand the collection as more publishers become comfortable with "
-"participating. All Bundle content is accessed via EZProxy."
+msgid "The Library Bundle is a collection of resources for which no application is required. If you meet the criteria laid out above, you will be authorized for access automatically upon logging in to the platform. Only some of our content is currently included in the Library Bundle, however we hope to expand the collection as more publishers become comfortable with participating. All Bundle content is accessed via EZProxy."
 msgstr ""
 
 #. Translators: This is the heading for a section on the About page (https://wikipedialibrary.wmflabs.org/about/).
@@ -2254,12 +1974,7 @@ msgstr ""
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:206
-msgid ""
-"Citation practices vary by project and even by article. Generally, we "
-"support editors citing where they found information, in a form that allows "
-"others to check it for themselves. That often means providing both original "
-"source details as well as a link to the partner database in which the source "
-"was found."
+msgid "Citation practices vary by project and even by article. Generally, we support editors citing where they found information, in a form that allows others to check it for themselves. That often means providing both original source details as well as a link to the partner database in which the source was found."
 msgstr ""
 
 #. Translators: This is the heading for a section on the About page (https://wikipedialibrary.wmflabs.org/about/).
@@ -2271,9 +1986,7 @@ msgstr ""
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:218
 #, python-format
-msgid ""
-"If you have questions, need help, or want to volunteer to help, please see "
-"our <a class=\"twl-links\" href=\"%(contact_url)s\">contact page</a>."
+msgid "If you have questions, need help, or want to volunteer to help, please see our <a class=\"twl-links\" href=\"%(contact_url)s\">contact page</a>."
 msgstr ""
 
 #. Translators: This is the title of the panel box detailing the contact information for the Wikipedia Library team.
@@ -2316,9 +2029,7 @@ msgstr "खालील विकिपिडीया ग्रंथालय 
 #. Translators: This is the text that appears at the bottom of the contact us form directing users to the suggestions form.
 #: TWLight/templates/contact.html:48
 #, python-format
-msgid ""
-"(If you would like to suggest a partner, <a class=\"twl-links\" href="
-"\"%(suggest)s\"><strong>go here</strong></a>.)"
+msgid "(If you would like to suggest a partner, <a class=\"twl-links\" href=\"%(suggest)s\"><strong>go here</strong></a>.)"
 msgstr ""
 
 #. Translators: On a special 'link to search' page, this message is shown if JavaScript is disabled.
@@ -2380,9 +2091,7 @@ msgstr "खालील विकिपिडीया ग्रंथालय 
 #. Translators: Information about The Wikipedia Library.
 #: TWLight/templates/login_partial.html:53 TWLight/templates/new_base.html:21
 #, python-format
-msgid ""
-"More than 100 of the world's top subscription-only databases, with content "
-"in %(no_of_languages)s languages, free for Wikipedians of all backgrounds"
+msgid "More than 100 of the world's top subscription-only databases, with content in %(no_of_languages)s languages, free for Wikipedians of all backgrounds"
 msgstr ""
 
 #. Translators: Information about The Wikipedia Library.
@@ -2391,9 +2100,7 @@ msgid "Meet these criteria for automatic access"
 msgstr ""
 
 #: TWLight/templates/login_partial.html:69
-msgid ""
-"These criteria grant you access to certain collections but not all. Some "
-"collections are accessible on a per application basis only."
+msgid "These criteria grant you access to certain collections but not all. Some collections are accessible on a per application basis only."
 msgstr ""
 
 #: TWLight/templates/login_partial.html:89
@@ -2403,29 +2110,19 @@ msgstr ""
 #. Translators: Shown if the current user doesn't have a registered email on their account. Don't translate contact_us_url or email_url.
 #: TWLight/templates/message_partial.html:15
 #, python-format
-msgid ""
-"You don't have an email on file. We can't finalize your access to partner "
-"resources, and you won't be able to <a class=\"twl-links\" href="
-"\"%(contact_us_url)s\">contact us</a> without an email. Please <a class="
-"\"twl-links\" href=\"%(email_url)s\">update your email</a>."
+msgid "You don't have an email on file. We can't finalize your access to partner resources, and you won't be able to <a class=\"twl-links\" href=\"%(contact_us_url)s\">contact us</a> without an email. Please <a class=\"twl-links\" href=\"%(email_url)s\">update your email</a>."
 msgstr ""
 
 #. Translators: Shown if the current user has requested the processing of their data should be restricted.
 #: TWLight/templates/message_partial.html:26
 #, python-format
-msgid ""
-"You have requested a restriction on the processing of your data. Most site "
-"functionality will not be available to you until you <a class=\"twl-links\" "
-"href=\"%(restrict_url)s\">lift this restriction</a>."
+msgid "You have requested a restriction on the processing of your data. Most site functionality will not be available to you until you <a class=\"twl-links\" href=\"%(restrict_url)s\">lift this restriction</a>."
 msgstr ""
 
 #. Translators: Shown if the current user has not agreed to the terms of use.
 #: TWLight/templates/message_partial.html:37
 #, python-format
-msgid ""
-"You have not agreed to the <a class=\"twl-links\" href=\"%(terms_url)s"
-"\">terms of use</a> of this site. Your applications will not be processed "
-"and you won't be able to apply or access resources you are approved for."
+msgid "You have not agreed to the <a class=\"twl-links\" href=\"%(terms_url)s\">terms of use</a> of this site. Your applications will not be processed and you won't be able to apply or access resources you are approved for."
 msgstr ""
 
 #. Translators: This link is at the bottom of every page and links to the 'About' page (https://wikipedialibrary.wmflabs.org/about/)
@@ -2473,9 +2170,7 @@ msgstr ""
 
 #. Translators: If a user goes to reset their password, this message asks them to enter their email to do so.
 #: TWLight/templates/registration/password_reset_form.html:13
-msgid ""
-"Forgot your password? Enter your email address below, and we'll email "
-"instructions for setting a new one."
+msgid "Forgot your password? Enter your email address below, and we'll email instructions for setting a new one."
 msgstr ""
 
 #. Translators: This is the label for a button that users click to update their public information.
@@ -2523,16 +2218,12 @@ msgstr ""
 
 #. Translators: This text explains how to disagree to the site's terms of use and the restrictions that will come into effect when users disagree to the terms of use.
 #: TWLight/users/forms.py:185
-msgid ""
-"By unchecking this box and clicking “Update” you may explore the site, but "
-"you will not be able to apply for access to materials or evaluate "
-"applications unless you agree with the terms of use."
+msgid "By unchecking this box and clicking “Update” you may explore the site, but you will not be able to apply for access to materials or evaluate applications unless you agree with the terms of use."
 msgstr ""
 
 #. Translators: Users click this button to set their website email address to the one linked to their Wikipedia account.
 #: TWLight/users/forms.py:211
-msgid ""
-"Use my Wikipedia email address (will be updated the next time you login)."
+msgid "Use my Wikipedia email address (will be updated the next time you login)."
 msgstr ""
 
 #. Translators: This labels a button which users click to change their email.
@@ -2543,17 +2234,8 @@ msgstr ""
 #. Translators: Shown if the current user tried to 'favorite' a partner they can't access. Do not translate '{partner}'
 #: TWLight/users/models.py:201
 #, python-brace-format
-msgid ""
-"Cannot add partner {partner} to your favorites because you don't have access "
-"to it"
+msgid "Cannot add partner {partner} to your favorites because you don't have access to it"
 msgstr ""
-
-#. Translators: Do not translate.
-#: TWLight/users/models.py:869
-#, fuzzy, python-brace-format
-#| msgid "Username"
-msgid "{wp_username}"
-msgstr "सदस्यनाव"
 
 #. Translators: This error message is shown when there's a problem with the authenticated login process.
 #: TWLight/users/oauth.py:243
@@ -2573,9 +2255,7 @@ msgstr ""
 
 #. Translators: this message is displayed to users that don't have accounts and clicked on a proxied link.
 #: TWLight/users/oauth.py:388
-msgid ""
-"To view this link you need to be an eligible library user. Please login to "
-"continue."
+msgid "To view this link you need to be an eligible library user. Please login to continue."
 msgstr ""
 
 #. Translators: This warning message is shown to users when the response received from Wikimedia OAuth servers is not a valid one.
@@ -2611,17 +2291,12 @@ msgstr ""
 
 #. Translators: If the user tries to log in, but their account does not meet certain requirements, they cannot login.
 #: TWLight/users/oauth.py:528
-msgid ""
-"Your Wikipedia account does not meet the eligibility criteria in the terms "
-"of use, so your Wikipedia Library Card Platform account cannot be activated."
+msgid "Your Wikipedia account does not meet the eligibility criteria in the terms of use, so your Wikipedia Library Card Platform account cannot be activated."
 msgstr ""
 
 #. Translators: If the user tries to log in, but their account does not meet certain requirements, they cannot login.
 #: TWLight/users/oauth.py:536
-msgid ""
-"Your Wikipedia account no longer meets the eligibility criteria in the terms "
-"of use, so you cannot be logged in. If you think you should be able to log "
-"in, please email wikipedialibrary@wikimedia.org."
+msgid "Your Wikipedia account no longer meets the eligibility criteria in the terms of use, so you cannot be logged in. If you think you should be able to log in, please email wikipedialibrary@wikimedia.org."
 msgstr ""
 
 #. Translators: this message is displayed to users with brand new accounts.
@@ -2632,10 +2307,7 @@ msgstr ""
 #. Translators: This message is displayed on the confirmation page where users can return their access to partner collections.
 #: TWLight/users/templates/users/authorization_confirm_return.html:13
 #, python-format
-msgid ""
-"You will no longer be able to access <b>%(partner)s's</b> resources via the "
-"Library Card platform, but can request access again by clicking 'renew', if "
-"you change your mind. Are you sure you want to return your access?"
+msgid "You will no longer be able to access <b>%(partner)s's</b> resources via the Library Card platform, but can request access again by clicking 'renew', if you change your mind. Are you sure you want to return your access?"
 msgstr ""
 
 #. Translators: On the MyLibrary page (https://wikipedialibrary.wmflabs.org/users/my_library), this tab shows all favorite collections a user has.
@@ -2709,10 +2381,7 @@ msgstr ""
 
 #. Translators: This is shown on editor profiles, in their profile page or on applications.
 #: TWLight/users/templates/users/editor_detail.html:59
-msgid ""
-"Information with an * was retrieved from Wikipedia directly. Other "
-"information was entered directly by users or site admins, in their preferred "
-"language."
+msgid "Information with an * was retrieved from Wikipedia directly. Other information was entered directly by users or site admins, in their preferred language."
 msgstr ""
 
 #. Translators: This distinguishes users who have been flagged as account coordinators. Don't translate username.
@@ -2723,10 +2392,7 @@ msgstr ""
 
 #. Translators: This is shown on editor profiles, under the heading for Wikipedia editor data.
 #: TWLight/users/templates/users/editor_detail_data.html:5
-msgid ""
-"This information is updated automatically from your Wikimedia account each "
-"time you log in, except for the Contributions field, where you can describe "
-"your Wikimedia editing history."
+msgid "This information is updated automatically from your Wikimedia account each time you log in, except for the Contributions field, where you can describe your Wikimedia editing history."
 msgstr ""
 
 #. Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this labels the user's username.
@@ -2756,17 +2422,13 @@ msgstr ""
 
 #. Translators: when viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this question has a yes or no answer.
 #: TWLight/users/templates/users/editor_detail_data.html:57
-msgid ""
-"at their last login, did this user meet the criteria set forth in the terms "
-"of use?"
+msgid "at their last login, did this user meet the criteria set forth in the terms of use?"
 msgstr ""
 
 #. Translators: When viewing a user's profile in an application, this message shows if the software doesn't think that the user is eligible for access. Don't translate username.
 #: TWLight/users/templates/users/editor_detail_data.html:72
 #, python-format
-msgid ""
-"%(username)s may still be eligible for access grants at the coordinators' "
-"discretion."
+msgid "%(username)s may still be eligible for access grants at the coordinators' discretion."
 msgstr ""
 
 #. Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this is the heading for a Yes/No ToU question.
@@ -2801,10 +2463,7 @@ msgstr ""
 #. Translators: This message is shown on a user's profile if their Wikimedia account is blocked on one or more projects. They may still be granted access to the Library Bundle, but need to contact Wikipedia Library staff to verify.
 #: TWLight/users/templates/users/editor_detail_data.html:137
 #, python-format
-msgid ""
-"It looks like you have an active block on your account. If you meet the "
-"other criteria you may still be permitted access to the library - please <a "
-"class=\"twl-links\" href=\"%(contact_url)s\">contact us</a>."
+msgid "It looks like you have an active block on your account. If you meet the other criteria you may still be permitted access to the library - please <a class=\"twl-links\" href=\"%(contact_url)s\">contact us</a>."
 msgstr ""
 
 #. Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this is the heading for a Yes/No program eligibility question.
@@ -2814,10 +2473,7 @@ msgstr ""
 
 #. Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this question has a Yes or No answer.
 #: TWLight/users/templates/users/editor_detail_data.html:156
-msgid ""
-"At their last login, did this user meet the criteria set forth in the "
-"Library Bundle? Note that satisfying terms of use is a prerequisite to "
-"bundle eligibility."
+msgid "At their last login, did this user meet the criteria set forth in the Library Bundle? Note that satisfying terms of use is a prerequisite to bundle eligibility."
 msgstr ""
 
 #. Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this is the heading for a Yes/No program eligibility question.
@@ -2862,18 +2518,13 @@ msgstr ""
 
 #. Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this text is in the 'Personal data' section. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/users/templates/users/editor_detail_data.html:262
-msgid ""
-"The following information is visible only to you, site administrators, "
-"publishing partners (where required), and volunteer Wikipedia Library "
-"coordinators (who have signed a Non-Disclosure Agreement)."
+msgid "The following information is visible only to you, site administrators, publishing partners (where required), and volunteer Wikipedia Library coordinators (who have signed a Non-Disclosure Agreement)."
 msgstr ""
 
 #. Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this labels a button which users can click to update or remove their personal information. Don't translate update_url.
 #: TWLight/users/templates/users/editor_detail_data.html:272
 #, python-format
-msgid ""
-"You may <a class=\"twl-links\" href=\"%(update_url)s\">update or delete</a> "
-"your data at any time."
+msgid "You may <a class=\"twl-links\" href=\"%(update_url)s\">update or delete</a> your data at any time."
 msgstr ""
 
 #. Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this labels the user's email. Don't remove the *.
@@ -2893,24 +2544,18 @@ msgstr ""
 
 #. Translators: This message tells users that they are not eligible to access The Wikipedia Library content.
 #: TWLight/users/templates/users/eligibility_modal.html:7
-msgid ""
-"Sorry, your Wikipedia account doesn’t currently qualify to access The "
-"Wikipedia Library."
+msgid "Sorry, your Wikipedia account doesn’t currently qualify to access The Wikipedia Library."
 msgstr ""
 
 #. Translators: This message tells users that they have not agreed to the terms of use, therefore are ineligible to access the content in The Wikipedia Library.
 #: TWLight/users/templates/users/eligibility_modal.html:30
 #, python-format
-msgid ""
-"Agreed with <a href=\"%(terms)s\" class=\"text-danger\"> terms of use </a>"
+msgid "Agreed with <a href=\"%(terms)s\" class=\"text-danger\"> terms of use </a>"
 msgstr ""
 
 #: TWLight/users/templates/users/eligibility_modal.html:40
 #, python-format
-msgid ""
-"It looks like you have an active block on your account. If you meet the "
-"other criteria you may still be permitted access to the library - please <a "
-"href=\"%(contact_url)s\">contact us</a>."
+msgid "It looks like you have an active block on your account. If you meet the other criteria you may still be permitted access to the library - please <a href=\"%(contact_url)s\">contact us</a>."
 msgstr ""
 
 #. Translators: Instructions to refresh a user's data.
@@ -2950,10 +2595,7 @@ msgstr ""
 
 #. Translators: This text on the user page helps users naviage to the TranslateWiki Wikipedia Library Card platform translation page.
 #: TWLight/users/templates/users/language_form.html:31
-msgid ""
-"You can help translate the tool at <a class=\"twl-links\" href=\"https://"
-"translatewiki.net/wiki/Translating:Wikipedia_Library_Card_Platform"
-"\">translatewiki.net</a>."
+msgid "You can help translate the tool at <a class=\"twl-links\" href=\"https://translatewiki.net/wiki/Translating:Wikipedia_Library_Card_Platform\">translatewiki.net</a>."
 msgstr ""
 
 #. Translators: When the user starts a new application and submits the application, the user can view the application and withdraw if need be. This changes the label for the Withdraw button.
@@ -2973,9 +2615,7 @@ msgstr "परत वर्गणी भरा"
 
 #. Translators: On the page listing applications, this text explains a user they cannot renew their application since they've already requested a renewal or there aren't any renewals available.
 #: TWLight/users/templates/users/my_applications.html:79
-msgid ""
-"Renewals are either not required, not available right now, or you have "
-"already requested a renewal."
+msgid "Renewals are either not required, not available right now, or you have already requested a renewal."
 msgstr ""
 
 #. Translators: This text is the heading of a section in a user's profile where they can change their preferences.
@@ -3042,19 +2682,12 @@ msgstr ""
 
 #. Translators: This message is displayed on the page where users can request we stop processing their data.
 #: TWLight/users/templates/users/restrict_data.html:15
-msgid ""
-"Checking this box and clicking “Restrict” will pause all processing of the "
-"data you have entered into this website. You will not be able to apply for "
-"access to resources, your applications will not be further processed, and "
-"none of your data will be altered, until you return to this page and uncheck "
-"the box. This is not the same as deleting your data."
+msgid "Checking this box and clicking “Restrict” will pause all processing of the data you have entered into this website. You will not be able to apply for access to resources, your applications will not be further processed, and none of your data will be altered, until you return to this page and uncheck the box. This is not the same as deleting your data."
 msgstr ""
 
 #. Translators: This warning message is shown to coordinators who view the data restriction page.
 #: TWLight/users/templates/users/restrict_data.html:26
-msgid ""
-"You are a coordinator on this site. If you restrict the processing of your "
-"data, your coordinator flag will be removed."
+msgid "You are a coordinator on this site. If you restrict the processing of your data, your coordinator flag will be removed."
 msgstr ""
 
 #. Translators: use the date *when you are translating*, in a language-appropriate format.
@@ -3075,24 +2708,12 @@ msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:51
-msgid ""
-"<a class=\"twl-links\" href=\"https://meta.wikimedia.org/wiki/"
-"The_Wikipedia_Library\"> The Wikipedia Library </a> has partnered with "
-"publishers around the world to allow users to access otherwise paywalled "
-"resources. This website allows Wikipedia editors to search and access these "
-"resources."
+msgid "<a class=\"twl-links\" href=\"https://meta.wikimedia.org/wiki/The_Wikipedia_Library\"> The Wikipedia Library </a> has partnered with publishers around the world to allow users to access otherwise paywalled resources. This website allows Wikipedia editors to search and access these resources."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Wikimedia Foundation should not be translated. WMF should not be translated. Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:63
-msgid ""
-"This program is administered by the Wikimedia Foundation (WMF). These terms "
-"of use and privacy notice pertain to your application for access to "
-"resources through the Wikipedia Library, your use of this website, and your "
-"access to and use of those resources. They also describe our handling of the "
-"information you provide to us in order to create and administer your "
-"Wikipedia Library account. If we make material changes to the terms, we will "
-"notify users."
+msgid "This program is administered by the Wikimedia Foundation (WMF). These terms of use and privacy notice pertain to your application for access to resources through the Wikipedia Library, your use of this website, and your access to and use of those resources. They also describe our handling of the information you provide to us in order to create and administer your Wikipedia Library account. If we make material changes to the terms, we will notify users."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
@@ -3102,37 +2723,17 @@ msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:78
-msgid ""
-"Access to resources via The Wikipedia Library is reserved for community "
-"members who have demonstrated their commitment to the Wikimedia projects, "
-"and who will use their access to these resources to improve project content. "
-"To that end, in order to be eligible for The Wikipedia Library, we require "
-"that you be registered for a user account on the projects, with at least 500 "
-"edits, six (6) months of activity, and 10+ edits in the last month. We ask "
-"that you do not request access to any publishers with a limited number of "
-"available accounts whose resources you can already access for free through "
-"your local library or university, or another institution or organization, in "
-"order to provide that opportunity to others."
+msgid "Access to resources via The Wikipedia Library is reserved for community members who have demonstrated their commitment to the Wikimedia projects, and who will use their access to these resources to improve project content. To that end, in order to be eligible for The Wikipedia Library, we require that you be registered for a user account on the projects, with at least 500 edits, six (6) months of activity, and 10+ edits in the last month. We ask that you do not request access to any publishers with a limited number of available accounts whose resources you can already access for free through your local library or university, or another institution or organization, in order to provide that opportunity to others."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:94
-msgid ""
-"Additionally, if you are currently blocked or banned from a Wikimedia "
-"project, applications to resources may be rejected or restricted. If you "
-"obtain a Wikipedia Library account, but a block or ban is subsequently "
-"instituted against you on one of the projects, you may lose access to your "
-"Wikipedia Library account."
+msgid "Additionally, if you are currently blocked or banned from a Wikimedia project, applications to resources may be rejected or restricted. If you obtain a Wikipedia Library account, but a block or ban is subsequently instituted against you on one of the projects, you may lose access to your Wikipedia Library account."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:104
-msgid ""
-"Your eligibility to access The Wikipedia Library is assessed at each login. "
-"While more than half of the library's content is provided via this automated "
-"eligibility check, access to other publisher's content may be time limited, "
-"typically lapsing after one year, after which you will usually need to apply "
-"for renewal."
+msgid "Your eligibility to access The Wikipedia Library is assessed at each login. While more than half of the library's content is provided via this automated eligibility check, access to other publisher's content may be time limited, typically lapsing after one year, after which you will usually need to apply for renewal."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
@@ -3143,47 +2744,27 @@ msgstr "खालील विकिपिडीया ग्रंथालय 
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:118
-msgid ""
-"In order to apply for access to a partner resource, you must provide us with "
-"certain information, which we will use to evaluate your application. If your "
-"application is approved, we may transfer the information you have given us "
-"to the publishers whose resources you wish to access. They will either "
-"contact you with the account information directly or we will send access "
-"information to you ourselves."
+msgid "In order to apply for access to a partner resource, you must provide us with certain information, which we will use to evaluate your application. If your application is approved, we may transfer the information you have given us to the publishers whose resources you wish to access. They will either contact you with the account information directly or we will send access information to you ourselves."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:130
-msgid ""
-"In addition to the basic information you provide to us, our system will "
-"retrieve some information directly from the Wikimedia projects: your "
-"username, email address, edit count, registration date, user ID number, "
-"groups to which you belong, and any special user rights."
+msgid "In addition to the basic information you provide to us, our system will retrieve some information directly from the Wikimedia projects: your username, email address, edit count, registration date, user ID number, groups to which you belong, and any special user rights."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:140
-msgid ""
-"Each time you log in to the Wikipedia Library Card Platform, this "
-"information will be automatically updated."
+msgid "Each time you log in to the Wikipedia Library Card Platform, this information will be automatically updated."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:148
-msgid ""
-"We will ask you to provide us with some information about your history of "
-"contributions to the Wikimedia projects. Information on contribution history "
-"is optional, but will greatly assist us in evaluating your application."
+msgid "We will ask you to provide us with some information about your history of contributions to the Wikimedia projects. Information on contribution history is optional, but will greatly assist us in evaluating your application."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). WMF should not be translated. Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:157
-msgid ""
-"The information you provide when creating your account will be visible to "
-"you while on the site but not to others unless they are approved Wikipedia "
-"Library Coordinators, WMF Staff, or WMF Contractors who need access to this "
-"data in order to carry out their work with the Wikipedia Library, all of "
-"whom are subject to non-disclosure obligations."
+msgid "The information you provide when creating your account will be visible to you while on the site but not to others unless they are approved Wikipedia Library Coordinators, WMF Staff, or WMF Contractors who need access to this data in order to carry out their work with the Wikipedia Library, all of whom are subject to non-disclosure obligations."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
@@ -3193,46 +2774,32 @@ msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:171
-msgid ""
-"In order to access an individual publisher’s resources, you must agree to "
-"that publisher’s terms of use and privacy policy. You agree that you will "
-"not violate such terms and policies in connection with your use of the "
-"Wikipedia Library. Additionally, the following activities are prohibited "
-"while accessing publisher resources through the Wikipedia Library."
+msgid "In order to access an individual publisher’s resources, you must agree to that publisher’s terms of use and privacy policy. You agree that you will not violate such terms and policies in connection with your use of the Wikipedia Library. Additionally, the following activities are prohibited while accessing publisher resources through the Wikipedia Library."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:184
-msgid ""
-"Sharing your Wikipedia account, usernames, passwords, or any access codes "
-"for publisher resources with others;"
+msgid "Sharing your Wikipedia account, usernames, passwords, or any access codes for publisher resources with others;"
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:191
-msgid ""
-"Automatically scraping or downloading restricted content from publishers;"
+msgid "Automatically scraping or downloading restricted content from publishers;"
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:197
-msgid ""
-"Systematically making printed or electronic copies of multiple extracts of "
-"restricted content available for any purpose;"
+msgid "Systematically making printed or electronic copies of multiple extracts of restricted content available for any purpose;"
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:204
-msgid ""
-"Data mining metadata without permission—for example, in order to use "
-"metadata for auto-created stub articles;"
+msgid "Data mining metadata without permission—for example, in order to use metadata for auto-created stub articles;"
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:211
-msgid ""
-"Using the access you receive through the Wikipedia Library for profit by "
-"selling access to your account or resources which you have through it."
+msgid "Using the access you receive through the Wikipedia Library for profit by selling access to your account or resources which you have through it."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
@@ -3242,18 +2809,12 @@ msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:224
-msgid ""
-"Certain resources may only be accessed using an external search service, "
-"such as the EBSCO Discovery Service, or a proxy service, such as OCLC "
-"EZProxy. If you use such external search and/or proxy services, please "
-"review the applicable terms of use and privacy policies."
+msgid "Certain resources may only be accessed using an external search service, such as the EBSCO Discovery Service, or a proxy service, such as OCLC EZProxy. If you use such external search and/or proxy services, please review the applicable terms of use and privacy policies."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:234
-msgid ""
-"In addition, if you use OCLC EZProxy, please note that you may not use it "
-"for commercial purposes."
+msgid "In addition, if you use OCLC EZProxy, please note that you may not use it for commercial purposes."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
@@ -3263,120 +2824,49 @@ msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Wikimedia Foundation should not be translated. Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:245
-msgid ""
-"The Wikimedia Foundation and our service providers use your information for "
-"the legitimate purpose of providing Wikipedia Library services in support of "
-"our charitable mission. When you apply for a Wikipedia Library account, or "
-"use your Wikipedia Library account, we may routinely collect the following "
-"information: your username, email address, edit count, registration date, "
-"user ID number, groups to which you belong, and any special user rights; "
-"your name, country of residence, and/or affiliation, if required by a "
-"partner to which you are applying; your narrative description of your "
-"contributions and reasons for applying for access to partner resources; and "
-"the date you agree to these terms of use."
+msgid "The Wikimedia Foundation and our service providers use your information for the legitimate purpose of providing Wikipedia Library services in support of our charitable mission. When you apply for a Wikipedia Library account, or use your Wikipedia Library account, we may routinely collect the following information: your username, email address, edit count, registration date, user ID number, groups to which you belong, and any special user rights; your name, country of residence, and/or affiliation, if required by a partner to which you are applying; your narrative description of your contributions and reasons for applying for access to partner resources; and the date you agree to these terms of use."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:262
 #, python-format
-msgid ""
-"Each publisher who is a member of the Wikipedia Library program requires "
-"different specific information in the application. Some publishers may "
-"request only an email address, while others request more detailed data, such "
-"as your name, location, or institutional affiliation. When you complete your "
-"application, you will only be asked to supply information required by the "
-"publishers you have chosen, and each publisher will only receive the "
-"information they require for providing you with access. Please see our <a "
-"class=\"twl-links\" href=\"%(all_partners_url)s\">partner information</a> "
-"pages to learn what information is required by each publisher to gain access "
-"to their resources."
+msgid "Each publisher who is a member of the Wikipedia Library program requires different specific information in the application. Some publishers may request only an email address, while others request more detailed data, such as your name, location, or institutional affiliation. When you complete your application, you will only be asked to supply information required by the publishers you have chosen, and each publisher will only receive the information they require for providing you with access. Please see our <a class=\"twl-links\" href=\"%(all_partners_url)s\">partner information</a> pages to learn what information is required by each publisher to gain access to their resources."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Wikimedia Foundation should not be translated. Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:277
-msgid ""
-"Some Wikipedia Library pages are visible without logging in, but you will "
-"need to log in to apply or access proprietary partner resources. We use the "
-"data provided by you via OAuth and Wikimedia API calls to assess your "
-"application for access and to process approved requests."
+msgid "Some Wikipedia Library pages are visible without logging in, but you will need to log in to apply or access proprietary partner resources. We use the data provided by you via OAuth and Wikimedia API calls to assess your application for access and to process approved requests."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:288
 #, python-format
-msgid ""
-"In order to administer the Wikipedia Library program, we will retain the "
-"application data we collect from you for three years after your most recent "
-"login, unless you delete your account, as described below. You can log in "
-"and go to <a class=\"twl-links\" href=\"%(profile_url)s\">your profile page</"
-"a> in order to see the information associated with your account, and can "
-"download it in JSON format. You may access, update, restrict, or delete this "
-"information at any time, except for the information that is automatically "
-"retrieved from the projects. If you have any questions or concerns about the "
-"handling of your data, please contact <a class=\"twl-links\" href=\"mailto:"
-"wikipedialibrary@wikimedia.org?Subject=Wikipedia%%20Library%%20Card"
-"%%20account%%20deactivation\"> wikipedialibrary@wikimedia.org </a>."
+msgid "In order to administer the Wikipedia Library program, we will retain the application data we collect from you for three years after your most recent login, unless you delete your account, as described below. You can log in and go to <a class=\"twl-links\" href=\"%(profile_url)s\">your profile page</a> in order to see the information associated with your account, and can download it in JSON format. You may access, update, restrict, or delete this information at any time, except for the information that is automatically retrieved from the projects. If you have any questions or concerns about the handling of your data, please contact <a class=\"twl-links\" href=\"mailto:wikipedialibrary@wikimedia.org?Subject=Wikipedia%%20Library%%20Card%%20account%%20deactivation\"> wikipedialibrary@wikimedia.org </a>."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:305
-msgid ""
-"If you decide to disable your Wikipedia Library account, you can use the "
-"delete button on your profile to delete certain personal information "
-"associated with your account. We will delete your real name, institutional "
-"affiliation, and country of residence. Please note that the system will "
-"retain a record of your username, the publishers to which you applied or had "
-"access, and the dates of that access. Note that deletion is not reversible. "
-"Deletion of your Wikipedia Library account may also correspond with the "
-"removal of any resource access to which you were eligible or approved. If "
-"you request the deletion of account information and later wish to apply for "
-"a new account, you will need to provide the necessary information again."
+msgid "If you decide to disable your Wikipedia Library account, you can use the delete button on your profile to delete certain personal information associated with your account. We will delete your real name, institutional affiliation, and country of residence. Please note that the system will retain a record of your username, the publishers to which you applied or had access, and the dates of that access. Note that deletion is not reversible. Deletion of your Wikipedia Library account may also correspond with the removal of any resource access to which you were eligible or approved. If you request the deletion of account information and later wish to apply for a new account, you will need to provide the necessary information again."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). WMF should not be translated. Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:321
-msgid ""
-"The Wikipedia Library is run by WMF Staff, Contractors, and approved "
-"volunteer Coordinators. The data associated with your account will be shared "
-"with the WMF staff, contractors, service providers, and volunteer "
-"coordinators who need to process the information in connection with their "
-"work for the Wikipedia Library, and who are subject to confidentiality "
-"obligations. We will also use your data for internal Wikipedia Library "
-"purposes such as distributing user surveys and account notifications, and in "
-"a depersonalized or aggregated fashion for statistical analysis and "
-"administration. Finally, we will share your information with the publishers "
-"whom you specifically select in order to provide you with access to "
-"resources. Otherwise, your information will not be shared with third "
-"parties, with the exception of the circumstances described below."
+msgid "The Wikipedia Library is run by WMF Staff, Contractors, and approved volunteer Coordinators. The data associated with your account will be shared with the WMF staff, contractors, service providers, and volunteer coordinators who need to process the information in connection with their work for the Wikipedia Library, and who are subject to confidentiality obligations. We will also use your data for internal Wikipedia Library purposes such as distributing user surveys and account notifications, and in a depersonalized or aggregated fashion for statistical analysis and administration. Finally, we will share your information with the publishers whom you specifically select in order to provide you with access to resources. Otherwise, your information will not be shared with third parties, with the exception of the circumstances described below."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). WMF should not be translated.
 #: TWLight/users/templates/users/terms.html:338
-msgid ""
-"We may disclose any collected information when required by law, when we have "
-"your permission, when needed to protect our rights, privacy, safety, users, "
-"or the general public, and when necessary to enforce these terms, WMF’s "
-"general <a class=\"twl-links\" href=\"https://foundation.wikimedia.org/wiki/"
-"Terms_of_Use\">Terms of Use</a>, or any other WMF policy."
+msgid "We may disclose any collected information when required by law, when we have your permission, when needed to protect our rights, privacy, safety, users, or the general public, and when necessary to enforce these terms, WMF’s general <a class=\"twl-links\" href=\"https://foundation.wikimedia.org/wiki/Terms_of_Use\">Terms of Use</a>, or any other WMF policy."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:349
-msgid ""
-"We take the security of your personal data seriously, and take reasonable "
-"precautions to ensure your data is protected. These precautions include "
-"access controls to limit who has access to your data and security "
-"technologies to protect data stored on the server. However, we cannot "
-"guarantee the safety of your data as it is transmitted and stored."
+msgid "We take the security of your personal data seriously, and take reasonable precautions to ensure your data is protected. These precautions include access controls to limit who has access to your data and security technologies to protect data stored on the server. However, we cannot guarantee the safety of your data as it is transmitted and stored."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:360
-msgid ""
-"Please note that these terms do not control the use and handling of your "
-"data by the publishers and service providers whose resources you access or "
-"apply to access. Please read their individual privacy policies for that "
-"information."
+msgid "Please note that these terms do not control the use and handling of your data by the publishers and service providers whose resources you access or apply to access. Please read their individual privacy policies for that information."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
@@ -3386,34 +2876,17 @@ msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Wikimedia Foundation should not be translated. Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:373
-msgid ""
-"The Wikimedia Foundation is a nonprofit organization based in San Francisco, "
-"California. The Wikipedia Library program provides access to resources held "
-"by publishers in multiple countries. If you apply for a Wikipedia Library "
-"account (whether you are inside or outside of the United States), you "
-"understand that your personal data will be collected, transferred, stored, "
-"processed, disclosed and otherwise used in the U.S. as described in this "
-"privacy policy. You also understand that your information may be transferred "
-"by us from the U.S. to other countries, which may have different or less "
-"stringent data protection laws than your country, in connection with "
-"providing services to you, including evaluating your application and "
-"securing access to your chosen publishers (locations for each publisher are "
-"outlined on their respective partner information pages)."
+msgid "The Wikimedia Foundation is a nonprofit organization based in San Francisco, California. The Wikipedia Library program provides access to resources held by publishers in multiple countries. If you apply for a Wikipedia Library account (whether you are inside or outside of the United States), you understand that your personal data will be collected, transferred, stored, processed, disclosed and otherwise used in the U.S. as described in this privacy policy. You also understand that your information may be transferred by us from the U.S. to other countries, which may have different or less stringent data protection laws than your country, in connection with providing services to you, including evaluating your application and securing access to your chosen publishers (locations for each publisher are outlined on their respective partner information pages)."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:392
-msgid ""
-"Please note that in the event of any differences in meaning or "
-"interpretation between the original English version of these terms and a "
-"translation, the original English version takes precedence."
+msgid "Please note that in the event of any differences in meaning or interpretation between the original English version of these terms and a translation, the original English version takes precedence."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Wikimedia Foundation should not be translated.
 #: TWLight/users/templates/users/terms.html:403
-msgid ""
-"See also the <a class=\"twl-links\" href=\"https://wikimediafoundation.org/"
-"wiki/Privacy_policy\">Wikimedia Foundation Privacy Policy</a>."
+msgid "See also the <a class=\"twl-links\" href=\"https://wikimediafoundation.org/wiki/Privacy_policy\">Wikimedia Foundation Privacy Policy</a>."
 msgstr ""
 
 #. Translators: This is the second to last line of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
@@ -3433,11 +2906,7 @@ msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:426
-msgid ""
-"By checking this box and clicking “Submit”, you agree that you have read the "
-"above terms and that you will adhere to the terms of use in your application "
-"to and use of the The Wikipedia Library, and the publishers’ services to "
-"which you gain access through The Wikipedia Library program."
+msgid "By checking this box and clicking “Submit”, you agree that you have read the above terms and that you will adhere to the terms of use in your application to and use of the The Wikipedia Library, and the publishers’ services to which you gain access through The Wikipedia Library program."
 msgstr ""
 
 #: TWLight/users/templates/users/user_collection_tile.html:32
@@ -3492,29 +2961,18 @@ msgstr ""
 
 #. Translators: This message is displayed on the page where users can request the deletion of their data.
 #: TWLight/users/templates/users/user_confirm_delete.html:17
-msgid ""
-"<b>Warning:</b> Performing this action will delete your Wikipedia Library "
-"Card user account and all associated applications. This process is not "
-"reversible. You may lose any partner accounts you were granted, and will not "
-"be able to renew those accounts or apply for new ones."
+msgid "<b>Warning:</b> Performing this action will delete your Wikipedia Library Card user account and all associated applications. This process is not reversible. You may lose any partner accounts you were granted, and will not be able to renew those accounts or apply for new ones."
 msgstr ""
 
 #. Translators: this should show up for people who log in with a username/password and not OAuth, so we don't know what their Wikipedia identity is.
-#.
 #: TWLight/users/templates/users/user_detail.html:12
 #, python-format
-msgid ""
-"Hi, %(username)s! You don't have a Wikipedia editor profile attached to your "
-"account here, so you are probably a site administrator."
+msgid "Hi, %(username)s! You don't have a Wikipedia editor profile attached to your account here, so you are probably a site administrator."
 msgstr ""
 
 #. Translators: In the unlikely scenario that someone is able to register an account without using OAuth (thus leaving us without some of the information required for applications), users will see this message, encouraging them to re-register.
 #: TWLight/users/templates/users/user_detail.html:20
-msgid ""
-"If you aren't a site administrator, something weird has happened. You won't "
-"be able to apply for access without a Wikipedia editor profile. You should "
-"log out and create a new account by logging in via OAuth, or contact a site "
-"administrator for help."
+msgid "If you aren't a site administrator, something weird has happened. You won't be able to apply for access without a Wikipedia editor profile. You should log out and create a new account by logging in via OAuth, or contact a site administrator for help."
 msgstr ""
 
 #. Translators: Labels a sections where coordinators can select their email preferences.
@@ -3525,17 +2983,12 @@ msgstr ""
 #. Translators: This message is shown on user's own profile page, encouraging them to make sure their information is up to date, so that account coordinators can use the information to judge applications.
 #: TWLight/users/views.py:176
 #, python-brace-format
-msgid ""
-"Please <a class='twl-links' href='{url}'>update your contributions</a> to "
-"Wikipedia to help coordinators evaluate your applications."
+msgid "Please <a class='twl-links' href='{url}'>update your contributions</a> to Wikipedia to help coordinators evaluate your applications."
 msgstr ""
 
 #. Translators: Coordinators are shown this message when they unselect all three types of reminder email options under preferences.
 #: TWLight/users/views.py:288
-msgid ""
-"You have chosen not to receive reminder emails. As a coordinator, you should "
-"receive at least one type of reminder emails, so consider changing your "
-"preferences."
+msgid "You have chosen not to receive reminder emails. As a coordinator, you should receive at least one type of reminder emails, so consider changing your preferences."
 msgstr ""
 
 #. Translators: Coordinators are shown this message when they make changes to their reminder email options under preferences.
@@ -3569,9 +3022,7 @@ msgstr ""
 
 #. Translators: If the user has not filled out their email, they can browse the website but cannot apply for access to resources.
 #: TWLight/users/views.py:487
-msgid ""
-"Your email is blank. You can still explore the site, but you won't be able "
-"to apply for access to partner resources without an email."
+msgid "Your email is blank. You can still explore the site, but you won't be able to apply for access to partner resources without an email."
 msgstr ""
 
 #. Translators: This message is shown once the access to a partner has successfully been returned.
@@ -3604,31 +3055,3 @@ msgstr ""
 msgid "10+ edits in the last 30 days"
 msgstr ""
 
-#: tests/shunit/data/bad_i18n_comment_1.py:3
-#: tests/shunit/data/bad_i18n_newline_1.py:5
-msgid "1"
-msgstr ""
-
-#. Translators: Lorem ipsum dolor sit amet, consectetur adipiscing elit. Mauris vitae ipsum ut purus faucibus pretium. Proin tempus neque et aliquet consectetur. Ut egestas sapien in consectetur sagittis. Mauris neque lacus, dapibus non viverra vitae, interdum ut aenean ipsum.
-#. Translators: Lorem ipsum dolor sit amet, consectetur adipiscing elit. Mauris vitae ipsum ut purus faucibus pretium. Proin tempus neque et aliquet consectetur. Ut egestas sapien in consectetur sagittis. Mauris neque lacus, dapibus non.
-#: tests/shunit/data/bad_i18n_comment_2.py:4
-#: tests/shunit/data/bad_i18n_newline_2.py:5 tests/shunit/data/good_i18n_1.py:2
-#: tests/shunit/data/good_i18n_2.py:2
-msgid "2"
-msgstr ""
-
-#: tests/shunit/data/bad_i18n_newline_3.py:5
-msgid "3"
-msgstr ""
-
-#: tests/shunit/data/bad_i18n_newline_4.py:5
-msgid "4"
-msgstr ""
-
-#: tests/shunit/data/bad_i18n_newline_5.py:5
-msgid "5"
-msgstr ""
-
-#: tests/shunit/data/bad_i18n_newline_6.py:5
-msgid "6"
-msgstr ""

--- a/locale/ms/LC_MESSAGES/django.po
+++ b/locale/ms/LC_MESSAGES/django.po
@@ -10,10 +10,11 @@
 # Author: Zulfadli51
 msgid ""
 msgstr ""
+""
 "Project-Id-Version: Wikipedia Library Card Platform - Website\n"
-"Report-Msgid-Bugs-To: wikipedialibrary@wikimedia.org\n"
+"Report-Msgid-Bugs-To: translatewiki.net\n"
 "POT-Creation-Date: 2024-07-11 20:54+0000\n"
-"PO-Revision-Date: 2024-07-11 12:30:17+0000\n"
+"PO-Revision-Date: 2024-07-15 12:29:17+0000\n"
 "Language: ms\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
@@ -45,12 +46,8 @@ msgstr "Mengenai anda"
 #. Translators: This note appears in a section of a form where we ask users to enter info (like country of residence) when applying for resource access.
 #: TWLight/applications/forms.py:179
 #, python-brace-format
-msgid ""
-"<p><small><i>Your personal data will be processed according to our <a "
-"class='twl-links' href='{terms_url}'> privacy policy</a>.</i></small></p>"
-msgstr ""
-"<p><small><i>Data peribadi anda akan diproses menurut <a class='twl-links' "
-"href='{terms_url}'>dasar peribadi</a> kami.</i></small></p>"
+msgid "<p><small><i>Your personal data will be processed according to our <a class='twl-links' href='{terms_url}'> privacy policy</a>.</i></small></p>"
+msgstr "<p><small><i>Data peribadi anda akan diproses menurut <a class='twl-links' href='{terms_url}'>dasar peribadi</a> kami.</i></small></p>"
 
 #. Translators: This is the title of the application form page, where users enter information required for the application. It lets the user know which partner application they are entering data for. {partner}
 #: TWLight/applications/forms.py:189
@@ -91,12 +88,8 @@ msgstr "E-mel untuk akaun anda di laman web rakan kongsi"
 #. Translators: This labels a choice field where users will have to select the number of months they wish to have their access for as part of the application renewal confirmation.
 #. Translators: When filling out an application, users may be required to enter the length of the account (expiry) they wish to have for proxy partners.
 #: TWLight/applications/forms.py:339 TWLight/applications/helpers.py:100
-msgid ""
-"The number of months you wish to have this access for before renewal is "
-"required"
-msgstr ""
-"Bilangan bulan yang anda berhajat untuk mendapat capaian ini sebelum "
-"pembaharuan diperlukan."
+msgid "The number of months you wish to have this access for before renewal is required"
+msgstr "Bilangan bulan yang anda berhajat untuk mendapat capaian ini sebelum pembaharuan diperlukan."
 
 #. Translators: When filling out an application, users may need to specify their name
 #: TWLight/applications/helpers.py:81
@@ -184,9 +177,7 @@ msgstr "E-mel"
 
 #. Translators: This comment is added to pending applications when our terms of use change.
 #: TWLight/applications/management/commands/notify_applicants_tou_changes.py:54
-msgid ""
-"Our terms of use have changed. Your applications will not be processed until "
-"you log in and agree to our updated terms."
+msgid "Our terms of use have changed. Your applications will not be processed until you log in and agree to our updated terms."
 msgstr ""
 
 #. Translators: This is the status of an application that has not yet been reviewed.
@@ -253,40 +244,26 @@ msgstr ""
 
 #. Translators: This text goes into account approval emails in the case that we need to send the user's details to a publisher for manual account setup.
 #: TWLight/applications/models.py:331
-msgid ""
-"You can expect to receive access details within a week or two once it has "
-"been processed."
-msgstr ""
-"Anda boleh mengharapkan untuk menerima butiran akses dalam seminggu atau dua "
-"sebaik sahaja ia telah diproses."
+msgid "You can expect to receive access details within a week or two once it has been processed."
+msgstr "Anda boleh mengharapkan untuk menerima butiran akses dalam seminggu atau dua sebaik sahaja ia telah diproses."
 
 #. Translators: This comment is added to open applications when a partner joins the Library Bundle, which does not require applications.
 #: TWLight/applications/signals.py:247
-msgid ""
-"This partner joined the Library Bundle, which does not require applications. "
-"This application will be marked as invalid."
+msgid "This partner joined the Library Bundle, which does not require applications. This application will be marked as invalid."
 msgstr ""
 
 #. Translators: This is shown to users if the application is to a partner for which we have run out of available accounts. The application is therefore on a 'waitlist', and will be reviewed when more accounts are available.
 #: TWLight/applications/templates/applications/application_evaluation.html:29
-msgid ""
-"This application is on the waitlist because this partner does not have any "
-"access grants available at this time."
-msgstr ""
-"Permohonan ini adalah dalam senarai menunggu kerana rakan kongsi ini tidak "
-"mempunyai sebarang kebenaran akses yang ada pada masa ini."
+msgid "This application is on the waitlist because this partner does not have any access grants available at this time."
+msgstr "Permohonan ini adalah dalam senarai menunggu kerana rakan kongsi ini tidak mempunyai sebarang kebenaran akses yang ada pada masa ini."
 
 #. Translators: This message is shown on pages where coordinators can see personal information about applicants.
 #: TWLight/applications/templates/applications/application_evaluation.html:36
 #: TWLight/applications/templates/applications/application_list_include.html:6
 #: TWLight/applications/templates/applications/send_partner.html:45
 #: TWLight/resources/templates/resources/partner_users.html:18
-msgid ""
-"Coordinators: This page may contain personal information such as real names "
-"and email addresses. Please remember that this information is confidential."
-msgstr ""
-"Penyelaras: Laman ini mungkin mengandungi maklumat peribadi seperti nama "
-"sebenar dan alamat e-mel. Sila ingat bahawa maklumat ini adalah rahsia."
+msgid "Coordinators: This page may contain personal information such as real names and email addresses. Please remember that this information is confidential."
+msgstr "Penyelaras: Laman ini mungkin mengandungi maklumat peribadi seperti nama sebenar dan alamat e-mel. Sila ingat bahawa maklumat ini adalah rahsia."
 
 #. Translators: This is the title of the application page shown to users who are a coordinator, and are able to accept or reject the application.
 #: TWLight/applications/templates/applications/application_evaluation.html:39
@@ -295,12 +272,8 @@ msgstr "Nilai permohonan"
 
 #. Translators: This text is shown to coordinators on application pages if the applicant has restricted processing of their data.
 #: TWLight/applications/templates/applications/application_evaluation.html:42
-msgid ""
-"This user has requested a restriction on the processing of their data, so "
-"you cannot change the status of their application."
-msgstr ""
-"Pengguna ini telah meminta sekatan ke atas pemprosesan data mereka, jadi "
-"anda tidak boleh menukar status permohonan mereka."
+msgid "This user has requested a restriction on the processing of their data, so you cannot change the status of their application."
+msgstr "Pengguna ini telah meminta sekatan ke atas pemprosesan data mereka, jadi anda tidak boleh menukar status permohonan mereka."
 
 #. Translators: This is the title of the application page shown to users who are not a coordinator.
 #: TWLight/applications/templates/applications/application_evaluation.html:48
@@ -373,9 +346,7 @@ msgstr "Tidak diketahui"
 
 #. Translators: This is the text displayed to coordinators when an applicant has no country of residence in their profile.
 #: TWLight/applications/templates/applications/application_evaluation.html:123
-msgid ""
-"Please request the applicant add their country of residence to their profile "
-"before proceeding further."
+msgid "Please request the applicant add their country of residence to their profile before proceeding further."
 msgstr ""
 
 #. Translators: This labels the section of an application showing the total number of accounts available for a partner or their collection.
@@ -386,12 +357,8 @@ msgstr ""
 #. Translators: This labels the section of an application showing whether the user had agreed to the terms of use or not.
 #: TWLight/applications/templates/applications/application_evaluation.html:145
 #, fuzzy, python-format
-msgid ""
-"Has agreed to the site's <a class=\"twl-links\" href=\"%(terms_url)s\">terms "
-"of use</a>?"
-msgstr ""
-"%(publisher)s memerlukan anda untuk bersetuju dengan <a href=\"%(url)s"
-"\">terma penggunaan</a>nya."
+msgid "Has agreed to the site's <a class=\"twl-links\" href=\"%(terms_url)s\">terms of use</a>?"
+msgstr "%(publisher)s memerlukan anda untuk bersetuju dengan <a href=\"%(url)s\">terma penggunaan</a>nya."
 
 #. Translators: Displayed to coordinators when they've agreed to the terms of use.
 #. Translators: Displayed if the user has agreed to the terms of use.
@@ -426,9 +393,7 @@ msgstr "Tidak"
 
 #. Translators: This is the text displayed to coordinators when an applicant has not agreed to the terms of use.
 #: TWLight/applications/templates/applications/application_evaluation.html:159
-msgid ""
-"Please request the applicant agree to the site's terms of use before "
-"approving this application."
+msgid "Please request the applicant agree to the site's terms of use before approving this application."
 msgstr ""
 
 #. Translators: This labels the section of an application containing the user's motivation for wanting access to this resource.
@@ -449,10 +414,8 @@ msgstr "Pembaharuan kebenaran akses yang sedia ada?"
 #. Translators: This message is shown next to the 'Renewal of existing access grant?' label if the application is a renewal. Don't translate HTML tags or parent_url.
 #: TWLight/applications/templates/applications/application_evaluation.html:195
 #, python-format
-msgid ""
-"Yes (<a class=\"twl-links\" href=\"%(parent_url)s\">previous application</a>)"
-msgstr ""
-"Ya (<a class=\"twl-links\" href=\"%(parent_url)s\">permohonan terdahulu</a>)"
+msgid "Yes (<a class=\"twl-links\" href=\"%(parent_url)s\">previous application</a>)"
+msgstr "Ya (<a class=\"twl-links\" href=\"%(parent_url)s\">permohonan terdahulu</a>)"
 
 #. Translators: This labels the section of the application showing the length of access remaining on the user's previous authorization.
 #: TWLight/applications/templates/applications/application_evaluation.html:208
@@ -486,12 +449,8 @@ msgstr "Tambah ulasan"
 
 #. Translators: On an application page, this text tells users that the comments posted on the application are visible to coordinators and the submitting user only.
 #: TWLight/applications/templates/applications/application_evaluation.html:297
-msgid ""
-"Comments are visible to all coordinators and to the editor who submitted "
-"this application."
-msgstr ""
-"Ulasan boleh dilihat oleh semua penyelaras dan penyunting yang mengemukakan "
-"permohonan ini."
+msgid "Comments are visible to all coordinators and to the editor who submitted this application."
+msgstr "Ulasan boleh dilihat oleh semua penyelaras dan penyunting yang mengemukakan permohonan ini."
 
 #. Translators: This is the title of the section of an application page which lists information about the user who submitted the application.
 #. Translators: On the page where coordinators can view data on applications to a partner they coordinate, this is a table column heading for the username.
@@ -703,12 +662,7 @@ msgstr "Tetapkan status"
 
 #: TWLight/applications/templates/applications/apply.html:20
 #, python-format
-msgid ""
-"If your application is successful we may share your email address with "
-"%(partner)s. This is required to set up your access to their resources. By "
-"submitting this form you agree to allow your email address to be shared with "
-"%(partner)s if your application is successful, for the purposes of account "
-"setup."
+msgid "If your application is successful we may share your email address with %(partner)s. This is required to set up your access to their resources. By submitting this form you agree to allow your email address to be shared with %(partner)s if your application is successful, for the purposes of account setup."
 msgstr ""
 
 #. Translators: This message is displayed on the page where users can confirm their renewal. Please do not translate partner.
@@ -737,9 +691,7 @@ msgstr "Apakah sumber yang anda ingin akses?"
 
 #. Translators: This text explains that Library Bundle partners are not shown in this list.
 #: TWLight/applications/templates/applications/request_for_application.html:26
-msgid ""
-"Library Bundle partners are not shown as eligibility is determined "
-"automatically."
+msgid "Library Bundle partners are not shown as eligibility is determined automatically."
 msgstr ""
 
 #. Translators: On the page where users can apply for multiple partners, this message shows next to the partner name, taking them to the full application page when clicked.
@@ -754,15 +706,8 @@ msgstr "Belum ada ditambah data rakan kongsi."
 
 #. Translators: the HTML is so that the word 'waitlisted' will look the same as it does in the page above; please translate 'waitlisted' the same way you did elsewhere in this file.
 #: TWLight/applications/templates/applications/request_for_application.html:74
-msgid ""
-"You can apply to <span class=\"badge badge-warning\">Waitlisted</span> "
-"partners, but they don't have access grants available right now. We will "
-"process those applications when access becomes available."
-msgstr ""
-"Anda boleh memohon kepada rakan kongsi <span class=\"badge badge-warning"
-"\">Disenarai tunggu</span>, tetapi mereka tidak mempunyai kebenaran akses "
-"yang ada pada masa ini. Kami akan memproses permohonan tersebut apabila "
-"akses sudah ada."
+msgid "You can apply to <span class=\"badge badge-warning\">Waitlisted</span> partners, but they don't have access grants available right now. We will process those applications when access becomes available."
+msgstr "Anda boleh memohon kepada rakan kongsi <span class=\"badge badge-warning\">Disenarai tunggu</span>, tetapi mereka tidak mempunyai kebenaran akses yang ada pada masa ini. Kami akan memproses permohonan tersebut apabila akses sudah ada."
 
 #. Translators: On the page where coordinators can see approved applications which have not had their details sent to the partner, this message shows when there are applications ready to be processed.
 #: TWLight/applications/templates/applications/send.html:10
@@ -772,8 +717,7 @@ msgstr "Rakan kongsi dengan pemohonan yang lulus, yang tidak dihantar"
 #. Translators: On the page where coordinators can see approved applications which have not had their details sent to the partner, this message shows when no such applications exist or all have already been sent.
 #: TWLight/applications/templates/applications/send.html:23
 msgid "There are no partners with applications ready to send."
-msgstr ""
-"Tiada sebarang rakan kongsi dengan permohonan yang sedia untuk dihantar."
+msgstr "Tiada sebarang rakan kongsi dengan permohonan yang sedia untuk dihantar."
 
 #. Translators: When viewing the list of applications ready to be sent for a particular partner, this is the title of the page, where object will be the name of the partner. Don't translate object.
 #: TWLight/applications/templates/applications/send_partner.html:40
@@ -784,19 +728,13 @@ msgstr "Data permohonan untuk %(object)s"
 #. Translators: This message is shown when applications exceed the number of accounts available.
 #: TWLight/applications/templates/applications/send_partner.html:54
 #, python-format
-msgid ""
-"Application(s) for %(object)s, if sent, will exceed the total available "
-"accounts for the partner. Please proceed at your own discretion."
-msgstr ""
-"Permohonan untuk %(object)s, jika dihantar, akan melebihi jumlah akaun yang "
-"sedia ada bagi rakan kongsi. Sila teruskan mengikut budi bicara anda sendiri."
+msgid "Application(s) for %(object)s, if sent, will exceed the total available accounts for the partner. Please proceed at your own discretion."
+msgstr "Permohonan untuk %(object)s, jika dihantar, akan melebihi jumlah akaun yang sedia ada bagi rakan kongsi. Sila teruskan mengikut budi bicara anda sendiri."
 
 #. Translators: When viewing the list of applications ready to be sent for a particular partner, this is instructions for the coordinator to click the 'mark as sent' button after they have sent the information.
 #: TWLight/applications/templates/applications/send_partner.html:65
 msgid "When you've processed the data below, click the 'mark as sent' button."
-msgstr ""
-"Apabila anda telah memproses data di bawah, klik butang 'tandakan sebagai "
-"dihantar'."
+msgstr "Apabila anda telah memproses data di bawah, klik butang 'tandakan sebagai dihantar'."
 
 #. Translators: When viewing the list of applications ready to be sent for a particular partner, this is the title of the section containing contact information for the people applications should be sent to.
 #: TWLight/applications/templates/applications/send_partner.html:71
@@ -806,12 +744,8 @@ msgstr[0] "Kenalan"
 
 #. Translators: When viewing the list of applications ready to be sent for a particular partner, this message shows if there is no information about who the applications should be sent to. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/applications/templates/applications/send_partner.html:89
-msgid ""
-"Whoops, we don't have any listed contacts. Please notify Wikipedia Library "
-"administrators."
-msgstr ""
-"Maaf, kami tidak mempunyai sebarang kenalan yang tersenarai. Sila maklumkan "
-"kepada pentadbir Perpustakaan Wikipedia."
+msgid "Whoops, we don't have any listed contacts. Please notify Wikipedia Library administrators."
+msgstr "Maaf, kami tidak mempunyai sebarang kenalan yang tersenarai. Sila maklumkan kepada pentadbir Perpustakaan Wikipedia."
 
 #. Translators: When viewing the list of applications ready to be sent for a particular partner, this is the title of the section containing the information about those applications.
 #: TWLight/applications/templates/applications/send_partner.html:94
@@ -826,9 +760,7 @@ msgstr "Tandakan sebagai dihantar"
 
 #. Translators: This text guides coordinators in using the code sending interface for approved applications.
 #: TWLight/applications/templates/applications/send_partner.html:152
-msgid ""
-"Use the dropdown menus to denote which editor will receive each code. Access "
-"codes will be sent to users automatically."
+msgid "Use the dropdown menus to denote which editor will receive each code. Access codes will be sent to users automatically."
 msgstr ""
 
 #. Translators: This labels a drop-down selection where staff can assign an access code to a user.
@@ -844,24 +776,14 @@ msgstr "Tiada sebarang permohonan yang diluluskan, yang tidak dihantar."
 #. Translators: When a user applies for a set of resources, they receive this message if none are currently available. They are instead placed on a 'waitlist' for later approval.
 #. Translators: When a user renews their resource, they receive this message if none are currently available. They are instead placed on a 'waitlist' for later approval.
 #: TWLight/applications/views.py:140 TWLight/applications/views.py:1282
-msgid ""
-"This partner does not have any access grants available at this time. You may "
-"still apply for access; your application will be reviewed when access grants "
-"become available."
-msgstr ""
-"Rakan kongsi ini tidak mempunyai sebarang kebenaran akses yang sedia ada "
-"pada masa ini. Anda masih boleh memohon akses; permohonan anda akan disemak "
-"apabila kebenaran akses sudah ada."
+msgid "This partner does not have any access grants available at this time. You may still apply for access; your application will be reviewed when access grants become available."
+msgstr "Rakan kongsi ini tidak mempunyai sebarang kebenaran akses yang sedia ada pada masa ini. Anda masih boleh memohon akses; permohonan anda akan disemak apabila kebenaran akses sudah ada."
 
 #. Translators: This message is shown to users once they've successfully submitted their application for review.
 #: TWLight/applications/views.py:163
 #, fuzzy, python-brace-format
-msgid ""
-"Your application has been submitted for review. Head over to <a "
-"href='{applications_url}'>My Applications</a> to view the status."
-msgstr ""
-"Permohonan anda telah diserahkan untuk semakan. Anda boleh menyemak status "
-"permohonan anda di halaman ini."
+msgid "Your application has been submitted for review. Head over to <a href='{applications_url}'>My Applications</a> to view the status."
+msgstr "Permohonan anda telah diserahkan untuk semakan. Anda boleh menyemak status permohonan anda di halaman ini."
 
 #. Translators: This text is displayed to users when the user has chosen to restrict data and is trying to apply for multiple partners
 #: TWLight/applications/views.py:276
@@ -909,16 +831,12 @@ msgstr "Permohonan yang dihantar"
 
 #. Translators: After a coordinator has changed the status of an application to APPROVED, if the corresponding partner/collection is waitlisted this message appears.
 #: TWLight/applications/views.py:756
-msgid ""
-"Cannot approve application as partner with proxy authorization method is "
-"waitlisted."
+msgid "Cannot approve application as partner with proxy authorization method is waitlisted."
 msgstr ""
 
 #. Translators: After a coordinator has changed the status of an application to APPROVED, if the corresponding partner/collection has no accounts for distribution, this message appears.
 #: TWLight/applications/views.py:780
-msgid ""
-"Cannot approve application as partner with proxy authorization method is "
-"waitlisted and (or) has zero accounts available for distribution."
+msgid "Cannot approve application as partner with proxy authorization method is waitlisted and (or) has zero accounts available for distribution."
 msgstr ""
 
 #. Translators: This message appears on an "access denied" screen that stops users who attempt to authorize an editor to access a resource during a time period for which they are already authorized.
@@ -929,11 +847,7 @@ msgstr "Anda cuba mencipta kebenaran pendua."
 #. Translators: This message is shown to users when they access an application page of a now Bundle partner (new applications aren't allowed for Bundle partners and the status of old applications cannot be modified)
 #: TWLight/applications/views.py:857
 #, python-brace-format
-msgid ""
-"This application cannot be modified since this partner is now part of our <a "
-"href='{bundle}'>bundle access</a>. If you are eligible, you can access this "
-"resource from <a href='{library}'>your library</a>. <a "
-"href='{contact}'>Contact us</a> if you have any questions."
+msgid "This application cannot be modified since this partner is now part of our <a href='{bundle}'>bundle access</a>. If you are eligible, you can access this resource from <a href='{library}'>your library</a>. <a href='{contact}'>Contact us</a> if you have any questions."
 msgstr ""
 
 #. Translators: this lets a reviewer set the status of a single application.
@@ -943,9 +857,7 @@ msgstr "Tetapkan status permohonan"
 
 #. Translators: This warning is message is shown to applicants when the number of pending applications is greater than the number of accounts available.
 #: TWLight/applications/views.py:891
-msgid ""
-"There are more pending applications than available accounts. Your "
-"application might get waitlisted."
+msgid "There are more pending applications than available accounts. Your application might get waitlisted."
 msgstr ""
 
 #. Translators: this message is shown to coordinators who attempt to change an application's Status from INVALID to any other Status.
@@ -966,11 +878,7 @@ msgstr "Kemas kini kumpulan berjaya."
 
 #. Translators: After a coordinator has changed the status of a number of applications to APPROVED, if the corresponding partner(s) is/are waitlisted or has no accounts for distribution, this message appears.
 #: TWLight/applications/views.py:1051
-msgid ""
-"Cannot approve application(s) {} as partner(s) with proxy authorization "
-"method is/are waitlisted and (or) has/have not enough accounts available. If "
-"not enough accounts are available, prioritise the applications and then "
-"approve applications equal to the accounts available."
+msgid "Cannot approve application(s) {} as partner(s) with proxy authorization method is/are waitlisted and (or) has/have not enough accounts available. If not enough accounts are available, prioritise the applications and then approve applications equal to the accounts available."
 msgstr ""
 
 #. Translators: This message is shown to coordinators who attempt to assign the same access code to multiple users.
@@ -985,9 +893,7 @@ msgstr "Semua permohonan yang terpilih telah ditandakan sebagai dihantar."
 
 #. Translators: When a user tries to renew their resource, they receive this message if the partner is not available.
 #: TWLight/applications/views.py:1272
-msgid ""
-"Cannot renew application at this time as partner is not available. Please "
-"check back later, or contact us for more information."
+msgid "Cannot renew application at this time as partner is not available. Please check back later, or contact us for more information."
 msgstr ""
 
 #. Translators: This message is displayed when an attempt by a user to renew an application has been denied for some reason.
@@ -998,21 +904,13 @@ msgstr ""
 
 #. Translators: If a user requests the renewal of their account, but it wasn't renewed, this message is shown to them.
 #: TWLight/applications/views.py:1385
-msgid ""
-"This object cannot be renewed. (This probably means that you have already "
-"requested that it be renewed.)"
-msgstr ""
-"Objek ini tidak boleh diperbaharui. (Ini mungkin bermakna anda telah meminta "
-"supaya ia diperbaharui.)"
+msgid "This object cannot be renewed. (This probably means that you have already requested that it be renewed.)"
+msgstr "Objek ini tidak boleh diperbaharui. (Ini mungkin bermakna anda telah meminta supaya ia diperbaharui.)"
 
 #. Translators: If a user requests the renewal of their account, this message is shown to them.
 #: TWLight/applications/views.py:1395
-msgid ""
-"Your renewal request has been received. A coordinator will review your "
-"request."
-msgstr ""
-"Permintaan pembaharuan anda telah diterima. Penyelaras akan menyemak "
-"permintaan anda."
+msgid "Your renewal request has been received. A coordinator will review your request."
+msgstr "Permintaan pembaharuan anda telah diterima. Penyelaras akan menyemak permintaan anda."
 
 #. Translators: This labels a textfield where users can enter their email ID.
 #: TWLight/emails/forms.py:18
@@ -1021,12 +919,8 @@ msgstr "E-mel anda"
 
 #. Translators: This is the help text for the email field in the contact us form letting users know the field is updated by value pulled from their respective user profiles.
 #: TWLight/emails/forms.py:21
-msgid ""
-"This field is automatically updated with the email from your <a class='twl-"
-"links' href='{}'>user profile</a>."
-msgstr ""
-"Medan ini dikemas kini secara automatik dengan e-mel daripada <a class='twl-"
-"links' href='{}'>profil pengguna</a> anda."
+msgid "This field is automatically updated with the email from your <a class='twl-links' href='{}'>user profile</a>."
+msgstr "Medan ini dikemas kini secara automatik dengan e-mel daripada <a class='twl-links' href='{}'>profil pengguna</a> anda."
 
 #. Translators: This labels a textfield where users can enter their email message.
 #: TWLight/emails/forms.py:26
@@ -1049,19 +943,13 @@ msgstr "Hantar"
 #. Translators: This email is sent to users with their access code. Don't translate Jinja variables in curly braces like user or partner. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/access_code_email-body-html.html:5
 #, python-format
-msgid ""
-"<p>Your approved application to %(partner)s has now been finalised. Your "
-"access code or login details can be found below:</p> <p><b>%(access_code)s</"
-"b></p> <p>%(user_instructions)s</p>"
+msgid "<p>Your approved application to %(partner)s has now been finalised. Your access code or login details can be found below:</p> <p><b>%(access_code)s</b></p> <p>%(user_instructions)s</p>"
 msgstr ""
 
 #. Translators: This email is sent to users with their access code. Don't translate Jinja variables in curly braces like user or partner. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/access_code_email-body-text.html:3
 #, python-format
-msgid ""
-"Your approved application to %(partner)s has now been finalised. Your access "
-"code or login details can be found below: %(access_code)s "
-"%(user_instructions)s"
+msgid "Your approved application to %(partner)s has now been finalised. Your access code or login details can be found below: %(access_code)s %(user_instructions)s"
 msgstr ""
 
 #. Translators: This is the subject line of an email sent to users with their access code.
@@ -1072,33 +960,14 @@ msgstr "Kod akses Perpustakaan Wikipedia anda"
 #. Translators: This email is sent to users when their application is approved. Don't translate Jinja variables in curly braces like user or partner; don't translate html tags either. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/approval_notification-body-html.html:5
 #, fuzzy, python-format
-msgid ""
-"<p>Dear %(user)s,</p> <p>Thank you for applying for access to %(partner)s "
-"resources through The Wikipedia Library. We are happy to inform you that "
-"your application has been approved.</p> <p>%(user_instructions)s</p> <p>You "
-"can view the collections you're authorized to access at My Library: "
-"%(link)s</p> <p>Cheers!</p> <p>The Wikipedia Library</p>"
-msgstr ""
-"<p>Wahai %(user)s,</p> <p>Terima kasih kerana memohon untuk mengakses sumber "
-"%(partner)s menerusi Perpustakaan Wikipedia. Kami berbesar hati untuk "
-"memaklumkan kepada anda bahawa permohonan anda telah diluluskan.</p> <p>"
-"%(user_instructions)s</p> <p>Tahniah!</p> <p>Perpustakaan Wikipedia</p>"
+msgid "<p>Dear %(user)s,</p> <p>Thank you for applying for access to %(partner)s resources through The Wikipedia Library. We are happy to inform you that your application has been approved.</p> <p>%(user_instructions)s</p> <p>You can view the collections you're authorized to access at My Library: %(link)s</p> <p>Cheers!</p> <p>The Wikipedia Library</p>"
+msgstr "<p>Wahai %(user)s,</p> <p>Terima kasih kerana memohon untuk mengakses sumber %(partner)s menerusi Perpustakaan Wikipedia. Kami berbesar hati untuk memaklumkan kepada anda bahawa permohonan anda telah diluluskan.</p> <p>%(user_instructions)s</p> <p>Tahniah!</p> <p>Perpustakaan Wikipedia</p>"
 
 #. Translators: This email is sent to users when their application is approved. Don't translate Jinja variables in curly braces like user or partner. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/approval_notification-body-text.html:3
 #, python-format
-msgid ""
-"Dear %(user)s, Thank you for applying for access to %(partner)s resources "
-"through The Wikipedia Library. We are happy to inform you that your "
-"application has been approved. %(user_instructions)s You can view the "
-"collections you're authorized to access at My Library: %(link)s Cheers! The "
-"Wikipedia Library"
-msgstr ""
-"Wahai %(user)s, Terima kasih kerana memohon untuk mengakses sumber "
-"%(partner)s menerusi Perpustakaan Wikipedia. Kami berbesar hati untuk "
-"memaklumkan kepada anda bahawa permohonan anda telah diluluskan. "
-"%(user_instructions)s Anda boleh melihat koleksi yang dibenarkan akses di "
-"Perpustakaan Saya: %(link)s Tahniah! Perpustakaan Wikipedia"
+msgid "Dear %(user)s, Thank you for applying for access to %(partner)s resources through The Wikipedia Library. We are happy to inform you that your application has been approved. %(user_instructions)s You can view the collections you're authorized to access at My Library: %(link)s Cheers! The Wikipedia Library"
+msgstr "Wahai %(user)s, Terima kasih kerana memohon untuk mengakses sumber %(partner)s menerusi Perpustakaan Wikipedia. Kami berbesar hati untuk memaklumkan kepada anda bahawa permohonan anda telah diluluskan. %(user_instructions)s Anda boleh melihat koleksi yang dibenarkan akses di Perpustakaan Saya: %(link)s Tahniah! Perpustakaan Wikipedia"
 
 #. Translators: This is the subject of an email which is sent to users when their application has been approved. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/approval_notification-subject.html:4
@@ -1108,19 +977,13 @@ msgstr "Permohonan Perpustakaan Wikipedia anda telah diluluskan"
 #. Translators: This email is sent to coordinators when a comment is left on an application they are processing. Don't translate Jinja variables in curly braces like user or partner. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/comment_notification_coordinator-body-html.html:5
 #, python-format
-msgid ""
-"<p style=\"color: #500050\">%(submit_date)s - %(commenter)s</p> "
-"<blockquote><p>%(comment)s</p></blockquote> <p>Please reply to these at: <a "
-"href=\"%(app_url)s\">%(app_url)s</a></p> <p>Best,</p> <p>The Wikipedia "
-"Library</p>"
+msgid "<p style=\"color: #500050\">%(submit_date)s - %(commenter)s</p> <blockquote><p>%(comment)s</p></blockquote> <p>Please reply to these at: <a href=\"%(app_url)s\">%(app_url)s</a></p> <p>Best,</p> <p>The Wikipedia Library</p>"
 msgstr ""
 
 #. Translators: This email is sent to coordinators when a comment is left on an application they are processing. Don't translate Jinja variables in curly braces like user or partner. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/comment_notification_coordinator-body-text.html:3
 #, python-format
-msgid ""
-"%(submit_date)s - %(commenter)s %(comment)s Please reply to this at: "
-"%(app_url)s Best, The Wikipedia Library"
+msgid "%(submit_date)s - %(commenter)s %(comment)s Please reply to this at: %(app_url)s Best, The Wikipedia Library"
 msgstr ""
 
 #. Translators: This is the subject line of an email sent to coordinators when a comment is left on an application they processed.
@@ -1131,19 +994,13 @@ msgstr "Ulasan baharu pada permohonan Perpustakaan Wikipedia yang anda proses"
 #. Translators: This email is sent to users when they receive a comment on their application. Don't translate Jinja variables in curly braces like user or partner; don't translate html tags either. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/comment_notification_editors-body-html.html:5
 #, python-format
-msgid ""
-"<p style=\"color: #500050\">%(submit_date)s - %(commenter)s</p> "
-"<blockquote><p>%(comment)s</p></blockquote> <p>Please reply to these at <a "
-"href=\"%(app_url)s\">%(app_url)s</a> so we can evaluate your application.</"
-"p> <p>Best,</p> <p>The Wikipedia Library</p>"
+msgid "<p style=\"color: #500050\">%(submit_date)s - %(commenter)s</p> <blockquote><p>%(comment)s</p></blockquote> <p>Please reply to these at <a href=\"%(app_url)s\">%(app_url)s</a> so we can evaluate your application.</p> <p>Best,</p> <p>The Wikipedia Library</p>"
 msgstr ""
 
 #. Translators: This email is sent to users when they receive a comment on their application. Don't translate Jinja variables in curly braces like user or partner. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/comment_notification_editors-body-text.html:3
 #, python-format
-msgid ""
-"%(submit_date)s - %(commenter)s %(comment)s Please reply to these at: "
-"%(app_url)s so we can evaluate your application. Best, The Wikipedia Library"
+msgid "%(submit_date)s - %(commenter)s %(comment)s Please reply to these at: %(app_url)s so we can evaluate your application. Best, The Wikipedia Library"
 msgstr ""
 
 #. Translators: This is the subject line of an email sent to users who have a comment added to one of their applications. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
@@ -1154,33 +1011,24 @@ msgstr "Ulasan baharu pada permohonan Perpustakaan Wikipedia anda"
 #. Translators: This email is sent to users when an application they commented on receives another comment. Don't translate Jinja variables in curly braces like app_url; don't translate html tags either. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/comment_notification_others-body-html.html:5
 #, python-format
-msgid ""
-"<p style=\"color: #500050\">%(submit_date)s - %(commenter)s</p> "
-"<blockquote><p>%(comment)s</p></blockquote> See it at <a href=\"%(app_url)s"
-"\">%(app_url)s</a>. Thanks for helping review Wikipedia Library applications!"
+msgid "<p style=\"color: #500050\">%(submit_date)s - %(commenter)s</p> <blockquote><p>%(comment)s</p></blockquote> See it at <a href=\"%(app_url)s\">%(app_url)s</a>. Thanks for helping review Wikipedia Library applications!"
 msgstr ""
 
 #. Translators: This email is sent to users when an application they commented on receives another comment. Don't translate Jinja variables in curly braces like app_url. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/comment_notification_others-body-text.html:3
 #, python-format
-msgid ""
-"%(submit_date)s - %(commenter)s %(comment)s See it at: %(app_url)s Thanks "
-"for helping review Wikipedia Library applications!"
+msgid "%(submit_date)s - %(commenter)s %(comment)s See it at: %(app_url)s Thanks for helping review Wikipedia Library applications!"
 msgstr ""
 
 #. Translators: This is the subject line of an email sent to users who have a comment added to an application they also commented on. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/comment_notification_others-subject.html:4
 msgid "New comment on a Wikipedia Library application you commented on"
-msgstr ""
-"Ulasan baharu pada permohonan Perpustakaan Wikipedia yang anda berikan ulasan"
+msgstr "Ulasan baharu pada permohonan Perpustakaan Wikipedia yang anda berikan ulasan"
 
 #. Translators: This text is part of a scheduled reminder email sent to coordinators who have applications requiring action. Don't translate Jinja variables in curly braces like total_apps, or user.
 #: TWLight/emails/templates/emails/coordinator_reminder_notification-body-html.html:5
 #, python-format
-msgid ""
-"<p>Dear %(user)s,</p> <p>Our records indicate that you are the designated "
-"coordinator for partners that have a total of %(total_apps)s applications.</"
-"p>"
+msgid "<p>Dear %(user)s,</p> <p>Our records indicate that you are the designated coordinator for partners that have a total of %(total_apps)s applications.</p>"
 msgstr ""
 
 #. Translators: Breakdown as in 'cost breakdown'; analysis.
@@ -1216,31 +1064,19 @@ msgstr[0] "Bilangan permohonan yang diluluskan"
 #. Translators: This text is part of a scheduled reminder email sent to coordinators who have applications requiring action. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library). Don't translate Jinja variables in curly braces like link; don't translate email addresses or html tags either.
 #: TWLight/emails/templates/emails/coordinator_reminder_notification-body-html.html:39
 #, python-format
-msgid ""
-"<p>This is a gentle reminder that you may review applications at <a href="
-"\"%(link)s\">%(link)s</a>.</p> <p>You can customise your reminders under "
-"'preferences' in your user profile.</p> <p>If you received this message in "
-"error, drop us a line at wikipedialibrary@wikimedia.org.</p> <p>Thanks for "
-"helping review Wikipedia Library applications!</p>"
+msgid "<p>This is a gentle reminder that you may review applications at <a href=\"%(link)s\">%(link)s</a>.</p> <p>You can customise your reminders under 'preferences' in your user profile.</p> <p>If you received this message in error, drop us a line at wikipedialibrary@wikimedia.org.</p> <p>Thanks for helping review Wikipedia Library applications!</p>"
 msgstr ""
 
 #. Translators: This text is part of a scheduled reminder email sent to coordinators who have applications requiring action. Don't translate Jinja variables in curly braces like total_apps, or user.
 #: TWLight/emails/templates/emails/coordinator_reminder_notification-body-text.html:3
 #, python-format
-msgid ""
-"Dear %(user)s, Our records indicate that you are the designated coordinator "
-"for partners that have a total of %(total_apps)s applications."
+msgid "Dear %(user)s, Our records indicate that you are the designated coordinator for partners that have a total of %(total_apps)s applications."
 msgstr ""
 
 #. Translators: This text is part of a scheduled reminder email sent to coordinators who have applications requiring action. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library). Don't translate Jinja variables in curly braces like link; don't translate the email address either.
 #: TWLight/emails/templates/emails/coordinator_reminder_notification-body-text.html:38
 #, python-format
-msgid ""
-"This is a gentle reminder that you may review applications at: %(link)s. You "
-"can customise your reminders under 'preferences' in your user profile. If "
-"you received this message in error, drop us a line at: "
-"wikipedialibrary@wikimedia.org Thanks for helping review Wikipedia Library "
-"applications!"
+msgid "This is a gentle reminder that you may review applications at: %(link)s. You can customise your reminders under 'preferences' in your user profile. If you received this message in error, drop us a line at: wikipedialibrary@wikimedia.org Thanks for helping review Wikipedia Library applications!"
 msgstr ""
 
 #. Translators: This is the subject line of a scheduled reminder email sent to coordinators who have applications to review. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library). Do not translate items in curly braces.
@@ -1251,32 +1087,14 @@ msgstr "Permohonan Perpustakaan Wikipedia menanti semakan anda"
 #. Translators: This email is sent to users when their application is rejected. Don't translate Jinja variables in curly braces like user or partner; don't translate html tags either. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/rejection_notification-body-html.html:5
 #, python-format
-msgid ""
-"<p>Dear %(user)s,</p> <p>Thank you for applying for access to %(partner)s "
-"resources through The Wikipedia Library. Unfortunately at this time your "
-"application has not been approved. You can view your application and review "
-"comments at <a href=\"%(app_url)s\">%(app_url)s</a>.</p> <p>Best,</p> <p>The "
-"Wikipedia Library</p>"
-msgstr ""
-"<p>Wahai %(user)s,</p> <p>Terima kasih kerana memohon akses kepada sumber "
-"%(partner)s melalui Perpustakaan Wikipedia. Malangnya permohonan anda pada "
-"masa ini tidak diluluskan. Anda boleh melihat permohonan anda dan menyemak "
-"ulasan di <a href=\"%(app_url)s\">%(app_url)s</a>.</p> <p>Yang benar,</p> "
-"<p>Perpustakaan Wikipedia</p>"
+msgid "<p>Dear %(user)s,</p> <p>Thank you for applying for access to %(partner)s resources through The Wikipedia Library. Unfortunately at this time your application has not been approved. You can view your application and review comments at <a href=\"%(app_url)s\">%(app_url)s</a>.</p> <p>Best,</p> <p>The Wikipedia Library</p>"
+msgstr "<p>Wahai %(user)s,</p> <p>Terima kasih kerana memohon akses kepada sumber %(partner)s melalui Perpustakaan Wikipedia. Malangnya permohonan anda pada masa ini tidak diluluskan. Anda boleh melihat permohonan anda dan menyemak ulasan di <a href=\"%(app_url)s\">%(app_url)s</a>.</p> <p>Yang benar,</p> <p>Perpustakaan Wikipedia</p>"
 
 #. Translators: This email is sent to users when their application is rejected. Don't translate Jinja variables in curly braces like user or partner. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/rejection_notification-body-text.html:3
 #, python-format
-msgid ""
-"Dear %(user)s, Thank you for applying for access to %(partner)s resources "
-"through The Wikipedia Library. Unfortunately at this time your application "
-"has not been approved. You can view your application and review comments at: "
-"%(app_url)s Best, The Wikipedia Library"
-msgstr ""
-"Wahai %(user)s, Terima kasih kerana memohon akses kepada sumber %(partner)s "
-"melalui Perpustakaan Wikipedia. Malangnya permohonan anda pada masa ini "
-"tidak diluluskan. Anda boleh melihat permohonan anda dan menyemak ulasan di "
-"%(app_url)s Yang benar, Perpustakaan Wikipedia"
+msgid "Dear %(user)s, Thank you for applying for access to %(partner)s resources through The Wikipedia Library. Unfortunately at this time your application has not been approved. You can view your application and review comments at: %(app_url)s Best, The Wikipedia Library"
+msgstr "Wahai %(user)s, Terima kasih kerana memohon akses kepada sumber %(partner)s melalui Perpustakaan Wikipedia. Malangnya permohonan anda pada masa ini tidak diluluskan. Anda boleh melihat permohonan anda dan menyemak ulasan di %(app_url)s Yang benar, Perpustakaan Wikipedia"
 
 #. Translators: This is the subject of an email which is sent to users when their application has been rejected. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/rejection_notification-subject.html:4
@@ -1286,39 +1104,14 @@ msgstr ""
 #. Translators: This email is sent to users when they have an account that is soon to expire. Don't translate Jinja variables in curly braces like partner_name or partner_link; don't translate html tags either. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/user_renewal_notice-body-html.html:5
 #, fuzzy, python-format
-msgid ""
-"<p>Dear %(user)s,</p> <p>According to our records, your access to "
-"%(partner_name)s will soon expire and you may lose access. If you want to "
-"continue making use of your free account, you can request renewal of your "
-"account by clicking the 'Renew' or 'Extend' button at %(partner_link)s.</p> "
-"<p>Best,</p> <p>The Wikipedia Library</p> <p>You can disable these emails in "
-"your user page preferences: https://wikipedialibrary.wmflabs.org/users/</p>"
-msgstr ""
-"<p>Wahai %(user)s,</p> <p>Menurut rekod kami, akses anda ke %(partner_name)s "
-"akan mansuh tidak lama lagi dan anda mungkin kehilangan akses. Jika anda "
-"ingin terus memanfaatkan akaun percuma anda, anda boleh meminta pembaharuan "
-"akaun anda dengan mengklik butang Perbaharui di %(partner_link)s.</p> "
-"<p>Yang benar,</p> <p>Perpustakaan Wikipedia</p> <p>Anda boleh menyahdayakan "
-"e-mel ini dalam keutamaan halaman pengguna anda: https://wikipedialibrary."
-"wmflabs.org/users/</p>"
+msgid "<p>Dear %(user)s,</p> <p>According to our records, your access to %(partner_name)s will soon expire and you may lose access. If you want to continue making use of your free account, you can request renewal of your account by clicking the 'Renew' or 'Extend' button at %(partner_link)s.</p> <p>Best,</p> <p>The Wikipedia Library</p> <p>You can disable these emails in your user page preferences: https://wikipedialibrary.wmflabs.org/users/</p>"
+msgstr "<p>Wahai %(user)s,</p> <p>Menurut rekod kami, akses anda ke %(partner_name)s akan mansuh tidak lama lagi dan anda mungkin kehilangan akses. Jika anda ingin terus memanfaatkan akaun percuma anda, anda boleh meminta pembaharuan akaun anda dengan mengklik butang Perbaharui di %(partner_link)s.</p> <p>Yang benar,</p> <p>Perpustakaan Wikipedia</p> <p>Anda boleh menyahdayakan e-mel ini dalam keutamaan halaman pengguna anda: https://wikipedialibrary.wmflabs.org/users/</p>"
 
 #. Translators: This email is sent to users when they have an account that is soon to expire. Don't translate Jinja variables in curly braces like partner_name or partner_link; don't translate html tags either. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/user_renewal_notice-body-text.html:3
 #, python-format
-msgid ""
-"Dear %(user)s, According to our records, your access to %(partner_name)s "
-"will soon expire and you may lose access. If you want to continue making use "
-"of your free account, you can request renewal of your account by clicking "
-"the Renew button at %(partner_link)s. Best, The Wikipedia Library You can "
-"disable these emails in your user page preferences: https://wikipedialibrary."
-"wmflabs.org/users/"
-msgstr ""
-"Wahai %(user)s, Menurut rekod kami, akses anda ke %(partner_name)s akan "
-"mansuh tidak lama lagi dan anda mungkin kehilangan akses. Jika anda ingin "
-"terus memanfaatkan akaun percuma anda, anda boleh meminta pembaharuan akaun "
-"anda dengan mengklik butang Perbaharui di %(partner_link)s. Yang benar, "
-"Perpustakaan Wikipedia Anda boleh menyahdayakan e-mel ini dalam keutamaan "
-"halaman pengguna anda: https://wikipedialibrary.wmflabs.org/users/"
+msgid "Dear %(user)s, According to our records, your access to %(partner_name)s will soon expire and you may lose access. If you want to continue making use of your free account, you can request renewal of your account by clicking the Renew button at %(partner_link)s. Best, The Wikipedia Library You can disable these emails in your user page preferences: https://wikipedialibrary.wmflabs.org/users/"
+msgstr "Wahai %(user)s, Menurut rekod kami, akses anda ke %(partner_name)s akan mansuh tidak lama lagi dan anda mungkin kehilangan akses. Jika anda ingin terus memanfaatkan akaun percuma anda, anda boleh meminta pembaharuan akaun anda dengan mengklik butang Perbaharui di %(partner_link)s. Yang benar, Perpustakaan Wikipedia Anda boleh menyahdayakan e-mel ini dalam keutamaan halaman pengguna anda: https://wikipedialibrary.wmflabs.org/users/"
 
 #. Translators: This is the subject of an email sent to users when they have an account that is soon to expire. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/user_renewal_notice-subject.html:4
@@ -1328,36 +1121,14 @@ msgstr "Akses Perpustakaan Wikipedia anda akan mansuh tidak lama lagi"
 #. Translators: This email is sent to users when their application is waitlisted because there are no more accounts available. Don't translate Jinja variables in curly braces like user or partner; don't translate html tags either. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/waitlist_notification-body-html.html:5
 #, python-format
-msgid ""
-"<p>Dear %(user)s,</p> <p>Thank you for applying for access to %(partner)s "
-"resources through The Wikipedia Library. There are no accounts currently "
-"available so your application has been waitlisted. Your application will be "
-"evaluated if/when more accounts become available. You can see all available "
-"resources at <a href=\"%(link)s\">%(link)s</a>.</p> <p>Best,</p> <p>The "
-"Wikipedia Library</p>"
-msgstr ""
-"<p>Wahai %(user)s,</p> <p>Terima kasih kerana memohon akses ke sumber "
-"%(partner)s melalui Perpustakaan Wikipedia. Tiada sebarang akaun yang sedia "
-"ada pada masa ini maka permohonan anda telah disenarai tunggu. Permohonan "
-"anda akan dinilai jika/apabila lebih banyak akaun tersedia. Anda boleh "
-"melihat semua sumber yang ada di <a href=\"%(link)s\">%(link)s</a>.</p> "
-"<p>Yang benar,</p> <p>Perpustakaan Wikipedia</p>"
+msgid "<p>Dear %(user)s,</p> <p>Thank you for applying for access to %(partner)s resources through The Wikipedia Library. There are no accounts currently available so your application has been waitlisted. Your application will be evaluated if/when more accounts become available. You can see all available resources at <a href=\"%(link)s\">%(link)s</a>.</p> <p>Best,</p> <p>The Wikipedia Library</p>"
+msgstr "<p>Wahai %(user)s,</p> <p>Terima kasih kerana memohon akses ke sumber %(partner)s melalui Perpustakaan Wikipedia. Tiada sebarang akaun yang sedia ada pada masa ini maka permohonan anda telah disenarai tunggu. Permohonan anda akan dinilai jika/apabila lebih banyak akaun tersedia. Anda boleh melihat semua sumber yang ada di <a href=\"%(link)s\">%(link)s</a>.</p> <p>Yang benar,</p> <p>Perpustakaan Wikipedia</p>"
 
 #. Translators: This email is sent to users when their application is waitlisted because there are no more accounts available. Don't translate Jinja variables in curly braces like user or partner. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/waitlist_notification-body-text.html:3
 #, python-format
-msgid ""
-"Dear %(user)s, Thank you for applying for access to %(partner)s resources "
-"through The Wikipedia Library. There are no accounts currently available so "
-"your application has been waitlisted. Your application will be evaluated if/"
-"when more accounts become available. You can see all available resources at: "
-"%(link)s Best, The Wikipedia Library"
-msgstr ""
-"Wahai %(user)s, Terima kasih kerana memohon akses ke sumber %(partner)s "
-"melalui Perpustakaan Wikipedia. Tiada sebarang akaun yang sedia ada pada "
-"masa ini maka permohonan anda telah disenarai tunggu. Permohonan anda akan "
-"dinilai jika/apabila lebih banyak akaun tersedia. Anda boleh melihat semua "
-"sumber yang ada di: %(link)s Yang benar, Perpustakaan Wikipedia"
+msgid "Dear %(user)s, Thank you for applying for access to %(partner)s resources through The Wikipedia Library. There are no accounts currently available so your application has been waitlisted. Your application will be evaluated if/when more accounts become available. You can see all available resources at: %(link)s Best, The Wikipedia Library"
+msgstr "Wahai %(user)s, Terima kasih kerana memohon akses ke sumber %(partner)s melalui Perpustakaan Wikipedia. Tiada sebarang akaun yang sedia ada pada masa ini maka permohonan anda telah disenarai tunggu. Permohonan anda akan dinilai jika/apabila lebih banyak akaun tersedia. Anda boleh melihat semua sumber yang ada di: %(link)s Yang benar, Perpustakaan Wikipedia"
 
 #. Translators: This is the subject of an email sent to users when their application is waitlisted because there are no more accounts available. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/waitlist_notification-subject.html:4
@@ -1367,9 +1138,7 @@ msgstr "Permohonan Perpustakaan Wikipedia anda telah disenarai tunggu"
 #. Translators: Shown to users when they successfully submit a new message using the contact us form.
 #: TWLight/emails/views.py:51
 msgid "Your message has been sent. We'll get back to you soon!"
-msgstr ""
-"Pesanan anda telah dihantar. Kami akan menghubungi anda kembali tidak lama "
-"lagi!"
+msgstr "Pesanan anda telah dihantar. Kami akan menghubungi anda kembali tidak lama lagi!"
 
 #. Translators: This message is shown to non-wikipedia editors who attempt to post data to the contact us form.
 #. Translators: This message is shown to non-wikipedia editors who attempt to post data to suggestion form.
@@ -1523,17 +1292,14 @@ msgstr "Tiada"
 #: TWLight/resources/templates/resources/filter_section.html:14
 #: TWLight/templates/about.html:12
 #: TWLight/users/templates/users/filter_section.html:13
-msgid ""
-"The Wikipedia Library allows active editors to access a wide range of "
-"collections of paywalled reliable sources for free!"
+msgid "The Wikipedia Library allows active editors to access a wide range of collections of paywalled reliable sources for free!"
 msgstr ""
 
 #. Translators: On the Browse Partners page (https://wikipedialibrary.wmflabs.org/partners/), this introduces users to The Wikipedia Library.
 #. Translators: On the MyLibrary page (https://wikipedialibrary.wmflabs.org/users/my_library), this introduces users to The Wikipedia Library.
 #: TWLight/resources/templates/resources/filter_section.html:17
 #: TWLight/users/templates/users/filter_section.html:15
-msgid ""
-"Start with the search bar at the top or browse publisher websites directly."
+msgid "Start with the search bar at the top or browse publisher websites directly."
 msgstr ""
 
 #. Translators: On the Browse Partners page (https://wikipedialibrary.wmflabs.org/partners/), this appears below introductory text and links to the 'About' page (https://wikipedialibrary.wmflabs.org/about/)
@@ -1615,58 +1381,38 @@ msgstr ""
 #. Translators: If we have no available accounts for a partner, the coordinator can change the application system to a waiting list.
 #: TWLight/resources/templates/resources/partner_detail.html:36
 #: TWLight/resources/templates/resources/partner_detail_apply.html:17
-msgid ""
-"There are no access grants available for this partner at this time. You can "
-"still apply for access; applications will be processed when access is "
-"available."
-msgstr ""
-"Tiada sebarang kebenaran akses tersedia untuk rakan kongsi ini pada masa "
-"ini. Anda masih boleh memohon akses; permohonan akan diproses apabila akses "
-"sudah ada."
+msgid "There are no access grants available for this partner at this time. You can still apply for access; applications will be processed when access is available."
+msgstr "Tiada sebarang kebenaran akses tersedia untuk rakan kongsi ini pada masa ini. Anda masih boleh memohon akses; permohonan akan diproses apabila akses sudah ada."
 
 #. Translators: This text links to the minimum user requirements and terms of use on the partner page.
 #: TWLight/resources/templates/resources/partner_detail.html:48
 #: TWLight/resources/templates/resources/partner_detail_apply.html:29
 #, python-format
-msgid ""
-"Before applying, please review the <strong><a class=\"twl-links\" href="
-"\"%(about)s#req\">minimum requirements</a></strong> for access and our "
-"<strong><a class=\"twl-links\" href=\"%(terms)s\">terms of use</a></strong>."
-msgstr ""
-"Sebelum memohon, sila semak <strong><a class=\"twl-links\" href="
-"\"%(about)s#req\">keperluan minimum</a></strong> untuk akses dan <strong><a "
-"class=\"twl-links\" href=\"%(terms)s\">terma penggunaan</a></strong> kami."
+msgid "Before applying, please review the <strong><a class=\"twl-links\" href=\"%(about)s#req\">minimum requirements</a></strong> for access and our <strong><a class=\"twl-links\" href=\"%(terms)s\">terms of use</a></strong>."
+msgstr "Sebelum memohon, sila semak <strong><a class=\"twl-links\" href=\"%(about)s#req\">keperluan minimum</a></strong> untuk akses dan <strong><a class=\"twl-links\" href=\"%(terms)s\">terma penggunaan</a></strong> kami."
 
 #. Translators: This text refers to the page containing the content a user is authorized to access.
 #: TWLight/resources/templates/resources/partner_detail.html:69
 #, python-format
-msgid ""
-"View the status of your access in <strong><a class=\"twl-links\" href="
-"\"%(library_url)s\">My Library</a></strong> page."
+msgid "View the status of your access in <strong><a class=\"twl-links\" href=\"%(library_url)s\">My Library</a></strong> page."
 msgstr ""
 
 #. Translators: This message is shown when a user has open applications, linking to their respective applications page.
 #: TWLight/resources/templates/resources/partner_detail.html:78
 #, python-format
-msgid ""
-"View the status of your application(s) on your <strong><a class=\"twl-links"
-"\" href=\"%(applications_url)s\">My Applications</a></strong> page."
+msgid "View the status of your application(s) on your <strong><a class=\"twl-links\" href=\"%(applications_url)s\">My Applications</a></strong> page."
 msgstr ""
 
 #. Translators: This message is shown when a user has authorizations, linking to their respective collections page.
 #: TWLight/resources/templates/resources/partner_detail_apply.html:50
 #, python-format
-msgid ""
-"View the status of your access on your <strong><a href=\"%(library_url)s\" "
-"class=\"twl-links\">My Library</a></strong> page."
+msgid "View the status of your access on your <strong><a href=\"%(library_url)s\" class=\"twl-links\">My Library</a></strong> page."
 msgstr ""
 
 #. Translators: This message is shown when a user has open applications, linking to their respective applications page.
 #: TWLight/resources/templates/resources/partner_detail_apply.html:60
 #, python-format
-msgid ""
-"View the status of your application(s) on your <strong><a href="
-"\"%(applications_url)s\">My Applications</a></strong> page."
+msgid "View the status of your application(s) on your <strong><a href=\"%(applications_url)s\">My Applications</a></strong> page."
 msgstr ""
 
 #. Translators: One the partner detail page, this text labels the button which coordinators can click to remove a partner from waitlisted status.
@@ -1696,15 +1442,8 @@ msgstr "Laman Khas:Emel pengguna"
 
 #. Translators: If no account coordinator is assigned to a partner, the Wikipedia Library team will coordinate signups. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/resources/templates/resources/partner_detail_apply.html:112
-msgid ""
-"The Wikipedia Library team will process this application. Want to help? <a "
-"class=\"twl-links\" href=\"https://en.wikipedia.org/wiki/Wikipedia:"
-"The_Wikipedia_Library/Coordinators/Signup\">Sign up as a coordinator.</a>"
-msgstr ""
-"Pasukan Perpustakaan Wikipedia akan memproses permohonan ini. Ingin "
-"membantu? <a class=\"twl-links\" href=\"https://en.wikipedia.org/wiki/"
-"Wikipedia:The_Wikipedia_Library/Coordinators/Signup\">Daftar sebagai "
-"penyelaras.</a>"
+msgid "The Wikipedia Library team will process this application. Want to help? <a class=\"twl-links\" href=\"https://en.wikipedia.org/wiki/Wikipedia:The_Wikipedia_Library/Coordinators/Signup\">Sign up as a coordinator.</a>"
+msgstr "Pasukan Perpustakaan Wikipedia akan memproses permohonan ini. Ingin membantu? <a class=\"twl-links\" href=\"https://en.wikipedia.org/wiki/Wikipedia:The_Wikipedia_Library/Coordinators/Signup\">Daftar sebagai penyelaras.</a>"
 
 #. Translators: This text labels a button coordinators can click to view a list of users who have applied for access for a particular partner
 #: TWLight/resources/templates/resources/partner_detail_apply.html:121
@@ -1733,18 +1472,13 @@ msgstr ""
 
 #. Translators: Text shown to authenticated, bundle eligible users when they visit a Bundle partner page.
 #: TWLight/resources/templates/resources/partner_detail_apply.html:138
-msgid ""
-"You are eligible to access Library Bundle partners. Click the button above "
-"to access the collection."
+msgid "You are eligible to access Library Bundle partners. Click the button above to access the collection."
 msgstr ""
 
 #. Translators: Text shown to authenticated, bundle ineligible users when they visit a Bundle partner page.
 #: TWLight/resources/templates/resources/partner_detail_apply.html:152
 #, python-format
-msgid ""
-"You are not eligible to access Library Bundle partners. Visit the <a class="
-"\"twl-links\" href=\"%(homepage)s\">homepage</a> to check the eligibility "
-"criteria."
+msgid "You are not eligible to access Library Bundle partners. Visit the <a class=\"twl-links\" href=\"%(homepage)s\">homepage</a> to check the eligibility criteria."
 msgstr ""
 
 #. Translators: Buttton prompting users to log in.
@@ -1756,10 +1490,7 @@ msgstr "Log masuk"
 #. Translators: Text shown to unauthenticated users when they visit a Bundle partner page.
 #: TWLight/resources/templates/resources/partner_detail_apply.html:168
 #, python-format
-msgid ""
-"This resource is part of our <a class=\"twl-links\" href=\"%(about)s"
-"\">Library Bundle</a>, which you can access if you meet our minimum "
-"eligibility criteria. Log in to find out if you are eligible."
+msgid "This resource is part of our <a class=\"twl-links\" href=\"%(about)s\">Library Bundle</a>, which you can access if you meet our minimum eligibility criteria. Log in to find out if you are eligible."
 msgstr ""
 
 #. Translators: This is the label for a number which shows the total active accounts for one partner. (e.g. https://wikipedialibrary.wmflabs.org/partners/8/).
@@ -1810,34 +1541,20 @@ msgstr "Had petikan"
 #. Translators: If a partner has specified the excerpt limit both in words and percentage, this message will display the percentage of words and the number of words on the partner page.
 #: TWLight/resources/templates/resources/partner_detail_timeline.html:99
 #, python-format
-msgid ""
-"%(object)s allows a maximum of %(excerpt_limit)s words or "
-"%(excerpt_limit_percentage)s%% of an article be excerpted into a Wikipedia "
-"article."
-msgstr ""
-"%(object)s membenarkan maksimum %(excerpt_limit)s patah perkataan atau "
-"%(excerpt_limit_percentage)s%% dari rencana yang dijadikan petikan ke dalam "
-"rencana Wikipedia."
+msgid "%(object)s allows a maximum of %(excerpt_limit)s words or %(excerpt_limit_percentage)s%% of an article be excerpted into a Wikipedia article."
+msgstr "%(object)s membenarkan maksimum %(excerpt_limit)s patah perkataan atau %(excerpt_limit_percentage)s%% dari rencana yang dijadikan petikan ke dalam rencana Wikipedia."
 
 #. Translators: If a partner has specified the excerpt limit in words, this message will display the number of words on the partner page.
 #: TWLight/resources/templates/resources/partner_detail_timeline.html:106
 #, python-format
-msgid ""
-"%(object)s allows a maximum of %(excerpt_limit)s words be excerpted into a "
-"Wikipedia article."
-msgstr ""
-"%(object)s membenarkan maksimum %(excerpt_limit)s patah perkataan untuk "
-"dijadikan petikan ke dalam rencana Wikipedia."
+msgid "%(object)s allows a maximum of %(excerpt_limit)s words be excerpted into a Wikipedia article."
+msgstr "%(object)s membenarkan maksimum %(excerpt_limit)s patah perkataan untuk dijadikan petikan ke dalam rencana Wikipedia."
 
 #. Translators: If a partner has specified the excerpt limit in percentage, this message will display the percentage of words on the partner page.
 #: TWLight/resources/templates/resources/partner_detail_timeline.html:113
 #, python-format
-msgid ""
-"%(object)s allows a maximum of %(excerpt_limit_percentage)s%% of an article "
-"be excerpted into a Wikipedia article."
-msgstr ""
-"%(object)s membenarkan maksimum %(excerpt_limit_percentage)s%% dari rencana "
-"untuk dijadikan petikan ke dalam rencana Wikipedia."
+msgid "%(object)s allows a maximum of %(excerpt_limit_percentage)s%% of an article be excerpted into a Wikipedia article."
+msgstr "%(object)s membenarkan maksimum %(excerpt_limit_percentage)s%% dari rencana untuk dijadikan petikan ke dalam rencana Wikipedia."
 
 #. Translators: If a partner has other requirements for access, this text shows as the title for that information field. (e.g. https://wikipedialibrary.wmflabs.org/partners/10/).
 #: TWLight/resources/templates/resources/partner_detail_timeline.html:132
@@ -1847,12 +1564,8 @@ msgstr "Keperluan khas untuk pemohon"
 #. Translators: If a user must agree to a Terms of Use document, they see this message, and must enter the name of the resource. Don't translate publisher or url.
 #: TWLight/resources/templates/resources/partner_detail_timeline.html:140
 #, python-format
-msgid ""
-"%(publisher)s requires that you agree with its <a href=\"%(url)s\">terms of "
-"use</a>."
-msgstr ""
-"%(publisher)s memerlukan anda untuk bersetuju dengan <a href=\"%(url)s"
-"\">terma penggunaan</a>nya."
+msgid "%(publisher)s requires that you agree with its <a href=\"%(url)s\">terms of use</a>."
+msgstr "%(publisher)s memerlukan anda untuk bersetuju dengan <a href=\"%(url)s\">terma penggunaan</a>nya."
 
 #. Translators: If a user must provide their real name to apply to a partner, they see this message, and must enter the name of the resource. Don't translate publisher.
 #: TWLight/resources/templates/resources/partner_detail_timeline.html:150
@@ -1870,27 +1583,19 @@ msgstr "%(publisher)s memerlukan anda untuk memberi negara mastautin anda."
 #: TWLight/resources/templates/resources/partner_detail_timeline.html:168
 #, python-format
 msgid "%(publisher)s requires that you provide your institutional affiliation."
-msgstr ""
-"%(publisher)s memerlukan anda untuk menyatakan afiliasi institusi anda."
+msgstr "%(publisher)s memerlukan anda untuk menyatakan afiliasi institusi anda."
 
 #. Translators: If a user must select a specific resource to apply for, they see this message, and must enter the name of the resource. Don't translate publisher.
 #: TWLight/resources/templates/resources/partner_detail_timeline.html:177
 #, python-format
-msgid ""
-"%(publisher)s requires that you specify a particular title that you want to "
-"access."
-msgstr ""
-"%(publisher)s memerlukan anda untuk memperincikan tajuk tertentu yang anda "
-"mahu akses."
+msgid "%(publisher)s requires that you specify a particular title that you want to access."
+msgstr "%(publisher)s memerlukan anda untuk memperincikan tajuk tertentu yang anda mahu akses."
 
 #. Translators: If a user must register on the partner website before applying, they see this message. Don't translate partner.
 #: TWLight/resources/templates/resources/partner_detail_timeline.html:187
 #, python-format
-msgid ""
-"%(publisher)s requires that you sign up for an account before applying for "
-"access."
-msgstr ""
-"%(publisher)s memerlukan anda untuk mendaftar akaun sebelum memohon akses."
+msgid "%(publisher)s requires that you sign up for an account before applying for access."
+msgstr "%(publisher)s memerlukan anda untuk mendaftar akaun sebelum memohon akses."
 
 #. Translators: If a partner has their location listed, this message is a label for that location
 #: TWLight/resources/templates/resources/partner_detail_timeline.html:206
@@ -2017,9 +1722,7 @@ msgstr "Adakah anda pasti ingin menghapuskan <b>%(object)s</b>?"
 
 #. Translators: If multiple authorizations where returned for a collection, this message is shown to a user
 #: TWLight/resources/views.py:268
-msgid ""
-"Multiple authorizations were returned – something's wrong. Please contact us "
-"and don't forget to mention this message."
+msgid "Multiple authorizations were returned – something's wrong. Please contact us and don't forget to mention this message."
 msgstr ""
 
 #. Translators: This message is shown when user tries to access a NOT_AVAILABLE Partner
@@ -2060,23 +1763,8 @@ msgstr "Maaf; kami tidak tahu apa yang perlu dilakukan dengannya."
 #. Translators: Shown on the website's 400 page, when a user sends a bad request. Don't translate path or Phabricator.
 #: TWLight/templates/400.html:20
 #, python-format
-msgid ""
-"If you think we should know what to do with that, please email us about this "
-"error at <a class=\"twl-links\" href=\"mailto:wikipedialibrary@wikimedia.org?"
-"Subject=Wikipedia%%20Library%%20%(path)s%%20Permission%%20denied"
-"\">wikipedialibrary@wikimedia.org</a> or report it to us on <a class=\"twl-"
-"links\" href=\"https://phabricator.wikimedia.org/maniphest/task/edit/form/1/?"
-"projectPHIDs=Library-Card-Platform&title=Wikipedia%%20Library%%20%(path)s"
-"%%20Bad%%20Request\">Phabricator</a>"
-msgstr ""
-"Jika anda fikir kami harus tahu apa yang perlu dilakukan dengannya, sila e-"
-"mel kami tentang ralat ini di <a class=\"twl-links\" href=\"mailto:"
-"wikipedialibrary@wikimedia.org?Subject=Wikipedia%%20Library%%20%(path)s"
-"%%20Permission%%20denied\">wikipedialibrary@wikimedia.org</a> atau "
-"laporkannya kepada kami di <a class=\"twl-links\" href=\"https://phabricator."
-"wikimedia.org/maniphest/task/edit/form/1/?projectPHIDs=Library-Card-"
-"Platform&title=Wikipedia%%20Library%%20%(path)s%%20Bad%%20Request"
-"\">Phabricator</a>"
+msgid "If you think we should know what to do with that, please email us about this error at <a class=\"twl-links\" href=\"mailto:wikipedialibrary@wikimedia.org?Subject=Wikipedia%%20Library%%20%(path)s%%20Permission%%20denied\">wikipedialibrary@wikimedia.org</a> or report it to us on <a class=\"twl-links\" href=\"https://phabricator.wikimedia.org/maniphest/task/edit/form/1/?projectPHIDs=Library-Card-Platform&title=Wikipedia%%20Library%%20%(path)s%%20Bad%%20Request\">Phabricator</a>"
+msgstr "Jika anda fikir kami harus tahu apa yang perlu dilakukan dengannya, sila e-mel kami tentang ralat ini di <a class=\"twl-links\" href=\"mailto:wikipedialibrary@wikimedia.org?Subject=Wikipedia%%20Library%%20%(path)s%%20Permission%%20denied\">wikipedialibrary@wikimedia.org</a> atau laporkannya kepada kami di <a class=\"twl-links\" href=\"https://phabricator.wikimedia.org/maniphest/task/edit/form/1/?projectPHIDs=Library-Card-Platform&title=Wikipedia%%20Library%%20%(path)s%%20Bad%%20Request\">Phabricator</a>"
 
 #. Translators: Alt text for an image shown on the 400 error page.
 #. Translators: Alt text for an image shown on the 403 error page.
@@ -2097,23 +1785,8 @@ msgstr "Maaf; anda tidak dibenarkan untuk berbuat sedemikian."
 #. Translators: Shown on the website's 403 page, when a user attempts to navigate to a page they don't have permission to view. Don't translate path or Phabricator.
 #: TWLight/templates/403.html:20
 #, python-format
-msgid ""
-"If you think your account should be able to do that, please email us about "
-"this error at <a class=\"twl-links\" href=\"mailto:"
-"wikipedialibrary@wikimedia.org?Subject=Wikipedia%%20Library%%20%(path)s"
-"%%20Permission%%20denied\">wikipedialibrary@wikimedia.org</a> or report it "
-"to us on <a class=\"twl-links\" href=\"https://phabricator.wikimedia.org/"
-"maniphest/task/edit/form/1/?projectPHIDs=Library-Card-"
-"Platform&title=Wikipedia%%20Library%%20%(path)s%%20Permission%%20denied"
-"\">Phabricator</a>"
-msgstr ""
-"Jika anda fikir akaun anda boleh melakukannya, sila e-mel kami tentang ralat "
-"ini di <a class=\"twl-links\" href=\"mailto:wikipedialibrary@wikimedia.org?"
-"Subject=Wikipedia%%20Library%%20%(path)s%%20Permission%%20denied"
-"\">wikipedialibrary@wikimedia.org</a> atau laporkan kepada kami di <a class="
-"\"twl-links\" href=\"https://phabricator.wikimedia.org/maniphest/task/edit/"
-"form/1/?projectPHIDs=Library-Card-Platform&title=Wikipedia%%20Library"
-"%%20%(path)s%%20Permission%%20denied\">Phabricator</a>"
+msgid "If you think your account should be able to do that, please email us about this error at <a class=\"twl-links\" href=\"mailto:wikipedialibrary@wikimedia.org?Subject=Wikipedia%%20Library%%20%(path)s%%20Permission%%20denied\">wikipedialibrary@wikimedia.org</a> or report it to us on <a class=\"twl-links\" href=\"https://phabricator.wikimedia.org/maniphest/task/edit/form/1/?projectPHIDs=Library-Card-Platform&title=Wikipedia%%20Library%%20%(path)s%%20Permission%%20denied\">Phabricator</a>"
+msgstr "Jika anda fikir akaun anda boleh melakukannya, sila e-mel kami tentang ralat ini di <a class=\"twl-links\" href=\"mailto:wikipedialibrary@wikimedia.org?Subject=Wikipedia%%20Library%%20%(path)s%%20Permission%%20denied\">wikipedialibrary@wikimedia.org</a> atau laporkan kepada kami di <a class=\"twl-links\" href=\"https://phabricator.wikimedia.org/maniphest/task/edit/form/1/?projectPHIDs=Library-Card-Platform&title=Wikipedia%%20Library%%20%(path)s%%20Permission%%20denied\">Phabricator</a>"
 
 #. Translators: Shown on the website's 404 page, when a user attempts to navigate to a page that doesn't exist.
 #: TWLight/templates/404.html:11
@@ -2128,23 +1801,8 @@ msgstr "Maaf; kami tidak dapat mencarinya."
 #. Translators: Shown on the website's 404 page, when a user attempts to navigate to a page that doesn't exist. Don't translate path or Phabricator.
 #: TWLight/templates/404.html:19
 #, python-format
-msgid ""
-"If you are certain that something should be here, please email us about this "
-"error at <a class=\"twl-links\" href=\"mailto:wikipedialibrary@wikimedia.org?"
-"Subject=Wikipedia%%20Library%%20%(path)s%%20Not%%20found\"> "
-"wikipedialibrary@wikimedia.org</a> or report it to us on <a class=\"twl-links"
-"\" href=\"https://phabricator.wikimedia.org/maniphest/task/edit/form/1/?"
-"projectPHIDs=Library-Card-Platform&title=Wikipedia%%20Library%%20%(path)s"
-"%%20Not%%20found\">Phabricator</a>"
-msgstr ""
-"Jika anda pasti ada sesuatu yang sepatutnya ada di sini, sila e-mel kami "
-"tentang ralat ini di <a class=\"twl-links\" href=\"mailto:"
-"wikipedialibrary@wikimedia.org?Subject=Wikipedia%%20Library%%20%(path)s"
-"%%20Not%%20found\"> wikipedialibrary@wikimedia.org</a> atau laporkan kepada "
-"kami di <a class=\"twl-links\" href=\"https://phabricator.wikimedia.org/"
-"maniphest/task/edit/form/1/?projectPHIDs=Library-Card-"
-"Platform&title=Wikipedia%%20Library%%20%(path)s%%20Not%%20found"
-"\">Phabricator</a>"
+msgid "If you are certain that something should be here, please email us about this error at <a class=\"twl-links\" href=\"mailto:wikipedialibrary@wikimedia.org?Subject=Wikipedia%%20Library%%20%(path)s%%20Not%%20found\"> wikipedialibrary@wikimedia.org</a> or report it to us on <a class=\"twl-links\" href=\"https://phabricator.wikimedia.org/maniphest/task/edit/form/1/?projectPHIDs=Library-Card-Platform&title=Wikipedia%%20Library%%20%(path)s%%20Not%%20found\">Phabricator</a>"
+msgstr "Jika anda pasti ada sesuatu yang sepatutnya ada di sini, sila e-mel kami tentang ralat ini di <a class=\"twl-links\" href=\"mailto:wikipedialibrary@wikimedia.org?Subject=Wikipedia%%20Library%%20%(path)s%%20Not%%20found\"> wikipedialibrary@wikimedia.org</a> atau laporkan kepada kami di <a class=\"twl-links\" href=\"https://phabricator.wikimedia.org/maniphest/task/edit/form/1/?projectPHIDs=Library-Card-Platform&title=Wikipedia%%20Library%%20%(path)s%%20Not%%20found\">Phabricator</a>"
 
 #. Translators: Alt text for an image shown on the 404 error page.
 #: TWLight/templates/404.html:32
@@ -2158,32 +1816,18 @@ msgstr "Mengenai Perpustakaan Wikipedia"
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:20
-msgid ""
-"This platform is our central tool for facilitating access to our available "
-"collections. Here you can see which partnerships are available, search their "
-"contents, and apply for and access the ones you’re interested in."
+msgid "This platform is our central tool for facilitating access to our available collections. Here you can see which partnerships are available, search their contents, and apply for and access the ones you’re interested in."
 msgstr ""
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/). Wikimedia Foundation should not be translated.
 #: TWLight/templates/about.html:29
-msgid ""
-"All users receive immediate access to some collections, which can be browsed "
-"by clicking the 'Access collection' buttons or using the search bar at the "
-"top of the page. Other collections require an application before access is "
-"granted, and may be accessed directly or via an individual login or access "
-"code. Volunteer coordinators, who have signed non-disclosure agreements with "
-"the Wikimedia Foundation, review these applications and work with publishers "
-"to get you your free access."
+msgid "All users receive immediate access to some collections, which can be browsed by clicking the 'Access collection' buttons or using the search bar at the top of the page. Other collections require an application before access is granted, and may be accessed directly or via an individual login or access code. Volunteer coordinators, who have signed non-disclosure agreements with the Wikimedia Foundation, review these applications and work with publishers to get you your free access."
 msgstr ""
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/). Don't translate terms_url.
 #: TWLight/templates/about.html:43
 #, python-format
-msgid ""
-"For more information about how your information is stored and reviewed "
-"please see our <a class=\"twl-links\" href=\"%(terms_url)s\"> terms of use "
-"and privacy policy</a>. Accounts you apply for are also subject to the Terms "
-"of Use provided by each partner’s platform; please review them."
+msgid "For more information about how your information is stored and reviewed please see our <a class=\"twl-links\" href=\"%(terms_url)s\"> terms of use and privacy policy</a>. Accounts you apply for are also subject to the Terms of Use provided by each partner’s platform; please review them."
 msgstr ""
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
@@ -2193,12 +1837,7 @@ msgstr ""
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/). Wikimedia Foundation should not be translated.
 #: TWLight/templates/about.html:55
-msgid ""
-"Any active editor in good standing can receive access. For publishers with "
-"limited numbers of accounts, applications are reviewed based on the editor’s "
-"needs and contributions. If you think you could use access to one of our "
-"partner resources and are an active editor in any project supported by the "
-"Wikimedia Foundation, please apply."
+msgid "Any active editor in good standing can receive access. For publishers with limited numbers of accounts, applications are reviewed based on the editor’s needs and contributions. If you think you could use access to one of our partner resources and are an active editor in any project supported by the Wikimedia Foundation, please apply."
 msgstr ""
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
@@ -2228,23 +1867,12 @@ msgstr ""
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/)
 #: TWLight/templates/about.html:89
-msgid ""
-"If you are applying for an available collection, please first check that you "
-"don't already have access through another library or institution. If you do, "
-"please consider using that access rather than taking up a seat for this "
-"resource in The Wikipedia Library."
+msgid "If you are applying for an available collection, please first check that you don't already have access through another library or institution. If you do, please consider using that access rather than taking up a seat for this resource in The Wikipedia Library."
 msgstr ""
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/)
 #: TWLight/templates/about.html:99
-msgid ""
-"If your account is blocked on one or more Wikimedia projects, you may still "
-"be granted access to The Wikipedia Library. You will need to contact the "
-"Wikipedia Library team, who will review your blocks. If you have been "
-"blocked for content issues, most notably copyright violations, or have "
-"multiple long-term blocks, we may decline your request. Additionally, if "
-"your block status changes after being approved, you will need to request "
-"another review."
+msgid "If your account is blocked on one or more Wikimedia projects, you may still be granted access to The Wikipedia Library. You will need to contact the Wikipedia Library team, who will review your blocks. If you have been blocked for content issues, most notably copyright violations, or have multiple long-term blocks, we may decline your request. Additionally, if your block status changes after being approved, you will need to request another review."
 msgstr ""
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
@@ -2279,9 +1907,7 @@ msgstr ""
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:136
-msgid ""
-"Share their account logins or passwords with others, or sell their access to "
-"other parties"
+msgid "Share their account logins or passwords with others, or sell their access to other parties"
 msgstr ""
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
@@ -2291,23 +1917,17 @@ msgstr ""
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:144
-msgid ""
-"Systematically make printed or electronic copies of multiple extracts of "
-"restricted content available for any purpose"
+msgid "Systematically make printed or electronic copies of multiple extracts of restricted content available for any purpose"
 msgstr ""
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/). Stub is a technical term for a short Wikipedia article, use the appropriate Wikipedia term in your language.
 #: TWLight/templates/about.html:148
-msgid ""
-"Datamine metadata without permission, in order, for instance, to use "
-"metadata for auto-created stub articles"
+msgid "Datamine metadata without permission, in order, for instance, to use metadata for auto-created stub articles"
 msgstr ""
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:154
-msgid ""
-"Respecting these agreements allows us to continue growing the partnerships "
-"available to the community."
+msgid "Respecting these agreements allows us to continue growing the partnerships available to the community."
 msgstr ""
 
 #. Translators: This is the heading for a section on the About page (https://wikipedialibrary.wmflabs.org/about/).
@@ -2317,41 +1937,22 @@ msgstr ""
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:164
-msgid ""
-"EZProxy is a proxy server used to authenticate users for many Wikipedia "
-"Library partners. Users sign into EZProxy via the Library Card platform to "
-"verify that they are authorized users, and then the server accesses "
-"requested resources using its own IP address."
+msgid "EZProxy is a proxy server used to authenticate users for many Wikipedia Library partners. Users sign into EZProxy via the Library Card platform to verify that they are authorized users, and then the server accesses requested resources using its own IP address."
 msgstr ""
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:173
-msgid ""
-"You may notice that when accessing resources via EZProxy that URLs are "
-"dynamically rewritten. This is why we recommend logging in via the Library "
-"Card platform rather than going directly to the unproxied partner website. "
-"When in doubt, check the URL for ‘idm.oclc’. If it’s there, then you’re "
-"connected via EZProxy."
+msgid "You may notice that when accessing resources via EZProxy that URLs are dynamically rewritten. This is why we recommend logging in via the Library Card platform rather than going directly to the unproxied partner website. When in doubt, check the URL for ‘idm.oclc’. If it’s there, then you’re connected via EZProxy."
 msgstr ""
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:182
-msgid ""
-"Typically once you’ve logged in your session will remain active in your "
-"browser for up to two hours after you’ve finished searching. Note that use "
-"of EZProxy requires you to enable cookies. If you are having problems you "
-"should also try clearing your cache and restarting your browser."
+msgid "Typically once you’ve logged in your session will remain active in your browser for up to two hours after you’ve finished searching. Note that use of EZProxy requires you to enable cookies. If you are having problems you should also try clearing your cache and restarting your browser."
 msgstr ""
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/)
 #: TWLight/templates/about.html:193
-msgid ""
-"The Library Bundle is a collection of resources for which no application is "
-"required. If you meet the criteria laid out above, you will be authorized "
-"for access automatically upon logging in to the platform. Only some of our "
-"content is currently included in the Library Bundle, however we hope to "
-"expand the collection as more publishers become comfortable with "
-"participating. All Bundle content is accessed via EZProxy."
+msgid "The Library Bundle is a collection of resources for which no application is required. If you meet the criteria laid out above, you will be authorized for access automatically upon logging in to the platform. Only some of our content is currently included in the Library Bundle, however we hope to expand the collection as more publishers become comfortable with participating. All Bundle content is accessed via EZProxy."
 msgstr ""
 
 #. Translators: This is the heading for a section on the About page (https://wikipedialibrary.wmflabs.org/about/).
@@ -2361,12 +1962,7 @@ msgstr ""
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:206
-msgid ""
-"Citation practices vary by project and even by article. Generally, we "
-"support editors citing where they found information, in a form that allows "
-"others to check it for themselves. That often means providing both original "
-"source details as well as a link to the partner database in which the source "
-"was found."
+msgid "Citation practices vary by project and even by article. Generally, we support editors citing where they found information, in a form that allows others to check it for themselves. That often means providing both original source details as well as a link to the partner database in which the source was found."
 msgstr ""
 
 #. Translators: This is the heading for a section on the About page (https://wikipedialibrary.wmflabs.org/about/).
@@ -2378,9 +1974,7 @@ msgstr "Hubungi kami"
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:218
 #, python-format
-msgid ""
-"If you have questions, need help, or want to volunteer to help, please see "
-"our <a class=\"twl-links\" href=\"%(contact_url)s\">contact page</a>."
+msgid "If you have questions, need help, or want to volunteer to help, please see our <a class=\"twl-links\" href=\"%(contact_url)s\">contact page</a>."
 msgstr ""
 
 #. Translators: This is the title of the panel box detailing the contact information for the Wikipedia Library team.
@@ -2420,12 +2014,8 @@ msgstr "Laman Twitter Perpustakaan Wikipedia"
 #. Translators: This is the text that appears at the bottom of the contact us form directing users to the suggestions form.
 #: TWLight/templates/contact.html:48
 #, python-format
-msgid ""
-"(If you would like to suggest a partner, <a class=\"twl-links\" href="
-"\"%(suggest)s\"><strong>go here</strong></a>.)"
-msgstr ""
-"(Jika anda ingin mencadangkan rakan kongsi, <a class=\"twl-links\" href="
-"\"%(suggest)s\"><strong>pergi ke sini</strong></a>.)"
+msgid "(If you would like to suggest a partner, <a class=\"twl-links\" href=\"%(suggest)s\"><strong>go here</strong></a>.)"
+msgstr "(Jika anda ingin mencadangkan rakan kongsi, <a class=\"twl-links\" href=\"%(suggest)s\"><strong>pergi ke sini</strong></a>.)"
 
 #. Translators: On a special 'link to search' page, this message is shown if JavaScript is disabled.
 #: TWLight/templates/eds_search_endpoint.html:7
@@ -2486,9 +2076,7 @@ msgstr "Perpustakaan Wikipedia"
 #. Translators: Information about The Wikipedia Library.
 #: TWLight/templates/login_partial.html:53 TWLight/templates/new_base.html:21
 #, python-format
-msgid ""
-"More than 100 of the world's top subscription-only databases, with content "
-"in %(no_of_languages)s languages, free for Wikipedians of all backgrounds"
+msgid "More than 100 of the world's top subscription-only databases, with content in %(no_of_languages)s languages, free for Wikipedians of all backgrounds"
 msgstr ""
 
 #. Translators: Information about The Wikipedia Library.
@@ -2497,9 +2085,7 @@ msgid "Meet these criteria for automatic access"
 msgstr ""
 
 #: TWLight/templates/login_partial.html:69
-msgid ""
-"These criteria grant you access to certain collections but not all. Some "
-"collections are accessible on a per application basis only."
+msgid "These criteria grant you access to certain collections but not all. Some collections are accessible on a per application basis only."
 msgstr ""
 
 #: TWLight/templates/login_partial.html:89
@@ -2509,29 +2095,19 @@ msgstr "Log masuk melalui Wikipedia"
 #. Translators: Shown if the current user doesn't have a registered email on their account. Don't translate contact_us_url or email_url.
 #: TWLight/templates/message_partial.html:15
 #, python-format
-msgid ""
-"You don't have an email on file. We can't finalize your access to partner "
-"resources, and you won't be able to <a class=\"twl-links\" href="
-"\"%(contact_us_url)s\">contact us</a> without an email. Please <a class="
-"\"twl-links\" href=\"%(email_url)s\">update your email</a>."
+msgid "You don't have an email on file. We can't finalize your access to partner resources, and you won't be able to <a class=\"twl-links\" href=\"%(contact_us_url)s\">contact us</a> without an email. Please <a class=\"twl-links\" href=\"%(email_url)s\">update your email</a>."
 msgstr ""
 
 #. Translators: Shown if the current user has requested the processing of their data should be restricted.
 #: TWLight/templates/message_partial.html:26
 #, python-format
-msgid ""
-"You have requested a restriction on the processing of your data. Most site "
-"functionality will not be available to you until you <a class=\"twl-links\" "
-"href=\"%(restrict_url)s\">lift this restriction</a>."
+msgid "You have requested a restriction on the processing of your data. Most site functionality will not be available to you until you <a class=\"twl-links\" href=\"%(restrict_url)s\">lift this restriction</a>."
 msgstr ""
 
 #. Translators: Shown if the current user has not agreed to the terms of use.
 #: TWLight/templates/message_partial.html:37
 #, python-format
-msgid ""
-"You have not agreed to the <a class=\"twl-links\" href=\"%(terms_url)s"
-"\">terms of use</a> of this site. Your applications will not be processed "
-"and you won't be able to apply or access resources you are approved for."
+msgid "You have not agreed to the <a class=\"twl-links\" href=\"%(terms_url)s\">terms of use</a> of this site. Your applications will not be processed and you won't be able to apply or access resources you are approved for."
 msgstr ""
 
 #. Translators: This link is at the bottom of every page and links to the 'About' page (https://wikipedialibrary.wmflabs.org/about/)
@@ -2579,9 +2155,7 @@ msgstr "Set semula kata laluan"
 
 #. Translators: If a user goes to reset their password, this message asks them to enter their email to do so.
 #: TWLight/templates/registration/password_reset_form.html:13
-msgid ""
-"Forgot your password? Enter your email address below, and we'll email "
-"instructions for setting a new one."
+msgid "Forgot your password? Enter your email address below, and we'll email instructions for setting a new one."
 msgstr ""
 
 #. Translators: This is the label for a button that users click to update their public information.
@@ -2626,16 +2200,12 @@ msgstr ""
 
 #. Translators: This text explains how to disagree to the site's terms of use and the restrictions that will come into effect when users disagree to the terms of use.
 #: TWLight/users/forms.py:185
-msgid ""
-"By unchecking this box and clicking “Update” you may explore the site, but "
-"you will not be able to apply for access to materials or evaluate "
-"applications unless you agree with the terms of use."
+msgid "By unchecking this box and clicking “Update” you may explore the site, but you will not be able to apply for access to materials or evaluate applications unless you agree with the terms of use."
 msgstr ""
 
 #. Translators: Users click this button to set their website email address to the one linked to their Wikipedia account.
 #: TWLight/users/forms.py:211
-msgid ""
-"Use my Wikipedia email address (will be updated the next time you login)."
+msgid "Use my Wikipedia email address (will be updated the next time you login)."
 msgstr ""
 
 #. Translators: This labels a button which users click to change their email.
@@ -2646,17 +2216,8 @@ msgstr "Kemas kini e-mel"
 #. Translators: Shown if the current user tried to 'favorite' a partner they can't access. Do not translate '{partner}'
 #: TWLight/users/models.py:201
 #, python-brace-format
-msgid ""
-"Cannot add partner {partner} to your favorites because you don't have access "
-"to it"
+msgid "Cannot add partner {partner} to your favorites because you don't have access to it"
 msgstr ""
-
-#. Translators: Do not translate.
-#: TWLight/users/models.py:869
-#, fuzzy, python-brace-format
-#| msgid "Username"
-msgid "{wp_username}"
-msgstr "Nama pengguna"
 
 #. Translators: This error message is shown when there's a problem with the authenticated login process.
 #: TWLight/users/oauth.py:243
@@ -2676,9 +2237,7 @@ msgstr ""
 
 #. Translators: this message is displayed to users that don't have accounts and clicked on a proxied link.
 #: TWLight/users/oauth.py:388
-msgid ""
-"To view this link you need to be an eligible library user. Please login to "
-"continue."
+msgid "To view this link you need to be an eligible library user. Please login to continue."
 msgstr ""
 
 #. Translators: This warning message is shown to users when the response received from Wikimedia OAuth servers is not a valid one.
@@ -2714,17 +2273,12 @@ msgstr "Maklumat perkhidmatan"
 
 #. Translators: If the user tries to log in, but their account does not meet certain requirements, they cannot login.
 #: TWLight/users/oauth.py:528
-msgid ""
-"Your Wikipedia account does not meet the eligibility criteria in the terms "
-"of use, so your Wikipedia Library Card Platform account cannot be activated."
+msgid "Your Wikipedia account does not meet the eligibility criteria in the terms of use, so your Wikipedia Library Card Platform account cannot be activated."
 msgstr ""
 
 #. Translators: If the user tries to log in, but their account does not meet certain requirements, they cannot login.
 #: TWLight/users/oauth.py:536
-msgid ""
-"Your Wikipedia account no longer meets the eligibility criteria in the terms "
-"of use, so you cannot be logged in. If you think you should be able to log "
-"in, please email wikipedialibrary@wikimedia.org."
+msgid "Your Wikipedia account no longer meets the eligibility criteria in the terms of use, so you cannot be logged in. If you think you should be able to log in, please email wikipedialibrary@wikimedia.org."
 msgstr ""
 
 #. Translators: this message is displayed to users with brand new accounts.
@@ -2735,10 +2289,7 @@ msgstr ""
 #. Translators: This message is displayed on the confirmation page where users can return their access to partner collections.
 #: TWLight/users/templates/users/authorization_confirm_return.html:13
 #, python-format
-msgid ""
-"You will no longer be able to access <b>%(partner)s's</b> resources via the "
-"Library Card platform, but can request access again by clicking 'renew', if "
-"you change your mind. Are you sure you want to return your access?"
+msgid "You will no longer be able to access <b>%(partner)s's</b> resources via the Library Card platform, but can request access again by clicking 'renew', if you change your mind. Are you sure you want to return your access?"
 msgstr ""
 
 #. Translators: On the MyLibrary page (https://wikipedialibrary.wmflabs.org/users/my_library), this tab shows all favorite collections a user has.
@@ -2810,10 +2361,7 @@ msgstr ""
 
 #. Translators: This is shown on editor profiles, in their profile page or on applications.
 #: TWLight/users/templates/users/editor_detail.html:59
-msgid ""
-"Information with an * was retrieved from Wikipedia directly. Other "
-"information was entered directly by users or site admins, in their preferred "
-"language."
+msgid "Information with an * was retrieved from Wikipedia directly. Other information was entered directly by users or site admins, in their preferred language."
 msgstr ""
 
 #. Translators: This distinguishes users who have been flagged as account coordinators. Don't translate username.
@@ -2824,10 +2372,7 @@ msgstr ""
 
 #. Translators: This is shown on editor profiles, under the heading for Wikipedia editor data.
 #: TWLight/users/templates/users/editor_detail_data.html:5
-msgid ""
-"This information is updated automatically from your Wikimedia account each "
-"time you log in, except for the Contributions field, where you can describe "
-"your Wikimedia editing history."
+msgid "This information is updated automatically from your Wikimedia account each time you log in, except for the Contributions field, where you can describe your Wikimedia editing history."
 msgstr ""
 
 #. Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this labels the user's username.
@@ -2857,17 +2402,13 @@ msgstr ""
 
 #. Translators: when viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this question has a yes or no answer.
 #: TWLight/users/templates/users/editor_detail_data.html:57
-msgid ""
-"at their last login, did this user meet the criteria set forth in the terms "
-"of use?"
+msgid "at their last login, did this user meet the criteria set forth in the terms of use?"
 msgstr ""
 
 #. Translators: When viewing a user's profile in an application, this message shows if the software doesn't think that the user is eligible for access. Don't translate username.
 #: TWLight/users/templates/users/editor_detail_data.html:72
 #, python-format
-msgid ""
-"%(username)s may still be eligible for access grants at the coordinators' "
-"discretion."
+msgid "%(username)s may still be eligible for access grants at the coordinators' discretion."
 msgstr ""
 
 #. Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this is the heading for a Yes/No ToU question.
@@ -2902,10 +2443,7 @@ msgstr ""
 #. Translators: This message is shown on a user's profile if their Wikimedia account is blocked on one or more projects. They may still be granted access to the Library Bundle, but need to contact Wikipedia Library staff to verify.
 #: TWLight/users/templates/users/editor_detail_data.html:137
 #, python-format
-msgid ""
-"It looks like you have an active block on your account. If you meet the "
-"other criteria you may still be permitted access to the library - please <a "
-"class=\"twl-links\" href=\"%(contact_url)s\">contact us</a>."
+msgid "It looks like you have an active block on your account. If you meet the other criteria you may still be permitted access to the library - please <a class=\"twl-links\" href=\"%(contact_url)s\">contact us</a>."
 msgstr ""
 
 #. Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this is the heading for a Yes/No program eligibility question.
@@ -2915,10 +2453,7 @@ msgstr ""
 
 #. Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this question has a Yes or No answer.
 #: TWLight/users/templates/users/editor_detail_data.html:156
-msgid ""
-"At their last login, did this user meet the criteria set forth in the "
-"Library Bundle? Note that satisfying terms of use is a prerequisite to "
-"bundle eligibility."
+msgid "At their last login, did this user meet the criteria set forth in the Library Bundle? Note that satisfying terms of use is a prerequisite to bundle eligibility."
 msgstr ""
 
 #. Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this is the heading for a Yes/No program eligibility question.
@@ -2963,18 +2498,13 @@ msgstr "Data peribadi"
 
 #. Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this text is in the 'Personal data' section. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/users/templates/users/editor_detail_data.html:262
-msgid ""
-"The following information is visible only to you, site administrators, "
-"publishing partners (where required), and volunteer Wikipedia Library "
-"coordinators (who have signed a Non-Disclosure Agreement)."
+msgid "The following information is visible only to you, site administrators, publishing partners (where required), and volunteer Wikipedia Library coordinators (who have signed a Non-Disclosure Agreement)."
 msgstr ""
 
 #. Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this labels a button which users can click to update or remove their personal information. Don't translate update_url.
 #: TWLight/users/templates/users/editor_detail_data.html:272
 #, python-format
-msgid ""
-"You may <a class=\"twl-links\" href=\"%(update_url)s\">update or delete</a> "
-"your data at any time."
+msgid "You may <a class=\"twl-links\" href=\"%(update_url)s\">update or delete</a> your data at any time."
 msgstr ""
 
 #. Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this labels the user's email. Don't remove the *.
@@ -2994,24 +2524,18 @@ msgstr ""
 
 #. Translators: This message tells users that they are not eligible to access The Wikipedia Library content.
 #: TWLight/users/templates/users/eligibility_modal.html:7
-msgid ""
-"Sorry, your Wikipedia account doesn’t currently qualify to access The "
-"Wikipedia Library."
+msgid "Sorry, your Wikipedia account doesn’t currently qualify to access The Wikipedia Library."
 msgstr ""
 
 #. Translators: This message tells users that they have not agreed to the terms of use, therefore are ineligible to access the content in The Wikipedia Library.
 #: TWLight/users/templates/users/eligibility_modal.html:30
 #, python-format
-msgid ""
-"Agreed with <a href=\"%(terms)s\" class=\"text-danger\"> terms of use </a>"
+msgid "Agreed with <a href=\"%(terms)s\" class=\"text-danger\"> terms of use </a>"
 msgstr ""
 
 #: TWLight/users/templates/users/eligibility_modal.html:40
 #, python-format
-msgid ""
-"It looks like you have an active block on your account. If you meet the "
-"other criteria you may still be permitted access to the library - please <a "
-"href=\"%(contact_url)s\">contact us</a>."
+msgid "It looks like you have an active block on your account. If you meet the other criteria you may still be permitted access to the library - please <a href=\"%(contact_url)s\">contact us</a>."
 msgstr ""
 
 #. Translators: Instructions to refresh a user's data.
@@ -3051,10 +2575,7 @@ msgstr "Pilih bahasa"
 
 #. Translators: This text on the user page helps users naviage to the TranslateWiki Wikipedia Library Card platform translation page.
 #: TWLight/users/templates/users/language_form.html:31
-msgid ""
-"You can help translate the tool at <a class=\"twl-links\" href=\"https://"
-"translatewiki.net/wiki/Translating:Wikipedia_Library_Card_Platform"
-"\">translatewiki.net</a>."
+msgid "You can help translate the tool at <a class=\"twl-links\" href=\"https://translatewiki.net/wiki/Translating:Wikipedia_Library_Card_Platform\">translatewiki.net</a>."
 msgstr ""
 
 #. Translators: When the user starts a new application and submits the application, the user can view the application and withdraw if need be. This changes the label for the Withdraw button.
@@ -3074,12 +2595,8 @@ msgstr "Minta pembaharuan"
 
 #. Translators: On the page listing applications, this text explains a user they cannot renew their application since they've already requested a renewal or there aren't any renewals available.
 #: TWLight/users/templates/users/my_applications.html:79
-msgid ""
-"Renewals are either not required, not available right now, or you have "
-"already requested a renewal."
-msgstr ""
-"Pembaharuan sama ada tidak diperlukan, tidak ada pada masa ini, atau anda "
-"telah meminta pembaharuan."
+msgid "Renewals are either not required, not available right now, or you have already requested a renewal."
+msgstr "Pembaharuan sama ada tidak diperlukan, tidak ada pada masa ini, atau anda telah meminta pembaharuan."
 
 #. Translators: This text is the heading of a section in a user's profile where they can change their preferences.
 #: TWLight/users/templates/users/preferences.html:6
@@ -3142,19 +2659,12 @@ msgstr ""
 
 #. Translators: This message is displayed on the page where users can request we stop processing their data.
 #: TWLight/users/templates/users/restrict_data.html:15
-msgid ""
-"Checking this box and clicking “Restrict” will pause all processing of the "
-"data you have entered into this website. You will not be able to apply for "
-"access to resources, your applications will not be further processed, and "
-"none of your data will be altered, until you return to this page and uncheck "
-"the box. This is not the same as deleting your data."
+msgid "Checking this box and clicking “Restrict” will pause all processing of the data you have entered into this website. You will not be able to apply for access to resources, your applications will not be further processed, and none of your data will be altered, until you return to this page and uncheck the box. This is not the same as deleting your data."
 msgstr ""
 
 #. Translators: This warning message is shown to coordinators who view the data restriction page.
 #: TWLight/users/templates/users/restrict_data.html:26
-msgid ""
-"You are a coordinator on this site. If you restrict the processing of your "
-"data, your coordinator flag will be removed."
+msgid "You are a coordinator on this site. If you restrict the processing of your data, your coordinator flag will be removed."
 msgstr ""
 
 #. Translators: use the date *when you are translating*, in a language-appropriate format.
@@ -3174,24 +2684,12 @@ msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:51
-msgid ""
-"<a class=\"twl-links\" href=\"https://meta.wikimedia.org/wiki/"
-"The_Wikipedia_Library\"> The Wikipedia Library </a> has partnered with "
-"publishers around the world to allow users to access otherwise paywalled "
-"resources. This website allows Wikipedia editors to search and access these "
-"resources."
+msgid "<a class=\"twl-links\" href=\"https://meta.wikimedia.org/wiki/The_Wikipedia_Library\"> The Wikipedia Library </a> has partnered with publishers around the world to allow users to access otherwise paywalled resources. This website allows Wikipedia editors to search and access these resources."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Wikimedia Foundation should not be translated. WMF should not be translated. Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:63
-msgid ""
-"This program is administered by the Wikimedia Foundation (WMF). These terms "
-"of use and privacy notice pertain to your application for access to "
-"resources through the Wikipedia Library, your use of this website, and your "
-"access to and use of those resources. They also describe our handling of the "
-"information you provide to us in order to create and administer your "
-"Wikipedia Library account. If we make material changes to the terms, we will "
-"notify users."
+msgid "This program is administered by the Wikimedia Foundation (WMF). These terms of use and privacy notice pertain to your application for access to resources through the Wikipedia Library, your use of this website, and your access to and use of those resources. They also describe our handling of the information you provide to us in order to create and administer your Wikipedia Library account. If we make material changes to the terms, we will notify users."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
@@ -3201,37 +2699,17 @@ msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:78
-msgid ""
-"Access to resources via The Wikipedia Library is reserved for community "
-"members who have demonstrated their commitment to the Wikimedia projects, "
-"and who will use their access to these resources to improve project content. "
-"To that end, in order to be eligible for The Wikipedia Library, we require "
-"that you be registered for a user account on the projects, with at least 500 "
-"edits, six (6) months of activity, and 10+ edits in the last month. We ask "
-"that you do not request access to any publishers with a limited number of "
-"available accounts whose resources you can already access for free through "
-"your local library or university, or another institution or organization, in "
-"order to provide that opportunity to others."
+msgid "Access to resources via The Wikipedia Library is reserved for community members who have demonstrated their commitment to the Wikimedia projects, and who will use their access to these resources to improve project content. To that end, in order to be eligible for The Wikipedia Library, we require that you be registered for a user account on the projects, with at least 500 edits, six (6) months of activity, and 10+ edits in the last month. We ask that you do not request access to any publishers with a limited number of available accounts whose resources you can already access for free through your local library or university, or another institution or organization, in order to provide that opportunity to others."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:94
-msgid ""
-"Additionally, if you are currently blocked or banned from a Wikimedia "
-"project, applications to resources may be rejected or restricted. If you "
-"obtain a Wikipedia Library account, but a block or ban is subsequently "
-"instituted against you on one of the projects, you may lose access to your "
-"Wikipedia Library account."
+msgid "Additionally, if you are currently blocked or banned from a Wikimedia project, applications to resources may be rejected or restricted. If you obtain a Wikipedia Library account, but a block or ban is subsequently instituted against you on one of the projects, you may lose access to your Wikipedia Library account."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:104
-msgid ""
-"Your eligibility to access The Wikipedia Library is assessed at each login. "
-"While more than half of the library's content is provided via this automated "
-"eligibility check, access to other publisher's content may be time limited, "
-"typically lapsing after one year, after which you will usually need to apply "
-"for renewal."
+msgid "Your eligibility to access The Wikipedia Library is assessed at each login. While more than half of the library's content is provided via this automated eligibility check, access to other publisher's content may be time limited, typically lapsing after one year, after which you will usually need to apply for renewal."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
@@ -3241,47 +2719,27 @@ msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:118
-msgid ""
-"In order to apply for access to a partner resource, you must provide us with "
-"certain information, which we will use to evaluate your application. If your "
-"application is approved, we may transfer the information you have given us "
-"to the publishers whose resources you wish to access. They will either "
-"contact you with the account information directly or we will send access "
-"information to you ourselves."
+msgid "In order to apply for access to a partner resource, you must provide us with certain information, which we will use to evaluate your application. If your application is approved, we may transfer the information you have given us to the publishers whose resources you wish to access. They will either contact you with the account information directly or we will send access information to you ourselves."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:130
-msgid ""
-"In addition to the basic information you provide to us, our system will "
-"retrieve some information directly from the Wikimedia projects: your "
-"username, email address, edit count, registration date, user ID number, "
-"groups to which you belong, and any special user rights."
+msgid "In addition to the basic information you provide to us, our system will retrieve some information directly from the Wikimedia projects: your username, email address, edit count, registration date, user ID number, groups to which you belong, and any special user rights."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:140
-msgid ""
-"Each time you log in to the Wikipedia Library Card Platform, this "
-"information will be automatically updated."
+msgid "Each time you log in to the Wikipedia Library Card Platform, this information will be automatically updated."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:148
-msgid ""
-"We will ask you to provide us with some information about your history of "
-"contributions to the Wikimedia projects. Information on contribution history "
-"is optional, but will greatly assist us in evaluating your application."
+msgid "We will ask you to provide us with some information about your history of contributions to the Wikimedia projects. Information on contribution history is optional, but will greatly assist us in evaluating your application."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). WMF should not be translated. Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:157
-msgid ""
-"The information you provide when creating your account will be visible to "
-"you while on the site but not to others unless they are approved Wikipedia "
-"Library Coordinators, WMF Staff, or WMF Contractors who need access to this "
-"data in order to carry out their work with the Wikipedia Library, all of "
-"whom are subject to non-disclosure obligations."
+msgid "The information you provide when creating your account will be visible to you while on the site but not to others unless they are approved Wikipedia Library Coordinators, WMF Staff, or WMF Contractors who need access to this data in order to carry out their work with the Wikipedia Library, all of whom are subject to non-disclosure obligations."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
@@ -3291,46 +2749,32 @@ msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:171
-msgid ""
-"In order to access an individual publisher’s resources, you must agree to "
-"that publisher’s terms of use and privacy policy. You agree that you will "
-"not violate such terms and policies in connection with your use of the "
-"Wikipedia Library. Additionally, the following activities are prohibited "
-"while accessing publisher resources through the Wikipedia Library."
+msgid "In order to access an individual publisher’s resources, you must agree to that publisher’s terms of use and privacy policy. You agree that you will not violate such terms and policies in connection with your use of the Wikipedia Library. Additionally, the following activities are prohibited while accessing publisher resources through the Wikipedia Library."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:184
-msgid ""
-"Sharing your Wikipedia account, usernames, passwords, or any access codes "
-"for publisher resources with others;"
+msgid "Sharing your Wikipedia account, usernames, passwords, or any access codes for publisher resources with others;"
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:191
-msgid ""
-"Automatically scraping or downloading restricted content from publishers;"
+msgid "Automatically scraping or downloading restricted content from publishers;"
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:197
-msgid ""
-"Systematically making printed or electronic copies of multiple extracts of "
-"restricted content available for any purpose;"
+msgid "Systematically making printed or electronic copies of multiple extracts of restricted content available for any purpose;"
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:204
-msgid ""
-"Data mining metadata without permission—for example, in order to use "
-"metadata for auto-created stub articles;"
+msgid "Data mining metadata without permission—for example, in order to use metadata for auto-created stub articles;"
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:211
-msgid ""
-"Using the access you receive through the Wikipedia Library for profit by "
-"selling access to your account or resources which you have through it."
+msgid "Using the access you receive through the Wikipedia Library for profit by selling access to your account or resources which you have through it."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
@@ -3340,18 +2784,12 @@ msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:224
-msgid ""
-"Certain resources may only be accessed using an external search service, "
-"such as the EBSCO Discovery Service, or a proxy service, such as OCLC "
-"EZProxy. If you use such external search and/or proxy services, please "
-"review the applicable terms of use and privacy policies."
+msgid "Certain resources may only be accessed using an external search service, such as the EBSCO Discovery Service, or a proxy service, such as OCLC EZProxy. If you use such external search and/or proxy services, please review the applicable terms of use and privacy policies."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:234
-msgid ""
-"In addition, if you use OCLC EZProxy, please note that you may not use it "
-"for commercial purposes."
+msgid "In addition, if you use OCLC EZProxy, please note that you may not use it for commercial purposes."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
@@ -3361,120 +2799,49 @@ msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Wikimedia Foundation should not be translated. Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:245
-msgid ""
-"The Wikimedia Foundation and our service providers use your information for "
-"the legitimate purpose of providing Wikipedia Library services in support of "
-"our charitable mission. When you apply for a Wikipedia Library account, or "
-"use your Wikipedia Library account, we may routinely collect the following "
-"information: your username, email address, edit count, registration date, "
-"user ID number, groups to which you belong, and any special user rights; "
-"your name, country of residence, and/or affiliation, if required by a "
-"partner to which you are applying; your narrative description of your "
-"contributions and reasons for applying for access to partner resources; and "
-"the date you agree to these terms of use."
+msgid "The Wikimedia Foundation and our service providers use your information for the legitimate purpose of providing Wikipedia Library services in support of our charitable mission. When you apply for a Wikipedia Library account, or use your Wikipedia Library account, we may routinely collect the following information: your username, email address, edit count, registration date, user ID number, groups to which you belong, and any special user rights; your name, country of residence, and/or affiliation, if required by a partner to which you are applying; your narrative description of your contributions and reasons for applying for access to partner resources; and the date you agree to these terms of use."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:262
 #, python-format
-msgid ""
-"Each publisher who is a member of the Wikipedia Library program requires "
-"different specific information in the application. Some publishers may "
-"request only an email address, while others request more detailed data, such "
-"as your name, location, or institutional affiliation. When you complete your "
-"application, you will only be asked to supply information required by the "
-"publishers you have chosen, and each publisher will only receive the "
-"information they require for providing you with access. Please see our <a "
-"class=\"twl-links\" href=\"%(all_partners_url)s\">partner information</a> "
-"pages to learn what information is required by each publisher to gain access "
-"to their resources."
+msgid "Each publisher who is a member of the Wikipedia Library program requires different specific information in the application. Some publishers may request only an email address, while others request more detailed data, such as your name, location, or institutional affiliation. When you complete your application, you will only be asked to supply information required by the publishers you have chosen, and each publisher will only receive the information they require for providing you with access. Please see our <a class=\"twl-links\" href=\"%(all_partners_url)s\">partner information</a> pages to learn what information is required by each publisher to gain access to their resources."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Wikimedia Foundation should not be translated. Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:277
-msgid ""
-"Some Wikipedia Library pages are visible without logging in, but you will "
-"need to log in to apply or access proprietary partner resources. We use the "
-"data provided by you via OAuth and Wikimedia API calls to assess your "
-"application for access and to process approved requests."
+msgid "Some Wikipedia Library pages are visible without logging in, but you will need to log in to apply or access proprietary partner resources. We use the data provided by you via OAuth and Wikimedia API calls to assess your application for access and to process approved requests."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:288
 #, python-format
-msgid ""
-"In order to administer the Wikipedia Library program, we will retain the "
-"application data we collect from you for three years after your most recent "
-"login, unless you delete your account, as described below. You can log in "
-"and go to <a class=\"twl-links\" href=\"%(profile_url)s\">your profile page</"
-"a> in order to see the information associated with your account, and can "
-"download it in JSON format. You may access, update, restrict, or delete this "
-"information at any time, except for the information that is automatically "
-"retrieved from the projects. If you have any questions or concerns about the "
-"handling of your data, please contact <a class=\"twl-links\" href=\"mailto:"
-"wikipedialibrary@wikimedia.org?Subject=Wikipedia%%20Library%%20Card"
-"%%20account%%20deactivation\"> wikipedialibrary@wikimedia.org </a>."
+msgid "In order to administer the Wikipedia Library program, we will retain the application data we collect from you for three years after your most recent login, unless you delete your account, as described below. You can log in and go to <a class=\"twl-links\" href=\"%(profile_url)s\">your profile page</a> in order to see the information associated with your account, and can download it in JSON format. You may access, update, restrict, or delete this information at any time, except for the information that is automatically retrieved from the projects. If you have any questions or concerns about the handling of your data, please contact <a class=\"twl-links\" href=\"mailto:wikipedialibrary@wikimedia.org?Subject=Wikipedia%%20Library%%20Card%%20account%%20deactivation\"> wikipedialibrary@wikimedia.org </a>."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:305
-msgid ""
-"If you decide to disable your Wikipedia Library account, you can use the "
-"delete button on your profile to delete certain personal information "
-"associated with your account. We will delete your real name, institutional "
-"affiliation, and country of residence. Please note that the system will "
-"retain a record of your username, the publishers to which you applied or had "
-"access, and the dates of that access. Note that deletion is not reversible. "
-"Deletion of your Wikipedia Library account may also correspond with the "
-"removal of any resource access to which you were eligible or approved. If "
-"you request the deletion of account information and later wish to apply for "
-"a new account, you will need to provide the necessary information again."
+msgid "If you decide to disable your Wikipedia Library account, you can use the delete button on your profile to delete certain personal information associated with your account. We will delete your real name, institutional affiliation, and country of residence. Please note that the system will retain a record of your username, the publishers to which you applied or had access, and the dates of that access. Note that deletion is not reversible. Deletion of your Wikipedia Library account may also correspond with the removal of any resource access to which you were eligible or approved. If you request the deletion of account information and later wish to apply for a new account, you will need to provide the necessary information again."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). WMF should not be translated. Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:321
-msgid ""
-"The Wikipedia Library is run by WMF Staff, Contractors, and approved "
-"volunteer Coordinators. The data associated with your account will be shared "
-"with the WMF staff, contractors, service providers, and volunteer "
-"coordinators who need to process the information in connection with their "
-"work for the Wikipedia Library, and who are subject to confidentiality "
-"obligations. We will also use your data for internal Wikipedia Library "
-"purposes such as distributing user surveys and account notifications, and in "
-"a depersonalized or aggregated fashion for statistical analysis and "
-"administration. Finally, we will share your information with the publishers "
-"whom you specifically select in order to provide you with access to "
-"resources. Otherwise, your information will not be shared with third "
-"parties, with the exception of the circumstances described below."
+msgid "The Wikipedia Library is run by WMF Staff, Contractors, and approved volunteer Coordinators. The data associated with your account will be shared with the WMF staff, contractors, service providers, and volunteer coordinators who need to process the information in connection with their work for the Wikipedia Library, and who are subject to confidentiality obligations. We will also use your data for internal Wikipedia Library purposes such as distributing user surveys and account notifications, and in a depersonalized or aggregated fashion for statistical analysis and administration. Finally, we will share your information with the publishers whom you specifically select in order to provide you with access to resources. Otherwise, your information will not be shared with third parties, with the exception of the circumstances described below."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). WMF should not be translated.
 #: TWLight/users/templates/users/terms.html:338
-msgid ""
-"We may disclose any collected information when required by law, when we have "
-"your permission, when needed to protect our rights, privacy, safety, users, "
-"or the general public, and when necessary to enforce these terms, WMF’s "
-"general <a class=\"twl-links\" href=\"https://foundation.wikimedia.org/wiki/"
-"Terms_of_Use\">Terms of Use</a>, or any other WMF policy."
+msgid "We may disclose any collected information when required by law, when we have your permission, when needed to protect our rights, privacy, safety, users, or the general public, and when necessary to enforce these terms, WMF’s general <a class=\"twl-links\" href=\"https://foundation.wikimedia.org/wiki/Terms_of_Use\">Terms of Use</a>, or any other WMF policy."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:349
-msgid ""
-"We take the security of your personal data seriously, and take reasonable "
-"precautions to ensure your data is protected. These precautions include "
-"access controls to limit who has access to your data and security "
-"technologies to protect data stored on the server. However, we cannot "
-"guarantee the safety of your data as it is transmitted and stored."
+msgid "We take the security of your personal data seriously, and take reasonable precautions to ensure your data is protected. These precautions include access controls to limit who has access to your data and security technologies to protect data stored on the server. However, we cannot guarantee the safety of your data as it is transmitted and stored."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:360
-msgid ""
-"Please note that these terms do not control the use and handling of your "
-"data by the publishers and service providers whose resources you access or "
-"apply to access. Please read their individual privacy policies for that "
-"information."
+msgid "Please note that these terms do not control the use and handling of your data by the publishers and service providers whose resources you access or apply to access. Please read their individual privacy policies for that information."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
@@ -3484,34 +2851,17 @@ msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Wikimedia Foundation should not be translated. Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:373
-msgid ""
-"The Wikimedia Foundation is a nonprofit organization based in San Francisco, "
-"California. The Wikipedia Library program provides access to resources held "
-"by publishers in multiple countries. If you apply for a Wikipedia Library "
-"account (whether you are inside or outside of the United States), you "
-"understand that your personal data will be collected, transferred, stored, "
-"processed, disclosed and otherwise used in the U.S. as described in this "
-"privacy policy. You also understand that your information may be transferred "
-"by us from the U.S. to other countries, which may have different or less "
-"stringent data protection laws than your country, in connection with "
-"providing services to you, including evaluating your application and "
-"securing access to your chosen publishers (locations for each publisher are "
-"outlined on their respective partner information pages)."
+msgid "The Wikimedia Foundation is a nonprofit organization based in San Francisco, California. The Wikipedia Library program provides access to resources held by publishers in multiple countries. If you apply for a Wikipedia Library account (whether you are inside or outside of the United States), you understand that your personal data will be collected, transferred, stored, processed, disclosed and otherwise used in the U.S. as described in this privacy policy. You also understand that your information may be transferred by us from the U.S. to other countries, which may have different or less stringent data protection laws than your country, in connection with providing services to you, including evaluating your application and securing access to your chosen publishers (locations for each publisher are outlined on their respective partner information pages)."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:392
-msgid ""
-"Please note that in the event of any differences in meaning or "
-"interpretation between the original English version of these terms and a "
-"translation, the original English version takes precedence."
+msgid "Please note that in the event of any differences in meaning or interpretation between the original English version of these terms and a translation, the original English version takes precedence."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Wikimedia Foundation should not be translated.
 #: TWLight/users/templates/users/terms.html:403
-msgid ""
-"See also the <a class=\"twl-links\" href=\"https://wikimediafoundation.org/"
-"wiki/Privacy_policy\">Wikimedia Foundation Privacy Policy</a>."
+msgid "See also the <a class=\"twl-links\" href=\"https://wikimediafoundation.org/wiki/Privacy_policy\">Wikimedia Foundation Privacy Policy</a>."
 msgstr ""
 
 #. Translators: This is the second to last line of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
@@ -3531,11 +2881,7 @@ msgstr "Yayasan Wikimedia"
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:426
-msgid ""
-"By checking this box and clicking “Submit”, you agree that you have read the "
-"above terms and that you will adhere to the terms of use in your application "
-"to and use of the The Wikipedia Library, and the publishers’ services to "
-"which you gain access through The Wikipedia Library program."
+msgid "By checking this box and clicking “Submit”, you agree that you have read the above terms and that you will adhere to the terms of use in your application to and use of the The Wikipedia Library, and the publishers’ services to which you gain access through The Wikipedia Library program."
 msgstr ""
 
 #: TWLight/users/templates/users/user_collection_tile.html:32
@@ -3589,29 +2935,18 @@ msgstr ""
 
 #. Translators: This message is displayed on the page where users can request the deletion of their data.
 #: TWLight/users/templates/users/user_confirm_delete.html:17
-msgid ""
-"<b>Warning:</b> Performing this action will delete your Wikipedia Library "
-"Card user account and all associated applications. This process is not "
-"reversible. You may lose any partner accounts you were granted, and will not "
-"be able to renew those accounts or apply for new ones."
+msgid "<b>Warning:</b> Performing this action will delete your Wikipedia Library Card user account and all associated applications. This process is not reversible. You may lose any partner accounts you were granted, and will not be able to renew those accounts or apply for new ones."
 msgstr ""
 
 #. Translators: this should show up for people who log in with a username/password and not OAuth, so we don't know what their Wikipedia identity is.
-#.
 #: TWLight/users/templates/users/user_detail.html:12
 #, python-format
-msgid ""
-"Hi, %(username)s! You don't have a Wikipedia editor profile attached to your "
-"account here, so you are probably a site administrator."
+msgid "Hi, %(username)s! You don't have a Wikipedia editor profile attached to your account here, so you are probably a site administrator."
 msgstr ""
 
 #. Translators: In the unlikely scenario that someone is able to register an account without using OAuth (thus leaving us without some of the information required for applications), users will see this message, encouraging them to re-register.
 #: TWLight/users/templates/users/user_detail.html:20
-msgid ""
-"If you aren't a site administrator, something weird has happened. You won't "
-"be able to apply for access without a Wikipedia editor profile. You should "
-"log out and create a new account by logging in via OAuth, or contact a site "
-"administrator for help."
+msgid "If you aren't a site administrator, something weird has happened. You won't be able to apply for access without a Wikipedia editor profile. You should log out and create a new account by logging in via OAuth, or contact a site administrator for help."
 msgstr ""
 
 #. Translators: Labels a sections where coordinators can select their email preferences.
@@ -3622,17 +2957,12 @@ msgstr ""
 #. Translators: This message is shown on user's own profile page, encouraging them to make sure their information is up to date, so that account coordinators can use the information to judge applications.
 #: TWLight/users/views.py:176
 #, python-brace-format
-msgid ""
-"Please <a class='twl-links' href='{url}'>update your contributions</a> to "
-"Wikipedia to help coordinators evaluate your applications."
+msgid "Please <a class='twl-links' href='{url}'>update your contributions</a> to Wikipedia to help coordinators evaluate your applications."
 msgstr ""
 
 #. Translators: Coordinators are shown this message when they unselect all three types of reminder email options under preferences.
 #: TWLight/users/views.py:288
-msgid ""
-"You have chosen not to receive reminder emails. As a coordinator, you should "
-"receive at least one type of reminder emails, so consider changing your "
-"preferences."
+msgid "You have chosen not to receive reminder emails. As a coordinator, you should receive at least one type of reminder emails, so consider changing your preferences."
 msgstr ""
 
 #. Translators: Coordinators are shown this message when they make changes to their reminder email options under preferences.
@@ -3666,9 +2996,7 @@ msgstr ""
 
 #. Translators: If the user has not filled out their email, they can browse the website but cannot apply for access to resources.
 #: TWLight/users/views.py:487
-msgid ""
-"Your email is blank. You can still explore the site, but you won't be able "
-"to apply for access to partner resources without an email."
+msgid "Your email is blank. You can still explore the site, but you won't be able to apply for access to partner resources without an email."
 msgstr ""
 
 #. Translators: This message is shown once the access to a partner has successfully been returned.
@@ -3702,31 +3030,3 @@ msgstr ""
 msgid "10+ edits in the last 30 days"
 msgstr "10+ suntingan pada bulan lepas"
 
-#: tests/shunit/data/bad_i18n_comment_1.py:3
-#: tests/shunit/data/bad_i18n_newline_1.py:5
-msgid "1"
-msgstr ""
-
-#. Translators: Lorem ipsum dolor sit amet, consectetur adipiscing elit. Mauris vitae ipsum ut purus faucibus pretium. Proin tempus neque et aliquet consectetur. Ut egestas sapien in consectetur sagittis. Mauris neque lacus, dapibus non viverra vitae, interdum ut aenean ipsum.
-#. Translators: Lorem ipsum dolor sit amet, consectetur adipiscing elit. Mauris vitae ipsum ut purus faucibus pretium. Proin tempus neque et aliquet consectetur. Ut egestas sapien in consectetur sagittis. Mauris neque lacus, dapibus non.
-#: tests/shunit/data/bad_i18n_comment_2.py:4
-#: tests/shunit/data/bad_i18n_newline_2.py:5 tests/shunit/data/good_i18n_1.py:2
-#: tests/shunit/data/good_i18n_2.py:2
-msgid "2"
-msgstr ""
-
-#: tests/shunit/data/bad_i18n_newline_3.py:5
-msgid "3"
-msgstr ""
-
-#: tests/shunit/data/bad_i18n_newline_4.py:5
-msgid "4"
-msgstr ""
-
-#: tests/shunit/data/bad_i18n_newline_5.py:5
-msgid "5"
-msgstr ""
-
-#: tests/shunit/data/bad_i18n_newline_6.py:5
-msgid "6"
-msgstr ""

--- a/locale/my/LC_MESSAGES/django.po
+++ b/locale/my/LC_MESSAGES/django.po
@@ -6,10 +6,11 @@
 # Author: Teitei Para
 msgid ""
 msgstr ""
+""
 "Project-Id-Version: Wikipedia Library Card Platform - Website\n"
-"Report-Msgid-Bugs-To: wikipedialibrary@wikimedia.org\n"
+"Report-Msgid-Bugs-To: translatewiki.net\n"
 "POT-Creation-Date: 2024-07-11 20:54+0000\n"
-"PO-Revision-Date: 2024-07-11 12:30:17+0000\n"
+"PO-Revision-Date: 2024-07-15 12:29:17+0000\n"
 "Language: my\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
@@ -41,9 +42,7 @@ msgstr "သင့်အကြောင်း"
 #. Translators: This note appears in a section of a form where we ask users to enter info (like country of residence) when applying for resource access.
 #: TWLight/applications/forms.py:179
 #, python-brace-format
-msgid ""
-"<p><small><i>Your personal data will be processed according to our <a "
-"class='twl-links' href='{terms_url}'> privacy policy</a>.</i></small></p>"
+msgid "<p><small><i>Your personal data will be processed according to our <a class='twl-links' href='{terms_url}'> privacy policy</a>.</i></small></p>"
 msgstr ""
 
 #. Translators: This is the title of the application form page, where users enter information required for the application. It lets the user know which partner application they are entering data for. {partner}
@@ -86,9 +85,7 @@ msgstr ""
 #. Translators: This labels a choice field where users will have to select the number of months they wish to have their access for as part of the application renewal confirmation.
 #. Translators: When filling out an application, users may be required to enter the length of the account (expiry) they wish to have for proxy partners.
 #: TWLight/applications/forms.py:339 TWLight/applications/helpers.py:100
-msgid ""
-"The number of months you wish to have this access for before renewal is "
-"required"
+msgid "The number of months you wish to have this access for before renewal is required"
 msgstr ""
 
 #. Translators: When filling out an application, users may need to specify their name
@@ -177,9 +174,7 @@ msgstr "အီးမေးလ်"
 
 #. Translators: This comment is added to pending applications when our terms of use change.
 #: TWLight/applications/management/commands/notify_applicants_tou_changes.py:54
-msgid ""
-"Our terms of use have changed. Your applications will not be processed until "
-"you log in and agree to our updated terms."
+msgid "Our terms of use have changed. Your applications will not be processed until you log in and agree to our updated terms."
 msgstr ""
 
 #. Translators: This is the status of an application that has not yet been reviewed.
@@ -248,23 +243,17 @@ msgstr ""
 
 #. Translators: This text goes into account approval emails in the case that we need to send the user's details to a publisher for manual account setup.
 #: TWLight/applications/models.py:331
-msgid ""
-"You can expect to receive access details within a week or two once it has "
-"been processed."
+msgid "You can expect to receive access details within a week or two once it has been processed."
 msgstr ""
 
 #. Translators: This comment is added to open applications when a partner joins the Library Bundle, which does not require applications.
 #: TWLight/applications/signals.py:247
-msgid ""
-"This partner joined the Library Bundle, which does not require applications. "
-"This application will be marked as invalid."
+msgid "This partner joined the Library Bundle, which does not require applications. This application will be marked as invalid."
 msgstr ""
 
 #. Translators: This is shown to users if the application is to a partner for which we have run out of available accounts. The application is therefore on a 'waitlist', and will be reviewed when more accounts are available.
 #: TWLight/applications/templates/applications/application_evaluation.html:29
-msgid ""
-"This application is on the waitlist because this partner does not have any "
-"access grants available at this time."
+msgid "This application is on the waitlist because this partner does not have any access grants available at this time."
 msgstr ""
 
 #. Translators: This message is shown on pages where coordinators can see personal information about applicants.
@@ -272,9 +261,7 @@ msgstr ""
 #: TWLight/applications/templates/applications/application_list_include.html:6
 #: TWLight/applications/templates/applications/send_partner.html:45
 #: TWLight/resources/templates/resources/partner_users.html:18
-msgid ""
-"Coordinators: This page may contain personal information such as real names "
-"and email addresses. Please remember that this information is confidential."
+msgid "Coordinators: This page may contain personal information such as real names and email addresses. Please remember that this information is confidential."
 msgstr ""
 
 #. Translators: This is the title of the application page shown to users who are a coordinator, and are able to accept or reject the application.
@@ -284,9 +271,7 @@ msgstr ""
 
 #. Translators: This text is shown to coordinators on application pages if the applicant has restricted processing of their data.
 #: TWLight/applications/templates/applications/application_evaluation.html:42
-msgid ""
-"This user has requested a restriction on the processing of their data, so "
-"you cannot change the status of their application."
+msgid "This user has requested a restriction on the processing of their data, so you cannot change the status of their application."
 msgstr ""
 
 #. Translators: This is the title of the application page shown to users who are not a coordinator.
@@ -362,9 +347,7 @@ msgstr ""
 
 #. Translators: This is the text displayed to coordinators when an applicant has no country of residence in their profile.
 #: TWLight/applications/templates/applications/application_evaluation.html:123
-msgid ""
-"Please request the applicant add their country of residence to their profile "
-"before proceeding further."
+msgid "Please request the applicant add their country of residence to their profile before proceeding further."
 msgstr ""
 
 #. Translators: This labels the section of an application showing the total number of accounts available for a partner or their collection.
@@ -376,9 +359,7 @@ msgstr "အကောင့်များ ရရှိနိုင်မှု"
 #. Translators: This labels the section of an application showing whether the user had agreed to the terms of use or not.
 #: TWLight/applications/templates/applications/application_evaluation.html:145
 #, python-format
-msgid ""
-"Has agreed to the site's <a class=\"twl-links\" href=\"%(terms_url)s\">terms "
-"of use</a>?"
+msgid "Has agreed to the site's <a class=\"twl-links\" href=\"%(terms_url)s\">terms of use</a>?"
 msgstr ""
 
 #. Translators: Displayed to coordinators when they've agreed to the terms of use.
@@ -414,9 +395,7 @@ msgstr ""
 
 #. Translators: This is the text displayed to coordinators when an applicant has not agreed to the terms of use.
 #: TWLight/applications/templates/applications/application_evaluation.html:159
-msgid ""
-"Please request the applicant agree to the site's terms of use before "
-"approving this application."
+msgid "Please request the applicant agree to the site's terms of use before approving this application."
 msgstr ""
 
 #. Translators: This labels the section of an application containing the user's motivation for wanting access to this resource.
@@ -437,8 +416,7 @@ msgstr ""
 #. Translators: This message is shown next to the 'Renewal of existing access grant?' label if the application is a renewal. Don't translate HTML tags or parent_url.
 #: TWLight/applications/templates/applications/application_evaluation.html:195
 #, python-format
-msgid ""
-"Yes (<a class=\"twl-links\" href=\"%(parent_url)s\">previous application</a>)"
+msgid "Yes (<a class=\"twl-links\" href=\"%(parent_url)s\">previous application</a>)"
 msgstr ""
 
 #. Translators: This labels the section of the application showing the length of access remaining on the user's previous authorization.
@@ -475,9 +453,7 @@ msgstr "မှတ်ချက် ပေါင်းထည့်ရန်"
 
 #. Translators: On an application page, this text tells users that the comments posted on the application are visible to coordinators and the submitting user only.
 #: TWLight/applications/templates/applications/application_evaluation.html:297
-msgid ""
-"Comments are visible to all coordinators and to the editor who submitted "
-"this application."
+msgid "Comments are visible to all coordinators and to the editor who submitted this application."
 msgstr ""
 
 #. Translators: This is the title of the section of an application page which lists information about the user who submitted the application.
@@ -691,12 +667,7 @@ msgstr ""
 
 #: TWLight/applications/templates/applications/apply.html:20
 #, python-format
-msgid ""
-"If your application is successful we may share your email address with "
-"%(partner)s. This is required to set up your access to their resources. By "
-"submitting this form you agree to allow your email address to be shared with "
-"%(partner)s if your application is successful, for the purposes of account "
-"setup."
+msgid "If your application is successful we may share your email address with %(partner)s. This is required to set up your access to their resources. By submitting this form you agree to allow your email address to be shared with %(partner)s if your application is successful, for the purposes of account setup."
 msgstr ""
 
 #. Translators: This message is displayed on the page where users can confirm their renewal. Please do not translate partner.
@@ -725,9 +696,7 @@ msgstr ""
 
 #. Translators: This text explains that Library Bundle partners are not shown in this list.
 #: TWLight/applications/templates/applications/request_for_application.html:26
-msgid ""
-"Library Bundle partners are not shown as eligibility is determined "
-"automatically."
+msgid "Library Bundle partners are not shown as eligibility is determined automatically."
 msgstr ""
 
 #. Translators: On the page where users can apply for multiple partners, this message shows next to the partner name, taking them to the full application page when clicked.
@@ -742,10 +711,7 @@ msgstr ""
 
 #. Translators: the HTML is so that the word 'waitlisted' will look the same as it does in the page above; please translate 'waitlisted' the same way you did elsewhere in this file.
 #: TWLight/applications/templates/applications/request_for_application.html:74
-msgid ""
-"You can apply to <span class=\"badge badge-warning\">Waitlisted</span> "
-"partners, but they don't have access grants available right now. We will "
-"process those applications when access becomes available."
+msgid "You can apply to <span class=\"badge badge-warning\">Waitlisted</span> partners, but they don't have access grants available right now. We will process those applications when access becomes available."
 msgstr ""
 
 #. Translators: On the page where coordinators can see approved applications which have not had their details sent to the partner, this message shows when there are applications ready to be processed.
@@ -767,9 +733,7 @@ msgstr ""
 #. Translators: This message is shown when applications exceed the number of accounts available.
 #: TWLight/applications/templates/applications/send_partner.html:54
 #, python-format
-msgid ""
-"Application(s) for %(object)s, if sent, will exceed the total available "
-"accounts for the partner. Please proceed at your own discretion."
+msgid "Application(s) for %(object)s, if sent, will exceed the total available accounts for the partner. Please proceed at your own discretion."
 msgstr ""
 
 #. Translators: When viewing the list of applications ready to be sent for a particular partner, this is instructions for the coordinator to click the 'mark as sent' button after they have sent the information.
@@ -786,9 +750,7 @@ msgstr[1] ""
 
 #. Translators: When viewing the list of applications ready to be sent for a particular partner, this message shows if there is no information about who the applications should be sent to. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/applications/templates/applications/send_partner.html:89
-msgid ""
-"Whoops, we don't have any listed contacts. Please notify Wikipedia Library "
-"administrators."
+msgid "Whoops, we don't have any listed contacts. Please notify Wikipedia Library administrators."
 msgstr ""
 
 #. Translators: When viewing the list of applications ready to be sent for a particular partner, this is the title of the section containing the information about those applications.
@@ -804,9 +766,7 @@ msgstr "ပေးပို့ပြီးကြောင်း မှတ်သ�
 
 #. Translators: This text guides coordinators in using the code sending interface for approved applications.
 #: TWLight/applications/templates/applications/send_partner.html:152
-msgid ""
-"Use the dropdown menus to denote which editor will receive each code. Access "
-"codes will be sent to users automatically."
+msgid "Use the dropdown menus to denote which editor will receive each code. Access codes will be sent to users automatically."
 msgstr ""
 
 #. Translators: This labels a drop-down selection where staff can assign an access code to a user.
@@ -822,18 +782,13 @@ msgstr ""
 #. Translators: When a user applies for a set of resources, they receive this message if none are currently available. They are instead placed on a 'waitlist' for later approval.
 #. Translators: When a user renews their resource, they receive this message if none are currently available. They are instead placed on a 'waitlist' for later approval.
 #: TWLight/applications/views.py:140 TWLight/applications/views.py:1282
-msgid ""
-"This partner does not have any access grants available at this time. You may "
-"still apply for access; your application will be reviewed when access grants "
-"become available."
+msgid "This partner does not have any access grants available at this time. You may still apply for access; your application will be reviewed when access grants become available."
 msgstr ""
 
 #. Translators: This message is shown to users once they've successfully submitted their application for review.
 #: TWLight/applications/views.py:163
 #, python-brace-format
-msgid ""
-"Your application has been submitted for review. Head over to <a "
-"href='{applications_url}'>My Applications</a> to view the status."
+msgid "Your application has been submitted for review. Head over to <a href='{applications_url}'>My Applications</a> to view the status."
 msgstr ""
 
 #. Translators: This text is displayed to users when the user has chosen to restrict data and is trying to apply for multiple partners
@@ -882,16 +837,12 @@ msgstr ""
 
 #. Translators: After a coordinator has changed the status of an application to APPROVED, if the corresponding partner/collection is waitlisted this message appears.
 #: TWLight/applications/views.py:756
-msgid ""
-"Cannot approve application as partner with proxy authorization method is "
-"waitlisted."
+msgid "Cannot approve application as partner with proxy authorization method is waitlisted."
 msgstr ""
 
 #. Translators: After a coordinator has changed the status of an application to APPROVED, if the corresponding partner/collection has no accounts for distribution, this message appears.
 #: TWLight/applications/views.py:780
-msgid ""
-"Cannot approve application as partner with proxy authorization method is "
-"waitlisted and (or) has zero accounts available for distribution."
+msgid "Cannot approve application as partner with proxy authorization method is waitlisted and (or) has zero accounts available for distribution."
 msgstr ""
 
 #. Translators: This message appears on an "access denied" screen that stops users who attempt to authorize an editor to access a resource during a time period for which they are already authorized.
@@ -902,11 +853,7 @@ msgstr ""
 #. Translators: This message is shown to users when they access an application page of a now Bundle partner (new applications aren't allowed for Bundle partners and the status of old applications cannot be modified)
 #: TWLight/applications/views.py:857
 #, python-brace-format
-msgid ""
-"This application cannot be modified since this partner is now part of our <a "
-"href='{bundle}'>bundle access</a>. If you are eligible, you can access this "
-"resource from <a href='{library}'>your library</a>. <a "
-"href='{contact}'>Contact us</a> if you have any questions."
+msgid "This application cannot be modified since this partner is now part of our <a href='{bundle}'>bundle access</a>. If you are eligible, you can access this resource from <a href='{library}'>your library</a>. <a href='{contact}'>Contact us</a> if you have any questions."
 msgstr ""
 
 #. Translators: this lets a reviewer set the status of a single application.
@@ -916,9 +863,7 @@ msgstr ""
 
 #. Translators: This warning is message is shown to applicants when the number of pending applications is greater than the number of accounts available.
 #: TWLight/applications/views.py:891
-msgid ""
-"There are more pending applications than available accounts. Your "
-"application might get waitlisted."
+msgid "There are more pending applications than available accounts. Your application might get waitlisted."
 msgstr ""
 
 #. Translators: this message is shown to coordinators who attempt to change an application's Status from INVALID to any other Status.
@@ -938,11 +883,7 @@ msgstr ""
 
 #. Translators: After a coordinator has changed the status of a number of applications to APPROVED, if the corresponding partner(s) is/are waitlisted or has no accounts for distribution, this message appears.
 #: TWLight/applications/views.py:1051
-msgid ""
-"Cannot approve application(s) {} as partner(s) with proxy authorization "
-"method is/are waitlisted and (or) has/have not enough accounts available. If "
-"not enough accounts are available, prioritise the applications and then "
-"approve applications equal to the accounts available."
+msgid "Cannot approve application(s) {} as partner(s) with proxy authorization method is/are waitlisted and (or) has/have not enough accounts available. If not enough accounts are available, prioritise the applications and then approve applications equal to the accounts available."
 msgstr ""
 
 #. Translators: This message is shown to coordinators who attempt to assign the same access code to multiple users.
@@ -957,9 +898,7 @@ msgstr ""
 
 #. Translators: When a user tries to renew their resource, they receive this message if the partner is not available.
 #: TWLight/applications/views.py:1272
-msgid ""
-"Cannot renew application at this time as partner is not available. Please "
-"check back later, or contact us for more information."
+msgid "Cannot renew application at this time as partner is not available. Please check back later, or contact us for more information."
 msgstr ""
 
 #. Translators: This message is displayed when an attempt by a user to renew an application has been denied for some reason.
@@ -970,16 +909,12 @@ msgstr ""
 
 #. Translators: If a user requests the renewal of their account, but it wasn't renewed, this message is shown to them.
 #: TWLight/applications/views.py:1385
-msgid ""
-"This object cannot be renewed. (This probably means that you have already "
-"requested that it be renewed.)"
+msgid "This object cannot be renewed. (This probably means that you have already requested that it be renewed.)"
 msgstr ""
 
 #. Translators: If a user requests the renewal of their account, this message is shown to them.
 #: TWLight/applications/views.py:1395
-msgid ""
-"Your renewal request has been received. A coordinator will review your "
-"request."
+msgid "Your renewal request has been received. A coordinator will review your request."
 msgstr ""
 
 #. Translators: This labels a textfield where users can enter their email ID.
@@ -990,9 +925,7 @@ msgstr "အကောင့် အီးမေးလ်"
 
 #. Translators: This is the help text for the email field in the contact us form letting users know the field is updated by value pulled from their respective user profiles.
 #: TWLight/emails/forms.py:21
-msgid ""
-"This field is automatically updated with the email from your <a class='twl-"
-"links' href='{}'>user profile</a>."
+msgid "This field is automatically updated with the email from your <a class='twl-links' href='{}'>user profile</a>."
 msgstr ""
 
 #. Translators: This labels a textfield where users can enter their email message.
@@ -1016,19 +949,13 @@ msgstr "ထည့်သွင်းရန်"
 #. Translators: This email is sent to users with their access code. Don't translate Jinja variables in curly braces like user or partner. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/access_code_email-body-html.html:5
 #, python-format
-msgid ""
-"<p>Your approved application to %(partner)s has now been finalised. Your "
-"access code or login details can be found below:</p> <p><b>%(access_code)s</"
-"b></p> <p>%(user_instructions)s</p>"
+msgid "<p>Your approved application to %(partner)s has now been finalised. Your access code or login details can be found below:</p> <p><b>%(access_code)s</b></p> <p>%(user_instructions)s</p>"
 msgstr ""
 
 #. Translators: This email is sent to users with their access code. Don't translate Jinja variables in curly braces like user or partner. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/access_code_email-body-text.html:3
 #, python-format
-msgid ""
-"Your approved application to %(partner)s has now been finalised. Your access "
-"code or login details can be found below: %(access_code)s "
-"%(user_instructions)s"
+msgid "Your approved application to %(partner)s has now been finalised. Your access code or login details can be found below: %(access_code)s %(user_instructions)s"
 msgstr ""
 
 #. Translators: This is the subject line of an email sent to users with their access code.
@@ -1040,23 +967,13 @@ msgstr "ဝီကီပီးဒီးယား စာကြည့်တို�
 #. Translators: This email is sent to users when their application is approved. Don't translate Jinja variables in curly braces like user or partner; don't translate html tags either. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/approval_notification-body-html.html:5
 #, python-format
-msgid ""
-"<p>Dear %(user)s,</p> <p>Thank you for applying for access to %(partner)s "
-"resources through The Wikipedia Library. We are happy to inform you that "
-"your application has been approved.</p> <p>%(user_instructions)s</p> <p>You "
-"can view the collections you're authorized to access at My Library: "
-"%(link)s</p> <p>Cheers!</p> <p>The Wikipedia Library</p>"
+msgid "<p>Dear %(user)s,</p> <p>Thank you for applying for access to %(partner)s resources through The Wikipedia Library. We are happy to inform you that your application has been approved.</p> <p>%(user_instructions)s</p> <p>You can view the collections you're authorized to access at My Library: %(link)s</p> <p>Cheers!</p> <p>The Wikipedia Library</p>"
 msgstr ""
 
 #. Translators: This email is sent to users when their application is approved. Don't translate Jinja variables in curly braces like user or partner. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/approval_notification-body-text.html:3
 #, python-format
-msgid ""
-"Dear %(user)s, Thank you for applying for access to %(partner)s resources "
-"through The Wikipedia Library. We are happy to inform you that your "
-"application has been approved. %(user_instructions)s You can view the "
-"collections you're authorized to access at My Library: %(link)s Cheers! The "
-"Wikipedia Library"
+msgid "Dear %(user)s, Thank you for applying for access to %(partner)s resources through The Wikipedia Library. We are happy to inform you that your application has been approved. %(user_instructions)s You can view the collections you're authorized to access at My Library: %(link)s Cheers! The Wikipedia Library"
 msgstr ""
 
 #. Translators: This is the subject of an email which is sent to users when their application has been approved. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
@@ -1067,19 +984,13 @@ msgstr ""
 #. Translators: This email is sent to coordinators when a comment is left on an application they are processing. Don't translate Jinja variables in curly braces like user or partner. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/comment_notification_coordinator-body-html.html:5
 #, python-format
-msgid ""
-"<p style=\"color: #500050\">%(submit_date)s - %(commenter)s</p> "
-"<blockquote><p>%(comment)s</p></blockquote> <p>Please reply to these at: <a "
-"href=\"%(app_url)s\">%(app_url)s</a></p> <p>Best,</p> <p>The Wikipedia "
-"Library</p>"
+msgid "<p style=\"color: #500050\">%(submit_date)s - %(commenter)s</p> <blockquote><p>%(comment)s</p></blockquote> <p>Please reply to these at: <a href=\"%(app_url)s\">%(app_url)s</a></p> <p>Best,</p> <p>The Wikipedia Library</p>"
 msgstr ""
 
 #. Translators: This email is sent to coordinators when a comment is left on an application they are processing. Don't translate Jinja variables in curly braces like user or partner. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/comment_notification_coordinator-body-text.html:3
 #, python-format
-msgid ""
-"%(submit_date)s - %(commenter)s %(comment)s Please reply to this at: "
-"%(app_url)s Best, The Wikipedia Library"
+msgid "%(submit_date)s - %(commenter)s %(comment)s Please reply to this at: %(app_url)s Best, The Wikipedia Library"
 msgstr ""
 
 #. Translators: This is the subject line of an email sent to coordinators when a comment is left on an application they processed.
@@ -1090,19 +1001,13 @@ msgstr ""
 #. Translators: This email is sent to users when they receive a comment on their application. Don't translate Jinja variables in curly braces like user or partner; don't translate html tags either. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/comment_notification_editors-body-html.html:5
 #, python-format
-msgid ""
-"<p style=\"color: #500050\">%(submit_date)s - %(commenter)s</p> "
-"<blockquote><p>%(comment)s</p></blockquote> <p>Please reply to these at <a "
-"href=\"%(app_url)s\">%(app_url)s</a> so we can evaluate your application.</"
-"p> <p>Best,</p> <p>The Wikipedia Library</p>"
+msgid "<p style=\"color: #500050\">%(submit_date)s - %(commenter)s</p> <blockquote><p>%(comment)s</p></blockquote> <p>Please reply to these at <a href=\"%(app_url)s\">%(app_url)s</a> so we can evaluate your application.</p> <p>Best,</p> <p>The Wikipedia Library</p>"
 msgstr ""
 
 #. Translators: This email is sent to users when they receive a comment on their application. Don't translate Jinja variables in curly braces like user or partner. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/comment_notification_editors-body-text.html:3
 #, python-format
-msgid ""
-"%(submit_date)s - %(commenter)s %(comment)s Please reply to these at: "
-"%(app_url)s so we can evaluate your application. Best, The Wikipedia Library"
+msgid "%(submit_date)s - %(commenter)s %(comment)s Please reply to these at: %(app_url)s so we can evaluate your application. Best, The Wikipedia Library"
 msgstr ""
 
 #. Translators: This is the subject line of an email sent to users who have a comment added to one of their applications. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
@@ -1113,18 +1018,13 @@ msgstr ""
 #. Translators: This email is sent to users when an application they commented on receives another comment. Don't translate Jinja variables in curly braces like app_url; don't translate html tags either. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/comment_notification_others-body-html.html:5
 #, python-format
-msgid ""
-"<p style=\"color: #500050\">%(submit_date)s - %(commenter)s</p> "
-"<blockquote><p>%(comment)s</p></blockquote> See it at <a href=\"%(app_url)s"
-"\">%(app_url)s</a>. Thanks for helping review Wikipedia Library applications!"
+msgid "<p style=\"color: #500050\">%(submit_date)s - %(commenter)s</p> <blockquote><p>%(comment)s</p></blockquote> See it at <a href=\"%(app_url)s\">%(app_url)s</a>. Thanks for helping review Wikipedia Library applications!"
 msgstr ""
 
 #. Translators: This email is sent to users when an application they commented on receives another comment. Don't translate Jinja variables in curly braces like app_url. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/comment_notification_others-body-text.html:3
 #, python-format
-msgid ""
-"%(submit_date)s - %(commenter)s %(comment)s See it at: %(app_url)s Thanks "
-"for helping review Wikipedia Library applications!"
+msgid "%(submit_date)s - %(commenter)s %(comment)s See it at: %(app_url)s Thanks for helping review Wikipedia Library applications!"
 msgstr ""
 
 #. Translators: This is the subject line of an email sent to users who have a comment added to an application they also commented on. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
@@ -1135,10 +1035,7 @@ msgstr ""
 #. Translators: This text is part of a scheduled reminder email sent to coordinators who have applications requiring action. Don't translate Jinja variables in curly braces like total_apps, or user.
 #: TWLight/emails/templates/emails/coordinator_reminder_notification-body-html.html:5
 #, python-format
-msgid ""
-"<p>Dear %(user)s,</p> <p>Our records indicate that you are the designated "
-"coordinator for partners that have a total of %(total_apps)s applications.</"
-"p>"
+msgid "<p>Dear %(user)s,</p> <p>Our records indicate that you are the designated coordinator for partners that have a total of %(total_apps)s applications.</p>"
 msgstr ""
 
 #. Translators: Breakdown as in 'cost breakdown'; analysis.
@@ -1177,31 +1074,19 @@ msgstr[1] "လျှောက်လွှာ ရက်စွဲ"
 #. Translators: This text is part of a scheduled reminder email sent to coordinators who have applications requiring action. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library). Don't translate Jinja variables in curly braces like link; don't translate email addresses or html tags either.
 #: TWLight/emails/templates/emails/coordinator_reminder_notification-body-html.html:39
 #, python-format
-msgid ""
-"<p>This is a gentle reminder that you may review applications at <a href="
-"\"%(link)s\">%(link)s</a>.</p> <p>You can customise your reminders under "
-"'preferences' in your user profile.</p> <p>If you received this message in "
-"error, drop us a line at wikipedialibrary@wikimedia.org.</p> <p>Thanks for "
-"helping review Wikipedia Library applications!</p>"
+msgid "<p>This is a gentle reminder that you may review applications at <a href=\"%(link)s\">%(link)s</a>.</p> <p>You can customise your reminders under 'preferences' in your user profile.</p> <p>If you received this message in error, drop us a line at wikipedialibrary@wikimedia.org.</p> <p>Thanks for helping review Wikipedia Library applications!</p>"
 msgstr ""
 
 #. Translators: This text is part of a scheduled reminder email sent to coordinators who have applications requiring action. Don't translate Jinja variables in curly braces like total_apps, or user.
 #: TWLight/emails/templates/emails/coordinator_reminder_notification-body-text.html:3
 #, python-format
-msgid ""
-"Dear %(user)s, Our records indicate that you are the designated coordinator "
-"for partners that have a total of %(total_apps)s applications."
+msgid "Dear %(user)s, Our records indicate that you are the designated coordinator for partners that have a total of %(total_apps)s applications."
 msgstr ""
 
 #. Translators: This text is part of a scheduled reminder email sent to coordinators who have applications requiring action. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library). Don't translate Jinja variables in curly braces like link; don't translate the email address either.
 #: TWLight/emails/templates/emails/coordinator_reminder_notification-body-text.html:38
 #, python-format
-msgid ""
-"This is a gentle reminder that you may review applications at: %(link)s. You "
-"can customise your reminders under 'preferences' in your user profile. If "
-"you received this message in error, drop us a line at: "
-"wikipedialibrary@wikimedia.org Thanks for helping review Wikipedia Library "
-"applications!"
+msgid "This is a gentle reminder that you may review applications at: %(link)s. You can customise your reminders under 'preferences' in your user profile. If you received this message in error, drop us a line at: wikipedialibrary@wikimedia.org Thanks for helping review Wikipedia Library applications!"
 msgstr ""
 
 #. Translators: This is the subject line of a scheduled reminder email sent to coordinators who have applications to review. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library). Do not translate items in curly braces.
@@ -1212,22 +1097,13 @@ msgstr ""
 #. Translators: This email is sent to users when their application is rejected. Don't translate Jinja variables in curly braces like user or partner; don't translate html tags either. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/rejection_notification-body-html.html:5
 #, python-format
-msgid ""
-"<p>Dear %(user)s,</p> <p>Thank you for applying for access to %(partner)s "
-"resources through The Wikipedia Library. Unfortunately at this time your "
-"application has not been approved. You can view your application and review "
-"comments at <a href=\"%(app_url)s\">%(app_url)s</a>.</p> <p>Best,</p> <p>The "
-"Wikipedia Library</p>"
+msgid "<p>Dear %(user)s,</p> <p>Thank you for applying for access to %(partner)s resources through The Wikipedia Library. Unfortunately at this time your application has not been approved. You can view your application and review comments at <a href=\"%(app_url)s\">%(app_url)s</a>.</p> <p>Best,</p> <p>The Wikipedia Library</p>"
 msgstr ""
 
 #. Translators: This email is sent to users when their application is rejected. Don't translate Jinja variables in curly braces like user or partner. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/rejection_notification-body-text.html:3
 #, python-format
-msgid ""
-"Dear %(user)s, Thank you for applying for access to %(partner)s resources "
-"through The Wikipedia Library. Unfortunately at this time your application "
-"has not been approved. You can view your application and review comments at: "
-"%(app_url)s Best, The Wikipedia Library"
+msgid "Dear %(user)s, Thank you for applying for access to %(partner)s resources through The Wikipedia Library. Unfortunately at this time your application has not been approved. You can view your application and review comments at: %(app_url)s Best, The Wikipedia Library"
 msgstr ""
 
 #. Translators: This is the subject of an email which is sent to users when their application has been rejected. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
@@ -1239,25 +1115,13 @@ msgstr "ဝီကီပီးဒီးယား စာကြည့်တို�
 #. Translators: This email is sent to users when they have an account that is soon to expire. Don't translate Jinja variables in curly braces like partner_name or partner_link; don't translate html tags either. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/user_renewal_notice-body-html.html:5
 #, python-format
-msgid ""
-"<p>Dear %(user)s,</p> <p>According to our records, your access to "
-"%(partner_name)s will soon expire and you may lose access. If you want to "
-"continue making use of your free account, you can request renewal of your "
-"account by clicking the 'Renew' or 'Extend' button at %(partner_link)s.</p> "
-"<p>Best,</p> <p>The Wikipedia Library</p> <p>You can disable these emails in "
-"your user page preferences: https://wikipedialibrary.wmflabs.org/users/</p>"
+msgid "<p>Dear %(user)s,</p> <p>According to our records, your access to %(partner_name)s will soon expire and you may lose access. If you want to continue making use of your free account, you can request renewal of your account by clicking the 'Renew' or 'Extend' button at %(partner_link)s.</p> <p>Best,</p> <p>The Wikipedia Library</p> <p>You can disable these emails in your user page preferences: https://wikipedialibrary.wmflabs.org/users/</p>"
 msgstr ""
 
 #. Translators: This email is sent to users when they have an account that is soon to expire. Don't translate Jinja variables in curly braces like partner_name or partner_link; don't translate html tags either. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/user_renewal_notice-body-text.html:3
 #, python-format
-msgid ""
-"Dear %(user)s, According to our records, your access to %(partner_name)s "
-"will soon expire and you may lose access. If you want to continue making use "
-"of your free account, you can request renewal of your account by clicking "
-"the Renew button at %(partner_link)s. Best, The Wikipedia Library You can "
-"disable these emails in your user page preferences: https://wikipedialibrary."
-"wmflabs.org/users/"
+msgid "Dear %(user)s, According to our records, your access to %(partner_name)s will soon expire and you may lose access. If you want to continue making use of your free account, you can request renewal of your account by clicking the Renew button at %(partner_link)s. Best, The Wikipedia Library You can disable these emails in your user page preferences: https://wikipedialibrary.wmflabs.org/users/"
 msgstr ""
 
 #. Translators: This is the subject of an email sent to users when they have an account that is soon to expire. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
@@ -1269,24 +1133,13 @@ msgstr "ဝီကီပီးဒီးယား စာကြည့်တို�
 #. Translators: This email is sent to users when their application is waitlisted because there are no more accounts available. Don't translate Jinja variables in curly braces like user or partner; don't translate html tags either. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/waitlist_notification-body-html.html:5
 #, python-format
-msgid ""
-"<p>Dear %(user)s,</p> <p>Thank you for applying for access to %(partner)s "
-"resources through The Wikipedia Library. There are no accounts currently "
-"available so your application has been waitlisted. Your application will be "
-"evaluated if/when more accounts become available. You can see all available "
-"resources at <a href=\"%(link)s\">%(link)s</a>.</p> <p>Best,</p> <p>The "
-"Wikipedia Library</p>"
+msgid "<p>Dear %(user)s,</p> <p>Thank you for applying for access to %(partner)s resources through The Wikipedia Library. There are no accounts currently available so your application has been waitlisted. Your application will be evaluated if/when more accounts become available. You can see all available resources at <a href=\"%(link)s\">%(link)s</a>.</p> <p>Best,</p> <p>The Wikipedia Library</p>"
 msgstr ""
 
 #. Translators: This email is sent to users when their application is waitlisted because there are no more accounts available. Don't translate Jinja variables in curly braces like user or partner. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/waitlist_notification-body-text.html:3
 #, python-format
-msgid ""
-"Dear %(user)s, Thank you for applying for access to %(partner)s resources "
-"through The Wikipedia Library. There are no accounts currently available so "
-"your application has been waitlisted. Your application will be evaluated if/"
-"when more accounts become available. You can see all available resources at: "
-"%(link)s Best, The Wikipedia Library"
+msgid "Dear %(user)s, Thank you for applying for access to %(partner)s resources through The Wikipedia Library. There are no accounts currently available so your application has been waitlisted. Your application will be evaluated if/when more accounts become available. You can see all available resources at: %(link)s Best, The Wikipedia Library"
 msgstr ""
 
 #. Translators: This is the subject of an email sent to users when their application is waitlisted because there are no more accounts available. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
@@ -1453,17 +1306,14 @@ msgstr "မရရှိနိုင်ပါ"
 #: TWLight/resources/templates/resources/filter_section.html:14
 #: TWLight/templates/about.html:12
 #: TWLight/users/templates/users/filter_section.html:13
-msgid ""
-"The Wikipedia Library allows active editors to access a wide range of "
-"collections of paywalled reliable sources for free!"
+msgid "The Wikipedia Library allows active editors to access a wide range of collections of paywalled reliable sources for free!"
 msgstr ""
 
 #. Translators: On the Browse Partners page (https://wikipedialibrary.wmflabs.org/partners/), this introduces users to The Wikipedia Library.
 #. Translators: On the MyLibrary page (https://wikipedialibrary.wmflabs.org/users/my_library), this introduces users to The Wikipedia Library.
 #: TWLight/resources/templates/resources/filter_section.html:17
 #: TWLight/users/templates/users/filter_section.html:15
-msgid ""
-"Start with the search bar at the top or browse publisher websites directly."
+msgid "Start with the search bar at the top or browse publisher websites directly."
 msgstr ""
 
 #. Translators: On the Browse Partners page (https://wikipedialibrary.wmflabs.org/partners/), this appears below introductory text and links to the 'About' page (https://wikipedialibrary.wmflabs.org/about/)
@@ -1542,52 +1392,38 @@ msgstr "လုပ်ဖော်ကိုင်ဖက် စုစုပေါ�
 #. Translators: If we have no available accounts for a partner, the coordinator can change the application system to a waiting list.
 #: TWLight/resources/templates/resources/partner_detail.html:36
 #: TWLight/resources/templates/resources/partner_detail_apply.html:17
-msgid ""
-"There are no access grants available for this partner at this time. You can "
-"still apply for access; applications will be processed when access is "
-"available."
+msgid "There are no access grants available for this partner at this time. You can still apply for access; applications will be processed when access is available."
 msgstr ""
 
 #. Translators: This text links to the minimum user requirements and terms of use on the partner page.
 #: TWLight/resources/templates/resources/partner_detail.html:48
 #: TWLight/resources/templates/resources/partner_detail_apply.html:29
 #, python-format
-msgid ""
-"Before applying, please review the <strong><a class=\"twl-links\" href="
-"\"%(about)s#req\">minimum requirements</a></strong> for access and our "
-"<strong><a class=\"twl-links\" href=\"%(terms)s\">terms of use</a></strong>."
+msgid "Before applying, please review the <strong><a class=\"twl-links\" href=\"%(about)s#req\">minimum requirements</a></strong> for access and our <strong><a class=\"twl-links\" href=\"%(terms)s\">terms of use</a></strong>."
 msgstr ""
 
 #. Translators: This text refers to the page containing the content a user is authorized to access.
 #: TWLight/resources/templates/resources/partner_detail.html:69
 #, python-format
-msgid ""
-"View the status of your access in <strong><a class=\"twl-links\" href="
-"\"%(library_url)s\">My Library</a></strong> page."
+msgid "View the status of your access in <strong><a class=\"twl-links\" href=\"%(library_url)s\">My Library</a></strong> page."
 msgstr ""
 
 #. Translators: This message is shown when a user has open applications, linking to their respective applications page.
 #: TWLight/resources/templates/resources/partner_detail.html:78
 #, python-format
-msgid ""
-"View the status of your application(s) on your <strong><a class=\"twl-links"
-"\" href=\"%(applications_url)s\">My Applications</a></strong> page."
+msgid "View the status of your application(s) on your <strong><a class=\"twl-links\" href=\"%(applications_url)s\">My Applications</a></strong> page."
 msgstr ""
 
 #. Translators: This message is shown when a user has authorizations, linking to their respective collections page.
 #: TWLight/resources/templates/resources/partner_detail_apply.html:50
 #, python-format
-msgid ""
-"View the status of your access on your <strong><a href=\"%(library_url)s\" "
-"class=\"twl-links\">My Library</a></strong> page."
+msgid "View the status of your access on your <strong><a href=\"%(library_url)s\" class=\"twl-links\">My Library</a></strong> page."
 msgstr ""
 
 #. Translators: This message is shown when a user has open applications, linking to their respective applications page.
 #: TWLight/resources/templates/resources/partner_detail_apply.html:60
 #, python-format
-msgid ""
-"View the status of your application(s) on your <strong><a href="
-"\"%(applications_url)s\">My Applications</a></strong> page."
+msgid "View the status of your application(s) on your <strong><a href=\"%(applications_url)s\">My Applications</a></strong> page."
 msgstr ""
 
 #. Translators: One the partner detail page, this text labels the button which coordinators can click to remove a partner from waitlisted status.
@@ -1617,10 +1453,7 @@ msgstr ""
 
 #. Translators: If no account coordinator is assigned to a partner, the Wikipedia Library team will coordinate signups. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/resources/templates/resources/partner_detail_apply.html:112
-msgid ""
-"The Wikipedia Library team will process this application. Want to help? <a "
-"class=\"twl-links\" href=\"https://en.wikipedia.org/wiki/Wikipedia:"
-"The_Wikipedia_Library/Coordinators/Signup\">Sign up as a coordinator.</a>"
+msgid "The Wikipedia Library team will process this application. Want to help? <a class=\"twl-links\" href=\"https://en.wikipedia.org/wiki/Wikipedia:The_Wikipedia_Library/Coordinators/Signup\">Sign up as a coordinator.</a>"
 msgstr ""
 
 #. Translators: This text labels a button coordinators can click to view a list of users who have applied for access for a particular partner
@@ -1651,18 +1484,13 @@ msgstr ""
 
 #. Translators: Text shown to authenticated, bundle eligible users when they visit a Bundle partner page.
 #: TWLight/resources/templates/resources/partner_detail_apply.html:138
-msgid ""
-"You are eligible to access Library Bundle partners. Click the button above "
-"to access the collection."
+msgid "You are eligible to access Library Bundle partners. Click the button above to access the collection."
 msgstr ""
 
 #. Translators: Text shown to authenticated, bundle ineligible users when they visit a Bundle partner page.
 #: TWLight/resources/templates/resources/partner_detail_apply.html:152
 #, python-format
-msgid ""
-"You are not eligible to access Library Bundle partners. Visit the <a class="
-"\"twl-links\" href=\"%(homepage)s\">homepage</a> to check the eligibility "
-"criteria."
+msgid "You are not eligible to access Library Bundle partners. Visit the <a class=\"twl-links\" href=\"%(homepage)s\">homepage</a> to check the eligibility criteria."
 msgstr ""
 
 #. Translators: Buttton prompting users to log in.
@@ -1674,10 +1502,7 @@ msgstr "အကောင့်ဝင်ရန်"
 #. Translators: Text shown to unauthenticated users when they visit a Bundle partner page.
 #: TWLight/resources/templates/resources/partner_detail_apply.html:168
 #, python-format
-msgid ""
-"This resource is part of our <a class=\"twl-links\" href=\"%(about)s"
-"\">Library Bundle</a>, which you can access if you meet our minimum "
-"eligibility criteria. Log in to find out if you are eligible."
+msgid "This resource is part of our <a class=\"twl-links\" href=\"%(about)s\">Library Bundle</a>, which you can access if you meet our minimum eligibility criteria. Log in to find out if you are eligible."
 msgstr ""
 
 #. Translators: This is the label for a number which shows the total active accounts for one partner. (e.g. https://wikipedialibrary.wmflabs.org/partners/8/).
@@ -1728,26 +1553,19 @@ msgstr ""
 #. Translators: If a partner has specified the excerpt limit both in words and percentage, this message will display the percentage of words and the number of words on the partner page.
 #: TWLight/resources/templates/resources/partner_detail_timeline.html:99
 #, python-format
-msgid ""
-"%(object)s allows a maximum of %(excerpt_limit)s words or "
-"%(excerpt_limit_percentage)s%% of an article be excerpted into a Wikipedia "
-"article."
+msgid "%(object)s allows a maximum of %(excerpt_limit)s words or %(excerpt_limit_percentage)s%% of an article be excerpted into a Wikipedia article."
 msgstr ""
 
 #. Translators: If a partner has specified the excerpt limit in words, this message will display the number of words on the partner page.
 #: TWLight/resources/templates/resources/partner_detail_timeline.html:106
 #, python-format
-msgid ""
-"%(object)s allows a maximum of %(excerpt_limit)s words be excerpted into a "
-"Wikipedia article."
+msgid "%(object)s allows a maximum of %(excerpt_limit)s words be excerpted into a Wikipedia article."
 msgstr ""
 
 #. Translators: If a partner has specified the excerpt limit in percentage, this message will display the percentage of words on the partner page.
 #: TWLight/resources/templates/resources/partner_detail_timeline.html:113
 #, python-format
-msgid ""
-"%(object)s allows a maximum of %(excerpt_limit_percentage)s%% of an article "
-"be excerpted into a Wikipedia article."
+msgid "%(object)s allows a maximum of %(excerpt_limit_percentage)s%% of an article be excerpted into a Wikipedia article."
 msgstr ""
 
 #. Translators: If a partner has other requirements for access, this text shows as the title for that information field. (e.g. https://wikipedialibrary.wmflabs.org/partners/10/).
@@ -1758,9 +1576,7 @@ msgstr ""
 #. Translators: If a user must agree to a Terms of Use document, they see this message, and must enter the name of the resource. Don't translate publisher or url.
 #: TWLight/resources/templates/resources/partner_detail_timeline.html:140
 #, python-format
-msgid ""
-"%(publisher)s requires that you agree with its <a href=\"%(url)s\">terms of "
-"use</a>."
+msgid "%(publisher)s requires that you agree with its <a href=\"%(url)s\">terms of use</a>."
 msgstr ""
 
 #. Translators: If a user must provide their real name to apply to a partner, they see this message, and must enter the name of the resource. Don't translate publisher.
@@ -1784,17 +1600,13 @@ msgstr ""
 #. Translators: If a user must select a specific resource to apply for, they see this message, and must enter the name of the resource. Don't translate publisher.
 #: TWLight/resources/templates/resources/partner_detail_timeline.html:177
 #, python-format
-msgid ""
-"%(publisher)s requires that you specify a particular title that you want to "
-"access."
+msgid "%(publisher)s requires that you specify a particular title that you want to access."
 msgstr ""
 
 #. Translators: If a user must register on the partner website before applying, they see this message. Don't translate partner.
 #: TWLight/resources/templates/resources/partner_detail_timeline.html:187
 #, python-format
-msgid ""
-"%(publisher)s requires that you sign up for an account before applying for "
-"access."
+msgid "%(publisher)s requires that you sign up for an account before applying for access."
 msgstr ""
 
 #. Translators: If a partner has their location listed, this message is a label for that location
@@ -1925,9 +1737,7 @@ msgstr ""
 
 #. Translators: If multiple authorizations where returned for a collection, this message is shown to a user
 #: TWLight/resources/views.py:268
-msgid ""
-"Multiple authorizations were returned – something's wrong. Please contact us "
-"and don't forget to mention this message."
+msgid "Multiple authorizations were returned – something's wrong. Please contact us and don't forget to mention this message."
 msgstr ""
 
 #. Translators: This message is shown when user tries to access a NOT_AVAILABLE Partner
@@ -1970,14 +1780,7 @@ msgstr ""
 #. Translators: Shown on the website's 400 page, when a user sends a bad request. Don't translate path or Phabricator.
 #: TWLight/templates/400.html:20
 #, python-format
-msgid ""
-"If you think we should know what to do with that, please email us about this "
-"error at <a class=\"twl-links\" href=\"mailto:wikipedialibrary@wikimedia.org?"
-"Subject=Wikipedia%%20Library%%20%(path)s%%20Permission%%20denied"
-"\">wikipedialibrary@wikimedia.org</a> or report it to us on <a class=\"twl-"
-"links\" href=\"https://phabricator.wikimedia.org/maniphest/task/edit/form/1/?"
-"projectPHIDs=Library-Card-Platform&title=Wikipedia%%20Library%%20%(path)s"
-"%%20Bad%%20Request\">Phabricator</a>"
+msgid "If you think we should know what to do with that, please email us about this error at <a class=\"twl-links\" href=\"mailto:wikipedialibrary@wikimedia.org?Subject=Wikipedia%%20Library%%20%(path)s%%20Permission%%20denied\">wikipedialibrary@wikimedia.org</a> or report it to us on <a class=\"twl-links\" href=\"https://phabricator.wikimedia.org/maniphest/task/edit/form/1/?projectPHIDs=Library-Card-Platform&title=Wikipedia%%20Library%%20%(path)s%%20Bad%%20Request\">Phabricator</a>"
 msgstr ""
 
 #. Translators: Alt text for an image shown on the 400 error page.
@@ -1999,15 +1802,7 @@ msgstr ""
 #. Translators: Shown on the website's 403 page, when a user attempts to navigate to a page they don't have permission to view. Don't translate path or Phabricator.
 #: TWLight/templates/403.html:20
 #, python-format
-msgid ""
-"If you think your account should be able to do that, please email us about "
-"this error at <a class=\"twl-links\" href=\"mailto:"
-"wikipedialibrary@wikimedia.org?Subject=Wikipedia%%20Library%%20%(path)s"
-"%%20Permission%%20denied\">wikipedialibrary@wikimedia.org</a> or report it "
-"to us on <a class=\"twl-links\" href=\"https://phabricator.wikimedia.org/"
-"maniphest/task/edit/form/1/?projectPHIDs=Library-Card-"
-"Platform&title=Wikipedia%%20Library%%20%(path)s%%20Permission%%20denied"
-"\">Phabricator</a>"
+msgid "If you think your account should be able to do that, please email us about this error at <a class=\"twl-links\" href=\"mailto:wikipedialibrary@wikimedia.org?Subject=Wikipedia%%20Library%%20%(path)s%%20Permission%%20denied\">wikipedialibrary@wikimedia.org</a> or report it to us on <a class=\"twl-links\" href=\"https://phabricator.wikimedia.org/maniphest/task/edit/form/1/?projectPHIDs=Library-Card-Platform&title=Wikipedia%%20Library%%20%(path)s%%20Permission%%20denied\">Phabricator</a>"
 msgstr ""
 
 #. Translators: Shown on the website's 404 page, when a user attempts to navigate to a page that doesn't exist.
@@ -2023,14 +1818,7 @@ msgstr ""
 #. Translators: Shown on the website's 404 page, when a user attempts to navigate to a page that doesn't exist. Don't translate path or Phabricator.
 #: TWLight/templates/404.html:19
 #, python-format
-msgid ""
-"If you are certain that something should be here, please email us about this "
-"error at <a class=\"twl-links\" href=\"mailto:wikipedialibrary@wikimedia.org?"
-"Subject=Wikipedia%%20Library%%20%(path)s%%20Not%%20found\"> "
-"wikipedialibrary@wikimedia.org</a> or report it to us on <a class=\"twl-links"
-"\" href=\"https://phabricator.wikimedia.org/maniphest/task/edit/form/1/?"
-"projectPHIDs=Library-Card-Platform&title=Wikipedia%%20Library%%20%(path)s"
-"%%20Not%%20found\">Phabricator</a>"
+msgid "If you are certain that something should be here, please email us about this error at <a class=\"twl-links\" href=\"mailto:wikipedialibrary@wikimedia.org?Subject=Wikipedia%%20Library%%20%(path)s%%20Not%%20found\"> wikipedialibrary@wikimedia.org</a> or report it to us on <a class=\"twl-links\" href=\"https://phabricator.wikimedia.org/maniphest/task/edit/form/1/?projectPHIDs=Library-Card-Platform&title=Wikipedia%%20Library%%20%(path)s%%20Not%%20found\">Phabricator</a>"
 msgstr ""
 
 #. Translators: Alt text for an image shown on the 404 error page.
@@ -2045,32 +1833,18 @@ msgstr "ဝီကီပီးဒီးယား စာကြည့်တို�
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:20
-msgid ""
-"This platform is our central tool for facilitating access to our available "
-"collections. Here you can see which partnerships are available, search their "
-"contents, and apply for and access the ones you’re interested in."
+msgid "This platform is our central tool for facilitating access to our available collections. Here you can see which partnerships are available, search their contents, and apply for and access the ones you’re interested in."
 msgstr ""
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/). Wikimedia Foundation should not be translated.
 #: TWLight/templates/about.html:29
-msgid ""
-"All users receive immediate access to some collections, which can be browsed "
-"by clicking the 'Access collection' buttons or using the search bar at the "
-"top of the page. Other collections require an application before access is "
-"granted, and may be accessed directly or via an individual login or access "
-"code. Volunteer coordinators, who have signed non-disclosure agreements with "
-"the Wikimedia Foundation, review these applications and work with publishers "
-"to get you your free access."
+msgid "All users receive immediate access to some collections, which can be browsed by clicking the 'Access collection' buttons or using the search bar at the top of the page. Other collections require an application before access is granted, and may be accessed directly or via an individual login or access code. Volunteer coordinators, who have signed non-disclosure agreements with the Wikimedia Foundation, review these applications and work with publishers to get you your free access."
 msgstr ""
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/). Don't translate terms_url.
 #: TWLight/templates/about.html:43
 #, python-format
-msgid ""
-"For more information about how your information is stored and reviewed "
-"please see our <a class=\"twl-links\" href=\"%(terms_url)s\"> terms of use "
-"and privacy policy</a>. Accounts you apply for are also subject to the Terms "
-"of Use provided by each partner’s platform; please review them."
+msgid "For more information about how your information is stored and reviewed please see our <a class=\"twl-links\" href=\"%(terms_url)s\"> terms of use and privacy policy</a>. Accounts you apply for are also subject to the Terms of Use provided by each partner’s platform; please review them."
 msgstr ""
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
@@ -2080,12 +1854,7 @@ msgstr ""
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/). Wikimedia Foundation should not be translated.
 #: TWLight/templates/about.html:55
-msgid ""
-"Any active editor in good standing can receive access. For publishers with "
-"limited numbers of accounts, applications are reviewed based on the editor’s "
-"needs and contributions. If you think you could use access to one of our "
-"partner resources and are an active editor in any project supported by the "
-"Wikimedia Foundation, please apply."
+msgid "Any active editor in good standing can receive access. For publishers with limited numbers of accounts, applications are reviewed based on the editor’s needs and contributions. If you think you could use access to one of our partner resources and are an active editor in any project supported by the Wikimedia Foundation, please apply."
 msgstr ""
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
@@ -2115,23 +1884,12 @@ msgstr "သင့်ကို ဝီကီပီးဒီးယားပရေ�
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/)
 #: TWLight/templates/about.html:89
-msgid ""
-"If you are applying for an available collection, please first check that you "
-"don't already have access through another library or institution. If you do, "
-"please consider using that access rather than taking up a seat for this "
-"resource in The Wikipedia Library."
+msgid "If you are applying for an available collection, please first check that you don't already have access through another library or institution. If you do, please consider using that access rather than taking up a seat for this resource in The Wikipedia Library."
 msgstr ""
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/)
 #: TWLight/templates/about.html:99
-msgid ""
-"If your account is blocked on one or more Wikimedia projects, you may still "
-"be granted access to The Wikipedia Library. You will need to contact the "
-"Wikipedia Library team, who will review your blocks. If you have been "
-"blocked for content issues, most notably copyright violations, or have "
-"multiple long-term blocks, we may decline your request. Additionally, if "
-"your block status changes after being approved, you will need to request "
-"another review."
+msgid "If your account is blocked on one or more Wikimedia projects, you may still be granted access to The Wikipedia Library. You will need to contact the Wikipedia Library team, who will review your blocks. If you have been blocked for content issues, most notably copyright violations, or have multiple long-term blocks, we may decline your request. Additionally, if your block status changes after being approved, you will need to request another review."
 msgstr ""
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
@@ -2166,9 +1924,7 @@ msgstr ""
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:136
-msgid ""
-"Share their account logins or passwords with others, or sell their access to "
-"other parties"
+msgid "Share their account logins or passwords with others, or sell their access to other parties"
 msgstr ""
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
@@ -2178,23 +1934,17 @@ msgstr ""
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:144
-msgid ""
-"Systematically make printed or electronic copies of multiple extracts of "
-"restricted content available for any purpose"
+msgid "Systematically make printed or electronic copies of multiple extracts of restricted content available for any purpose"
 msgstr ""
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/). Stub is a technical term for a short Wikipedia article, use the appropriate Wikipedia term in your language.
 #: TWLight/templates/about.html:148
-msgid ""
-"Datamine metadata without permission, in order, for instance, to use "
-"metadata for auto-created stub articles"
+msgid "Datamine metadata without permission, in order, for instance, to use metadata for auto-created stub articles"
 msgstr ""
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:154
-msgid ""
-"Respecting these agreements allows us to continue growing the partnerships "
-"available to the community."
+msgid "Respecting these agreements allows us to continue growing the partnerships available to the community."
 msgstr ""
 
 #. Translators: This is the heading for a section on the About page (https://wikipedialibrary.wmflabs.org/about/).
@@ -2204,41 +1954,22 @@ msgstr ""
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:164
-msgid ""
-"EZProxy is a proxy server used to authenticate users for many Wikipedia "
-"Library partners. Users sign into EZProxy via the Library Card platform to "
-"verify that they are authorized users, and then the server accesses "
-"requested resources using its own IP address."
+msgid "EZProxy is a proxy server used to authenticate users for many Wikipedia Library partners. Users sign into EZProxy via the Library Card platform to verify that they are authorized users, and then the server accesses requested resources using its own IP address."
 msgstr ""
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:173
-msgid ""
-"You may notice that when accessing resources via EZProxy that URLs are "
-"dynamically rewritten. This is why we recommend logging in via the Library "
-"Card platform rather than going directly to the unproxied partner website. "
-"When in doubt, check the URL for ‘idm.oclc’. If it’s there, then you’re "
-"connected via EZProxy."
+msgid "You may notice that when accessing resources via EZProxy that URLs are dynamically rewritten. This is why we recommend logging in via the Library Card platform rather than going directly to the unproxied partner website. When in doubt, check the URL for ‘idm.oclc’. If it’s there, then you’re connected via EZProxy."
 msgstr ""
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:182
-msgid ""
-"Typically once you’ve logged in your session will remain active in your "
-"browser for up to two hours after you’ve finished searching. Note that use "
-"of EZProxy requires you to enable cookies. If you are having problems you "
-"should also try clearing your cache and restarting your browser."
+msgid "Typically once you’ve logged in your session will remain active in your browser for up to two hours after you’ve finished searching. Note that use of EZProxy requires you to enable cookies. If you are having problems you should also try clearing your cache and restarting your browser."
 msgstr ""
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/)
 #: TWLight/templates/about.html:193
-msgid ""
-"The Library Bundle is a collection of resources for which no application is "
-"required. If you meet the criteria laid out above, you will be authorized "
-"for access automatically upon logging in to the platform. Only some of our "
-"content is currently included in the Library Bundle, however we hope to "
-"expand the collection as more publishers become comfortable with "
-"participating. All Bundle content is accessed via EZProxy."
+msgid "The Library Bundle is a collection of resources for which no application is required. If you meet the criteria laid out above, you will be authorized for access automatically upon logging in to the platform. Only some of our content is currently included in the Library Bundle, however we hope to expand the collection as more publishers become comfortable with participating. All Bundle content is accessed via EZProxy."
 msgstr ""
 
 #. Translators: This is the heading for a section on the About page (https://wikipedialibrary.wmflabs.org/about/).
@@ -2248,12 +1979,7 @@ msgstr ""
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:206
-msgid ""
-"Citation practices vary by project and even by article. Generally, we "
-"support editors citing where they found information, in a form that allows "
-"others to check it for themselves. That often means providing both original "
-"source details as well as a link to the partner database in which the source "
-"was found."
+msgid "Citation practices vary by project and even by article. Generally, we support editors citing where they found information, in a form that allows others to check it for themselves. That often means providing both original source details as well as a link to the partner database in which the source was found."
 msgstr ""
 
 #. Translators: This is the heading for a section on the About page (https://wikipedialibrary.wmflabs.org/about/).
@@ -2265,9 +1991,7 @@ msgstr "မိမိတို့အား ဆက်သွယ်ရန်"
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:218
 #, python-format
-msgid ""
-"If you have questions, need help, or want to volunteer to help, please see "
-"our <a class=\"twl-links\" href=\"%(contact_url)s\">contact page</a>."
+msgid "If you have questions, need help, or want to volunteer to help, please see our <a class=\"twl-links\" href=\"%(contact_url)s\">contact page</a>."
 msgstr ""
 
 #. Translators: This is the title of the panel box detailing the contact information for the Wikipedia Library team.
@@ -2307,9 +2031,7 @@ msgstr "ဝီကီပီးဒီးယားစာကြည့်တိုက
 #. Translators: This is the text that appears at the bottom of the contact us form directing users to the suggestions form.
 #: TWLight/templates/contact.html:48
 #, python-format
-msgid ""
-"(If you would like to suggest a partner, <a class=\"twl-links\" href="
-"\"%(suggest)s\"><strong>go here</strong></a>.)"
+msgid "(If you would like to suggest a partner, <a class=\"twl-links\" href=\"%(suggest)s\"><strong>go here</strong></a>.)"
 msgstr ""
 
 #. Translators: On a special 'link to search' page, this message is shown if JavaScript is disabled.
@@ -2368,9 +2090,7 @@ msgstr "ဝီကီပီးဒီးယား စာကြည့်တို�
 #. Translators: Information about The Wikipedia Library.
 #: TWLight/templates/login_partial.html:53 TWLight/templates/new_base.html:21
 #, python-format
-msgid ""
-"More than 100 of the world's top subscription-only databases, with content "
-"in %(no_of_languages)s languages, free for Wikipedians of all backgrounds"
+msgid "More than 100 of the world's top subscription-only databases, with content in %(no_of_languages)s languages, free for Wikipedians of all backgrounds"
 msgstr ""
 
 #. Translators: Information about The Wikipedia Library.
@@ -2379,9 +2099,7 @@ msgid "Meet these criteria for automatic access"
 msgstr ""
 
 #: TWLight/templates/login_partial.html:69
-msgid ""
-"These criteria grant you access to certain collections but not all. Some "
-"collections are accessible on a per application basis only."
+msgid "These criteria grant you access to certain collections but not all. Some collections are accessible on a per application basis only."
 msgstr ""
 
 #: TWLight/templates/login_partial.html:89
@@ -2392,29 +2110,19 @@ msgstr "ဝီကီပီးဒီးယားအကောင့်ဖြင့
 #. Translators: Shown if the current user doesn't have a registered email on their account. Don't translate contact_us_url or email_url.
 #: TWLight/templates/message_partial.html:15
 #, python-format
-msgid ""
-"You don't have an email on file. We can't finalize your access to partner "
-"resources, and you won't be able to <a class=\"twl-links\" href="
-"\"%(contact_us_url)s\">contact us</a> without an email. Please <a class="
-"\"twl-links\" href=\"%(email_url)s\">update your email</a>."
+msgid "You don't have an email on file. We can't finalize your access to partner resources, and you won't be able to <a class=\"twl-links\" href=\"%(contact_us_url)s\">contact us</a> without an email. Please <a class=\"twl-links\" href=\"%(email_url)s\">update your email</a>."
 msgstr ""
 
 #. Translators: Shown if the current user has requested the processing of their data should be restricted.
 #: TWLight/templates/message_partial.html:26
 #, python-format
-msgid ""
-"You have requested a restriction on the processing of your data. Most site "
-"functionality will not be available to you until you <a class=\"twl-links\" "
-"href=\"%(restrict_url)s\">lift this restriction</a>."
+msgid "You have requested a restriction on the processing of your data. Most site functionality will not be available to you until you <a class=\"twl-links\" href=\"%(restrict_url)s\">lift this restriction</a>."
 msgstr ""
 
 #. Translators: Shown if the current user has not agreed to the terms of use.
 #: TWLight/templates/message_partial.html:37
 #, python-format
-msgid ""
-"You have not agreed to the <a class=\"twl-links\" href=\"%(terms_url)s"
-"\">terms of use</a> of this site. Your applications will not be processed "
-"and you won't be able to apply or access resources you are approved for."
+msgid "You have not agreed to the <a class=\"twl-links\" href=\"%(terms_url)s\">terms of use</a> of this site. Your applications will not be processed and you won't be able to apply or access resources you are approved for."
 msgstr ""
 
 #. Translators: This link is at the bottom of every page and links to the 'About' page (https://wikipedialibrary.wmflabs.org/about/)
@@ -2461,9 +2169,7 @@ msgstr "စကားဝှက်ကို ပြန်ချိန်ရန်"
 
 #. Translators: If a user goes to reset their password, this message asks them to enter their email to do so.
 #: TWLight/templates/registration/password_reset_form.html:13
-msgid ""
-"Forgot your password? Enter your email address below, and we'll email "
-"instructions for setting a new one."
+msgid "Forgot your password? Enter your email address below, and we'll email instructions for setting a new one."
 msgstr ""
 
 #. Translators: This is the label for a button that users click to update their public information.
@@ -2511,16 +2217,12 @@ msgstr "အသုံးပြုခြင်းဆိုင်ရာ သတ်�
 
 #. Translators: This text explains how to disagree to the site's terms of use and the restrictions that will come into effect when users disagree to the terms of use.
 #: TWLight/users/forms.py:185
-msgid ""
-"By unchecking this box and clicking “Update” you may explore the site, but "
-"you will not be able to apply for access to materials or evaluate "
-"applications unless you agree with the terms of use."
+msgid "By unchecking this box and clicking “Update” you may explore the site, but you will not be able to apply for access to materials or evaluate applications unless you agree with the terms of use."
 msgstr ""
 
 #. Translators: Users click this button to set their website email address to the one linked to their Wikipedia account.
 #: TWLight/users/forms.py:211
-msgid ""
-"Use my Wikipedia email address (will be updated the next time you login)."
+msgid "Use my Wikipedia email address (will be updated the next time you login)."
 msgstr ""
 
 #. Translators: This labels a button which users click to change their email.
@@ -2531,17 +2233,8 @@ msgstr "အီးမေးလ် မွမ်းမံရန်"
 #. Translators: Shown if the current user tried to 'favorite' a partner they can't access. Do not translate '{partner}'
 #: TWLight/users/models.py:201
 #, python-brace-format
-msgid ""
-"Cannot add partner {partner} to your favorites because you don't have access "
-"to it"
+msgid "Cannot add partner {partner} to your favorites because you don't have access to it"
 msgstr ""
-
-#. Translators: Do not translate.
-#: TWLight/users/models.py:869
-#, fuzzy, python-brace-format
-#| msgid "Username"
-msgid "{wp_username}"
-msgstr "အသုံးပြုသူအမည်"
 
 #. Translators: This error message is shown when there's a problem with the authenticated login process.
 #: TWLight/users/oauth.py:243
@@ -2561,9 +2254,7 @@ msgstr ""
 
 #. Translators: this message is displayed to users that don't have accounts and clicked on a proxied link.
 #: TWLight/users/oauth.py:388
-msgid ""
-"To view this link you need to be an eligible library user. Please login to "
-"continue."
+msgid "To view this link you need to be an eligible library user. Please login to continue."
 msgstr ""
 
 #. Translators: This warning message is shown to users when the response received from Wikimedia OAuth servers is not a valid one.
@@ -2599,17 +2290,12 @@ msgstr "အသုံးပြုသူ သတင်းအချက်အလက�
 
 #. Translators: If the user tries to log in, but their account does not meet certain requirements, they cannot login.
 #: TWLight/users/oauth.py:528
-msgid ""
-"Your Wikipedia account does not meet the eligibility criteria in the terms "
-"of use, so your Wikipedia Library Card Platform account cannot be activated."
+msgid "Your Wikipedia account does not meet the eligibility criteria in the terms of use, so your Wikipedia Library Card Platform account cannot be activated."
 msgstr ""
 
 #. Translators: If the user tries to log in, but their account does not meet certain requirements, they cannot login.
 #: TWLight/users/oauth.py:536
-msgid ""
-"Your Wikipedia account no longer meets the eligibility criteria in the terms "
-"of use, so you cannot be logged in. If you think you should be able to log "
-"in, please email wikipedialibrary@wikimedia.org."
+msgid "Your Wikipedia account no longer meets the eligibility criteria in the terms of use, so you cannot be logged in. If you think you should be able to log in, please email wikipedialibrary@wikimedia.org."
 msgstr ""
 
 #. Translators: this message is displayed to users with brand new accounts.
@@ -2620,10 +2306,7 @@ msgstr "ကြိုဆိုပါသည်၊ အသုံးပြုခြ�
 #. Translators: This message is displayed on the confirmation page where users can return their access to partner collections.
 #: TWLight/users/templates/users/authorization_confirm_return.html:13
 #, python-format
-msgid ""
-"You will no longer be able to access <b>%(partner)s's</b> resources via the "
-"Library Card platform, but can request access again by clicking 'renew', if "
-"you change your mind. Are you sure you want to return your access?"
+msgid "You will no longer be able to access <b>%(partner)s's</b> resources via the Library Card platform, but can request access again by clicking 'renew', if you change your mind. Are you sure you want to return your access?"
 msgstr ""
 
 #. Translators: On the MyLibrary page (https://wikipedialibrary.wmflabs.org/users/my_library), this tab shows all favorite collections a user has.
@@ -2697,10 +2380,7 @@ msgstr ""
 
 #. Translators: This is shown on editor profiles, in their profile page or on applications.
 #: TWLight/users/templates/users/editor_detail.html:59
-msgid ""
-"Information with an * was retrieved from Wikipedia directly. Other "
-"information was entered directly by users or site admins, in their preferred "
-"language."
+msgid "Information with an * was retrieved from Wikipedia directly. Other information was entered directly by users or site admins, in their preferred language."
 msgstr ""
 
 #. Translators: This distinguishes users who have been flagged as account coordinators. Don't translate username.
@@ -2711,10 +2391,7 @@ msgstr ""
 
 #. Translators: This is shown on editor profiles, under the heading for Wikipedia editor data.
 #: TWLight/users/templates/users/editor_detail_data.html:5
-msgid ""
-"This information is updated automatically from your Wikimedia account each "
-"time you log in, except for the Contributions field, where you can describe "
-"your Wikimedia editing history."
+msgid "This information is updated automatically from your Wikimedia account each time you log in, except for the Contributions field, where you can describe your Wikimedia editing history."
 msgstr ""
 
 #. Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this labels the user's username.
@@ -2745,17 +2422,13 @@ msgstr "အသုံးပြုခြင်းဆိုင်ရာ သတ်�
 
 #. Translators: when viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this question has a yes or no answer.
 #: TWLight/users/templates/users/editor_detail_data.html:57
-msgid ""
-"at their last login, did this user meet the criteria set forth in the terms "
-"of use?"
+msgid "at their last login, did this user meet the criteria set forth in the terms of use?"
 msgstr ""
 
 #. Translators: When viewing a user's profile in an application, this message shows if the software doesn't think that the user is eligible for access. Don't translate username.
 #: TWLight/users/templates/users/editor_detail_data.html:72
 #, python-format
-msgid ""
-"%(username)s may still be eligible for access grants at the coordinators' "
-"discretion."
+msgid "%(username)s may still be eligible for access grants at the coordinators' discretion."
 msgstr ""
 
 #. Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this is the heading for a Yes/No ToU question.
@@ -2792,10 +2465,7 @@ msgstr ""
 #. Translators: This message is shown on a user's profile if their Wikimedia account is blocked on one or more projects. They may still be granted access to the Library Bundle, but need to contact Wikipedia Library staff to verify.
 #: TWLight/users/templates/users/editor_detail_data.html:137
 #, python-format
-msgid ""
-"It looks like you have an active block on your account. If you meet the "
-"other criteria you may still be permitted access to the library - please <a "
-"class=\"twl-links\" href=\"%(contact_url)s\">contact us</a>."
+msgid "It looks like you have an active block on your account. If you meet the other criteria you may still be permitted access to the library - please <a class=\"twl-links\" href=\"%(contact_url)s\">contact us</a>."
 msgstr ""
 
 #. Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this is the heading for a Yes/No program eligibility question.
@@ -2805,10 +2475,7 @@ msgstr ""
 
 #. Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this question has a Yes or No answer.
 #: TWLight/users/templates/users/editor_detail_data.html:156
-msgid ""
-"At their last login, did this user meet the criteria set forth in the "
-"Library Bundle? Note that satisfying terms of use is a prerequisite to "
-"bundle eligibility."
+msgid "At their last login, did this user meet the criteria set forth in the Library Bundle? Note that satisfying terms of use is a prerequisite to bundle eligibility."
 msgstr ""
 
 #. Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this is the heading for a Yes/No program eligibility question.
@@ -2856,18 +2523,13 @@ msgstr "ပုဂ္ဂိုလ်ရေးဒေတာ"
 
 #. Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this text is in the 'Personal data' section. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/users/templates/users/editor_detail_data.html:262
-msgid ""
-"The following information is visible only to you, site administrators, "
-"publishing partners (where required), and volunteer Wikipedia Library "
-"coordinators (who have signed a Non-Disclosure Agreement)."
+msgid "The following information is visible only to you, site administrators, publishing partners (where required), and volunteer Wikipedia Library coordinators (who have signed a Non-Disclosure Agreement)."
 msgstr ""
 
 #. Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this labels a button which users can click to update or remove their personal information. Don't translate update_url.
 #: TWLight/users/templates/users/editor_detail_data.html:272
 #, python-format
-msgid ""
-"You may <a class=\"twl-links\" href=\"%(update_url)s\">update or delete</a> "
-"your data at any time."
+msgid "You may <a class=\"twl-links\" href=\"%(update_url)s\">update or delete</a> your data at any time."
 msgstr ""
 
 #. Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this labels the user's email. Don't remove the *.
@@ -2888,24 +2550,18 @@ msgstr ""
 
 #. Translators: This message tells users that they are not eligible to access The Wikipedia Library content.
 #: TWLight/users/templates/users/eligibility_modal.html:7
-msgid ""
-"Sorry, your Wikipedia account doesn’t currently qualify to access The "
-"Wikipedia Library."
+msgid "Sorry, your Wikipedia account doesn’t currently qualify to access The Wikipedia Library."
 msgstr ""
 
 #. Translators: This message tells users that they have not agreed to the terms of use, therefore are ineligible to access the content in The Wikipedia Library.
 #: TWLight/users/templates/users/eligibility_modal.html:30
 #, python-format
-msgid ""
-"Agreed with <a href=\"%(terms)s\" class=\"text-danger\"> terms of use </a>"
+msgid "Agreed with <a href=\"%(terms)s\" class=\"text-danger\"> terms of use </a>"
 msgstr ""
 
 #: TWLight/users/templates/users/eligibility_modal.html:40
 #, python-format
-msgid ""
-"It looks like you have an active block on your account. If you meet the "
-"other criteria you may still be permitted access to the library - please <a "
-"href=\"%(contact_url)s\">contact us</a>."
+msgid "It looks like you have an active block on your account. If you meet the other criteria you may still be permitted access to the library - please <a href=\"%(contact_url)s\">contact us</a>."
 msgstr ""
 
 #. Translators: Instructions to refresh a user's data.
@@ -2945,10 +2601,7 @@ msgstr "ဘာသာစကား သတ်မှတ်ရန်"
 
 #. Translators: This text on the user page helps users naviage to the TranslateWiki Wikipedia Library Card platform translation page.
 #: TWLight/users/templates/users/language_form.html:31
-msgid ""
-"You can help translate the tool at <a class=\"twl-links\" href=\"https://"
-"translatewiki.net/wiki/Translating:Wikipedia_Library_Card_Platform"
-"\">translatewiki.net</a>."
+msgid "You can help translate the tool at <a class=\"twl-links\" href=\"https://translatewiki.net/wiki/Translating:Wikipedia_Library_Card_Platform\">translatewiki.net</a>."
 msgstr ""
 
 #. Translators: When the user starts a new application and submits the application, the user can view the application and withdraw if need be. This changes the label for the Withdraw button.
@@ -2968,9 +2621,7 @@ msgstr ""
 
 #. Translators: On the page listing applications, this text explains a user they cannot renew their application since they've already requested a renewal or there aren't any renewals available.
 #: TWLight/users/templates/users/my_applications.html:79
-msgid ""
-"Renewals are either not required, not available right now, or you have "
-"already requested a renewal."
+msgid "Renewals are either not required, not available right now, or you have already requested a renewal."
 msgstr ""
 
 #. Translators: This text is the heading of a section in a user's profile where they can change their preferences.
@@ -3037,19 +2688,12 @@ msgstr ""
 
 #. Translators: This message is displayed on the page where users can request we stop processing their data.
 #: TWLight/users/templates/users/restrict_data.html:15
-msgid ""
-"Checking this box and clicking “Restrict” will pause all processing of the "
-"data you have entered into this website. You will not be able to apply for "
-"access to resources, your applications will not be further processed, and "
-"none of your data will be altered, until you return to this page and uncheck "
-"the box. This is not the same as deleting your data."
+msgid "Checking this box and clicking “Restrict” will pause all processing of the data you have entered into this website. You will not be able to apply for access to resources, your applications will not be further processed, and none of your data will be altered, until you return to this page and uncheck the box. This is not the same as deleting your data."
 msgstr ""
 
 #. Translators: This warning message is shown to coordinators who view the data restriction page.
 #: TWLight/users/templates/users/restrict_data.html:26
-msgid ""
-"You are a coordinator on this site. If you restrict the processing of your "
-"data, your coordinator flag will be removed."
+msgid "You are a coordinator on this site. If you restrict the processing of your data, your coordinator flag will be removed."
 msgstr ""
 
 #. Translators: use the date *when you are translating*, in a language-appropriate format.
@@ -3069,24 +2713,12 @@ msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:51
-msgid ""
-"<a class=\"twl-links\" href=\"https://meta.wikimedia.org/wiki/"
-"The_Wikipedia_Library\"> The Wikipedia Library </a> has partnered with "
-"publishers around the world to allow users to access otherwise paywalled "
-"resources. This website allows Wikipedia editors to search and access these "
-"resources."
+msgid "<a class=\"twl-links\" href=\"https://meta.wikimedia.org/wiki/The_Wikipedia_Library\"> The Wikipedia Library </a> has partnered with publishers around the world to allow users to access otherwise paywalled resources. This website allows Wikipedia editors to search and access these resources."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Wikimedia Foundation should not be translated. WMF should not be translated. Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:63
-msgid ""
-"This program is administered by the Wikimedia Foundation (WMF). These terms "
-"of use and privacy notice pertain to your application for access to "
-"resources through the Wikipedia Library, your use of this website, and your "
-"access to and use of those resources. They also describe our handling of the "
-"information you provide to us in order to create and administer your "
-"Wikipedia Library account. If we make material changes to the terms, we will "
-"notify users."
+msgid "This program is administered by the Wikimedia Foundation (WMF). These terms of use and privacy notice pertain to your application for access to resources through the Wikipedia Library, your use of this website, and your access to and use of those resources. They also describe our handling of the information you provide to us in order to create and administer your Wikipedia Library account. If we make material changes to the terms, we will notify users."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
@@ -3096,37 +2728,17 @@ msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:78
-msgid ""
-"Access to resources via The Wikipedia Library is reserved for community "
-"members who have demonstrated their commitment to the Wikimedia projects, "
-"and who will use their access to these resources to improve project content. "
-"To that end, in order to be eligible for The Wikipedia Library, we require "
-"that you be registered for a user account on the projects, with at least 500 "
-"edits, six (6) months of activity, and 10+ edits in the last month. We ask "
-"that you do not request access to any publishers with a limited number of "
-"available accounts whose resources you can already access for free through "
-"your local library or university, or another institution or organization, in "
-"order to provide that opportunity to others."
+msgid "Access to resources via The Wikipedia Library is reserved for community members who have demonstrated their commitment to the Wikimedia projects, and who will use their access to these resources to improve project content. To that end, in order to be eligible for The Wikipedia Library, we require that you be registered for a user account on the projects, with at least 500 edits, six (6) months of activity, and 10+ edits in the last month. We ask that you do not request access to any publishers with a limited number of available accounts whose resources you can already access for free through your local library or university, or another institution or organization, in order to provide that opportunity to others."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:94
-msgid ""
-"Additionally, if you are currently blocked or banned from a Wikimedia "
-"project, applications to resources may be rejected or restricted. If you "
-"obtain a Wikipedia Library account, but a block or ban is subsequently "
-"instituted against you on one of the projects, you may lose access to your "
-"Wikipedia Library account."
+msgid "Additionally, if you are currently blocked or banned from a Wikimedia project, applications to resources may be rejected or restricted. If you obtain a Wikipedia Library account, but a block or ban is subsequently instituted against you on one of the projects, you may lose access to your Wikipedia Library account."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:104
-msgid ""
-"Your eligibility to access The Wikipedia Library is assessed at each login. "
-"While more than half of the library's content is provided via this automated "
-"eligibility check, access to other publisher's content may be time limited, "
-"typically lapsing after one year, after which you will usually need to apply "
-"for renewal."
+msgid "Your eligibility to access The Wikipedia Library is assessed at each login. While more than half of the library's content is provided via this automated eligibility check, access to other publisher's content may be time limited, typically lapsing after one year, after which you will usually need to apply for renewal."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
@@ -3137,47 +2749,27 @@ msgstr "ဝီကီပီးဒီးယား စာကြည့်တို�
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:118
-msgid ""
-"In order to apply for access to a partner resource, you must provide us with "
-"certain information, which we will use to evaluate your application. If your "
-"application is approved, we may transfer the information you have given us "
-"to the publishers whose resources you wish to access. They will either "
-"contact you with the account information directly or we will send access "
-"information to you ourselves."
+msgid "In order to apply for access to a partner resource, you must provide us with certain information, which we will use to evaluate your application. If your application is approved, we may transfer the information you have given us to the publishers whose resources you wish to access. They will either contact you with the account information directly or we will send access information to you ourselves."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:130
-msgid ""
-"In addition to the basic information you provide to us, our system will "
-"retrieve some information directly from the Wikimedia projects: your "
-"username, email address, edit count, registration date, user ID number, "
-"groups to which you belong, and any special user rights."
+msgid "In addition to the basic information you provide to us, our system will retrieve some information directly from the Wikimedia projects: your username, email address, edit count, registration date, user ID number, groups to which you belong, and any special user rights."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:140
-msgid ""
-"Each time you log in to the Wikipedia Library Card Platform, this "
-"information will be automatically updated."
+msgid "Each time you log in to the Wikipedia Library Card Platform, this information will be automatically updated."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:148
-msgid ""
-"We will ask you to provide us with some information about your history of "
-"contributions to the Wikimedia projects. Information on contribution history "
-"is optional, but will greatly assist us in evaluating your application."
+msgid "We will ask you to provide us with some information about your history of contributions to the Wikimedia projects. Information on contribution history is optional, but will greatly assist us in evaluating your application."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). WMF should not be translated. Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:157
-msgid ""
-"The information you provide when creating your account will be visible to "
-"you while on the site but not to others unless they are approved Wikipedia "
-"Library Coordinators, WMF Staff, or WMF Contractors who need access to this "
-"data in order to carry out their work with the Wikipedia Library, all of "
-"whom are subject to non-disclosure obligations."
+msgid "The information you provide when creating your account will be visible to you while on the site but not to others unless they are approved Wikipedia Library Coordinators, WMF Staff, or WMF Contractors who need access to this data in order to carry out their work with the Wikipedia Library, all of whom are subject to non-disclosure obligations."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
@@ -3187,46 +2779,32 @@ msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:171
-msgid ""
-"In order to access an individual publisher’s resources, you must agree to "
-"that publisher’s terms of use and privacy policy. You agree that you will "
-"not violate such terms and policies in connection with your use of the "
-"Wikipedia Library. Additionally, the following activities are prohibited "
-"while accessing publisher resources through the Wikipedia Library."
+msgid "In order to access an individual publisher’s resources, you must agree to that publisher’s terms of use and privacy policy. You agree that you will not violate such terms and policies in connection with your use of the Wikipedia Library. Additionally, the following activities are prohibited while accessing publisher resources through the Wikipedia Library."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:184
-msgid ""
-"Sharing your Wikipedia account, usernames, passwords, or any access codes "
-"for publisher resources with others;"
+msgid "Sharing your Wikipedia account, usernames, passwords, or any access codes for publisher resources with others;"
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:191
-msgid ""
-"Automatically scraping or downloading restricted content from publishers;"
+msgid "Automatically scraping or downloading restricted content from publishers;"
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:197
-msgid ""
-"Systematically making printed or electronic copies of multiple extracts of "
-"restricted content available for any purpose;"
+msgid "Systematically making printed or electronic copies of multiple extracts of restricted content available for any purpose;"
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:204
-msgid ""
-"Data mining metadata without permission—for example, in order to use "
-"metadata for auto-created stub articles;"
+msgid "Data mining metadata without permission—for example, in order to use metadata for auto-created stub articles;"
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:211
-msgid ""
-"Using the access you receive through the Wikipedia Library for profit by "
-"selling access to your account or resources which you have through it."
+msgid "Using the access you receive through the Wikipedia Library for profit by selling access to your account or resources which you have through it."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
@@ -3236,18 +2814,12 @@ msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:224
-msgid ""
-"Certain resources may only be accessed using an external search service, "
-"such as the EBSCO Discovery Service, or a proxy service, such as OCLC "
-"EZProxy. If you use such external search and/or proxy services, please "
-"review the applicable terms of use and privacy policies."
+msgid "Certain resources may only be accessed using an external search service, such as the EBSCO Discovery Service, or a proxy service, such as OCLC EZProxy. If you use such external search and/or proxy services, please review the applicable terms of use and privacy policies."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:234
-msgid ""
-"In addition, if you use OCLC EZProxy, please note that you may not use it "
-"for commercial purposes."
+msgid "In addition, if you use OCLC EZProxy, please note that you may not use it for commercial purposes."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
@@ -3257,120 +2829,49 @@ msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Wikimedia Foundation should not be translated. Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:245
-msgid ""
-"The Wikimedia Foundation and our service providers use your information for "
-"the legitimate purpose of providing Wikipedia Library services in support of "
-"our charitable mission. When you apply for a Wikipedia Library account, or "
-"use your Wikipedia Library account, we may routinely collect the following "
-"information: your username, email address, edit count, registration date, "
-"user ID number, groups to which you belong, and any special user rights; "
-"your name, country of residence, and/or affiliation, if required by a "
-"partner to which you are applying; your narrative description of your "
-"contributions and reasons for applying for access to partner resources; and "
-"the date you agree to these terms of use."
+msgid "The Wikimedia Foundation and our service providers use your information for the legitimate purpose of providing Wikipedia Library services in support of our charitable mission. When you apply for a Wikipedia Library account, or use your Wikipedia Library account, we may routinely collect the following information: your username, email address, edit count, registration date, user ID number, groups to which you belong, and any special user rights; your name, country of residence, and/or affiliation, if required by a partner to which you are applying; your narrative description of your contributions and reasons for applying for access to partner resources; and the date you agree to these terms of use."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:262
 #, python-format
-msgid ""
-"Each publisher who is a member of the Wikipedia Library program requires "
-"different specific information in the application. Some publishers may "
-"request only an email address, while others request more detailed data, such "
-"as your name, location, or institutional affiliation. When you complete your "
-"application, you will only be asked to supply information required by the "
-"publishers you have chosen, and each publisher will only receive the "
-"information they require for providing you with access. Please see our <a "
-"class=\"twl-links\" href=\"%(all_partners_url)s\">partner information</a> "
-"pages to learn what information is required by each publisher to gain access "
-"to their resources."
+msgid "Each publisher who is a member of the Wikipedia Library program requires different specific information in the application. Some publishers may request only an email address, while others request more detailed data, such as your name, location, or institutional affiliation. When you complete your application, you will only be asked to supply information required by the publishers you have chosen, and each publisher will only receive the information they require for providing you with access. Please see our <a class=\"twl-links\" href=\"%(all_partners_url)s\">partner information</a> pages to learn what information is required by each publisher to gain access to their resources."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Wikimedia Foundation should not be translated. Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:277
-msgid ""
-"Some Wikipedia Library pages are visible without logging in, but you will "
-"need to log in to apply or access proprietary partner resources. We use the "
-"data provided by you via OAuth and Wikimedia API calls to assess your "
-"application for access and to process approved requests."
+msgid "Some Wikipedia Library pages are visible without logging in, but you will need to log in to apply or access proprietary partner resources. We use the data provided by you via OAuth and Wikimedia API calls to assess your application for access and to process approved requests."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:288
 #, python-format
-msgid ""
-"In order to administer the Wikipedia Library program, we will retain the "
-"application data we collect from you for three years after your most recent "
-"login, unless you delete your account, as described below. You can log in "
-"and go to <a class=\"twl-links\" href=\"%(profile_url)s\">your profile page</"
-"a> in order to see the information associated with your account, and can "
-"download it in JSON format. You may access, update, restrict, or delete this "
-"information at any time, except for the information that is automatically "
-"retrieved from the projects. If you have any questions or concerns about the "
-"handling of your data, please contact <a class=\"twl-links\" href=\"mailto:"
-"wikipedialibrary@wikimedia.org?Subject=Wikipedia%%20Library%%20Card"
-"%%20account%%20deactivation\"> wikipedialibrary@wikimedia.org </a>."
+msgid "In order to administer the Wikipedia Library program, we will retain the application data we collect from you for three years after your most recent login, unless you delete your account, as described below. You can log in and go to <a class=\"twl-links\" href=\"%(profile_url)s\">your profile page</a> in order to see the information associated with your account, and can download it in JSON format. You may access, update, restrict, or delete this information at any time, except for the information that is automatically retrieved from the projects. If you have any questions or concerns about the handling of your data, please contact <a class=\"twl-links\" href=\"mailto:wikipedialibrary@wikimedia.org?Subject=Wikipedia%%20Library%%20Card%%20account%%20deactivation\"> wikipedialibrary@wikimedia.org </a>."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:305
-msgid ""
-"If you decide to disable your Wikipedia Library account, you can use the "
-"delete button on your profile to delete certain personal information "
-"associated with your account. We will delete your real name, institutional "
-"affiliation, and country of residence. Please note that the system will "
-"retain a record of your username, the publishers to which you applied or had "
-"access, and the dates of that access. Note that deletion is not reversible. "
-"Deletion of your Wikipedia Library account may also correspond with the "
-"removal of any resource access to which you were eligible or approved. If "
-"you request the deletion of account information and later wish to apply for "
-"a new account, you will need to provide the necessary information again."
+msgid "If you decide to disable your Wikipedia Library account, you can use the delete button on your profile to delete certain personal information associated with your account. We will delete your real name, institutional affiliation, and country of residence. Please note that the system will retain a record of your username, the publishers to which you applied or had access, and the dates of that access. Note that deletion is not reversible. Deletion of your Wikipedia Library account may also correspond with the removal of any resource access to which you were eligible or approved. If you request the deletion of account information and later wish to apply for a new account, you will need to provide the necessary information again."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). WMF should not be translated. Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:321
-msgid ""
-"The Wikipedia Library is run by WMF Staff, Contractors, and approved "
-"volunteer Coordinators. The data associated with your account will be shared "
-"with the WMF staff, contractors, service providers, and volunteer "
-"coordinators who need to process the information in connection with their "
-"work for the Wikipedia Library, and who are subject to confidentiality "
-"obligations. We will also use your data for internal Wikipedia Library "
-"purposes such as distributing user surveys and account notifications, and in "
-"a depersonalized or aggregated fashion for statistical analysis and "
-"administration. Finally, we will share your information with the publishers "
-"whom you specifically select in order to provide you with access to "
-"resources. Otherwise, your information will not be shared with third "
-"parties, with the exception of the circumstances described below."
+msgid "The Wikipedia Library is run by WMF Staff, Contractors, and approved volunteer Coordinators. The data associated with your account will be shared with the WMF staff, contractors, service providers, and volunteer coordinators who need to process the information in connection with their work for the Wikipedia Library, and who are subject to confidentiality obligations. We will also use your data for internal Wikipedia Library purposes such as distributing user surveys and account notifications, and in a depersonalized or aggregated fashion for statistical analysis and administration. Finally, we will share your information with the publishers whom you specifically select in order to provide you with access to resources. Otherwise, your information will not be shared with third parties, with the exception of the circumstances described below."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). WMF should not be translated.
 #: TWLight/users/templates/users/terms.html:338
-msgid ""
-"We may disclose any collected information when required by law, when we have "
-"your permission, when needed to protect our rights, privacy, safety, users, "
-"or the general public, and when necessary to enforce these terms, WMF’s "
-"general <a class=\"twl-links\" href=\"https://foundation.wikimedia.org/wiki/"
-"Terms_of_Use\">Terms of Use</a>, or any other WMF policy."
+msgid "We may disclose any collected information when required by law, when we have your permission, when needed to protect our rights, privacy, safety, users, or the general public, and when necessary to enforce these terms, WMF’s general <a class=\"twl-links\" href=\"https://foundation.wikimedia.org/wiki/Terms_of_Use\">Terms of Use</a>, or any other WMF policy."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:349
-msgid ""
-"We take the security of your personal data seriously, and take reasonable "
-"precautions to ensure your data is protected. These precautions include "
-"access controls to limit who has access to your data and security "
-"technologies to protect data stored on the server. However, we cannot "
-"guarantee the safety of your data as it is transmitted and stored."
+msgid "We take the security of your personal data seriously, and take reasonable precautions to ensure your data is protected. These precautions include access controls to limit who has access to your data and security technologies to protect data stored on the server. However, we cannot guarantee the safety of your data as it is transmitted and stored."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:360
-msgid ""
-"Please note that these terms do not control the use and handling of your "
-"data by the publishers and service providers whose resources you access or "
-"apply to access. Please read their individual privacy policies for that "
-"information."
+msgid "Please note that these terms do not control the use and handling of your data by the publishers and service providers whose resources you access or apply to access. Please read their individual privacy policies for that information."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
@@ -3380,34 +2881,17 @@ msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Wikimedia Foundation should not be translated. Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:373
-msgid ""
-"The Wikimedia Foundation is a nonprofit organization based in San Francisco, "
-"California. The Wikipedia Library program provides access to resources held "
-"by publishers in multiple countries. If you apply for a Wikipedia Library "
-"account (whether you are inside or outside of the United States), you "
-"understand that your personal data will be collected, transferred, stored, "
-"processed, disclosed and otherwise used in the U.S. as described in this "
-"privacy policy. You also understand that your information may be transferred "
-"by us from the U.S. to other countries, which may have different or less "
-"stringent data protection laws than your country, in connection with "
-"providing services to you, including evaluating your application and "
-"securing access to your chosen publishers (locations for each publisher are "
-"outlined on their respective partner information pages)."
+msgid "The Wikimedia Foundation is a nonprofit organization based in San Francisco, California. The Wikipedia Library program provides access to resources held by publishers in multiple countries. If you apply for a Wikipedia Library account (whether you are inside or outside of the United States), you understand that your personal data will be collected, transferred, stored, processed, disclosed and otherwise used in the U.S. as described in this privacy policy. You also understand that your information may be transferred by us from the U.S. to other countries, which may have different or less stringent data protection laws than your country, in connection with providing services to you, including evaluating your application and securing access to your chosen publishers (locations for each publisher are outlined on their respective partner information pages)."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:392
-msgid ""
-"Please note that in the event of any differences in meaning or "
-"interpretation between the original English version of these terms and a "
-"translation, the original English version takes precedence."
+msgid "Please note that in the event of any differences in meaning or interpretation between the original English version of these terms and a translation, the original English version takes precedence."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Wikimedia Foundation should not be translated.
 #: TWLight/users/templates/users/terms.html:403
-msgid ""
-"See also the <a class=\"twl-links\" href=\"https://wikimediafoundation.org/"
-"wiki/Privacy_policy\">Wikimedia Foundation Privacy Policy</a>."
+msgid "See also the <a class=\"twl-links\" href=\"https://wikimediafoundation.org/wiki/Privacy_policy\">Wikimedia Foundation Privacy Policy</a>."
 msgstr ""
 
 #. Translators: This is the second to last line of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
@@ -3428,11 +2912,7 @@ msgstr "ဝီကီမီဒီယာဖောင်ဒေးရှင်း �
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:426
-msgid ""
-"By checking this box and clicking “Submit”, you agree that you have read the "
-"above terms and that you will adhere to the terms of use in your application "
-"to and use of the The Wikipedia Library, and the publishers’ services to "
-"which you gain access through The Wikipedia Library program."
+msgid "By checking this box and clicking “Submit”, you agree that you have read the above terms and that you will adhere to the terms of use in your application to and use of the The Wikipedia Library, and the publishers’ services to which you gain access through The Wikipedia Library program."
 msgstr ""
 
 #: TWLight/users/templates/users/user_collection_tile.html:32
@@ -3487,29 +2967,18 @@ msgstr "ဒေတာအားလုံး ဖျက်ပစ်ရန်"
 
 #. Translators: This message is displayed on the page where users can request the deletion of their data.
 #: TWLight/users/templates/users/user_confirm_delete.html:17
-msgid ""
-"<b>Warning:</b> Performing this action will delete your Wikipedia Library "
-"Card user account and all associated applications. This process is not "
-"reversible. You may lose any partner accounts you were granted, and will not "
-"be able to renew those accounts or apply for new ones."
+msgid "<b>Warning:</b> Performing this action will delete your Wikipedia Library Card user account and all associated applications. This process is not reversible. You may lose any partner accounts you were granted, and will not be able to renew those accounts or apply for new ones."
 msgstr ""
 
 #. Translators: this should show up for people who log in with a username/password and not OAuth, so we don't know what their Wikipedia identity is.
-#.
 #: TWLight/users/templates/users/user_detail.html:12
 #, python-format
-msgid ""
-"Hi, %(username)s! You don't have a Wikipedia editor profile attached to your "
-"account here, so you are probably a site administrator."
+msgid "Hi, %(username)s! You don't have a Wikipedia editor profile attached to your account here, so you are probably a site administrator."
 msgstr ""
 
 #. Translators: In the unlikely scenario that someone is able to register an account without using OAuth (thus leaving us without some of the information required for applications), users will see this message, encouraging them to re-register.
 #: TWLight/users/templates/users/user_detail.html:20
-msgid ""
-"If you aren't a site administrator, something weird has happened. You won't "
-"be able to apply for access without a Wikipedia editor profile. You should "
-"log out and create a new account by logging in via OAuth, or contact a site "
-"administrator for help."
+msgid "If you aren't a site administrator, something weird has happened. You won't be able to apply for access without a Wikipedia editor profile. You should log out and create a new account by logging in via OAuth, or contact a site administrator for help."
 msgstr ""
 
 #. Translators: Labels a sections where coordinators can select their email preferences.
@@ -3520,17 +2989,12 @@ msgstr ""
 #. Translators: This message is shown on user's own profile page, encouraging them to make sure their information is up to date, so that account coordinators can use the information to judge applications.
 #: TWLight/users/views.py:176
 #, python-brace-format
-msgid ""
-"Please <a class='twl-links' href='{url}'>update your contributions</a> to "
-"Wikipedia to help coordinators evaluate your applications."
+msgid "Please <a class='twl-links' href='{url}'>update your contributions</a> to Wikipedia to help coordinators evaluate your applications."
 msgstr ""
 
 #. Translators: Coordinators are shown this message when they unselect all three types of reminder email options under preferences.
 #: TWLight/users/views.py:288
-msgid ""
-"You have chosen not to receive reminder emails. As a coordinator, you should "
-"receive at least one type of reminder emails, so consider changing your "
-"preferences."
+msgid "You have chosen not to receive reminder emails. As a coordinator, you should receive at least one type of reminder emails, so consider changing your preferences."
 msgstr ""
 
 #. Translators: Coordinators are shown this message when they make changes to their reminder email options under preferences.
@@ -3565,9 +3029,7 @@ msgstr "သင်၏အီးမေးလ်ကို {email} သို့ ပ�
 
 #. Translators: If the user has not filled out their email, they can browse the website but cannot apply for access to resources.
 #: TWLight/users/views.py:487
-msgid ""
-"Your email is blank. You can still explore the site, but you won't be able "
-"to apply for access to partner resources without an email."
+msgid "Your email is blank. You can still explore the site, but you won't be able to apply for access to partner resources without an email."
 msgstr ""
 
 #. Translators: This message is shown once the access to a partner has successfully been returned.
@@ -3602,31 +3064,3 @@ msgstr ""
 msgid "10+ edits in the last 30 days"
 msgstr ""
 
-#: tests/shunit/data/bad_i18n_comment_1.py:3
-#: tests/shunit/data/bad_i18n_newline_1.py:5
-msgid "1"
-msgstr ""
-
-#. Translators: Lorem ipsum dolor sit amet, consectetur adipiscing elit. Mauris vitae ipsum ut purus faucibus pretium. Proin tempus neque et aliquet consectetur. Ut egestas sapien in consectetur sagittis. Mauris neque lacus, dapibus non viverra vitae, interdum ut aenean ipsum.
-#. Translators: Lorem ipsum dolor sit amet, consectetur adipiscing elit. Mauris vitae ipsum ut purus faucibus pretium. Proin tempus neque et aliquet consectetur. Ut egestas sapien in consectetur sagittis. Mauris neque lacus, dapibus non.
-#: tests/shunit/data/bad_i18n_comment_2.py:4
-#: tests/shunit/data/bad_i18n_newline_2.py:5 tests/shunit/data/good_i18n_1.py:2
-#: tests/shunit/data/good_i18n_2.py:2
-msgid "2"
-msgstr ""
-
-#: tests/shunit/data/bad_i18n_newline_3.py:5
-msgid "3"
-msgstr ""
-
-#: tests/shunit/data/bad_i18n_newline_4.py:5
-msgid "4"
-msgstr ""
-
-#: tests/shunit/data/bad_i18n_newline_5.py:5
-msgid "5"
-msgstr ""
-
-#: tests/shunit/data/bad_i18n_newline_6.py:5
-msgid "6"
-msgstr ""

--- a/locale/nl/LC_MESSAGES/django.po
+++ b/locale/nl/LC_MESSAGES/django.po
@@ -17,10 +17,11 @@
 # Author: Xbaked potatox
 msgid ""
 msgstr ""
+""
 "Project-Id-Version: Wikipedia Library Card Platform - Website\n"
-"Report-Msgid-Bugs-To: wikipedialibrary@wikimedia.org\n"
+"Report-Msgid-Bugs-To: translatewiki.net\n"
 "POT-Creation-Date: 2024-07-11 20:54+0000\n"
-"PO-Revision-Date: 2024-07-11 12:30:17+0000\n"
+"PO-Revision-Date: 2024-07-15 12:29:18+0000\n"
 "Language: nl\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
@@ -52,12 +53,8 @@ msgstr "Over u"
 #. Translators: This note appears in a section of a form where we ask users to enter info (like country of residence) when applying for resource access.
 #: TWLight/applications/forms.py:179
 #, python-brace-format
-msgid ""
-"<p><small><i>Your personal data will be processed according to our <a "
-"class='twl-links' href='{terms_url}'> privacy policy</a>.</i></small></p>"
-msgstr ""
-"<p><small><i>Uw persoonsgegevens worden verwerkt overeenkomstig ons <a "
-"href='{terms_url}'> privacybeleid</a>.</i></small></p>"
+msgid "<p><small><i>Your personal data will be processed according to our <a class='twl-links' href='{terms_url}'> privacy policy</a>.</i></small></p>"
+msgstr "<p><small><i>Uw persoonsgegevens worden verwerkt overeenkomstig ons <a href='{terms_url}'> privacybeleid</a>.</i></small></p>"
 
 #. Translators: This is the title of the application form page, where users enter information required for the application. It lets the user know which partner application they are entering data for. {partner}
 #: TWLight/applications/forms.py:189
@@ -93,18 +90,13 @@ msgstr "Bevestiging van verlenging"
 #. Translators: When filling out an application, users may be required to enter an email they have used to register on the partner's website.
 #: TWLight/applications/forms.py:329 TWLight/applications/helpers.py:97
 msgid "The email for your account on the partner's website"
-msgstr ""
-"Het e-mailadres voor uw account op de website van de partnerorganisatie"
+msgstr "Het e-mailadres voor uw account op de website van de partnerorganisatie"
 
 #. Translators: This labels a choice field where users will have to select the number of months they wish to have their access for as part of the application renewal confirmation.
 #. Translators: When filling out an application, users may be required to enter the length of the account (expiry) they wish to have for proxy partners.
 #: TWLight/applications/forms.py:339 TWLight/applications/helpers.py:100
-msgid ""
-"The number of months you wish to have this access for before renewal is "
-"required"
-msgstr ""
-"Het aantal maanden dat u over deze toegang wenst te beschikken voordat deze "
-"verlengd moet worden."
+msgid "The number of months you wish to have this access for before renewal is required"
+msgstr "Het aantal maanden dat u over deze toegang wenst te beschikken voordat deze verlengd moet worden."
 
 #. Translators: When filling out an application, users may need to specify their name
 #: TWLight/applications/helpers.py:81
@@ -192,12 +184,8 @@ msgstr "E-mail"
 
 #. Translators: This comment is added to pending applications when our terms of use change.
 #: TWLight/applications/management/commands/notify_applicants_tou_changes.py:54
-msgid ""
-"Our terms of use have changed. Your applications will not be processed until "
-"you log in and agree to our updated terms."
-msgstr ""
-"Onze gebruiksvoorwaarden zijn gewijzigd. Uw aanvragen worden niet verwerkt "
-"totdat u inlogt en akkoord gaat met onze nieuwe voorwaarden."
+msgid "Our terms of use have changed. Your applications will not be processed until you log in and agree to our updated terms."
+msgstr "Onze gebruiksvoorwaarden zijn gewijzigd. Uw aanvragen worden niet verwerkt totdat u inlogt en akkoord gaat met onze nieuwe voorwaarden."
 
 #. Translators: This is the status of an application that has not yet been reviewed.
 #: TWLight/applications/models.py:54
@@ -263,43 +251,26 @@ msgstr "Toegangs-URL: {access_url}"
 
 #. Translators: This text goes into account approval emails in the case that we need to send the user's details to a publisher for manual account setup.
 #: TWLight/applications/models.py:331
-msgid ""
-"You can expect to receive access details within a week or two once it has "
-"been processed."
-msgstr ""
-"U ontvangt de toegangsgegevens binnen een week of twee na de verwerking van "
-"uw aanvraag."
+msgid "You can expect to receive access details within a week or two once it has been processed."
+msgstr "U ontvangt de toegangsgegevens binnen een week of twee na de verwerking van uw aanvraag."
 
 #. Translators: This comment is added to open applications when a partner joins the Library Bundle, which does not require applications.
 #: TWLight/applications/signals.py:247
-msgid ""
-"This partner joined the Library Bundle, which does not require applications. "
-"This application will be marked as invalid."
-msgstr ""
-"Deze partner is lid geworden van de Bibliotheekbundel, waardoor er geen "
-"aparte aanvraag meer nodig is. Uw aanvraag wordt daarom als ongeldig "
-"gemarkeerd."
+msgid "This partner joined the Library Bundle, which does not require applications. This application will be marked as invalid."
+msgstr "Deze partner is lid geworden van de Bibliotheekbundel, waardoor er geen aparte aanvraag meer nodig is. Uw aanvraag wordt daarom als ongeldig gemarkeerd."
 
 #. Translators: This is shown to users if the application is to a partner for which we have run out of available accounts. The application is therefore on a 'waitlist', and will be reviewed when more accounts are available.
 #: TWLight/applications/templates/applications/application_evaluation.html:29
-msgid ""
-"This application is on the waitlist because this partner does not have any "
-"access grants available at this time."
-msgstr ""
-"Deze aanvraag staat op de wachtlijst omdat deze partner op dit moment geen "
-"accounts beschikbaar heeft."
+msgid "This application is on the waitlist because this partner does not have any access grants available at this time."
+msgstr "Deze aanvraag staat op de wachtlijst omdat deze partner op dit moment geen accounts beschikbaar heeft."
 
 #. Translators: This message is shown on pages where coordinators can see personal information about applicants.
 #: TWLight/applications/templates/applications/application_evaluation.html:36
 #: TWLight/applications/templates/applications/application_list_include.html:6
 #: TWLight/applications/templates/applications/send_partner.html:45
 #: TWLight/resources/templates/resources/partner_users.html:18
-msgid ""
-"Coordinators: This page may contain personal information such as real names "
-"and email addresses. Please remember that this information is confidential."
-msgstr ""
-"Coördinatoren: Deze pagina kan persoonlijke informatie bevatten, zoals echte "
-"namen en e-mailadressen. Onthoud dat deze informatie vertrouwelijk is."
+msgid "Coordinators: This page may contain personal information such as real names and email addresses. Please remember that this information is confidential."
+msgstr "Coördinatoren: Deze pagina kan persoonlijke informatie bevatten, zoals echte namen en e-mailadressen. Onthoud dat deze informatie vertrouwelijk is."
 
 #. Translators: This is the title of the application page shown to users who are a coordinator, and are able to accept or reject the application.
 #: TWLight/applications/templates/applications/application_evaluation.html:39
@@ -308,12 +279,8 @@ msgstr "Aanvraag beoordelen"
 
 #. Translators: This text is shown to coordinators on application pages if the applicant has restricted processing of their data.
 #: TWLight/applications/templates/applications/application_evaluation.html:42
-msgid ""
-"This user has requested a restriction on the processing of their data, so "
-"you cannot change the status of their application."
-msgstr ""
-"Deze gebruiker heeft verzocht om beperking van de verwerking van diens "
-"gegevens. Daarom kunt u de status van de aanvraag niet wijzigen."
+msgid "This user has requested a restriction on the processing of their data, so you cannot change the status of their application."
+msgstr "Deze gebruiker heeft verzocht om beperking van de verwerking van diens gegevens. Daarom kunt u de status van de aanvraag niet wijzigen."
 
 #. Translators: This is the title of the application page shown to users who are not a coordinator.
 #: TWLight/applications/templates/applications/application_evaluation.html:48
@@ -386,12 +353,8 @@ msgstr "Onbekend"
 
 #. Translators: This is the text displayed to coordinators when an applicant has no country of residence in their profile.
 #: TWLight/applications/templates/applications/application_evaluation.html:123
-msgid ""
-"Please request the applicant add their country of residence to their profile "
-"before proceeding further."
-msgstr ""
-"Verzoek de aanvrager diens land van verblijf in diens profiel op te nemen "
-"alvorens verder te gaan."
+msgid "Please request the applicant add their country of residence to their profile before proceeding further."
+msgstr "Verzoek de aanvrager diens land van verblijf in diens profiel op te nemen alvorens verder te gaan."
 
 #. Translators: This labels the section of an application showing the total number of accounts available for a partner or their collection.
 #: TWLight/applications/templates/applications/application_evaluation.html:134
@@ -401,12 +364,8 @@ msgstr "Beschikbare accounts"
 #. Translators: This labels the section of an application showing whether the user had agreed to the terms of use or not.
 #: TWLight/applications/templates/applications/application_evaluation.html:145
 #, python-format
-msgid ""
-"Has agreed to the site's <a class=\"twl-links\" href=\"%(terms_url)s\">terms "
-"of use</a>?"
-msgstr ""
-"Is akkoord gegaan met de <a class=\"twl-links\" href=\"%(terms_url)s"
-"\">gebruiksvoorwaarden</a>?"
+msgid "Has agreed to the site's <a class=\"twl-links\" href=\"%(terms_url)s\">terms of use</a>?"
+msgstr "Is akkoord gegaan met de <a class=\"twl-links\" href=\"%(terms_url)s\">gebruiksvoorwaarden</a>?"
 
 #. Translators: Displayed to coordinators when they've agreed to the terms of use.
 #. Translators: Displayed if the user has agreed to the terms of use.
@@ -441,12 +400,8 @@ msgstr "Nee"
 
 #. Translators: This is the text displayed to coordinators when an applicant has not agreed to the terms of use.
 #: TWLight/applications/templates/applications/application_evaluation.html:159
-msgid ""
-"Please request the applicant agree to the site's terms of use before "
-"approving this application."
-msgstr ""
-"Verzoek de aanvrager akkoord te gaan met de gebruiksvoorwaarden van de site "
-"alvorens deze aanvraag goed te keuren."
+msgid "Please request the applicant agree to the site's terms of use before approving this application."
+msgstr "Verzoek de aanvrager akkoord te gaan met de gebruiksvoorwaarden van de site alvorens deze aanvraag goed te keuren."
 
 #. Translators: This labels the section of an application containing the user's motivation for wanting access to this resource.
 #: TWLight/applications/templates/applications/application_evaluation.html:176
@@ -466,10 +421,8 @@ msgstr "Is dit een verlenging van een bestaande toegang?"
 #. Translators: This message is shown next to the 'Renewal of existing access grant?' label if the application is a renewal. Don't translate HTML tags or parent_url.
 #: TWLight/applications/templates/applications/application_evaluation.html:195
 #, python-format
-msgid ""
-"Yes (<a class=\"twl-links\" href=\"%(parent_url)s\">previous application</a>)"
-msgstr ""
-"Ja (<a class=\"twl-links\" href=\"%(parent_url)s\">vorige aanvraag</a>)"
+msgid "Yes (<a class=\"twl-links\" href=\"%(parent_url)s\">previous application</a>)"
+msgstr "Ja (<a class=\"twl-links\" href=\"%(parent_url)s\">vorige aanvraag</a>)"
 
 #. Translators: This labels the section of the application showing the length of access remaining on the user's previous authorization.
 #: TWLight/applications/templates/applications/application_evaluation.html:208
@@ -503,12 +456,8 @@ msgstr "Opmerking toevoegen"
 
 #. Translators: On an application page, this text tells users that the comments posted on the application are visible to coordinators and the submitting user only.
 #: TWLight/applications/templates/applications/application_evaluation.html:297
-msgid ""
-"Comments are visible to all coordinators and to the editor who submitted "
-"this application."
-msgstr ""
-"Opmerkingen zijn zichtbaar voor alle coördinatoren en voor de gebruiker die "
-"deze aanvraag heeft ingediend."
+msgid "Comments are visible to all coordinators and to the editor who submitted this application."
+msgstr "Opmerkingen zijn zichtbaar voor alle coördinatoren en voor de gebruiker die deze aanvraag heeft ingediend."
 
 #. Translators: This is the title of the section of an application page which lists information about the user who submitted the application.
 #. Translators: On the page where coordinators can view data on applications to a partner they coordinate, this is a table column heading for the username.
@@ -719,18 +668,8 @@ msgstr "Status instellen"
 
 #: TWLight/applications/templates/applications/apply.html:20
 #, python-format
-msgid ""
-"If your application is successful we may share your email address with "
-"%(partner)s. This is required to set up your access to their resources. By "
-"submitting this form you agree to allow your email address to be shared with "
-"%(partner)s if your application is successful, for the purposes of account "
-"setup."
-msgstr ""
-"Als uw aanvraag wordt ingewilligd, kunnen wij uw e-mailadres delen met "
-"%(partner)s. Dit is nodig om uw toegang tot hun informatiebronnen in te "
-"stellen. Door het indienen van dit formulier gaat u ermee akkoord dat uw e-"
-"mailadres wordt gedeeld met %(partner)s als uw aanvraag wordt ingewilligd, "
-"met het oog op het inrichten van uw account."
+msgid "If your application is successful we may share your email address with %(partner)s. This is required to set up your access to their resources. By submitting this form you agree to allow your email address to be shared with %(partner)s if your application is successful, for the purposes of account setup."
+msgstr "Als uw aanvraag wordt ingewilligd, kunnen wij uw e-mailadres delen met %(partner)s. Dit is nodig om uw toegang tot hun informatiebronnen in te stellen. Door het indienen van dit formulier gaat u ermee akkoord dat uw e-mailadres wordt gedeeld met %(partner)s als uw aanvraag wordt ingewilligd, met het oog op het inrichten van uw account."
 
 #. Translators: This message is displayed on the page where users can confirm their renewal. Please do not translate partner.
 #: TWLight/applications/templates/applications/confirm_renewal.html:23
@@ -758,12 +697,8 @@ msgstr "Tot welke bronnen wilt u toegang hebben?"
 
 #. Translators: This text explains that Library Bundle partners are not shown in this list.
 #: TWLight/applications/templates/applications/request_for_application.html:26
-msgid ""
-"Library Bundle partners are not shown as eligibility is determined "
-"automatically."
-msgstr ""
-"Partners van de Bibliotheekbundel worden niet weergegeven, want het wordt "
-"automatisch bepaald of u in aanmerking komt."
+msgid "Library Bundle partners are not shown as eligibility is determined automatically."
+msgstr "Partners van de Bibliotheekbundel worden niet weergegeven, want het wordt automatisch bepaald of u in aanmerking komt."
 
 #. Translators: On the page where users can apply for multiple partners, this message shows next to the partner name, taking them to the full application page when clicked.
 #: TWLight/applications/templates/applications/request_for_application.html:48
@@ -777,15 +712,8 @@ msgstr "Er zijn nog geen partnergegevens toegevoegd."
 
 #. Translators: the HTML is so that the word 'waitlisted' will look the same as it does in the page above; please translate 'waitlisted' the same way you did elsewhere in this file.
 #: TWLight/applications/templates/applications/request_for_application.html:74
-msgid ""
-"You can apply to <span class=\"badge badge-warning\">Waitlisted</span> "
-"partners, but they don't have access grants available right now. We will "
-"process those applications when access becomes available."
-msgstr ""
-"U kunt zich aanmelden voor toegang bij partnerorganisaties op de <span class="
-"\"badge badge-warning\">wachtlijst</span>, maar zij hebben momenteel geen "
-"accounts beschikbaar. We zullen deze aanmeldingen verwerken wanneer er "
-"accounts beschikbaar komen."
+msgid "You can apply to <span class=\"badge badge-warning\">Waitlisted</span> partners, but they don't have access grants available right now. We will process those applications when access becomes available."
+msgstr "U kunt zich aanmelden voor toegang bij partnerorganisaties op de <span class=\"badge badge-warning\">wachtlijst</span>, maar zij hebben momenteel geen accounts beschikbaar. We zullen deze aanmeldingen verwerken wanneer er accounts beschikbaar komen."
 
 #. Translators: On the page where coordinators can see approved applications which have not had their details sent to the partner, this message shows when there are applications ready to be processed.
 #: TWLight/applications/templates/applications/send.html:10
@@ -795,8 +723,7 @@ msgstr "Partners met goedgekeurde, nog niet verzonden aanvragen"
 #. Translators: On the page where coordinators can see approved applications which have not had their details sent to the partner, this message shows when no such applications exist or all have already been sent.
 #: TWLight/applications/templates/applications/send.html:23
 msgid "There are no partners with applications ready to send."
-msgstr ""
-"Er zijn geen partners met aanvragen die klaar zijn om te worden verzonden."
+msgstr "Er zijn geen partners met aanvragen die klaar zijn om te worden verzonden."
 
 #. Translators: When viewing the list of applications ready to be sent for a particular partner, this is the title of the page, where object will be the name of the partner. Don't translate object.
 #: TWLight/applications/templates/applications/send_partner.html:40
@@ -807,20 +734,13 @@ msgstr "Aanvraaggegevens voor %(object)s"
 #. Translators: This message is shown when applications exceed the number of accounts available.
 #: TWLight/applications/templates/applications/send_partner.html:54
 #, python-format
-msgid ""
-"Application(s) for %(object)s, if sent, will exceed the total available "
-"accounts for the partner. Please proceed at your own discretion."
-msgstr ""
-"De aanvragen voor %(object)s zouden, indien verzonden, het totaal aantal "
-"beschikbare accounts voor deze partner overschrijden. Overweeg de gevolgen "
-"hiervan voordat u verder gaat."
+msgid "Application(s) for %(object)s, if sent, will exceed the total available accounts for the partner. Please proceed at your own discretion."
+msgstr "De aanvragen voor %(object)s zouden, indien verzonden, het totaal aantal beschikbare accounts voor deze partner overschrijden. Overweeg de gevolgen hiervan voordat u verder gaat."
 
 #. Translators: When viewing the list of applications ready to be sent for a particular partner, this is instructions for the coordinator to click the 'mark as sent' button after they have sent the information.
 #: TWLight/applications/templates/applications/send_partner.html:65
 msgid "When you've processed the data below, click the 'mark as sent' button."
-msgstr ""
-"Wanneer u de onderstaande gegevens hebt verwerkt, klikt u op de knop "
-"\"markeren als verzonden\"."
+msgstr "Wanneer u de onderstaande gegevens hebt verwerkt, klikt u op de knop \"markeren als verzonden\"."
 
 #. Translators: When viewing the list of applications ready to be sent for a particular partner, this is the title of the section containing contact information for the people applications should be sent to.
 #: TWLight/applications/templates/applications/send_partner.html:71
@@ -831,12 +751,8 @@ msgstr[1] "Contacten"
 
 #. Translators: When viewing the list of applications ready to be sent for a particular partner, this message shows if there is no information about who the applications should be sent to. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/applications/templates/applications/send_partner.html:89
-msgid ""
-"Whoops, we don't have any listed contacts. Please notify Wikipedia Library "
-"administrators."
-msgstr ""
-"Oeps, er staan geen contactpersonen in de lijst. Informeer de beheerders van "
-"de Wikipedia-bibliotheek."
+msgid "Whoops, we don't have any listed contacts. Please notify Wikipedia Library administrators."
+msgstr "Oeps, er staan geen contactpersonen in de lijst. Informeer de beheerders van de Wikipedia-bibliotheek."
 
 #. Translators: When viewing the list of applications ready to be sent for a particular partner, this is the title of the section containing the information about those applications.
 #: TWLight/applications/templates/applications/send_partner.html:94
@@ -851,12 +767,8 @@ msgstr "Markeren als verzonden"
 
 #. Translators: This text guides coordinators in using the code sending interface for approved applications.
 #: TWLight/applications/templates/applications/send_partner.html:152
-msgid ""
-"Use the dropdown menus to denote which editor will receive each code. Access "
-"codes will be sent to users automatically."
-msgstr ""
-"Gebruik de vervolgkeuzemenu’s om aan te geven welke gebruiker welke code "
-"ontvangt. De toegangscodes worden automatisch naar de gebruikers gestuurd."
+msgid "Use the dropdown menus to denote which editor will receive each code. Access codes will be sent to users automatically."
+msgstr "Gebruik de vervolgkeuzemenu’s om aan te geven welke gebruiker welke code ontvangt. De toegangscodes worden automatisch naar de gebruikers gestuurd."
 
 #. Translators: This labels a drop-down selection where staff can assign an access code to a user.
 #: TWLight/applications/templates/applications/send_partner.html:173
@@ -871,24 +783,14 @@ msgstr "Er zijn geen goedgekeurde, nog niet verzonden aanvragen."
 #. Translators: When a user applies for a set of resources, they receive this message if none are currently available. They are instead placed on a 'waitlist' for later approval.
 #. Translators: When a user renews their resource, they receive this message if none are currently available. They are instead placed on a 'waitlist' for later approval.
 #: TWLight/applications/views.py:140 TWLight/applications/views.py:1282
-msgid ""
-"This partner does not have any access grants available at this time. You may "
-"still apply for access; your application will be reviewed when access grants "
-"become available."
-msgstr ""
-"Deze partnerorganisatie heeft momenteel geen accounts beschikbaar. U kunt "
-"wel toegang aanvragen; uw aanvraag wordt beoordeeld wanneer accounts "
-"beschikbaar komen."
+msgid "This partner does not have any access grants available at this time. You may still apply for access; your application will be reviewed when access grants become available."
+msgstr "Deze partnerorganisatie heeft momenteel geen accounts beschikbaar. U kunt wel toegang aanvragen; uw aanvraag wordt beoordeeld wanneer accounts beschikbaar komen."
 
 #. Translators: This message is shown to users once they've successfully submitted their application for review.
 #: TWLight/applications/views.py:163
 #, python-brace-format
-msgid ""
-"Your application has been submitted for review. Head over to <a "
-"href='{applications_url}'>My Applications</a> to view the status."
-msgstr ""
-"Uw aanvraag is ingediend voor beoordeling. Ga naar <a "
-"href='{applications_url}'>Mijn aanvragen</a> om de status te bekijken."
+msgid "Your application has been submitted for review. Head over to <a href='{applications_url}'>My Applications</a> to view the status."
+msgstr "Uw aanvraag is ingediend voor beoordeling. Ga naar <a href='{applications_url}'>Mijn aanvragen</a> om de status te bekijken."
 
 #. Translators: This text is displayed to users when the user has chosen to restrict data and is trying to apply for multiple partners
 #: TWLight/applications/views.py:276
@@ -936,22 +838,13 @@ msgstr "Verzonden aanvragen"
 
 #. Translators: After a coordinator has changed the status of an application to APPROVED, if the corresponding partner/collection is waitlisted this message appears.
 #: TWLight/applications/views.py:756
-msgid ""
-"Cannot approve application as partner with proxy authorization method is "
-"waitlisted."
-msgstr ""
-"De aanvraag kan niet worden goedgekeurd omdat er een partner op de "
-"wachtlijst staat die gebruik maakt van autorisatie bij volmacht."
+msgid "Cannot approve application as partner with proxy authorization method is waitlisted."
+msgstr "De aanvraag kan niet worden goedgekeurd omdat er een partner op de wachtlijst staat die gebruik maakt van autorisatie bij volmacht."
 
 #. Translators: After a coordinator has changed the status of an application to APPROVED, if the corresponding partner/collection has no accounts for distribution, this message appears.
 #: TWLight/applications/views.py:780
-msgid ""
-"Cannot approve application as partner with proxy authorization method is "
-"waitlisted and (or) has zero accounts available for distribution."
-msgstr ""
-"De aanvraag kan niet worden goedgekeurd omdat er een partner op de "
-"wachtlijst staat die gebruik maakt van autorisatie bij volmacht en/of die "
-"geen accounts beschikbaar heeft."
+msgid "Cannot approve application as partner with proxy authorization method is waitlisted and (or) has zero accounts available for distribution."
+msgstr "De aanvraag kan niet worden goedgekeurd omdat er een partner op de wachtlijst staat die gebruik maakt van autorisatie bij volmacht en/of die geen accounts beschikbaar heeft."
 
 #. Translators: This message appears on an "access denied" screen that stops users who attempt to authorize an editor to access a resource during a time period for which they are already authorized.
 #: TWLight/applications/views.py:803
@@ -961,17 +854,8 @@ msgstr "U probeerde een dubbele autorisatie aan te maken."
 #. Translators: This message is shown to users when they access an application page of a now Bundle partner (new applications aren't allowed for Bundle partners and the status of old applications cannot be modified)
 #: TWLight/applications/views.py:857
 #, python-brace-format
-msgid ""
-"This application cannot be modified since this partner is now part of our <a "
-"href='{bundle}'>bundle access</a>. If you are eligible, you can access this "
-"resource from <a href='{library}'>your library</a>. <a "
-"href='{contact}'>Contact us</a> if you have any questions."
-msgstr ""
-"Deze aanvraag kan niet worden gewijzigd omdat deze partner nu deel uitmaakt "
-"van onze <a href='{bundle}'>bundeltoegang</a>. Als u aan de voorwaarden "
-"voldoet, kunt u toegang krijgen tot deze bron vanuit <a href='{library}'>uw "
-"bibliotheek</a>. <a href='{contact}'>Neem contact met ons op</a> als u "
-"vragen hebt."
+msgid "This application cannot be modified since this partner is now part of our <a href='{bundle}'>bundle access</a>. If you are eligible, you can access this resource from <a href='{library}'>your library</a>. <a href='{contact}'>Contact us</a> if you have any questions."
+msgstr "Deze aanvraag kan niet worden gewijzigd omdat deze partner nu deel uitmaakt van onze <a href='{bundle}'>bundeltoegang</a>. Als u aan de voorwaarden voldoet, kunt u toegang krijgen tot deze bron vanuit <a href='{library}'>uw bibliotheek</a>. <a href='{contact}'>Neem contact met ons op</a> als u vragen hebt."
 
 #. Translators: this lets a reviewer set the status of a single application.
 #: TWLight/applications/views.py:873
@@ -980,12 +864,8 @@ msgstr "Aanvraagstatus instellen"
 
 #. Translators: This warning is message is shown to applicants when the number of pending applications is greater than the number of accounts available.
 #: TWLight/applications/views.py:891
-msgid ""
-"There are more pending applications than available accounts. Your "
-"application might get waitlisted."
-msgstr ""
-"Er zijn meer aanvragen in behandeling dan er accounts beschikbaar zijn. Uw "
-"aanvraag kan op de wachtlijst komen te staan."
+msgid "There are more pending applications than available accounts. Your application might get waitlisted."
+msgstr "Er zijn meer aanvragen in behandeling dan er accounts beschikbaar zijn. Uw aanvraag kan op de wachtlijst komen te staan."
 
 #. Translators: this message is shown to coordinators who attempt to change an application's Status from INVALID to any other Status.
 #: TWLight/applications/views.py:904
@@ -1004,17 +884,8 @@ msgstr "Batchupdate van aanvraag/aanvragen {} succesvol."
 
 #. Translators: After a coordinator has changed the status of a number of applications to APPROVED, if the corresponding partner(s) is/are waitlisted or has no accounts for distribution, this message appears.
 #: TWLight/applications/views.py:1051
-msgid ""
-"Cannot approve application(s) {} as partner(s) with proxy authorization "
-"method is/are waitlisted and (or) has/have not enough accounts available. If "
-"not enough accounts are available, prioritise the applications and then "
-"approve applications equal to the accounts available."
-msgstr ""
-"Kan de aanvraag/aanvragen {} niet goedkeuren omdat er een of meer partners "
-"met proxy-autorisatiemethode op de wachtlijst staan en/of niet genoeg "
-"accounts beschikbaar hebben. Als er niet genoeg accounts beschikbaar zijn, "
-"prioriteert u de aanvragen en keurt u vervolgens zoveel aanvragen goed als "
-"er beschikbare accounts zijn."
+msgid "Cannot approve application(s) {} as partner(s) with proxy authorization method is/are waitlisted and (or) has/have not enough accounts available. If not enough accounts are available, prioritise the applications and then approve applications equal to the accounts available."
+msgstr "Kan de aanvraag/aanvragen {} niet goedkeuren omdat er een of meer partners met proxy-autorisatiemethode op de wachtlijst staan en/of niet genoeg accounts beschikbaar hebben. Als er niet genoeg accounts beschikbaar zijn, prioriteert u de aanvragen en keurt u vervolgens zoveel aanvragen goed als er beschikbare accounts zijn."
 
 #. Translators: This message is shown to coordinators who attempt to assign the same access code to multiple users.
 #: TWLight/applications/views.py:1191
@@ -1028,37 +899,24 @@ msgstr "Alle geselecteerde aanvragen zijn gemarkeerd als verzonden."
 
 #. Translators: When a user tries to renew their resource, they receive this message if the partner is not available.
 #: TWLight/applications/views.py:1272
-msgid ""
-"Cannot renew application at this time as partner is not available. Please "
-"check back later, or contact us for more information."
-msgstr ""
-"Kan de aanvraag op dit moment niet verlengen omdat de partner niet "
-"beschikbaar is. Kom later nog eens terug of neem contact met ons op voor "
-"meer informatie."
+msgid "Cannot renew application at this time as partner is not available. Please check back later, or contact us for more information."
+msgstr "Kan de aanvraag op dit moment niet verlengen omdat de partner niet beschikbaar is. Kom later nog eens terug of neem contact met ons op voor meer informatie."
 
 #. Translators: This message is displayed when an attempt by a user to renew an application has been denied for some reason.
 #: TWLight/applications/views.py:1308
 #, python-brace-format
 msgid "Attempt to renew unapproved application #{pk} has been denied"
-msgstr ""
-"De poging om de niet-goedgekeurde aanvraag #{pk} te verlengen is geweigerd"
+msgstr "De poging om de niet-goedgekeurde aanvraag #{pk} te verlengen is geweigerd"
 
 #. Translators: If a user requests the renewal of their account, but it wasn't renewed, this message is shown to them.
 #: TWLight/applications/views.py:1385
-msgid ""
-"This object cannot be renewed. (This probably means that you have already "
-"requested that it be renewed.)"
-msgstr ""
-"Dit object kan niet worden verlengd. (Dit betekent waarschijnlijk dat u al "
-"om verlenging heeft verzocht.)"
+msgid "This object cannot be renewed. (This probably means that you have already requested that it be renewed.)"
+msgstr "Dit object kan niet worden verlengd. (Dit betekent waarschijnlijk dat u al om verlenging heeft verzocht.)"
 
 #. Translators: If a user requests the renewal of their account, this message is shown to them.
 #: TWLight/applications/views.py:1395
-msgid ""
-"Your renewal request has been received. A coordinator will review your "
-"request."
-msgstr ""
-"Uw verlengingsverzoek is ontvangen. Een coördinator beoordeelt uw aanvraag."
+msgid "Your renewal request has been received. A coordinator will review your request."
+msgstr "Uw verlengingsverzoek is ontvangen. Een coördinator beoordeelt uw aanvraag."
 
 #. Translators: This labels a textfield where users can enter their email ID.
 #: TWLight/emails/forms.py:18
@@ -1067,12 +925,8 @@ msgstr "Uw e-mailadres"
 
 #. Translators: This is the help text for the email field in the contact us form letting users know the field is updated by value pulled from their respective user profiles.
 #: TWLight/emails/forms.py:21
-msgid ""
-"This field is automatically updated with the email from your <a class='twl-"
-"links' href='{}'>user profile</a>."
-msgstr ""
-"Dit veld wordt automatisch bijgewerkt met het e-mailadres van uw <a "
-"class='twl-links' href='{}'>gebruikersprofiel</a>."
+msgid "This field is automatically updated with the email from your <a class='twl-links' href='{}'>user profile</a>."
+msgstr "Dit veld wordt automatisch bijgewerkt met het e-mailadres van uw <a class='twl-links' href='{}'>gebruikersprofiel</a>."
 
 #. Translators: This labels a textfield where users can enter their email message.
 #: TWLight/emails/forms.py:26
@@ -1095,25 +949,14 @@ msgstr "Verzenden"
 #. Translators: This email is sent to users with their access code. Don't translate Jinja variables in curly braces like user or partner. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/access_code_email-body-html.html:5
 #, python-format
-msgid ""
-"<p>Your approved application to %(partner)s has now been finalised. Your "
-"access code or login details can be found below:</p> <p><b>%(access_code)s</"
-"b></p> <p>%(user_instructions)s</p>"
-msgstr ""
-"<p>Uw goedgekeurde aanvraag bij %(partner)s is nu afgerond. Uw toegangscode "
-"of inloggegevens vindt u hieronder:</p> <p><b>%(access_code)s</b></p> <p>"
-"%(user_instructions)s</p>"
+msgid "<p>Your approved application to %(partner)s has now been finalised. Your access code or login details can be found below:</p> <p><b>%(access_code)s</b></p> <p>%(user_instructions)s</p>"
+msgstr "<p>Uw goedgekeurde aanvraag bij %(partner)s is nu afgerond. Uw toegangscode of inloggegevens vindt u hieronder:</p> <p><b>%(access_code)s</b></p> <p>%(user_instructions)s</p>"
 
 #. Translators: This email is sent to users with their access code. Don't translate Jinja variables in curly braces like user or partner. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/access_code_email-body-text.html:3
 #, python-format
-msgid ""
-"Your approved application to %(partner)s has now been finalised. Your access "
-"code or login details can be found below: %(access_code)s "
-"%(user_instructions)s"
-msgstr ""
-"Uw goedgekeurde aanvraag bij %(partner)s is nu afgerond. Uw toegangscode of "
-"inloggegevens vindt u hieronder: %(access_code)s %(user_instructions)s"
+msgid "Your approved application to %(partner)s has now been finalised. Your access code or login details can be found below: %(access_code)s %(user_instructions)s"
+msgstr "Uw goedgekeurde aanvraag bij %(partner)s is nu afgerond. Uw toegangscode of inloggegevens vindt u hieronder: %(access_code)s %(user_instructions)s"
 
 #. Translators: This is the subject line of an email sent to users with their access code.
 #: TWLight/emails/templates/emails/access_code_email-subject.html:3
@@ -1123,34 +966,14 @@ msgstr "Uw toegangscode voor de Wikipedia-bibliotheek"
 #. Translators: This email is sent to users when their application is approved. Don't translate Jinja variables in curly braces like user or partner; don't translate html tags either. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/approval_notification-body-html.html:5
 #, python-format
-msgid ""
-"<p>Dear %(user)s,</p> <p>Thank you for applying for access to %(partner)s "
-"resources through The Wikipedia Library. We are happy to inform you that "
-"your application has been approved.</p> <p>%(user_instructions)s</p> <p>You "
-"can view the collections you're authorized to access at My Library: "
-"%(link)s</p> <p>Cheers!</p> <p>The Wikipedia Library</p>"
-msgstr ""
-"<p>Beste %(user)s,</p> <p>Bedankt voor het aanvragen van toegang tot bronnen "
-"van %(partner)s via de Wikipedia-bibliotheek. We zijn verheugd u te kunnen "
-"meedelen dat uw aanvraag is goedgekeurd.</p> <p>%(user_instructions)s</p> "
-"<p>U kunt de collecties waartoe u toegang heeft, bekijken in Mijn "
-"bibliotheek: %(link)s</p> <p>Succes!</p> <p>De Wikipedia-bibliotheek</p>"
+msgid "<p>Dear %(user)s,</p> <p>Thank you for applying for access to %(partner)s resources through The Wikipedia Library. We are happy to inform you that your application has been approved.</p> <p>%(user_instructions)s</p> <p>You can view the collections you're authorized to access at My Library: %(link)s</p> <p>Cheers!</p> <p>The Wikipedia Library</p>"
+msgstr "<p>Beste %(user)s,</p> <p>Bedankt voor het aanvragen van toegang tot bronnen van %(partner)s via de Wikipedia-bibliotheek. We zijn verheugd u te kunnen meedelen dat uw aanvraag is goedgekeurd.</p> <p>%(user_instructions)s</p> <p>U kunt de collecties waartoe u toegang heeft, bekijken in Mijn bibliotheek: %(link)s</p> <p>Succes!</p> <p>De Wikipedia-bibliotheek</p>"
 
 #. Translators: This email is sent to users when their application is approved. Don't translate Jinja variables in curly braces like user or partner. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/approval_notification-body-text.html:3
 #, python-format
-msgid ""
-"Dear %(user)s, Thank you for applying for access to %(partner)s resources "
-"through The Wikipedia Library. We are happy to inform you that your "
-"application has been approved. %(user_instructions)s You can view the "
-"collections you're authorized to access at My Library: %(link)s Cheers! The "
-"Wikipedia Library"
-msgstr ""
-"Beste %(user)s, Bedankt voor het aanvragen van toegang tot %(partner)s "
-"bronnen via de Wikipedia-bibliotheek. We zijn verheugd u te kunnen melden "
-"dat uw aanvraag is goedgekeurd. %(user_instructions)s U kunt de collecties "
-"waartoe u toegang heeft bekijken in Mijn bibliotheek: %(link)s Succes! De "
-"Wikipedia-bibliotheek"
+msgid "Dear %(user)s, Thank you for applying for access to %(partner)s resources through The Wikipedia Library. We are happy to inform you that your application has been approved. %(user_instructions)s You can view the collections you're authorized to access at My Library: %(link)s Cheers! The Wikipedia Library"
+msgstr "Beste %(user)s, Bedankt voor het aanvragen van toegang tot %(partner)s bronnen via de Wikipedia-bibliotheek. We zijn verheugd u te kunnen melden dat uw aanvraag is goedgekeurd. %(user_instructions)s U kunt de collecties waartoe u toegang heeft bekijken in Mijn bibliotheek: %(link)s Succes! De Wikipedia-bibliotheek"
 
 #. Translators: This is the subject of an email which is sent to users when their application has been approved. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/approval_notification-subject.html:4
@@ -1160,59 +983,31 @@ msgstr "Uw aanvraag voor de Wikipedia-bibliotheek is goedgekeurd"
 #. Translators: This email is sent to coordinators when a comment is left on an application they are processing. Don't translate Jinja variables in curly braces like user or partner. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/comment_notification_coordinator-body-html.html:5
 #, python-format
-msgid ""
-"<p style=\"color: #500050\">%(submit_date)s - %(commenter)s</p> "
-"<blockquote><p>%(comment)s</p></blockquote> <p>Please reply to these at: <a "
-"href=\"%(app_url)s\">%(app_url)s</a></p> <p>Best,</p> <p>The Wikipedia "
-"Library</p>"
-msgstr ""
-"<p style=\"color: #500050\">%(submit_date)s - %(commenter)s</p> "
-"<blockquote><p>%(comment)s</p></blockquote> <p>Reageer alstublieft hierop "
-"via: <a href=\"%(app_url)s\">%(app_url)s</a></p> <p>Met vriendelijke groet,</"
-"p> <p>De Wikipedia-bibliotheek</p>"
+msgid "<p style=\"color: #500050\">%(submit_date)s - %(commenter)s</p> <blockquote><p>%(comment)s</p></blockquote> <p>Please reply to these at: <a href=\"%(app_url)s\">%(app_url)s</a></p> <p>Best,</p> <p>The Wikipedia Library</p>"
+msgstr "<p style=\"color: #500050\">%(submit_date)s - %(commenter)s</p> <blockquote><p>%(comment)s</p></blockquote> <p>Reageer alstublieft hierop via: <a href=\"%(app_url)s\">%(app_url)s</a></p> <p>Met vriendelijke groet,</p> <p>De Wikipedia-bibliotheek</p>"
 
 #. Translators: This email is sent to coordinators when a comment is left on an application they are processing. Don't translate Jinja variables in curly braces like user or partner. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/comment_notification_coordinator-body-text.html:3
 #, python-format
-msgid ""
-"%(submit_date)s - %(commenter)s %(comment)s Please reply to this at: "
-"%(app_url)s Best, The Wikipedia Library"
-msgstr ""
-"%(submit_date)s - %(commenter)s %(comment)s Beantwoord dit alstublieft op: "
-"%(app_url)s Met vriendelijke groet, De Wikipedia-bibliotheek"
+msgid "%(submit_date)s - %(commenter)s %(comment)s Please reply to this at: %(app_url)s Best, The Wikipedia Library"
+msgstr "%(submit_date)s - %(commenter)s %(comment)s Beantwoord dit alstublieft op: %(app_url)s Met vriendelijke groet, De Wikipedia-bibliotheek"
 
 #. Translators: This is the subject line of an email sent to coordinators when a comment is left on an application they processed.
 #: TWLight/emails/templates/emails/comment_notification_coordinator-subject.html:3
 msgid "New comment on a Wikipedia Library application you processed"
-msgstr ""
-"Nieuwe reactie op een aanvraag in de Wikipedia-bibliotheek die u heeft "
-"verwerkt"
+msgstr "Nieuwe reactie op een aanvraag in de Wikipedia-bibliotheek die u heeft verwerkt"
 
 #. Translators: This email is sent to users when they receive a comment on their application. Don't translate Jinja variables in curly braces like user or partner; don't translate html tags either. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/comment_notification_editors-body-html.html:5
 #, python-format
-msgid ""
-"<p style=\"color: #500050\">%(submit_date)s - %(commenter)s</p> "
-"<blockquote><p>%(comment)s</p></blockquote> <p>Please reply to these at <a "
-"href=\"%(app_url)s\">%(app_url)s</a> so we can evaluate your application.</"
-"p> <p>Best,</p> <p>The Wikipedia Library</p>"
-msgstr ""
-"<p style=\"color: #500050\">%(submit_date)s - %(commenter)s</p> "
-"<blockquote><p>%(comment)s</p></blockquote> <p>Reageer alstublieft hierop "
-"via <a href=\"%(app_url)s\">%(app_url)s</a> zodat we uw aanvraag kunnen "
-"evalueren.</p> <p>Met vriendelijke groet,</p> <p>De Wikipedia-bibliotheek </"
-"p>"
+msgid "<p style=\"color: #500050\">%(submit_date)s - %(commenter)s</p> <blockquote><p>%(comment)s</p></blockquote> <p>Please reply to these at <a href=\"%(app_url)s\">%(app_url)s</a> so we can evaluate your application.</p> <p>Best,</p> <p>The Wikipedia Library</p>"
+msgstr "<p style=\"color: #500050\">%(submit_date)s - %(commenter)s</p> <blockquote><p>%(comment)s</p></blockquote> <p>Reageer alstublieft hierop via <a href=\"%(app_url)s\">%(app_url)s</a> zodat we uw aanvraag kunnen evalueren.</p> <p>Met vriendelijke groet,</p> <p>De Wikipedia-bibliotheek </p>"
 
 #. Translators: This email is sent to users when they receive a comment on their application. Don't translate Jinja variables in curly braces like user or partner. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/comment_notification_editors-body-text.html:3
 #, python-format
-msgid ""
-"%(submit_date)s - %(commenter)s %(comment)s Please reply to these at: "
-"%(app_url)s so we can evaluate your application. Best, The Wikipedia Library"
-msgstr ""
-"%(submit_date)s - %(commenter)s %(comment)s Gelieve deze te beantwoorden op: "
-"%(app_url)s zodat we uw aanvraag kunnen evalueren. Met vriendelijke groet, "
-"De Wikipedia-bibliotheek"
+msgid "%(submit_date)s - %(commenter)s %(comment)s Please reply to these at: %(app_url)s so we can evaluate your application. Best, The Wikipedia Library"
+msgstr "%(submit_date)s - %(commenter)s %(comment)s Gelieve deze te beantwoorden op: %(app_url)s zodat we uw aanvraag kunnen evalueren. Met vriendelijke groet, De Wikipedia-bibliotheek"
 
 #. Translators: This is the subject line of an email sent to users who have a comment added to one of their applications. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/comment_notification_editors-subject.html:3
@@ -1222,44 +1017,25 @@ msgstr "Nieuwe reactie op uw aanvraag in de Wikipedia-bibliotheek"
 #. Translators: This email is sent to users when an application they commented on receives another comment. Don't translate Jinja variables in curly braces like app_url; don't translate html tags either. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/comment_notification_others-body-html.html:5
 #, python-format
-msgid ""
-"<p style=\"color: #500050\">%(submit_date)s - %(commenter)s</p> "
-"<blockquote><p>%(comment)s</p></blockquote> See it at <a href=\"%(app_url)s"
-"\">%(app_url)s</a>. Thanks for helping review Wikipedia Library applications!"
-msgstr ""
-"<p style=\"color: #500050\">%(submit_date)s - %(commenter)s</p> "
-"<blockquote><p>%(comment)s</p></blockquote> Bekijk het op <a href="
-"\"%(app_url)s\">%(app_url)s</a>. Bedankt voor uw hulp bij het beoordelen van "
-"aanvragen van de Wikipedia-bibliotheek!"
+msgid "<p style=\"color: #500050\">%(submit_date)s - %(commenter)s</p> <blockquote><p>%(comment)s</p></blockquote> See it at <a href=\"%(app_url)s\">%(app_url)s</a>. Thanks for helping review Wikipedia Library applications!"
+msgstr "<p style=\"color: #500050\">%(submit_date)s - %(commenter)s</p> <blockquote><p>%(comment)s</p></blockquote> Bekijk het op <a href=\"%(app_url)s\">%(app_url)s</a>. Bedankt voor uw hulp bij het beoordelen van aanvragen van de Wikipedia-bibliotheek!"
 
 #. Translators: This email is sent to users when an application they commented on receives another comment. Don't translate Jinja variables in curly braces like app_url. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/comment_notification_others-body-text.html:3
 #, python-format
-msgid ""
-"%(submit_date)s - %(commenter)s %(comment)s See it at: %(app_url)s Thanks "
-"for helping review Wikipedia Library applications!"
-msgstr ""
-"%(submit_date)s - %(commenter)s %(comment)s Zie het op: %(app_url)s Bedankt "
-"voor het helpen beoordelen van aanvragen in de Wikipedia-bibliotheek!"
+msgid "%(submit_date)s - %(commenter)s %(comment)s See it at: %(app_url)s Thanks for helping review Wikipedia Library applications!"
+msgstr "%(submit_date)s - %(commenter)s %(comment)s Zie het op: %(app_url)s Bedankt voor het helpen beoordelen van aanvragen in de Wikipedia-bibliotheek!"
 
 #. Translators: This is the subject line of an email sent to users who have a comment added to an application they also commented on. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/comment_notification_others-subject.html:4
 msgid "New comment on a Wikipedia Library application you commented on"
-msgstr ""
-"Nieuwe reactie op een aanvraag in de Wikipedia-bibliotheek waarop u "
-"gereageerd heeft"
+msgstr "Nieuwe reactie op een aanvraag in de Wikipedia-bibliotheek waarop u gereageerd heeft"
 
 #. Translators: This text is part of a scheduled reminder email sent to coordinators who have applications requiring action. Don't translate Jinja variables in curly braces like total_apps, or user.
 #: TWLight/emails/templates/emails/coordinator_reminder_notification-body-html.html:5
 #, python-format
-msgid ""
-"<p>Dear %(user)s,</p> <p>Our records indicate that you are the designated "
-"coordinator for partners that have a total of %(total_apps)s applications.</"
-"p>"
-msgstr ""
-"<p>Beste %(user)s,</p> <p>Uit onze gegevens blijkt dat u de aangewezen "
-"coördinator bent voor partners die in totaal %(total_apps)s aanvragen hebben."
-"</p>"
+msgid "<p>Dear %(user)s,</p> <p>Our records indicate that you are the designated coordinator for partners that have a total of %(total_apps)s applications.</p>"
+msgstr "<p>Beste %(user)s,</p> <p>Uit onze gegevens blijkt dat u de aangewezen coördinator bent voor partners die in totaal %(total_apps)s aanvragen hebben.</p>"
 
 #. Translators: Breakdown as in 'cost breakdown'; analysis.
 #: TWLight/emails/templates/emails/coordinator_reminder_notification-body-html.html:11
@@ -1297,45 +1073,20 @@ msgstr[1] "%(counter)s goedgekeurde aanvragen."
 #. Translators: This text is part of a scheduled reminder email sent to coordinators who have applications requiring action. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library). Don't translate Jinja variables in curly braces like link; don't translate email addresses or html tags either.
 #: TWLight/emails/templates/emails/coordinator_reminder_notification-body-html.html:39
 #, python-format
-msgid ""
-"<p>This is a gentle reminder that you may review applications at <a href="
-"\"%(link)s\">%(link)s</a>.</p> <p>You can customise your reminders under "
-"'preferences' in your user profile.</p> <p>If you received this message in "
-"error, drop us a line at wikipedialibrary@wikimedia.org.</p> <p>Thanks for "
-"helping review Wikipedia Library applications!</p>"
-msgstr ""
-"<p>Dit is een vriendelijke herinnering dat u aanvragen kunt beoordelen op <a "
-"href=\"%(link)s\">%(link)s</a>.</p> <p>U kunt dit soort herinneringen "
-"aanpassen onder 'voorkeuren' in uw gebruikersprofiel.</p> <p>Als u dit "
-"bericht abusievelijk heeft ontvangen, stuur ons dan een bericht op "
-"wikipedialibrary@wikimedia.org.</p> <p>Bedankt voor u hulp bij het "
-"beoordelen van aanvragen in de Wikipedia-bibliotheek!</ p>"
+msgid "<p>This is a gentle reminder that you may review applications at <a href=\"%(link)s\">%(link)s</a>.</p> <p>You can customise your reminders under 'preferences' in your user profile.</p> <p>If you received this message in error, drop us a line at wikipedialibrary@wikimedia.org.</p> <p>Thanks for helping review Wikipedia Library applications!</p>"
+msgstr "<p>Dit is een vriendelijke herinnering dat u aanvragen kunt beoordelen op <a href=\"%(link)s\">%(link)s</a>.</p> <p>U kunt dit soort herinneringen aanpassen onder 'voorkeuren' in uw gebruikersprofiel.</p> <p>Als u dit bericht abusievelijk heeft ontvangen, stuur ons dan een bericht op wikipedialibrary@wikimedia.org.</p> <p>Bedankt voor u hulp bij het beoordelen van aanvragen in de Wikipedia-bibliotheek!</ p>"
 
 #. Translators: This text is part of a scheduled reminder email sent to coordinators who have applications requiring action. Don't translate Jinja variables in curly braces like total_apps, or user.
 #: TWLight/emails/templates/emails/coordinator_reminder_notification-body-text.html:3
 #, python-format
-msgid ""
-"Dear %(user)s, Our records indicate that you are the designated coordinator "
-"for partners that have a total of %(total_apps)s applications."
-msgstr ""
-"Beste %(user)s, Uit onze gegevens blijkt dat u de aangewezen coördinator "
-"bent voor partners die in totaal %(total_apps)s aanvragen hebben."
+msgid "Dear %(user)s, Our records indicate that you are the designated coordinator for partners that have a total of %(total_apps)s applications."
+msgstr "Beste %(user)s, Uit onze gegevens blijkt dat u de aangewezen coördinator bent voor partners die in totaal %(total_apps)s aanvragen hebben."
 
 #. Translators: This text is part of a scheduled reminder email sent to coordinators who have applications requiring action. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library). Don't translate Jinja variables in curly braces like link; don't translate the email address either.
 #: TWLight/emails/templates/emails/coordinator_reminder_notification-body-text.html:38
 #, python-format
-msgid ""
-"This is a gentle reminder that you may review applications at: %(link)s. You "
-"can customise your reminders under 'preferences' in your user profile. If "
-"you received this message in error, drop us a line at: "
-"wikipedialibrary@wikimedia.org Thanks for helping review Wikipedia Library "
-"applications!"
-msgstr ""
-"Dit is een vriendelijke herinnering dat u aanvragen kunt beoordelen op: "
-"%(link)s. U kunt uw herinneringen aanpassen onder 'voorkeuren' in uw "
-"gebruikersprofiel. Als u dit bericht per abuis hebt ontvangen, stuur ons dan "
-"een bericht op: wikipedialibrary@wikimedia.org Bedankt voor uw hulp bij het "
-"beoordelen van aanvragen in de Wikipedia-bibliotheek!"
+msgid "This is a gentle reminder that you may review applications at: %(link)s. You can customise your reminders under 'preferences' in your user profile. If you received this message in error, drop us a line at: wikipedialibrary@wikimedia.org Thanks for helping review Wikipedia Library applications!"
+msgstr "Dit is een vriendelijke herinnering dat u aanvragen kunt beoordelen op: %(link)s. U kunt uw herinneringen aanpassen onder 'voorkeuren' in uw gebruikersprofiel. Als u dit bericht per abuis hebt ontvangen, stuur ons dan een bericht op: wikipedialibrary@wikimedia.org Bedankt voor uw hulp bij het beoordelen van aanvragen in de Wikipedia-bibliotheek!"
 
 #. Translators: This is the subject line of a scheduled reminder email sent to coordinators who have applications to review. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library). Do not translate items in curly braces.
 #: TWLight/emails/templates/emails/coordinator_reminder_notification-subject.html:4
@@ -1345,32 +1096,14 @@ msgstr "Aanvragen in de Wikipedia-bibliotheek die wachten op uw beoordeling"
 #. Translators: This email is sent to users when their application is rejected. Don't translate Jinja variables in curly braces like user or partner; don't translate html tags either. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/rejection_notification-body-html.html:5
 #, python-format
-msgid ""
-"<p>Dear %(user)s,</p> <p>Thank you for applying for access to %(partner)s "
-"resources through The Wikipedia Library. Unfortunately at this time your "
-"application has not been approved. You can view your application and review "
-"comments at <a href=\"%(app_url)s\">%(app_url)s</a>.</p> <p>Best,</p> <p>The "
-"Wikipedia Library</p>"
-msgstr ""
-"<p>Beste %(user)s,</p> <p>Bedankt voor het aanvragen van toegang tot bronnen "
-"van %(partner)s via de Wikipedia-bibliotheek. Op dit moment is uw aanvraag "
-"helaas niet goedgekeurd. U kunt uw aanvraag en opmerkingen bekijken op <a "
-"href=\"%(app_url)s\">%(app_url)s</a>.</p> <p>Met vriendelijke groet,</p> "
-"<p>De Wikipedia-bibliotheek </p>"
+msgid "<p>Dear %(user)s,</p> <p>Thank you for applying for access to %(partner)s resources through The Wikipedia Library. Unfortunately at this time your application has not been approved. You can view your application and review comments at <a href=\"%(app_url)s\">%(app_url)s</a>.</p> <p>Best,</p> <p>The Wikipedia Library</p>"
+msgstr "<p>Beste %(user)s,</p> <p>Bedankt voor het aanvragen van toegang tot bronnen van %(partner)s via de Wikipedia-bibliotheek. Op dit moment is uw aanvraag helaas niet goedgekeurd. U kunt uw aanvraag en opmerkingen bekijken op <a href=\"%(app_url)s\">%(app_url)s</a>.</p> <p>Met vriendelijke groet,</p> <p>De Wikipedia-bibliotheek </p>"
 
 #. Translators: This email is sent to users when their application is rejected. Don't translate Jinja variables in curly braces like user or partner. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/rejection_notification-body-text.html:3
 #, python-format
-msgid ""
-"Dear %(user)s, Thank you for applying for access to %(partner)s resources "
-"through The Wikipedia Library. Unfortunately at this time your application "
-"has not been approved. You can view your application and review comments at: "
-"%(app_url)s Best, The Wikipedia Library"
-msgstr ""
-"Beste %(user)s, Bedankt voor het aanvragen van toegang tot bronnen van "
-"%(partner)s via de Wikipedia-bibliotheek. Op dit moment is uw aanvraag "
-"helaas niet goedgekeurd. U kunt uw aanvraag bekijken en opmerkingen bekijken "
-"op: %(app_url)s Met vriendelijke groet, De Wikipedia-bibliotheek"
+msgid "Dear %(user)s, Thank you for applying for access to %(partner)s resources through The Wikipedia Library. Unfortunately at this time your application has not been approved. You can view your application and review comments at: %(app_url)s Best, The Wikipedia Library"
+msgstr "Beste %(user)s, Bedankt voor het aanvragen van toegang tot bronnen van %(partner)s via de Wikipedia-bibliotheek. Op dit moment is uw aanvraag helaas niet goedgekeurd. U kunt uw aanvraag bekijken en opmerkingen bekijken op: %(app_url)s Met vriendelijke groet, De Wikipedia-bibliotheek"
 
 #. Translators: This is the subject of an email which is sent to users when their application has been rejected. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/rejection_notification-subject.html:4
@@ -1380,41 +1113,14 @@ msgstr "Uw aanvraag voor de Wikipedia Library"
 #. Translators: This email is sent to users when they have an account that is soon to expire. Don't translate Jinja variables in curly braces like partner_name or partner_link; don't translate html tags either. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/user_renewal_notice-body-html.html:5
 #, python-format
-msgid ""
-"<p>Dear %(user)s,</p> <p>According to our records, your access to "
-"%(partner_name)s will soon expire and you may lose access. If you want to "
-"continue making use of your free account, you can request renewal of your "
-"account by clicking the 'Renew' or 'Extend' button at %(partner_link)s.</p> "
-"<p>Best,</p> <p>The Wikipedia Library</p> <p>You can disable these emails in "
-"your user page preferences: https://wikipedialibrary.wmflabs.org/users/</p>"
-msgstr ""
-"<p>Beste %(user)s,</p> <p>Volgens onze gegevens zal uw toegang tot "
-"%(partner_name)s binnenkort verlopen en kunt u de toegang verliezen. Als u "
-"gebruik wilt blijven maken van uw gratis account, kunt u verlenging van uw "
-"account aanvragen door op de knop Vernieuwen of Verlengen op "
-"%(partner_link)s te klikken.</p> <p>Met vriendelijke groet,</p> <p>De "
-"Wikipedia-bibliotheek </p> <p>U kunt deze e-mails uitschakelen in de "
-"voorkeuren van uw gebruikerspagina: https://wikipedialibrary.wmflabs.org/"
-"users/</p>"
+msgid "<p>Dear %(user)s,</p> <p>According to our records, your access to %(partner_name)s will soon expire and you may lose access. If you want to continue making use of your free account, you can request renewal of your account by clicking the 'Renew' or 'Extend' button at %(partner_link)s.</p> <p>Best,</p> <p>The Wikipedia Library</p> <p>You can disable these emails in your user page preferences: https://wikipedialibrary.wmflabs.org/users/</p>"
+msgstr "<p>Beste %(user)s,</p> <p>Volgens onze gegevens zal uw toegang tot %(partner_name)s binnenkort verlopen en kunt u de toegang verliezen. Als u gebruik wilt blijven maken van uw gratis account, kunt u verlenging van uw account aanvragen door op de knop Vernieuwen of Verlengen op %(partner_link)s te klikken.</p> <p>Met vriendelijke groet,</p> <p>De Wikipedia-bibliotheek </p> <p>U kunt deze e-mails uitschakelen in de voorkeuren van uw gebruikerspagina: https://wikipedialibrary.wmflabs.org/users/</p>"
 
 #. Translators: This email is sent to users when they have an account that is soon to expire. Don't translate Jinja variables in curly braces like partner_name or partner_link; don't translate html tags either. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/user_renewal_notice-body-text.html:3
 #, python-format
-msgid ""
-"Dear %(user)s, According to our records, your access to %(partner_name)s "
-"will soon expire and you may lose access. If you want to continue making use "
-"of your free account, you can request renewal of your account by clicking "
-"the Renew button at %(partner_link)s. Best, The Wikipedia Library You can "
-"disable these emails in your user page preferences: https://wikipedialibrary."
-"wmflabs.org/users/"
-msgstr ""
-"Beste %(user)s, Volgens onze gegevens zal uw toegang tot %(partner_name)s "
-"binnenkort verlopen en kunt u de toegang verliezen. Als u gebruik wilt "
-"blijven maken van uw gratis account, kunt u verlenging van uw account "
-"aanvragen door op de knop Verlengen op %(partner_link)s te klikken. Met "
-"vriendelijke groet, de Wikipedia-bibliotheek U kunt deze e-mails "
-"uitschakelen in de voorkeuren van uw gebruikerspagina: https://"
-"wikipedialibrary.wmflabs.org/users/"
+msgid "Dear %(user)s, According to our records, your access to %(partner_name)s will soon expire and you may lose access. If you want to continue making use of your free account, you can request renewal of your account by clicking the Renew button at %(partner_link)s. Best, The Wikipedia Library You can disable these emails in your user page preferences: https://wikipedialibrary.wmflabs.org/users/"
+msgstr "Beste %(user)s, Volgens onze gegevens zal uw toegang tot %(partner_name)s binnenkort verlopen en kunt u de toegang verliezen. Als u gebruik wilt blijven maken van uw gratis account, kunt u verlenging van uw account aanvragen door op de knop Verlengen op %(partner_link)s te klikken. Met vriendelijke groet, de Wikipedia-bibliotheek U kunt deze e-mails uitschakelen in de voorkeuren van uw gebruikerspagina: https://wikipedialibrary.wmflabs.org/users/"
 
 #. Translators: This is the subject of an email sent to users when they have an account that is soon to expire. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/user_renewal_notice-subject.html:4
@@ -1424,37 +1130,14 @@ msgstr "Uw toegang tot de Wikipedia Library kan binnenkort verlopen"
 #. Translators: This email is sent to users when their application is waitlisted because there are no more accounts available. Don't translate Jinja variables in curly braces like user or partner; don't translate html tags either. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/waitlist_notification-body-html.html:5
 #, python-format
-msgid ""
-"<p>Dear %(user)s,</p> <p>Thank you for applying for access to %(partner)s "
-"resources through The Wikipedia Library. There are no accounts currently "
-"available so your application has been waitlisted. Your application will be "
-"evaluated if/when more accounts become available. You can see all available "
-"resources at <a href=\"%(link)s\">%(link)s</a>.</p> <p>Best,</p> <p>The "
-"Wikipedia Library</p>"
-msgstr ""
-"<p>Beste %(user)s,</p> <p>Bedankt voor het aanvragen van toegang tot bronnen "
-"van %(partner)s via de Wikipedia-bibliotheek. Er zijn momenteel geen "
-"accounts beschikbaar, dus uw aanvraag staat op de wachtlijst. Uw aanvraag "
-"wordt beoordeeld als/wanneer er meer accounts beschikbaar komen. U kunt alle "
-"beschikbare bronnen bekijken op <a href=\"%(link)s\">%(link)s</a>.</p> "
-"<p>Met vriendelijke groet,</p> <p>De Wikipedia-bibliotheek</ p>"
+msgid "<p>Dear %(user)s,</p> <p>Thank you for applying for access to %(partner)s resources through The Wikipedia Library. There are no accounts currently available so your application has been waitlisted. Your application will be evaluated if/when more accounts become available. You can see all available resources at <a href=\"%(link)s\">%(link)s</a>.</p> <p>Best,</p> <p>The Wikipedia Library</p>"
+msgstr "<p>Beste %(user)s,</p> <p>Bedankt voor het aanvragen van toegang tot bronnen van %(partner)s via de Wikipedia-bibliotheek. Er zijn momenteel geen accounts beschikbaar, dus uw aanvraag staat op de wachtlijst. Uw aanvraag wordt beoordeeld als/wanneer er meer accounts beschikbaar komen. U kunt alle beschikbare bronnen bekijken op <a href=\"%(link)s\">%(link)s</a>.</p> <p>Met vriendelijke groet,</p> <p>De Wikipedia-bibliotheek</ p>"
 
 #. Translators: This email is sent to users when their application is waitlisted because there are no more accounts available. Don't translate Jinja variables in curly braces like user or partner. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/waitlist_notification-body-text.html:3
 #, python-format
-msgid ""
-"Dear %(user)s, Thank you for applying for access to %(partner)s resources "
-"through The Wikipedia Library. There are no accounts currently available so "
-"your application has been waitlisted. Your application will be evaluated if/"
-"when more accounts become available. You can see all available resources at: "
-"%(link)s Best, The Wikipedia Library"
-msgstr ""
-"Beste %(user)s, Bedankt voor het aanvragen van toegang tot bronnen van "
-"%(partner)s via de Wikipedia-bibliotheek. Er zijn momenteel geen accounts "
-"beschikbaar, dus uw aanvraag staat op de wachtlijst. Uw aanvraag wordt "
-"beoordeeld als/wanneer er meer accounts beschikbaar komen. U kunt alle "
-"beschikbare bronnen bekijken op: %(link)s Met vriendelijke groet, De "
-"Wikipedia-bibliotheek"
+msgid "Dear %(user)s, Thank you for applying for access to %(partner)s resources through The Wikipedia Library. There are no accounts currently available so your application has been waitlisted. Your application will be evaluated if/when more accounts become available. You can see all available resources at: %(link)s Best, The Wikipedia Library"
+msgstr "Beste %(user)s, Bedankt voor het aanvragen van toegang tot bronnen van %(partner)s via de Wikipedia-bibliotheek. Er zijn momenteel geen accounts beschikbaar, dus uw aanvraag staat op de wachtlijst. Uw aanvraag wordt beoordeeld als/wanneer er meer accounts beschikbaar komen. U kunt alle beschikbare bronnen bekijken op: %(link)s Met vriendelijke groet, De Wikipedia-bibliotheek"
 
 #. Translators: This is the subject of an email sent to users when their application is waitlisted because there are no more accounts available. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/waitlist_notification-subject.html:4
@@ -1615,22 +1298,15 @@ msgstr "Niet beschikbaar"
 #: TWLight/resources/templates/resources/filter_section.html:14
 #: TWLight/templates/about.html:12
 #: TWLight/users/templates/users/filter_section.html:13
-msgid ""
-"The Wikipedia Library allows active editors to access a wide range of "
-"collections of paywalled reliable sources for free!"
-msgstr ""
-"Met de Wikipedia-bibliotheek hebben actieve redacteuren gratis toegang tot "
-"een breed scala aan collecties van betrouwbare bronnen achter een betaalmuur!"
+msgid "The Wikipedia Library allows active editors to access a wide range of collections of paywalled reliable sources for free!"
+msgstr "Met de Wikipedia-bibliotheek hebben actieve redacteuren gratis toegang tot een breed scala aan collecties van betrouwbare bronnen achter een betaalmuur!"
 
 #. Translators: On the Browse Partners page (https://wikipedialibrary.wmflabs.org/partners/), this introduces users to The Wikipedia Library.
 #. Translators: On the MyLibrary page (https://wikipedialibrary.wmflabs.org/users/my_library), this introduces users to The Wikipedia Library.
 #: TWLight/resources/templates/resources/filter_section.html:17
 #: TWLight/users/templates/users/filter_section.html:15
-msgid ""
-"Start with the search bar at the top or browse publisher websites directly."
-msgstr ""
-"Begin met de zoekbalk bovenaan of blader rechtstreeks door websites van "
-"uitgevers."
+msgid "Start with the search bar at the top or browse publisher websites directly."
+msgstr "Begin met de zoekbalk bovenaan of blader rechtstreeks door websites van uitgevers."
 
 #. Translators: On the Browse Partners page (https://wikipedialibrary.wmflabs.org/partners/), this appears below introductory text and links to the 'About' page (https://wikipedialibrary.wmflabs.org/about/)
 #. Translators: On the MyLibrary page (https://wikipedialibrary.wmflabs.org/users/my_library), this appears below introductory text and links to the 'About' page (https://wikipedialibrary.wmflabs.org/about/)
@@ -1703,68 +1379,39 @@ msgstr "Terug naar partnerorganisaties"
 #. Translators: If we have no available accounts for a partner, the coordinator can change the application system to a waiting list.
 #: TWLight/resources/templates/resources/partner_detail.html:36
 #: TWLight/resources/templates/resources/partner_detail_apply.html:17
-msgid ""
-"There are no access grants available for this partner at this time. You can "
-"still apply for access; applications will be processed when access is "
-"available."
-msgstr ""
-"Er zijn op dit moment geen toegangaccounts beschikbaar voor deze partner. U "
-"kunt nog steeds toegang aanvragen; aanvragen worden verwerkt wanneer toegang "
-"beschikbaar is."
+msgid "There are no access grants available for this partner at this time. You can still apply for access; applications will be processed when access is available."
+msgstr "Er zijn op dit moment geen toegangaccounts beschikbaar voor deze partner. U kunt nog steeds toegang aanvragen; aanvragen worden verwerkt wanneer toegang beschikbaar is."
 
 #. Translators: This text links to the minimum user requirements and terms of use on the partner page.
 #: TWLight/resources/templates/resources/partner_detail.html:48
 #: TWLight/resources/templates/resources/partner_detail_apply.html:29
 #, python-format
-msgid ""
-"Before applying, please review the <strong><a class=\"twl-links\" href="
-"\"%(about)s#req\">minimum requirements</a></strong> for access and our "
-"<strong><a class=\"twl-links\" href=\"%(terms)s\">terms of use</a></strong>."
-msgstr ""
-"Lees voordat u zich aanmeldt de <strong><a class=\"twl-links\" href="
-"\"%(about)s#req\">minimumvereisten</a></strong> voor toegang en onze "
-"<strong><a-klasse =\"twl-links\" href=\"%(terms)s\">gebruiksvoorwaarden</a></"
-"strong>."
+msgid "Before applying, please review the <strong><a class=\"twl-links\" href=\"%(about)s#req\">minimum requirements</a></strong> for access and our <strong><a class=\"twl-links\" href=\"%(terms)s\">terms of use</a></strong>."
+msgstr "Lees voordat u zich aanmeldt de <strong><a class=\"twl-links\" href=\"%(about)s#req\">minimumvereisten</a></strong> voor toegang en onze <strong><a-klasse =\"twl-links\" href=\"%(terms)s\">gebruiksvoorwaarden</a></strong>."
 
 #. Translators: This text refers to the page containing the content a user is authorized to access.
 #: TWLight/resources/templates/resources/partner_detail.html:69
 #, python-format
-msgid ""
-"View the status of your access in <strong><a class=\"twl-links\" href="
-"\"%(library_url)s\">My Library</a></strong> page."
-msgstr ""
-"Bekijk de status van uw toegang op de pagina <strong><a class=\"twl-links\" "
-"href=\"%(library_url)s\">Mijn bibliotheek</a></strong>."
+msgid "View the status of your access in <strong><a class=\"twl-links\" href=\"%(library_url)s\">My Library</a></strong> page."
+msgstr "Bekijk de status van uw toegang op de pagina <strong><a class=\"twl-links\" href=\"%(library_url)s\">Mijn bibliotheek</a></strong>."
 
 #. Translators: This message is shown when a user has open applications, linking to their respective applications page.
 #: TWLight/resources/templates/resources/partner_detail.html:78
 #, python-format
-msgid ""
-"View the status of your application(s) on your <strong><a class=\"twl-links"
-"\" href=\"%(applications_url)s\">My Applications</a></strong> page."
-msgstr ""
-"Bekijk de status van uw aanvraag(en) op uw <strong><a class=\"twl-links\" "
-"href=\"%(applications_url)s\">Mijn aanvragen</a></strong> pagina."
+msgid "View the status of your application(s) on your <strong><a class=\"twl-links\" href=\"%(applications_url)s\">My Applications</a></strong> page."
+msgstr "Bekijk de status van uw aanvraag(en) op uw <strong><a class=\"twl-links\" href=\"%(applications_url)s\">Mijn aanvragen</a></strong> pagina."
 
 #. Translators: This message is shown when a user has authorizations, linking to their respective collections page.
 #: TWLight/resources/templates/resources/partner_detail_apply.html:50
 #, python-format
-msgid ""
-"View the status of your access on your <strong><a href=\"%(library_url)s\" "
-"class=\"twl-links\">My Library</a></strong> page."
-msgstr ""
-"Bekijk de status van uw toegang op de pagina <strong><a href="
-"\"%(library_url)s\" class=\"twl-links\"> Mijn bibliotheek </a></strong>."
+msgid "View the status of your access on your <strong><a href=\"%(library_url)s\" class=\"twl-links\">My Library</a></strong> page."
+msgstr "Bekijk de status van uw toegang op de pagina <strong><a href=\"%(library_url)s\" class=\"twl-links\"> Mijn bibliotheek </a></strong>."
 
 #. Translators: This message is shown when a user has open applications, linking to their respective applications page.
 #: TWLight/resources/templates/resources/partner_detail_apply.html:60
 #, python-format
-msgid ""
-"View the status of your application(s) on your <strong><a href="
-"\"%(applications_url)s\">My Applications</a></strong> page."
-msgstr ""
-"Bekijk de status van uw aanvraag(en) op de pagina <strong><a href="
-"\"%(applications_url)s\">Mijn aanvragen</a></strong>."
+msgid "View the status of your application(s) on your <strong><a href=\"%(applications_url)s\">My Applications</a></strong> page."
+msgstr "Bekijk de status van uw aanvraag(en) op de pagina <strong><a href=\"%(applications_url)s\">Mijn aanvragen</a></strong>."
 
 #. Translators: One the partner detail page, this text labels the button which coordinators can click to remove a partner from waitlisted status.
 #: TWLight/resources/templates/resources/partner_detail_apply.html:73
@@ -1793,15 +1440,8 @@ msgstr "Speciaal:GebruikerE-mailen-pagina"
 
 #. Translators: If no account coordinator is assigned to a partner, the Wikipedia Library team will coordinate signups. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/resources/templates/resources/partner_detail_apply.html:112
-msgid ""
-"The Wikipedia Library team will process this application. Want to help? <a "
-"class=\"twl-links\" href=\"https://en.wikipedia.org/wiki/Wikipedia:"
-"The_Wikipedia_Library/Coordinators/Signup\">Sign up as a coordinator.</a>"
-msgstr ""
-"Het team van de Wikipedia-bibliotheek zal deze aanvraag verwerken. Wilt u "
-"helpen? <a class=\"twl-links\" href=\"https://en.wikipedia.org/wiki/"
-"Wikipedia:The_Wikipedia_Library/Coordinators/Signup\">Meld u aan als "
-"coördinator.</a>"
+msgid "The Wikipedia Library team will process this application. Want to help? <a class=\"twl-links\" href=\"https://en.wikipedia.org/wiki/Wikipedia:The_Wikipedia_Library/Coordinators/Signup\">Sign up as a coordinator.</a>"
+msgstr "Het team van de Wikipedia-bibliotheek zal deze aanvraag verwerken. Wilt u helpen? <a class=\"twl-links\" href=\"https://en.wikipedia.org/wiki/Wikipedia:The_Wikipedia_Library/Coordinators/Signup\">Meld u aan als coördinator.</a>"
 
 #. Translators: This text labels a button coordinators can click to view a list of users who have applied for access for a particular partner
 #: TWLight/resources/templates/resources/partner_detail_apply.html:121
@@ -1830,24 +1470,14 @@ msgstr "Toegang Bibliotheekbundel"
 
 #. Translators: Text shown to authenticated, bundle eligible users when they visit a Bundle partner page.
 #: TWLight/resources/templates/resources/partner_detail_apply.html:138
-msgid ""
-"You are eligible to access Library Bundle partners. Click the button above "
-"to access the collection."
-msgstr ""
-"U komt in aanmerking voor toegang tot Bibliotheekbundel-partners. Klik op de "
-"knop hierboven om naar de collectie te gaan."
+msgid "You are eligible to access Library Bundle partners. Click the button above to access the collection."
+msgstr "U komt in aanmerking voor toegang tot Bibliotheekbundel-partners. Klik op de knop hierboven om naar de collectie te gaan."
 
 #. Translators: Text shown to authenticated, bundle ineligible users when they visit a Bundle partner page.
 #: TWLight/resources/templates/resources/partner_detail_apply.html:152
 #, python-format
-msgid ""
-"You are not eligible to access Library Bundle partners. Visit the <a class="
-"\"twl-links\" href=\"%(homepage)s\">homepage</a> to check the eligibility "
-"criteria."
-msgstr ""
-"U komt niet in aanmerking voor toegang tot de partners van de "
-"Bibliotheekbundel. Bezoek de <a class=\"twl-links\" href=\"%(homepage)s"
-"\">homepage</a> om de geschiktheidscriteria te controleren."
+msgid "You are not eligible to access Library Bundle partners. Visit the <a class=\"twl-links\" href=\"%(homepage)s\">homepage</a> to check the eligibility criteria."
+msgstr "U komt niet in aanmerking voor toegang tot de partners van de Bibliotheekbundel. Bezoek de <a class=\"twl-links\" href=\"%(homepage)s\">homepage</a> om de geschiktheidscriteria te controleren."
 
 #. Translators: Buttton prompting users to log in.
 #: TWLight/resources/templates/resources/partner_detail_apply.html:160
@@ -1858,14 +1488,8 @@ msgstr "Aanmelden"
 #. Translators: Text shown to unauthenticated users when they visit a Bundle partner page.
 #: TWLight/resources/templates/resources/partner_detail_apply.html:168
 #, python-format
-msgid ""
-"This resource is part of our <a class=\"twl-links\" href=\"%(about)s"
-"\">Library Bundle</a>, which you can access if you meet our minimum "
-"eligibility criteria. Log in to find out if you are eligible."
-msgstr ""
-"Deze bron maakt deel uit van onze <a class=\"twl-links\" href=\"%(about)s"
-"\">Bibliotheekbundel</a>, die u kunt openen als u voldoet aan onze minimale "
-"geschiktheidscriteria. Meld u aan om te zien of u in aanmerking komt."
+msgid "This resource is part of our <a class=\"twl-links\" href=\"%(about)s\">Library Bundle</a>, which you can access if you meet our minimum eligibility criteria. Log in to find out if you are eligible."
+msgstr "Deze bron maakt deel uit van onze <a class=\"twl-links\" href=\"%(about)s\">Bibliotheekbundel</a>, die u kunt openen als u voldoet aan onze minimale geschiktheidscriteria. Meld u aan om te zien of u in aanmerking komt."
 
 #. Translators: This is the label for a number which shows the total active accounts for one partner. (e.g. https://wikipedialibrary.wmflabs.org/partners/8/).
 #: TWLight/resources/templates/resources/partner_detail_stats.html:21
@@ -1915,34 +1539,20 @@ msgstr "Limiet ingesteld door partner"
 #. Translators: If a partner has specified the excerpt limit both in words and percentage, this message will display the percentage of words and the number of words on the partner page.
 #: TWLight/resources/templates/resources/partner_detail_timeline.html:99
 #, python-format
-msgid ""
-"%(object)s allows a maximum of %(excerpt_limit)s words or "
-"%(excerpt_limit_percentage)s%% of an article be excerpted into a Wikipedia "
-"article."
-msgstr ""
-"%(object)s staat toe dat een maximum van %(excerpt_limit)s woorden of "
-"%(excerpt_limit_percentage)s%% van een artikel worden overgenomen in een "
-"Wikipedia-artikel."
+msgid "%(object)s allows a maximum of %(excerpt_limit)s words or %(excerpt_limit_percentage)s%% of an article be excerpted into a Wikipedia article."
+msgstr "%(object)s staat toe dat een maximum van %(excerpt_limit)s woorden of %(excerpt_limit_percentage)s%% van een artikel worden overgenomen in een Wikipedia-artikel."
 
 #. Translators: If a partner has specified the excerpt limit in words, this message will display the number of words on the partner page.
 #: TWLight/resources/templates/resources/partner_detail_timeline.html:106
 #, python-format
-msgid ""
-"%(object)s allows a maximum of %(excerpt_limit)s words be excerpted into a "
-"Wikipedia article."
-msgstr ""
-"%(object)s staat toe dat een maximum van %(excerpt_limit)s woorden worden "
-"overgenomen in een Wikipedia-artikel."
+msgid "%(object)s allows a maximum of %(excerpt_limit)s words be excerpted into a Wikipedia article."
+msgstr "%(object)s staat toe dat een maximum van %(excerpt_limit)s woorden worden overgenomen in een Wikipedia-artikel."
 
 #. Translators: If a partner has specified the excerpt limit in percentage, this message will display the percentage of words on the partner page.
 #: TWLight/resources/templates/resources/partner_detail_timeline.html:113
 #, python-format
-msgid ""
-"%(object)s allows a maximum of %(excerpt_limit_percentage)s%% of an article "
-"be excerpted into a Wikipedia article."
-msgstr ""
-"%(object)s staat toe dat een maximum van %(excerpt_limit_percentage)s%% van "
-"een artikel wordt overgenomen in een Wikipedia-artikel."
+msgid "%(object)s allows a maximum of %(excerpt_limit_percentage)s%% of an article be excerpted into a Wikipedia article."
+msgstr "%(object)s staat toe dat een maximum van %(excerpt_limit_percentage)s%% van een artikel wordt overgenomen in een Wikipedia-artikel."
 
 #. Translators: If a partner has other requirements for access, this text shows as the title for that information field. (e.g. https://wikipedialibrary.wmflabs.org/partners/10/).
 #: TWLight/resources/templates/resources/partner_detail_timeline.html:132
@@ -1952,12 +1562,8 @@ msgstr "Speciale vereisten voor aanvragers"
 #. Translators: If a user must agree to a Terms of Use document, they see this message, and must enter the name of the resource. Don't translate publisher or url.
 #: TWLight/resources/templates/resources/partner_detail_timeline.html:140
 #, python-format
-msgid ""
-"%(publisher)s requires that you agree with its <a href=\"%(url)s\">terms of "
-"use</a>."
-msgstr ""
-"%(publisher)s vereist dat u akkoord gaat met hun <a href=\"%(url)s"
-"\">gebruiksvoorwaarden</a>."
+msgid "%(publisher)s requires that you agree with its <a href=\"%(url)s\">terms of use</a>."
+msgstr "%(publisher)s vereist dat u akkoord gaat met hun <a href=\"%(url)s\">gebruiksvoorwaarden</a>."
 
 #. Translators: If a user must provide their real name to apply to a partner, they see this message, and must enter the name of the resource. Don't translate publisher.
 #: TWLight/resources/templates/resources/partner_detail_timeline.html:150
@@ -1975,28 +1581,19 @@ msgstr "%(publisher)s vereist dat u uw land waar u woont opgeeft."
 #: TWLight/resources/templates/resources/partner_detail_timeline.html:168
 #, python-format
 msgid "%(publisher)s requires that you provide your institutional affiliation."
-msgstr ""
-"%(publisher)s vereist dat u opgeeft aan welke instelling u verbonden bent."
+msgstr "%(publisher)s vereist dat u opgeeft aan welke instelling u verbonden bent."
 
 #. Translators: If a user must select a specific resource to apply for, they see this message, and must enter the name of the resource. Don't translate publisher.
 #: TWLight/resources/templates/resources/partner_detail_timeline.html:177
 #, python-format
-msgid ""
-"%(publisher)s requires that you specify a particular title that you want to "
-"access."
-msgstr ""
-"%(publisher)s vereist dat u een bepaalde titel specificeert waartoe u "
-"toegang wilt."
+msgid "%(publisher)s requires that you specify a particular title that you want to access."
+msgstr "%(publisher)s vereist dat u een bepaalde titel specificeert waartoe u toegang wilt."
 
 #. Translators: If a user must register on the partner website before applying, they see this message. Don't translate partner.
 #: TWLight/resources/templates/resources/partner_detail_timeline.html:187
 #, python-format
-msgid ""
-"%(publisher)s requires that you sign up for an account before applying for "
-"access."
-msgstr ""
-"%(publisher)s vereist dat u zich aanmeldt voor een account voordat u toegang "
-"aanvraagt."
+msgid "%(publisher)s requires that you sign up for an account before applying for access."
+msgstr "%(publisher)s vereist dat u zich aanmeldt voor een account voordat u toegang aanvraagt."
 
 #. Translators: If a partner has their location listed, this message is a label for that location
 #: TWLight/resources/templates/resources/partner_detail_timeline.html:206
@@ -2122,12 +1719,8 @@ msgstr "Weet u zeker dat u <b>%(object)s</b> wilt verwijderen?"
 
 #. Translators: If multiple authorizations where returned for a collection, this message is shown to a user
 #: TWLight/resources/views.py:268
-msgid ""
-"Multiple authorizations were returned – something's wrong. Please contact us "
-"and don't forget to mention this message."
-msgstr ""
-"Er zijn meerdere autorisaties geretourneerd - er is iets mis. Neem contact "
-"met ons op en vergeet dit bericht niet te vermelden."
+msgid "Multiple authorizations were returned – something's wrong. Please contact us and don't forget to mention this message."
+msgstr "Er zijn meerdere autorisaties geretourneerd - er is iets mis. Neem contact met ons op en vergeet dit bericht niet te vermelden."
 
 #. Translators: This message is shown when user tries to access a NOT_AVAILABLE Partner
 #: TWLight/resources/views.py:316
@@ -2167,23 +1760,8 @@ msgstr "Sorry, we weten niet wat we daarmee aan moeten."
 #. Translators: Shown on the website's 400 page, when a user sends a bad request. Don't translate path or Phabricator.
 #: TWLight/templates/400.html:20
 #, python-format
-msgid ""
-"If you think we should know what to do with that, please email us about this "
-"error at <a class=\"twl-links\" href=\"mailto:wikipedialibrary@wikimedia.org?"
-"Subject=Wikipedia%%20Library%%20%(path)s%%20Permission%%20denied"
-"\">wikipedialibrary@wikimedia.org</a> or report it to us on <a class=\"twl-"
-"links\" href=\"https://phabricator.wikimedia.org/maniphest/task/edit/form/1/?"
-"projectPHIDs=Library-Card-Platform&title=Wikipedia%%20Library%%20%(path)s"
-"%%20Bad%%20Request\">Phabricator</a>"
-msgstr ""
-"Als u denkt dat we zouden moeten weten wat we daarmee moeten doen, stuur ons "
-"dan een e-mail over deze fout op <a class=\"twl-links\" href=\"mailto:"
-"wikipedialibrary@wikimedia.org?Subject=Wikipedia%%20Library%%20%(path)s"
-"%%20Permission%%20denied\">wikipedialibrary@wikimedia.org</a> of meld het "
-"aan ons op <a class=\"twl-links\" href=\"https://phabricator.wikimedia.org/"
-"maniphest/task/edit/form/1/?projectPHIDs=Library-Card-"
-"Platform&title=Wikipedia%%20Library%%20%(path)s%%20Bad%%20Request"
-"\">Phabricator</a>"
+msgid "If you think we should know what to do with that, please email us about this error at <a class=\"twl-links\" href=\"mailto:wikipedialibrary@wikimedia.org?Subject=Wikipedia%%20Library%%20%(path)s%%20Permission%%20denied\">wikipedialibrary@wikimedia.org</a> or report it to us on <a class=\"twl-links\" href=\"https://phabricator.wikimedia.org/maniphest/task/edit/form/1/?projectPHIDs=Library-Card-Platform&title=Wikipedia%%20Library%%20%(path)s%%20Bad%%20Request\">Phabricator</a>"
+msgstr "Als u denkt dat we zouden moeten weten wat we daarmee moeten doen, stuur ons dan een e-mail over deze fout op <a class=\"twl-links\" href=\"mailto:wikipedialibrary@wikimedia.org?Subject=Wikipedia%%20Library%%20%(path)s%%20Permission%%20denied\">wikipedialibrary@wikimedia.org</a> of meld het aan ons op <a class=\"twl-links\" href=\"https://phabricator.wikimedia.org/maniphest/task/edit/form/1/?projectPHIDs=Library-Card-Platform&title=Wikipedia%%20Library%%20%(path)s%%20Bad%%20Request\">Phabricator</a>"
 
 #. Translators: Alt text for an image shown on the 400 error page.
 #. Translators: Alt text for an image shown on the 403 error page.
@@ -2204,24 +1782,8 @@ msgstr "Sorry, het is u niet toegestaan om dat te doen."
 #. Translators: Shown on the website's 403 page, when a user attempts to navigate to a page they don't have permission to view. Don't translate path or Phabricator.
 #: TWLight/templates/403.html:20
 #, python-format
-msgid ""
-"If you think your account should be able to do that, please email us about "
-"this error at <a class=\"twl-links\" href=\"mailto:"
-"wikipedialibrary@wikimedia.org?Subject=Wikipedia%%20Library%%20%(path)s"
-"%%20Permission%%20denied\">wikipedialibrary@wikimedia.org</a> or report it "
-"to us on <a class=\"twl-links\" href=\"https://phabricator.wikimedia.org/"
-"maniphest/task/edit/form/1/?projectPHIDs=Library-Card-"
-"Platform&title=Wikipedia%%20Library%%20%(path)s%%20Permission%%20denied"
-"\">Phabricator</a>"
-msgstr ""
-"Als u denkt dat uw account dat zou moeten kunnen, kunt u ons een e-mail "
-"sturen over deze fout op <a class=\"twl-links\" href=\"mailto:"
-"wikipedialibrary@wikimedia.org?Subject=Wikipedia%%20Library%%20%(path)s"
-"%%20Permission%%20denied\">wikipedialibrary@wikimedia.org</a> of meld het "
-"aan ons op <a class=\"twl-links\" href=\"https://phabricator.wikimedia.org/"
-"maniphest/task/edit/form/1/?projectPHIDs=Library-Card-"
-"Platform&title=Wikipedia%%20Library%%20%(path)s%%20Permission%%20denied"
-"\">Phabricator</a>"
+msgid "If you think your account should be able to do that, please email us about this error at <a class=\"twl-links\" href=\"mailto:wikipedialibrary@wikimedia.org?Subject=Wikipedia%%20Library%%20%(path)s%%20Permission%%20denied\">wikipedialibrary@wikimedia.org</a> or report it to us on <a class=\"twl-links\" href=\"https://phabricator.wikimedia.org/maniphest/task/edit/form/1/?projectPHIDs=Library-Card-Platform&title=Wikipedia%%20Library%%20%(path)s%%20Permission%%20denied\">Phabricator</a>"
+msgstr "Als u denkt dat uw account dat zou moeten kunnen, kunt u ons een e-mail sturen over deze fout op <a class=\"twl-links\" href=\"mailto:wikipedialibrary@wikimedia.org?Subject=Wikipedia%%20Library%%20%(path)s%%20Permission%%20denied\">wikipedialibrary@wikimedia.org</a> of meld het aan ons op <a class=\"twl-links\" href=\"https://phabricator.wikimedia.org/maniphest/task/edit/form/1/?projectPHIDs=Library-Card-Platform&title=Wikipedia%%20Library%%20%(path)s%%20Permission%%20denied\">Phabricator</a>"
 
 #. Translators: Shown on the website's 404 page, when a user attempts to navigate to a page that doesn't exist.
 #: TWLight/templates/404.html:11
@@ -2236,22 +1798,8 @@ msgstr "Sorry, dat kunnen we niet vinden."
 #. Translators: Shown on the website's 404 page, when a user attempts to navigate to a page that doesn't exist. Don't translate path or Phabricator.
 #: TWLight/templates/404.html:19
 #, python-format
-msgid ""
-"If you are certain that something should be here, please email us about this "
-"error at <a class=\"twl-links\" href=\"mailto:wikipedialibrary@wikimedia.org?"
-"Subject=Wikipedia%%20Library%%20%(path)s%%20Not%%20found\"> "
-"wikipedialibrary@wikimedia.org</a> or report it to us on <a class=\"twl-links"
-"\" href=\"https://phabricator.wikimedia.org/maniphest/task/edit/form/1/?"
-"projectPHIDs=Library-Card-Platform&title=Wikipedia%%20Library%%20%(path)s"
-"%%20Not%%20found\">Phabricator</a>"
-msgstr ""
-"Als u zeker weet dat hier iets zou moeten staan, stuur ons dan een e-mail "
-"over deze fout op <a class=\"twl-links\" href=\"mailto:"
-"wikipedialibrary@wikimedia.org?Subject=Wikipedia%%20Library%%20%(path) s"
-"%%20Not%%20found\"> wikipedialibrary@wikimedia.org</a> of meld het aan ons "
-"op <a class=\"twl-links\" href=\"https://phabricator.wikimedia.org/maniphest/"
-"task/edit/form/1/?projectPHIDs=Library-Card-Platform&title=Wikipedia"
-"%%20Library%%20%(path)s%%20Not%%20found\">Phabricator</a>"
+msgid "If you are certain that something should be here, please email us about this error at <a class=\"twl-links\" href=\"mailto:wikipedialibrary@wikimedia.org?Subject=Wikipedia%%20Library%%20%(path)s%%20Not%%20found\"> wikipedialibrary@wikimedia.org</a> or report it to us on <a class=\"twl-links\" href=\"https://phabricator.wikimedia.org/maniphest/task/edit/form/1/?projectPHIDs=Library-Card-Platform&title=Wikipedia%%20Library%%20%(path)s%%20Not%%20found\">Phabricator</a>"
+msgstr "Als u zeker weet dat hier iets zou moeten staan, stuur ons dan een e-mail over deze fout op <a class=\"twl-links\" href=\"mailto:wikipedialibrary@wikimedia.org?Subject=Wikipedia%%20Library%%20%(path) s%%20Not%%20found\"> wikipedialibrary@wikimedia.org</a> of meld het aan ons op <a class=\"twl-links\" href=\"https://phabricator.wikimedia.org/maniphest/task/edit/form/1/?projectPHIDs=Library-Card-Platform&title=Wikipedia%%20Library%%20%(path)s%%20Not%%20found\">Phabricator</a>"
 
 #. Translators: Alt text for an image shown on the 404 error page.
 #: TWLight/templates/404.html:32
@@ -2265,50 +1813,19 @@ msgstr "Over de Wikipedia bibliotheek"
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:20
-msgid ""
-"This platform is our central tool for facilitating access to our available "
-"collections. Here you can see which partnerships are available, search their "
-"contents, and apply for and access the ones you’re interested in."
-msgstr ""
-"Dit platform is onze centrale tool om de toegang tot onze beschikbare "
-"collecties te vergemakkelijken. Hier kunt u zien welke partnerschappen "
-"beschikbaar zijn, de inhoud ervan doorzoeken en de partnerschappen aanvragen "
-"en openen waarin u geïnteresseerd bent."
+msgid "This platform is our central tool for facilitating access to our available collections. Here you can see which partnerships are available, search their contents, and apply for and access the ones you’re interested in."
+msgstr "Dit platform is onze centrale tool om de toegang tot onze beschikbare collecties te vergemakkelijken. Hier kunt u zien welke partnerschappen beschikbaar zijn, de inhoud ervan doorzoeken en de partnerschappen aanvragen en openen waarin u geïnteresseerd bent."
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/). Wikimedia Foundation should not be translated.
 #: TWLight/templates/about.html:29
-msgid ""
-"All users receive immediate access to some collections, which can be browsed "
-"by clicking the 'Access collection' buttons or using the search bar at the "
-"top of the page. Other collections require an application before access is "
-"granted, and may be accessed directly or via an individual login or access "
-"code. Volunteer coordinators, who have signed non-disclosure agreements with "
-"the Wikimedia Foundation, review these applications and work with publishers "
-"to get you your free access."
-msgstr ""
-"Alle gebruikers krijgen onmiddellijk toegang tot sommige collecties, die "
-"kunnen worden doorzocht door op de knoppen 'Toegang tot collectie' te "
-"klikken of door de zoekbalk bovenaan de pagina te gebruiken. Andere "
-"collecties vereisen een aanvraag voordat toegang wordt verleend en kunnen "
-"rechtstreeks of via een individuele login of toegangscode worden geopend. "
-"Vrijwillige coördinatoren, die geheimhoudingsovereenkomsten hebben getekend "
-"met de Wikimedia Foundation, beoordelen deze aanvragen en werken samen met "
-"uitgevers om u gratis toegang te geven."
+msgid "All users receive immediate access to some collections, which can be browsed by clicking the 'Access collection' buttons or using the search bar at the top of the page. Other collections require an application before access is granted, and may be accessed directly or via an individual login or access code. Volunteer coordinators, who have signed non-disclosure agreements with the Wikimedia Foundation, review these applications and work with publishers to get you your free access."
+msgstr "Alle gebruikers krijgen onmiddellijk toegang tot sommige collecties, die kunnen worden doorzocht door op de knoppen 'Toegang tot collectie' te klikken of door de zoekbalk bovenaan de pagina te gebruiken. Andere collecties vereisen een aanvraag voordat toegang wordt verleend en kunnen rechtstreeks of via een individuele login of toegangscode worden geopend. Vrijwillige coördinatoren, die geheimhoudingsovereenkomsten hebben getekend met de Wikimedia Foundation, beoordelen deze aanvragen en werken samen met uitgevers om u gratis toegang te geven."
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/). Don't translate terms_url.
 #: TWLight/templates/about.html:43
 #, python-format
-msgid ""
-"For more information about how your information is stored and reviewed "
-"please see our <a class=\"twl-links\" href=\"%(terms_url)s\"> terms of use "
-"and privacy policy</a>. Accounts you apply for are also subject to the Terms "
-"of Use provided by each partner’s platform; please review them."
-msgstr ""
-"Raadpleeg onze <a class=\"twl-links\" href=\"%(terms_url)s"
-"\">gebruiksvoorwaarden en privacybeleid</a> voor meer informatie over hoe uw "
-"informatie wordt opgeslagen en beoordeeld. Accounts waarvoor u een aanvraag "
-"indient, zijn ook onderworpen aan de gebruiksvoorwaarden die door het "
-"platform van elke partner worden verstrekt; bekijk ze alstublieft."
+msgid "For more information about how your information is stored and reviewed please see our <a class=\"twl-links\" href=\"%(terms_url)s\"> terms of use and privacy policy</a>. Accounts you apply for are also subject to the Terms of Use provided by each partner’s platform; please review them."
+msgstr "Raadpleeg onze <a class=\"twl-links\" href=\"%(terms_url)s\">gebruiksvoorwaarden en privacybeleid</a> voor meer informatie over hoe uw informatie wordt opgeslagen en beoordeeld. Accounts waarvoor u een aanvraag indient, zijn ook onderworpen aan de gebruiksvoorwaarden die door het platform van elke partner worden verstrekt; bekijk ze alstublieft."
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:51
@@ -2317,26 +1834,13 @@ msgstr "Wie kan toegang krijgen?"
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/). Wikimedia Foundation should not be translated.
 #: TWLight/templates/about.html:55
-msgid ""
-"Any active editor in good standing can receive access. For publishers with "
-"limited numbers of accounts, applications are reviewed based on the editor’s "
-"needs and contributions. If you think you could use access to one of our "
-"partner resources and are an active editor in any project supported by the "
-"Wikimedia Foundation, please apply."
-msgstr ""
-"Elke actieve redacteur met een goede reputatie kan toegang krijgen. Voor "
-"uitgevers met een beperkt aantal accounts worden aanvragen beoordeeld op "
-"basis van de behoeften en bijdragen van de redacteur. Als u denkt dat u "
-"toegang tot een van onze partnerbronnen zou kunnen gebruiken en een actieve "
-"redacteur bent in een project dat wordt ondersteund door de Wikimedia "
-"Foundation, meld u dan aan."
+msgid "Any active editor in good standing can receive access. For publishers with limited numbers of accounts, applications are reviewed based on the editor’s needs and contributions. If you think you could use access to one of our partner resources and are an active editor in any project supported by the Wikimedia Foundation, please apply."
+msgstr "Elke actieve redacteur met een goede reputatie kan toegang krijgen. Voor uitgevers met een beperkt aantal accounts worden aanvragen beoordeeld op basis van de behoeften en bijdragen van de redacteur. Als u denkt dat u toegang tot een van onze partnerbronnen zou kunnen gebruiken en een actieve redacteur bent in een project dat wordt ondersteund door de Wikimedia Foundation, meld u dan aan."
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:65
 msgid "Any editor can use the library if they meet a few basic requirements:"
-msgstr ""
-"Elke redacteur kan de bibliotheek gebruiken als deze aan een paar "
-"basisvereisten voldoet:"
+msgstr "Elke redacteur kan de bibliotheek gebruiken als deze aan een paar basisvereisten voldoet:"
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:71
@@ -2351,48 +1855,22 @@ msgstr "U hebt minimaal 500 bewerkingen aangebracht op Wikimedia-projecten"
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:79
 msgid "You have made at least 10 edits to Wikimedia projects in the last month"
-msgstr ""
-"U heeft de afgelopen maand ten minste 10 wijzigingen aangebracht in "
-"Wikimedia-projecten"
+msgstr "U heeft de afgelopen maand ten minste 10 wijzigingen aangebracht in Wikimedia-projecten"
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:83
 msgid "You are not currently blocked from editing a Wikimedia project"
-msgstr ""
-"U bent momenteel niet geblokkeerd voor het bewerken van een Wikimedia-project"
+msgstr "U bent momenteel niet geblokkeerd voor het bewerken van een Wikimedia-project"
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/)
 #: TWLight/templates/about.html:89
-msgid ""
-"If you are applying for an available collection, please first check that you "
-"don't already have access through another library or institution. If you do, "
-"please consider using that access rather than taking up a seat for this "
-"resource in The Wikipedia Library."
-msgstr ""
-"Als u een beschikbare collectie aanvraagt, controleer dan eerst of u niet al "
-"toegang heeft via een andere bibliotheek of instelling. Als u dat heeft, "
-"overweeg dan om die toegang te gebruiken in plaats van de plek in te nemen "
-"van deze bron die iemand anders in de Wikipedia-bibliotheek ook kan "
-"gebruiken."
+msgid "If you are applying for an available collection, please first check that you don't already have access through another library or institution. If you do, please consider using that access rather than taking up a seat for this resource in The Wikipedia Library."
+msgstr "Als u een beschikbare collectie aanvraagt, controleer dan eerst of u niet al toegang heeft via een andere bibliotheek of instelling. Als u dat heeft, overweeg dan om die toegang te gebruiken in plaats van de plek in te nemen van deze bron die iemand anders in de Wikipedia-bibliotheek ook kan gebruiken."
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/)
 #: TWLight/templates/about.html:99
-msgid ""
-"If your account is blocked on one or more Wikimedia projects, you may still "
-"be granted access to The Wikipedia Library. You will need to contact the "
-"Wikipedia Library team, who will review your blocks. If you have been "
-"blocked for content issues, most notably copyright violations, or have "
-"multiple long-term blocks, we may decline your request. Additionally, if "
-"your block status changes after being approved, you will need to request "
-"another review."
-msgstr ""
-"Als uw account is geblokkeerd op een of meer Wikimedia-projecten, krijgt u "
-"mogelijk nog steeds toegang tot de Wikipedia-bibliotheek. U moet contact "
-"opnemen met het team van de Wikipedia-bibliotheek, die uw blokkade zal "
-"beoordelen. Als u bent geblokkeerd vanwege inhoudelijke problemen, met name "
-"auteursrechtschendingen, of als u meerdere langdurige blokkeringen heeft, "
-"kunnen we uw verzoek afwijzen. Als uw blokkeringsstatus verandert nadat deze "
-"is goedgekeurd, moet u bovendien een nieuwe beoordeling aanvragen."
+msgid "If your account is blocked on one or more Wikimedia projects, you may still be granted access to The Wikipedia Library. You will need to contact the Wikipedia Library team, who will review your blocks. If you have been blocked for content issues, most notably copyright violations, or have multiple long-term blocks, we may decline your request. Additionally, if your block status changes after being approved, you will need to request another review."
+msgstr "Als uw account is geblokkeerd op een of meer Wikimedia-projecten, krijgt u mogelijk nog steeds toegang tot de Wikipedia-bibliotheek. U moet contact opnemen met het team van de Wikipedia-bibliotheek, die uw blokkade zal beoordelen. Als u bent geblokkeerd vanwege inhoudelijke problemen, met name auteursrechtschendingen, of als u meerdere langdurige blokkeringen heeft, kunnen we uw verzoek afwijzen. Als uw blokkeringsstatus verandert nadat deze is goedgekeurd, moet u bovendien een nieuwe beoordeling aanvragen."
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:110
@@ -2407,9 +1885,7 @@ msgstr "Goedgekeurde redacteuren <i>kunnen</i> hun toegang gebruiken om:"
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:118
 msgid "Search, view, retrieve, and display partner content"
-msgstr ""
-"Inhoud op de website van partners te doorzoeken, te bekijken, op te halen en "
-"weer te geven"
+msgstr "Inhoud op de website van partners te doorzoeken, te bekijken, op te halen en weer te geven"
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:122
@@ -2428,12 +1904,8 @@ msgstr "Goedgekeurde redacteuren <i>mogen niet</i>:"
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:136
-msgid ""
-"Share their account logins or passwords with others, or sell their access to "
-"other parties"
-msgstr ""
-"Hun accountaanmeldingen of wachtwoorden delen met anderen of hun toegang aan "
-"andere partijen verkopen"
+msgid "Share their account logins or passwords with others, or sell their access to other parties"
+msgstr "Hun accountaanmeldingen of wachtwoorden delen met anderen of hun toegang aan andere partijen verkopen"
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:140
@@ -2442,30 +1914,18 @@ msgstr "Massaal scrapen of massaal inhoud van partners downloaden"
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:144
-msgid ""
-"Systematically make printed or electronic copies of multiple extracts of "
-"restricted content available for any purpose"
-msgstr ""
-"Systematisch gedrukte of elektronische kopieën maken van meerdere fragmenten "
-"van beperkt toegankelijke inhoud voor welk doel dan ook"
+msgid "Systematically make printed or electronic copies of multiple extracts of restricted content available for any purpose"
+msgstr "Systematisch gedrukte of elektronische kopieën maken van meerdere fragmenten van beperkt toegankelijke inhoud voor welk doel dan ook"
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/). Stub is a technical term for a short Wikipedia article, use the appropriate Wikipedia term in your language.
 #: TWLight/templates/about.html:148
-msgid ""
-"Datamine metadata without permission, in order, for instance, to use "
-"metadata for auto-created stub articles"
-msgstr ""
-"Metadata dataminen zonder toestemming, om bijvoorbeeld metadata te gebruiken "
-"voor automatisch aangemaakte beginnetjes-artikelen"
+msgid "Datamine metadata without permission, in order, for instance, to use metadata for auto-created stub articles"
+msgstr "Metadata dataminen zonder toestemming, om bijvoorbeeld metadata te gebruiken voor automatisch aangemaakte beginnetjes-artikelen"
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:154
-msgid ""
-"Respecting these agreements allows us to continue growing the partnerships "
-"available to the community."
-msgstr ""
-"Door deze overeenkomsten te respecteren, kunnen we de voor de gemeenschap "
-"beschikbare partnerschappen blijven uitbreiden."
+msgid "Respecting these agreements allows us to continue growing the partnerships available to the community."
+msgstr "Door deze overeenkomsten te respecteren, kunnen we de voor de gemeenschap beschikbare partnerschappen blijven uitbreiden."
 
 #. Translators: This is the heading for a section on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:160
@@ -2474,63 +1934,23 @@ msgstr "EZProxy"
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:164
-msgid ""
-"EZProxy is a proxy server used to authenticate users for many Wikipedia "
-"Library partners. Users sign into EZProxy via the Library Card platform to "
-"verify that they are authorized users, and then the server accesses "
-"requested resources using its own IP address."
-msgstr ""
-"EZProxy is een volmachtsserver waarmee gebruikers zich centraal kunnen "
-"aanmelden bij vele van de partners van de Wikipedia-bibliotheek. Gebruikers "
-"melden zich via het Bibliotheekkaart-platform bij EZProxy aan zodat kan "
-"worden gecontroleerd of ze gemachtigd zijn. De server benadert de "
-"aangevraagde bronnen dan vanaf zijn eigen IP-adres."
+msgid "EZProxy is a proxy server used to authenticate users for many Wikipedia Library partners. Users sign into EZProxy via the Library Card platform to verify that they are authorized users, and then the server accesses requested resources using its own IP address."
+msgstr "EZProxy is een volmachtsserver waarmee gebruikers zich centraal kunnen aanmelden bij vele van de partners van de Wikipedia-bibliotheek. Gebruikers melden zich via het Bibliotheekkaart-platform bij EZProxy aan zodat kan worden gecontroleerd of ze gemachtigd zijn. De server benadert de aangevraagde bronnen dan vanaf zijn eigen IP-adres."
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:173
-msgid ""
-"You may notice that when accessing resources via EZProxy that URLs are "
-"dynamically rewritten. This is why we recommend logging in via the Library "
-"Card platform rather than going directly to the unproxied partner website. "
-"When in doubt, check the URL for ‘idm.oclc’. If it’s there, then you’re "
-"connected via EZProxy."
-msgstr ""
-"Mogelijk merkt u bij het openen van bronnen via EZProxy dat URL’s dynamisch "
-"worden aangepast. Daarom raden we aan om u aan te melden via het Bibliotheek-"
-"platform in plaats van rechtstreeks zonder proxy naar de partnerwebsite te "
-"gaan. Controleer bij twijfel de URL voor 'idm.oclc'. Als dit er is, bent u "
-"verbonden via EZProxy."
+msgid "You may notice that when accessing resources via EZProxy that URLs are dynamically rewritten. This is why we recommend logging in via the Library Card platform rather than going directly to the unproxied partner website. When in doubt, check the URL for ‘idm.oclc’. If it’s there, then you’re connected via EZProxy."
+msgstr "Mogelijk merkt u bij het openen van bronnen via EZProxy dat URL’s dynamisch worden aangepast. Daarom raden we aan om u aan te melden via het Bibliotheek-platform in plaats van rechtstreeks zonder proxy naar de partnerwebsite te gaan. Controleer bij twijfel de URL voor 'idm.oclc'. Als dit er is, bent u verbonden via EZProxy."
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:182
-msgid ""
-"Typically once you’ve logged in your session will remain active in your "
-"browser for up to two hours after you’ve finished searching. Note that use "
-"of EZProxy requires you to enable cookies. If you are having problems you "
-"should also try clearing your cache and restarting your browser."
-msgstr ""
-"Als u zich eenmaal hebt aangemeld, blijft uw sessie meestal tot twee uur "
-"actief in uw browser nadat u klaar bent met zoeken. Houd er rekening mee dat "
-"het gebruik van EZProxy vereist dat u cookies inschakelt. Als u problemen "
-"ondervindt, probeer dan ook uw cachegeheugen te wissen en uw browser opnieuw "
-"op te starten."
+msgid "Typically once you’ve logged in your session will remain active in your browser for up to two hours after you’ve finished searching. Note that use of EZProxy requires you to enable cookies. If you are having problems you should also try clearing your cache and restarting your browser."
+msgstr "Als u zich eenmaal hebt aangemeld, blijft uw sessie meestal tot twee uur actief in uw browser nadat u klaar bent met zoeken. Houd er rekening mee dat het gebruik van EZProxy vereist dat u cookies inschakelt. Als u problemen ondervindt, probeer dan ook uw cachegeheugen te wissen en uw browser opnieuw op te starten."
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/)
 #: TWLight/templates/about.html:193
-msgid ""
-"The Library Bundle is a collection of resources for which no application is "
-"required. If you meet the criteria laid out above, you will be authorized "
-"for access automatically upon logging in to the platform. Only some of our "
-"content is currently included in the Library Bundle, however we hope to "
-"expand the collection as more publishers become comfortable with "
-"participating. All Bundle content is accessed via EZProxy."
-msgstr ""
-"De Bibliotheekbundel is een verzameling bronnen waarvoor geen aanvraag "
-"vereist is. Als u aan de bovenstaande criteria voldoet, wordt u automatisch "
-"geautoriseerd voor toegang wanneer u zich bij het platform aanmeldt. Slechts "
-"een deel van onze inhoud is momenteel opgenomen in de Bibliotheekbundel, "
-"maar we hopen de collectie uit te breiden naarmate meer uitgevers deel "
-"willen nemen. Alle inhoud van de bundel is toegankelijk via EZProxy."
+msgid "The Library Bundle is a collection of resources for which no application is required. If you meet the criteria laid out above, you will be authorized for access automatically upon logging in to the platform. Only some of our content is currently included in the Library Bundle, however we hope to expand the collection as more publishers become comfortable with participating. All Bundle content is accessed via EZProxy."
+msgstr "De Bibliotheekbundel is een verzameling bronnen waarvoor geen aanvraag vereist is. Als u aan de bovenstaande criteria voldoet, wordt u automatisch geautoriseerd voor toegang wanneer u zich bij het platform aanmeldt. Slechts een deel van onze inhoud is momenteel opgenomen in de Bibliotheekbundel, maar we hopen de collectie uit te breiden naarmate meer uitgevers deel willen nemen. Alle inhoud van de bundel is toegankelijk via EZProxy."
 
 #. Translators: This is the heading for a section on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:202
@@ -2539,18 +1959,8 @@ msgstr "Referentie-praktijken"
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:206
-msgid ""
-"Citation practices vary by project and even by article. Generally, we "
-"support editors citing where they found information, in a form that allows "
-"others to check it for themselves. That often means providing both original "
-"source details as well as a link to the partner database in which the source "
-"was found."
-msgstr ""
-"Het toepassen van referenties verschilt per project en zelfs per artikel. "
-"Over het algemeen ondersteunen we redacteuren die vermelden waar ze "
-"informatie hebben gevonden, in een vorm die anderen in staat stelt deze zelf "
-"te controleren. Dat betekent vaak het verstrekken van zowel originele "
-"brongegevens als een link naar de partnerdatabase waarin de bron is gevonden."
+msgid "Citation practices vary by project and even by article. Generally, we support editors citing where they found information, in a form that allows others to check it for themselves. That often means providing both original source details as well as a link to the partner database in which the source was found."
+msgstr "Het toepassen van referenties verschilt per project en zelfs per artikel. Over het algemeen ondersteunen we redacteuren die vermelden waar ze informatie hebben gevonden, in een vorm die anderen in staat stelt deze zelf te controleren. Dat betekent vaak het verstrekken van zowel originele brongegevens als een link naar de partnerdatabase waarin de bron is gevonden."
 
 #. Translators: This is the heading for a section on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #. Translators: This link is at the bottom of every page and can be clicked by users to contact the wikipedia library team.
@@ -2561,13 +1971,8 @@ msgstr "Contact opnemen"
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:218
 #, python-format
-msgid ""
-"If you have questions, need help, or want to volunteer to help, please see "
-"our <a class=\"twl-links\" href=\"%(contact_url)s\">contact page</a>."
-msgstr ""
-"Indien u vragen hebt, hulp nodig hebt of vrijwillig hulp wilt bieden, "
-"raadpleegt u onze <a class=\"twl-links\" href=\"%(contact_url)s"
-"\">contactpagina</a>."
+msgid "If you have questions, need help, or want to volunteer to help, please see our <a class=\"twl-links\" href=\"%(contact_url)s\">contact page</a>."
+msgstr "Indien u vragen hebt, hulp nodig hebt of vrijwillig hulp wilt bieden, raadpleegt u onze <a class=\"twl-links\" href=\"%(contact_url)s\">contactpagina</a>."
 
 #. Translators: This is the title of the panel box detailing the contact information for the Wikipedia Library team.
 #: TWLight/templates/contact.html:14
@@ -2606,18 +2011,13 @@ msgstr "Twitter-pagina van Wikipedia-bibliotheek"
 #. Translators: This is the text that appears at the bottom of the contact us form directing users to the suggestions form.
 #: TWLight/templates/contact.html:48
 #, python-format
-msgid ""
-"(If you would like to suggest a partner, <a class=\"twl-links\" href="
-"\"%(suggest)s\"><strong>go here</strong></a>.)"
-msgstr ""
-"(Als u een partner wilt voorstellen, <a class=\"twl-links\" href="
-"\"%(suggest)s\"><strong>ga hierheen</strong></a>.)"
+msgid "(If you would like to suggest a partner, <a class=\"twl-links\" href=\"%(suggest)s\"><strong>go here</strong></a>.)"
+msgstr "(Als u een partner wilt voorstellen, <a class=\"twl-links\" href=\"%(suggest)s\"><strong>ga hierheen</strong></a>.)"
 
 #. Translators: On a special 'link to search' page, this message is shown if JavaScript is disabled.
 #: TWLight/templates/eds_search_endpoint.html:7
 msgid "JavaScript is disabled; use the button below to continue."
-msgstr ""
-"JavaScript is uitgeschakeld; gebruik de onderstaande knop om verder te gaan."
+msgstr "JavaScript is uitgeschakeld; gebruik de onderstaande knop om verder te gaan."
 
 #. Translators: Alt text for the Wikipedia Library shown in the top left of all pages.
 #: TWLight/templates/header_partial_b4.html:14
@@ -2668,13 +2068,8 @@ msgstr "De Wikipedia-bibliotheek"
 #. Translators: Information about The Wikipedia Library.
 #: TWLight/templates/login_partial.html:53 TWLight/templates/new_base.html:21
 #, python-format
-msgid ""
-"More than 100 of the world's top subscription-only databases, with content "
-"in %(no_of_languages)s languages, free for Wikipedians of all backgrounds"
-msgstr ""
-"Meer dan 100 van 's werelds beste abonnementsgebonden databases, in "
-"%(no_of_languages)s talen, gratis voor alle Wikipedianen ongeacht hun "
-"achtergrond"
+msgid "More than 100 of the world's top subscription-only databases, with content in %(no_of_languages)s languages, free for Wikipedians of all backgrounds"
+msgstr "Meer dan 100 van 's werelds beste abonnementsgebonden databases, in %(no_of_languages)s talen, gratis voor alle Wikipedianen ongeacht hun achtergrond"
 
 #. Translators: Information about The Wikipedia Library.
 #: TWLight/templates/login_partial.html:64
@@ -2682,12 +2077,8 @@ msgid "Meet these criteria for automatic access"
 msgstr "Voldoe aan deze criteria voor automatische toegang"
 
 #: TWLight/templates/login_partial.html:69
-msgid ""
-"These criteria grant you access to certain collections but not all. Some "
-"collections are accessible on a per application basis only."
-msgstr ""
-"Deze criteria geven u toegang tot bepaalde collecties, maar niet tot alle. "
-"Sommige collecties zijn alleen per aanvraag toegankelijk."
+msgid "These criteria grant you access to certain collections but not all. Some collections are accessible on a per application basis only."
+msgstr "Deze criteria geven u toegang tot bepaalde collecties, maar niet tot alle. Sommige collecties zijn alleen per aanvraag toegankelijk."
 
 #: TWLight/templates/login_partial.html:89
 msgid "Login via Wikipedia"
@@ -2696,40 +2087,20 @@ msgstr "Aanmelden via Wikipedia"
 #. Translators: Shown if the current user doesn't have a registered email on their account. Don't translate contact_us_url or email_url.
 #: TWLight/templates/message_partial.html:15
 #, python-format
-msgid ""
-"You don't have an email on file. We can't finalize your access to partner "
-"resources, and you won't be able to <a class=\"twl-links\" href="
-"\"%(contact_us_url)s\">contact us</a> without an email. Please <a class="
-"\"twl-links\" href=\"%(email_url)s\">update your email</a>."
-msgstr ""
-"U hebt geen e-mail in het bestand. We kunnen uw toegang tot partnerbronnen "
-"niet voltooien en u kunt geen <a class=\"twl-links\" href="
-"\"%(contact_us_url)s\"> contact met ons opnemen </a> zonder e-mail. <a class="
-"\"twl-links\" href=\"%(email_url)s\">Update uw e-mail </a>."
+msgid "You don't have an email on file. We can't finalize your access to partner resources, and you won't be able to <a class=\"twl-links\" href=\"%(contact_us_url)s\">contact us</a> without an email. Please <a class=\"twl-links\" href=\"%(email_url)s\">update your email</a>."
+msgstr "U hebt geen e-mail in het bestand. We kunnen uw toegang tot partnerbronnen niet voltooien en u kunt geen <a class=\"twl-links\" href=\"%(contact_us_url)s\"> contact met ons opnemen </a> zonder e-mail. <a class=\"twl-links\" href=\"%(email_url)s\">Update uw e-mail </a>."
 
 #. Translators: Shown if the current user has requested the processing of their data should be restricted.
 #: TWLight/templates/message_partial.html:26
 #, python-format
-msgid ""
-"You have requested a restriction on the processing of your data. Most site "
-"functionality will not be available to you until you <a class=\"twl-links\" "
-"href=\"%(restrict_url)s\">lift this restriction</a>."
-msgstr ""
-"U heeft een beperking van de verwerking van uw gegevens aangevraagd. De "
-"meeste functionaliteiten op de site zijn pas beschikbaar als u <a class="
-"\"twl-links\" href=\"%(restrict_url)s\">deze beperking opheft</a>."
+msgid "You have requested a restriction on the processing of your data. Most site functionality will not be available to you until you <a class=\"twl-links\" href=\"%(restrict_url)s\">lift this restriction</a>."
+msgstr "U heeft een beperking van de verwerking van uw gegevens aangevraagd. De meeste functionaliteiten op de site zijn pas beschikbaar als u <a class=\"twl-links\" href=\"%(restrict_url)s\">deze beperking opheft</a>."
 
 #. Translators: Shown if the current user has not agreed to the terms of use.
 #: TWLight/templates/message_partial.html:37
 #, python-format
-msgid ""
-"You have not agreed to the <a class=\"twl-links\" href=\"%(terms_url)s"
-"\">terms of use</a> of this site. Your applications will not be processed "
-"and you won't be able to apply or access resources you are approved for."
-msgstr ""
-"U bent niet akkoord gegaan met de <a class=\"twl-links\" href=\"%(terms_url)s"
-"\">gebruiksvoorwaarden</a> van deze site. Uw aanvragen worden niet verwerkt "
-"en u kunt geen bronnen aanvragen of gebruiken waarvoor u bent goedgekeurd."
+msgid "You have not agreed to the <a class=\"twl-links\" href=\"%(terms_url)s\">terms of use</a> of this site. Your applications will not be processed and you won't be able to apply or access resources you are approved for."
+msgstr "U bent niet akkoord gegaan met de <a class=\"twl-links\" href=\"%(terms_url)s\">gebruiksvoorwaarden</a> van deze site. Uw aanvragen worden niet verwerkt en u kunt geen bronnen aanvragen of gebruiken waarvoor u bent goedgekeurd."
 
 #. Translators: This link is at the bottom of every page and links to the 'About' page (https://wikipedialibrary.wmflabs.org/about/)
 #: TWLight/templates/new_base.html:107
@@ -2775,12 +2146,8 @@ msgstr "Wachtwoord opnieuw instellen"
 
 #. Translators: If a user goes to reset their password, this message asks them to enter their email to do so.
 #: TWLight/templates/registration/password_reset_form.html:13
-msgid ""
-"Forgot your password? Enter your email address below, and we'll email "
-"instructions for setting a new one."
-msgstr ""
-"Uw wachtwoord vergeten? Voer hieronder uw e-mailadres in en we sturen u een "
-"e-mail met instructies om een nieuw adres in te stellen."
+msgid "Forgot your password? Enter your email address below, and we'll email instructions for setting a new one."
+msgstr "Uw wachtwoord vergeten? Voer hieronder uw e-mailadres in en we sturen u een e-mail met instructies om een nieuw adres in te stellen."
 
 #. Translators: This is the label for a button that users click to update their public information.
 #: TWLight/users/forms.py:36
@@ -2790,9 +2157,7 @@ msgstr "Profiel bijwerken"
 #. Translators: This labels a field where users can describe their activity on Wikipedia in a small biography.
 #: TWLight/users/forms.py:45
 msgid "Describe your contributions to Wikipedia: topics edited, et cetera."
-msgstr ""
-"Beschrijf uw bijdragen aan Wikipedia: onderwerpen waarover geschreven is, "
-"enzovoorts."
+msgstr "Beschrijf uw bijdragen aan Wikipedia: onderwerpen waarover geschreven is, enzovoorts."
 
 #. Translators: In the preferences section (Emails) of a user profile, this text labels the checkbox users can (un)click to change if they wish to receive account renewal notices or not.
 #: TWLight/users/forms.py:98
@@ -2826,22 +2191,13 @@ msgstr "Ik ga akkoord met de gebruiksvoorwaarden"
 
 #. Translators: This text explains how to disagree to the site's terms of use and the restrictions that will come into effect when users disagree to the terms of use.
 #: TWLight/users/forms.py:185
-msgid ""
-"By unchecking this box and clicking “Update” you may explore the site, but "
-"you will not be able to apply for access to materials or evaluate "
-"applications unless you agree with the terms of use."
-msgstr ""
-"Door dit vakje uit te schakelen en op \"Bijwerken\" te klikken, kunt u de "
-"site verkennen, maar u kunt geen toegang tot materialen aanvragen of "
-"aanvragen evalueren, tenzij u akkoord gaat met de gebruiksvoorwaarden."
+msgid "By unchecking this box and clicking “Update” you may explore the site, but you will not be able to apply for access to materials or evaluate applications unless you agree with the terms of use."
+msgstr "Door dit vakje uit te schakelen en op \"Bijwerken\" te klikken, kunt u de site verkennen, maar u kunt geen toegang tot materialen aanvragen of aanvragen evalueren, tenzij u akkoord gaat met de gebruiksvoorwaarden."
 
 #. Translators: Users click this button to set their website email address to the one linked to their Wikipedia account.
 #: TWLight/users/forms.py:211
-msgid ""
-"Use my Wikipedia email address (will be updated the next time you login)."
-msgstr ""
-"Gebruik mijn Wikipedia-e-mailadres (wordt bijgewerkt de volgende keer dat u "
-"inlogt)."
+msgid "Use my Wikipedia email address (will be updated the next time you login)."
+msgstr "Gebruik mijn Wikipedia-e-mailadres (wordt bijgewerkt de volgende keer dat u inlogt)."
 
 #. Translators: This labels a button which users click to change their email.
 #: TWLight/users/forms.py:232
@@ -2851,26 +2207,13 @@ msgstr "E-mail bijwerken"
 #. Translators: Shown if the current user tried to 'favorite' a partner they can't access. Do not translate '{partner}'
 #: TWLight/users/models.py:201
 #, python-brace-format
-msgid ""
-"Cannot add partner {partner} to your favorites because you don't have access "
-"to it"
-msgstr ""
-"Kan partner {partner} niet toevoegen aan uw favorieten omdat u er geen "
-"toegang toe hebt"
-
-#. Translators: Do not translate.
-#: TWLight/users/models.py:869
-#, fuzzy, python-brace-format
-#| msgid "Username"
-msgid "{wp_username}"
-msgstr "Gebruikersnaam"
+msgid "Cannot add partner {partner} to your favorites because you don't have access to it"
+msgstr "Kan partner {partner} niet toevoegen aan uw favorieten omdat u er geen toegang toe hebt"
 
 #. Translators: This error message is shown when there's a problem with the authenticated login process.
 #: TWLight/users/oauth.py:243
 msgid "You tried to log in but presented an invalid access token."
-msgstr ""
-"U hebt geprobeerd zich aan te melden, maar u hebt een ongeldig toegangstoken "
-"verstrekt."
+msgstr "U hebt geprobeerd zich aan te melden, maar u hebt een ongeldig toegangstoken verstrekt."
 
 #. Translators: This message is shown when the OAuth login process fails because the request came from the wrong website. Don't translate {domain}.
 #: TWLight/users/oauth.py:298 TWLight/users/oauth.py:444
@@ -2885,12 +2228,8 @@ msgstr "Handshaker niet gestart. Probeer u opnieuw aan te melden."
 
 #. Translators: this message is displayed to users that don't have accounts and clicked on a proxied link.
 #: TWLight/users/oauth.py:388
-msgid ""
-"To view this link you need to be an eligible library user. Please login to "
-"continue."
-msgstr ""
-"Om deze koppeling te bekijken moet u een in aanmerking komende "
-"bibliotheekgebruiker zijn. Meld u aan om verder te gaan."
+msgid "To view this link you need to be an eligible library user. Please login to continue."
+msgstr "Om deze koppeling te bekijken moet u een in aanmerking komende bibliotheekgebruiker zijn. Meld u aan om verder te gaan."
 
 #. Translators: This warning message is shown to users when the response received from Wikimedia OAuth servers is not a valid one.
 #: TWLight/users/oauth.py:430
@@ -2915,9 +2254,7 @@ msgstr "Geen aanvraagtoken."
 #. Translators: This message is shown when the OAuth login process fails.
 #: TWLight/users/oauth.py:498
 msgid "Access token generation failed, please try logging in again."
-msgstr ""
-"Het aanmaken van het toegangstoken is mislukt. Probeer u opnieuw aan te "
-"melden."
+msgstr "Het aanmaken van het toegangstoken is mislukt. Probeer u opnieuw aan te melden."
 
 #. Translators: This message is shown when more information is available on another page. Do not translate {issue}
 #: TWLight/users/oauth.py:507
@@ -2927,25 +2264,13 @@ msgstr "Meer informatie: {issue}"
 
 #. Translators: If the user tries to log in, but their account does not meet certain requirements, they cannot login.
 #: TWLight/users/oauth.py:528
-msgid ""
-"Your Wikipedia account does not meet the eligibility criteria in the terms "
-"of use, so your Wikipedia Library Card Platform account cannot be activated."
-msgstr ""
-"Uw Wikipedia-account voldoet niet aan de geschiktheidscriteria in de "
-"gebruiksvoorwaarden, dus uw bibliotheekkaart in het platform van de "
-"Wikipedia-bibliotheek kan niet worden geactiveerd."
+msgid "Your Wikipedia account does not meet the eligibility criteria in the terms of use, so your Wikipedia Library Card Platform account cannot be activated."
+msgstr "Uw Wikipedia-account voldoet niet aan de geschiktheidscriteria in de gebruiksvoorwaarden, dus uw bibliotheekkaart in het platform van de Wikipedia-bibliotheek kan niet worden geactiveerd."
 
 #. Translators: If the user tries to log in, but their account does not meet certain requirements, they cannot login.
 #: TWLight/users/oauth.py:536
-msgid ""
-"Your Wikipedia account no longer meets the eligibility criteria in the terms "
-"of use, so you cannot be logged in. If you think you should be able to log "
-"in, please email wikipedialibrary@wikimedia.org."
-msgstr ""
-"Uw Wikipedia-account voldoet niet langer aan de geschiktheidscriteria in de "
-"gebruiksvoorwaarden. Daarom kunt u zich niet aanmelden. Als u denkt dat u "
-"zich wel zou moeten kunnen aanmelden, stuur dan een e-mail naar "
-"wikipedialibrary@wikimedia.org."
+msgid "Your Wikipedia account no longer meets the eligibility criteria in the terms of use, so you cannot be logged in. If you think you should be able to log in, please email wikipedialibrary@wikimedia.org."
+msgstr "Uw Wikipedia-account voldoet niet langer aan de geschiktheidscriteria in de gebruiksvoorwaarden. Daarom kunt u zich niet aanmelden. Als u denkt dat u zich wel zou moeten kunnen aanmelden, stuur dan een e-mail naar wikipedialibrary@wikimedia.org."
 
 #. Translators: this message is displayed to users with brand new accounts.
 #: TWLight/users/oauth.py:549
@@ -2955,15 +2280,8 @@ msgstr "Welkom! Ga akkoord met de gebruiksvoorwaarden."
 #. Translators: This message is displayed on the confirmation page where users can return their access to partner collections.
 #: TWLight/users/templates/users/authorization_confirm_return.html:13
 #, python-format
-msgid ""
-"You will no longer be able to access <b>%(partner)s's</b> resources via the "
-"Library Card platform, but can request access again by clicking 'renew', if "
-"you change your mind. Are you sure you want to return your access?"
-msgstr ""
-"U heeft geen toegang meer tot de bronnen van <b>%(partner)s</b> via het "
-"bibliotheekplatform, maar kunt opnieuw toegang aanvragen door op "
-"'vernieuwen' te klikken als u van gedachten verandert. Weet u zeker dat u uw "
-"toegang wilt teruggeven?"
+msgid "You will no longer be able to access <b>%(partner)s's</b> resources via the Library Card platform, but can request access again by clicking 'renew', if you change your mind. Are you sure you want to return your access?"
+msgstr "U heeft geen toegang meer tot de bronnen van <b>%(partner)s</b> via het bibliotheekplatform, maar kunt opnieuw toegang aanvragen door op 'vernieuwen' te klikken als u van gedachten verandert. Weet u zeker dat u uw toegang wilt teruggeven?"
 
 #. Translators: On the MyLibrary page (https://wikipedialibrary.wmflabs.org/users/my_library), this tab shows all favorite collections a user has.
 #: TWLight/users/templates/users/collections_section.html:9
@@ -3032,14 +2350,8 @@ msgstr "Data van redacteur"
 
 #. Translators: This is shown on editor profiles, in their profile page or on applications.
 #: TWLight/users/templates/users/editor_detail.html:59
-msgid ""
-"Information with an * was retrieved from Wikipedia directly. Other "
-"information was entered directly by users or site admins, in their preferred "
-"language."
-msgstr ""
-"Informatie met een * is rechtstreeks uit Wikipedia gehaald. Andere "
-"informatie is rechtstreeks ingevoerd door gebruikers of sitebeheerders, in "
-"hun voorkeurstaal."
+msgid "Information with an * was retrieved from Wikipedia directly. Other information was entered directly by users or site admins, in their preferred language."
+msgstr "Informatie met een * is rechtstreeks uit Wikipedia gehaald. Andere informatie is rechtstreeks ingevoerd door gebruikers of sitebeheerders, in hun voorkeurstaal."
 
 #. Translators: This distinguishes users who have been flagged as account coordinators. Don't translate username.
 #: TWLight/users/templates/users/editor_detail.html:71
@@ -3049,14 +2361,8 @@ msgstr "%(username)s heeft coördinatorrechten op deze site."
 
 #. Translators: This is shown on editor profiles, under the heading for Wikipedia editor data.
 #: TWLight/users/templates/users/editor_detail_data.html:5
-msgid ""
-"This information is updated automatically from your Wikimedia account each "
-"time you log in, except for the Contributions field, where you can describe "
-"your Wikimedia editing history."
-msgstr ""
-"Deze informatie wordt automatisch bijgewerkt vanaf uw Wikimedia-account elke "
-"keer dat u inlogt, behalve het veld Bijdragen, waar u uw "
-"bewerkingsgeschiedenis op Wikimedia kunt beschrijven."
+msgid "This information is updated automatically from your Wikimedia account each time you log in, except for the Contributions field, where you can describe your Wikimedia editing history."
+msgstr "Deze informatie wordt automatisch bijgewerkt vanaf uw Wikimedia-account elke keer dat u inlogt, behalve het veld Bijdragen, waar u uw bewerkingsgeschiedenis op Wikimedia kunt beschrijven."
 
 #. Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this labels the user's username.
 #: TWLight/users/templates/users/editor_detail_data.html:17
@@ -3085,22 +2391,14 @@ msgstr "Voldoet aan de gebruiksvoorwaarden?"
 
 #. Translators: when viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this question has a yes or no answer.
 #: TWLight/users/templates/users/editor_detail_data.html:57
-msgid ""
-"at their last login, did this user meet the criteria set forth in the terms "
-"of use?"
-msgstr ""
-"Voldeed deze gebruiker bij de laatste aanmelding aan de criteria in de "
-"gebruiksvoorwaarden?"
+msgid "at their last login, did this user meet the criteria set forth in the terms of use?"
+msgstr "Voldeed deze gebruiker bij de laatste aanmelding aan de criteria in de gebruiksvoorwaarden?"
 
 #. Translators: When viewing a user's profile in an application, this message shows if the software doesn't think that the user is eligible for access. Don't translate username.
 #: TWLight/users/templates/users/editor_detail_data.html:72
 #, python-format
-msgid ""
-"%(username)s may still be eligible for access grants at the coordinators' "
-"discretion."
-msgstr ""
-"%(username)s kan naar goeddunken van de coördinatoren nog steeds in "
-"aanmerking komen voor toegang."
+msgid "%(username)s may still be eligible for access grants at the coordinators' discretion."
+msgstr "%(username)s kan naar goeddunken van de coördinatoren nog steeds in aanmerking komen voor toegang."
 
 #. Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this is the heading for a Yes/No ToU question.
 #: TWLight/users/templates/users/editor_detail_data.html:83
@@ -3134,15 +2432,8 @@ msgstr "(vrijstelling verleend)"
 #. Translators: This message is shown on a user's profile if their Wikimedia account is blocked on one or more projects. They may still be granted access to the Library Bundle, but need to contact Wikipedia Library staff to verify.
 #: TWLight/users/templates/users/editor_detail_data.html:137
 #, python-format
-msgid ""
-"It looks like you have an active block on your account. If you meet the "
-"other criteria you may still be permitted access to the library - please <a "
-"class=\"twl-links\" href=\"%(contact_url)s\">contact us</a>."
-msgstr ""
-"Het lijkt erop dat u een actieve blokkering op uw account heeft. Als u aan "
-"de andere criteria voldoet, krijgt u mogelijk nog steeds toegang tot de "
-"bibliotheek - <a class=\"twl-links\" href=\"%(contact_url)s\">neem contact "
-"met ons op</a>."
+msgid "It looks like you have an active block on your account. If you meet the other criteria you may still be permitted access to the library - please <a class=\"twl-links\" href=\"%(contact_url)s\">contact us</a>."
+msgstr "Het lijkt erop dat u een actieve blokkering op uw account heeft. Als u aan de andere criteria voldoet, krijgt u mogelijk nog steeds toegang tot de bibliotheek - <a class=\"twl-links\" href=\"%(contact_url)s\">neem contact met ons op</a>."
 
 #. Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this is the heading for a Yes/No program eligibility question.
 #: TWLight/users/templates/users/editor_detail_data.html:153
@@ -3151,15 +2442,8 @@ msgstr "Komt in aanmerking voor de Bibliotheekbundel?"
 
 #. Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this question has a Yes or No answer.
 #: TWLight/users/templates/users/editor_detail_data.html:156
-msgid ""
-"At their last login, did this user meet the criteria set forth in the "
-"Library Bundle? Note that satisfying terms of use is a prerequisite to "
-"bundle eligibility."
-msgstr ""
-"Voldeed deze gebruiker bij de laatste aanmelding aan de criteria die zijn "
-"uiteengezet in de Bibliotheekbundel? Houd er rekening mee dat het voldoen "
-"aan de gebruiksvoorwaarden een voorwaarde is om in aanmerking te komen voor "
-"de bundel."
+msgid "At their last login, did this user meet the criteria set forth in the Library Bundle? Note that satisfying terms of use is a prerequisite to bundle eligibility."
+msgstr "Voldeed deze gebruiker bij de laatste aanmelding aan de criteria die zijn uiteengezet in de Bibliotheekbundel? Houd er rekening mee dat het voldoen aan de gebruiksvoorwaarden een voorwaarde is om in aanmerking te komen voor de bundel."
 
 #. Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this is the heading for a Yes/No program eligibility question.
 #: TWLight/users/templates/users/editor_detail_data.html:177
@@ -3203,24 +2487,14 @@ msgstr "Persoonlijke gegevens"
 
 #. Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this text is in the 'Personal data' section. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/users/templates/users/editor_detail_data.html:262
-msgid ""
-"The following information is visible only to you, site administrators, "
-"publishing partners (where required), and volunteer Wikipedia Library "
-"coordinators (who have signed a Non-Disclosure Agreement)."
-msgstr ""
-"De volgende informatie is alleen zichtbaar voor u, sitebeheerders, "
-"uitgeverspartners (indien vereist) en vrijwillige coördinatoren van de "
-"Wikipedia-bibliotheek (die een geheimhoudingsverklaring hebben ondertekend)."
+msgid "The following information is visible only to you, site administrators, publishing partners (where required), and volunteer Wikipedia Library coordinators (who have signed a Non-Disclosure Agreement)."
+msgstr "De volgende informatie is alleen zichtbaar voor u, sitebeheerders, uitgeverspartners (indien vereist) en vrijwillige coördinatoren van de Wikipedia-bibliotheek (die een geheimhoudingsverklaring hebben ondertekend)."
 
 #. Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this labels a button which users can click to update or remove their personal information. Don't translate update_url.
 #: TWLight/users/templates/users/editor_detail_data.html:272
 #, python-format
-msgid ""
-"You may <a class=\"twl-links\" href=\"%(update_url)s\">update or delete</a> "
-"your data at any time."
-msgstr ""
-"U kunt uw gegevens op elk moment <a class=\"twl-links\" href=\"%(update_url)s"
-"\">bijwerken of verwijderen</a>."
+msgid "You may <a class=\"twl-links\" href=\"%(update_url)s\">update or delete</a> your data at any time."
+msgstr "U kunt uw gegevens op elk moment <a class=\"twl-links\" href=\"%(update_url)s\">bijwerken of verwijderen</a>."
 
 #. Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this labels the user's email. Don't remove the *.
 #: TWLight/users/templates/users/editor_detail_data.html:283
@@ -3239,32 +2513,19 @@ msgstr "Instelling waaraan u verbonden bent"
 
 #. Translators: This message tells users that they are not eligible to access The Wikipedia Library content.
 #: TWLight/users/templates/users/eligibility_modal.html:7
-msgid ""
-"Sorry, your Wikipedia account doesn’t currently qualify to access The "
-"Wikipedia Library."
-msgstr ""
-"Sorry, uw Wikipedia-account komt momenteel niet in aanmerking voor toegang "
-"tot de Wikipedia-bibliotheek."
+msgid "Sorry, your Wikipedia account doesn’t currently qualify to access The Wikipedia Library."
+msgstr "Sorry, uw Wikipedia-account komt momenteel niet in aanmerking voor toegang tot de Wikipedia-bibliotheek."
 
 #. Translators: This message tells users that they have not agreed to the terms of use, therefore are ineligible to access the content in The Wikipedia Library.
 #: TWLight/users/templates/users/eligibility_modal.html:30
 #, python-format
-msgid ""
-"Agreed with <a href=\"%(terms)s\" class=\"text-danger\"> terms of use </a>"
-msgstr ""
-"Is akkoord gegaan met de <a href=\"%(terms)s\" class=\"text-danger"
-"\">gebruiksvoorwaarden</a>?"
+msgid "Agreed with <a href=\"%(terms)s\" class=\"text-danger\"> terms of use </a>"
+msgstr "Is akkoord gegaan met de <a href=\"%(terms)s\" class=\"text-danger\">gebruiksvoorwaarden</a>?"
 
 #: TWLight/users/templates/users/eligibility_modal.html:40
 #, python-format
-msgid ""
-"It looks like you have an active block on your account. If you meet the "
-"other criteria you may still be permitted access to the library - please <a "
-"href=\"%(contact_url)s\">contact us</a>."
-msgstr ""
-"Het lijkt erop dat u een actieve blokkering op uw account heeft. Als u aan "
-"de andere criteria voldoet, krijgt u mogelijk nog steeds toegang tot de "
-"bibliotheek - <a href=\"%(contact_url)s\">neem contact met ons op</a>."
+msgid "It looks like you have an active block on your account. If you meet the other criteria you may still be permitted access to the library - please <a href=\"%(contact_url)s\">contact us</a>."
+msgstr "Het lijkt erop dat u een actieve blokkering op uw account heeft. Als u aan de andere criteria voldoet, krijgt u mogelijk nog steeds toegang tot de bibliotheek - <a href=\"%(contact_url)s\">neem contact met ons op</a>."
 
 #. Translators: Instructions to refresh a user's data.
 #: TWLight/users/templates/users/eligibility_modal.html:50
@@ -3303,14 +2564,8 @@ msgstr "Taal instellen"
 
 #. Translators: This text on the user page helps users naviage to the TranslateWiki Wikipedia Library Card platform translation page.
 #: TWLight/users/templates/users/language_form.html:31
-msgid ""
-"You can help translate the tool at <a class=\"twl-links\" href=\"https://"
-"translatewiki.net/wiki/Translating:Wikipedia_Library_Card_Platform"
-"\">translatewiki.net</a>."
-msgstr ""
-"U kunt de tool helpen vertalen op <a class=\"twl-links\" href=\"https://"
-"translatewiki.net/wiki/Translating:Wikipedia_Library_Card_Platform"
-"\">translatewiki.net</a>."
+msgid "You can help translate the tool at <a class=\"twl-links\" href=\"https://translatewiki.net/wiki/Translating:Wikipedia_Library_Card_Platform\">translatewiki.net</a>."
+msgstr "U kunt de tool helpen vertalen op <a class=\"twl-links\" href=\"https://translatewiki.net/wiki/Translating:Wikipedia_Library_Card_Platform\">translatewiki.net</a>."
 
 #. Translators: When the user starts a new application and submits the application, the user can view the application and withdraw if need be. This changes the label for the Withdraw button.
 #: TWLight/users/templates/users/my_applications.html:65
@@ -3329,12 +2584,8 @@ msgstr "Vernieuwing aanvraag"
 
 #. Translators: On the page listing applications, this text explains a user they cannot renew their application since they've already requested a renewal or there aren't any renewals available.
 #: TWLight/users/templates/users/my_applications.html:79
-msgid ""
-"Renewals are either not required, not available right now, or you have "
-"already requested a renewal."
-msgstr ""
-"Verlengingen zijn ofwel niet vereist, zijn momenteel niet beschikbaar of u "
-"heeft al een verlenging aangevraagd."
+msgid "Renewals are either not required, not available right now, or you have already requested a renewal."
+msgstr "Verlengingen zijn ofwel niet vereist, zijn momenteel niet beschikbaar of u heeft al een verlenging aangevraagd."
 
 #. Translators: This text is the heading of a section in a user's profile where they can change their preferences.
 #: TWLight/users/templates/users/preferences.html:6
@@ -3397,28 +2648,13 @@ msgstr "Gegevensverwerking beperken"
 
 #. Translators: This message is displayed on the page where users can request we stop processing their data.
 #: TWLight/users/templates/users/restrict_data.html:15
-msgid ""
-"Checking this box and clicking “Restrict” will pause all processing of the "
-"data you have entered into this website. You will not be able to apply for "
-"access to resources, your applications will not be further processed, and "
-"none of your data will be altered, until you return to this page and uncheck "
-"the box. This is not the same as deleting your data."
-msgstr ""
-"Als u dit vakje aanvinkt en op \"Beperken\" klikt, wordt alle verwerking van "
-"gegevens onderbroken die u op deze website heeft ingevoerd. U kunt geen "
-"toegang tot bronnen aanvragen, uw aanvragen worden niet verder verwerkt en "
-"uw gegevens worden niet gewijzigd totdat u terugkeert naar deze pagina en "
-"het selectievakje uitvinkt. Dit is niet hetzelfde als het verwijderen van uw "
-"gegevens."
+msgid "Checking this box and clicking “Restrict” will pause all processing of the data you have entered into this website. You will not be able to apply for access to resources, your applications will not be further processed, and none of your data will be altered, until you return to this page and uncheck the box. This is not the same as deleting your data."
+msgstr "Als u dit vakje aanvinkt en op \"Beperken\" klikt, wordt alle verwerking van gegevens onderbroken die u op deze website heeft ingevoerd. U kunt geen toegang tot bronnen aanvragen, uw aanvragen worden niet verder verwerkt en uw gegevens worden niet gewijzigd totdat u terugkeert naar deze pagina en het selectievakje uitvinkt. Dit is niet hetzelfde als het verwijderen van uw gegevens."
 
 #. Translators: This warning message is shown to coordinators who view the data restriction page.
 #: TWLight/users/templates/users/restrict_data.html:26
-msgid ""
-"You are a coordinator on this site. If you restrict the processing of your "
-"data, your coordinator flag will be removed."
-msgstr ""
-"U bent coördinator op deze site. Als u de verwerking van uw gegevens "
-"beperkt, wordt uw coördinator-vlag verwijderd."
+msgid "You are a coordinator on this site. If you restrict the processing of your data, your coordinator flag will be removed."
+msgstr "U bent coördinator op deze site. Als u de verwerking van uw gegevens beperkt, wordt uw coördinator-vlag verwijderd."
 
 #. Translators: use the date *when you are translating*, in a language-appropriate format.
 #: TWLight/users/templates/users/terms.html:33
@@ -3433,43 +2669,17 @@ msgstr "Privacybeleid van de Wikimedia Foundation"
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:41
 msgid "Wikipedia Library Card Terms of Use and Privacy Statement"
-msgstr ""
-"Gebruiksvoorwaarden en privacyverklaring van Wikipedia-bibliotheekkaart"
+msgstr "Gebruiksvoorwaarden en privacyverklaring van Wikipedia-bibliotheekkaart"
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:51
-msgid ""
-"<a class=\"twl-links\" href=\"https://meta.wikimedia.org/wiki/"
-"The_Wikipedia_Library\"> The Wikipedia Library </a> has partnered with "
-"publishers around the world to allow users to access otherwise paywalled "
-"resources. This website allows Wikipedia editors to search and access these "
-"resources."
-msgstr ""
-"<a class=\"twl-links\" href=\"https://meta.wikimedia.org/wiki/"
-"The_Wikipedia_Library\"> De Wikipedia-bibliotheek </a> werkt samen met "
-"uitgevers over de hele wereld om gebruikers toegang te geven tot bronnen die "
-"anders een betaalmuur zouden zitten. Deze website stelt Wikipedia-"
-"redacteuren in staat om deze bronnen te doorzoeken en te openen."
+msgid "<a class=\"twl-links\" href=\"https://meta.wikimedia.org/wiki/The_Wikipedia_Library\"> The Wikipedia Library </a> has partnered with publishers around the world to allow users to access otherwise paywalled resources. This website allows Wikipedia editors to search and access these resources."
+msgstr "<a class=\"twl-links\" href=\"https://meta.wikimedia.org/wiki/The_Wikipedia_Library\"> De Wikipedia-bibliotheek </a> werkt samen met uitgevers over de hele wereld om gebruikers toegang te geven tot bronnen die anders een betaalmuur zouden zitten. Deze website stelt Wikipedia-redacteuren in staat om deze bronnen te doorzoeken en te openen."
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Wikimedia Foundation should not be translated. WMF should not be translated. Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:63
-msgid ""
-"This program is administered by the Wikimedia Foundation (WMF). These terms "
-"of use and privacy notice pertain to your application for access to "
-"resources through the Wikipedia Library, your use of this website, and your "
-"access to and use of those resources. They also describe our handling of the "
-"information you provide to us in order to create and administer your "
-"Wikipedia Library account. If we make material changes to the terms, we will "
-"notify users."
-msgstr ""
-"Dit programma wordt beheerd door de Wikimedia Foundation (WMF). Deze "
-"gebruiksvoorwaarden en privacyverklaring hebben betrekking op uw aanvraag "
-"voor toegang tot bronnen via de Wikipedia-bibliotheek, uw gebruik van deze "
-"website en uw toegang tot en gebruik van die bronnen. Ze beschrijven ook hoe "
-"we omgaan met de informatie die u ons verstrekt om uw account in de "
-"Wikipedia-bibliotheek aan te maken en te beheren. Als we belangrijke "
-"wijzigingen aanbrengen in de voorwaarden, zullen we gebruikers hiervan op de "
-"hoogte stellen."
+msgid "This program is administered by the Wikimedia Foundation (WMF). These terms of use and privacy notice pertain to your application for access to resources through the Wikipedia Library, your use of this website, and your access to and use of those resources. They also describe our handling of the information you provide to us in order to create and administer your Wikipedia Library account. If we make material changes to the terms, we will notify users."
+msgstr "Dit programma wordt beheerd door de Wikimedia Foundation (WMF). Deze gebruiksvoorwaarden en privacyverklaring hebben betrekking op uw aanvraag voor toegang tot bronnen via de Wikipedia-bibliotheek, uw gebruik van deze website en uw toegang tot en gebruik van die bronnen. Ze beschrijven ook hoe we omgaan met de informatie die u ons verstrekt om uw account in de Wikipedia-bibliotheek aan te maken en te beheren. Als we belangrijke wijzigingen aanbrengen in de voorwaarden, zullen we gebruikers hiervan op de hoogte stellen."
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:74
@@ -3478,59 +2688,18 @@ msgstr "Vereisten voor een account in de Wikipedia-bibliotheek"
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:78
-msgid ""
-"Access to resources via The Wikipedia Library is reserved for community "
-"members who have demonstrated their commitment to the Wikimedia projects, "
-"and who will use their access to these resources to improve project content. "
-"To that end, in order to be eligible for The Wikipedia Library, we require "
-"that you be registered for a user account on the projects, with at least 500 "
-"edits, six (6) months of activity, and 10+ edits in the last month. We ask "
-"that you do not request access to any publishers with a limited number of "
-"available accounts whose resources you can already access for free through "
-"your local library or university, or another institution or organization, in "
-"order to provide that opportunity to others."
-msgstr ""
-"Toegang tot bronnen via de Wikipedia-bibliotheek is gereserveerd voor leden "
-"van de gemeenschap die hun betrokkenheid bij de Wikimedia-projecten hebben "
-"getoond en die hun toegang tot deze bronnen zullen gebruiken om de "
-"projectinhoud te verbeteren. Om in aanmerking te komen voor de Wikipedia-"
-"bibliotheek, vereisen we daarom dat u geregistreerd bent met een "
-"gebruikersaccount voor de projecten, met ten minste 500 bewerkingen, zes "
-"maanden activiteit en 10+ bewerkingen in de afgelopen maand. We vragen u "
-"geen toegang te vragen van uitgevers met een beperkt aantal beschikbare "
-"accounts waarvan u al gratis toegang heeft via uw plaatselijke bibliotheek "
-"of universiteit, of een andere instelling of organisatie, zodat we die "
-"mogelijkheid aan anderen kunnen bieden."
+msgid "Access to resources via The Wikipedia Library is reserved for community members who have demonstrated their commitment to the Wikimedia projects, and who will use their access to these resources to improve project content. To that end, in order to be eligible for The Wikipedia Library, we require that you be registered for a user account on the projects, with at least 500 edits, six (6) months of activity, and 10+ edits in the last month. We ask that you do not request access to any publishers with a limited number of available accounts whose resources you can already access for free through your local library or university, or another institution or organization, in order to provide that opportunity to others."
+msgstr "Toegang tot bronnen via de Wikipedia-bibliotheek is gereserveerd voor leden van de gemeenschap die hun betrokkenheid bij de Wikimedia-projecten hebben getoond en die hun toegang tot deze bronnen zullen gebruiken om de projectinhoud te verbeteren. Om in aanmerking te komen voor de Wikipedia-bibliotheek, vereisen we daarom dat u geregistreerd bent met een gebruikersaccount voor de projecten, met ten minste 500 bewerkingen, zes maanden activiteit en 10+ bewerkingen in de afgelopen maand. We vragen u geen toegang te vragen van uitgevers met een beperkt aantal beschikbare accounts waarvan u al gratis toegang heeft via uw plaatselijke bibliotheek of universiteit, of een andere instelling of organisatie, zodat we die mogelijkheid aan anderen kunnen bieden."
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:94
-msgid ""
-"Additionally, if you are currently blocked or banned from a Wikimedia "
-"project, applications to resources may be rejected or restricted. If you "
-"obtain a Wikipedia Library account, but a block or ban is subsequently "
-"instituted against you on one of the projects, you may lose access to your "
-"Wikipedia Library account."
-msgstr ""
-"Bovendien, als u momenteel bent geblokkeerd of verbannen uit een Wikimedia-"
-"project, kunnen aanvragen voor bronnen worden afgewezen of beperkt. Als u "
-"een account in de Wikipedia-bibliotheek verkrijgt, maar er vervolgens een "
-"blokkering of verbod op u wordt ingesteld voor een van de projecten, kunt u "
-"de toegang tot uw account in de Wikipedia-bibliotheek kwijtraken."
+msgid "Additionally, if you are currently blocked or banned from a Wikimedia project, applications to resources may be rejected or restricted. If you obtain a Wikipedia Library account, but a block or ban is subsequently instituted against you on one of the projects, you may lose access to your Wikipedia Library account."
+msgstr "Bovendien, als u momenteel bent geblokkeerd of verbannen uit een Wikimedia-project, kunnen aanvragen voor bronnen worden afgewezen of beperkt. Als u een account in de Wikipedia-bibliotheek verkrijgt, maar er vervolgens een blokkering of verbod op u wordt ingesteld voor een van de projecten, kunt u de toegang tot uw account in de Wikipedia-bibliotheek kwijtraken."
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:104
-msgid ""
-"Your eligibility to access The Wikipedia Library is assessed at each login. "
-"While more than half of the library's content is provided via this automated "
-"eligibility check, access to other publisher's content may be time limited, "
-"typically lapsing after one year, after which you will usually need to apply "
-"for renewal."
-msgstr ""
-"Bij elke login wordt beoordeeld of u in aanmerking komt voor toegang tot de "
-"Wikipedia-bibliotheek. Hoewel meer dan de helft van de inhoud van de "
-"bibliotheek wordt geleverd via deze geautomatiseerde geschiktheidscontrole, "
-"kan de toegang tot de inhoud van andere uitgevers in de tijd beperkt zijn, "
-"meestal na een jaar, waarna u gewoonlijk verlenging moet aanvragen."
+msgid "Your eligibility to access The Wikipedia Library is assessed at each login. While more than half of the library's content is provided via this automated eligibility check, access to other publisher's content may be time limited, typically lapsing after one year, after which you will usually need to apply for renewal."
+msgstr "Bij elke login wordt beoordeeld of u in aanmerking komt voor toegang tot de Wikipedia-bibliotheek. Hoewel meer dan de helft van de inhoud van de bibliotheek wordt geleverd via deze geautomatiseerde geschiktheidscontrole, kan de toegang tot de inhoud van andere uitgevers in de tijd beperkt zijn, meestal na een jaar, waarna u gewoonlijk verlenging moet aanvragen."
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:114
@@ -3539,70 +2708,28 @@ msgstr "Uw account in de Wikipedia-bibliotheek aanvragen"
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:118
-msgid ""
-"In order to apply for access to a partner resource, you must provide us with "
-"certain information, which we will use to evaluate your application. If your "
-"application is approved, we may transfer the information you have given us "
-"to the publishers whose resources you wish to access. They will either "
-"contact you with the account information directly or we will send access "
-"information to you ourselves."
-msgstr ""
-"Om toegang tot een partnerbron aan te vragen, moet u ons bepaalde informatie "
-"verstrekken, die we zullen gebruiken om uw aanvraag te evalueren. Als uw "
-"aanvraag wordt goedgekeurd, kunnen we de informatie die u ons hebt gegeven "
-"overdragen aan de uitgevers waarvan u toegang wilt hebben. Ze zullen ofwel "
-"rechtstreeks contact met u opnemen met de accountgegevens of we zullen u "
-"zelf toegangsgegevens toesturen."
+msgid "In order to apply for access to a partner resource, you must provide us with certain information, which we will use to evaluate your application. If your application is approved, we may transfer the information you have given us to the publishers whose resources you wish to access. They will either contact you with the account information directly or we will send access information to you ourselves."
+msgstr "Om toegang tot een partnerbron aan te vragen, moet u ons bepaalde informatie verstrekken, die we zullen gebruiken om uw aanvraag te evalueren. Als uw aanvraag wordt goedgekeurd, kunnen we de informatie die u ons hebt gegeven overdragen aan de uitgevers waarvan u toegang wilt hebben. Ze zullen ofwel rechtstreeks contact met u opnemen met de accountgegevens of we zullen u zelf toegangsgegevens toesturen."
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:130
-msgid ""
-"In addition to the basic information you provide to us, our system will "
-"retrieve some information directly from the Wikimedia projects: your "
-"username, email address, edit count, registration date, user ID number, "
-"groups to which you belong, and any special user rights."
-msgstr ""
-"Naast de basisinformatie die u aan ons verstrekt, haalt ons systeem "
-"informatie rechtstreeks uit de Wikimedia-projecten: uw gebruikersnaam, e-"
-"mailadres, aantal bewerkingen, registratiedatum, gebruikersnummer, groepen "
-"waartoe u behoort en eventuele speciale gebruikersrechten."
+msgid "In addition to the basic information you provide to us, our system will retrieve some information directly from the Wikimedia projects: your username, email address, edit count, registration date, user ID number, groups to which you belong, and any special user rights."
+msgstr "Naast de basisinformatie die u aan ons verstrekt, haalt ons systeem informatie rechtstreeks uit de Wikimedia-projecten: uw gebruikersnaam, e-mailadres, aantal bewerkingen, registratiedatum, gebruikersnummer, groepen waartoe u behoort en eventuele speciale gebruikersrechten."
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:140
-msgid ""
-"Each time you log in to the Wikipedia Library Card Platform, this "
-"information will be automatically updated."
-msgstr ""
-"Elke keer dat u inlogt op het platform van de Wikipedia-bibliotheek, wordt "
-"deze informatie automatisch bijgewerkt."
+msgid "Each time you log in to the Wikipedia Library Card Platform, this information will be automatically updated."
+msgstr "Elke keer dat u inlogt op het platform van de Wikipedia-bibliotheek, wordt deze informatie automatisch bijgewerkt."
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:148
-msgid ""
-"We will ask you to provide us with some information about your history of "
-"contributions to the Wikimedia projects. Information on contribution history "
-"is optional, but will greatly assist us in evaluating your application."
-msgstr ""
-"We zullen u vragen om ons wat informatie te verstrekken over uw geschiedenis "
-"van bijdragen aan de Wikimedia-projecten. Informatie over de "
-"bijdragegeschiedenis is optioneel, maar zal ons enorm helpen bij het "
-"evalueren van uw aanvraag."
+msgid "We will ask you to provide us with some information about your history of contributions to the Wikimedia projects. Information on contribution history is optional, but will greatly assist us in evaluating your application."
+msgstr "We zullen u vragen om ons wat informatie te verstrekken over uw geschiedenis van bijdragen aan de Wikimedia-projecten. Informatie over de bijdragegeschiedenis is optioneel, maar zal ons enorm helpen bij het evalueren van uw aanvraag."
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). WMF should not be translated. Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:157
-msgid ""
-"The information you provide when creating your account will be visible to "
-"you while on the site but not to others unless they are approved Wikipedia "
-"Library Coordinators, WMF Staff, or WMF Contractors who need access to this "
-"data in order to carry out their work with the Wikipedia Library, all of "
-"whom are subject to non-disclosure obligations."
-msgstr ""
-"De informatie die u verstrekt bij het maken van uw account is voor u "
-"zichtbaar terwijl u op de site bent, maar niet voor anderen, tenzij dit "
-"goedgekeurde coördinatoren van de Wikipedia-bibliotheek, WMF-medewerkers of "
-"WMF-contractanten zijn die toegang tot deze gegevens nodig hebben voor hun "
-"werk in de Wikipedia-bibliotheek en die allemaal onderworpen zijn aan "
-"geheimhoudingsverplichtingen."
+msgid "The information you provide when creating your account will be visible to you while on the site but not to others unless they are approved Wikipedia Library Coordinators, WMF Staff, or WMF Contractors who need access to this data in order to carry out their work with the Wikipedia Library, all of whom are subject to non-disclosure obligations."
+msgstr "De informatie die u verstrekt bij het maken van uw account is voor u zichtbaar terwijl u op de site bent, maar niet voor anderen, tenzij dit goedgekeurde coördinatoren van de Wikipedia-bibliotheek, WMF-medewerkers of WMF-contractanten zijn die toegang tot deze gegevens nodig hebben voor hun werk in de Wikipedia-bibliotheek en die allemaal onderworpen zijn aan geheimhoudingsverplichtingen."
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:167
@@ -3611,64 +2738,33 @@ msgstr "Uw gebruik van uitgeversbronnen"
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:171
-msgid ""
-"In order to access an individual publisher’s resources, you must agree to "
-"that publisher’s terms of use and privacy policy. You agree that you will "
-"not violate such terms and policies in connection with your use of the "
-"Wikipedia Library. Additionally, the following activities are prohibited "
-"while accessing publisher resources through the Wikipedia Library."
-msgstr ""
-"Om toegang te krijgen tot de bronnen van een individuele uitgever, moet u "
-"akkoord gaan met de gebruiksvoorwaarden en het privacybeleid van die "
-"uitgever. U stemt ermee in dat u dergelijke voorwaarden en beleid in verband "
-"met uw gebruik van de Wikipedia-bibliotheek niet zult schenden. Bovendien "
-"zijn de volgende activiteiten verboden tijdens het openen van bronnen van "
-"uitgevers via de Wikipedia-bibliotheek."
+msgid "In order to access an individual publisher’s resources, you must agree to that publisher’s terms of use and privacy policy. You agree that you will not violate such terms and policies in connection with your use of the Wikipedia Library. Additionally, the following activities are prohibited while accessing publisher resources through the Wikipedia Library."
+msgstr "Om toegang te krijgen tot de bronnen van een individuele uitgever, moet u akkoord gaan met de gebruiksvoorwaarden en het privacybeleid van die uitgever. U stemt ermee in dat u dergelijke voorwaarden en beleid in verband met uw gebruik van de Wikipedia-bibliotheek niet zult schenden. Bovendien zijn de volgende activiteiten verboden tijdens het openen van bronnen van uitgevers via de Wikipedia-bibliotheek."
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:184
-msgid ""
-"Sharing your Wikipedia account, usernames, passwords, or any access codes "
-"for publisher resources with others;"
-msgstr ""
-"Het delen van uw Wikipedia-account, gebruikersnamen, wachtwoorden of "
-"toegangscodes voor bronnen van uitgevers met anderen;"
+msgid "Sharing your Wikipedia account, usernames, passwords, or any access codes for publisher resources with others;"
+msgstr "Het delen van uw Wikipedia-account, gebruikersnamen, wachtwoorden of toegangscodes voor bronnen van uitgevers met anderen;"
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:191
-msgid ""
-"Automatically scraping or downloading restricted content from publishers;"
-msgstr ""
-"Automatisch scrapen of downloaden van de beperkt toegankelijke inhoud van "
-"uitgevers;"
+msgid "Automatically scraping or downloading restricted content from publishers;"
+msgstr "Automatisch scrapen of downloaden van de beperkt toegankelijke inhoud van uitgevers;"
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:197
-msgid ""
-"Systematically making printed or electronic copies of multiple extracts of "
-"restricted content available for any purpose;"
-msgstr ""
-"Het systematisch beschikbaar stellen van gedrukte of elektronische kopieën "
-"van meerdere fragmenten van beperkt toegankelijke inhoud voor welk doel dan "
-"ook;"
+msgid "Systematically making printed or electronic copies of multiple extracts of restricted content available for any purpose;"
+msgstr "Het systematisch beschikbaar stellen van gedrukte of elektronische kopieën van meerdere fragmenten van beperkt toegankelijke inhoud voor welk doel dan ook;"
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:204
-msgid ""
-"Data mining metadata without permission—for example, in order to use "
-"metadata for auto-created stub articles;"
-msgstr ""
-"Datamining van metadata zonder toestemming, bijvoorbeeld om metadata te "
-"gebruiken voor automatisch gemaakte beginnetjes-artikelen;"
+msgid "Data mining metadata without permission—for example, in order to use metadata for auto-created stub articles;"
+msgstr "Datamining van metadata zonder toestemming, bijvoorbeeld om metadata te gebruiken voor automatisch gemaakte beginnetjes-artikelen;"
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:211
-msgid ""
-"Using the access you receive through the Wikipedia Library for profit by "
-"selling access to your account or resources which you have through it."
-msgstr ""
-"De toegang die u krijgt via de Wikipedia-bibliotheek voor winst gebruiken "
-"door toegang tot uw account of bronnen die u erdoor heeft te verkopen."
+msgid "Using the access you receive through the Wikipedia Library for profit by selling access to your account or resources which you have through it."
+msgstr "De toegang die u krijgt via de Wikipedia-bibliotheek voor winst gebruiken door toegang tot uw account of bronnen die u erdoor heeft te verkopen."
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:220
@@ -3677,25 +2773,13 @@ msgstr "Externe zoek- en volmachtsdiensten"
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:224
-msgid ""
-"Certain resources may only be accessed using an external search service, "
-"such as the EBSCO Discovery Service, or a proxy service, such as OCLC "
-"EZProxy. If you use such external search and/or proxy services, please "
-"review the applicable terms of use and privacy policies."
-msgstr ""
-"Bepaalde bronnen zijn alleen toegankelijk via een externe zoekdienst, zoals "
-"de EBSCO Discovery Service, of een volmachtsdienst, zoals OCLC EZProxy. Als "
-"u dergelijke externe zoek- en/of volmachtsdiensten gebruikt, raadpleeg dan "
-"de toepasselijke gebruiksvoorwaarden en het privacybeleid."
+msgid "Certain resources may only be accessed using an external search service, such as the EBSCO Discovery Service, or a proxy service, such as OCLC EZProxy. If you use such external search and/or proxy services, please review the applicable terms of use and privacy policies."
+msgstr "Bepaalde bronnen zijn alleen toegankelijk via een externe zoekdienst, zoals de EBSCO Discovery Service, of een volmachtsdienst, zoals OCLC EZProxy. Als u dergelijke externe zoek- en/of volmachtsdiensten gebruikt, raadpleeg dan de toepasselijke gebruiksvoorwaarden en het privacybeleid."
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:234
-msgid ""
-"In addition, if you use OCLC EZProxy, please note that you may not use it "
-"for commercial purposes."
-msgstr ""
-"In aanvulling hierop, als u OCLC EZProxy gebruikt, houd er dan rekening mee "
-"dat u deze niet voor commerciële doeleinden mag gebruiken."
+msgid "In addition, if you use OCLC EZProxy, please note that you may not use it for commercial purposes."
+msgstr "In aanvulling hierop, als u OCLC EZProxy gebruikt, houd er dan rekening mee dat u deze niet voor commerciële doeleinden mag gebruiken."
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:241
@@ -3704,201 +2788,50 @@ msgstr "Bewaring en verwerking van gegevens"
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Wikimedia Foundation should not be translated. Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:245
-msgid ""
-"The Wikimedia Foundation and our service providers use your information for "
-"the legitimate purpose of providing Wikipedia Library services in support of "
-"our charitable mission. When you apply for a Wikipedia Library account, or "
-"use your Wikipedia Library account, we may routinely collect the following "
-"information: your username, email address, edit count, registration date, "
-"user ID number, groups to which you belong, and any special user rights; "
-"your name, country of residence, and/or affiliation, if required by a "
-"partner to which you are applying; your narrative description of your "
-"contributions and reasons for applying for access to partner resources; and "
-"the date you agree to these terms of use."
-msgstr ""
-"De Wikimedia Foundation en onze serviceproviders gebruiken uw informatie "
-"voor het legitieme doel om Wikipedia-bibliotheekdiensten te leveren ter "
-"ondersteuning van onze liefdadigheidsmissie. Wanneer u een account in de "
-"Wikipedia-bibliotheek aanvraagt of uw bibliotheekaccount gebruikt, kunnen we "
-"routinematig de volgende informatie verzamelen: uw gebruikersnaam, e-"
-"mailadres, bewerkingsaantal, registratiedatum, gebruikersnummer, groepen "
-"waartoe u behoort en eventuele speciale gebruikersrechten; uw naam, land van "
-"verblijf en/of de instelling waaraan u verbonden bent, indien vereist door "
-"een partner bij wie u aanvraagt; uw beschrijvende beschrijving van uw "
-"bijdragen en redenen voor het aanvragen van toegang tot partnerbronnen; en "
-"de datum waarop u akkoord gaat met deze gebruiksvoorwaarden."
+msgid "The Wikimedia Foundation and our service providers use your information for the legitimate purpose of providing Wikipedia Library services in support of our charitable mission. When you apply for a Wikipedia Library account, or use your Wikipedia Library account, we may routinely collect the following information: your username, email address, edit count, registration date, user ID number, groups to which you belong, and any special user rights; your name, country of residence, and/or affiliation, if required by a partner to which you are applying; your narrative description of your contributions and reasons for applying for access to partner resources; and the date you agree to these terms of use."
+msgstr "De Wikimedia Foundation en onze serviceproviders gebruiken uw informatie voor het legitieme doel om Wikipedia-bibliotheekdiensten te leveren ter ondersteuning van onze liefdadigheidsmissie. Wanneer u een account in de Wikipedia-bibliotheek aanvraagt of uw bibliotheekaccount gebruikt, kunnen we routinematig de volgende informatie verzamelen: uw gebruikersnaam, e-mailadres, bewerkingsaantal, registratiedatum, gebruikersnummer, groepen waartoe u behoort en eventuele speciale gebruikersrechten; uw naam, land van verblijf en/of de instelling waaraan u verbonden bent, indien vereist door een partner bij wie u aanvraagt; uw beschrijvende beschrijving van uw bijdragen en redenen voor het aanvragen van toegang tot partnerbronnen; en de datum waarop u akkoord gaat met deze gebruiksvoorwaarden."
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:262
 #, python-format
-msgid ""
-"Each publisher who is a member of the Wikipedia Library program requires "
-"different specific information in the application. Some publishers may "
-"request only an email address, while others request more detailed data, such "
-"as your name, location, or institutional affiliation. When you complete your "
-"application, you will only be asked to supply information required by the "
-"publishers you have chosen, and each publisher will only receive the "
-"information they require for providing you with access. Please see our <a "
-"class=\"twl-links\" href=\"%(all_partners_url)s\">partner information</a> "
-"pages to learn what information is required by each publisher to gain access "
-"to their resources."
-msgstr ""
-"Elke uitgever die lid is van het programma van de Wikipedia-bibliotheek "
-"heeft andere specifieke informatie nodig in de aanvraag. Sommige uitgevers "
-"vragen mogelijk alleen om een e-mailadres, terwijl andere om meer "
-"gedetailleerde gegevens vragen, zoals uw naam, locatie of instelling. "
-"Wanneer u uw aanvraag voltooit, wordt u alleen gevraagd om informatie te "
-"verstrekken die nodig is door de uitgevers die u heeft gekozen, en elke "
-"uitgever ontvangt alleen de informatie die ze nodig hebben om u toegang te "
-"verlenen. Bekijk onze <a class=\"twl-links\" href=\"%(all_partners_url)s"
-"\">partnerinformatie</a>-pagina's om te zien welke informatie elke uitgever "
-"nodig heeft om toegang te krijgen tot hun bronnen."
+msgid "Each publisher who is a member of the Wikipedia Library program requires different specific information in the application. Some publishers may request only an email address, while others request more detailed data, such as your name, location, or institutional affiliation. When you complete your application, you will only be asked to supply information required by the publishers you have chosen, and each publisher will only receive the information they require for providing you with access. Please see our <a class=\"twl-links\" href=\"%(all_partners_url)s\">partner information</a> pages to learn what information is required by each publisher to gain access to their resources."
+msgstr "Elke uitgever die lid is van het programma van de Wikipedia-bibliotheek heeft andere specifieke informatie nodig in de aanvraag. Sommige uitgevers vragen mogelijk alleen om een e-mailadres, terwijl andere om meer gedetailleerde gegevens vragen, zoals uw naam, locatie of instelling. Wanneer u uw aanvraag voltooit, wordt u alleen gevraagd om informatie te verstrekken die nodig is door de uitgevers die u heeft gekozen, en elke uitgever ontvangt alleen de informatie die ze nodig hebben om u toegang te verlenen. Bekijk onze <a class=\"twl-links\" href=\"%(all_partners_url)s\">partnerinformatie</a>-pagina's om te zien welke informatie elke uitgever nodig heeft om toegang te krijgen tot hun bronnen."
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Wikimedia Foundation should not be translated. Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:277
-msgid ""
-"Some Wikipedia Library pages are visible without logging in, but you will "
-"need to log in to apply or access proprietary partner resources. We use the "
-"data provided by you via OAuth and Wikimedia API calls to assess your "
-"application for access and to process approved requests."
-msgstr ""
-"Sommige Wikipedia-bibliotheekpagina’s zijn zichtbaar zonder aanmelden. Wel "
-"moet u zich aanmelden om materiaal van partners aan te vragen of te openen. "
-"We gebruiken de gegevens die u via OAuth en Wikimedia API-aanroepen "
-"verstrekt om uw aanvraag voor toegang te beoordelen en goedgekeurde "
-"verzoeken te verwerken."
+msgid "Some Wikipedia Library pages are visible without logging in, but you will need to log in to apply or access proprietary partner resources. We use the data provided by you via OAuth and Wikimedia API calls to assess your application for access and to process approved requests."
+msgstr "Sommige Wikipedia-bibliotheekpagina’s zijn zichtbaar zonder aanmelden. Wel moet u zich aanmelden om materiaal van partners aan te vragen of te openen. We gebruiken de gegevens die u via OAuth en Wikimedia API-aanroepen verstrekt om uw aanvraag voor toegang te beoordelen en goedgekeurde verzoeken te verwerken."
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:288
 #, python-format
-msgid ""
-"In order to administer the Wikipedia Library program, we will retain the "
-"application data we collect from you for three years after your most recent "
-"login, unless you delete your account, as described below. You can log in "
-"and go to <a class=\"twl-links\" href=\"%(profile_url)s\">your profile page</"
-"a> in order to see the information associated with your account, and can "
-"download it in JSON format. You may access, update, restrict, or delete this "
-"information at any time, except for the information that is automatically "
-"retrieved from the projects. If you have any questions or concerns about the "
-"handling of your data, please contact <a class=\"twl-links\" href=\"mailto:"
-"wikipedialibrary@wikimedia.org?Subject=Wikipedia%%20Library%%20Card"
-"%%20account%%20deactivation\"> wikipedialibrary@wikimedia.org </a>."
-msgstr ""
-"Om het programma van de Wikipedia-bibliotheek te beheren, bewaren we de "
-"aanvraaggegevens die we van u verzamelen gedurende drie jaar na uw meest "
-"recente aanmelding, tenzij u uw account verwijdert, zoals hieronder "
-"beschreven. U kunt zich aanmelden en naar <a class=\"twl-links\" href="
-"\"%(profile_url)s\">uw profielpagina</a> gaan om de informatie te zien die "
-"aan uw account is gekoppeld en deze in JSON-formaat downloaden. U kunt deze "
-"informatie op elk moment openen, bijwerken, beperken of verwijderen, behalve "
-"de informatie die automatisch wordt opgehaald uit de projecten. Als u vragen "
-"of opmerkingen heeft over de verwerking van uw gegevens, neem dan contact op "
-"met <a class=\"twl-links\" href=\"mailto:wikipedialibrary@wikimedia.org?"
-"Subject=Wikipedia%%20Library%%20Card%%20account%% 20deactivatie\"> "
-"wikipedialibrary@wikimedia.org </a>."
+msgid "In order to administer the Wikipedia Library program, we will retain the application data we collect from you for three years after your most recent login, unless you delete your account, as described below. You can log in and go to <a class=\"twl-links\" href=\"%(profile_url)s\">your profile page</a> in order to see the information associated with your account, and can download it in JSON format. You may access, update, restrict, or delete this information at any time, except for the information that is automatically retrieved from the projects. If you have any questions or concerns about the handling of your data, please contact <a class=\"twl-links\" href=\"mailto:wikipedialibrary@wikimedia.org?Subject=Wikipedia%%20Library%%20Card%%20account%%20deactivation\"> wikipedialibrary@wikimedia.org </a>."
+msgstr "Om het programma van de Wikipedia-bibliotheek te beheren, bewaren we de aanvraaggegevens die we van u verzamelen gedurende drie jaar na uw meest recente aanmelding, tenzij u uw account verwijdert, zoals hieronder beschreven. U kunt zich aanmelden en naar <a class=\"twl-links\" href=\"%(profile_url)s\">uw profielpagina</a> gaan om de informatie te zien die aan uw account is gekoppeld en deze in JSON-formaat downloaden. U kunt deze informatie op elk moment openen, bijwerken, beperken of verwijderen, behalve de informatie die automatisch wordt opgehaald uit de projecten. Als u vragen of opmerkingen heeft over de verwerking van uw gegevens, neem dan contact op met <a class=\"twl-links\" href=\"mailto:wikipedialibrary@wikimedia.org?Subject=Wikipedia%%20Library%%20Card%%20account%% 20deactivatie\"> wikipedialibrary@wikimedia.org </a>."
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:305
-msgid ""
-"If you decide to disable your Wikipedia Library account, you can use the "
-"delete button on your profile to delete certain personal information "
-"associated with your account. We will delete your real name, institutional "
-"affiliation, and country of residence. Please note that the system will "
-"retain a record of your username, the publishers to which you applied or had "
-"access, and the dates of that access. Note that deletion is not reversible. "
-"Deletion of your Wikipedia Library account may also correspond with the "
-"removal of any resource access to which you were eligible or approved. If "
-"you request the deletion of account information and later wish to apply for "
-"a new account, you will need to provide the necessary information again."
-msgstr ""
-"Als u besluit uw account in de Wikipedia-bibliotheek uit te schakelen, kunt "
-"u de verwijderknop op uw profiel gebruiken om bepaalde persoonlijke "
-"informatie te verwijderen die aan uw account is gekoppeld. We zullen uw "
-"echte naam, institutionele aansluiting en land van verblijf verwijderen. "
-"Houd er rekening mee dat het systeem uw gebruikersnaam, de uitgevers waarbij "
-"u zich heeft aangemeld of toegang had, en de data van die toegang bijhoudt. "
-"Houd er rekening mee dat het verwijderen niet onomkeerbaar is. Het "
-"verwijderen van uw account in de Wikipedia-bibliotheek kan ook overeenkomen "
-"met het verwijderen van toegang tot bronnen waarvoor u in aanmerking kwam of "
-"waarvoor u was goedgekeurd. Als u verzoekt om verwijdering van "
-"accountgegevens en later een nieuw bibliotheekaccount wilt aanvragen, moet u "
-"de benodigde gegevens opnieuw verstrekken."
+msgid "If you decide to disable your Wikipedia Library account, you can use the delete button on your profile to delete certain personal information associated with your account. We will delete your real name, institutional affiliation, and country of residence. Please note that the system will retain a record of your username, the publishers to which you applied or had access, and the dates of that access. Note that deletion is not reversible. Deletion of your Wikipedia Library account may also correspond with the removal of any resource access to which you were eligible or approved. If you request the deletion of account information and later wish to apply for a new account, you will need to provide the necessary information again."
+msgstr "Als u besluit uw account in de Wikipedia-bibliotheek uit te schakelen, kunt u de verwijderknop op uw profiel gebruiken om bepaalde persoonlijke informatie te verwijderen die aan uw account is gekoppeld. We zullen uw echte naam, institutionele aansluiting en land van verblijf verwijderen. Houd er rekening mee dat het systeem uw gebruikersnaam, de uitgevers waarbij u zich heeft aangemeld of toegang had, en de data van die toegang bijhoudt. Houd er rekening mee dat het verwijderen niet onomkeerbaar is. Het verwijderen van uw account in de Wikipedia-bibliotheek kan ook overeenkomen met het verwijderen van toegang tot bronnen waarvoor u in aanmerking kwam of waarvoor u was goedgekeurd. Als u verzoekt om verwijdering van accountgegevens en later een nieuw bibliotheekaccount wilt aanvragen, moet u de benodigde gegevens opnieuw verstrekken."
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). WMF should not be translated. Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:321
-msgid ""
-"The Wikipedia Library is run by WMF Staff, Contractors, and approved "
-"volunteer Coordinators. The data associated with your account will be shared "
-"with the WMF staff, contractors, service providers, and volunteer "
-"coordinators who need to process the information in connection with their "
-"work for the Wikipedia Library, and who are subject to confidentiality "
-"obligations. We will also use your data for internal Wikipedia Library "
-"purposes such as distributing user surveys and account notifications, and in "
-"a depersonalized or aggregated fashion for statistical analysis and "
-"administration. Finally, we will share your information with the publishers "
-"whom you specifically select in order to provide you with access to "
-"resources. Otherwise, your information will not be shared with third "
-"parties, with the exception of the circumstances described below."
-msgstr ""
-"De Wikipedia-bibliotheek wordt beheerd door WMF-personeel, contractanten en "
-"goedgekeurde vrijwillige coördinatoren. De gegevens die aan uw account zijn "
-"gekoppeld, worden gedeeld met het WMF-personeel, contractanten, "
-"dienstverleners en vrijwillige coördinatoren die de informatie moeten "
-"verwerken in verband met hun werk voor de Wikipedia-bibliotheek en die "
-"onderworpen zijn aan vertrouwelijkheidsverplichtingen. We zullen uw gegevens "
-"ook gebruiken voor interne doeleinden van de Wikipedia-bibliotheek, zoals "
-"het verspreiden van gebruikersenquêtes en accountmeldingen, en op een "
-"gedepersonaliseerde of geaggregeerde manier voor statistische analyse en "
-"administratie. Ten slotte zullen we uw informatie delen met de uitgevers die "
-"u specifiek selecteert om u toegang te geven tot bronnen. Anderszins worden "
-"uw gegevens niet gedeeld met derden, met uitzondering van de hieronder "
-"beschreven omstandigheden."
+msgid "The Wikipedia Library is run by WMF Staff, Contractors, and approved volunteer Coordinators. The data associated with your account will be shared with the WMF staff, contractors, service providers, and volunteer coordinators who need to process the information in connection with their work for the Wikipedia Library, and who are subject to confidentiality obligations. We will also use your data for internal Wikipedia Library purposes such as distributing user surveys and account notifications, and in a depersonalized or aggregated fashion for statistical analysis and administration. Finally, we will share your information with the publishers whom you specifically select in order to provide you with access to resources. Otherwise, your information will not be shared with third parties, with the exception of the circumstances described below."
+msgstr "De Wikipedia-bibliotheek wordt beheerd door WMF-personeel, contractanten en goedgekeurde vrijwillige coördinatoren. De gegevens die aan uw account zijn gekoppeld, worden gedeeld met het WMF-personeel, contractanten, dienstverleners en vrijwillige coördinatoren die de informatie moeten verwerken in verband met hun werk voor de Wikipedia-bibliotheek en die onderworpen zijn aan vertrouwelijkheidsverplichtingen. We zullen uw gegevens ook gebruiken voor interne doeleinden van de Wikipedia-bibliotheek, zoals het verspreiden van gebruikersenquêtes en accountmeldingen, en op een gedepersonaliseerde of geaggregeerde manier voor statistische analyse en administratie. Ten slotte zullen we uw informatie delen met de uitgevers die u specifiek selecteert om u toegang te geven tot bronnen. Anderszins worden uw gegevens niet gedeeld met derden, met uitzondering van de hieronder beschreven omstandigheden."
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). WMF should not be translated.
 #: TWLight/users/templates/users/terms.html:338
-msgid ""
-"We may disclose any collected information when required by law, when we have "
-"your permission, when needed to protect our rights, privacy, safety, users, "
-"or the general public, and when necessary to enforce these terms, WMF’s "
-"general <a class=\"twl-links\" href=\"https://foundation.wikimedia.org/wiki/"
-"Terms_of_Use\">Terms of Use</a>, or any other WMF policy."
-msgstr ""
-"We kunnen alle verzamelde informatie vrijgeven wanneer dit wettelijk vereist "
-"is, wanneer we uw toestemming hebben, wanneer dat nodig is om onze rechten, "
-"privacy, veiligheid, gebruikers of het grote publiek te beschermen, en "
-"wanneer nodig om deze voorwaarden, WMF's algemene <a class=\" twl-links\" "
-"href=\"https://foundation.wikimedia.org/wiki/Terms_of_Use"
-"\">Gebruiksvoorwaarden</a> of enig ander WMF-beleid af te dwingen."
+msgid "We may disclose any collected information when required by law, when we have your permission, when needed to protect our rights, privacy, safety, users, or the general public, and when necessary to enforce these terms, WMF’s general <a class=\"twl-links\" href=\"https://foundation.wikimedia.org/wiki/Terms_of_Use\">Terms of Use</a>, or any other WMF policy."
+msgstr "We kunnen alle verzamelde informatie vrijgeven wanneer dit wettelijk vereist is, wanneer we uw toestemming hebben, wanneer dat nodig is om onze rechten, privacy, veiligheid, gebruikers of het grote publiek te beschermen, en wanneer nodig om deze voorwaarden, WMF's algemene <a class=\" twl-links\" href=\"https://foundation.wikimedia.org/wiki/Terms_of_Use\">Gebruiksvoorwaarden</a> of enig ander WMF-beleid af te dwingen."
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:349
-msgid ""
-"We take the security of your personal data seriously, and take reasonable "
-"precautions to ensure your data is protected. These precautions include "
-"access controls to limit who has access to your data and security "
-"technologies to protect data stored on the server. However, we cannot "
-"guarantee the safety of your data as it is transmitted and stored."
-msgstr ""
-"We nemen de beveiliging van uw persoonlijke gegevens serieus en nemen "
-"redelijke voorzorgsmaatregelen om ervoor te zorgen dat uw gegevens worden "
-"beschermd. Deze voorzorgsmaatregelen omvatten toegangscontroles om te "
-"beperken wie toegang heeft tot uw gegevens en beveiligingstechnologieën om "
-"gegevens die op de server zijn opgeslagen te beschermen. We kunnen de "
-"veiligheid van uw gegevens bij het verzenden en opslaan echter niet "
-"garanderen."
+msgid "We take the security of your personal data seriously, and take reasonable precautions to ensure your data is protected. These precautions include access controls to limit who has access to your data and security technologies to protect data stored on the server. However, we cannot guarantee the safety of your data as it is transmitted and stored."
+msgstr "We nemen de beveiliging van uw persoonlijke gegevens serieus en nemen redelijke voorzorgsmaatregelen om ervoor te zorgen dat uw gegevens worden beschermd. Deze voorzorgsmaatregelen omvatten toegangscontroles om te beperken wie toegang heeft tot uw gegevens en beveiligingstechnologieën om gegevens die op de server zijn opgeslagen te beschermen. We kunnen de veiligheid van uw gegevens bij het verzenden en opslaan echter niet garanderen."
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:360
-msgid ""
-"Please note that these terms do not control the use and handling of your "
-"data by the publishers and service providers whose resources you access or "
-"apply to access. Please read their individual privacy policies for that "
-"information."
-msgstr ""
-"Houd er rekening mee dat deze voorwaarden geen betrekking hebben op het "
-"gebruik en de verwerking van uw gegevens door de uitgevers en "
-"serviceproviders van de bronnen die u bekijkt of toegang die u aanvraagt. "
-"Lees hun individuele privacybeleid voor die informatie."
+msgid "Please note that these terms do not control the use and handling of your data by the publishers and service providers whose resources you access or apply to access. Please read their individual privacy policies for that information."
+msgstr "Houd er rekening mee dat deze voorwaarden geen betrekking hebben op het gebruik en de verwerking van uw gegevens door de uitgevers en serviceproviders van de bronnen die u bekijkt of toegang die u aanvraagt. Lees hun individuele privacybeleid voor die informatie."
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:368
@@ -3907,54 +2840,18 @@ msgstr "Belangrijke opmerking"
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Wikimedia Foundation should not be translated. Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:373
-msgid ""
-"The Wikimedia Foundation is a nonprofit organization based in San Francisco, "
-"California. The Wikipedia Library program provides access to resources held "
-"by publishers in multiple countries. If you apply for a Wikipedia Library "
-"account (whether you are inside or outside of the United States), you "
-"understand that your personal data will be collected, transferred, stored, "
-"processed, disclosed and otherwise used in the U.S. as described in this "
-"privacy policy. You also understand that your information may be transferred "
-"by us from the U.S. to other countries, which may have different or less "
-"stringent data protection laws than your country, in connection with "
-"providing services to you, including evaluating your application and "
-"securing access to your chosen publishers (locations for each publisher are "
-"outlined on their respective partner information pages)."
-msgstr ""
-"De Wikimedia Foundation is een non-profitorganisatie gevestigd in San "
-"Francisco, Californië. Het programma van de Wikipedia-bibliotheek biedt "
-"toegang tot bronnen die in het bezit zijn van uitgevers in meerdere landen. "
-"Als u een account in de Wikipedia-bibliotheek aanvraagt (of u nu binnen of "
-"buiten de Verenigde Staten bent), begrijpt u dat uw persoonlijke gegevens "
-"zullen worden verzameld, overgedragen, opgeslagen, verwerkt, openbaar "
-"gemaakt en anderszins gebruikt in de Verenigde Staten zoals beschreven in "
-"dit privacybeleid. U begrijpt ook dat uw informatie door ons kan worden "
-"overgedragen vanuit de Verenigde Staten naar andere landen, die mogelijk "
-"andere of minder strenge wetten inzake gegevensbescherming hebben dan uw "
-"land, in verband met het verlenen van diensten aan u, inclusief het "
-"evalueren van uw aanvraag en het beveiligen van toegang tot uw gekozen "
-"uitgevers (locaties voor elke uitgever worden beschreven op hun respectieve "
-"partnerinformatiepagina's)."
+msgid "The Wikimedia Foundation is a nonprofit organization based in San Francisco, California. The Wikipedia Library program provides access to resources held by publishers in multiple countries. If you apply for a Wikipedia Library account (whether you are inside or outside of the United States), you understand that your personal data will be collected, transferred, stored, processed, disclosed and otherwise used in the U.S. as described in this privacy policy. You also understand that your information may be transferred by us from the U.S. to other countries, which may have different or less stringent data protection laws than your country, in connection with providing services to you, including evaluating your application and securing access to your chosen publishers (locations for each publisher are outlined on their respective partner information pages)."
+msgstr "De Wikimedia Foundation is een non-profitorganisatie gevestigd in San Francisco, Californië. Het programma van de Wikipedia-bibliotheek biedt toegang tot bronnen die in het bezit zijn van uitgevers in meerdere landen. Als u een account in de Wikipedia-bibliotheek aanvraagt (of u nu binnen of buiten de Verenigde Staten bent), begrijpt u dat uw persoonlijke gegevens zullen worden verzameld, overgedragen, opgeslagen, verwerkt, openbaar gemaakt en anderszins gebruikt in de Verenigde Staten zoals beschreven in dit privacybeleid. U begrijpt ook dat uw informatie door ons kan worden overgedragen vanuit de Verenigde Staten naar andere landen, die mogelijk andere of minder strenge wetten inzake gegevensbescherming hebben dan uw land, in verband met het verlenen van diensten aan u, inclusief het evalueren van uw aanvraag en het beveiligen van toegang tot uw gekozen uitgevers (locaties voor elke uitgever worden beschreven op hun respectieve partnerinformatiepagina's)."
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:392
-msgid ""
-"Please note that in the event of any differences in meaning or "
-"interpretation between the original English version of these terms and a "
-"translation, the original English version takes precedence."
-msgstr ""
-"Houd er rekening mee dat bij eventuele verschillen in betekenis of "
-"interpretatie tussen de originele Engelse versie van deze voorwaarden en een "
-"vertaling, de originele Engelse versie voorrang heeft."
+msgid "Please note that in the event of any differences in meaning or interpretation between the original English version of these terms and a translation, the original English version takes precedence."
+msgstr "Houd er rekening mee dat bij eventuele verschillen in betekenis of interpretatie tussen de originele Engelse versie van deze voorwaarden en een vertaling, de originele Engelse versie voorrang heeft."
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Wikimedia Foundation should not be translated.
 #: TWLight/users/templates/users/terms.html:403
-msgid ""
-"See also the <a class=\"twl-links\" href=\"https://wikimediafoundation.org/"
-"wiki/Privacy_policy\">Wikimedia Foundation Privacy Policy</a>."
-msgstr ""
-"Zie ook het <a class=\"twl-links\" href=\"https://wikimediafoundation.org/"
-"wiki/Privacy_policy\">Privacybeleid van de Wikimedia Foundation</a>."
+msgid "See also the <a class=\"twl-links\" href=\"https://wikimediafoundation.org/wiki/Privacy_policy\">Wikimedia Foundation Privacy Policy</a>."
+msgstr "Zie ook het <a class=\"twl-links\" href=\"https://wikimediafoundation.org/wiki/Privacy_policy\">Privacybeleid van de Wikimedia Foundation</a>."
 
 #. Translators: This is the second to last line of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:412
@@ -3973,17 +2870,8 @@ msgstr "Wikimedia Foundation"
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:426
-msgid ""
-"By checking this box and clicking “Submit”, you agree that you have read the "
-"above terms and that you will adhere to the terms of use in your application "
-"to and use of the The Wikipedia Library, and the publishers’ services to "
-"which you gain access through The Wikipedia Library program."
-msgstr ""
-"Door dit vakje aan te vinken en op \"Verzenden\" te klikken, gaat u ermee "
-"akkoord dat u de bovenstaande voorwaarden heeft gelezen en dat u zich zult "
-"houden aan de gebruiksvoorwaarden in uw aanvraag voor en het gebruik van de "
-"Wikipedia-bibliotheek en de diensten van de uitgevers waarvan u profiteert "
-"met uw toegang via het programma de Wikipedia-bibliotheek."
+msgid "By checking this box and clicking “Submit”, you agree that you have read the above terms and that you will adhere to the terms of use in your application to and use of the The Wikipedia Library, and the publishers’ services to which you gain access through The Wikipedia Library program."
+msgstr "Door dit vakje aan te vinken en op \"Verzenden\" te klikken, gaat u ermee akkoord dat u de bovenstaande voorwaarden heeft gelezen en dat u zich zult houden aan de gebruiksvoorwaarden in uw aanvraag voor en het gebruik van de Wikipedia-bibliotheek en de diensten van de uitgevers waarvan u profiteert met uw toegang via het programma de Wikipedia-bibliotheek."
 
 #: TWLight/users/templates/users/user_collection_tile.html:32
 msgid "Remove this collection from favorites"
@@ -4035,41 +2923,19 @@ msgstr "Verwijder alle data"
 
 #. Translators: This message is displayed on the page where users can request the deletion of their data.
 #: TWLight/users/templates/users/user_confirm_delete.html:17
-msgid ""
-"<b>Warning:</b> Performing this action will delete your Wikipedia Library "
-"Card user account and all associated applications. This process is not "
-"reversible. You may lose any partner accounts you were granted, and will not "
-"be able to renew those accounts or apply for new ones."
-msgstr ""
-"<b>Waarschuwing:</b> Door het verrichten van deze handeling worden uw "
-"gebruikersaccount van de Wikipedia-bibliotheekkaart en alle bijbehorende "
-"aanvragen verwijderd. Dit proces is niet omkeerbaar. U kunt eventuele "
-"partneraccounts kwijtraken die u hebt gekregen en u kunt deze accounts niet "
-"verlengen of nieuwe aanvragen."
+msgid "<b>Warning:</b> Performing this action will delete your Wikipedia Library Card user account and all associated applications. This process is not reversible. You may lose any partner accounts you were granted, and will not be able to renew those accounts or apply for new ones."
+msgstr "<b>Waarschuwing:</b> Door het verrichten van deze handeling worden uw gebruikersaccount van de Wikipedia-bibliotheekkaart en alle bijbehorende aanvragen verwijderd. Dit proces is niet omkeerbaar. U kunt eventuele partneraccounts kwijtraken die u hebt gekregen en u kunt deze accounts niet verlengen of nieuwe aanvragen."
 
 #. Translators: this should show up for people who log in with a username/password and not OAuth, so we don't know what their Wikipedia identity is.
-#.
 #: TWLight/users/templates/users/user_detail.html:12
 #, python-format
-msgid ""
-"Hi, %(username)s! You don't have a Wikipedia editor profile attached to your "
-"account here, so you are probably a site administrator."
-msgstr ""
-"Hallo, %(username)s! U heeft hier geen Wikipedia-redacteurprofiel aan uw "
-"account gekoppeld, dus u bent waarschijnlijk een sitebeheerder."
+msgid "Hi, %(username)s! You don't have a Wikipedia editor profile attached to your account here, so you are probably a site administrator."
+msgstr "Hallo, %(username)s! U heeft hier geen Wikipedia-redacteurprofiel aan uw account gekoppeld, dus u bent waarschijnlijk een sitebeheerder."
 
 #. Translators: In the unlikely scenario that someone is able to register an account without using OAuth (thus leaving us without some of the information required for applications), users will see this message, encouraging them to re-register.
 #: TWLight/users/templates/users/user_detail.html:20
-msgid ""
-"If you aren't a site administrator, something weird has happened. You won't "
-"be able to apply for access without a Wikipedia editor profile. You should "
-"log out and create a new account by logging in via OAuth, or contact a site "
-"administrator for help."
-msgstr ""
-"Als u geen sitebeheerder bent, is er iets vreemds gebeurd. U kunt geen "
-"toegang aanvragen zonder een Wikipedia-redacteurprofiel. Meld u af en maak "
-"dan een nieuw account aan door u aan te melden via OAuth, of neem contact op "
-"met een sitebeheerder voor hulp."
+msgid "If you aren't a site administrator, something weird has happened. You won't be able to apply for access without a Wikipedia editor profile. You should log out and create a new account by logging in via OAuth, or contact a site administrator for help."
+msgstr "Als u geen sitebeheerder bent, is er iets vreemds gebeurd. U kunt geen toegang aanvragen zonder een Wikipedia-redacteurprofiel. Meld u af en maak dan een nieuw account aan door u aan te melden via OAuth, of neem contact op met een sitebeheerder voor hulp."
 
 #. Translators: Labels a sections where coordinators can select their email preferences.
 #: TWLight/users/templates/users/user_email_preferences.html:15
@@ -4079,23 +2945,13 @@ msgstr "Alleen coördinatoren"
 #. Translators: This message is shown on user's own profile page, encouraging them to make sure their information is up to date, so that account coordinators can use the information to judge applications.
 #: TWLight/users/views.py:176
 #, python-brace-format
-msgid ""
-"Please <a class='twl-links' href='{url}'>update your contributions</a> to "
-"Wikipedia to help coordinators evaluate your applications."
-msgstr ""
-"<a class='twl-links' href='{url}'>Werk uw bijdragen op Wikipedia bij</a> om "
-"de coördinatoren te helpen uw aanvragen te beoordelen."
+msgid "Please <a class='twl-links' href='{url}'>update your contributions</a> to Wikipedia to help coordinators evaluate your applications."
+msgstr "<a class='twl-links' href='{url}'>Werk uw bijdragen op Wikipedia bij</a> om de coördinatoren te helpen uw aanvragen te beoordelen."
 
 #. Translators: Coordinators are shown this message when they unselect all three types of reminder email options under preferences.
 #: TWLight/users/views.py:288
-msgid ""
-"You have chosen not to receive reminder emails. As a coordinator, you should "
-"receive at least one type of reminder emails, so consider changing your "
-"preferences."
-msgstr ""
-"U heeft ervoor gekozen geen herinneringsmails te ontvangen. Als coördinator "
-"dient u echter ten minste één type herinneringsmails te ontvangen. Overweeg "
-"om uw voorkeuren aan te passen."
+msgid "You have chosen not to receive reminder emails. As a coordinator, you should receive at least one type of reminder emails, so consider changing your preferences."
+msgstr "U heeft ervoor gekozen geen herinneringsmails te ontvangen. Als coördinator dient u echter ten minste één type herinneringsmails te ontvangen. Overweeg om uw voorkeuren aan te passen."
 
 #. Translators: Coordinators are shown this message when they make changes to their reminder email options under preferences.
 #: TWLight/users/views.py:296
@@ -4118,9 +2974,7 @@ msgstr "Uw informatie is bijgewerkt."
 #. Translators: If a user tries to save the 'email change form' without entering one and checking the 'use my Wikipedia email address' checkbox, this message is presented.
 #: TWLight/users/views.py:448
 msgid "Both the values cannot be blank. Either enter a email or check the box."
-msgstr ""
-"Beide waarden kunnen niet leeg zijn. Voer een e-mail in of vink het vakje "
-"aan."
+msgstr "Beide waarden kunnen niet leeg zijn. Voer een e-mail in of vink het vakje aan."
 
 #. Translators: Shown to users when they successfully modify their email. Don't translate {email}.
 #: TWLight/users/views.py:476
@@ -4130,12 +2984,8 @@ msgstr "Uw e-mailadres is gewijzigd naar {email}."
 
 #. Translators: If the user has not filled out their email, they can browse the website but cannot apply for access to resources.
 #: TWLight/users/views.py:487
-msgid ""
-"Your email is blank. You can still explore the site, but you won't be able "
-"to apply for access to partner resources without an email."
-msgstr ""
-"Uw e-mailadres is niet opgegeven. U kunt de site nog steeds verkennen, maar "
-"u kunt geen toegang tot partnerbronnen aanvragen zonder een e-mailadres."
+msgid "Your email is blank. You can still explore the site, but you won't be able to apply for access to partner resources without an email."
+msgstr "Uw e-mailadres is niet opgegeven. U kunt de site nog steeds verkennen, maar u kunt geen toegang tot partnerbronnen aanvragen zonder een e-mailadres."
 
 #. Translators: This message is shown once the access to a partner has successfully been returned.
 #: TWLight/users/views.py:801
@@ -4167,31 +3017,3 @@ msgstr "Geen actieve blokkades"
 msgid "10+ edits in the last 30 days"
 msgstr "10+ bewerkingen in de afgelopen 30 dagen"
 
-#: tests/shunit/data/bad_i18n_comment_1.py:3
-#: tests/shunit/data/bad_i18n_newline_1.py:5
-msgid "1"
-msgstr ""
-
-#. Translators: Lorem ipsum dolor sit amet, consectetur adipiscing elit. Mauris vitae ipsum ut purus faucibus pretium. Proin tempus neque et aliquet consectetur. Ut egestas sapien in consectetur sagittis. Mauris neque lacus, dapibus non viverra vitae, interdum ut aenean ipsum.
-#. Translators: Lorem ipsum dolor sit amet, consectetur adipiscing elit. Mauris vitae ipsum ut purus faucibus pretium. Proin tempus neque et aliquet consectetur. Ut egestas sapien in consectetur sagittis. Mauris neque lacus, dapibus non.
-#: tests/shunit/data/bad_i18n_comment_2.py:4
-#: tests/shunit/data/bad_i18n_newline_2.py:5 tests/shunit/data/good_i18n_1.py:2
-#: tests/shunit/data/good_i18n_2.py:2
-msgid "2"
-msgstr ""
-
-#: tests/shunit/data/bad_i18n_newline_3.py:5
-msgid "3"
-msgstr ""
-
-#: tests/shunit/data/bad_i18n_newline_4.py:5
-msgid "4"
-msgstr ""
-
-#: tests/shunit/data/bad_i18n_newline_5.py:5
-msgid "5"
-msgstr ""
-
-#: tests/shunit/data/bad_i18n_newline_6.py:5
-msgid "6"
-msgstr ""

--- a/locale/pl/LC_MESSAGES/django.po
+++ b/locale/pl/LC_MESSAGES/django.po
@@ -17,17 +17,17 @@
 # Author: Woytecr
 msgid ""
 msgstr ""
+""
 "Project-Id-Version: Wikipedia Library Card Platform - Website\n"
-"Report-Msgid-Bugs-To: wikipedialibrary@wikimedia.org\n"
+"Report-Msgid-Bugs-To: translatewiki.net\n"
 "POT-Creation-Date: 2024-07-11 20:54+0000\n"
-"PO-Revision-Date: 2024-07-11 12:30:18+0000\n"
+"PO-Revision-Date: 2024-07-15 12:29:18+0000\n"
 "Language: pl\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "X-POT-Import-Date: 2024-06-25 18:44:08+0000\n"
 "X-Generator: MediaWiki 1.43.0-alpha; Translate 2024-07-16\n"
-"Plural-Forms: nplurals=3; plural=(n == 1) ? 0 : ( (n%10 >= 2 && n%10 <= 4 && "
-"(n%100 < 10 || n%100 >= 20)) ? 1 : 2 );\n"
+"Plural-Forms: nplurals=3; plural=(n == 1) ? 0 : ( (n%10 >= 2 && n%10 <= 4 && (n%100 < 10 || n%100 >= 20)) ? 1 : 2 );\n"
 "X-Translation-Project: translatewiki.net <https://translatewiki.net>\n"
 
 #. Translators: Labels the button users click to apply for a partner's resources.
@@ -53,13 +53,8 @@ msgstr "O Tobie"
 #. Translators: This note appears in a section of a form where we ask users to enter info (like country of residence) when applying for resource access.
 #: TWLight/applications/forms.py:179
 #, python-brace-format
-msgid ""
-"<p><small><i>Your personal data will be processed according to our <a "
-"class='twl-links' href='{terms_url}'> privacy policy</a>.</i></small></p>"
-msgstr ""
-"<p><small><i>Twoje dane osobowe będą przetwarzane zgodnie z naszą <a "
-"class='twl-links' href='{terms_url}'>polityką prywatności</a>.</i></small></"
-"p>"
+msgid "<p><small><i>Your personal data will be processed according to our <a class='twl-links' href='{terms_url}'> privacy policy</a>.</i></small></p>"
+msgstr "<p><small><i>Twoje dane osobowe będą przetwarzane zgodnie z naszą <a class='twl-links' href='{terms_url}'>polityką prywatności</a>.</i></small></p>"
 
 #. Translators: This is the title of the application form page, where users enter information required for the application. It lets the user know which partner application they are entering data for. {partner}
 #: TWLight/applications/forms.py:189
@@ -71,8 +66,7 @@ msgstr "Twoje zgłoszenie do {partner}"
 #: TWLight/applications/forms.py:220
 #, python-brace-format
 msgid "You must register at {url} before applying."
-msgstr ""
-"Musisz zarejestrować się w {url} zanim będziesz mieć możliwość aplikować."
+msgstr "Musisz zarejestrować się w {url} zanim będziesz mieć możliwość aplikować."
 
 #. Translators: Label of the field where coordinators can enter the username of a user
 #. Translators: This labels the column description that lists the name of the applicants.
@@ -101,12 +95,8 @@ msgstr "E-mail dla twojego konta na witrynie partnera"
 #. Translators: This labels a choice field where users will have to select the number of months they wish to have their access for as part of the application renewal confirmation.
 #. Translators: When filling out an application, users may be required to enter the length of the account (expiry) they wish to have for proxy partners.
 #: TWLight/applications/forms.py:339 TWLight/applications/helpers.py:100
-msgid ""
-"The number of months you wish to have this access for before renewal is "
-"required"
-msgstr ""
-"Przez ile miesięcy chcesz mieć dostęp do usługi, zanim wymagane będzie "
-"odnowienie uprawnień"
+msgid "The number of months you wish to have this access for before renewal is required"
+msgstr "Przez ile miesięcy chcesz mieć dostęp do usługi, zanim wymagane będzie odnowienie uprawnień"
 
 #. Translators: When filling out an application, users may need to specify their name
 #: TWLight/applications/helpers.py:81
@@ -194,13 +184,8 @@ msgstr "E‐mail"
 
 #. Translators: This comment is added to pending applications when our terms of use change.
 #: TWLight/applications/management/commands/notify_applicants_tou_changes.py:54
-msgid ""
-"Our terms of use have changed. Your applications will not be processed until "
-"you log in and agree to our updated terms."
-msgstr ""
-"Nasze warunki użytkowania zostały zmienione. Twoje zgłoszenia nie będą "
-"rozpatrywane, dopóki nie zalogujesz się i nie zaakceptujesz zaktualizowanych "
-"warunków."
+msgid "Our terms of use have changed. Your applications will not be processed until you log in and agree to our updated terms."
+msgstr "Nasze warunki użytkowania zostały zmienione. Twoje zgłoszenia nie będą rozpatrywane, dopóki nie zalogujesz się i nie zaakceptujesz zaktualizowanych warunków."
 
 #. Translators: This is the status of an application that has not yet been reviewed.
 #: TWLight/applications/models.py:54
@@ -266,42 +251,26 @@ msgstr "URL dostępowy: {access_url}"
 
 #. Translators: This text goes into account approval emails in the case that we need to send the user's details to a publisher for manual account setup.
 #: TWLight/applications/models.py:331
-msgid ""
-"You can expect to receive access details within a week or two once it has "
-"been processed."
-msgstr ""
-"Szczegółowe informacje o dostępie będą przesłane, gdy tylko zostaną "
-"przetworzone; możesz się ich spodziewać za około tydzień lub dwa."
+msgid "You can expect to receive access details within a week or two once it has been processed."
+msgstr "Szczegółowe informacje o dostępie będą przesłane, gdy tylko zostaną przetworzone; możesz się ich spodziewać za około tydzień lub dwa."
 
 #. Translators: This comment is added to open applications when a partner joins the Library Bundle, which does not require applications.
 #: TWLight/applications/signals.py:247
-msgid ""
-"This partner joined the Library Bundle, which does not require applications. "
-"This application will be marked as invalid."
-msgstr ""
-"Ta instytucja partnerska dołączyła do Pakietu Bazowego, do którego nie "
-"składa się wniosków. Zgłoszenie zostanie oznaczone jako nieważne."
+msgid "This partner joined the Library Bundle, which does not require applications. This application will be marked as invalid."
+msgstr "Ta instytucja partnerska dołączyła do Pakietu Bazowego, do którego nie składa się wniosków. Zgłoszenie zostanie oznaczone jako nieważne."
 
 #. Translators: This is shown to users if the application is to a partner for which we have run out of available accounts. The application is therefore on a 'waitlist', and will be reviewed when more accounts are available.
 #: TWLight/applications/templates/applications/application_evaluation.html:29
-msgid ""
-"This application is on the waitlist because this partner does not have any "
-"access grants available at this time."
-msgstr ""
-"Zgłoszenie znajduje się na liście oczekujących, ponieważ przyznano już "
-"maksymalną liczbę zezwoleń na dostęp do tego partnera."
+msgid "This application is on the waitlist because this partner does not have any access grants available at this time."
+msgstr "Zgłoszenie znajduje się na liście oczekujących, ponieważ przyznano już maksymalną liczbę zezwoleń na dostęp do tego partnera."
 
 #. Translators: This message is shown on pages where coordinators can see personal information about applicants.
 #: TWLight/applications/templates/applications/application_evaluation.html:36
 #: TWLight/applications/templates/applications/application_list_include.html:6
 #: TWLight/applications/templates/applications/send_partner.html:45
 #: TWLight/resources/templates/resources/partner_users.html:18
-msgid ""
-"Coordinators: This page may contain personal information such as real names "
-"and email addresses. Please remember that this information is confidential."
-msgstr ""
-"Koordynatorzy(-ki): Ta strona może zawierać dane personalne takie jak imiona "
-"i nazwiska oraz adres mailowe. Pamiętaj proszę, że te dane są poufne."
+msgid "Coordinators: This page may contain personal information such as real names and email addresses. Please remember that this information is confidential."
+msgstr "Koordynatorzy(-ki): Ta strona może zawierać dane personalne takie jak imiona i nazwiska oraz adres mailowe. Pamiętaj proszę, że te dane są poufne."
 
 #. Translators: This is the title of the application page shown to users who are a coordinator, and are able to accept or reject the application.
 #: TWLight/applications/templates/applications/application_evaluation.html:39
@@ -310,12 +279,8 @@ msgstr "Ocena zgłoszenia"
 
 #. Translators: This text is shown to coordinators on application pages if the applicant has restricted processing of their data.
 #: TWLight/applications/templates/applications/application_evaluation.html:42
-msgid ""
-"This user has requested a restriction on the processing of their data, so "
-"you cannot change the status of their application."
-msgstr ""
-"Ten użytkownik zastrzegł przetwarzanie swoich informacji, więc nie możesz "
-"zmienić statusu tego zgłoszenia."
+msgid "This user has requested a restriction on the processing of their data, so you cannot change the status of their application."
+msgstr "Ten użytkownik zastrzegł przetwarzanie swoich informacji, więc nie możesz zmienić statusu tego zgłoszenia."
 
 #. Translators: This is the title of the application page shown to users who are not a coordinator.
 #: TWLight/applications/templates/applications/application_evaluation.html:48
@@ -388,12 +353,8 @@ msgstr "Nieznany"
 
 #. Translators: This is the text displayed to coordinators when an applicant has no country of residence in their profile.
 #: TWLight/applications/templates/applications/application_evaluation.html:123
-msgid ""
-"Please request the applicant add their country of residence to their profile "
-"before proceeding further."
-msgstr ""
-"Zanim przejdziesz dalej, poproś aplikującą osobę, żeby dodała kraj "
-"zamieszkania do jej profilu."
+msgid "Please request the applicant add their country of residence to their profile before proceeding further."
+msgstr "Zanim przejdziesz dalej, poproś aplikującą osobę, żeby dodała kraj zamieszkania do jej profilu."
 
 #. Translators: This labels the section of an application showing the total number of accounts available for a partner or their collection.
 #: TWLight/applications/templates/applications/application_evaluation.html:134
@@ -403,12 +364,8 @@ msgstr "Dostępne konta"
 #. Translators: This labels the section of an application showing whether the user had agreed to the terms of use or not.
 #: TWLight/applications/templates/applications/application_evaluation.html:145
 #, python-format
-msgid ""
-"Has agreed to the site's <a class=\"twl-links\" href=\"%(terms_url)s\">terms "
-"of use</a>?"
-msgstr ""
-"Zgodził(-a) się na <a class=\"twl-links\" href=\"%(terms_url)s\">warunki "
-"użycia</a> witryny?"
+msgid "Has agreed to the site's <a class=\"twl-links\" href=\"%(terms_url)s\">terms of use</a>?"
+msgstr "Zgodził(-a) się na <a class=\"twl-links\" href=\"%(terms_url)s\">warunki użycia</a> witryny?"
 
 #. Translators: Displayed to coordinators when they've agreed to the terms of use.
 #. Translators: Displayed if the user has agreed to the terms of use.
@@ -443,12 +400,8 @@ msgstr "Nie"
 
 #. Translators: This is the text displayed to coordinators when an applicant has not agreed to the terms of use.
 #: TWLight/applications/templates/applications/application_evaluation.html:159
-msgid ""
-"Please request the applicant agree to the site's terms of use before "
-"approving this application."
-msgstr ""
-"Zanim przejdziesz dalej, poproś aplikującą osobę, żeby zgodziła się warunki "
-"użycia danej witryny."
+msgid "Please request the applicant agree to the site's terms of use before approving this application."
+msgstr "Zanim przejdziesz dalej, poproś aplikującą osobę, żeby zgodziła się warunki użycia danej witryny."
 
 #. Translators: This labels the section of an application containing the user's motivation for wanting access to this resource.
 #: TWLight/applications/templates/applications/application_evaluation.html:176
@@ -468,11 +421,8 @@ msgstr "Odnowienie przyznanego prawa dostępu?"
 #. Translators: This message is shown next to the 'Renewal of existing access grant?' label if the application is a renewal. Don't translate HTML tags or parent_url.
 #: TWLight/applications/templates/applications/application_evaluation.html:195
 #, python-format
-msgid ""
-"Yes (<a class=\"twl-links\" href=\"%(parent_url)s\">previous application</a>)"
-msgstr ""
-"Tak (<a class=\"twl-links\" href=\"%(parent_url)s\">poprzednie zgłoszenie</"
-"a>)"
+msgid "Yes (<a class=\"twl-links\" href=\"%(parent_url)s\">previous application</a>)"
+msgstr "Tak (<a class=\"twl-links\" href=\"%(parent_url)s\">poprzednie zgłoszenie</a>)"
 
 #. Translators: This labels the section of the application showing the length of access remaining on the user's previous authorization.
 #: TWLight/applications/templates/applications/application_evaluation.html:208
@@ -506,12 +456,8 @@ msgstr "Dodaj komentarz"
 
 #. Translators: On an application page, this text tells users that the comments posted on the application are visible to coordinators and the submitting user only.
 #: TWLight/applications/templates/applications/application_evaluation.html:297
-msgid ""
-"Comments are visible to all coordinators and to the editor who submitted "
-"this application."
-msgstr ""
-"Komentarze są widoczne dla wszystkich osób koordynujących oraz do osoby, "
-"która wysłała zgłoszenie."
+msgid "Comments are visible to all coordinators and to the editor who submitted this application."
+msgstr "Komentarze są widoczne dla wszystkich osób koordynujących oraz do osoby, która wysłała zgłoszenie."
 
 #. Translators: This is the title of the section of an application page which lists information about the user who submitted the application.
 #. Translators: On the page where coordinators can view data on applications to a partner they coordinate, this is a table column heading for the username.
@@ -722,18 +668,8 @@ msgstr "Ustaw status"
 
 #: TWLight/applications/templates/applications/apply.html:20
 #, python-format
-msgid ""
-"If your application is successful we may share your email address with "
-"%(partner)s. This is required to set up your access to their resources. By "
-"submitting this form you agree to allow your email address to be shared with "
-"%(partner)s if your application is successful, for the purposes of account "
-"setup."
-msgstr ""
-"Jeśli zgłoszenie zostanie rozpatrzone pozytywnie, możemy udostępnić Twój "
-"adres e-mail partnerowi %(partner)s. Jest to konieczne, aby skonfigurować "
-"Twój dostęp do jego zasobów. Wysyłając ten formularz, wyrażasz zgodę na "
-"udostępnienie swojego adresu e-mail partnerowi %(partner)s w celu "
-"skonfigurowania konta po pozytywnym rozpatrzeniu zgłoszenia."
+msgid "If your application is successful we may share your email address with %(partner)s. This is required to set up your access to their resources. By submitting this form you agree to allow your email address to be shared with %(partner)s if your application is successful, for the purposes of account setup."
+msgstr "Jeśli zgłoszenie zostanie rozpatrzone pozytywnie, możemy udostępnić Twój adres e-mail partnerowi %(partner)s. Jest to konieczne, aby skonfigurować Twój dostęp do jego zasobów. Wysyłając ten formularz, wyrażasz zgodę na udostępnienie swojego adresu e-mail partnerowi %(partner)s w celu skonfigurowania konta po pozytywnym rozpatrzeniu zgłoszenia."
 
 #. Translators: This message is displayed on the page where users can confirm their renewal. Please do not translate partner.
 #: TWLight/applications/templates/applications/confirm_renewal.html:23
@@ -761,12 +697,8 @@ msgstr "Do jakich zasobów chcesz uzyskać dostęp?"
 
 #. Translators: This text explains that Library Bundle partners are not shown in this list.
 #: TWLight/applications/templates/applications/request_for_application.html:26
-msgid ""
-"Library Bundle partners are not shown as eligibility is determined "
-"automatically."
-msgstr ""
-"Lista nie obejmuje partnerów wchodzących w skład Pakietu Bazowego, do "
-"których dostęp jest przyznawany automatycznie po spełnieniu kryteriów."
+msgid "Library Bundle partners are not shown as eligibility is determined automatically."
+msgstr "Lista nie obejmuje partnerów wchodzących w skład Pakietu Bazowego, do których dostęp jest przyznawany automatycznie po spełnieniu kryteriów."
 
 #. Translators: On the page where users can apply for multiple partners, this message shows next to the partner name, taking them to the full application page when clicked.
 #: TWLight/applications/templates/applications/request_for_application.html:48
@@ -780,14 +712,8 @@ msgstr "Nie dodano jeszcze żadnych danych partnerów."
 
 #. Translators: the HTML is so that the word 'waitlisted' will look the same as it does in the page above; please translate 'waitlisted' the same way you did elsewhere in this file.
 #: TWLight/applications/templates/applications/request_for_application.html:74
-msgid ""
-"You can apply to <span class=\"badge badge-warning\">Waitlisted</span> "
-"partners, but they don't have access grants available right now. We will "
-"process those applications when access becomes available."
-msgstr ""
-"Możesz wysłać zgłoszenia do partnerów z <span class=\"badge badge-warning"
-"\">listą oczekujących</span>, ale nie ma obecnie możliwości przyznania do "
-"nich dostępu. Rozpatrzymy takie zgłoszenia, gdy dostęp będzie możliwy."
+msgid "You can apply to <span class=\"badge badge-warning\">Waitlisted</span> partners, but they don't have access grants available right now. We will process those applications when access becomes available."
+msgstr "Możesz wysłać zgłoszenia do partnerów z <span class=\"badge badge-warning\">listą oczekujących</span>, ale nie ma obecnie możliwości przyznania do nich dostępu. Rozpatrzymy takie zgłoszenia, gdy dostęp będzie możliwy."
 
 #. Translators: On the page where coordinators can see approved applications which have not had their details sent to the partner, this message shows when there are applications ready to be processed.
 #: TWLight/applications/templates/applications/send.html:10
@@ -808,16 +734,13 @@ msgstr "Data zgłoszenia dla %(object)s"
 #. Translators: This message is shown when applications exceed the number of accounts available.
 #: TWLight/applications/templates/applications/send_partner.html:54
 #, python-format
-msgid ""
-"Application(s) for %(object)s, if sent, will exceed the total available "
-"accounts for the partner. Please proceed at your own discretion."
+msgid "Application(s) for %(object)s, if sent, will exceed the total available accounts for the partner. Please proceed at your own discretion."
 msgstr ""
 
 #. Translators: When viewing the list of applications ready to be sent for a particular partner, this is instructions for the coordinator to click the 'mark as sent' button after they have sent the information.
 #: TWLight/applications/templates/applications/send_partner.html:65
 msgid "When you've processed the data below, click the 'mark as sent' button."
-msgstr ""
-"Kiedy przetworzysz poniższe dane, kliknij przyscisk 'zaznacz jako wysłane'."
+msgstr "Kiedy przetworzysz poniższe dane, kliknij przyscisk 'zaznacz jako wysłane'."
 
 #. Translators: When viewing the list of applications ready to be sent for a particular partner, this is the title of the section containing contact information for the people applications should be sent to.
 #: TWLight/applications/templates/applications/send_partner.html:71
@@ -829,12 +752,8 @@ msgstr[2] "Osoby kontaktowe"
 
 #. Translators: When viewing the list of applications ready to be sent for a particular partner, this message shows if there is no information about who the applications should be sent to. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/applications/templates/applications/send_partner.html:89
-msgid ""
-"Whoops, we don't have any listed contacts. Please notify Wikipedia Library "
-"administrators."
-msgstr ""
-"Ups, nie mamy podanych żadnych osób do kontaktu. Poinformuj o tym "
-"administratorów Biblioteki Wikipedia."
+msgid "Whoops, we don't have any listed contacts. Please notify Wikipedia Library administrators."
+msgstr "Ups, nie mamy podanych żadnych osób do kontaktu. Poinformuj o tym administratorów Biblioteki Wikipedia."
 
 #. Translators: When viewing the list of applications ready to be sent for a particular partner, this is the title of the section containing the information about those applications.
 #: TWLight/applications/templates/applications/send_partner.html:94
@@ -849,12 +768,8 @@ msgstr "Oznacz jako wysłane"
 
 #. Translators: This text guides coordinators in using the code sending interface for approved applications.
 #: TWLight/applications/templates/applications/send_partner.html:152
-msgid ""
-"Use the dropdown menus to denote which editor will receive each code. Access "
-"codes will be sent to users automatically."
-msgstr ""
-"Korzystając z list rozwijanych, wybierz osoby, które otrzymają poszczególne "
-"kody. Kody dostępu zostaną wysłane do użytkowników automatycznie."
+msgid "Use the dropdown menus to denote which editor will receive each code. Access codes will be sent to users automatically."
+msgstr "Korzystając z list rozwijanych, wybierz osoby, które otrzymają poszczególne kody. Kody dostępu zostaną wysłane do użytkowników automatycznie."
 
 #. Translators: This labels a drop-down selection where staff can assign an access code to a user.
 #: TWLight/applications/templates/applications/send_partner.html:173
@@ -869,24 +784,14 @@ msgstr "Nie ma żadnych zatwierdzonych wniosków, które nie zostały wysłane."
 #. Translators: When a user applies for a set of resources, they receive this message if none are currently available. They are instead placed on a 'waitlist' for later approval.
 #. Translators: When a user renews their resource, they receive this message if none are currently available. They are instead placed on a 'waitlist' for later approval.
 #: TWLight/applications/views.py:140 TWLight/applications/views.py:1282
-msgid ""
-"This partner does not have any access grants available at this time. You may "
-"still apply for access; your application will be reviewed when access grants "
-"become available."
-msgstr ""
-"Przyznaliśmy już maksymalną liczbę zezwoleń na dostęp do tego partnera. "
-"Nadal możesz ubiegać się o dostęp; zgłoszenia będą rozpatrywane po "
-"zwolnieniu się miejsc."
+msgid "This partner does not have any access grants available at this time. You may still apply for access; your application will be reviewed when access grants become available."
+msgstr "Przyznaliśmy już maksymalną liczbę zezwoleń na dostęp do tego partnera. Nadal możesz ubiegać się o dostęp; zgłoszenia będą rozpatrywane po zwolnieniu się miejsc."
 
 #. Translators: This message is shown to users once they've successfully submitted their application for review.
 #: TWLight/applications/views.py:163
 #, python-brace-format
-msgid ""
-"Your application has been submitted for review. Head over to <a "
-"href='{applications_url}'>My Applications</a> to view the status."
-msgstr ""
-"Twoje zgłoszenie zostało przesłane do przejrzenia. Przejdź na stronę <a "
-"href='{applications_url}'>Moje zgłoszenia</a>, żeby zobaczyć status."
+msgid "Your application has been submitted for review. Head over to <a href='{applications_url}'>My Applications</a> to view the status."
+msgstr "Twoje zgłoszenie zostało przesłane do przejrzenia. Przejdź na stronę <a href='{applications_url}'>Moje zgłoszenia</a>, żeby zobaczyć status."
 
 #. Translators: This text is displayed to users when the user has chosen to restrict data and is trying to apply for multiple partners
 #: TWLight/applications/views.py:276
@@ -934,16 +839,12 @@ msgstr "Wysłane zgłoszenia"
 
 #. Translators: After a coordinator has changed the status of an application to APPROVED, if the corresponding partner/collection is waitlisted this message appears.
 #: TWLight/applications/views.py:756
-msgid ""
-"Cannot approve application as partner with proxy authorization method is "
-"waitlisted."
+msgid "Cannot approve application as partner with proxy authorization method is waitlisted."
 msgstr ""
 
 #. Translators: After a coordinator has changed the status of an application to APPROVED, if the corresponding partner/collection has no accounts for distribution, this message appears.
 #: TWLight/applications/views.py:780
-msgid ""
-"Cannot approve application as partner with proxy authorization method is "
-"waitlisted and (or) has zero accounts available for distribution."
+msgid "Cannot approve application as partner with proxy authorization method is waitlisted and (or) has zero accounts available for distribution."
 msgstr ""
 
 #. Translators: This message appears on an "access denied" screen that stops users who attempt to authorize an editor to access a resource during a time period for which they are already authorized.
@@ -954,17 +855,8 @@ msgstr ""
 #. Translators: This message is shown to users when they access an application page of a now Bundle partner (new applications aren't allowed for Bundle partners and the status of old applications cannot be modified)
 #: TWLight/applications/views.py:857
 #, python-brace-format
-msgid ""
-"This application cannot be modified since this partner is now part of our <a "
-"href='{bundle}'>bundle access</a>. If you are eligible, you can access this "
-"resource from <a href='{library}'>your library</a>. <a "
-"href='{contact}'>Contact us</a> if you have any questions."
-msgstr ""
-"Nie można zmienić zgłoszenia, ponieważ ten partner jest teraz częścią "
-"naszego <a href='{bundle}'>Pakietu Bazowego</a>. Jeśli się kwalifikujesz, "
-"możesz uzyskać dostęp do tego zasobu z poziomu <a href='{library}'>swojej "
-"biblioteki</a>. <a href='{contact}'>Skontaktuj się z nami</a>, jeśli masz "
-"jakieś pytania."
+msgid "This application cannot be modified since this partner is now part of our <a href='{bundle}'>bundle access</a>. If you are eligible, you can access this resource from <a href='{library}'>your library</a>. <a href='{contact}'>Contact us</a> if you have any questions."
+msgstr "Nie można zmienić zgłoszenia, ponieważ ten partner jest teraz częścią naszego <a href='{bundle}'>Pakietu Bazowego</a>. Jeśli się kwalifikujesz, możesz uzyskać dostęp do tego zasobu z poziomu <a href='{library}'>swojej biblioteki</a>. <a href='{contact}'>Skontaktuj się z nami</a>, jeśli masz jakieś pytania."
 
 #. Translators: this lets a reviewer set the status of a single application.
 #: TWLight/applications/views.py:873
@@ -973,12 +865,8 @@ msgstr "Ustaw status wniosku"
 
 #. Translators: This warning is message is shown to applicants when the number of pending applications is greater than the number of accounts available.
 #: TWLight/applications/views.py:891
-msgid ""
-"There are more pending applications than available accounts. Your "
-"application might get waitlisted."
-msgstr ""
-"Jest obecnie więcej oczekujących wniosków, niż dostępów do przyznania. Twój "
-"wniosek może trafić na listę oczekiwania."
+msgid "There are more pending applications than available accounts. Your application might get waitlisted."
+msgstr "Jest obecnie więcej oczekujących wniosków, niż dostępów do przyznania. Twój wniosek może trafić na listę oczekiwania."
 
 #. Translators: this message is shown to coordinators who attempt to change an application's Status from INVALID to any other Status.
 #: TWLight/applications/views.py:904
@@ -997,11 +885,7 @@ msgstr "Zbiorcza aktualizacja wniosków {} zakończona sukcesem."
 
 #. Translators: After a coordinator has changed the status of a number of applications to APPROVED, if the corresponding partner(s) is/are waitlisted or has no accounts for distribution, this message appears.
 #: TWLight/applications/views.py:1051
-msgid ""
-"Cannot approve application(s) {} as partner(s) with proxy authorization "
-"method is/are waitlisted and (or) has/have not enough accounts available. If "
-"not enough accounts are available, prioritise the applications and then "
-"approve applications equal to the accounts available."
+msgid "Cannot approve application(s) {} as partner(s) with proxy authorization method is/are waitlisted and (or) has/have not enough accounts available. If not enough accounts are available, prioritise the applications and then approve applications equal to the accounts available."
 msgstr ""
 
 #. Translators: This message is shown to coordinators who attempt to assign the same access code to multiple users.
@@ -1016,9 +900,7 @@ msgstr "Wszystkie zaznaczone wnioski zostały oznaczone jako wysłane."
 
 #. Translators: When a user tries to renew their resource, they receive this message if the partner is not available.
 #: TWLight/applications/views.py:1272
-msgid ""
-"Cannot renew application at this time as partner is not available. Please "
-"check back later, or contact us for more information."
+msgid "Cannot renew application at this time as partner is not available. Please check back later, or contact us for more information."
 msgstr ""
 
 #. Translators: This message is displayed when an attempt by a user to renew an application has been denied for some reason.
@@ -1029,21 +911,13 @@ msgstr "Próba odnowienia niezatwierdzonego zgłoszenia #{pk} została odrzucona
 
 #. Translators: If a user requests the renewal of their account, but it wasn't renewed, this message is shown to them.
 #: TWLight/applications/views.py:1385
-msgid ""
-"This object cannot be renewed. (This probably means that you have already "
-"requested that it be renewed.)"
-msgstr ""
-"Ten obiekt nie może być odnowiony. (Prawdopodobnie oznacza to, że już "
-"wystąpiłeś o jego odnowienie)."
+msgid "This object cannot be renewed. (This probably means that you have already requested that it be renewed.)"
+msgstr "Ten obiekt nie może być odnowiony. (Prawdopodobnie oznacza to, że już wystąpiłeś o jego odnowienie)."
 
 #. Translators: If a user requests the renewal of their account, this message is shown to them.
 #: TWLight/applications/views.py:1395
-msgid ""
-"Your renewal request has been received. A coordinator will review your "
-"request."
-msgstr ""
-"Otrzymaliśmy Twój wniosek o odnowienie odstępu. Zgłoszenie zostanie "
-"rozpatrzone przez koordynatora."
+msgid "Your renewal request has been received. A coordinator will review your request."
+msgstr "Otrzymaliśmy Twój wniosek o odnowienie odstępu. Zgłoszenie zostanie rozpatrzone przez koordynatora."
 
 #. Translators: This labels a textfield where users can enter their email ID.
 #: TWLight/emails/forms.py:18
@@ -1052,12 +926,8 @@ msgstr "Twój e-mail"
 
 #. Translators: This is the help text for the email field in the contact us form letting users know the field is updated by value pulled from their respective user profiles.
 #: TWLight/emails/forms.py:21
-msgid ""
-"This field is automatically updated with the email from your <a class='twl-"
-"links' href='{}'>user profile</a>."
-msgstr ""
-"To pole zostało automatycznie uzupełnione adresem e-mail z <a class='twl-"
-"links' href='{}'>Twojego profilu</a>."
+msgid "This field is automatically updated with the email from your <a class='twl-links' href='{}'>user profile</a>."
+msgstr "To pole zostało automatycznie uzupełnione adresem e-mail z <a class='twl-links' href='{}'>Twojego profilu</a>."
 
 #. Translators: This labels a textfield where users can enter their email message.
 #: TWLight/emails/forms.py:26
@@ -1080,26 +950,14 @@ msgstr "Wyślij"
 #. Translators: This email is sent to users with their access code. Don't translate Jinja variables in curly braces like user or partner. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/access_code_email-body-html.html:5
 #, python-format
-msgid ""
-"<p>Your approved application to %(partner)s has now been finalised. Your "
-"access code or login details can be found below:</p> <p><b>%(access_code)s</"
-"b></p> <p>%(user_instructions)s</p>"
-msgstr ""
-"<p>Twój wniosek został zatwierdzony i masz już dostęp do %(partner)s. "
-"Poniżej znajdziesz swój kod dostępu lub dane do logowania:</p> <p><b>"
-"%(access_code)s</b></p> <p>%(user_instructions)s</p>"
+msgid "<p>Your approved application to %(partner)s has now been finalised. Your access code or login details can be found below:</p> <p><b>%(access_code)s</b></p> <p>%(user_instructions)s</p>"
+msgstr "<p>Twój wniosek został zatwierdzony i masz już dostęp do %(partner)s. Poniżej znajdziesz swój kod dostępu lub dane do logowania:</p> <p><b>%(access_code)s</b></p> <p>%(user_instructions)s</p>"
 
 #. Translators: This email is sent to users with their access code. Don't translate Jinja variables in curly braces like user or partner. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/access_code_email-body-text.html:3
 #, python-format
-msgid ""
-"Your approved application to %(partner)s has now been finalised. Your access "
-"code or login details can be found below: %(access_code)s "
-"%(user_instructions)s"
-msgstr ""
-"Twój wniosek został zatwierdzony i masz już dostęp do %(partner)s. Poniżej "
-"znajdziesz swój kod dostępu lub dane do logowania: %(access_code)s "
-"%(user_instructions)s"
+msgid "Your approved application to %(partner)s has now been finalised. Your access code or login details can be found below: %(access_code)s %(user_instructions)s"
+msgstr "Twój wniosek został zatwierdzony i masz już dostęp do %(partner)s. Poniżej znajdziesz swój kod dostępu lub dane do logowania: %(access_code)s %(user_instructions)s"
 
 #. Translators: This is the subject line of an email sent to users with their access code.
 #: TWLight/emails/templates/emails/access_code_email-subject.html:3
@@ -1109,34 +967,14 @@ msgstr "Twój kod dostępu do Biblioteki Wikipedia"
 #. Translators: This email is sent to users when their application is approved. Don't translate Jinja variables in curly braces like user or partner; don't translate html tags either. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/approval_notification-body-html.html:5
 #, python-format
-msgid ""
-"<p>Dear %(user)s,</p> <p>Thank you for applying for access to %(partner)s "
-"resources through The Wikipedia Library. We are happy to inform you that "
-"your application has been approved.</p> <p>%(user_instructions)s</p> <p>You "
-"can view the collections you're authorized to access at My Library: "
-"%(link)s</p> <p>Cheers!</p> <p>The Wikipedia Library</p>"
-msgstr ""
-"<p>Witaj %(user)s!</p> <p>Dziękujemy za złożenie wniosku o dostęp do zasobów "
-"%(partner)s poprzez Bibliotekę Wikipedia. Z radością zawiadamiamy, że "
-"wniosek został przyjęty.</p> <p>%(user_instructions)s</p> <p>Kolekcje, do "
-"których masz dostęp, możesz przeglądać w swojej bibliotece: %(link)s</p> "
-"<p>Z pozdrowieniami,</p> <p>Biblioteka Wikipedia</p>"
+msgid "<p>Dear %(user)s,</p> <p>Thank you for applying for access to %(partner)s resources through The Wikipedia Library. We are happy to inform you that your application has been approved.</p> <p>%(user_instructions)s</p> <p>You can view the collections you're authorized to access at My Library: %(link)s</p> <p>Cheers!</p> <p>The Wikipedia Library</p>"
+msgstr "<p>Witaj %(user)s!</p> <p>Dziękujemy za złożenie wniosku o dostęp do zasobów %(partner)s poprzez Bibliotekę Wikipedia. Z radością zawiadamiamy, że wniosek został przyjęty.</p> <p>%(user_instructions)s</p> <p>Kolekcje, do których masz dostęp, możesz przeglądać w swojej bibliotece: %(link)s</p> <p>Z pozdrowieniami,</p> <p>Biblioteka Wikipedia</p>"
 
 #. Translators: This email is sent to users when their application is approved. Don't translate Jinja variables in curly braces like user or partner. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/approval_notification-body-text.html:3
 #, python-format
-msgid ""
-"Dear %(user)s, Thank you for applying for access to %(partner)s resources "
-"through The Wikipedia Library. We are happy to inform you that your "
-"application has been approved. %(user_instructions)s You can view the "
-"collections you're authorized to access at My Library: %(link)s Cheers! The "
-"Wikipedia Library"
-msgstr ""
-"Witaj %(user)s! Dziękujemy za złożenie wniosku o dostęp do zasobów "
-"%(partner)s poprzez Bibliotekę Wikipedia. Z radością zawiadamiamy, że "
-"wniosek został przyjęty. %(user_instructions)s Kolekcje, do których masz "
-"dostęp, możesz przeglądać w swojej bibliotece: %(link)s Z pozdrowieniami, "
-"Biblioteka Wikipedia"
+msgid "Dear %(user)s, Thank you for applying for access to %(partner)s resources through The Wikipedia Library. We are happy to inform you that your application has been approved. %(user_instructions)s You can view the collections you're authorized to access at My Library: %(link)s Cheers! The Wikipedia Library"
+msgstr "Witaj %(user)s! Dziękujemy za złożenie wniosku o dostęp do zasobów %(partner)s poprzez Bibliotekę Wikipedia. Z radością zawiadamiamy, że wniosek został przyjęty. %(user_instructions)s Kolekcje, do których masz dostęp, możesz przeglądać w swojej bibliotece: %(link)s Z pozdrowieniami, Biblioteka Wikipedia"
 
 #. Translators: This is the subject of an email which is sent to users when their application has been approved. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/approval_notification-subject.html:4
@@ -1146,19 +984,13 @@ msgstr "Twój wniosek o dostęp do Biblioteki Wikipedia został przyjęty"
 #. Translators: This email is sent to coordinators when a comment is left on an application they are processing. Don't translate Jinja variables in curly braces like user or partner. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/comment_notification_coordinator-body-html.html:5
 #, python-format
-msgid ""
-"<p style=\"color: #500050\">%(submit_date)s - %(commenter)s</p> "
-"<blockquote><p>%(comment)s</p></blockquote> <p>Please reply to these at: <a "
-"href=\"%(app_url)s\">%(app_url)s</a></p> <p>Best,</p> <p>The Wikipedia "
-"Library</p>"
+msgid "<p style=\"color: #500050\">%(submit_date)s - %(commenter)s</p> <blockquote><p>%(comment)s</p></blockquote> <p>Please reply to these at: <a href=\"%(app_url)s\">%(app_url)s</a></p> <p>Best,</p> <p>The Wikipedia Library</p>"
 msgstr ""
 
 #. Translators: This email is sent to coordinators when a comment is left on an application they are processing. Don't translate Jinja variables in curly braces like user or partner. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/comment_notification_coordinator-body-text.html:3
 #, python-format
-msgid ""
-"%(submit_date)s - %(commenter)s %(comment)s Please reply to this at: "
-"%(app_url)s Best, The Wikipedia Library"
+msgid "%(submit_date)s - %(commenter)s %(comment)s Please reply to this at: %(app_url)s Best, The Wikipedia Library"
 msgstr ""
 
 #. Translators: This is the subject line of an email sent to coordinators when a comment is left on an application they processed.
@@ -1169,19 +1001,13 @@ msgstr "Nowy komentarz na wniosku do Biblioteki Wikipedii, który przeglądałe�
 #. Translators: This email is sent to users when they receive a comment on their application. Don't translate Jinja variables in curly braces like user or partner; don't translate html tags either. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/comment_notification_editors-body-html.html:5
 #, python-format
-msgid ""
-"<p style=\"color: #500050\">%(submit_date)s - %(commenter)s</p> "
-"<blockquote><p>%(comment)s</p></blockquote> <p>Please reply to these at <a "
-"href=\"%(app_url)s\">%(app_url)s</a> so we can evaluate your application.</"
-"p> <p>Best,</p> <p>The Wikipedia Library</p>"
+msgid "<p style=\"color: #500050\">%(submit_date)s - %(commenter)s</p> <blockquote><p>%(comment)s</p></blockquote> <p>Please reply to these at <a href=\"%(app_url)s\">%(app_url)s</a> so we can evaluate your application.</p> <p>Best,</p> <p>The Wikipedia Library</p>"
 msgstr ""
 
 #. Translators: This email is sent to users when they receive a comment on their application. Don't translate Jinja variables in curly braces like user or partner. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/comment_notification_editors-body-text.html:3
 #, python-format
-msgid ""
-"%(submit_date)s - %(commenter)s %(comment)s Please reply to these at: "
-"%(app_url)s so we can evaluate your application. Best, The Wikipedia Library"
+msgid "%(submit_date)s - %(commenter)s %(comment)s Please reply to these at: %(app_url)s so we can evaluate your application. Best, The Wikipedia Library"
 msgstr ""
 
 #. Translators: This is the subject line of an email sent to users who have a comment added to one of their applications. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
@@ -1192,33 +1018,24 @@ msgstr "Nowy komentarz na twoim wniosku do Biblioteki Wikipedii"
 #. Translators: This email is sent to users when an application they commented on receives another comment. Don't translate Jinja variables in curly braces like app_url; don't translate html tags either. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/comment_notification_others-body-html.html:5
 #, python-format
-msgid ""
-"<p style=\"color: #500050\">%(submit_date)s - %(commenter)s</p> "
-"<blockquote><p>%(comment)s</p></blockquote> See it at <a href=\"%(app_url)s"
-"\">%(app_url)s</a>. Thanks for helping review Wikipedia Library applications!"
+msgid "<p style=\"color: #500050\">%(submit_date)s - %(commenter)s</p> <blockquote><p>%(comment)s</p></blockquote> See it at <a href=\"%(app_url)s\">%(app_url)s</a>. Thanks for helping review Wikipedia Library applications!"
 msgstr ""
 
 #. Translators: This email is sent to users when an application they commented on receives another comment. Don't translate Jinja variables in curly braces like app_url. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/comment_notification_others-body-text.html:3
 #, python-format
-msgid ""
-"%(submit_date)s - %(commenter)s %(comment)s See it at: %(app_url)s Thanks "
-"for helping review Wikipedia Library applications!"
+msgid "%(submit_date)s - %(commenter)s %(comment)s See it at: %(app_url)s Thanks for helping review Wikipedia Library applications!"
 msgstr ""
 
 #. Translators: This is the subject line of an email sent to users who have a comment added to an application they also commented on. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/comment_notification_others-subject.html:4
 msgid "New comment on a Wikipedia Library application you commented on"
-msgstr ""
-"Nowy komentarz na wniosku do Biblioteki Wikipedii, który komentowałeś/-aś"
+msgstr "Nowy komentarz na wniosku do Biblioteki Wikipedii, który komentowałeś/-aś"
 
 #. Translators: This text is part of a scheduled reminder email sent to coordinators who have applications requiring action. Don't translate Jinja variables in curly braces like total_apps, or user.
 #: TWLight/emails/templates/emails/coordinator_reminder_notification-body-html.html:5
 #, python-format
-msgid ""
-"<p>Dear %(user)s,</p> <p>Our records indicate that you are the designated "
-"coordinator for partners that have a total of %(total_apps)s applications.</"
-"p>"
+msgid "<p>Dear %(user)s,</p> <p>Our records indicate that you are the designated coordinator for partners that have a total of %(total_apps)s applications.</p>"
 msgstr ""
 
 #. Translators: Breakdown as in 'cost breakdown'; analysis.
@@ -1260,43 +1077,20 @@ msgstr[2] "%(counter)s zaakceptowanych zgłoszeń."
 #. Translators: This text is part of a scheduled reminder email sent to coordinators who have applications requiring action. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library). Don't translate Jinja variables in curly braces like link; don't translate email addresses or html tags either.
 #: TWLight/emails/templates/emails/coordinator_reminder_notification-body-html.html:39
 #, python-format
-msgid ""
-"<p>This is a gentle reminder that you may review applications at <a href="
-"\"%(link)s\">%(link)s</a>.</p> <p>You can customise your reminders under "
-"'preferences' in your user profile.</p> <p>If you received this message in "
-"error, drop us a line at wikipedialibrary@wikimedia.org.</p> <p>Thanks for "
-"helping review Wikipedia Library applications!</p>"
-msgstr ""
-"<p>Chcielibyśmy przypomnieć, że możesz rozpatrywać zgłoszenia na stronie <a "
-"href=\"%(link)s\">%(link)s</a>.</p> <p>Aby dostosować przypomnienia, przejdź "
-"do zakładki „Preferencje” w swoim profilu użytkownika.</p> <p>Jeżeli ta "
-"wiadomość została wysłana przez pomyłkę, napisz do nas na adres "
-"wikipedialibrary@wikimedia.org.</p> <p>Dziękujemy za pomoc w rozpatrywaniu "
-"zgłoszeń w Bibliotece Wikipedia!</p>"
+msgid "<p>This is a gentle reminder that you may review applications at <a href=\"%(link)s\">%(link)s</a>.</p> <p>You can customise your reminders under 'preferences' in your user profile.</p> <p>If you received this message in error, drop us a line at wikipedialibrary@wikimedia.org.</p> <p>Thanks for helping review Wikipedia Library applications!</p>"
+msgstr "<p>Chcielibyśmy przypomnieć, że możesz rozpatrywać zgłoszenia na stronie <a href=\"%(link)s\">%(link)s</a>.</p> <p>Aby dostosować przypomnienia, przejdź do zakładki „Preferencje” w swoim profilu użytkownika.</p> <p>Jeżeli ta wiadomość została wysłana przez pomyłkę, napisz do nas na adres wikipedialibrary@wikimedia.org.</p> <p>Dziękujemy za pomoc w rozpatrywaniu zgłoszeń w Bibliotece Wikipedia!</p>"
 
 #. Translators: This text is part of a scheduled reminder email sent to coordinators who have applications requiring action. Don't translate Jinja variables in curly braces like total_apps, or user.
 #: TWLight/emails/templates/emails/coordinator_reminder_notification-body-text.html:3
 #, python-format
-msgid ""
-"Dear %(user)s, Our records indicate that you are the designated coordinator "
-"for partners that have a total of %(total_apps)s applications."
+msgid "Dear %(user)s, Our records indicate that you are the designated coordinator for partners that have a total of %(total_apps)s applications."
 msgstr ""
 
 #. Translators: This text is part of a scheduled reminder email sent to coordinators who have applications requiring action. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library). Don't translate Jinja variables in curly braces like link; don't translate the email address either.
 #: TWLight/emails/templates/emails/coordinator_reminder_notification-body-text.html:38
 #, python-format
-msgid ""
-"This is a gentle reminder that you may review applications at: %(link)s. You "
-"can customise your reminders under 'preferences' in your user profile. If "
-"you received this message in error, drop us a line at: "
-"wikipedialibrary@wikimedia.org Thanks for helping review Wikipedia Library "
-"applications!"
-msgstr ""
-"Chcielibyśmy przypomnieć, że możesz rozpatrywać zgłoszenia na stronie "
-"%(link)s. Aby dostosować przypomnienia, przejdź do zakładki „Preferencje” w "
-"swoim profilu użytkownika. Jeżeli ta wiadomość została wysłana przez "
-"pomyłkę, napisz do nas na adres wikipedialibrary@wikimedia.org. Dziękujemy "
-"za pomoc w rozpatrywaniu zgłoszeń w Bibliotece Wikipedia!"
+msgid "This is a gentle reminder that you may review applications at: %(link)s. You can customise your reminders under 'preferences' in your user profile. If you received this message in error, drop us a line at: wikipedialibrary@wikimedia.org Thanks for helping review Wikipedia Library applications!"
+msgstr "Chcielibyśmy przypomnieć, że możesz rozpatrywać zgłoszenia na stronie %(link)s. Aby dostosować przypomnienia, przejdź do zakładki „Preferencje” w swoim profilu użytkownika. Jeżeli ta wiadomość została wysłana przez pomyłkę, napisz do nas na adres wikipedialibrary@wikimedia.org. Dziękujemy za pomoc w rozpatrywaniu zgłoszeń w Bibliotece Wikipedia!"
 
 #. Translators: This is the subject line of a scheduled reminder email sent to coordinators who have applications to review. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library). Do not translate items in curly braces.
 #: TWLight/emails/templates/emails/coordinator_reminder_notification-subject.html:4
@@ -1306,32 +1100,14 @@ msgstr "Zgłoszenia w Bibliotece Wikipedia oczekują na przejrzenie"
 #. Translators: This email is sent to users when their application is rejected. Don't translate Jinja variables in curly braces like user or partner; don't translate html tags either. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/rejection_notification-body-html.html:5
 #, python-format
-msgid ""
-"<p>Dear %(user)s,</p> <p>Thank you for applying for access to %(partner)s "
-"resources through The Wikipedia Library. Unfortunately at this time your "
-"application has not been approved. You can view your application and review "
-"comments at <a href=\"%(app_url)s\">%(app_url)s</a>.</p> <p>Best,</p> <p>The "
-"Wikipedia Library</p>"
-msgstr ""
-"<p>Witaj %(user)s!</p> <p>Dziękujemy za złożenie wniosku o dostęp do zasobów "
-"%(partner)s poprzez Bibliotekę Wikipedia. Niestety Twoje zgłoszenie nie "
-"zostało zatwierdzone. Aby zapoznać się ze zgłoszeniem i komentarzami, "
-"odwiedź stronę: <a href=\"%(app_url)s\">%(app_url)s</a>.</p> <p>Z "
-"pozdrowieniami,</p> <p>Biblioteka Wikipedia</p>"
+msgid "<p>Dear %(user)s,</p> <p>Thank you for applying for access to %(partner)s resources through The Wikipedia Library. Unfortunately at this time your application has not been approved. You can view your application and review comments at <a href=\"%(app_url)s\">%(app_url)s</a>.</p> <p>Best,</p> <p>The Wikipedia Library</p>"
+msgstr "<p>Witaj %(user)s!</p> <p>Dziękujemy za złożenie wniosku o dostęp do zasobów %(partner)s poprzez Bibliotekę Wikipedia. Niestety Twoje zgłoszenie nie zostało zatwierdzone. Aby zapoznać się ze zgłoszeniem i komentarzami, odwiedź stronę: <a href=\"%(app_url)s\">%(app_url)s</a>.</p> <p>Z pozdrowieniami,</p> <p>Biblioteka Wikipedia</p>"
 
 #. Translators: This email is sent to users when their application is rejected. Don't translate Jinja variables in curly braces like user or partner. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/rejection_notification-body-text.html:3
 #, python-format
-msgid ""
-"Dear %(user)s, Thank you for applying for access to %(partner)s resources "
-"through The Wikipedia Library. Unfortunately at this time your application "
-"has not been approved. You can view your application and review comments at: "
-"%(app_url)s Best, The Wikipedia Library"
-msgstr ""
-"Witaj %(user)s! Dziękujemy za złożenie wniosku o dostęp do zasobów "
-"%(partner)s poprzez Bibliotekę Wikipedia. Niestety Twoje zgłoszenie nie "
-"zostało zatwierdzone. Aby zapoznać się ze zgłoszeniem i komentarzami, "
-"odwiedź stronę: %(app_url)s Z pozdrowieniami, Biblioteka Wikipedia"
+msgid "Dear %(user)s, Thank you for applying for access to %(partner)s resources through The Wikipedia Library. Unfortunately at this time your application has not been approved. You can view your application and review comments at: %(app_url)s Best, The Wikipedia Library"
+msgstr "Witaj %(user)s! Dziękujemy za złożenie wniosku o dostęp do zasobów %(partner)s poprzez Bibliotekę Wikipedia. Niestety Twoje zgłoszenie nie zostało zatwierdzone. Aby zapoznać się ze zgłoszeniem i komentarzami, odwiedź stronę: %(app_url)s Z pozdrowieniami, Biblioteka Wikipedia"
 
 #. Translators: This is the subject of an email which is sent to users when their application has been rejected. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/rejection_notification-subject.html:4
@@ -1341,40 +1117,14 @@ msgstr "Twoje zgłoszenie w Bibliotece Wikipedia"
 #. Translators: This email is sent to users when they have an account that is soon to expire. Don't translate Jinja variables in curly braces like partner_name or partner_link; don't translate html tags either. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/user_renewal_notice-body-html.html:5
 #, python-format
-msgid ""
-"<p>Dear %(user)s,</p> <p>According to our records, your access to "
-"%(partner_name)s will soon expire and you may lose access. If you want to "
-"continue making use of your free account, you can request renewal of your "
-"account by clicking the 'Renew' or 'Extend' button at %(partner_link)s.</p> "
-"<p>Best,</p> <p>The Wikipedia Library</p> <p>You can disable these emails in "
-"your user page preferences: https://wikipedialibrary.wmflabs.org/users/</p>"
-msgstr ""
-"<p>Witaj %(user)s!</p> <p>Z naszych danych wynika, że Twój dostęp do "
-"%(partner_name)s wkrótce wygaśnie i możesz utracić do niego dostęp. Jeśli "
-"chcesz nadal korzystać ze swojego bezpłatnego konta, złóż wniosek o jego "
-"odnowienie. W tym celu kliknij przycisk „Odnów” lub „Przedłuż” na stronie "
-"%(partner_link)s.</p> <p>Z pozdrowieniami,</p> <p>Biblioteka Wikipedia</p> "
-"<p>Możesz wyłączyć otrzymywanie przypomnień e-mail w preferencjach na swojej "
-"stronie użytkownika: https://wikipedialibrary.wmflabs.org/users/</p>"
+msgid "<p>Dear %(user)s,</p> <p>According to our records, your access to %(partner_name)s will soon expire and you may lose access. If you want to continue making use of your free account, you can request renewal of your account by clicking the 'Renew' or 'Extend' button at %(partner_link)s.</p> <p>Best,</p> <p>The Wikipedia Library</p> <p>You can disable these emails in your user page preferences: https://wikipedialibrary.wmflabs.org/users/</p>"
+msgstr "<p>Witaj %(user)s!</p> <p>Z naszych danych wynika, że Twój dostęp do %(partner_name)s wkrótce wygaśnie i możesz utracić do niego dostęp. Jeśli chcesz nadal korzystać ze swojego bezpłatnego konta, złóż wniosek o jego odnowienie. W tym celu kliknij przycisk „Odnów” lub „Przedłuż” na stronie %(partner_link)s.</p> <p>Z pozdrowieniami,</p> <p>Biblioteka Wikipedia</p> <p>Możesz wyłączyć otrzymywanie przypomnień e-mail w preferencjach na swojej stronie użytkownika: https://wikipedialibrary.wmflabs.org/users/</p>"
 
 #. Translators: This email is sent to users when they have an account that is soon to expire. Don't translate Jinja variables in curly braces like partner_name or partner_link; don't translate html tags either. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/user_renewal_notice-body-text.html:3
 #, python-format
-msgid ""
-"Dear %(user)s, According to our records, your access to %(partner_name)s "
-"will soon expire and you may lose access. If you want to continue making use "
-"of your free account, you can request renewal of your account by clicking "
-"the Renew button at %(partner_link)s. Best, The Wikipedia Library You can "
-"disable these emails in your user page preferences: https://wikipedialibrary."
-"wmflabs.org/users/"
-msgstr ""
-"Witaj %(user)s! Z naszych danych wynika, że Twój dostęp do %(partner_name)s "
-"wkrótce wygaśnie i możesz utracić do niego dostęp. Jeśli chcesz nadal "
-"korzystać ze swojego bezpłatnego konta, złóż wniosek o jego odnowienie. W "
-"tym celu kliknij przycisk „Odnów” na stronie %(partner_link)s. Z "
-"pozdrowieniami, Biblioteka Wikipedia Możesz wyłączyć otrzymywanie "
-"przypomnień e-mail w preferencjach na swojej stronie użytkownika: https://"
-"wikipedialibrary.wmflabs.org/users/"
+msgid "Dear %(user)s, According to our records, your access to %(partner_name)s will soon expire and you may lose access. If you want to continue making use of your free account, you can request renewal of your account by clicking the Renew button at %(partner_link)s. Best, The Wikipedia Library You can disable these emails in your user page preferences: https://wikipedialibrary.wmflabs.org/users/"
+msgstr "Witaj %(user)s! Z naszych danych wynika, że Twój dostęp do %(partner_name)s wkrótce wygaśnie i możesz utracić do niego dostęp. Jeśli chcesz nadal korzystać ze swojego bezpłatnego konta, złóż wniosek o jego odnowienie. W tym celu kliknij przycisk „Odnów” na stronie %(partner_link)s. Z pozdrowieniami, Biblioteka Wikipedia Możesz wyłączyć otrzymywanie przypomnień e-mail w preferencjach na swojej stronie użytkownika: https://wikipedialibrary.wmflabs.org/users/"
 
 #. Translators: This is the subject of an email sent to users when they have an account that is soon to expire. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/user_renewal_notice-subject.html:4
@@ -1384,24 +1134,13 @@ msgstr "Twój dostęp w Bibliotece Wikipedia może wkrótce wygasnąć"
 #. Translators: This email is sent to users when their application is waitlisted because there are no more accounts available. Don't translate Jinja variables in curly braces like user or partner; don't translate html tags either. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/waitlist_notification-body-html.html:5
 #, python-format
-msgid ""
-"<p>Dear %(user)s,</p> <p>Thank you for applying for access to %(partner)s "
-"resources through The Wikipedia Library. There are no accounts currently "
-"available so your application has been waitlisted. Your application will be "
-"evaluated if/when more accounts become available. You can see all available "
-"resources at <a href=\"%(link)s\">%(link)s</a>.</p> <p>Best,</p> <p>The "
-"Wikipedia Library</p>"
+msgid "<p>Dear %(user)s,</p> <p>Thank you for applying for access to %(partner)s resources through The Wikipedia Library. There are no accounts currently available so your application has been waitlisted. Your application will be evaluated if/when more accounts become available. You can see all available resources at <a href=\"%(link)s\">%(link)s</a>.</p> <p>Best,</p> <p>The Wikipedia Library</p>"
 msgstr ""
 
 #. Translators: This email is sent to users when their application is waitlisted because there are no more accounts available. Don't translate Jinja variables in curly braces like user or partner. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/waitlist_notification-body-text.html:3
 #, python-format
-msgid ""
-"Dear %(user)s, Thank you for applying for access to %(partner)s resources "
-"through The Wikipedia Library. There are no accounts currently available so "
-"your application has been waitlisted. Your application will be evaluated if/"
-"when more accounts become available. You can see all available resources at: "
-"%(link)s Best, The Wikipedia Library"
+msgid "Dear %(user)s, Thank you for applying for access to %(partner)s resources through The Wikipedia Library. There are no accounts currently available so your application has been waitlisted. Your application will be evaluated if/when more accounts become available. You can see all available resources at: %(link)s Best, The Wikipedia Library"
 msgstr ""
 
 #. Translators: This is the subject of an email sent to users when their application is waitlisted because there are no more accounts available. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
@@ -1563,22 +1302,15 @@ msgstr "Niedostępna"
 #: TWLight/resources/templates/resources/filter_section.html:14
 #: TWLight/templates/about.html:12
 #: TWLight/users/templates/users/filter_section.html:13
-msgid ""
-"The Wikipedia Library allows active editors to access a wide range of "
-"collections of paywalled reliable sources for free!"
-msgstr ""
-"Biblioteka Wikipedia zapewnia aktywnym wikipedystom bezpłatny dostęp do "
-"licznych kolekcji wiarygodnych źródeł ukrytych za paywallem."
+msgid "The Wikipedia Library allows active editors to access a wide range of collections of paywalled reliable sources for free!"
+msgstr "Biblioteka Wikipedia zapewnia aktywnym wikipedystom bezpłatny dostęp do licznych kolekcji wiarygodnych źródeł ukrytych za paywallem."
 
 #. Translators: On the Browse Partners page (https://wikipedialibrary.wmflabs.org/partners/), this introduces users to The Wikipedia Library.
 #. Translators: On the MyLibrary page (https://wikipedialibrary.wmflabs.org/users/my_library), this introduces users to The Wikipedia Library.
 #: TWLight/resources/templates/resources/filter_section.html:17
 #: TWLight/users/templates/users/filter_section.html:15
-msgid ""
-"Start with the search bar at the top or browse publisher websites directly."
-msgstr ""
-"Skorzystaj z wyszukiwarki u góry strony lub przeglądaj witryny wydawców "
-"indywidualnie."
+msgid "Start with the search bar at the top or browse publisher websites directly."
+msgstr "Skorzystaj z wyszukiwarki u góry strony lub przeglądaj witryny wydawców indywidualnie."
 
 #. Translators: On the Browse Partners page (https://wikipedialibrary.wmflabs.org/partners/), this appears below introductory text and links to the 'About' page (https://wikipedialibrary.wmflabs.org/about/)
 #. Translators: On the MyLibrary page (https://wikipedialibrary.wmflabs.org/users/my_library), this appears below introductory text and links to the 'About' page (https://wikipedialibrary.wmflabs.org/about/)
@@ -1651,68 +1383,39 @@ msgstr "Powrót do partnerów"
 #. Translators: If we have no available accounts for a partner, the coordinator can change the application system to a waiting list.
 #: TWLight/resources/templates/resources/partner_detail.html:36
 #: TWLight/resources/templates/resources/partner_detail_apply.html:17
-msgid ""
-"There are no access grants available for this partner at this time. You can "
-"still apply for access; applications will be processed when access is "
-"available."
-msgstr ""
-"Przyznaliśmy już maksymalną liczbę zezwoleń na dostęp do tego partnera. "
-"Nadal możesz ubiegać się o dostęp; zgłoszenia będą rozpatrywane po "
-"zwolnieniu się miejsc."
+msgid "There are no access grants available for this partner at this time. You can still apply for access; applications will be processed when access is available."
+msgstr "Przyznaliśmy już maksymalną liczbę zezwoleń na dostęp do tego partnera. Nadal możesz ubiegać się o dostęp; zgłoszenia będą rozpatrywane po zwolnieniu się miejsc."
 
 #. Translators: This text links to the minimum user requirements and terms of use on the partner page.
 #: TWLight/resources/templates/resources/partner_detail.html:48
 #: TWLight/resources/templates/resources/partner_detail_apply.html:29
 #, python-format
-msgid ""
-"Before applying, please review the <strong><a class=\"twl-links\" href="
-"\"%(about)s#req\">minimum requirements</a></strong> for access and our "
-"<strong><a class=\"twl-links\" href=\"%(terms)s\">terms of use</a></strong>."
-msgstr ""
-"Przed wysłaniem zgłoszenia należy zapoznać się z <strong><a class=\"twl-links"
-"\" href=\"%(about)s#req\">minimalnymi wymaganiami</a></strong> dotyczącymi "
-"dostępu oraz naszymi <strong><a class=\"twl-links\" href=\"%(terms)s"
-"\">warunkami użytkowania</a></strong>."
+msgid "Before applying, please review the <strong><a class=\"twl-links\" href=\"%(about)s#req\">minimum requirements</a></strong> for access and our <strong><a class=\"twl-links\" href=\"%(terms)s\">terms of use</a></strong>."
+msgstr "Przed wysłaniem zgłoszenia należy zapoznać się z <strong><a class=\"twl-links\" href=\"%(about)s#req\">minimalnymi wymaganiami</a></strong> dotyczącymi dostępu oraz naszymi <strong><a class=\"twl-links\" href=\"%(terms)s\">warunkami użytkowania</a></strong>."
 
 #. Translators: This text refers to the page containing the content a user is authorized to access.
 #: TWLight/resources/templates/resources/partner_detail.html:69
 #, python-format
-msgid ""
-"View the status of your access in <strong><a class=\"twl-links\" href="
-"\"%(library_url)s\">My Library</a></strong> page."
-msgstr ""
-"Wyświetl kolekcje z przyznanym dostępem na stronie <strong><a class=\"twl-"
-"links\" href=\"%(library_url)s\">Moja biblioteka</a></strong>."
+msgid "View the status of your access in <strong><a class=\"twl-links\" href=\"%(library_url)s\">My Library</a></strong> page."
+msgstr "Wyświetl kolekcje z przyznanym dostępem na stronie <strong><a class=\"twl-links\" href=\"%(library_url)s\">Moja biblioteka</a></strong>."
 
 #. Translators: This message is shown when a user has open applications, linking to their respective applications page.
 #: TWLight/resources/templates/resources/partner_detail.html:78
 #, python-format
-msgid ""
-"View the status of your application(s) on your <strong><a class=\"twl-links"
-"\" href=\"%(applications_url)s\">My Applications</a></strong> page."
-msgstr ""
-"Wyświetl statusy zgłoszeń na stronie <strong><a class=\"twl-links\" href="
-"\"%(applications_url)s\">Moje zgłoszenia</a></strong>."
+msgid "View the status of your application(s) on your <strong><a class=\"twl-links\" href=\"%(applications_url)s\">My Applications</a></strong> page."
+msgstr "Wyświetl statusy zgłoszeń na stronie <strong><a class=\"twl-links\" href=\"%(applications_url)s\">Moje zgłoszenia</a></strong>."
 
 #. Translators: This message is shown when a user has authorizations, linking to their respective collections page.
 #: TWLight/resources/templates/resources/partner_detail_apply.html:50
 #, python-format
-msgid ""
-"View the status of your access on your <strong><a href=\"%(library_url)s\" "
-"class=\"twl-links\">My Library</a></strong> page."
-msgstr ""
-"Wyświetl kolekcje z przyznanym dostępem na stronie <strong><a class=\"twl-"
-"links\" href=\"%(library_url)s\">Moja biblioteka</a></strong>."
+msgid "View the status of your access on your <strong><a href=\"%(library_url)s\" class=\"twl-links\">My Library</a></strong> page."
+msgstr "Wyświetl kolekcje z przyznanym dostępem na stronie <strong><a class=\"twl-links\" href=\"%(library_url)s\">Moja biblioteka</a></strong>."
 
 #. Translators: This message is shown when a user has open applications, linking to their respective applications page.
 #: TWLight/resources/templates/resources/partner_detail_apply.html:60
 #, python-format
-msgid ""
-"View the status of your application(s) on your <strong><a href="
-"\"%(applications_url)s\">My Applications</a></strong> page."
-msgstr ""
-"Wyświetl statusy zgłoszeń na stronie <strong><a class=\"twl-links\" href="
-"\"%(applications_url)s\">Moje zgłoszenia</a></strong>."
+msgid "View the status of your application(s) on your <strong><a href=\"%(applications_url)s\">My Applications</a></strong> page."
+msgstr "Wyświetl statusy zgłoszeń na stronie <strong><a class=\"twl-links\" href=\"%(applications_url)s\">Moje zgłoszenia</a></strong>."
 
 #. Translators: One the partner detail page, this text labels the button which coordinators can click to remove a partner from waitlisted status.
 #: TWLight/resources/templates/resources/partner_detail_apply.html:73
@@ -1741,14 +1444,8 @@ msgstr "Strona Specjalna:E-mail"
 
 #. Translators: If no account coordinator is assigned to a partner, the Wikipedia Library team will coordinate signups. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/resources/templates/resources/partner_detail_apply.html:112
-msgid ""
-"The Wikipedia Library team will process this application. Want to help? <a "
-"class=\"twl-links\" href=\"https://en.wikipedia.org/wiki/Wikipedia:"
-"The_Wikipedia_Library/Coordinators/Signup\">Sign up as a coordinator.</a>"
-msgstr ""
-"Zgłoszenie zostanie rozpatrzone przez zespół Biblioteki Wikipedia. Chcesz "
-"pomóc? <a class=\"twl-links\" href=\"https://en.wikipedia.org/wiki/Wikipedia:"
-"The_Wikipedia_Library/Coordinators/Signup\">Zostań koordynatorem.</a>"
+msgid "The Wikipedia Library team will process this application. Want to help? <a class=\"twl-links\" href=\"https://en.wikipedia.org/wiki/Wikipedia:The_Wikipedia_Library/Coordinators/Signup\">Sign up as a coordinator.</a>"
+msgstr "Zgłoszenie zostanie rozpatrzone przez zespół Biblioteki Wikipedia. Chcesz pomóc? <a class=\"twl-links\" href=\"https://en.wikipedia.org/wiki/Wikipedia:The_Wikipedia_Library/Coordinators/Signup\">Zostań koordynatorem.</a>"
 
 #. Translators: This text labels a button coordinators can click to view a list of users who have applied for access for a particular partner
 #: TWLight/resources/templates/resources/partner_detail_apply.html:121
@@ -1777,24 +1474,14 @@ msgstr "Dostęp w ramach Pakietu Bazowego"
 
 #. Translators: Text shown to authenticated, bundle eligible users when they visit a Bundle partner page.
 #: TWLight/resources/templates/resources/partner_detail_apply.html:138
-msgid ""
-"You are eligible to access Library Bundle partners. Click the button above "
-"to access the collection."
-msgstr ""
-"Masz dostęp do partnerów z Pakietu Bazowego. Kliknij przycisk powyżej, aby "
-"przejść do kolekcji."
+msgid "You are eligible to access Library Bundle partners. Click the button above to access the collection."
+msgstr "Masz dostęp do partnerów z Pakietu Bazowego. Kliknij przycisk powyżej, aby przejść do kolekcji."
 
 #. Translators: Text shown to authenticated, bundle ineligible users when they visit a Bundle partner page.
 #: TWLight/resources/templates/resources/partner_detail_apply.html:152
 #, python-format
-msgid ""
-"You are not eligible to access Library Bundle partners. Visit the <a class="
-"\"twl-links\" href=\"%(homepage)s\">homepage</a> to check the eligibility "
-"criteria."
-msgstr ""
-"Nie masz dostępu do partnerów z Pakietu Bazowego. Przejdź na <a class=\"twl-"
-"links\" href=\"%(homepage)s\">stronę główną</a>, aby sprawdzić warunki "
-"dostępu."
+msgid "You are not eligible to access Library Bundle partners. Visit the <a class=\"twl-links\" href=\"%(homepage)s\">homepage</a> to check the eligibility criteria."
+msgstr "Nie masz dostępu do partnerów z Pakietu Bazowego. Przejdź na <a class=\"twl-links\" href=\"%(homepage)s\">stronę główną</a>, aby sprawdzić warunki dostępu."
 
 #. Translators: Buttton prompting users to log in.
 #: TWLight/resources/templates/resources/partner_detail_apply.html:160
@@ -1805,15 +1492,8 @@ msgstr "Zaloguj się"
 #. Translators: Text shown to unauthenticated users when they visit a Bundle partner page.
 #: TWLight/resources/templates/resources/partner_detail_apply.html:168
 #, python-format
-msgid ""
-"This resource is part of our <a class=\"twl-links\" href=\"%(about)s"
-"\">Library Bundle</a>, which you can access if you meet our minimum "
-"eligibility criteria. Log in to find out if you are eligible."
-msgstr ""
-"Ta zawartość jest częścią naszego <a class=\"twl-links\" href=\"%(about)s"
-"\">Pakietu Bazowego</a>, do którego możesz uzyskać dostęp, jeśli spełniasz "
-"minimalne kryteria dostępu. Zaloguj się, aby dowiedzieć się, czy się "
-"kwalifikujesz."
+msgid "This resource is part of our <a class=\"twl-links\" href=\"%(about)s\">Library Bundle</a>, which you can access if you meet our minimum eligibility criteria. Log in to find out if you are eligible."
+msgstr "Ta zawartość jest częścią naszego <a class=\"twl-links\" href=\"%(about)s\">Pakietu Bazowego</a>, do którego możesz uzyskać dostęp, jeśli spełniasz minimalne kryteria dostępu. Zaloguj się, aby dowiedzieć się, czy się kwalifikujesz."
 
 #. Translators: This is the label for a number which shows the total active accounts for one partner. (e.g. https://wikipedialibrary.wmflabs.org/partners/8/).
 #: TWLight/resources/templates/resources/partner_detail_stats.html:21
@@ -1863,34 +1543,20 @@ msgstr "Maksymalna długość cytatu"
 #. Translators: If a partner has specified the excerpt limit both in words and percentage, this message will display the percentage of words and the number of words on the partner page.
 #: TWLight/resources/templates/resources/partner_detail_timeline.html:99
 #, python-format
-msgid ""
-"%(object)s allows a maximum of %(excerpt_limit)s words or "
-"%(excerpt_limit_percentage)s%% of an article be excerpted into a Wikipedia "
-"article."
-msgstr ""
-"%(object)s zezwala na użycie maksymalnie %(excerpt_limit)s słów lub "
-"%(excerpt_limit_percentage)s%% publikacji jako fragmentu do zacytowania w "
-"artykułach Wikipedii."
+msgid "%(object)s allows a maximum of %(excerpt_limit)s words or %(excerpt_limit_percentage)s%% of an article be excerpted into a Wikipedia article."
+msgstr "%(object)s zezwala na użycie maksymalnie %(excerpt_limit)s słów lub %(excerpt_limit_percentage)s%% publikacji jako fragmentu do zacytowania w artykułach Wikipedii."
 
 #. Translators: If a partner has specified the excerpt limit in words, this message will display the number of words on the partner page.
 #: TWLight/resources/templates/resources/partner_detail_timeline.html:106
 #, python-format
-msgid ""
-"%(object)s allows a maximum of %(excerpt_limit)s words be excerpted into a "
-"Wikipedia article."
-msgstr ""
-"%(object)s zezwala na zacytowanie w artykule w Wikipedii fragmentu "
-"publikacji liczącego maksymalnie %(excerpt_limit)s słów."
+msgid "%(object)s allows a maximum of %(excerpt_limit)s words be excerpted into a Wikipedia article."
+msgstr "%(object)s zezwala na zacytowanie w artykule w Wikipedii fragmentu publikacji liczącego maksymalnie %(excerpt_limit)s słów."
 
 #. Translators: If a partner has specified the excerpt limit in percentage, this message will display the percentage of words on the partner page.
 #: TWLight/resources/templates/resources/partner_detail_timeline.html:113
 #, python-format
-msgid ""
-"%(object)s allows a maximum of %(excerpt_limit_percentage)s%% of an article "
-"be excerpted into a Wikipedia article."
-msgstr ""
-"%(object)s zezwala na zacytowanie w artykule w Wikipedii maksymalnie "
-"%(excerpt_limit_percentage)s%% tekstu publikacji."
+msgid "%(object)s allows a maximum of %(excerpt_limit_percentage)s%% of an article be excerpted into a Wikipedia article."
+msgstr "%(object)s zezwala na zacytowanie w artykule w Wikipedii maksymalnie %(excerpt_limit_percentage)s%% tekstu publikacji."
 
 #. Translators: If a partner has other requirements for access, this text shows as the title for that information field. (e.g. https://wikipedialibrary.wmflabs.org/partners/10/).
 #: TWLight/resources/templates/resources/partner_detail_timeline.html:132
@@ -1900,12 +1566,8 @@ msgstr "Dodatkowe wymagania wobec osób aplikujących o dostęp"
 #. Translators: If a user must agree to a Terms of Use document, they see this message, and must enter the name of the resource. Don't translate publisher or url.
 #: TWLight/resources/templates/resources/partner_detail_timeline.html:140
 #, python-format
-msgid ""
-"%(publisher)s requires that you agree with its <a href=\"%(url)s\">terms of "
-"use</a>."
-msgstr ""
-"%(publisher)s wymaga, aby użytkownik zaakceptował jego <a href=\"%(url)s"
-"\">warunki użytkowania</a>."
+msgid "%(publisher)s requires that you agree with its <a href=\"%(url)s\">terms of use</a>."
+msgstr "%(publisher)s wymaga, aby użytkownik zaakceptował jego <a href=\"%(url)s\">warunki użytkowania</a>."
 
 #. Translators: If a user must provide their real name to apply to a partner, they see this message, and must enter the name of the resource. Don't translate publisher.
 #: TWLight/resources/templates/resources/partner_detail_timeline.html:150
@@ -1928,21 +1590,14 @@ msgstr "%(publisher)s wymaga podania przynależności instytucjonalnej."
 #. Translators: If a user must select a specific resource to apply for, they see this message, and must enter the name of the resource. Don't translate publisher.
 #: TWLight/resources/templates/resources/partner_detail_timeline.html:177
 #, python-format
-msgid ""
-"%(publisher)s requires that you specify a particular title that you want to "
-"access."
-msgstr ""
-"%(publisher)s wymaga, aby użytkownik wskazał konkretny tytuł, do którego "
-"chce uzyskać dostęp."
+msgid "%(publisher)s requires that you specify a particular title that you want to access."
+msgstr "%(publisher)s wymaga, aby użytkownik wskazał konkretny tytuł, do którego chce uzyskać dostęp."
 
 #. Translators: If a user must register on the partner website before applying, they see this message. Don't translate partner.
 #: TWLight/resources/templates/resources/partner_detail_timeline.html:187
 #, python-format
-msgid ""
-"%(publisher)s requires that you sign up for an account before applying for "
-"access."
-msgstr ""
-"%(publisher)s wymaga zarejestrowania konta przed złożeniem wniosku o dostęp."
+msgid "%(publisher)s requires that you sign up for an account before applying for access."
+msgstr "%(publisher)s wymaga zarejestrowania konta przed złożeniem wniosku o dostęp."
 
 #. Translators: If a partner has their location listed, this message is a label for that location
 #: TWLight/resources/templates/resources/partner_detail_timeline.html:206
@@ -2068,12 +1723,8 @@ msgstr "Czy na pewno chcesz usunąć <b>%(object)s</b>?"
 
 #. Translators: If multiple authorizations where returned for a collection, this message is shown to a user
 #: TWLight/resources/views.py:268
-msgid ""
-"Multiple authorizations were returned – something's wrong. Please contact us "
-"and don't forget to mention this message."
-msgstr ""
-"System zwrócił wiele autoryzacji dostępu – coś jest nie tak. Skontaktuj się "
-"z nami i koniecznie wspomnij o tym komunikacie."
+msgid "Multiple authorizations were returned – something's wrong. Please contact us and don't forget to mention this message."
+msgstr "System zwrócił wiele autoryzacji dostępu – coś jest nie tak. Skontaktuj się z nami i koniecznie wspomnij o tym komunikacie."
 
 #. Translators: This message is shown when user tries to access a NOT_AVAILABLE Partner
 #: TWLight/resources/views.py:316
@@ -2113,23 +1764,8 @@ msgstr "Przykro nam, ale nie wiemy, jak przetworzyć to działanie."
 #. Translators: Shown on the website's 400 page, when a user sends a bad request. Don't translate path or Phabricator.
 #: TWLight/templates/400.html:20
 #, python-format
-msgid ""
-"If you think we should know what to do with that, please email us about this "
-"error at <a class=\"twl-links\" href=\"mailto:wikipedialibrary@wikimedia.org?"
-"Subject=Wikipedia%%20Library%%20%(path)s%%20Permission%%20denied"
-"\">wikipedialibrary@wikimedia.org</a> or report it to us on <a class=\"twl-"
-"links\" href=\"https://phabricator.wikimedia.org/maniphest/task/edit/form/1/?"
-"projectPHIDs=Library-Card-Platform&title=Wikipedia%%20Library%%20%(path)s"
-"%%20Bad%%20Request\">Phabricator</a>"
-msgstr ""
-"Jeśli uważasz, że powinniśmy być na to przygotowani, poinformuj nas o "
-"zaistniałym błędzie poprzez e-mail <a class=\"twl-links\" href=\"mailto:"
-"wikipedialibrary@wikimedia.org?Subject=Wikipedia%%20Library%%20%(path)s"
-"%%20Permission%%20denied\">wikipedialibrary@wikimedia.org</a> lub zgłoś go "
-"nam w <a class=\"twl-links\" href=\"https://phabricator.wikimedia.org/"
-"maniphest/task/edit/form/1/?projectPHIDs=Library-Card-"
-"Platform&title=Wikipedia%%20Library%%20%(path)s%%20Bad%%20Request"
-"\">Phabricatorze</a>"
+msgid "If you think we should know what to do with that, please email us about this error at <a class=\"twl-links\" href=\"mailto:wikipedialibrary@wikimedia.org?Subject=Wikipedia%%20Library%%20%(path)s%%20Permission%%20denied\">wikipedialibrary@wikimedia.org</a> or report it to us on <a class=\"twl-links\" href=\"https://phabricator.wikimedia.org/maniphest/task/edit/form/1/?projectPHIDs=Library-Card-Platform&title=Wikipedia%%20Library%%20%(path)s%%20Bad%%20Request\">Phabricator</a>"
+msgstr "Jeśli uważasz, że powinniśmy być na to przygotowani, poinformuj nas o zaistniałym błędzie poprzez e-mail <a class=\"twl-links\" href=\"mailto:wikipedialibrary@wikimedia.org?Subject=Wikipedia%%20Library%%20%(path)s%%20Permission%%20denied\">wikipedialibrary@wikimedia.org</a> lub zgłoś go nam w <a class=\"twl-links\" href=\"https://phabricator.wikimedia.org/maniphest/task/edit/form/1/?projectPHIDs=Library-Card-Platform&title=Wikipedia%%20Library%%20%(path)s%%20Bad%%20Request\">Phabricatorze</a>"
 
 #. Translators: Alt text for an image shown on the 400 error page.
 #. Translators: Alt text for an image shown on the 403 error page.
@@ -2150,24 +1786,8 @@ msgstr "Przykro nam, ale nie możesz tego zrobić."
 #. Translators: Shown on the website's 403 page, when a user attempts to navigate to a page they don't have permission to view. Don't translate path or Phabricator.
 #: TWLight/templates/403.html:20
 #, python-format
-msgid ""
-"If you think your account should be able to do that, please email us about "
-"this error at <a class=\"twl-links\" href=\"mailto:"
-"wikipedialibrary@wikimedia.org?Subject=Wikipedia%%20Library%%20%(path)s"
-"%%20Permission%%20denied\">wikipedialibrary@wikimedia.org</a> or report it "
-"to us on <a class=\"twl-links\" href=\"https://phabricator.wikimedia.org/"
-"maniphest/task/edit/form/1/?projectPHIDs=Library-Card-"
-"Platform&title=Wikipedia%%20Library%%20%(path)s%%20Permission%%20denied"
-"\">Phabricator</a>"
-msgstr ""
-"Jeśli uważasz, że to działanie powinno być możliwe na Twoim koncie, wyślij "
-"do nas wiadomość e-mail z informacją o zaistniałym błędzie na adres <a class="
-"\"twl-links\" href=\"mailto:wikipedialibrary@wikimedia.org?Subject=Wikipedia"
-"%%20Library%%20%(path)s%%20Permission%%20denied\">wikipedialibrary@wikimedia."
-"org</a> lub zgłoś go nam w <a class=\"twl-links\" href=\"https://phabricator."
-"wikimedia.org/maniphest/task/edit/form/1/?projectPHIDs=Library-Card-"
-"Platform&title=Wikipedia%%20Library%%20%(path)s%%20Permission%%20denied"
-"\">Phabricatorze</a>"
+msgid "If you think your account should be able to do that, please email us about this error at <a class=\"twl-links\" href=\"mailto:wikipedialibrary@wikimedia.org?Subject=Wikipedia%%20Library%%20%(path)s%%20Permission%%20denied\">wikipedialibrary@wikimedia.org</a> or report it to us on <a class=\"twl-links\" href=\"https://phabricator.wikimedia.org/maniphest/task/edit/form/1/?projectPHIDs=Library-Card-Platform&title=Wikipedia%%20Library%%20%(path)s%%20Permission%%20denied\">Phabricator</a>"
+msgstr "Jeśli uważasz, że to działanie powinno być możliwe na Twoim koncie, wyślij do nas wiadomość e-mail z informacją o zaistniałym błędzie na adres <a class=\"twl-links\" href=\"mailto:wikipedialibrary@wikimedia.org?Subject=Wikipedia%%20Library%%20%(path)s%%20Permission%%20denied\">wikipedialibrary@wikimedia.org</a> lub zgłoś go nam w <a class=\"twl-links\" href=\"https://phabricator.wikimedia.org/maniphest/task/edit/form/1/?projectPHIDs=Library-Card-Platform&title=Wikipedia%%20Library%%20%(path)s%%20Permission%%20denied\">Phabricatorze</a>"
 
 #. Translators: Shown on the website's 404 page, when a user attempts to navigate to a page that doesn't exist.
 #: TWLight/templates/404.html:11
@@ -2182,22 +1802,8 @@ msgstr "Przykro nam, ale nie znaleźliśmy tej strony."
 #. Translators: Shown on the website's 404 page, when a user attempts to navigate to a page that doesn't exist. Don't translate path or Phabricator.
 #: TWLight/templates/404.html:19
 #, python-format
-msgid ""
-"If you are certain that something should be here, please email us about this "
-"error at <a class=\"twl-links\" href=\"mailto:wikipedialibrary@wikimedia.org?"
-"Subject=Wikipedia%%20Library%%20%(path)s%%20Not%%20found\"> "
-"wikipedialibrary@wikimedia.org</a> or report it to us on <a class=\"twl-links"
-"\" href=\"https://phabricator.wikimedia.org/maniphest/task/edit/form/1/?"
-"projectPHIDs=Library-Card-Platform&title=Wikipedia%%20Library%%20%(path)s"
-"%%20Not%%20found\">Phabricator</a>"
-msgstr ""
-"Jeśli masz pewność, że coś powinno znajdować się pod tym adresem, poinformuj "
-"nas o tym błędzie poprzez e-mail <a class=\"twl-links\" href=\"mailto:"
-"wikipedialibrary@wikimedia.org?Subject=Wikipedia%%20Library%%20%(path)s"
-"%%20Not%%20found\"> wikipedialibrary@wikimedia.org</a> lub zgłoś go nam w <a "
-"class=\"twl-links\" href=\"https://phabricator.wikimedia.org/maniphest/task/"
-"edit/form/1/?projectPHIDs=Library-Card-Platform&title=Wikipedia%%20Library"
-"%%20%(path)s%%20Not%%20found\">Phabricatorze</a>"
+msgid "If you are certain that something should be here, please email us about this error at <a class=\"twl-links\" href=\"mailto:wikipedialibrary@wikimedia.org?Subject=Wikipedia%%20Library%%20%(path)s%%20Not%%20found\"> wikipedialibrary@wikimedia.org</a> or report it to us on <a class=\"twl-links\" href=\"https://phabricator.wikimedia.org/maniphest/task/edit/form/1/?projectPHIDs=Library-Card-Platform&title=Wikipedia%%20Library%%20%(path)s%%20Not%%20found\">Phabricator</a>"
+msgstr "Jeśli masz pewność, że coś powinno znajdować się pod tym adresem, poinformuj nas o tym błędzie poprzez e-mail <a class=\"twl-links\" href=\"mailto:wikipedialibrary@wikimedia.org?Subject=Wikipedia%%20Library%%20%(path)s%%20Not%%20found\"> wikipedialibrary@wikimedia.org</a> lub zgłoś go nam w <a class=\"twl-links\" href=\"https://phabricator.wikimedia.org/maniphest/task/edit/form/1/?projectPHIDs=Library-Card-Platform&title=Wikipedia%%20Library%%20%(path)s%%20Not%%20found\">Phabricatorze</a>"
 
 #. Translators: Alt text for an image shown on the 404 error page.
 #: TWLight/templates/404.html:32
@@ -2211,50 +1817,19 @@ msgstr "Informacje o Bibliotece Wikipedia"
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:20
-msgid ""
-"This platform is our central tool for facilitating access to our available "
-"collections. Here you can see which partnerships are available, search their "
-"contents, and apply for and access the ones you’re interested in."
-msgstr ""
-"Ta platforma stanowi centralne narzędzie ułatwiające korzystanie ze zbiorów "
-"udostępnionych przez naszych partnerów. Tutaj możesz sprawdzić, jakie "
-"kolekcje są dostępne, przeszukiwać ich zawartość i składać wnioski o dostęp "
-"do interesujących Cię materiałów."
+msgid "This platform is our central tool for facilitating access to our available collections. Here you can see which partnerships are available, search their contents, and apply for and access the ones you’re interested in."
+msgstr "Ta platforma stanowi centralne narzędzie ułatwiające korzystanie ze zbiorów udostępnionych przez naszych partnerów. Tutaj możesz sprawdzić, jakie kolekcje są dostępne, przeszukiwać ich zawartość i składać wnioski o dostęp do interesujących Cię materiałów."
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/). Wikimedia Foundation should not be translated.
 #: TWLight/templates/about.html:29
-msgid ""
-"All users receive immediate access to some collections, which can be browsed "
-"by clicking the 'Access collection' buttons or using the search bar at the "
-"top of the page. Other collections require an application before access is "
-"granted, and may be accessed directly or via an individual login or access "
-"code. Volunteer coordinators, who have signed non-disclosure agreements with "
-"the Wikimedia Foundation, review these applications and work with publishers "
-"to get you your free access."
-msgstr ""
-"Część kolekcji jest dostępna dla wszystkich użytkowników od razu – wystarczy "
-"kliknąć przycisk „Przejdź do kolekcji” lub skorzystać z paska wyszukiwania u "
-"góry strony. Dostęp do pozostałych zasobów wymaga wcześniejszego złożenia "
-"wniosku. Zostanie on rozpatrzony przez naszych wolontariuszy-koordynatorów, "
-"związanych umowami o zachowaniu poufności z Wikimedia Foundation i "
-"współpracujących z wydawcami. Po uzyskaniu uprawnienia można korzystać z "
-"tych zasobów bezpośrednio lub za pomocą indywidualnego loginu lub kodu "
-"dostępu."
+msgid "All users receive immediate access to some collections, which can be browsed by clicking the 'Access collection' buttons or using the search bar at the top of the page. Other collections require an application before access is granted, and may be accessed directly or via an individual login or access code. Volunteer coordinators, who have signed non-disclosure agreements with the Wikimedia Foundation, review these applications and work with publishers to get you your free access."
+msgstr "Część kolekcji jest dostępna dla wszystkich użytkowników od razu – wystarczy kliknąć przycisk „Przejdź do kolekcji” lub skorzystać z paska wyszukiwania u góry strony. Dostęp do pozostałych zasobów wymaga wcześniejszego złożenia wniosku. Zostanie on rozpatrzony przez naszych wolontariuszy-koordynatorów, związanych umowami o zachowaniu poufności z Wikimedia Foundation i współpracujących z wydawcami. Po uzyskaniu uprawnienia można korzystać z tych zasobów bezpośrednio lub za pomocą indywidualnego loginu lub kodu dostępu."
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/). Don't translate terms_url.
 #: TWLight/templates/about.html:43
 #, python-format
-msgid ""
-"For more information about how your information is stored and reviewed "
-"please see our <a class=\"twl-links\" href=\"%(terms_url)s\"> terms of use "
-"and privacy policy</a>. Accounts you apply for are also subject to the Terms "
-"of Use provided by each partner’s platform; please review them."
-msgstr ""
-"Więcej informacji na temat przechowywania i weryfikacji Twoich danych "
-"znajdziesz w naszych <a class=\"twl-links\" href=\"%(terms_url)s\">warunkach "
-"użytkowania i polityce prywatności</a>. Konta, o których założenie "
-"wnioskujesz, podlegają również warunkom użytkowania obowiązującym na "
-"platformach poszczególnych partnerów. Zapoznaj się z nimi uważnie."
+msgid "For more information about how your information is stored and reviewed please see our <a class=\"twl-links\" href=\"%(terms_url)s\"> terms of use and privacy policy</a>. Accounts you apply for are also subject to the Terms of Use provided by each partner’s platform; please review them."
+msgstr "Więcej informacji na temat przechowywania i weryfikacji Twoich danych znajdziesz w naszych <a class=\"twl-links\" href=\"%(terms_url)s\">warunkach użytkowania i polityce prywatności</a>. Konta, o których założenie wnioskujesz, podlegają również warunkom użytkowania obowiązującym na platformach poszczególnych partnerów. Zapoznaj się z nimi uważnie."
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:51
@@ -2263,25 +1838,13 @@ msgstr "Kto może otrzymać dostęp?"
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/). Wikimedia Foundation should not be translated.
 #: TWLight/templates/about.html:55
-msgid ""
-"Any active editor in good standing can receive access. For publishers with "
-"limited numbers of accounts, applications are reviewed based on the editor’s "
-"needs and contributions. If you think you could use access to one of our "
-"partner resources and are an active editor in any project supported by the "
-"Wikimedia Foundation, please apply."
-msgstr ""
-"Dostęp do Biblioteki Wikipedia mogą uzyskać wszyscy aktywni wikipedyści z "
-"nienaganną reputacją. W przypadku wydawców oferujących ograniczoną liczbę "
-"kont wnioski są rozpatrywane na podstawie potrzeb i wkładu redaktora. Jeśli "
-"uważasz, że dostęp do zasobu jednego z naszych partnerów mógłby wspomóc "
-"Twoją pracę w projektach Wikimedia Foundation, zachęcamy do złożenia wniosku."
+msgid "Any active editor in good standing can receive access. For publishers with limited numbers of accounts, applications are reviewed based on the editor’s needs and contributions. If you think you could use access to one of our partner resources and are an active editor in any project supported by the Wikimedia Foundation, please apply."
+msgstr "Dostęp do Biblioteki Wikipedia mogą uzyskać wszyscy aktywni wikipedyści z nienaganną reputacją. W przypadku wydawców oferujących ograniczoną liczbę kont wnioski są rozpatrywane na podstawie potrzeb i wkładu redaktora. Jeśli uważasz, że dostęp do zasobu jednego z naszych partnerów mógłby wspomóc Twoją pracę w projektach Wikimedia Foundation, zachęcamy do złożenia wniosku."
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:65
 msgid "Any editor can use the library if they meet a few basic requirements:"
-msgstr ""
-"Każdy redaktor może korzystać z Biblioteki Wikipedia, jeśli spełnia kilka "
-"podstawowych wymagań:"
+msgstr "Każdy redaktor może korzystać z Biblioteki Wikipedia, jeśli spełnia kilka podstawowych wymagań:"
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:71
@@ -2301,40 +1864,17 @@ msgstr "co najmniej 10 edycji w projektach Wikimedia w ciągu ostatnich 30 dni,"
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:83
 msgid "You are not currently blocked from editing a Wikimedia project"
-msgstr ""
-"brak aktywnych blokad uniemożliwiających edytowanie w projektach Wikimedia."
+msgstr "brak aktywnych blokad uniemożliwiających edytowanie w projektach Wikimedia."
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/)
 #: TWLight/templates/about.html:89
-msgid ""
-"If you are applying for an available collection, please first check that you "
-"don't already have access through another library or institution. If you do, "
-"please consider using that access rather than taking up a seat for this "
-"resource in The Wikipedia Library."
-msgstr ""
-"Zanim złożysz wniosek o dostęp do interesującej Cię kolekcji, sprawdź, czy "
-"nie masz już do niej dostępu za pośrednictwem innej biblioteki lub "
-"instytucji. W takim przypadku rozważ wykorzystanie swojego dotychczasowego "
-"dostępu, aby nie blokować miejsca innym redaktorom."
+msgid "If you are applying for an available collection, please first check that you don't already have access through another library or institution. If you do, please consider using that access rather than taking up a seat for this resource in The Wikipedia Library."
+msgstr "Zanim złożysz wniosek o dostęp do interesującej Cię kolekcji, sprawdź, czy nie masz już do niej dostępu za pośrednictwem innej biblioteki lub instytucji. W takim przypadku rozważ wykorzystanie swojego dotychczasowego dostępu, aby nie blokować miejsca innym redaktorom."
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/)
 #: TWLight/templates/about.html:99
-msgid ""
-"If your account is blocked on one or more Wikimedia projects, you may still "
-"be granted access to The Wikipedia Library. You will need to contact the "
-"Wikipedia Library team, who will review your blocks. If you have been "
-"blocked for content issues, most notably copyright violations, or have "
-"multiple long-term blocks, we may decline your request. Additionally, if "
-"your block status changes after being approved, you will need to request "
-"another review."
-msgstr ""
-"Jeśli Twoje konto jest zablokowane w jednym lub kilku projektach Wikimedia, "
-"nadal możesz ubiegać się o dostęp do Biblioteki Wikipedia. Skontaktuj się z "
-"naszym zespołem, który oceni Twoją sytuację. Możemy odrzucić Twój wniosek "
-"jeśli Twoje blokady wynikają z łamania zasad we wprowadzanych przez Ciebie "
-"treściach, w szczególności w przypadku naruszania praw autorskich, lub jeśli "
-"masz wiele długotrwałych blokad. Ponadto jeśli stan Twoich blokad zmieni się "
-"po zatwierdzeniu wniosku, konieczne będzie jego ponowne złożenie."
+msgid "If your account is blocked on one or more Wikimedia projects, you may still be granted access to The Wikipedia Library. You will need to contact the Wikipedia Library team, who will review your blocks. If you have been blocked for content issues, most notably copyright violations, or have multiple long-term blocks, we may decline your request. Additionally, if your block status changes after being approved, you will need to request another review."
+msgstr "Jeśli Twoje konto jest zablokowane w jednym lub kilku projektach Wikimedia, nadal możesz ubiegać się o dostęp do Biblioteki Wikipedia. Skontaktuj się z naszym zespołem, który oceni Twoją sytuację. Możemy odrzucić Twój wniosek jeśli Twoje blokady wynikają z łamania zasad we wprowadzanych przez Ciebie treściach, w szczególności w przypadku naruszania praw autorskich, lub jeśli masz wiele długotrwałych blokad. Ponadto jeśli stan Twoich blokad zmieni się po zatwierdzeniu wniosku, konieczne będzie jego ponowne złożenie."
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:110
@@ -2349,8 +1889,7 @@ msgstr "Zatwierdzeni redaktorzy <i>mogą</i> wykorzystać swój dostęp do:"
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:118
 msgid "Search, view, retrieve, and display partner content"
-msgstr ""
-"wyszukiwania, przeglądania, pobierania i wyświetlania treści partnerów,"
+msgstr "wyszukiwania, przeglądania, pobierania i wyświetlania treści partnerów,"
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:122
@@ -2369,12 +1908,8 @@ msgstr "Zatwierdzeni redaktorzy <i>nie powinni</i>:"
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:136
-msgid ""
-"Share their account logins or passwords with others, or sell their access to "
-"other parties"
-msgstr ""
-"udostępniać loginów i haseł do swoich kont innym osobom ani odsprzedawać "
-"dostępu stronom trzecim,"
+msgid "Share their account logins or passwords with others, or sell their access to other parties"
+msgstr "udostępniać loginów i haseł do swoich kont innym osobom ani odsprzedawać dostępu stronom trzecim,"
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:140
@@ -2383,30 +1918,18 @@ msgstr "masowo pobierać ani kopiować treści partnerów,"
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:144
-msgid ""
-"Systematically make printed or electronic copies of multiple extracts of "
-"restricted content available for any purpose"
-msgstr ""
-"systematycznie tworzyć drukowane lub elektroniczne kopie wielu fragmentów "
-"treści o ograniczonym dostępie w jakimkolwiek celu,"
+msgid "Systematically make printed or electronic copies of multiple extracts of restricted content available for any purpose"
+msgstr "systematycznie tworzyć drukowane lub elektroniczne kopie wielu fragmentów treści o ograniczonym dostępie w jakimkolwiek celu,"
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/). Stub is a technical term for a short Wikipedia article, use the appropriate Wikipedia term in your language.
 #: TWLight/templates/about.html:148
-msgid ""
-"Datamine metadata without permission, in order, for instance, to use "
-"metadata for auto-created stub articles"
-msgstr ""
-"przetwarzać metadanych bez zezwolenia, na przykład, aby wykorzystywać je do "
-"automatycznego tworzenia zalążków artykułów."
+msgid "Datamine metadata without permission, in order, for instance, to use metadata for auto-created stub articles"
+msgstr "przetwarzać metadanych bez zezwolenia, na przykład, aby wykorzystywać je do automatycznego tworzenia zalążków artykułów."
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:154
-msgid ""
-"Respecting these agreements allows us to continue growing the partnerships "
-"available to the community."
-msgstr ""
-"Przestrzeganie tych zasad jest kluczowe dla dalszego rozwoju programu i "
-"rozszerzania partnerstw dostępnych dla społeczności."
+msgid "Respecting these agreements allows us to continue growing the partnerships available to the community."
+msgstr "Przestrzeganie tych zasad jest kluczowe dla dalszego rozwoju programu i rozszerzania partnerstw dostępnych dla społeczności."
 
 #. Translators: This is the heading for a section on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:160
@@ -2415,64 +1938,23 @@ msgstr "EZProxy"
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:164
-msgid ""
-"EZProxy is a proxy server used to authenticate users for many Wikipedia "
-"Library partners. Users sign into EZProxy via the Library Card platform to "
-"verify that they are authorized users, and then the server accesses "
-"requested resources using its own IP address."
-msgstr ""
-"EZProxy jest serwerem proxy, którego używamy do uwierzytelniania naszych "
-"użytkowników w wielu serwisach partnerskich Biblioteki Wikipedia. "
-"Użytkownicy logują się do EZProxy poprzez naszą platformę, po czym serwer "
-"pośredniczy w dostępie do treści poprzez swój własny adres IP."
+msgid "EZProxy is a proxy server used to authenticate users for many Wikipedia Library partners. Users sign into EZProxy via the Library Card platform to verify that they are authorized users, and then the server accesses requested resources using its own IP address."
+msgstr "EZProxy jest serwerem proxy, którego używamy do uwierzytelniania naszych użytkowników w wielu serwisach partnerskich Biblioteki Wikipedia. Użytkownicy logują się do EZProxy poprzez naszą platformę, po czym serwer pośredniczy w dostępie do treści poprzez swój własny adres IP."
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:173
-msgid ""
-"You may notice that when accessing resources via EZProxy that URLs are "
-"dynamically rewritten. This is why we recommend logging in via the Library "
-"Card platform rather than going directly to the unproxied partner website. "
-"When in doubt, check the URL for ‘idm.oclc’. If it’s there, then you’re "
-"connected via EZProxy."
-msgstr ""
-"Podczas uzyskiwania dostępu do materiałów źródłowych za pośrednictwem "
-"EZPRoxy można zauważyć, że ich adresy URL są dynamicznie aktualizowane. Nie "
-"jest to możliwe przy przeglądaniu stron naszych partnerów z pominięciem "
-"EZPRoxy, dlatego zalecamy, aby uprzednio zalogować się w naszej platformie. "
-"W przypadku wątpliwości co do korzystania z serwera proxy należy sprawdzić, "
-"czy adres URL zawiera ciąg „idm.oclc”. Jeśli tak, oznacza to, że użytkownik "
-"korzysta z EZProxy."
+msgid "You may notice that when accessing resources via EZProxy that URLs are dynamically rewritten. This is why we recommend logging in via the Library Card platform rather than going directly to the unproxied partner website. When in doubt, check the URL for ‘idm.oclc’. If it’s there, then you’re connected via EZProxy."
+msgstr "Podczas uzyskiwania dostępu do materiałów źródłowych za pośrednictwem EZPRoxy można zauważyć, że ich adresy URL są dynamicznie aktualizowane. Nie jest to możliwe przy przeglądaniu stron naszych partnerów z pominięciem EZPRoxy, dlatego zalecamy, aby uprzednio zalogować się w naszej platformie. W przypadku wątpliwości co do korzystania z serwera proxy należy sprawdzić, czy adres URL zawiera ciąg „idm.oclc”. Jeśli tak, oznacza to, że użytkownik korzysta z EZProxy."
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:182
-msgid ""
-"Typically once you’ve logged in your session will remain active in your "
-"browser for up to two hours after you’ve finished searching. Note that use "
-"of EZProxy requires you to enable cookies. If you are having problems you "
-"should also try clearing your cache and restarting your browser."
-msgstr ""
-"Zazwyczaj użytkownik pozostaje zalogowany w ramach sesji przeglądania przez "
-"dwie godziny po zakończeniu wyszukiwania. Należy pamiętać, że korzystanie z "
-"EZProxy wymaga włączenia obsługi plików cookie. W przypadku problemów "
-"polecamy także wyczyścić pamięć podręczną i ponownie uruchomić przeglądarkę."
+msgid "Typically once you’ve logged in your session will remain active in your browser for up to two hours after you’ve finished searching. Note that use of EZProxy requires you to enable cookies. If you are having problems you should also try clearing your cache and restarting your browser."
+msgstr "Zazwyczaj użytkownik pozostaje zalogowany w ramach sesji przeglądania przez dwie godziny po zakończeniu wyszukiwania. Należy pamiętać, że korzystanie z EZProxy wymaga włączenia obsługi plików cookie. W przypadku problemów polecamy także wyczyścić pamięć podręczną i ponownie uruchomić przeglądarkę."
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/)
 #: TWLight/templates/about.html:193
-msgid ""
-"The Library Bundle is a collection of resources for which no application is "
-"required. If you meet the criteria laid out above, you will be authorized "
-"for access automatically upon logging in to the platform. Only some of our "
-"content is currently included in the Library Bundle, however we hope to "
-"expand the collection as more publishers become comfortable with "
-"participating. All Bundle content is accessed via EZProxy."
-msgstr ""
-"Pakiet Bazowy to zbiór zasobów, do których dostęp nie wymaga składania "
-"dodatkowych wniosków. Jeśli spełniasz kryteria określone powyżej, otrzymasz "
-"dostęp automatycznie po zalogowaniu się na platformie. Obecnie tylko "
-"niektóre serwisy partnerskie są dostępne w Pakiecie Bazowym, ale mamy "
-"nadzieję, że uda nam nam się poszerzyć kolekcję i zachęcić więcej wydawców "
-"do dołączenia. Wszystkie treści w Pakiecie są udostępniane za pośrednictwem "
-"EZProxy."
+msgid "The Library Bundle is a collection of resources for which no application is required. If you meet the criteria laid out above, you will be authorized for access automatically upon logging in to the platform. Only some of our content is currently included in the Library Bundle, however we hope to expand the collection as more publishers become comfortable with participating. All Bundle content is accessed via EZProxy."
+msgstr "Pakiet Bazowy to zbiór zasobów, do których dostęp nie wymaga składania dodatkowych wniosków. Jeśli spełniasz kryteria określone powyżej, otrzymasz dostęp automatycznie po zalogowaniu się na platformie. Obecnie tylko niektóre serwisy partnerskie są dostępne w Pakiecie Bazowym, ale mamy nadzieję, że uda nam nam się poszerzyć kolekcję i zachęcić więcej wydawców do dołączenia. Wszystkie treści w Pakiecie są udostępniane za pośrednictwem EZProxy."
 
 #. Translators: This is the heading for a section on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:202
@@ -2481,18 +1963,8 @@ msgstr "Sposób cytowania"
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:206
-msgid ""
-"Citation practices vary by project and even by article. Generally, we "
-"support editors citing where they found information, in a form that allows "
-"others to check it for themselves. That often means providing both original "
-"source details as well as a link to the partner database in which the source "
-"was found."
-msgstr ""
-"Sposób cytowania źródeł może się różnić w zależności od projektu Wikimedia, "
-"a nawet artykułu. Ogólnie rzecz biorąc, zachęcamy do podawania źródeł "
-"informacji w sposób umożliwiający innym osobom ich sprawdzenie. Często "
-"oznacza to podanie zarówno szczegółów oryginalnego źródła, jak i linku do "
-"bazy danych partnera, w której źródło zostało znalezione."
+msgid "Citation practices vary by project and even by article. Generally, we support editors citing where they found information, in a form that allows others to check it for themselves. That often means providing both original source details as well as a link to the partner database in which the source was found."
+msgstr "Sposób cytowania źródeł może się różnić w zależności od projektu Wikimedia, a nawet artykułu. Ogólnie rzecz biorąc, zachęcamy do podawania źródeł informacji w sposób umożliwiający innym osobom ich sprawdzenie. Często oznacza to podanie zarówno szczegółów oryginalnego źródła, jak i linku do bazy danych partnera, w której źródło zostało znalezione."
 
 #. Translators: This is the heading for a section on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #. Translators: This link is at the bottom of every page and can be clicked by users to contact the wikipedia library team.
@@ -2503,13 +1975,8 @@ msgstr "Skontaktuj się z nami"
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:218
 #, python-format
-msgid ""
-"If you have questions, need help, or want to volunteer to help, please see "
-"our <a class=\"twl-links\" href=\"%(contact_url)s\">contact page</a>."
-msgstr ""
-"Jeśli masz pytania, potrzebujesz pomocy lub chcesz zostać wolontariuszem, "
-"odwiedź naszą <a class=\"twl-links\" href=\"%(contact_url)s\">stronę "
-"kontaktową</a>."
+msgid "If you have questions, need help, or want to volunteer to help, please see our <a class=\"twl-links\" href=\"%(contact_url)s\">contact page</a>."
+msgstr "Jeśli masz pytania, potrzebujesz pomocy lub chcesz zostać wolontariuszem, odwiedź naszą <a class=\"twl-links\" href=\"%(contact_url)s\">stronę kontaktową</a>."
 
 #. Translators: This is the title of the panel box detailing the contact information for the Wikipedia Library team.
 #: TWLight/templates/contact.html:14
@@ -2548,18 +2015,13 @@ msgstr "Biblioteka Wikipedia na Twitterze"
 #. Translators: This is the text that appears at the bottom of the contact us form directing users to the suggestions form.
 #: TWLight/templates/contact.html:48
 #, python-format
-msgid ""
-"(If you would like to suggest a partner, <a class=\"twl-links\" href="
-"\"%(suggest)s\"><strong>go here</strong></a>.)"
-msgstr ""
-"(Jeśli chcesz zaproponować nową instytucję partnerską, <a class=\"twl-links"
-"\" href=\"%(suggest)s\"><strong>przejdź tutaj</strong></a>.)"
+msgid "(If you would like to suggest a partner, <a class=\"twl-links\" href=\"%(suggest)s\"><strong>go here</strong></a>.)"
+msgstr "(Jeśli chcesz zaproponować nową instytucję partnerską, <a class=\"twl-links\" href=\"%(suggest)s\"><strong>przejdź tutaj</strong></a>.)"
 
 #. Translators: On a special 'link to search' page, this message is shown if JavaScript is disabled.
 #: TWLight/templates/eds_search_endpoint.html:7
 msgid "JavaScript is disabled; use the button below to continue."
-msgstr ""
-"Obsługa JavaScript jest wyłączona; aby kontynuować, kliknij przycisk poniżej."
+msgstr "Obsługa JavaScript jest wyłączona; aby kontynuować, kliknij przycisk poniżej."
 
 #. Translators: Alt text for the Wikipedia Library shown in the top left of all pages.
 #: TWLight/templates/header_partial_b4.html:14
@@ -2610,13 +2072,8 @@ msgstr "Biblioteka Wikipedia"
 #. Translators: Information about The Wikipedia Library.
 #: TWLight/templates/login_partial.html:53 TWLight/templates/new_base.html:21
 #, python-format
-msgid ""
-"More than 100 of the world's top subscription-only databases, with content "
-"in %(no_of_languages)s languages, free for Wikipedians of all backgrounds"
-msgstr ""
-"Bezpłatny dostęp do ponad 100 najlepszych subskrypcyjnych baz danych z "
-"materiałami źródłowymi w %(no_of_languages)s językach dla wszystkich "
-"aktywnych wikipedystów!"
+msgid "More than 100 of the world's top subscription-only databases, with content in %(no_of_languages)s languages, free for Wikipedians of all backgrounds"
+msgstr "Bezpłatny dostęp do ponad 100 najlepszych subskrypcyjnych baz danych z materiałami źródłowymi w %(no_of_languages)s językach dla wszystkich aktywnych wikipedystów!"
 
 #. Translators: Information about The Wikipedia Library.
 #: TWLight/templates/login_partial.html:64
@@ -2624,12 +2081,8 @@ msgid "Meet these criteria for automatic access"
 msgstr "Uzyskaj automatyczny dostęp po spełnieniu kryteriów"
 
 #: TWLight/templates/login_partial.html:69
-msgid ""
-"These criteria grant you access to certain collections but not all. Some "
-"collections are accessible on a per application basis only."
-msgstr ""
-"Wymienione kryteria zapewniają automatyczny dostęp do niektórych, ale nie "
-"wszystkich kolekcji. Niektóre kolekcje są udostępniane tylko na życzenie."
+msgid "These criteria grant you access to certain collections but not all. Some collections are accessible on a per application basis only."
+msgstr "Wymienione kryteria zapewniają automatyczny dostęp do niektórych, ale nie wszystkich kolekcji. Niektóre kolekcje są udostępniane tylko na życzenie."
 
 #: TWLight/templates/login_partial.html:89
 msgid "Login via Wikipedia"
@@ -2638,32 +2091,19 @@ msgstr "Zaloguj się przez Wikipedię"
 #. Translators: Shown if the current user doesn't have a registered email on their account. Don't translate contact_us_url or email_url.
 #: TWLight/templates/message_partial.html:15
 #, python-format
-msgid ""
-"You don't have an email on file. We can't finalize your access to partner "
-"resources, and you won't be able to <a class=\"twl-links\" href="
-"\"%(contact_us_url)s\">contact us</a> without an email. Please <a class="
-"\"twl-links\" href=\"%(email_url)s\">update your email</a>."
+msgid "You don't have an email on file. We can't finalize your access to partner resources, and you won't be able to <a class=\"twl-links\" href=\"%(contact_us_url)s\">contact us</a> without an email. Please <a class=\"twl-links\" href=\"%(email_url)s\">update your email</a>."
 msgstr ""
 
 #. Translators: Shown if the current user has requested the processing of their data should be restricted.
 #: TWLight/templates/message_partial.html:26
 #, python-format
-msgid ""
-"You have requested a restriction on the processing of your data. Most site "
-"functionality will not be available to you until you <a class=\"twl-links\" "
-"href=\"%(restrict_url)s\">lift this restriction</a>."
-msgstr ""
-"Użytkownik zastrzegł przetwarzanie swoich danych. Większość funkcji witryny "
-"nie będzie dostępna do czasu <a class=\"twl-links\" href=\"%(restrict_url)s"
-"\">zniesienia tego ograniczenia</a>."
+msgid "You have requested a restriction on the processing of your data. Most site functionality will not be available to you until you <a class=\"twl-links\" href=\"%(restrict_url)s\">lift this restriction</a>."
+msgstr "Użytkownik zastrzegł przetwarzanie swoich danych. Większość funkcji witryny nie będzie dostępna do czasu <a class=\"twl-links\" href=\"%(restrict_url)s\">zniesienia tego ograniczenia</a>."
 
 #. Translators: Shown if the current user has not agreed to the terms of use.
 #: TWLight/templates/message_partial.html:37
 #, python-format
-msgid ""
-"You have not agreed to the <a class=\"twl-links\" href=\"%(terms_url)s"
-"\">terms of use</a> of this site. Your applications will not be processed "
-"and you won't be able to apply or access resources you are approved for."
+msgid "You have not agreed to the <a class=\"twl-links\" href=\"%(terms_url)s\">terms of use</a> of this site. Your applications will not be processed and you won't be able to apply or access resources you are approved for."
 msgstr ""
 
 #. Translators: This link is at the bottom of every page and links to the 'About' page (https://wikipedialibrary.wmflabs.org/about/)
@@ -2710,12 +2150,8 @@ msgstr "Zresetuj hasło"
 
 #. Translators: If a user goes to reset their password, this message asks them to enter their email to do so.
 #: TWLight/templates/registration/password_reset_form.html:13
-msgid ""
-"Forgot your password? Enter your email address below, and we'll email "
-"instructions for setting a new one."
-msgstr ""
-"Nie pamiętasz hasła? Wpisz swój adres e-mail poniżej, aby otrzymać "
-"instrukcję jego zmiany."
+msgid "Forgot your password? Enter your email address below, and we'll email instructions for setting a new one."
+msgstr "Nie pamiętasz hasła? Wpisz swój adres e-mail poniżej, aby otrzymać instrukcję jego zmiany."
 
 #. Translators: This is the label for a button that users click to update their public information.
 #: TWLight/users/forms.py:36
@@ -2759,23 +2195,13 @@ msgstr "Akceptuję warunki użytkowania"
 
 #. Translators: This text explains how to disagree to the site's terms of use and the restrictions that will come into effect when users disagree to the terms of use.
 #: TWLight/users/forms.py:185
-msgid ""
-"By unchecking this box and clicking “Update” you may explore the site, but "
-"you will not be able to apply for access to materials or evaluate "
-"applications unless you agree with the terms of use."
-msgstr ""
-"Jeśli usuniesz zaznaczenie tego pola i klikniesz przycisk „Aktualizuj”, "
-"nadal będziesz mieć dostęp do witryny, ale utracisz możliwość składania "
-"wniosków o dostęp lub ich rozpatrywania do czasu ponownego zaakceptowania "
-"warunków użytkowania."
+msgid "By unchecking this box and clicking “Update” you may explore the site, but you will not be able to apply for access to materials or evaluate applications unless you agree with the terms of use."
+msgstr "Jeśli usuniesz zaznaczenie tego pola i klikniesz przycisk „Aktualizuj”, nadal będziesz mieć dostęp do witryny, ale utracisz możliwość składania wniosków o dostęp lub ich rozpatrywania do czasu ponownego zaakceptowania warunków użytkowania."
 
 #. Translators: Users click this button to set their website email address to the one linked to their Wikipedia account.
 #: TWLight/users/forms.py:211
-msgid ""
-"Use my Wikipedia email address (will be updated the next time you login)."
-msgstr ""
-"Użyj mojego adresu e-mail z Wikipedii (zostanie on zaktualizowany przy "
-"następnym logowaniu)."
+msgid "Use my Wikipedia email address (will be updated the next time you login)."
+msgstr "Użyj mojego adresu e-mail z Wikipedii (zostanie on zaktualizowany przy następnym logowaniu)."
 
 #. Translators: This labels a button which users click to change their email.
 #: TWLight/users/forms.py:232
@@ -2785,17 +2211,8 @@ msgstr "Aktualizuj e-mail"
 #. Translators: Shown if the current user tried to 'favorite' a partner they can't access. Do not translate '{partner}'
 #: TWLight/users/models.py:201
 #, python-brace-format
-msgid ""
-"Cannot add partner {partner} to your favorites because you don't have access "
-"to it"
+msgid "Cannot add partner {partner} to your favorites because you don't have access to it"
 msgstr ""
-
-#. Translators: Do not translate.
-#: TWLight/users/models.py:869
-#, fuzzy, python-brace-format
-#| msgid "Username"
-msgid "{wp_username}"
-msgstr "Nazwa użytkownika"
 
 #. Translators: This error message is shown when there's a problem with the authenticated login process.
 #: TWLight/users/oauth.py:243
@@ -2815,12 +2232,8 @@ msgstr ""
 
 #. Translators: this message is displayed to users that don't have accounts and clicked on a proxied link.
 #: TWLight/users/oauth.py:388
-msgid ""
-"To view this link you need to be an eligible library user. Please login to "
-"continue."
-msgstr ""
-"Ta strona jest dostępna tylko dla uprawnionych użytkowników Biblioteki. "
-"Zaloguj się, aby kontynuować."
+msgid "To view this link you need to be an eligible library user. Please login to continue."
+msgstr "Ta strona jest dostępna tylko dla uprawnionych użytkowników Biblioteki. Zaloguj się, aby kontynuować."
 
 #. Translators: This warning message is shown to users when the response received from Wikimedia OAuth servers is not a valid one.
 #: TWLight/users/oauth.py:430
@@ -2855,17 +2268,12 @@ msgstr "Więcej informacji na stronie {issue}"
 
 #. Translators: If the user tries to log in, but their account does not meet certain requirements, they cannot login.
 #: TWLight/users/oauth.py:528
-msgid ""
-"Your Wikipedia account does not meet the eligibility criteria in the terms "
-"of use, so your Wikipedia Library Card Platform account cannot be activated."
+msgid "Your Wikipedia account does not meet the eligibility criteria in the terms of use, so your Wikipedia Library Card Platform account cannot be activated."
 msgstr ""
 
 #. Translators: If the user tries to log in, but their account does not meet certain requirements, they cannot login.
 #: TWLight/users/oauth.py:536
-msgid ""
-"Your Wikipedia account no longer meets the eligibility criteria in the terms "
-"of use, so you cannot be logged in. If you think you should be able to log "
-"in, please email wikipedialibrary@wikimedia.org."
+msgid "Your Wikipedia account no longer meets the eligibility criteria in the terms of use, so you cannot be logged in. If you think you should be able to log in, please email wikipedialibrary@wikimedia.org."
 msgstr ""
 
 #. Translators: this message is displayed to users with brand new accounts.
@@ -2876,10 +2284,7 @@ msgstr ""
 #. Translators: This message is displayed on the confirmation page where users can return their access to partner collections.
 #: TWLight/users/templates/users/authorization_confirm_return.html:13
 #, python-format
-msgid ""
-"You will no longer be able to access <b>%(partner)s's</b> resources via the "
-"Library Card platform, but can request access again by clicking 'renew', if "
-"you change your mind. Are you sure you want to return your access?"
+msgid "You will no longer be able to access <b>%(partner)s's</b> resources via the Library Card platform, but can request access again by clicking 'renew', if you change your mind. Are you sure you want to return your access?"
 msgstr ""
 
 #. Translators: On the MyLibrary page (https://wikipedialibrary.wmflabs.org/users/my_library), this tab shows all favorite collections a user has.
@@ -2949,14 +2354,8 @@ msgstr "Dane wikipedysty"
 
 #. Translators: This is shown on editor profiles, in their profile page or on applications.
 #: TWLight/users/templates/users/editor_detail.html:59
-msgid ""
-"Information with an * was retrieved from Wikipedia directly. Other "
-"information was entered directly by users or site admins, in their preferred "
-"language."
-msgstr ""
-"Informacje oznaczone symbolem * zostały pobrane bezpośrednio z Wikipedii. "
-"Pozostałe informacje zostały dodane bezpośrednio przez użytkownika lub "
-"administratorów witryny w preferowanym przez nich języku."
+msgid "Information with an * was retrieved from Wikipedia directly. Other information was entered directly by users or site admins, in their preferred language."
+msgstr "Informacje oznaczone symbolem * zostały pobrane bezpośrednio z Wikipedii. Pozostałe informacje zostały dodane bezpośrednio przez użytkownika lub administratorów witryny w preferowanym przez nich języku."
 
 #. Translators: This distinguishes users who have been flagged as account coordinators. Don't translate username.
 #: TWLight/users/templates/users/editor_detail.html:71
@@ -2966,14 +2365,8 @@ msgstr "%(username)s ma uprawnienia koordynatora w tej witrynie."
 
 #. Translators: This is shown on editor profiles, under the heading for Wikipedia editor data.
 #: TWLight/users/templates/users/editor_detail_data.html:5
-msgid ""
-"This information is updated automatically from your Wikimedia account each "
-"time you log in, except for the Contributions field, where you can describe "
-"your Wikimedia editing history."
-msgstr ""
-"Poniższe informacje są automatycznie pobierane z Twojego konta Wikimedia "
-"przy każdym logowaniu. Jedynym wyjątkiem jest pole wkładu użytkownika, w "
-"którym możesz opisać swoją działalność w projektach Wikimedia."
+msgid "This information is updated automatically from your Wikimedia account each time you log in, except for the Contributions field, where you can describe your Wikimedia editing history."
+msgstr "Poniższe informacje są automatycznie pobierane z Twojego konta Wikimedia przy każdym logowaniu. Jedynym wyjątkiem jest pole wkładu użytkownika, w którym możesz opisać swoją działalność w projektach Wikimedia."
 
 #. Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this labels the user's username.
 #: TWLight/users/templates/users/editor_detail_data.html:17
@@ -3002,22 +2395,14 @@ msgstr "Czy spełnione są warunki użytkowania?"
 
 #. Translators: when viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this question has a yes or no answer.
 #: TWLight/users/templates/users/editor_detail_data.html:57
-msgid ""
-"at their last login, did this user meet the criteria set forth in the terms "
-"of use?"
-msgstr ""
-"Czy podczas ostatniego logowania użytkownik spełniał kryteria określone w "
-"warunkach użytkowania?"
+msgid "at their last login, did this user meet the criteria set forth in the terms of use?"
+msgstr "Czy podczas ostatniego logowania użytkownik spełniał kryteria określone w warunkach użytkowania?"
 
 #. Translators: When viewing a user's profile in an application, this message shows if the software doesn't think that the user is eligible for access. Don't translate username.
 #: TWLight/users/templates/users/editor_detail_data.html:72
 #, python-format
-msgid ""
-"%(username)s may still be eligible for access grants at the coordinators' "
-"discretion."
-msgstr ""
-"%(username)s może nadal kwalifikować się do dostępu według uznania "
-"koordynatorów."
+msgid "%(username)s may still be eligible for access grants at the coordinators' discretion."
+msgstr "%(username)s może nadal kwalifikować się do dostępu według uznania koordynatorów."
 
 #. Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this is the heading for a Yes/No ToU question.
 #: TWLight/users/templates/users/editor_detail_data.html:83
@@ -3051,14 +2436,8 @@ msgstr "(otrzymano zezwolenie)"
 #. Translators: This message is shown on a user's profile if their Wikimedia account is blocked on one or more projects. They may still be granted access to the Library Bundle, but need to contact Wikipedia Library staff to verify.
 #: TWLight/users/templates/users/editor_detail_data.html:137
 #, python-format
-msgid ""
-"It looks like you have an active block on your account. If you meet the "
-"other criteria you may still be permitted access to the library - please <a "
-"class=\"twl-links\" href=\"%(contact_url)s\">contact us</a>."
-msgstr ""
-"Wygląda na to, że Twoje konto jest aktualnie zablokowane. Jeśli spełniasz "
-"pozostałe kryteria, możesz nadal uzyskać dostęp do Biblioteki – <a class="
-"\"twl-links\" href=\"%(contact_url)s\">skontaktuj się z nami</a>."
+msgid "It looks like you have an active block on your account. If you meet the other criteria you may still be permitted access to the library - please <a class=\"twl-links\" href=\"%(contact_url)s\">contact us</a>."
+msgstr "Wygląda na to, że Twoje konto jest aktualnie zablokowane. Jeśli spełniasz pozostałe kryteria, możesz nadal uzyskać dostęp do Biblioteki – <a class=\"twl-links\" href=\"%(contact_url)s\">skontaktuj się z nami</a>."
 
 #. Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this is the heading for a Yes/No program eligibility question.
 #: TWLight/users/templates/users/editor_detail_data.html:153
@@ -3067,14 +2446,8 @@ msgstr "Czy przysługuje dostęp do Pakietu Bazowego?"
 
 #. Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this question has a Yes or No answer.
 #: TWLight/users/templates/users/editor_detail_data.html:156
-msgid ""
-"At their last login, did this user meet the criteria set forth in the "
-"Library Bundle? Note that satisfying terms of use is a prerequisite to "
-"bundle eligibility."
-msgstr ""
-"Czy podczas ostatniego logowania użytkownik spełniał kryteria dostępu do "
-"Pakietu Bazowego? Należy pamiętać, że warunkiem wstępnym jest spełnienie "
-"wymagań określonych w warunkach użytkowania."
+msgid "At their last login, did this user meet the criteria set forth in the Library Bundle? Note that satisfying terms of use is a prerequisite to bundle eligibility."
+msgstr "Czy podczas ostatniego logowania użytkownik spełniał kryteria dostępu do Pakietu Bazowego? Należy pamiętać, że warunkiem wstępnym jest spełnienie wymagań określonych w warunkach użytkowania."
 
 #. Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this is the heading for a Yes/No program eligibility question.
 #: TWLight/users/templates/users/editor_detail_data.html:177
@@ -3118,25 +2491,14 @@ msgstr "Dane osobowe"
 
 #. Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this text is in the 'Personal data' section. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/users/templates/users/editor_detail_data.html:262
-msgid ""
-"The following information is visible only to you, site administrators, "
-"publishing partners (where required), and volunteer Wikipedia Library "
-"coordinators (who have signed a Non-Disclosure Agreement)."
-msgstr ""
-"Poniższe informacje są widoczne tylko dla Ciebie, administratorów witryny, "
-"podmiotów partnerskich (jeśli jest to wymagane) i wolontariuszy "
-"koordynujących Bibliotekę Wikipedia (którzy podpisali umowę o zachowaniu "
-"poufności)."
+msgid "The following information is visible only to you, site administrators, publishing partners (where required), and volunteer Wikipedia Library coordinators (who have signed a Non-Disclosure Agreement)."
+msgstr "Poniższe informacje są widoczne tylko dla Ciebie, administratorów witryny, podmiotów partnerskich (jeśli jest to wymagane) i wolontariuszy koordynujących Bibliotekę Wikipedia (którzy podpisali umowę o zachowaniu poufności)."
 
 #. Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this labels a button which users can click to update or remove their personal information. Don't translate update_url.
 #: TWLight/users/templates/users/editor_detail_data.html:272
 #, python-format
-msgid ""
-"You may <a class=\"twl-links\" href=\"%(update_url)s\">update or delete</a> "
-"your data at any time."
-msgstr ""
-"Możesz <a class=\"twl-links\" href=\"%(update_url)s\">zaktualizować lub "
-"usunąć</a> swoje dane w dowolnym momencie."
+msgid "You may <a class=\"twl-links\" href=\"%(update_url)s\">update or delete</a> your data at any time."
+msgstr "Możesz <a class=\"twl-links\" href=\"%(update_url)s\">zaktualizować lub usunąć</a> swoje dane w dowolnym momencie."
 
 #. Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this labels the user's email. Don't remove the *.
 #: TWLight/users/templates/users/editor_detail_data.html:283
@@ -3155,38 +2517,24 @@ msgstr "Przynależność instytucjonalna"
 
 #. Translators: This message tells users that they are not eligible to access The Wikipedia Library content.
 #: TWLight/users/templates/users/eligibility_modal.html:7
-msgid ""
-"Sorry, your Wikipedia account doesn’t currently qualify to access The "
-"Wikipedia Library."
-msgstr ""
-"Niestety, Twoje konto w Wikipedii nie kwalifikuje się obecnie do dostępu do "
-"Biblioteki Wikipedia."
+msgid "Sorry, your Wikipedia account doesn’t currently qualify to access The Wikipedia Library."
+msgstr "Niestety, Twoje konto w Wikipedii nie kwalifikuje się obecnie do dostępu do Biblioteki Wikipedia."
 
 #. Translators: This message tells users that they have not agreed to the terms of use, therefore are ineligible to access the content in The Wikipedia Library.
 #: TWLight/users/templates/users/eligibility_modal.html:30
 #, python-format
-msgid ""
-"Agreed with <a href=\"%(terms)s\" class=\"text-danger\"> terms of use </a>"
-msgstr ""
-"Zgodził(-a) się na <a href=\"%(terms)s\" class=\"text-danger\">warunki "
-"użycia</a> witryny?"
+msgid "Agreed with <a href=\"%(terms)s\" class=\"text-danger\"> terms of use </a>"
+msgstr "Zgodził(-a) się na <a href=\"%(terms)s\" class=\"text-danger\">warunki użycia</a> witryny?"
 
 #: TWLight/users/templates/users/eligibility_modal.html:40
 #, python-format
-msgid ""
-"It looks like you have an active block on your account. If you meet the "
-"other criteria you may still be permitted access to the library - please <a "
-"href=\"%(contact_url)s\">contact us</a>."
-msgstr ""
-"Wygląda na to, że Twoje konto jest aktualnie zablokowane. Jeśli spełniasz "
-"pozostałe kryteria, możesz nadal uzyskać dostęp do Biblioteki – <a href="
-"\"%(contact_url)s\">skontaktuj się z nami</a>."
+msgid "It looks like you have an active block on your account. If you meet the other criteria you may still be permitted access to the library - please <a href=\"%(contact_url)s\">contact us</a>."
+msgstr "Wygląda na to, że Twoje konto jest aktualnie zablokowane. Jeśli spełniasz pozostałe kryteria, możesz nadal uzyskać dostęp do Biblioteki – <a href=\"%(contact_url)s\">skontaktuj się z nami</a>."
 
 #. Translators: Instructions to refresh a user's data.
 #: TWLight/users/templates/users/eligibility_modal.html:50
 msgid "To refresh your data, please log out and back in."
-msgstr ""
-"Aby odświeżyć informacje o swoim koncie, wyloguj się i zaloguj ponownie."
+msgstr "Aby odświeżyć informacje o swoim koncie, wyloguj się i zaloguj ponownie."
 
 #. Translators: A button that takes users to their profile.
 #: TWLight/users/templates/users/eligibility_modal.html:58
@@ -3220,14 +2568,8 @@ msgstr "Ustaw język"
 
 #. Translators: This text on the user page helps users naviage to the TranslateWiki Wikipedia Library Card platform translation page.
 #: TWLight/users/templates/users/language_form.html:31
-msgid ""
-"You can help translate the tool at <a class=\"twl-links\" href=\"https://"
-"translatewiki.net/wiki/Translating:Wikipedia_Library_Card_Platform"
-"\">translatewiki.net</a>."
-msgstr ""
-"Możesz pomóc w tłumaczeniu tego narzędzia na stronie <a class=\"twl-links\" "
-"href=\"https://translatewiki.net/wiki/Translating:"
-"Wikipedia_Library_Card_Platform\">translatewiki.net</a>."
+msgid "You can help translate the tool at <a class=\"twl-links\" href=\"https://translatewiki.net/wiki/Translating:Wikipedia_Library_Card_Platform\">translatewiki.net</a>."
+msgstr "Możesz pomóc w tłumaczeniu tego narzędzia na stronie <a class=\"twl-links\" href=\"https://translatewiki.net/wiki/Translating:Wikipedia_Library_Card_Platform\">translatewiki.net</a>."
 
 #. Translators: When the user starts a new application and submits the application, the user can view the application and withdraw if need be. This changes the label for the Withdraw button.
 #: TWLight/users/templates/users/my_applications.html:65
@@ -3246,12 +2588,8 @@ msgstr "Złóż wniosek o odnowienie"
 
 #. Translators: On the page listing applications, this text explains a user they cannot renew their application since they've already requested a renewal or there aren't any renewals available.
 #: TWLight/users/templates/users/my_applications.html:79
-msgid ""
-"Renewals are either not required, not available right now, or you have "
-"already requested a renewal."
-msgstr ""
-"Odnowienie nie jest wymagane, nie jest obecnie możliwe lub wniosek został "
-"już złożony."
+msgid "Renewals are either not required, not available right now, or you have already requested a renewal."
+msgstr "Odnowienie nie jest wymagane, nie jest obecnie możliwe lub wniosek został już złożony."
 
 #. Translators: This text is the heading of a section in a user's profile where they can change their preferences.
 #: TWLight/users/templates/users/preferences.html:6
@@ -3314,28 +2652,13 @@ msgstr "Zastrzeż przetwarzanie danych"
 
 #. Translators: This message is displayed on the page where users can request we stop processing their data.
 #: TWLight/users/templates/users/restrict_data.html:15
-msgid ""
-"Checking this box and clicking “Restrict” will pause all processing of the "
-"data you have entered into this website. You will not be able to apply for "
-"access to resources, your applications will not be further processed, and "
-"none of your data will be altered, until you return to this page and uncheck "
-"the box. This is not the same as deleting your data."
-msgstr ""
-"Zaznaczenie tego pola i kliknięcie przycisku „Zastrzeż” spowoduje "
-"wstrzymanie przetwarzania danych wprowadzonych przez Ciebie w Bibliotece "
-"Wikipedia. Dopóki nie wrócisz na tę stronę i nie odznaczysz tego pola, nie "
-"będziesz mieć możliwości ubiegania się o dostęp do zasobów, Twoje zgłoszenia "
-"nie będą rozpatrywane, a żadne z Twoich danych nie zostaną zmienione. Nie "
-"jest to równoznaczne z usunięciem danych."
+msgid "Checking this box and clicking “Restrict” will pause all processing of the data you have entered into this website. You will not be able to apply for access to resources, your applications will not be further processed, and none of your data will be altered, until you return to this page and uncheck the box. This is not the same as deleting your data."
+msgstr "Zaznaczenie tego pola i kliknięcie przycisku „Zastrzeż” spowoduje wstrzymanie przetwarzania danych wprowadzonych przez Ciebie w Bibliotece Wikipedia. Dopóki nie wrócisz na tę stronę i nie odznaczysz tego pola, nie będziesz mieć możliwości ubiegania się o dostęp do zasobów, Twoje zgłoszenia nie będą rozpatrywane, a żadne z Twoich danych nie zostaną zmienione. Nie jest to równoznaczne z usunięciem danych."
 
 #. Translators: This warning message is shown to coordinators who view the data restriction page.
 #: TWLight/users/templates/users/restrict_data.html:26
-msgid ""
-"You are a coordinator on this site. If you restrict the processing of your "
-"data, your coordinator flag will be removed."
-msgstr ""
-"Jesteś koordynatorem w tej witrynie. Zastrzeżenie przetwarzania Twoich "
-"danych spowoduje usunięcie Twojego uprawnienia koordynatora."
+msgid "You are a coordinator on this site. If you restrict the processing of your data, your coordinator flag will be removed."
+msgstr "Jesteś koordynatorem w tej witrynie. Zastrzeżenie przetwarzania Twoich danych spowoduje usunięcie Twojego uprawnienia koordynatora."
 
 #. Translators: use the date *when you are translating*, in a language-appropriate format.
 #: TWLight/users/templates/users/terms.html:33
@@ -3354,24 +2677,12 @@ msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:51
-msgid ""
-"<a class=\"twl-links\" href=\"https://meta.wikimedia.org/wiki/"
-"The_Wikipedia_Library\"> The Wikipedia Library </a> has partnered with "
-"publishers around the world to allow users to access otherwise paywalled "
-"resources. This website allows Wikipedia editors to search and access these "
-"resources."
+msgid "<a class=\"twl-links\" href=\"https://meta.wikimedia.org/wiki/The_Wikipedia_Library\"> The Wikipedia Library </a> has partnered with publishers around the world to allow users to access otherwise paywalled resources. This website allows Wikipedia editors to search and access these resources."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Wikimedia Foundation should not be translated. WMF should not be translated. Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:63
-msgid ""
-"This program is administered by the Wikimedia Foundation (WMF). These terms "
-"of use and privacy notice pertain to your application for access to "
-"resources through the Wikipedia Library, your use of this website, and your "
-"access to and use of those resources. They also describe our handling of the "
-"information you provide to us in order to create and administer your "
-"Wikipedia Library account. If we make material changes to the terms, we will "
-"notify users."
+msgid "This program is administered by the Wikimedia Foundation (WMF). These terms of use and privacy notice pertain to your application for access to resources through the Wikipedia Library, your use of this website, and your access to and use of those resources. They also describe our handling of the information you provide to us in order to create and administer your Wikipedia Library account. If we make material changes to the terms, we will notify users."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
@@ -3381,37 +2692,17 @@ msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:78
-msgid ""
-"Access to resources via The Wikipedia Library is reserved for community "
-"members who have demonstrated their commitment to the Wikimedia projects, "
-"and who will use their access to these resources to improve project content. "
-"To that end, in order to be eligible for The Wikipedia Library, we require "
-"that you be registered for a user account on the projects, with at least 500 "
-"edits, six (6) months of activity, and 10+ edits in the last month. We ask "
-"that you do not request access to any publishers with a limited number of "
-"available accounts whose resources you can already access for free through "
-"your local library or university, or another institution or organization, in "
-"order to provide that opportunity to others."
+msgid "Access to resources via The Wikipedia Library is reserved for community members who have demonstrated their commitment to the Wikimedia projects, and who will use their access to these resources to improve project content. To that end, in order to be eligible for The Wikipedia Library, we require that you be registered for a user account on the projects, with at least 500 edits, six (6) months of activity, and 10+ edits in the last month. We ask that you do not request access to any publishers with a limited number of available accounts whose resources you can already access for free through your local library or university, or another institution or organization, in order to provide that opportunity to others."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:94
-msgid ""
-"Additionally, if you are currently blocked or banned from a Wikimedia "
-"project, applications to resources may be rejected or restricted. If you "
-"obtain a Wikipedia Library account, but a block or ban is subsequently "
-"instituted against you on one of the projects, you may lose access to your "
-"Wikipedia Library account."
+msgid "Additionally, if you are currently blocked or banned from a Wikimedia project, applications to resources may be rejected or restricted. If you obtain a Wikipedia Library account, but a block or ban is subsequently instituted against you on one of the projects, you may lose access to your Wikipedia Library account."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:104
-msgid ""
-"Your eligibility to access The Wikipedia Library is assessed at each login. "
-"While more than half of the library's content is provided via this automated "
-"eligibility check, access to other publisher's content may be time limited, "
-"typically lapsing after one year, after which you will usually need to apply "
-"for renewal."
+msgid "Your eligibility to access The Wikipedia Library is assessed at each login. While more than half of the library's content is provided via this automated eligibility check, access to other publisher's content may be time limited, typically lapsing after one year, after which you will usually need to apply for renewal."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
@@ -3421,47 +2712,27 @@ msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:118
-msgid ""
-"In order to apply for access to a partner resource, you must provide us with "
-"certain information, which we will use to evaluate your application. If your "
-"application is approved, we may transfer the information you have given us "
-"to the publishers whose resources you wish to access. They will either "
-"contact you with the account information directly or we will send access "
-"information to you ourselves."
+msgid "In order to apply for access to a partner resource, you must provide us with certain information, which we will use to evaluate your application. If your application is approved, we may transfer the information you have given us to the publishers whose resources you wish to access. They will either contact you with the account information directly or we will send access information to you ourselves."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:130
-msgid ""
-"In addition to the basic information you provide to us, our system will "
-"retrieve some information directly from the Wikimedia projects: your "
-"username, email address, edit count, registration date, user ID number, "
-"groups to which you belong, and any special user rights."
+msgid "In addition to the basic information you provide to us, our system will retrieve some information directly from the Wikimedia projects: your username, email address, edit count, registration date, user ID number, groups to which you belong, and any special user rights."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:140
-msgid ""
-"Each time you log in to the Wikipedia Library Card Platform, this "
-"information will be automatically updated."
+msgid "Each time you log in to the Wikipedia Library Card Platform, this information will be automatically updated."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:148
-msgid ""
-"We will ask you to provide us with some information about your history of "
-"contributions to the Wikimedia projects. Information on contribution history "
-"is optional, but will greatly assist us in evaluating your application."
+msgid "We will ask you to provide us with some information about your history of contributions to the Wikimedia projects. Information on contribution history is optional, but will greatly assist us in evaluating your application."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). WMF should not be translated. Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:157
-msgid ""
-"The information you provide when creating your account will be visible to "
-"you while on the site but not to others unless they are approved Wikipedia "
-"Library Coordinators, WMF Staff, or WMF Contractors who need access to this "
-"data in order to carry out their work with the Wikipedia Library, all of "
-"whom are subject to non-disclosure obligations."
+msgid "The information you provide when creating your account will be visible to you while on the site but not to others unless they are approved Wikipedia Library Coordinators, WMF Staff, or WMF Contractors who need access to this data in order to carry out their work with the Wikipedia Library, all of whom are subject to non-disclosure obligations."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
@@ -3471,46 +2742,32 @@ msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:171
-msgid ""
-"In order to access an individual publisher’s resources, you must agree to "
-"that publisher’s terms of use and privacy policy. You agree that you will "
-"not violate such terms and policies in connection with your use of the "
-"Wikipedia Library. Additionally, the following activities are prohibited "
-"while accessing publisher resources through the Wikipedia Library."
+msgid "In order to access an individual publisher’s resources, you must agree to that publisher’s terms of use and privacy policy. You agree that you will not violate such terms and policies in connection with your use of the Wikipedia Library. Additionally, the following activities are prohibited while accessing publisher resources through the Wikipedia Library."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:184
-msgid ""
-"Sharing your Wikipedia account, usernames, passwords, or any access codes "
-"for publisher resources with others;"
+msgid "Sharing your Wikipedia account, usernames, passwords, or any access codes for publisher resources with others;"
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:191
-msgid ""
-"Automatically scraping or downloading restricted content from publishers;"
+msgid "Automatically scraping or downloading restricted content from publishers;"
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:197
-msgid ""
-"Systematically making printed or electronic copies of multiple extracts of "
-"restricted content available for any purpose;"
+msgid "Systematically making printed or electronic copies of multiple extracts of restricted content available for any purpose;"
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:204
-msgid ""
-"Data mining metadata without permission—for example, in order to use "
-"metadata for auto-created stub articles;"
+msgid "Data mining metadata without permission—for example, in order to use metadata for auto-created stub articles;"
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:211
-msgid ""
-"Using the access you receive through the Wikipedia Library for profit by "
-"selling access to your account or resources which you have through it."
+msgid "Using the access you receive through the Wikipedia Library for profit by selling access to your account or resources which you have through it."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
@@ -3520,18 +2777,12 @@ msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:224
-msgid ""
-"Certain resources may only be accessed using an external search service, "
-"such as the EBSCO Discovery Service, or a proxy service, such as OCLC "
-"EZProxy. If you use such external search and/or proxy services, please "
-"review the applicable terms of use and privacy policies."
+msgid "Certain resources may only be accessed using an external search service, such as the EBSCO Discovery Service, or a proxy service, such as OCLC EZProxy. If you use such external search and/or proxy services, please review the applicable terms of use and privacy policies."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:234
-msgid ""
-"In addition, if you use OCLC EZProxy, please note that you may not use it "
-"for commercial purposes."
+msgid "In addition, if you use OCLC EZProxy, please note that you may not use it for commercial purposes."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
@@ -3541,120 +2792,49 @@ msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Wikimedia Foundation should not be translated. Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:245
-msgid ""
-"The Wikimedia Foundation and our service providers use your information for "
-"the legitimate purpose of providing Wikipedia Library services in support of "
-"our charitable mission. When you apply for a Wikipedia Library account, or "
-"use your Wikipedia Library account, we may routinely collect the following "
-"information: your username, email address, edit count, registration date, "
-"user ID number, groups to which you belong, and any special user rights; "
-"your name, country of residence, and/or affiliation, if required by a "
-"partner to which you are applying; your narrative description of your "
-"contributions and reasons for applying for access to partner resources; and "
-"the date you agree to these terms of use."
+msgid "The Wikimedia Foundation and our service providers use your information for the legitimate purpose of providing Wikipedia Library services in support of our charitable mission. When you apply for a Wikipedia Library account, or use your Wikipedia Library account, we may routinely collect the following information: your username, email address, edit count, registration date, user ID number, groups to which you belong, and any special user rights; your name, country of residence, and/or affiliation, if required by a partner to which you are applying; your narrative description of your contributions and reasons for applying for access to partner resources; and the date you agree to these terms of use."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:262
 #, python-format
-msgid ""
-"Each publisher who is a member of the Wikipedia Library program requires "
-"different specific information in the application. Some publishers may "
-"request only an email address, while others request more detailed data, such "
-"as your name, location, or institutional affiliation. When you complete your "
-"application, you will only be asked to supply information required by the "
-"publishers you have chosen, and each publisher will only receive the "
-"information they require for providing you with access. Please see our <a "
-"class=\"twl-links\" href=\"%(all_partners_url)s\">partner information</a> "
-"pages to learn what information is required by each publisher to gain access "
-"to their resources."
+msgid "Each publisher who is a member of the Wikipedia Library program requires different specific information in the application. Some publishers may request only an email address, while others request more detailed data, such as your name, location, or institutional affiliation. When you complete your application, you will only be asked to supply information required by the publishers you have chosen, and each publisher will only receive the information they require for providing you with access. Please see our <a class=\"twl-links\" href=\"%(all_partners_url)s\">partner information</a> pages to learn what information is required by each publisher to gain access to their resources."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Wikimedia Foundation should not be translated. Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:277
-msgid ""
-"Some Wikipedia Library pages are visible without logging in, but you will "
-"need to log in to apply or access proprietary partner resources. We use the "
-"data provided by you via OAuth and Wikimedia API calls to assess your "
-"application for access and to process approved requests."
+msgid "Some Wikipedia Library pages are visible without logging in, but you will need to log in to apply or access proprietary partner resources. We use the data provided by you via OAuth and Wikimedia API calls to assess your application for access and to process approved requests."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:288
 #, python-format
-msgid ""
-"In order to administer the Wikipedia Library program, we will retain the "
-"application data we collect from you for three years after your most recent "
-"login, unless you delete your account, as described below. You can log in "
-"and go to <a class=\"twl-links\" href=\"%(profile_url)s\">your profile page</"
-"a> in order to see the information associated with your account, and can "
-"download it in JSON format. You may access, update, restrict, or delete this "
-"information at any time, except for the information that is automatically "
-"retrieved from the projects. If you have any questions or concerns about the "
-"handling of your data, please contact <a class=\"twl-links\" href=\"mailto:"
-"wikipedialibrary@wikimedia.org?Subject=Wikipedia%%20Library%%20Card"
-"%%20account%%20deactivation\"> wikipedialibrary@wikimedia.org </a>."
+msgid "In order to administer the Wikipedia Library program, we will retain the application data we collect from you for three years after your most recent login, unless you delete your account, as described below. You can log in and go to <a class=\"twl-links\" href=\"%(profile_url)s\">your profile page</a> in order to see the information associated with your account, and can download it in JSON format. You may access, update, restrict, or delete this information at any time, except for the information that is automatically retrieved from the projects. If you have any questions or concerns about the handling of your data, please contact <a class=\"twl-links\" href=\"mailto:wikipedialibrary@wikimedia.org?Subject=Wikipedia%%20Library%%20Card%%20account%%20deactivation\"> wikipedialibrary@wikimedia.org </a>."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:305
-msgid ""
-"If you decide to disable your Wikipedia Library account, you can use the "
-"delete button on your profile to delete certain personal information "
-"associated with your account. We will delete your real name, institutional "
-"affiliation, and country of residence. Please note that the system will "
-"retain a record of your username, the publishers to which you applied or had "
-"access, and the dates of that access. Note that deletion is not reversible. "
-"Deletion of your Wikipedia Library account may also correspond with the "
-"removal of any resource access to which you were eligible or approved. If "
-"you request the deletion of account information and later wish to apply for "
-"a new account, you will need to provide the necessary information again."
+msgid "If you decide to disable your Wikipedia Library account, you can use the delete button on your profile to delete certain personal information associated with your account. We will delete your real name, institutional affiliation, and country of residence. Please note that the system will retain a record of your username, the publishers to which you applied or had access, and the dates of that access. Note that deletion is not reversible. Deletion of your Wikipedia Library account may also correspond with the removal of any resource access to which you were eligible or approved. If you request the deletion of account information and later wish to apply for a new account, you will need to provide the necessary information again."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). WMF should not be translated. Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:321
-msgid ""
-"The Wikipedia Library is run by WMF Staff, Contractors, and approved "
-"volunteer Coordinators. The data associated with your account will be shared "
-"with the WMF staff, contractors, service providers, and volunteer "
-"coordinators who need to process the information in connection with their "
-"work for the Wikipedia Library, and who are subject to confidentiality "
-"obligations. We will also use your data for internal Wikipedia Library "
-"purposes such as distributing user surveys and account notifications, and in "
-"a depersonalized or aggregated fashion for statistical analysis and "
-"administration. Finally, we will share your information with the publishers "
-"whom you specifically select in order to provide you with access to "
-"resources. Otherwise, your information will not be shared with third "
-"parties, with the exception of the circumstances described below."
+msgid "The Wikipedia Library is run by WMF Staff, Contractors, and approved volunteer Coordinators. The data associated with your account will be shared with the WMF staff, contractors, service providers, and volunteer coordinators who need to process the information in connection with their work for the Wikipedia Library, and who are subject to confidentiality obligations. We will also use your data for internal Wikipedia Library purposes such as distributing user surveys and account notifications, and in a depersonalized or aggregated fashion for statistical analysis and administration. Finally, we will share your information with the publishers whom you specifically select in order to provide you with access to resources. Otherwise, your information will not be shared with third parties, with the exception of the circumstances described below."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). WMF should not be translated.
 #: TWLight/users/templates/users/terms.html:338
-msgid ""
-"We may disclose any collected information when required by law, when we have "
-"your permission, when needed to protect our rights, privacy, safety, users, "
-"or the general public, and when necessary to enforce these terms, WMF’s "
-"general <a class=\"twl-links\" href=\"https://foundation.wikimedia.org/wiki/"
-"Terms_of_Use\">Terms of Use</a>, or any other WMF policy."
+msgid "We may disclose any collected information when required by law, when we have your permission, when needed to protect our rights, privacy, safety, users, or the general public, and when necessary to enforce these terms, WMF’s general <a class=\"twl-links\" href=\"https://foundation.wikimedia.org/wiki/Terms_of_Use\">Terms of Use</a>, or any other WMF policy."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:349
-msgid ""
-"We take the security of your personal data seriously, and take reasonable "
-"precautions to ensure your data is protected. These precautions include "
-"access controls to limit who has access to your data and security "
-"technologies to protect data stored on the server. However, we cannot "
-"guarantee the safety of your data as it is transmitted and stored."
+msgid "We take the security of your personal data seriously, and take reasonable precautions to ensure your data is protected. These precautions include access controls to limit who has access to your data and security technologies to protect data stored on the server. However, we cannot guarantee the safety of your data as it is transmitted and stored."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:360
-msgid ""
-"Please note that these terms do not control the use and handling of your "
-"data by the publishers and service providers whose resources you access or "
-"apply to access. Please read their individual privacy policies for that "
-"information."
+msgid "Please note that these terms do not control the use and handling of your data by the publishers and service providers whose resources you access or apply to access. Please read their individual privacy policies for that information."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
@@ -3664,34 +2844,17 @@ msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Wikimedia Foundation should not be translated. Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:373
-msgid ""
-"The Wikimedia Foundation is a nonprofit organization based in San Francisco, "
-"California. The Wikipedia Library program provides access to resources held "
-"by publishers in multiple countries. If you apply for a Wikipedia Library "
-"account (whether you are inside or outside of the United States), you "
-"understand that your personal data will be collected, transferred, stored, "
-"processed, disclosed and otherwise used in the U.S. as described in this "
-"privacy policy. You also understand that your information may be transferred "
-"by us from the U.S. to other countries, which may have different or less "
-"stringent data protection laws than your country, in connection with "
-"providing services to you, including evaluating your application and "
-"securing access to your chosen publishers (locations for each publisher are "
-"outlined on their respective partner information pages)."
+msgid "The Wikimedia Foundation is a nonprofit organization based in San Francisco, California. The Wikipedia Library program provides access to resources held by publishers in multiple countries. If you apply for a Wikipedia Library account (whether you are inside or outside of the United States), you understand that your personal data will be collected, transferred, stored, processed, disclosed and otherwise used in the U.S. as described in this privacy policy. You also understand that your information may be transferred by us from the U.S. to other countries, which may have different or less stringent data protection laws than your country, in connection with providing services to you, including evaluating your application and securing access to your chosen publishers (locations for each publisher are outlined on their respective partner information pages)."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:392
-msgid ""
-"Please note that in the event of any differences in meaning or "
-"interpretation between the original English version of these terms and a "
-"translation, the original English version takes precedence."
+msgid "Please note that in the event of any differences in meaning or interpretation between the original English version of these terms and a translation, the original English version takes precedence."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Wikimedia Foundation should not be translated.
 #: TWLight/users/templates/users/terms.html:403
-msgid ""
-"See also the <a class=\"twl-links\" href=\"https://wikimediafoundation.org/"
-"wiki/Privacy_policy\">Wikimedia Foundation Privacy Policy</a>."
+msgid "See also the <a class=\"twl-links\" href=\"https://wikimediafoundation.org/wiki/Privacy_policy\">Wikimedia Foundation Privacy Policy</a>."
 msgstr ""
 
 #. Translators: This is the second to last line of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
@@ -3711,17 +2874,8 @@ msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:426
-msgid ""
-"By checking this box and clicking “Submit”, you agree that you have read the "
-"above terms and that you will adhere to the terms of use in your application "
-"to and use of the The Wikipedia Library, and the publishers’ services to "
-"which you gain access through The Wikipedia Library program."
-msgstr ""
-"Zaznaczając to pole i klikając przycisk „Wyślij”, potwierdzasz, że "
-"zapoznałeś(-aś) się z powyższymi warunkami użytkowania i zobowiązujesz się "
-"do ich przestrzegania przy ubieganiu się o dostęp do Biblioteki Wikipedia i "
-"korzystaniu z niej, a także podczas korzystania z usług wydawców, do których "
-"uzyskujesz dostęp w ramach Biblioteki Wikipedia."
+msgid "By checking this box and clicking “Submit”, you agree that you have read the above terms and that you will adhere to the terms of use in your application to and use of the The Wikipedia Library, and the publishers’ services to which you gain access through The Wikipedia Library program."
+msgstr "Zaznaczając to pole i klikając przycisk „Wyślij”, potwierdzasz, że zapoznałeś(-aś) się z powyższymi warunkami użytkowania i zobowiązujesz się do ich przestrzegania przy ubieganiu się o dostęp do Biblioteki Wikipedia i korzystaniu z niej, a także podczas korzystania z usług wydawców, do których uzyskujesz dostęp w ramach Biblioteki Wikipedia."
 
 #: TWLight/users/templates/users/user_collection_tile.html:32
 msgid "Remove this collection from favorites"
@@ -3773,33 +2927,18 @@ msgstr "Usuń wszystkie dane"
 
 #. Translators: This message is displayed on the page where users can request the deletion of their data.
 #: TWLight/users/templates/users/user_confirm_delete.html:17
-msgid ""
-"<b>Warning:</b> Performing this action will delete your Wikipedia Library "
-"Card user account and all associated applications. This process is not "
-"reversible. You may lose any partner accounts you were granted, and will not "
-"be able to renew those accounts or apply for new ones."
-msgstr ""
-"<b>Uwaga!</b> Wykonanie tej czynności spowoduje usunięcie konta użytkownika "
-"w Bibliotece Wikipedia i wszystkich powiązanych z nim zgłoszeń. Proces ten "
-"jest nieodwracalny. Możesz stracić wszystkie przyznane Ci konta partnerskie "
-"i nie będziesz mieć możliwości ich odnowienia ani ubiegania się o nowe."
+msgid "<b>Warning:</b> Performing this action will delete your Wikipedia Library Card user account and all associated applications. This process is not reversible. You may lose any partner accounts you were granted, and will not be able to renew those accounts or apply for new ones."
+msgstr "<b>Uwaga!</b> Wykonanie tej czynności spowoduje usunięcie konta użytkownika w Bibliotece Wikipedia i wszystkich powiązanych z nim zgłoszeń. Proces ten jest nieodwracalny. Możesz stracić wszystkie przyznane Ci konta partnerskie i nie będziesz mieć możliwości ich odnowienia ani ubiegania się o nowe."
 
 #. Translators: this should show up for people who log in with a username/password and not OAuth, so we don't know what their Wikipedia identity is.
-#.
 #: TWLight/users/templates/users/user_detail.html:12
 #, python-format
-msgid ""
-"Hi, %(username)s! You don't have a Wikipedia editor profile attached to your "
-"account here, so you are probably a site administrator."
+msgid "Hi, %(username)s! You don't have a Wikipedia editor profile attached to your account here, so you are probably a site administrator."
 msgstr ""
 
 #. Translators: In the unlikely scenario that someone is able to register an account without using OAuth (thus leaving us without some of the information required for applications), users will see this message, encouraging them to re-register.
 #: TWLight/users/templates/users/user_detail.html:20
-msgid ""
-"If you aren't a site administrator, something weird has happened. You won't "
-"be able to apply for access without a Wikipedia editor profile. You should "
-"log out and create a new account by logging in via OAuth, or contact a site "
-"administrator for help."
+msgid "If you aren't a site administrator, something weird has happened. You won't be able to apply for access without a Wikipedia editor profile. You should log out and create a new account by logging in via OAuth, or contact a site administrator for help."
 msgstr ""
 
 #. Translators: Labels a sections where coordinators can select their email preferences.
@@ -3810,19 +2949,12 @@ msgstr ""
 #. Translators: This message is shown on user's own profile page, encouraging them to make sure their information is up to date, so that account coordinators can use the information to judge applications.
 #: TWLight/users/views.py:176
 #, python-brace-format
-msgid ""
-"Please <a class='twl-links' href='{url}'>update your contributions</a> to "
-"Wikipedia to help coordinators evaluate your applications."
-msgstr ""
-"Aby ułatwić koordynatorom sprawdzanie Twoich zgłoszeń, uzupełnij <a "
-"class='twl-links' href='{url}'>opis swojego wkładu</a> w Wikipedii."
+msgid "Please <a class='twl-links' href='{url}'>update your contributions</a> to Wikipedia to help coordinators evaluate your applications."
+msgstr "Aby ułatwić koordynatorom sprawdzanie Twoich zgłoszeń, uzupełnij <a class='twl-links' href='{url}'>opis swojego wkładu</a> w Wikipedii."
 
 #. Translators: Coordinators are shown this message when they unselect all three types of reminder email options under preferences.
 #: TWLight/users/views.py:288
-msgid ""
-"You have chosen not to receive reminder emails. As a coordinator, you should "
-"receive at least one type of reminder emails, so consider changing your "
-"preferences."
+msgid "You have chosen not to receive reminder emails. As a coordinator, you should receive at least one type of reminder emails, so consider changing your preferences."
 msgstr ""
 
 #. Translators: Coordinators are shown this message when they make changes to their reminder email options under preferences.
@@ -3846,9 +2978,7 @@ msgstr "Informacje o użytkowniku zostały zaktualizowane."
 #. Translators: If a user tries to save the 'email change form' without entering one and checking the 'use my Wikipedia email address' checkbox, this message is presented.
 #: TWLight/users/views.py:448
 msgid "Both the values cannot be blank. Either enter a email or check the box."
-msgstr ""
-"Obie wartości nie mogą być puste. Wprowadź adres e-mail lub zaznacz pole "
-"wyboru."
+msgstr "Obie wartości nie mogą być puste. Wprowadź adres e-mail lub zaznacz pole wyboru."
 
 #. Translators: Shown to users when they successfully modify their email. Don't translate {email}.
 #: TWLight/users/views.py:476
@@ -3858,12 +2988,8 @@ msgstr "Twój adres e-mail został zmieniony na {email}."
 
 #. Translators: If the user has not filled out their email, they can browse the website but cannot apply for access to resources.
 #: TWLight/users/views.py:487
-msgid ""
-"Your email is blank. You can still explore the site, but you won't be able "
-"to apply for access to partner resources without an email."
-msgstr ""
-"Nie znamy Twojego adresu e-mail. Nadal możesz przeglądać witrynę, ale bez "
-"podania adresu e-mail nie możesz ubiegać się o dostęp do zasobów partnerów."
+msgid "Your email is blank. You can still explore the site, but you won't be able to apply for access to partner resources without an email."
+msgstr "Nie znamy Twojego adresu e-mail. Nadal możesz przeglądać witrynę, ale bez podania adresu e-mail nie możesz ubiegać się o dostęp do zasobów partnerów."
 
 #. Translators: This message is shown once the access to a partner has successfully been returned.
 #: TWLight/users/views.py:801
@@ -3895,31 +3021,3 @@ msgstr "Brak aktywnych blokad"
 msgid "10+ edits in the last 30 days"
 msgstr "Minimum 10 edycji w ciągu ostatnich 30 dni"
 
-#: tests/shunit/data/bad_i18n_comment_1.py:3
-#: tests/shunit/data/bad_i18n_newline_1.py:5
-msgid "1"
-msgstr ""
-
-#. Translators: Lorem ipsum dolor sit amet, consectetur adipiscing elit. Mauris vitae ipsum ut purus faucibus pretium. Proin tempus neque et aliquet consectetur. Ut egestas sapien in consectetur sagittis. Mauris neque lacus, dapibus non viverra vitae, interdum ut aenean ipsum.
-#. Translators: Lorem ipsum dolor sit amet, consectetur adipiscing elit. Mauris vitae ipsum ut purus faucibus pretium. Proin tempus neque et aliquet consectetur. Ut egestas sapien in consectetur sagittis. Mauris neque lacus, dapibus non.
-#: tests/shunit/data/bad_i18n_comment_2.py:4
-#: tests/shunit/data/bad_i18n_newline_2.py:5 tests/shunit/data/good_i18n_1.py:2
-#: tests/shunit/data/good_i18n_2.py:2
-msgid "2"
-msgstr ""
-
-#: tests/shunit/data/bad_i18n_newline_3.py:5
-msgid "3"
-msgstr ""
-
-#: tests/shunit/data/bad_i18n_newline_4.py:5
-msgid "4"
-msgstr ""
-
-#: tests/shunit/data/bad_i18n_newline_5.py:5
-msgid "5"
-msgstr ""
-
-#: tests/shunit/data/bad_i18n_newline_6.py:5
-msgid "6"
-msgstr ""

--- a/locale/pt/LC_MESSAGES/django.po
+++ b/locale/pt/LC_MESSAGES/django.po
@@ -12,10 +12,11 @@
 # Author: Ruila
 msgid ""
 msgstr ""
+""
 "Project-Id-Version: Wikipedia Library Card Platform - Website\n"
-"Report-Msgid-Bugs-To: wikipedialibrary@wikimedia.org\n"
+"Report-Msgid-Bugs-To: translatewiki.net\n"
 "POT-Creation-Date: 2024-07-11 20:54+0000\n"
-"PO-Revision-Date: 2024-07-11 12:30:18+0000\n"
+"PO-Revision-Date: 2024-07-15 12:29:18+0000\n"
 "Language: pt\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
@@ -47,13 +48,8 @@ msgstr "Sobre si"
 #. Translators: This note appears in a section of a form where we ask users to enter info (like country of residence) when applying for resource access.
 #: TWLight/applications/forms.py:179
 #, python-brace-format
-msgid ""
-"<p><small><i>Your personal data will be processed according to our <a "
-"class='twl-links' href='{terms_url}'> privacy policy</a>.</i></small></p>"
-msgstr ""
-"<p><small><i>Os seus dados pessoais serão processados de acordo com as "
-"nossas <a class='twl-links' href='{terms_url}'> normas de privacidade</a>.</"
-"i></small></p>"
+msgid "<p><small><i>Your personal data will be processed according to our <a class='twl-links' href='{terms_url}'> privacy policy</a>.</i></small></p>"
+msgstr "<p><small><i>Os seus dados pessoais serão processados de acordo com as nossas <a class='twl-links' href='{terms_url}'> normas de privacidade</a>.</i></small></p>"
 
 #. Translators: This is the title of the application form page, where users enter information required for the application. It lets the user know which partner application they are entering data for. {partner}
 #: TWLight/applications/forms.py:189
@@ -94,12 +90,8 @@ msgstr "O correio eletrónico da sua conta no <i>site</i> do parceiro"
 #. Translators: This labels a choice field where users will have to select the number of months they wish to have their access for as part of the application renewal confirmation.
 #. Translators: When filling out an application, users may be required to enter the length of the account (expiry) they wish to have for proxy partners.
 #: TWLight/applications/forms.py:339 TWLight/applications/helpers.py:100
-msgid ""
-"The number of months you wish to have this access for before renewal is "
-"required"
-msgstr ""
-"O número de meses durante os quais deseja ter este acesso, antes de ser "
-"necessária uma renovação"
+msgid "The number of months you wish to have this access for before renewal is required"
+msgstr "O número de meses durante os quais deseja ter este acesso, antes de ser necessária uma renovação"
 
 #. Translators: When filling out an application, users may need to specify their name
 #: TWLight/applications/helpers.py:81
@@ -187,13 +179,8 @@ msgstr "Correio eletrónico"
 
 #. Translators: This comment is added to pending applications when our terms of use change.
 #: TWLight/applications/management/commands/notify_applicants_tou_changes.py:54
-msgid ""
-"Our terms of use have changed. Your applications will not be processed until "
-"you log in and agree to our updated terms."
-msgstr ""
-"As nossas condições de utilização foram alteradas. As suas candidaturas não "
-"serão processadas até ter iniciado uma sessão e concordado com as condições "
-"atualizadas."
+msgid "Our terms of use have changed. Your applications will not be processed until you log in and agree to our updated terms."
+msgstr "As nossas condições de utilização foram alteradas. As suas candidaturas não serão processadas até ter iniciado uma sessão e concordado com as condições atualizadas."
 
 #. Translators: This is the status of an application that has not yet been reviewed.
 #: TWLight/applications/models.py:54
@@ -259,43 +246,26 @@ msgstr "URL de acesso: {access_url}"
 
 #. Translators: This text goes into account approval emails in the case that we need to send the user's details to a publisher for manual account setup.
 #: TWLight/applications/models.py:331
-msgid ""
-"You can expect to receive access details within a week or two once it has "
-"been processed."
-msgstr ""
-"Pode esperar receber os detalhes de acesso no prazo de uma ou duas semanas "
-"após o processamento."
+msgid "You can expect to receive access details within a week or two once it has been processed."
+msgstr "Pode esperar receber os detalhes de acesso no prazo de uma ou duas semanas após o processamento."
 
 #. Translators: This comment is added to open applications when a partner joins the Library Bundle, which does not require applications.
 #: TWLight/applications/signals.py:247
-msgid ""
-"This partner joined the Library Bundle, which does not require applications. "
-"This application will be marked as invalid."
-msgstr ""
-"Este parceiro aderiu ao Pacote Biblioteca, que não requer candidaturas. Esta "
-"candidatura será marcada como inválida."
+msgid "This partner joined the Library Bundle, which does not require applications. This application will be marked as invalid."
+msgstr "Este parceiro aderiu ao Pacote Biblioteca, que não requer candidaturas. Esta candidatura será marcada como inválida."
 
 #. Translators: This is shown to users if the application is to a partner for which we have run out of available accounts. The application is therefore on a 'waitlist', and will be reviewed when more accounts are available.
 #: TWLight/applications/templates/applications/application_evaluation.html:29
-msgid ""
-"This application is on the waitlist because this partner does not have any "
-"access grants available at this time."
-msgstr ""
-"Esta candidatura está em lista de espera porque este parceiro não tem "
-"nenhuma permissão de acesso disponível neste momento."
+msgid "This application is on the waitlist because this partner does not have any access grants available at this time."
+msgstr "Esta candidatura está em lista de espera porque este parceiro não tem nenhuma permissão de acesso disponível neste momento."
 
 #. Translators: This message is shown on pages where coordinators can see personal information about applicants.
 #: TWLight/applications/templates/applications/application_evaluation.html:36
 #: TWLight/applications/templates/applications/application_list_include.html:6
 #: TWLight/applications/templates/applications/send_partner.html:45
 #: TWLight/resources/templates/resources/partner_users.html:18
-msgid ""
-"Coordinators: This page may contain personal information such as real names "
-"and email addresses. Please remember that this information is confidential."
-msgstr ""
-"Coordenadores: esta página pode conter informações privadas, como nomes "
-"verdadeiros e endereços de correio eletrónico. Tenha em mente que esta "
-"informação é confidencial, por favor."
+msgid "Coordinators: This page may contain personal information such as real names and email addresses. Please remember that this information is confidential."
+msgstr "Coordenadores: esta página pode conter informações privadas, como nomes verdadeiros e endereços de correio eletrónico. Tenha em mente que esta informação é confidencial, por favor."
 
 #. Translators: This is the title of the application page shown to users who are a coordinator, and are able to accept or reject the application.
 #: TWLight/applications/templates/applications/application_evaluation.html:39
@@ -304,12 +274,8 @@ msgstr "Avaliar candidatura"
 
 #. Translators: This text is shown to coordinators on application pages if the applicant has restricted processing of their data.
 #: TWLight/applications/templates/applications/application_evaluation.html:42
-msgid ""
-"This user has requested a restriction on the processing of their data, so "
-"you cannot change the status of their application."
-msgstr ""
-"Este utilizador pediu uma restrição no processamento dos seus dados, por "
-"isso não pode alterar o estado da candidatura."
+msgid "This user has requested a restriction on the processing of their data, so you cannot change the status of their application."
+msgstr "Este utilizador pediu uma restrição no processamento dos seus dados, por isso não pode alterar o estado da candidatura."
 
 #. Translators: This is the title of the application page shown to users who are not a coordinator.
 #: TWLight/applications/templates/applications/application_evaluation.html:48
@@ -382,12 +348,8 @@ msgstr "Desconhecido"
 
 #. Translators: This is the text displayed to coordinators when an applicant has no country of residence in their profile.
 #: TWLight/applications/templates/applications/application_evaluation.html:123
-msgid ""
-"Please request the applicant add their country of residence to their profile "
-"before proceeding further."
-msgstr ""
-"Solicite ao candidato que adicione o país de residência ao seu perfil antes "
-"de prosseguir, por favor."
+msgid "Please request the applicant add their country of residence to their profile before proceeding further."
+msgstr "Solicite ao candidato que adicione o país de residência ao seu perfil antes de prosseguir, por favor."
 
 #. Translators: This labels the section of an application showing the total number of accounts available for a partner or their collection.
 #: TWLight/applications/templates/applications/application_evaluation.html:134
@@ -397,12 +359,8 @@ msgstr "Contas disponíveis"
 #. Translators: This labels the section of an application showing whether the user had agreed to the terms of use or not.
 #: TWLight/applications/templates/applications/application_evaluation.html:145
 #, python-format
-msgid ""
-"Has agreed to the site's <a class=\"twl-links\" href=\"%(terms_url)s\">terms "
-"of use</a>?"
-msgstr ""
-"Concordou com as <a class=\"twl-links\" href=\"%(terms_url)s\">condições de "
-"utilização</a> do ''site''?"
+msgid "Has agreed to the site's <a class=\"twl-links\" href=\"%(terms_url)s\">terms of use</a>?"
+msgstr "Concordou com as <a class=\"twl-links\" href=\"%(terms_url)s\">condições de utilização</a> do ''site''?"
 
 #. Translators: Displayed to coordinators when they've agreed to the terms of use.
 #. Translators: Displayed if the user has agreed to the terms of use.
@@ -437,12 +395,8 @@ msgstr "Não"
 
 #. Translators: This is the text displayed to coordinators when an applicant has not agreed to the terms of use.
 #: TWLight/applications/templates/applications/application_evaluation.html:159
-msgid ""
-"Please request the applicant agree to the site's terms of use before "
-"approving this application."
-msgstr ""
-"Solicite ao candidato que concorde com as condições de utilização do "
-"''site'' antes de aprovar esta candidatura, por favor."
+msgid "Please request the applicant agree to the site's terms of use before approving this application."
+msgstr "Solicite ao candidato que concorde com as condições de utilização do ''site'' antes de aprovar esta candidatura, por favor."
 
 #. Translators: This labels the section of an application containing the user's motivation for wanting access to this resource.
 #: TWLight/applications/templates/applications/application_evaluation.html:176
@@ -462,10 +416,8 @@ msgstr "Renovação de permissão de acesso existente?"
 #. Translators: This message is shown next to the 'Renewal of existing access grant?' label if the application is a renewal. Don't translate HTML tags or parent_url.
 #: TWLight/applications/templates/applications/application_evaluation.html:195
 #, python-format
-msgid ""
-"Yes (<a class=\"twl-links\" href=\"%(parent_url)s\">previous application</a>)"
-msgstr ""
-"Sim (<a class=\"twl-links\" href=\"%(parent_url)s\">candidatura anterior</a>)"
+msgid "Yes (<a class=\"twl-links\" href=\"%(parent_url)s\">previous application</a>)"
+msgstr "Sim (<a class=\"twl-links\" href=\"%(parent_url)s\">candidatura anterior</a>)"
 
 #. Translators: This labels the section of the application showing the length of access remaining on the user's previous authorization.
 #: TWLight/applications/templates/applications/application_evaluation.html:208
@@ -499,12 +451,8 @@ msgstr "Adicionar comentário"
 
 #. Translators: On an application page, this text tells users that the comments posted on the application are visible to coordinators and the submitting user only.
 #: TWLight/applications/templates/applications/application_evaluation.html:297
-msgid ""
-"Comments are visible to all coordinators and to the editor who submitted "
-"this application."
-msgstr ""
-"Os comentários podem ser vistos por todos os coordenadores e pelo editor que "
-"enviou esta candidatura."
+msgid "Comments are visible to all coordinators and to the editor who submitted this application."
+msgstr "Os comentários podem ser vistos por todos os coordenadores e pelo editor que enviou esta candidatura."
 
 #. Translators: This is the title of the section of an application page which lists information about the user who submitted the application.
 #. Translators: On the page where coordinators can view data on applications to a partner they coordinate, this is a table column heading for the username.
@@ -715,19 +663,8 @@ msgstr "Definir estado"
 
 #: TWLight/applications/templates/applications/apply.html:20
 #, python-format
-msgid ""
-"If your application is successful we may share your email address with "
-"%(partner)s. This is required to set up your access to their resources. By "
-"submitting this form you agree to allow your email address to be shared with "
-"%(partner)s if your application is successful, for the purposes of account "
-"setup."
-msgstr ""
-"Se a sua candidatura tiver êxito, poderemos partilhar o seu endereço de "
-"correio eletrónico com %(partner)s. Isto é necessário para criar o seu "
-"acesso aos recursos do parceiro. Ao submeter este formulário concorda "
-"permitir que o seu endereço de correio eletrónico seja partilhado com o "
-"parceiro %(partner)s se a sua candidatura tiver êxito, para fins de criação "
-"da sua conta."
+msgid "If your application is successful we may share your email address with %(partner)s. This is required to set up your access to their resources. By submitting this form you agree to allow your email address to be shared with %(partner)s if your application is successful, for the purposes of account setup."
+msgstr "Se a sua candidatura tiver êxito, poderemos partilhar o seu endereço de correio eletrónico com %(partner)s. Isto é necessário para criar o seu acesso aos recursos do parceiro. Ao submeter este formulário concorda permitir que o seu endereço de correio eletrónico seja partilhado com o parceiro %(partner)s se a sua candidatura tiver êxito, para fins de criação da sua conta."
 
 #. Translators: This message is displayed on the page where users can confirm their renewal. Please do not translate partner.
 #: TWLight/applications/templates/applications/confirm_renewal.html:23
@@ -755,12 +692,8 @@ msgstr "A que recursos pretende ter acesso?"
 
 #. Translators: This text explains that Library Bundle partners are not shown in this list.
 #: TWLight/applications/templates/applications/request_for_application.html:26
-msgid ""
-"Library Bundle partners are not shown as eligibility is determined "
-"automatically."
-msgstr ""
-"Os parceiros do Pacote Biblioteca não são mostrados porque a elegibilidade é "
-"determinada automaticamente."
+msgid "Library Bundle partners are not shown as eligibility is determined automatically."
+msgstr "Os parceiros do Pacote Biblioteca não são mostrados porque a elegibilidade é determinada automaticamente."
 
 #. Translators: On the page where users can apply for multiple partners, this message shows next to the partner name, taking them to the full application page when clicked.
 #: TWLight/applications/templates/applications/request_for_application.html:48
@@ -774,15 +707,8 @@ msgstr "Ainda não foram adicionados os dados do parceiro."
 
 #. Translators: the HTML is so that the word 'waitlisted' will look the same as it does in the page above; please translate 'waitlisted' the same way you did elsewhere in this file.
 #: TWLight/applications/templates/applications/request_for_application.html:74
-msgid ""
-"You can apply to <span class=\"badge badge-warning\">Waitlisted</span> "
-"partners, but they don't have access grants available right now. We will "
-"process those applications when access becomes available."
-msgstr ""
-"Pode enviar candidaturas a parceiros <span class=\"badge badge-warning\">com "
-"uma lista de espera</span>, mas estes não têm permissões de acesso "
-"disponíveis neste momento. Essas candidaturas serão processadas quando "
-"houver acessos disponíveis."
+msgid "You can apply to <span class=\"badge badge-warning\">Waitlisted</span> partners, but they don't have access grants available right now. We will process those applications when access becomes available."
+msgstr "Pode enviar candidaturas a parceiros <span class=\"badge badge-warning\">com uma lista de espera</span>, mas estes não têm permissões de acesso disponíveis neste momento. Essas candidaturas serão processadas quando houver acessos disponíveis."
 
 #. Translators: On the page where coordinators can see approved applications which have not had their details sent to the partner, this message shows when there are applications ready to be processed.
 #: TWLight/applications/templates/applications/send.html:10
@@ -803,19 +729,13 @@ msgstr "Dados de candidatura para %(object)s"
 #. Translators: This message is shown when applications exceed the number of accounts available.
 #: TWLight/applications/templates/applications/send_partner.html:54
 #, python-format
-msgid ""
-"Application(s) for %(object)s, if sent, will exceed the total available "
-"accounts for the partner. Please proceed at your own discretion."
-msgstr ""
-"Se as candidaturas para %(object)s forem enviadas, excederão o total de "
-"contas disponíveis para o parceiro. A partir daqui, prossegue por sua conta "
-"e risco."
+msgid "Application(s) for %(object)s, if sent, will exceed the total available accounts for the partner. Please proceed at your own discretion."
+msgstr "Se as candidaturas para %(object)s forem enviadas, excederão o total de contas disponíveis para o parceiro. A partir daqui, prossegue por sua conta e risco."
 
 #. Translators: When viewing the list of applications ready to be sent for a particular partner, this is instructions for the coordinator to click the 'mark as sent' button after they have sent the information.
 #: TWLight/applications/templates/applications/send_partner.html:65
 msgid "When you've processed the data below, click the 'mark as sent' button."
-msgstr ""
-"Depois de processar os dados abaixo, clique o botão 'Marcar como enviada'."
+msgstr "Depois de processar os dados abaixo, clique o botão 'Marcar como enviada'."
 
 #. Translators: When viewing the list of applications ready to be sent for a particular partner, this is the title of the section containing contact information for the people applications should be sent to.
 #: TWLight/applications/templates/applications/send_partner.html:71
@@ -826,12 +746,8 @@ msgstr[1] "Contactos"
 
 #. Translators: When viewing the list of applications ready to be sent for a particular partner, this message shows if there is no information about who the applications should be sent to. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/applications/templates/applications/send_partner.html:89
-msgid ""
-"Whoops, we don't have any listed contacts. Please notify Wikipedia Library "
-"administrators."
-msgstr ""
-"Infelizmente não temos nenhum contacto. Avise os administradores da "
-"Biblioteca da Wikipédia, por favor."
+msgid "Whoops, we don't have any listed contacts. Please notify Wikipedia Library administrators."
+msgstr "Infelizmente não temos nenhum contacto. Avise os administradores da Biblioteca da Wikipédia, por favor."
 
 #. Translators: When viewing the list of applications ready to be sent for a particular partner, this is the title of the section containing the information about those applications.
 #: TWLight/applications/templates/applications/send_partner.html:94
@@ -846,12 +762,8 @@ msgstr "Marcar como enviada"
 
 #. Translators: This text guides coordinators in using the code sending interface for approved applications.
 #: TWLight/applications/templates/applications/send_partner.html:152
-msgid ""
-"Use the dropdown menus to denote which editor will receive each code. Access "
-"codes will be sent to users automatically."
-msgstr ""
-"Use os menus descendentes para indicar o editor que receberá cada código. Os "
-"códigos de acesso serão enviados aos utilizadores automaticamente."
+msgid "Use the dropdown menus to denote which editor will receive each code. Access codes will be sent to users automatically."
+msgstr "Use os menus descendentes para indicar o editor que receberá cada código. Os códigos de acesso serão enviados aos utilizadores automaticamente."
 
 #. Translators: This labels a drop-down selection where staff can assign an access code to a user.
 #: TWLight/applications/templates/applications/send_partner.html:173
@@ -866,24 +778,14 @@ msgstr "Não há candidaturas aprovadas mas não enviadas."
 #. Translators: When a user applies for a set of resources, they receive this message if none are currently available. They are instead placed on a 'waitlist' for later approval.
 #. Translators: When a user renews their resource, they receive this message if none are currently available. They are instead placed on a 'waitlist' for later approval.
 #: TWLight/applications/views.py:140 TWLight/applications/views.py:1282
-msgid ""
-"This partner does not have any access grants available at this time. You may "
-"still apply for access; your application will be reviewed when access grants "
-"become available."
-msgstr ""
-"Este parceiro não tem nenhuma permissão de acesso disponível neste momento. "
-"Pode, ainda assim, pedir acesso; a sua candidatura será revista quando as "
-"permissões de acesso estiverem disponíveis."
+msgid "This partner does not have any access grants available at this time. You may still apply for access; your application will be reviewed when access grants become available."
+msgstr "Este parceiro não tem nenhuma permissão de acesso disponível neste momento. Pode, ainda assim, pedir acesso; a sua candidatura será revista quando as permissões de acesso estiverem disponíveis."
 
 #. Translators: This message is shown to users once they've successfully submitted their application for review.
 #: TWLight/applications/views.py:163
 #, python-brace-format
-msgid ""
-"Your application has been submitted for review. Head over to <a "
-"href='{applications_url}'>My Applications</a> to view the status."
-msgstr ""
-"A sua candidatura foi enviada para revisão. Dirija-se a <a "
-"href='{applications_url}'>Candidaturas</a> para ver o estado."
+msgid "Your application has been submitted for review. Head over to <a href='{applications_url}'>My Applications</a> to view the status."
+msgstr "A sua candidatura foi enviada para revisão. Dirija-se a <a href='{applications_url}'>Candidaturas</a> para ver o estado."
 
 #. Translators: This text is displayed to users when the user has chosen to restrict data and is trying to apply for multiple partners
 #: TWLight/applications/views.py:276
@@ -931,22 +833,13 @@ msgstr "Candidaturas enviadas"
 
 #. Translators: After a coordinator has changed the status of an application to APPROVED, if the corresponding partner/collection is waitlisted this message appears.
 #: TWLight/applications/views.py:756
-msgid ""
-"Cannot approve application as partner with proxy authorization method is "
-"waitlisted."
-msgstr ""
-"Não é possível aprovar a candidatura porque o parceiro com o método de "
-"autorização 'proxy' está em lista de espera."
+msgid "Cannot approve application as partner with proxy authorization method is waitlisted."
+msgstr "Não é possível aprovar a candidatura porque o parceiro com o método de autorização 'proxy' está em lista de espera."
 
 #. Translators: After a coordinator has changed the status of an application to APPROVED, if the corresponding partner/collection has no accounts for distribution, this message appears.
 #: TWLight/applications/views.py:780
-msgid ""
-"Cannot approve application as partner with proxy authorization method is "
-"waitlisted and (or) has zero accounts available for distribution."
-msgstr ""
-"Não é possível aprovar a candidatura porque o parceiro com o método de "
-"autorização 'proxy' está em lista de espera ou não tem nenhuma conta "
-"disponível para distribuição."
+msgid "Cannot approve application as partner with proxy authorization method is waitlisted and (or) has zero accounts available for distribution."
+msgstr "Não é possível aprovar a candidatura porque o parceiro com o método de autorização 'proxy' está em lista de espera ou não tem nenhuma conta disponível para distribuição."
 
 #. Translators: This message appears on an "access denied" screen that stops users who attempt to authorize an editor to access a resource during a time period for which they are already authorized.
 #: TWLight/applications/views.py:803
@@ -956,17 +849,8 @@ msgstr "Você tentou criar uma autorização duplicada."
 #. Translators: This message is shown to users when they access an application page of a now Bundle partner (new applications aren't allowed for Bundle partners and the status of old applications cannot be modified)
 #: TWLight/applications/views.py:857
 #, python-brace-format
-msgid ""
-"This application cannot be modified since this partner is now part of our <a "
-"href='{bundle}'>bundle access</a>. If you are eligible, you can access this "
-"resource from <a href='{library}'>your library</a>. <a "
-"href='{contact}'>Contact us</a> if you have any questions."
-msgstr ""
-"Esta candidatura não pode ser modificada porque este parceiro faz agora "
-"parte do nosso <a href='{bundle}'>acesso Pacote Biblioteca</a>. Se reúne os "
-"requisitos, pode aceder a este recurso na sua <a "
-"href='{library}'>Biblioteca</a>. <a href='{contact}'>Contacte-nos</a> se "
-"tiver alguma dúvida."
+msgid "This application cannot be modified since this partner is now part of our <a href='{bundle}'>bundle access</a>. If you are eligible, you can access this resource from <a href='{library}'>your library</a>. <a href='{contact}'>Contact us</a> if you have any questions."
+msgstr "Esta candidatura não pode ser modificada porque este parceiro faz agora parte do nosso <a href='{bundle}'>acesso Pacote Biblioteca</a>. Se reúne os requisitos, pode aceder a este recurso na sua <a href='{library}'>Biblioteca</a>. <a href='{contact}'>Contacte-nos</a> se tiver alguma dúvida."
 
 #. Translators: this lets a reviewer set the status of a single application.
 #: TWLight/applications/views.py:873
@@ -975,12 +859,8 @@ msgstr "Definir estado da candidatura"
 
 #. Translators: This warning is message is shown to applicants when the number of pending applications is greater than the number of accounts available.
 #: TWLight/applications/views.py:891
-msgid ""
-"There are more pending applications than available accounts. Your "
-"application might get waitlisted."
-msgstr ""
-"Existem mais candidaturas pendentes do que contas disponíveis. A sua "
-"candidatura pode ficar em lista de espera."
+msgid "There are more pending applications than available accounts. Your application might get waitlisted."
+msgstr "Existem mais candidaturas pendentes do que contas disponíveis. A sua candidatura pode ficar em lista de espera."
 
 #. Translators: this message is shown to coordinators who attempt to change an application's Status from INVALID to any other Status.
 #: TWLight/applications/views.py:904
@@ -999,17 +879,8 @@ msgstr "A atualização em segundo plano da(s) candidatura(s) {} foi realizada."
 
 #. Translators: After a coordinator has changed the status of a number of applications to APPROVED, if the corresponding partner(s) is/are waitlisted or has no accounts for distribution, this message appears.
 #: TWLight/applications/views.py:1051
-msgid ""
-"Cannot approve application(s) {} as partner(s) with proxy authorization "
-"method is/are waitlisted and (or) has/have not enough accounts available. If "
-"not enough accounts are available, prioritise the applications and then "
-"approve applications equal to the accounts available."
-msgstr ""
-"Não é possível aprovar a candidatura (ou candidaturas) {}, porque o parceiro "
-"(ou parceiros) com o método de autorização 'proxy' está/estão em lista de "
-"espera ou não tem/têm contas suficientes disponíveis. Se não há contas "
-"suficientes disponíveis, priorize as candidaturas e depois aprove um número "
-"delas igual ao das contas disponíveis."
+msgid "Cannot approve application(s) {} as partner(s) with proxy authorization method is/are waitlisted and (or) has/have not enough accounts available. If not enough accounts are available, prioritise the applications and then approve applications equal to the accounts available."
+msgstr "Não é possível aprovar a candidatura (ou candidaturas) {}, porque o parceiro (ou parceiros) com o método de autorização 'proxy' está/estão em lista de espera ou não tem/têm contas suficientes disponíveis. Se não há contas suficientes disponíveis, priorize as candidaturas e depois aprove um número delas igual ao das contas disponíveis."
 
 #. Translators: This message is shown to coordinators who attempt to assign the same access code to multiple users.
 #: TWLight/applications/views.py:1191
@@ -1023,38 +894,24 @@ msgstr "Todas as candidaturas selecionadas foram marcadas como enviadas."
 
 #. Translators: When a user tries to renew their resource, they receive this message if the partner is not available.
 #: TWLight/applications/views.py:1272
-msgid ""
-"Cannot renew application at this time as partner is not available. Please "
-"check back later, or contact us for more information."
-msgstr ""
-"Não é possível renovar a candidatura nesta altura porque o parceiro não está "
-"disponível. Verifique novamente mais tarde, por favor, ou contacte-nos para "
-"mais informações."
+msgid "Cannot renew application at this time as partner is not available. Please check back later, or contact us for more information."
+msgstr "Não é possível renovar a candidatura nesta altura porque o parceiro não está disponível. Verifique novamente mais tarde, por favor, ou contacte-nos para mais informações."
 
 #. Translators: This message is displayed when an attempt by a user to renew an application has been denied for some reason.
 #: TWLight/applications/views.py:1308
 #, python-brace-format
 msgid "Attempt to renew unapproved application #{pk} has been denied"
-msgstr ""
-"A tentativa de renovar a candidatura não aprovada nº {pk} foi rejeitada"
+msgstr "A tentativa de renovar a candidatura não aprovada nº {pk} foi rejeitada"
 
 #. Translators: If a user requests the renewal of their account, but it wasn't renewed, this message is shown to them.
 #: TWLight/applications/views.py:1385
-msgid ""
-"This object cannot be renewed. (This probably means that you have already "
-"requested that it be renewed.)"
-msgstr ""
-"Este objeto não pode ser renovado (isto provavelmente significa que já pediu "
-"a renovação)."
+msgid "This object cannot be renewed. (This probably means that you have already requested that it be renewed.)"
+msgstr "Este objeto não pode ser renovado (isto provavelmente significa que já pediu a renovação)."
 
 #. Translators: If a user requests the renewal of their account, this message is shown to them.
 #: TWLight/applications/views.py:1395
-msgid ""
-"Your renewal request has been received. A coordinator will review your "
-"request."
-msgstr ""
-"O seu pedido de renovação foi recebido. O pedido será revisto por um "
-"coordenador."
+msgid "Your renewal request has been received. A coordinator will review your request."
+msgstr "O seu pedido de renovação foi recebido. O pedido será revisto por um coordenador."
 
 #. Translators: This labels a textfield where users can enter their email ID.
 #: TWLight/emails/forms.py:18
@@ -1063,12 +920,8 @@ msgstr "O seu correio eletrónico"
 
 #. Translators: This is the help text for the email field in the contact us form letting users know the field is updated by value pulled from their respective user profiles.
 #: TWLight/emails/forms.py:21
-msgid ""
-"This field is automatically updated with the email from your <a class='twl-"
-"links' href='{}'>user profile</a>."
-msgstr ""
-"Este campo é atualizado automaticamente com o correio eletrónico do seu <a "
-"class='twl-links' href='{}'>perfil de utilizador</a>."
+msgid "This field is automatically updated with the email from your <a class='twl-links' href='{}'>user profile</a>."
+msgstr "Este campo é atualizado automaticamente com o correio eletrónico do seu <a class='twl-links' href='{}'>perfil de utilizador</a>."
 
 #. Translators: This labels a textfield where users can enter their email message.
 #: TWLight/emails/forms.py:26
@@ -1091,27 +944,14 @@ msgstr "Enviar"
 #. Translators: This email is sent to users with their access code. Don't translate Jinja variables in curly braces like user or partner. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/access_code_email-body-html.html:5
 #, python-format
-msgid ""
-"<p>Your approved application to %(partner)s has now been finalised. Your "
-"access code or login details can be found below:</p> <p><b>%(access_code)s</"
-"b></p> <p>%(user_instructions)s</p>"
-msgstr ""
-"<p>A sua candidatura aprovada para o parceiro %(partner)s foi finalizada. O "
-"seu código de acesso ou os detalhes para iniciar sessão podem ser "
-"encontrados abaixo:</p> <p><b>%(access_code)s</b></p> <p>"
-"%(user_instructions)s</p>"
+msgid "<p>Your approved application to %(partner)s has now been finalised. Your access code or login details can be found below:</p> <p><b>%(access_code)s</b></p> <p>%(user_instructions)s</p>"
+msgstr "<p>A sua candidatura aprovada para o parceiro %(partner)s foi finalizada. O seu código de acesso ou os detalhes para iniciar sessão podem ser encontrados abaixo:</p> <p><b>%(access_code)s</b></p> <p>%(user_instructions)s</p>"
 
 #. Translators: This email is sent to users with their access code. Don't translate Jinja variables in curly braces like user or partner. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/access_code_email-body-text.html:3
 #, python-format
-msgid ""
-"Your approved application to %(partner)s has now been finalised. Your access "
-"code or login details can be found below: %(access_code)s "
-"%(user_instructions)s"
-msgstr ""
-"A sua candidatura aprovada para o parceiro %(partner)s foi finalizada. O seu "
-"código de acesso ou os detalhes para iniciar sessão podem ser encontrados "
-"abaixo: %(access_code)s %(user_instructions)s"
+msgid "Your approved application to %(partner)s has now been finalised. Your access code or login details can be found below: %(access_code)s %(user_instructions)s"
+msgstr "A sua candidatura aprovada para o parceiro %(partner)s foi finalizada. O seu código de acesso ou os detalhes para iniciar sessão podem ser encontrados abaixo: %(access_code)s %(user_instructions)s"
 
 #. Translators: This is the subject line of an email sent to users with their access code.
 #: TWLight/emails/templates/emails/access_code_email-subject.html:3
@@ -1121,35 +961,14 @@ msgstr "O seu código de acesso à Biblioteca da Wikipédia"
 #. Translators: This email is sent to users when their application is approved. Don't translate Jinja variables in curly braces like user or partner; don't translate html tags either. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/approval_notification-body-html.html:5
 #, python-format
-msgid ""
-"<p>Dear %(user)s,</p> <p>Thank you for applying for access to %(partner)s "
-"resources through The Wikipedia Library. We are happy to inform you that "
-"your application has been approved.</p> <p>%(user_instructions)s</p> <p>You "
-"can view the collections you're authorized to access at My Library: "
-"%(link)s</p> <p>Cheers!</p> <p>The Wikipedia Library</p>"
-msgstr ""
-"<p>Caro(a) %(user)s,</p> <p>Agradecemos a sua candidatura de acesso aos "
-"recursos do parceiro %(partner)s através da Biblioteca da Wikipédia. Temos o "
-"prazer de informar que a sua candidatura foi aprovada.</p> <p>"
-"%(user_instructions)s</p> <p>Pode consultar os conjuntos de recursos que "
-"está autorizado a aceder na sua Biblioteca: %(link)s</p> <p>Cumprimentos!</"
-"p> <p>A Biblioteca da Wikipédia</p>"
+msgid "<p>Dear %(user)s,</p> <p>Thank you for applying for access to %(partner)s resources through The Wikipedia Library. We are happy to inform you that your application has been approved.</p> <p>%(user_instructions)s</p> <p>You can view the collections you're authorized to access at My Library: %(link)s</p> <p>Cheers!</p> <p>The Wikipedia Library</p>"
+msgstr "<p>Caro(a) %(user)s,</p> <p>Agradecemos a sua candidatura de acesso aos recursos do parceiro %(partner)s através da Biblioteca da Wikipédia. Temos o prazer de informar que a sua candidatura foi aprovada.</p> <p>%(user_instructions)s</p> <p>Pode consultar os conjuntos de recursos que está autorizado a aceder na sua Biblioteca: %(link)s</p> <p>Cumprimentos!</p> <p>A Biblioteca da Wikipédia</p>"
 
 #. Translators: This email is sent to users when their application is approved. Don't translate Jinja variables in curly braces like user or partner. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/approval_notification-body-text.html:3
 #, python-format
-msgid ""
-"Dear %(user)s, Thank you for applying for access to %(partner)s resources "
-"through The Wikipedia Library. We are happy to inform you that your "
-"application has been approved. %(user_instructions)s You can view the "
-"collections you're authorized to access at My Library: %(link)s Cheers! The "
-"Wikipedia Library"
-msgstr ""
-"Caro(a) %(user)s, Agradecemos  a sua candidatura de acesso aos recursos do "
-"parceiro %(partner)s através da Biblioteca da Wikipédia. Temos o prazer de "
-"informar que a sua candidatura foi aprovada. %(user_instructions)s Pode "
-"consultar os conjuntos de recursos que está autorizado a aceder na sua "
-"Biblioteca: %(link)s Cumprimentos! A Biblioteca da Wikipédia"
+msgid "Dear %(user)s, Thank you for applying for access to %(partner)s resources through The Wikipedia Library. We are happy to inform you that your application has been approved. %(user_instructions)s You can view the collections you're authorized to access at My Library: %(link)s Cheers! The Wikipedia Library"
+msgstr "Caro(a) %(user)s, Agradecemos  a sua candidatura de acesso aos recursos do parceiro %(partner)s através da Biblioteca da Wikipédia. Temos o prazer de informar que a sua candidatura foi aprovada. %(user_instructions)s Pode consultar os conjuntos de recursos que está autorizado a aceder na sua Biblioteca: %(link)s Cumprimentos! A Biblioteca da Wikipédia"
 
 #. Translators: This is the subject of an email which is sent to users when their application has been approved. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/approval_notification-subject.html:4
@@ -1159,58 +978,31 @@ msgstr "A sua candidatura da Biblioteca da Wikipédia foi aprovada"
 #. Translators: This email is sent to coordinators when a comment is left on an application they are processing. Don't translate Jinja variables in curly braces like user or partner. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/comment_notification_coordinator-body-html.html:5
 #, python-format
-msgid ""
-"<p style=\"color: #500050\">%(submit_date)s - %(commenter)s</p> "
-"<blockquote><p>%(comment)s</p></blockquote> <p>Please reply to these at: <a "
-"href=\"%(app_url)s\">%(app_url)s</a></p> <p>Best,</p> <p>The Wikipedia "
-"Library</p>"
-msgstr ""
-"<p style=\"color: #500050\">%(submit_date)s - %(commenter)s</p> "
-"<blockquote><p>%(comment)s</p></blockquote> <p>Responda a estes comentários "
-"em: <a href=\"%(app_url)s\">%(app_url)s</a></p> <p>Cumprimentos,</p> <p>A "
-"Biblioteca da Wikipédia</p>"
+msgid "<p style=\"color: #500050\">%(submit_date)s - %(commenter)s</p> <blockquote><p>%(comment)s</p></blockquote> <p>Please reply to these at: <a href=\"%(app_url)s\">%(app_url)s</a></p> <p>Best,</p> <p>The Wikipedia Library</p>"
+msgstr "<p style=\"color: #500050\">%(submit_date)s - %(commenter)s</p> <blockquote><p>%(comment)s</p></blockquote> <p>Responda a estes comentários em: <a href=\"%(app_url)s\">%(app_url)s</a></p> <p>Cumprimentos,</p> <p>A Biblioteca da Wikipédia</p>"
 
 #. Translators: This email is sent to coordinators when a comment is left on an application they are processing. Don't translate Jinja variables in curly braces like user or partner. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/comment_notification_coordinator-body-text.html:3
 #, python-format
-msgid ""
-"%(submit_date)s - %(commenter)s %(comment)s Please reply to this at: "
-"%(app_url)s Best, The Wikipedia Library"
-msgstr ""
-"%(submit_date)s - %(commenter)s %(comment)s Responda a estes comentários em: "
-"%(app_url)s Cumprimentos, A Biblioteca da Wikipédia"
+msgid "%(submit_date)s - %(commenter)s %(comment)s Please reply to this at: %(app_url)s Best, The Wikipedia Library"
+msgstr "%(submit_date)s - %(commenter)s %(comment)s Responda a estes comentários em: %(app_url)s Cumprimentos, A Biblioteca da Wikipédia"
 
 #. Translators: This is the subject line of an email sent to coordinators when a comment is left on an application they processed.
 #: TWLight/emails/templates/emails/comment_notification_coordinator-subject.html:3
 msgid "New comment on a Wikipedia Library application you processed"
-msgstr ""
-"Comentário novo numa candidatura da Biblioteca da Wikipédia que foi "
-"processada por si"
+msgstr "Comentário novo numa candidatura da Biblioteca da Wikipédia que foi processada por si"
 
 #. Translators: This email is sent to users when they receive a comment on their application. Don't translate Jinja variables in curly braces like user or partner; don't translate html tags either. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/comment_notification_editors-body-html.html:5
 #, python-format
-msgid ""
-"<p style=\"color: #500050\">%(submit_date)s - %(commenter)s</p> "
-"<blockquote><p>%(comment)s</p></blockquote> <p>Please reply to these at <a "
-"href=\"%(app_url)s\">%(app_url)s</a> so we can evaluate your application.</"
-"p> <p>Best,</p> <p>The Wikipedia Library</p>"
-msgstr ""
-"<p style=\"color: #500050\">%(submit_date)s - %(commenter)s</p> "
-"<blockquote><p>%(comment)s</p></blockquote> <p>Responda a estes comentários "
-"em <a href=\"%(app_url)s\">%(app_url)s</a> para podermos avaliar a sua "
-"candidatura.</p> <p>Cumprimentos,</p> <p>A Biblioteca da Wikipédia</p>"
+msgid "<p style=\"color: #500050\">%(submit_date)s - %(commenter)s</p> <blockquote><p>%(comment)s</p></blockquote> <p>Please reply to these at <a href=\"%(app_url)s\">%(app_url)s</a> so we can evaluate your application.</p> <p>Best,</p> <p>The Wikipedia Library</p>"
+msgstr "<p style=\"color: #500050\">%(submit_date)s - %(commenter)s</p> <blockquote><p>%(comment)s</p></blockquote> <p>Responda a estes comentários em <a href=\"%(app_url)s\">%(app_url)s</a> para podermos avaliar a sua candidatura.</p> <p>Cumprimentos,</p> <p>A Biblioteca da Wikipédia</p>"
 
 #. Translators: This email is sent to users when they receive a comment on their application. Don't translate Jinja variables in curly braces like user or partner. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/comment_notification_editors-body-text.html:3
 #, python-format
-msgid ""
-"%(submit_date)s - %(commenter)s %(comment)s Please reply to these at: "
-"%(app_url)s so we can evaluate your application. Best, The Wikipedia Library"
-msgstr ""
-"%(submit_date)s - %(commenter)s %(comment)s Responda a estes comentários em: "
-"%(app_url)s para podermos avaliar a sua candidatura. Cumprimentos, A "
-"Biblioteca da Wikipédia"
+msgid "%(submit_date)s - %(commenter)s %(comment)s Please reply to these at: %(app_url)s so we can evaluate your application. Best, The Wikipedia Library"
+msgstr "%(submit_date)s - %(commenter)s %(comment)s Responda a estes comentários em: %(app_url)s para podermos avaliar a sua candidatura. Cumprimentos, A Biblioteca da Wikipédia"
 
 #. Translators: This is the subject line of an email sent to users who have a comment added to one of their applications. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/comment_notification_editors-subject.html:3
@@ -1220,43 +1012,25 @@ msgstr "Comentário novo na sua candidatura da Biblioteca da Wikipédia"
 #. Translators: This email is sent to users when an application they commented on receives another comment. Don't translate Jinja variables in curly braces like app_url; don't translate html tags either. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/comment_notification_others-body-html.html:5
 #, python-format
-msgid ""
-"<p style=\"color: #500050\">%(submit_date)s - %(commenter)s</p> "
-"<blockquote><p>%(comment)s</p></blockquote> See it at <a href=\"%(app_url)s"
-"\">%(app_url)s</a>. Thanks for helping review Wikipedia Library applications!"
-msgstr ""
-"<p style=\"color: #500050\">%(submit_date)s - %(commenter)s</p> "
-"<blockquote><p>%(comment)s</p></blockquote> Pode vê-lo em <a href="
-"\"%(app_url)s\">%(app_url)s</a>. Obrigado por ajudar a rever as candidaturas "
-"da Biblioteca da Wikipédia!"
+msgid "<p style=\"color: #500050\">%(submit_date)s - %(commenter)s</p> <blockquote><p>%(comment)s</p></blockquote> See it at <a href=\"%(app_url)s\">%(app_url)s</a>. Thanks for helping review Wikipedia Library applications!"
+msgstr "<p style=\"color: #500050\">%(submit_date)s - %(commenter)s</p> <blockquote><p>%(comment)s</p></blockquote> Pode vê-lo em <a href=\"%(app_url)s\">%(app_url)s</a>. Obrigado por ajudar a rever as candidaturas da Biblioteca da Wikipédia!"
 
 #. Translators: This email is sent to users when an application they commented on receives another comment. Don't translate Jinja variables in curly braces like app_url. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/comment_notification_others-body-text.html:3
 #, python-format
-msgid ""
-"%(submit_date)s - %(commenter)s %(comment)s See it at: %(app_url)s Thanks "
-"for helping review Wikipedia Library applications!"
-msgstr ""
-"%(submit_date)s - %(commenter)s %(comment)s Pode vê-lo em: %(app_url)s "
-"Obrigado por ajudar a rever as candidaturas da Biblioteca da Wikipédia!"
+msgid "%(submit_date)s - %(commenter)s %(comment)s See it at: %(app_url)s Thanks for helping review Wikipedia Library applications!"
+msgstr "%(submit_date)s - %(commenter)s %(comment)s Pode vê-lo em: %(app_url)s Obrigado por ajudar a rever as candidaturas da Biblioteca da Wikipédia!"
 
 #. Translators: This is the subject line of an email sent to users who have a comment added to an application they also commented on. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/comment_notification_others-subject.html:4
 msgid "New comment on a Wikipedia Library application you commented on"
-msgstr ""
-"Comentário novo numa candidatura da Biblioteca da Wikipédia que foi "
-"comentada por si"
+msgstr "Comentário novo numa candidatura da Biblioteca da Wikipédia que foi comentada por si"
 
 #. Translators: This text is part of a scheduled reminder email sent to coordinators who have applications requiring action. Don't translate Jinja variables in curly braces like total_apps, or user.
 #: TWLight/emails/templates/emails/coordinator_reminder_notification-body-html.html:5
 #, python-format
-msgid ""
-"<p>Dear %(user)s,</p> <p>Our records indicate that you are the designated "
-"coordinator for partners that have a total of %(total_apps)s applications.</"
-"p>"
-msgstr ""
-"<p>Caro(a) %(user)s,</p> <p>Os nossos registos indicam que é o coordenador "
-"designado para parceiros que têm um total de %(total_apps)s candidaturas.</p>"
+msgid "<p>Dear %(user)s,</p> <p>Our records indicate that you are the designated coordinator for partners that have a total of %(total_apps)s applications.</p>"
+msgstr "<p>Caro(a) %(user)s,</p> <p>Os nossos registos indicam que é o coordenador designado para parceiros que têm um total de %(total_apps)s candidaturas.</p>"
 
 #. Translators: Breakdown as in 'cost breakdown'; analysis.
 #: TWLight/emails/templates/emails/coordinator_reminder_notification-body-html.html:11
@@ -1294,43 +1068,20 @@ msgstr[1] "%(counter)s candidaturas aprovadas."
 #. Translators: This text is part of a scheduled reminder email sent to coordinators who have applications requiring action. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library). Don't translate Jinja variables in curly braces like link; don't translate email addresses or html tags either.
 #: TWLight/emails/templates/emails/coordinator_reminder_notification-body-html.html:39
 #, python-format
-msgid ""
-"<p>This is a gentle reminder that you may review applications at <a href="
-"\"%(link)s\">%(link)s</a>.</p> <p>You can customise your reminders under "
-"'preferences' in your user profile.</p> <p>If you received this message in "
-"error, drop us a line at wikipedialibrary@wikimedia.org.</p> <p>Thanks for "
-"helping review Wikipedia Library applications!</p>"
-msgstr ""
-"<p>Relembramos que pode rever candidaturas em <a href=\"%(link)s\">%(link)s</"
-"a>.</p> <p>Pode personalizar os avisos em 'preferências' no seu perfil de "
-"utilizador.</p> <p>Se recebeu esta mensagem em erro, contacte-nos em "
-"wikipedialibrary@wikimedia.org.</p> <p>Obrigado por ajudar a rever as "
-"candidaturas da Biblioteca da Wikipédia!</p>"
+msgid "<p>This is a gentle reminder that you may review applications at <a href=\"%(link)s\">%(link)s</a>.</p> <p>You can customise your reminders under 'preferences' in your user profile.</p> <p>If you received this message in error, drop us a line at wikipedialibrary@wikimedia.org.</p> <p>Thanks for helping review Wikipedia Library applications!</p>"
+msgstr "<p>Relembramos que pode rever candidaturas em <a href=\"%(link)s\">%(link)s</a>.</p> <p>Pode personalizar os avisos em 'preferências' no seu perfil de utilizador.</p> <p>Se recebeu esta mensagem em erro, contacte-nos em wikipedialibrary@wikimedia.org.</p> <p>Obrigado por ajudar a rever as candidaturas da Biblioteca da Wikipédia!</p>"
 
 #. Translators: This text is part of a scheduled reminder email sent to coordinators who have applications requiring action. Don't translate Jinja variables in curly braces like total_apps, or user.
 #: TWLight/emails/templates/emails/coordinator_reminder_notification-body-text.html:3
 #, python-format
-msgid ""
-"Dear %(user)s, Our records indicate that you are the designated coordinator "
-"for partners that have a total of %(total_apps)s applications."
-msgstr ""
-"Caro(a) %(user)s, Os nossos registos indicam que é o coordenador designado "
-"para parceiros que têm um total de %(total_apps)s candidaturas."
+msgid "Dear %(user)s, Our records indicate that you are the designated coordinator for partners that have a total of %(total_apps)s applications."
+msgstr "Caro(a) %(user)s, Os nossos registos indicam que é o coordenador designado para parceiros que têm um total de %(total_apps)s candidaturas."
 
 #. Translators: This text is part of a scheduled reminder email sent to coordinators who have applications requiring action. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library). Don't translate Jinja variables in curly braces like link; don't translate the email address either.
 #: TWLight/emails/templates/emails/coordinator_reminder_notification-body-text.html:38
 #, python-format
-msgid ""
-"This is a gentle reminder that you may review applications at: %(link)s. You "
-"can customise your reminders under 'preferences' in your user profile. If "
-"you received this message in error, drop us a line at: "
-"wikipedialibrary@wikimedia.org Thanks for helping review Wikipedia Library "
-"applications!"
-msgstr ""
-"Relembramos que pode rever candidaturas em: %(link)s. Pode personalizar os "
-"avisos em 'preferências' no seu perfil de utilizador. Se recebeu esta "
-"mensagem em erro, contacte-nos em: wikipedialibrary@wikimedia.org Obrigado "
-"por ajudar a rever as candidaturas da Biblioteca da Wikipédia!"
+msgid "This is a gentle reminder that you may review applications at: %(link)s. You can customise your reminders under 'preferences' in your user profile. If you received this message in error, drop us a line at: wikipedialibrary@wikimedia.org Thanks for helping review Wikipedia Library applications!"
+msgstr "Relembramos que pode rever candidaturas em: %(link)s. Pode personalizar os avisos em 'preferências' no seu perfil de utilizador. Se recebeu esta mensagem em erro, contacte-nos em: wikipedialibrary@wikimedia.org Obrigado por ajudar a rever as candidaturas da Biblioteca da Wikipédia!"
 
 #. Translators: This is the subject line of a scheduled reminder email sent to coordinators who have applications to review. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library). Do not translate items in curly braces.
 #: TWLight/emails/templates/emails/coordinator_reminder_notification-subject.html:4
@@ -1340,32 +1091,14 @@ msgstr "Há candidaturas da Biblioteca da Wikipédia a aguardar a sua revisão"
 #. Translators: This email is sent to users when their application is rejected. Don't translate Jinja variables in curly braces like user or partner; don't translate html tags either. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/rejection_notification-body-html.html:5
 #, python-format
-msgid ""
-"<p>Dear %(user)s,</p> <p>Thank you for applying for access to %(partner)s "
-"resources through The Wikipedia Library. Unfortunately at this time your "
-"application has not been approved. You can view your application and review "
-"comments at <a href=\"%(app_url)s\">%(app_url)s</a>.</p> <p>Best,</p> <p>The "
-"Wikipedia Library</p>"
-msgstr ""
-"<p>Caro(a) %(user)s,</p> <p>Agradecemos a sua candidatura de acesso aos "
-"recursos do parceiro %(partner)s através da Biblioteca da Wikipédia. "
-"Infelizmente a sua candidatura não foi aprovada. Pode ver a candidatura e os "
-"comentários da revisão em <a href=\"%(app_url)s\">%(app_url)s</a>.</p> "
-"<p>Melhores cumprimentos,</p> <p>A Biblioteca da Wikipédia</p>"
+msgid "<p>Dear %(user)s,</p> <p>Thank you for applying for access to %(partner)s resources through The Wikipedia Library. Unfortunately at this time your application has not been approved. You can view your application and review comments at <a href=\"%(app_url)s\">%(app_url)s</a>.</p> <p>Best,</p> <p>The Wikipedia Library</p>"
+msgstr "<p>Caro(a) %(user)s,</p> <p>Agradecemos a sua candidatura de acesso aos recursos do parceiro %(partner)s através da Biblioteca da Wikipédia. Infelizmente a sua candidatura não foi aprovada. Pode ver a candidatura e os comentários da revisão em <a href=\"%(app_url)s\">%(app_url)s</a>.</p> <p>Melhores cumprimentos,</p> <p>A Biblioteca da Wikipédia</p>"
 
 #. Translators: This email is sent to users when their application is rejected. Don't translate Jinja variables in curly braces like user or partner. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/rejection_notification-body-text.html:3
 #, python-format
-msgid ""
-"Dear %(user)s, Thank you for applying for access to %(partner)s resources "
-"through The Wikipedia Library. Unfortunately at this time your application "
-"has not been approved. You can view your application and review comments at: "
-"%(app_url)s Best, The Wikipedia Library"
-msgstr ""
-"Caro(a) %(user)s, Agradecemos a sua candidatura de acesso aos recursos do "
-"parceiro %(partner)s através da Biblioteca da Wikipédia. Infelizmente a sua "
-"candidatura não foi aprovada. Pode ver a candidatura e os comentários da "
-"revisão em: %(app_url)s Melhores cumprimentos, A Biblioteca da Wikipédia"
+msgid "Dear %(user)s, Thank you for applying for access to %(partner)s resources through The Wikipedia Library. Unfortunately at this time your application has not been approved. You can view your application and review comments at: %(app_url)s Best, The Wikipedia Library"
+msgstr "Caro(a) %(user)s, Agradecemos a sua candidatura de acesso aos recursos do parceiro %(partner)s através da Biblioteca da Wikipédia. Infelizmente a sua candidatura não foi aprovada. Pode ver a candidatura e os comentários da revisão em: %(app_url)s Melhores cumprimentos, A Biblioteca da Wikipédia"
 
 #. Translators: This is the subject of an email which is sent to users when their application has been rejected. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/rejection_notification-subject.html:4
@@ -1375,39 +1108,14 @@ msgstr "A sua candidatura da Biblioteca da Wikipédia"
 #. Translators: This email is sent to users when they have an account that is soon to expire. Don't translate Jinja variables in curly braces like partner_name or partner_link; don't translate html tags either. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/user_renewal_notice-body-html.html:5
 #, python-format
-msgid ""
-"<p>Dear %(user)s,</p> <p>According to our records, your access to "
-"%(partner_name)s will soon expire and you may lose access. If you want to "
-"continue making use of your free account, you can request renewal of your "
-"account by clicking the 'Renew' or 'Extend' button at %(partner_link)s.</p> "
-"<p>Best,</p> <p>The Wikipedia Library</p> <p>You can disable these emails in "
-"your user page preferences: https://wikipedialibrary.wmflabs.org/users/</p>"
-msgstr ""
-"<p>Caro(a) %(user)s,</p> <p>De acordo com os nossos registos, o seu acesso "
-"aos recursos do parceiro %(partner_name)s expirará em breve e poderá perdê-"
-"lo. Se quiser continuar a usar a sua conta gratuita pode pedir a renovação "
-"da mesma clicando os botões 'Renovar' ou 'Prolongar' em %(partner_link)s.</"
-"p> <p>Cumprimentos,</p> <p>A Biblioteca da Wikipédia</p> <p>Pode desativar "
-"estas mensagens nas preferências da sua página de utilizador: https://"
-"wikipedialibrary.wmflabs.org/users/</p>"
+msgid "<p>Dear %(user)s,</p> <p>According to our records, your access to %(partner_name)s will soon expire and you may lose access. If you want to continue making use of your free account, you can request renewal of your account by clicking the 'Renew' or 'Extend' button at %(partner_link)s.</p> <p>Best,</p> <p>The Wikipedia Library</p> <p>You can disable these emails in your user page preferences: https://wikipedialibrary.wmflabs.org/users/</p>"
+msgstr "<p>Caro(a) %(user)s,</p> <p>De acordo com os nossos registos, o seu acesso aos recursos do parceiro %(partner_name)s expirará em breve e poderá perdê-lo. Se quiser continuar a usar a sua conta gratuita pode pedir a renovação da mesma clicando os botões 'Renovar' ou 'Prolongar' em %(partner_link)s.</p> <p>Cumprimentos,</p> <p>A Biblioteca da Wikipédia</p> <p>Pode desativar estas mensagens nas preferências da sua página de utilizador: https://wikipedialibrary.wmflabs.org/users/</p>"
 
 #. Translators: This email is sent to users when they have an account that is soon to expire. Don't translate Jinja variables in curly braces like partner_name or partner_link; don't translate html tags either. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/user_renewal_notice-body-text.html:3
 #, python-format
-msgid ""
-"Dear %(user)s, According to our records, your access to %(partner_name)s "
-"will soon expire and you may lose access. If you want to continue making use "
-"of your free account, you can request renewal of your account by clicking "
-"the Renew button at %(partner_link)s. Best, The Wikipedia Library You can "
-"disable these emails in your user page preferences: https://wikipedialibrary."
-"wmflabs.org/users/"
-msgstr ""
-"Caro(a) %(user)s, De acordo com os nossos registos, o seu acesso aos "
-"recursos do parceiro %(partner_name)s expirará em breve e poderá perdê-lo. "
-"Se quiser continuar a usar a sua conta gratuita, pode pedir a renovação da "
-"mesma clicando o botão Renovar em %(partner_link)s. Cumprimentos, A "
-"Biblioteca da Wikipédia Pode desativar estas mensagens nas preferências da "
-"sua página de utilizador: https://wikipedialibrary.wmflabs.org/users/"
+msgid "Dear %(user)s, According to our records, your access to %(partner_name)s will soon expire and you may lose access. If you want to continue making use of your free account, you can request renewal of your account by clicking the Renew button at %(partner_link)s. Best, The Wikipedia Library You can disable these emails in your user page preferences: https://wikipedialibrary.wmflabs.org/users/"
+msgstr "Caro(a) %(user)s, De acordo com os nossos registos, o seu acesso aos recursos do parceiro %(partner_name)s expirará em breve e poderá perdê-lo. Se quiser continuar a usar a sua conta gratuita, pode pedir a renovação da mesma clicando o botão Renovar em %(partner_link)s. Cumprimentos, A Biblioteca da Wikipédia Pode desativar estas mensagens nas preferências da sua página de utilizador: https://wikipedialibrary.wmflabs.org/users/"
 
 #. Translators: This is the subject of an email sent to users when they have an account that is soon to expire. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/user_renewal_notice-subject.html:4
@@ -1417,44 +1125,19 @@ msgstr "O seu acesso à Biblioteca da Wikipédia pode expirar brevemente"
 #. Translators: This email is sent to users when their application is waitlisted because there are no more accounts available. Don't translate Jinja variables in curly braces like user or partner; don't translate html tags either. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/waitlist_notification-body-html.html:5
 #, python-format
-msgid ""
-"<p>Dear %(user)s,</p> <p>Thank you for applying for access to %(partner)s "
-"resources through The Wikipedia Library. There are no accounts currently "
-"available so your application has been waitlisted. Your application will be "
-"evaluated if/when more accounts become available. You can see all available "
-"resources at <a href=\"%(link)s\">%(link)s</a>.</p> <p>Best,</p> <p>The "
-"Wikipedia Library</p>"
-msgstr ""
-"<p>Caro(a) %(user)s,</p> <p>Agradecemos a sua candidatura de acesso aos "
-"recursos do parceiro %(partner)s através da Biblioteca da Wikipédia. Neste "
-"momento não há nenhuma conta disponível, por isso a sua candidatura foi "
-"colocada em lista de espera. A candidatura será avaliada quando houverem "
-"contas disponíveis. Pode ver todos os recursos disponíveis em <a href="
-"\"%(link)s\">%(link)s</a>.</p> <p>Cumprimentos,</p> <p>A Biblioteca da "
-"Wikipédia</p>"
+msgid "<p>Dear %(user)s,</p> <p>Thank you for applying for access to %(partner)s resources through The Wikipedia Library. There are no accounts currently available so your application has been waitlisted. Your application will be evaluated if/when more accounts become available. You can see all available resources at <a href=\"%(link)s\">%(link)s</a>.</p> <p>Best,</p> <p>The Wikipedia Library</p>"
+msgstr "<p>Caro(a) %(user)s,</p> <p>Agradecemos a sua candidatura de acesso aos recursos do parceiro %(partner)s através da Biblioteca da Wikipédia. Neste momento não há nenhuma conta disponível, por isso a sua candidatura foi colocada em lista de espera. A candidatura será avaliada quando houverem contas disponíveis. Pode ver todos os recursos disponíveis em <a href=\"%(link)s\">%(link)s</a>.</p> <p>Cumprimentos,</p> <p>A Biblioteca da Wikipédia</p>"
 
 #. Translators: This email is sent to users when their application is waitlisted because there are no more accounts available. Don't translate Jinja variables in curly braces like user or partner. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/waitlist_notification-body-text.html:3
 #, python-format
-msgid ""
-"Dear %(user)s, Thank you for applying for access to %(partner)s resources "
-"through The Wikipedia Library. There are no accounts currently available so "
-"your application has been waitlisted. Your application will be evaluated if/"
-"when more accounts become available. You can see all available resources at: "
-"%(link)s Best, The Wikipedia Library"
-msgstr ""
-"Caro(a) %(user)s, Agradecemos a sua candidatura de acesso aos recursos do "
-"parceiro %(partner)s através da Biblioteca da Wikipédia. Neste momento não "
-"há nenhuma conta disponível, por isso a sua candidatura foi colocada em "
-"lista de espera. A candidatura será avaliada quando houverem contas "
-"disponíveis. Pode ver todos os recursos disponíveis em: %(link)s "
-"Cumprimentos, A Biblioteca da Wikipédia"
+msgid "Dear %(user)s, Thank you for applying for access to %(partner)s resources through The Wikipedia Library. There are no accounts currently available so your application has been waitlisted. Your application will be evaluated if/when more accounts become available. You can see all available resources at: %(link)s Best, The Wikipedia Library"
+msgstr "Caro(a) %(user)s, Agradecemos a sua candidatura de acesso aos recursos do parceiro %(partner)s através da Biblioteca da Wikipédia. Neste momento não há nenhuma conta disponível, por isso a sua candidatura foi colocada em lista de espera. A candidatura será avaliada quando houverem contas disponíveis. Pode ver todos os recursos disponíveis em: %(link)s Cumprimentos, A Biblioteca da Wikipédia"
 
 #. Translators: This is the subject of an email sent to users when their application is waitlisted because there are no more accounts available. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/waitlist_notification-subject.html:4
 msgid "Your Wikipedia Library application has been waitlisted"
-msgstr ""
-"A sua candidatura da Biblioteca da Wikipédia foi colocada em lista de espera"
+msgstr "A sua candidatura da Biblioteca da Wikipédia foi colocada em lista de espera"
 
 #. Translators: Shown to users when they successfully submit a new message using the contact us form.
 #: TWLight/emails/views.py:51
@@ -1610,23 +1293,15 @@ msgstr "Indisponível"
 #: TWLight/resources/templates/resources/filter_section.html:14
 #: TWLight/templates/about.html:12
 #: TWLight/users/templates/users/filter_section.html:13
-msgid ""
-"The Wikipedia Library allows active editors to access a wide range of "
-"collections of paywalled reliable sources for free!"
-msgstr ""
-"A Biblioteca da Wikipédia permite aos editores que são ativos aceder de "
-"forma gratuita a uma gama ampla de conjuntos de recursos pagos de fontes "
-"confiáveis!"
+msgid "The Wikipedia Library allows active editors to access a wide range of collections of paywalled reliable sources for free!"
+msgstr "A Biblioteca da Wikipédia permite aos editores que são ativos aceder de forma gratuita a uma gama ampla de conjuntos de recursos pagos de fontes confiáveis!"
 
 #. Translators: On the Browse Partners page (https://wikipedialibrary.wmflabs.org/partners/), this introduces users to The Wikipedia Library.
 #. Translators: On the MyLibrary page (https://wikipedialibrary.wmflabs.org/users/my_library), this introduces users to The Wikipedia Library.
 #: TWLight/resources/templates/resources/filter_section.html:17
 #: TWLight/users/templates/users/filter_section.html:15
-msgid ""
-"Start with the search bar at the top or browse publisher websites directly."
-msgstr ""
-"Comece pela barra de pesquisa no topo ou navegue diretamente nos sites da "
-"internet das editoras."
+msgid "Start with the search bar at the top or browse publisher websites directly."
+msgstr "Comece pela barra de pesquisa no topo ou navegue diretamente nos sites da internet das editoras."
 
 #. Translators: On the Browse Partners page (https://wikipedialibrary.wmflabs.org/partners/), this appears below introductory text and links to the 'About' page (https://wikipedialibrary.wmflabs.org/about/)
 #. Translators: On the MyLibrary page (https://wikipedialibrary.wmflabs.org/users/my_library), this appears below introductory text and links to the 'About' page (https://wikipedialibrary.wmflabs.org/about/)
@@ -1699,68 +1374,39 @@ msgstr "Voltar aos parceiros"
 #. Translators: If we have no available accounts for a partner, the coordinator can change the application system to a waiting list.
 #: TWLight/resources/templates/resources/partner_detail.html:36
 #: TWLight/resources/templates/resources/partner_detail_apply.html:17
-msgid ""
-"There are no access grants available for this partner at this time. You can "
-"still apply for access; applications will be processed when access is "
-"available."
-msgstr ""
-"Neste momento não há permissões de acesso disponíveis para este parceiro. "
-"Pode, mesmo assim, candidatar-se ao acesso; as candidaturas serão "
-"processadas quando houver acessos disponíveis."
+msgid "There are no access grants available for this partner at this time. You can still apply for access; applications will be processed when access is available."
+msgstr "Neste momento não há permissões de acesso disponíveis para este parceiro. Pode, mesmo assim, candidatar-se ao acesso; as candidaturas serão processadas quando houver acessos disponíveis."
 
 #. Translators: This text links to the minimum user requirements and terms of use on the partner page.
 #: TWLight/resources/templates/resources/partner_detail.html:48
 #: TWLight/resources/templates/resources/partner_detail_apply.html:29
 #, python-format
-msgid ""
-"Before applying, please review the <strong><a class=\"twl-links\" href="
-"\"%(about)s#req\">minimum requirements</a></strong> for access and our "
-"<strong><a class=\"twl-links\" href=\"%(terms)s\">terms of use</a></strong>."
-msgstr ""
-"Antes de se candidatar, leia os <strong><a class=\"twl-links\" href="
-"\"%(about)s#req\">requisitos mínimos</a></strong> para acesso e as nossas "
-"<strong><a class=\"twl-links\" href=\"%(terms)s\">condições de utilização</"
-"a></strong>, por favor."
+msgid "Before applying, please review the <strong><a class=\"twl-links\" href=\"%(about)s#req\">minimum requirements</a></strong> for access and our <strong><a class=\"twl-links\" href=\"%(terms)s\">terms of use</a></strong>."
+msgstr "Antes de se candidatar, leia os <strong><a class=\"twl-links\" href=\"%(about)s#req\">requisitos mínimos</a></strong> para acesso e as nossas <strong><a class=\"twl-links\" href=\"%(terms)s\">condições de utilização</a></strong>, por favor."
 
 #. Translators: This text refers to the page containing the content a user is authorized to access.
 #: TWLight/resources/templates/resources/partner_detail.html:69
 #, python-format
-msgid ""
-"View the status of your access in <strong><a class=\"twl-links\" href="
-"\"%(library_url)s\">My Library</a></strong> page."
-msgstr ""
-"Ver o estado dos seus acessos na página da sua <strong><a class=\"twl-links"
-"\" href=\"%(library_url)s\">Biblioteca</a></strong>."
+msgid "View the status of your access in <strong><a class=\"twl-links\" href=\"%(library_url)s\">My Library</a></strong> page."
+msgstr "Ver o estado dos seus acessos na página da sua <strong><a class=\"twl-links\" href=\"%(library_url)s\">Biblioteca</a></strong>."
 
 #. Translators: This message is shown when a user has open applications, linking to their respective applications page.
 #: TWLight/resources/templates/resources/partner_detail.html:78
 #, python-format
-msgid ""
-"View the status of your application(s) on your <strong><a class=\"twl-links"
-"\" href=\"%(applications_url)s\">My Applications</a></strong> page."
-msgstr ""
-"Ver o estado das suas candidaturas na página das suas <strong><a class=\"twl-"
-"links\" href=\"%(applications_url)s\">Candidaturas</a></strong>."
+msgid "View the status of your application(s) on your <strong><a class=\"twl-links\" href=\"%(applications_url)s\">My Applications</a></strong> page."
+msgstr "Ver o estado das suas candidaturas na página das suas <strong><a class=\"twl-links\" href=\"%(applications_url)s\">Candidaturas</a></strong>."
 
 #. Translators: This message is shown when a user has authorizations, linking to their respective collections page.
 #: TWLight/resources/templates/resources/partner_detail_apply.html:50
 #, python-format
-msgid ""
-"View the status of your access on your <strong><a href=\"%(library_url)s\" "
-"class=\"twl-links\">My Library</a></strong> page."
-msgstr ""
-"Ver o estado dos seus acessos na página da sua <strong><a href="
-"\"%(library_url)s\" class=\"twl-links\">Biblioteca</a></strong>."
+msgid "View the status of your access on your <strong><a href=\"%(library_url)s\" class=\"twl-links\">My Library</a></strong> page."
+msgstr "Ver o estado dos seus acessos na página da sua <strong><a href=\"%(library_url)s\" class=\"twl-links\">Biblioteca</a></strong>."
 
 #. Translators: This message is shown when a user has open applications, linking to their respective applications page.
 #: TWLight/resources/templates/resources/partner_detail_apply.html:60
 #, python-format
-msgid ""
-"View the status of your application(s) on your <strong><a href="
-"\"%(applications_url)s\">My Applications</a></strong> page."
-msgstr ""
-"Ver o estado das suas candidaturas na página das suas <strong><a href="
-"\"%(applications_url)s\">Candidaturas</a></strong>."
+msgid "View the status of your application(s) on your <strong><a href=\"%(applications_url)s\">My Applications</a></strong> page."
+msgstr "Ver o estado das suas candidaturas na página das suas <strong><a href=\"%(applications_url)s\">Candidaturas</a></strong>."
 
 #. Translators: One the partner detail page, this text labels the button which coordinators can click to remove a partner from waitlisted status.
 #: TWLight/resources/templates/resources/partner_detail_apply.html:73
@@ -1775,9 +1421,7 @@ msgstr "Definir como tendo lista de espera"
 #: TWLight/resources/templates/resources/partner_detail_apply.html:86
 #, python-format
 msgid "<strong>%(coordinator)s</strong> processes applications to %(partner)s."
-msgstr ""
-"<strong>%(coordinator)s</strong> processa candidaturas do parceiro "
-"%(partner)s."
+msgstr "<strong>%(coordinator)s</strong> processa candidaturas do parceiro %(partner)s."
 
 #. Translators: When a coordinator is assigned to a partner, their details are shown on the page. This text labels a link to their Talk page on Wikipedia, and should be translated to the text used for Talk pages in the language you are translating to.
 #: TWLight/resources/templates/resources/partner_detail_apply.html:95
@@ -1791,15 +1435,8 @@ msgstr "Enviar correio eletrónico ao utilizador"
 
 #. Translators: If no account coordinator is assigned to a partner, the Wikipedia Library team will coordinate signups. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/resources/templates/resources/partner_detail_apply.html:112
-msgid ""
-"The Wikipedia Library team will process this application. Want to help? <a "
-"class=\"twl-links\" href=\"https://en.wikipedia.org/wiki/Wikipedia:"
-"The_Wikipedia_Library/Coordinators/Signup\">Sign up as a coordinator.</a>"
-msgstr ""
-"A equipa da Biblioteca da Wikipédia irá processar esta candidatura. Quer "
-"ajudar? <a class=\"twl-links\" href=\"https://en.wikipedia.org/wiki/"
-"Wikipedia:The_Wikipedia_Library/Coordinators/Signup\">Inscreva-se como "
-"coordenador.</a>"
+msgid "The Wikipedia Library team will process this application. Want to help? <a class=\"twl-links\" href=\"https://en.wikipedia.org/wiki/Wikipedia:The_Wikipedia_Library/Coordinators/Signup\">Sign up as a coordinator.</a>"
+msgstr "A equipa da Biblioteca da Wikipédia irá processar esta candidatura. Quer ajudar? <a class=\"twl-links\" href=\"https://en.wikipedia.org/wiki/Wikipedia:The_Wikipedia_Library/Coordinators/Signup\">Inscreva-se como coordenador.</a>"
 
 #. Translators: This text labels a button coordinators can click to view a list of users who have applied for access for a particular partner
 #: TWLight/resources/templates/resources/partner_detail_apply.html:121
@@ -1828,24 +1465,14 @@ msgstr "Acesso Pacote Biblioteca"
 
 #. Translators: Text shown to authenticated, bundle eligible users when they visit a Bundle partner page.
 #: TWLight/resources/templates/resources/partner_detail_apply.html:138
-msgid ""
-"You are eligible to access Library Bundle partners. Click the button above "
-"to access the collection."
-msgstr ""
-"Você reúne os requisitos para aceder aos parceiros do Pacote Biblioteca. "
-"Clique o botão acima para aceder ao conjunto de recursos."
+msgid "You are eligible to access Library Bundle partners. Click the button above to access the collection."
+msgstr "Você reúne os requisitos para aceder aos parceiros do Pacote Biblioteca. Clique o botão acima para aceder ao conjunto de recursos."
 
 #. Translators: Text shown to authenticated, bundle ineligible users when they visit a Bundle partner page.
 #: TWLight/resources/templates/resources/partner_detail_apply.html:152
 #, python-format
-msgid ""
-"You are not eligible to access Library Bundle partners. Visit the <a class="
-"\"twl-links\" href=\"%(homepage)s\">homepage</a> to check the eligibility "
-"criteria."
-msgstr ""
-"Você não reúne os requisitos para aceder aos parceiros do Pacote Biblioteca. "
-"Visite a <a class=\"twl-links\" href=\"%(homepage)s\">página inicial</a> "
-"para conhecer os critérios de elegibilidade."
+msgid "You are not eligible to access Library Bundle partners. Visit the <a class=\"twl-links\" href=\"%(homepage)s\">homepage</a> to check the eligibility criteria."
+msgstr "Você não reúne os requisitos para aceder aos parceiros do Pacote Biblioteca. Visite a <a class=\"twl-links\" href=\"%(homepage)s\">página inicial</a> para conhecer os critérios de elegibilidade."
 
 #. Translators: Buttton prompting users to log in.
 #: TWLight/resources/templates/resources/partner_detail_apply.html:160
@@ -1856,15 +1483,8 @@ msgstr "Entrar"
 #. Translators: Text shown to unauthenticated users when they visit a Bundle partner page.
 #: TWLight/resources/templates/resources/partner_detail_apply.html:168
 #, python-format
-msgid ""
-"This resource is part of our <a class=\"twl-links\" href=\"%(about)s"
-"\">Library Bundle</a>, which you can access if you meet our minimum "
-"eligibility criteria. Log in to find out if you are eligible."
-msgstr ""
-"Este recurso faz parte do nosso <a class=\"twl-links\" href=\"%(about)s"
-"\">Pacote Biblioteca</a>, a que pode aceder se preencher os nossos critérios "
-"mínimos de elegibilidade. Inicie uma sessão para saber se reúne os "
-"requisitos."
+msgid "This resource is part of our <a class=\"twl-links\" href=\"%(about)s\">Library Bundle</a>, which you can access if you meet our minimum eligibility criteria. Log in to find out if you are eligible."
+msgstr "Este recurso faz parte do nosso <a class=\"twl-links\" href=\"%(about)s\">Pacote Biblioteca</a>, a que pode aceder se preencher os nossos critérios mínimos de elegibilidade. Inicie uma sessão para saber se reúne os requisitos."
 
 #. Translators: This is the label for a number which shows the total active accounts for one partner. (e.g. https://wikipedialibrary.wmflabs.org/partners/8/).
 #: TWLight/resources/templates/resources/partner_detail_stats.html:21
@@ -1914,34 +1534,20 @@ msgstr "Limite para excertos"
 #. Translators: If a partner has specified the excerpt limit both in words and percentage, this message will display the percentage of words and the number of words on the partner page.
 #: TWLight/resources/templates/resources/partner_detail_timeline.html:99
 #, python-format
-msgid ""
-"%(object)s allows a maximum of %(excerpt_limit)s words or "
-"%(excerpt_limit_percentage)s%% of an article be excerpted into a Wikipedia "
-"article."
-msgstr ""
-"%(object)s permite que um máximo de %(excerpt_limit)s palavras ou "
-"%(excerpt_limit_percentage)s%% de um artigo sejam usados como excerto num "
-"artigo da Wikipédia."
+msgid "%(object)s allows a maximum of %(excerpt_limit)s words or %(excerpt_limit_percentage)s%% of an article be excerpted into a Wikipedia article."
+msgstr "%(object)s permite que um máximo de %(excerpt_limit)s palavras ou %(excerpt_limit_percentage)s%% de um artigo sejam usados como excerto num artigo da Wikipédia."
 
 #. Translators: If a partner has specified the excerpt limit in words, this message will display the number of words on the partner page.
 #: TWLight/resources/templates/resources/partner_detail_timeline.html:106
 #, python-format
-msgid ""
-"%(object)s allows a maximum of %(excerpt_limit)s words be excerpted into a "
-"Wikipedia article."
-msgstr ""
-"%(object)s permite que um máximo de %(excerpt_limit)s palavras sejam usadas "
-"como excerto num artigo da Wikipédia."
+msgid "%(object)s allows a maximum of %(excerpt_limit)s words be excerpted into a Wikipedia article."
+msgstr "%(object)s permite que um máximo de %(excerpt_limit)s palavras sejam usadas como excerto num artigo da Wikipédia."
 
 #. Translators: If a partner has specified the excerpt limit in percentage, this message will display the percentage of words on the partner page.
 #: TWLight/resources/templates/resources/partner_detail_timeline.html:113
 #, python-format
-msgid ""
-"%(object)s allows a maximum of %(excerpt_limit_percentage)s%% of an article "
-"be excerpted into a Wikipedia article."
-msgstr ""
-"%(object)s permite que um máximo de %(excerpt_limit_percentage)s%% de um "
-"artigo seja usado como excerto num artigo da Wikipédia."
+msgid "%(object)s allows a maximum of %(excerpt_limit_percentage)s%% of an article be excerpted into a Wikipedia article."
+msgstr "%(object)s permite que um máximo de %(excerpt_limit_percentage)s%% de um artigo seja usado como excerto num artigo da Wikipédia."
 
 #. Translators: If a partner has other requirements for access, this text shows as the title for that information field. (e.g. https://wikipedialibrary.wmflabs.org/partners/10/).
 #: TWLight/resources/templates/resources/partner_detail_timeline.html:132
@@ -1951,12 +1557,8 @@ msgstr "Requisitos especiais para candidatos"
 #. Translators: If a user must agree to a Terms of Use document, they see this message, and must enter the name of the resource. Don't translate publisher or url.
 #: TWLight/resources/templates/resources/partner_detail_timeline.html:140
 #, python-format
-msgid ""
-"%(publisher)s requires that you agree with its <a href=\"%(url)s\">terms of "
-"use</a>."
-msgstr ""
-"%(publisher)s exige que concorde com as respetivas <a href=\"%(url)s"
-"\">condições de utilização</a>."
+msgid "%(publisher)s requires that you agree with its <a href=\"%(url)s\">terms of use</a>."
+msgstr "%(publisher)s exige que concorde com as respetivas <a href=\"%(url)s\">condições de utilização</a>."
 
 #. Translators: If a user must provide their real name to apply to a partner, they see this message, and must enter the name of the resource. Don't translate publisher.
 #: TWLight/resources/templates/resources/partner_detail_timeline.html:150
@@ -1979,21 +1581,14 @@ msgstr "%(publisher)s exige que forneça a sua filiação numa instituição."
 #. Translators: If a user must select a specific resource to apply for, they see this message, and must enter the name of the resource. Don't translate publisher.
 #: TWLight/resources/templates/resources/partner_detail_timeline.html:177
 #, python-format
-msgid ""
-"%(publisher)s requires that you specify a particular title that you want to "
-"access."
-msgstr ""
-"%(publisher)s exige que especifique o título da obra a que pretende aceder."
+msgid "%(publisher)s requires that you specify a particular title that you want to access."
+msgstr "%(publisher)s exige que especifique o título da obra a que pretende aceder."
 
 #. Translators: If a user must register on the partner website before applying, they see this message. Don't translate partner.
 #: TWLight/resources/templates/resources/partner_detail_timeline.html:187
 #, python-format
-msgid ""
-"%(publisher)s requires that you sign up for an account before applying for "
-"access."
-msgstr ""
-"%(publisher)s exige que se registe e obtenha uma conta antes de se "
-"candidatar a um acesso."
+msgid "%(publisher)s requires that you sign up for an account before applying for access."
+msgstr "%(publisher)s exige que se registe e obtenha uma conta antes de se candidatar a um acesso."
 
 #. Translators: If a partner has their location listed, this message is a label for that location
 #: TWLight/resources/templates/resources/partner_detail_timeline.html:206
@@ -2120,12 +1715,8 @@ msgstr "Tem a certeza de que quer eliminar <b>%(object)s</b>?"
 
 #. Translators: If multiple authorizations where returned for a collection, this message is shown to a user
 #: TWLight/resources/views.py:268
-msgid ""
-"Multiple authorizations were returned – something's wrong. Please contact us "
-"and don't forget to mention this message."
-msgstr ""
-"Foram devolvidas várias autorizações - algo não está bem. Contacte-nos, por "
-"favor, e não se esqueça de referir esta mensagem."
+msgid "Multiple authorizations were returned – something's wrong. Please contact us and don't forget to mention this message."
+msgstr "Foram devolvidas várias autorizações - algo não está bem. Contacte-nos, por favor, e não se esqueça de referir esta mensagem."
 
 #. Translators: This message is shown when user tries to access a NOT_AVAILABLE Partner
 #: TWLight/resources/views.py:316
@@ -2165,23 +1756,8 @@ msgstr "Lamentamos, mas não sabemos processar o seu pedido."
 #. Translators: Shown on the website's 400 page, when a user sends a bad request. Don't translate path or Phabricator.
 #: TWLight/templates/400.html:20
 #, python-format
-msgid ""
-"If you think we should know what to do with that, please email us about this "
-"error at <a class=\"twl-links\" href=\"mailto:wikipedialibrary@wikimedia.org?"
-"Subject=Wikipedia%%20Library%%20%(path)s%%20Permission%%20denied"
-"\">wikipedialibrary@wikimedia.org</a> or report it to us on <a class=\"twl-"
-"links\" href=\"https://phabricator.wikimedia.org/maniphest/task/edit/form/1/?"
-"projectPHIDs=Library-Card-Platform&title=Wikipedia%%20Library%%20%(path)s"
-"%%20Bad%%20Request\">Phabricator</a>"
-msgstr ""
-"Se acha que devíamos saber processar o seu pedido, descreva-nos este erro "
-"num correio eletrónico para <a class=\"twl-links\" href=\"mailto:"
-"wikipedialibrary@wikimedia.org?Subject=Wikipedia%%20Library%%20%(path)s"
-"%%20Permission%%20denied\">wikipedialibrary@wikimedia.org</a> ou reporte o "
-"erro no <a class=\"twl-links\" href=\"https://phabricator.wikimedia.org/"
-"maniphest/task/edit/form/1/?projectPHIDs=Library-Card-"
-"Platform&title=Wikipedia%%20Library%%20%(path)s%%20Bad%%20Request"
-"\">Phabricator</a>"
+msgid "If you think we should know what to do with that, please email us about this error at <a class=\"twl-links\" href=\"mailto:wikipedialibrary@wikimedia.org?Subject=Wikipedia%%20Library%%20%(path)s%%20Permission%%20denied\">wikipedialibrary@wikimedia.org</a> or report it to us on <a class=\"twl-links\" href=\"https://phabricator.wikimedia.org/maniphest/task/edit/form/1/?projectPHIDs=Library-Card-Platform&title=Wikipedia%%20Library%%20%(path)s%%20Bad%%20Request\">Phabricator</a>"
+msgstr "Se acha que devíamos saber processar o seu pedido, descreva-nos este erro num correio eletrónico para <a class=\"twl-links\" href=\"mailto:wikipedialibrary@wikimedia.org?Subject=Wikipedia%%20Library%%20%(path)s%%20Permission%%20denied\">wikipedialibrary@wikimedia.org</a> ou reporte o erro no <a class=\"twl-links\" href=\"https://phabricator.wikimedia.org/maniphest/task/edit/form/1/?projectPHIDs=Library-Card-Platform&title=Wikipedia%%20Library%%20%(path)s%%20Bad%%20Request\">Phabricator</a>"
 
 #. Translators: Alt text for an image shown on the 400 error page.
 #. Translators: Alt text for an image shown on the 403 error page.
@@ -2202,24 +1778,8 @@ msgstr "Desculpe, não tem permissão para fazer isso."
 #. Translators: Shown on the website's 403 page, when a user attempts to navigate to a page they don't have permission to view. Don't translate path or Phabricator.
 #: TWLight/templates/403.html:20
 #, python-format
-msgid ""
-"If you think your account should be able to do that, please email us about "
-"this error at <a class=\"twl-links\" href=\"mailto:"
-"wikipedialibrary@wikimedia.org?Subject=Wikipedia%%20Library%%20%(path)s"
-"%%20Permission%%20denied\">wikipedialibrary@wikimedia.org</a> or report it "
-"to us on <a class=\"twl-links\" href=\"https://phabricator.wikimedia.org/"
-"maniphest/task/edit/form/1/?projectPHIDs=Library-Card-"
-"Platform&title=Wikipedia%%20Library%%20%(path)s%%20Permission%%20denied"
-"\">Phabricator</a>"
-msgstr ""
-"Se acredita que a sua conta devia poder executar esta operação, descreva-nos "
-"este erro num correio eletrónico para <a class=\"twl-links\" href=\"mailto:"
-"wikipedialibrary@wikimedia.org?Subject=Wikipedia%%20Library%%20%(path)s"
-"%%20Permission%%20denied\">wikipedialibrary@wikimedia.org</a> ou reporte o "
-"erro no <a class=\"twl-links\" href=\"https://phabricator.wikimedia.org/"
-"maniphest/task/edit/form/1/?projectPHIDs=Library-Card-"
-"Platform&title=Wikipedia%%20Library%%20%(path)s%%20Permission%%20denied"
-"\">Phabricator</a>"
+msgid "If you think your account should be able to do that, please email us about this error at <a class=\"twl-links\" href=\"mailto:wikipedialibrary@wikimedia.org?Subject=Wikipedia%%20Library%%20%(path)s%%20Permission%%20denied\">wikipedialibrary@wikimedia.org</a> or report it to us on <a class=\"twl-links\" href=\"https://phabricator.wikimedia.org/maniphest/task/edit/form/1/?projectPHIDs=Library-Card-Platform&title=Wikipedia%%20Library%%20%(path)s%%20Permission%%20denied\">Phabricator</a>"
+msgstr "Se acredita que a sua conta devia poder executar esta operação, descreva-nos este erro num correio eletrónico para <a class=\"twl-links\" href=\"mailto:wikipedialibrary@wikimedia.org?Subject=Wikipedia%%20Library%%20%(path)s%%20Permission%%20denied\">wikipedialibrary@wikimedia.org</a> ou reporte o erro no <a class=\"twl-links\" href=\"https://phabricator.wikimedia.org/maniphest/task/edit/form/1/?projectPHIDs=Library-Card-Platform&title=Wikipedia%%20Library%%20%(path)s%%20Permission%%20denied\">Phabricator</a>"
 
 #. Translators: Shown on the website's 404 page, when a user attempts to navigate to a page that doesn't exist.
 #: TWLight/templates/404.html:11
@@ -2234,22 +1794,8 @@ msgstr "Desculpe, não conseguimos encontrar o que pretende."
 #. Translators: Shown on the website's 404 page, when a user attempts to navigate to a page that doesn't exist. Don't translate path or Phabricator.
 #: TWLight/templates/404.html:19
 #, python-format
-msgid ""
-"If you are certain that something should be here, please email us about this "
-"error at <a class=\"twl-links\" href=\"mailto:wikipedialibrary@wikimedia.org?"
-"Subject=Wikipedia%%20Library%%20%(path)s%%20Not%%20found\"> "
-"wikipedialibrary@wikimedia.org</a> or report it to us on <a class=\"twl-links"
-"\" href=\"https://phabricator.wikimedia.org/maniphest/task/edit/form/1/?"
-"projectPHIDs=Library-Card-Platform&title=Wikipedia%%20Library%%20%(path)s"
-"%%20Not%%20found\">Phabricator</a>"
-msgstr ""
-"Se tem a certeza de que devia existir aqui uma página, descreva-nos este "
-"erro num correio eletrónico para <a class=\"twl-links\" href=\"mailto:"
-"wikipedialibrary@wikimedia.org?Subject=Wikipedia%%20Library%%20%(path)s"
-"%%20Not%%20found\"> wikipedialibrary@wikimedia.org</a> ou reporte o erro no "
-"<a class=\"twl-links\" href=\"https://phabricator.wikimedia.org/maniphest/"
-"task/edit/form/1/?projectPHIDs=Library-Card-Platform&title=Wikipedia"
-"%%20Library%%20%(path)s%%20Not%%20found\">Phabricator</a>"
+msgid "If you are certain that something should be here, please email us about this error at <a class=\"twl-links\" href=\"mailto:wikipedialibrary@wikimedia.org?Subject=Wikipedia%%20Library%%20%(path)s%%20Not%%20found\"> wikipedialibrary@wikimedia.org</a> or report it to us on <a class=\"twl-links\" href=\"https://phabricator.wikimedia.org/maniphest/task/edit/form/1/?projectPHIDs=Library-Card-Platform&title=Wikipedia%%20Library%%20%(path)s%%20Not%%20found\">Phabricator</a>"
+msgstr "Se tem a certeza de que devia existir aqui uma página, descreva-nos este erro num correio eletrónico para <a class=\"twl-links\" href=\"mailto:wikipedialibrary@wikimedia.org?Subject=Wikipedia%%20Library%%20%(path)s%%20Not%%20found\"> wikipedialibrary@wikimedia.org</a> ou reporte o erro no <a class=\"twl-links\" href=\"https://phabricator.wikimedia.org/maniphest/task/edit/form/1/?projectPHIDs=Library-Card-Platform&title=Wikipedia%%20Library%%20%(path)s%%20Not%%20found\">Phabricator</a>"
 
 #. Translators: Alt text for an image shown on the 404 error page.
 #: TWLight/templates/404.html:32
@@ -2263,50 +1809,19 @@ msgstr "Sobre a Biblioteca da Wikipédia"
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:20
-msgid ""
-"This platform is our central tool for facilitating access to our available "
-"collections. Here you can see which partnerships are available, search their "
-"contents, and apply for and access the ones you’re interested in."
-msgstr ""
-"Esta plataforma é a nossa ferramenta central para dar acesso aos conjuntos "
-"de recursos disponíveis. Aqui, pode ver que parcerias estão disponíveis, "
-"fazer pesquisas nos respetivos conteúdos e candidatar-se ao acesso e aceder "
-"aos recursos que pretende."
+msgid "This platform is our central tool for facilitating access to our available collections. Here you can see which partnerships are available, search their contents, and apply for and access the ones you’re interested in."
+msgstr "Esta plataforma é a nossa ferramenta central para dar acesso aos conjuntos de recursos disponíveis. Aqui, pode ver que parcerias estão disponíveis, fazer pesquisas nos respetivos conteúdos e candidatar-se ao acesso e aceder aos recursos que pretende."
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/). Wikimedia Foundation should not be translated.
 #: TWLight/templates/about.html:29
-msgid ""
-"All users receive immediate access to some collections, which can be browsed "
-"by clicking the 'Access collection' buttons or using the search bar at the "
-"top of the page. Other collections require an application before access is "
-"granted, and may be accessed directly or via an individual login or access "
-"code. Volunteer coordinators, who have signed non-disclosure agreements with "
-"the Wikimedia Foundation, review these applications and work with publishers "
-"to get you your free access."
-msgstr ""
-"Todos os utilizadores recebem acesso imediato a alguns conjuntos de "
-"recursos, que podem ser visitados clicando os botões 'Aceder ao conjunto de "
-"recursos' ou usando a barra de pesquisa no topo da página. Outros conjuntos "
-"de recursos exigem uma candidatura antes de ser concedido acesso, e podem "
-"ser acedidos diretamente ou através de um utilizador ou código de acesso "
-"individual. Coordenadores voluntários, que assinaram acordos de "
-"confidencialidade com a Wikimedia Foundation, revêm as candidaturas e "
-"trabalham com as editoras para lhe dar o seu acesso gratuito."
+msgid "All users receive immediate access to some collections, which can be browsed by clicking the 'Access collection' buttons or using the search bar at the top of the page. Other collections require an application before access is granted, and may be accessed directly or via an individual login or access code. Volunteer coordinators, who have signed non-disclosure agreements with the Wikimedia Foundation, review these applications and work with publishers to get you your free access."
+msgstr "Todos os utilizadores recebem acesso imediato a alguns conjuntos de recursos, que podem ser visitados clicando os botões 'Aceder ao conjunto de recursos' ou usando a barra de pesquisa no topo da página. Outros conjuntos de recursos exigem uma candidatura antes de ser concedido acesso, e podem ser acedidos diretamente ou através de um utilizador ou código de acesso individual. Coordenadores voluntários, que assinaram acordos de confidencialidade com a Wikimedia Foundation, revêm as candidaturas e trabalham com as editoras para lhe dar o seu acesso gratuito."
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/). Don't translate terms_url.
 #: TWLight/templates/about.html:43
 #, python-format
-msgid ""
-"For more information about how your information is stored and reviewed "
-"please see our <a class=\"twl-links\" href=\"%(terms_url)s\"> terms of use "
-"and privacy policy</a>. Accounts you apply for are also subject to the Terms "
-"of Use provided by each partner’s platform; please review them."
-msgstr ""
-"Para obter mais informações sobre a forma como a sua informação é armazenada "
-"e revista, consulte as nossas <a class=\"twl-links\" href=\"%(terms_url)s"
-"\">condições de utilização e normas de privacidade</a>, por favor. As contas "
-"a que se candidata estão também sujeitas às Condições de Utilização da "
-"plataforma de cada parceiro; leia-as, por favor."
+msgid "For more information about how your information is stored and reviewed please see our <a class=\"twl-links\" href=\"%(terms_url)s\"> terms of use and privacy policy</a>. Accounts you apply for are also subject to the Terms of Use provided by each partner’s platform; please review them."
+msgstr "Para obter mais informações sobre a forma como a sua informação é armazenada e revista, consulte as nossas <a class=\"twl-links\" href=\"%(terms_url)s\">condições de utilização e normas de privacidade</a>, por favor. As contas a que se candidata estão também sujeitas às Condições de Utilização da plataforma de cada parceiro; leia-as, por favor."
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:51
@@ -2315,25 +1830,13 @@ msgstr "Quem pode receber acesso?"
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/). Wikimedia Foundation should not be translated.
 #: TWLight/templates/about.html:55
-msgid ""
-"Any active editor in good standing can receive access. For publishers with "
-"limited numbers of accounts, applications are reviewed based on the editor’s "
-"needs and contributions. If you think you could use access to one of our "
-"partner resources and are an active editor in any project supported by the "
-"Wikimedia Foundation, please apply."
-msgstr ""
-"Todos os editores ativos e em situação regular podem receber acesso. Para as "
-"editoras com um número limitado de contas, as candidaturas são revistas com "
-"base nas necessidades e contribuições do editor. Se achar que lhe seria útil "
-"ter acesso aos recursos de um dos nossos parceiros e for um editor ativo em "
-"qualquer projeto apoiado pela Wikimedia Foundation, candidate-se, por favor."
+msgid "Any active editor in good standing can receive access. For publishers with limited numbers of accounts, applications are reviewed based on the editor’s needs and contributions. If you think you could use access to one of our partner resources and are an active editor in any project supported by the Wikimedia Foundation, please apply."
+msgstr "Todos os editores ativos e em situação regular podem receber acesso. Para as editoras com um número limitado de contas, as candidaturas são revistas com base nas necessidades e contribuições do editor. Se achar que lhe seria útil ter acesso aos recursos de um dos nossos parceiros e for um editor ativo em qualquer projeto apoiado pela Wikimedia Foundation, candidate-se, por favor."
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:65
 msgid "Any editor can use the library if they meet a few basic requirements:"
-msgstr ""
-"Qualquer editor pode usar a biblioteca se satisfizer alguns requisitos "
-"básicos:"
+msgstr "Qualquer editor pode usar a biblioteca se satisfizer alguns requisitos básicos:"
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:71
@@ -2357,36 +1860,13 @@ msgstr "Não está atualmente impedido de editar um projeto da Wikimedia"
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/)
 #: TWLight/templates/about.html:89
-msgid ""
-"If you are applying for an available collection, please first check that you "
-"don't already have access through another library or institution. If you do, "
-"please consider using that access rather than taking up a seat for this "
-"resource in The Wikipedia Library."
-msgstr ""
-"Se está a candidatar-se a um dos conjuntos de recursos disponíveis, "
-"verifique primeiro que não dispõe já de acesso aos mesmos através de uma "
-"outra biblioteca ou instituição. Se dispuser, pondere utilizar esse acesso "
-"em vez de ocupar um dos acessos a estes recursos pertencente à Biblioteca da "
-"Wikipédia."
+msgid "If you are applying for an available collection, please first check that you don't already have access through another library or institution. If you do, please consider using that access rather than taking up a seat for this resource in The Wikipedia Library."
+msgstr "Se está a candidatar-se a um dos conjuntos de recursos disponíveis, verifique primeiro que não dispõe já de acesso aos mesmos através de uma outra biblioteca ou instituição. Se dispuser, pondere utilizar esse acesso em vez de ocupar um dos acessos a estes recursos pertencente à Biblioteca da Wikipédia."
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/)
 #: TWLight/templates/about.html:99
-msgid ""
-"If your account is blocked on one or more Wikimedia projects, you may still "
-"be granted access to The Wikipedia Library. You will need to contact the "
-"Wikipedia Library team, who will review your blocks. If you have been "
-"blocked for content issues, most notably copyright violations, or have "
-"multiple long-term blocks, we may decline your request. Additionally, if "
-"your block status changes after being approved, you will need to request "
-"another review."
-msgstr ""
-"Se a sua conta estiver bloqueada em um ou mais projetos Wikimedia, ainda "
-"assim poderá receber acesso à Biblioteca da Wikipédia. Para tal, terá de "
-"entrar em contacto com a equipa da Biblioteca da Wikipédia, que irá rever os "
-"seus bloqueios. Se foi bloqueado por problemas de conteúdo, principalmente "
-"por violações de direitos de autor, ou se tem vários bloqueios de longo "
-"prazo, poderemos recusar o seu pedido. Além disso, se o estado dos seus "
-"bloqueios se alterar após a aprovação, terá de pedir outra revisão."
+msgid "If your account is blocked on one or more Wikimedia projects, you may still be granted access to The Wikipedia Library. You will need to contact the Wikipedia Library team, who will review your blocks. If you have been blocked for content issues, most notably copyright violations, or have multiple long-term blocks, we may decline your request. Additionally, if your block status changes after being approved, you will need to request another review."
+msgstr "Se a sua conta estiver bloqueada em um ou mais projetos Wikimedia, ainda assim poderá receber acesso à Biblioteca da Wikipédia. Para tal, terá de entrar em contacto com a equipa da Biblioteca da Wikipédia, que irá rever os seus bloqueios. Se foi bloqueado por problemas de conteúdo, principalmente por violações de direitos de autor, ou se tem vários bloqueios de longo prazo, poderemos recusar o seu pedido. Além disso, se o estado dos seus bloqueios se alterar após a aprovação, terá de pedir outra revisão."
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:110
@@ -2420,46 +1900,28 @@ msgstr "Os editores aprovados <i>não devem</i>:"
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:136
-msgid ""
-"Share their account logins or passwords with others, or sell their access to "
-"other parties"
-msgstr ""
-"Partilhar as suas contas ou palavras-passe com outras pessoas, nem vender o "
-"seu acesso a outros intervenientes"
+msgid "Share their account logins or passwords with others, or sell their access to other parties"
+msgstr "Partilhar as suas contas ou palavras-passe com outras pessoas, nem vender o seu acesso a outros intervenientes"
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:140
 msgid "Mass scrape or mass download partner content"
-msgstr ""
-"Fazer raspagens de ecrã maciças nem descarregamentos maciços do conteúdo do "
-"parceiro"
+msgstr "Fazer raspagens de ecrã maciças nem descarregamentos maciços do conteúdo do parceiro"
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:144
-msgid ""
-"Systematically make printed or electronic copies of multiple extracts of "
-"restricted content available for any purpose"
-msgstr ""
-"Disponibilizar, para qualquer finalidade e de forma sistemática, cópias "
-"impressas ou eletrónicas de vários extratos de conteúdo restrito"
+msgid "Systematically make printed or electronic copies of multiple extracts of restricted content available for any purpose"
+msgstr "Disponibilizar, para qualquer finalidade e de forma sistemática, cópias impressas ou eletrónicas de vários extratos de conteúdo restrito"
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/). Stub is a technical term for a short Wikipedia article, use the appropriate Wikipedia term in your language.
 #: TWLight/templates/about.html:148
-msgid ""
-"Datamine metadata without permission, in order, for instance, to use "
-"metadata for auto-created stub articles"
-msgstr ""
-"Fazer a mineração não autorizada de metadados, para, por exemplo, usar esses "
-"metadados para a criação automática de artigos de esboço"
+msgid "Datamine metadata without permission, in order, for instance, to use metadata for auto-created stub articles"
+msgstr "Fazer a mineração não autorizada de metadados, para, por exemplo, usar esses metadados para a criação automática de artigos de esboço"
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:154
-msgid ""
-"Respecting these agreements allows us to continue growing the partnerships "
-"available to the community."
-msgstr ""
-"O respeito por estes acordos permitirá continuarmos a aumentar as parcerias "
-"que estarão à disposição da comunidade."
+msgid "Respecting these agreements allows us to continue growing the partnerships available to the community."
+msgstr "O respeito por estes acordos permitirá continuarmos a aumentar as parcerias que estarão à disposição da comunidade."
 
 #. Translators: This is the heading for a section on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:160
@@ -2468,63 +1930,23 @@ msgstr "EZProxy"
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:164
-msgid ""
-"EZProxy is a proxy server used to authenticate users for many Wikipedia "
-"Library partners. Users sign into EZProxy via the Library Card platform to "
-"verify that they are authorized users, and then the server accesses "
-"requested resources using its own IP address."
-msgstr ""
-"EZProxy é um servidor <i>proxy</i> usado para autenticar os utilizadores de "
-"muitos parceiros da Biblioteca da Wikipédia. Os utilizadores iniciam sessão "
-"no EZProxy através da plataforma Cartão da Biblioteca para verificar se são "
-"utilizadores autorizados. De seguida, o servidor acede aos recursos pedidos "
-"usando o seu próprio endereço IP."
+msgid "EZProxy is a proxy server used to authenticate users for many Wikipedia Library partners. Users sign into EZProxy via the Library Card platform to verify that they are authorized users, and then the server accesses requested resources using its own IP address."
+msgstr "EZProxy é um servidor <i>proxy</i> usado para autenticar os utilizadores de muitos parceiros da Biblioteca da Wikipédia. Os utilizadores iniciam sessão no EZProxy através da plataforma Cartão da Biblioteca para verificar se são utilizadores autorizados. De seguida, o servidor acede aos recursos pedidos usando o seu próprio endereço IP."
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:173
-msgid ""
-"You may notice that when accessing resources via EZProxy that URLs are "
-"dynamically rewritten. This is why we recommend logging in via the Library "
-"Card platform rather than going directly to the unproxied partner website. "
-"When in doubt, check the URL for ‘idm.oclc’. If it’s there, then you’re "
-"connected via EZProxy."
-msgstr ""
-"Poderá notar, ao aceder a recursos via EZProxy, que os URL são reescritos "
-"dinamicamente. É por isso que recomendamos que inicie a sessão através da "
-"plataforma Cartão da Biblioteca, em vez de aceder diretamente ao <i>site</i> "
-"do parceiro sem um <i>proxy</i> intermédio. Em caso de dúvida, verifique o "
-"URL para ‘idm.oclc’. Se existir um destino, está ligado via EZProxy."
+msgid "You may notice that when accessing resources via EZProxy that URLs are dynamically rewritten. This is why we recommend logging in via the Library Card platform rather than going directly to the unproxied partner website. When in doubt, check the URL for ‘idm.oclc’. If it’s there, then you’re connected via EZProxy."
+msgstr "Poderá notar, ao aceder a recursos via EZProxy, que os URL são reescritos dinamicamente. É por isso que recomendamos que inicie a sessão através da plataforma Cartão da Biblioteca, em vez de aceder diretamente ao <i>site</i> do parceiro sem um <i>proxy</i> intermédio. Em caso de dúvida, verifique o URL para ‘idm.oclc’. Se existir um destino, está ligado via EZProxy."
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:182
-msgid ""
-"Typically once you’ve logged in your session will remain active in your "
-"browser for up to two hours after you’ve finished searching. Note that use "
-"of EZProxy requires you to enable cookies. If you are having problems you "
-"should also try clearing your cache and restarting your browser."
-msgstr ""
-"Normalmente, após ter entrado, a sua sessão permanece ativa no ''browser'' "
-"até duas horas após terminar a pesquisa. Note que o uso do EZProxy exige a "
-"ativação dos ''cookies''. Se está a ter problemas, tente limpar a ''cache'' "
-"e reiniciar o ''browser''."
+msgid "Typically once you’ve logged in your session will remain active in your browser for up to two hours after you’ve finished searching. Note that use of EZProxy requires you to enable cookies. If you are having problems you should also try clearing your cache and restarting your browser."
+msgstr "Normalmente, após ter entrado, a sua sessão permanece ativa no ''browser'' até duas horas após terminar a pesquisa. Note que o uso do EZProxy exige a ativação dos ''cookies''. Se está a ter problemas, tente limpar a ''cache'' e reiniciar o ''browser''."
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/)
 #: TWLight/templates/about.html:193
-msgid ""
-"The Library Bundle is a collection of resources for which no application is "
-"required. If you meet the criteria laid out above, you will be authorized "
-"for access automatically upon logging in to the platform. Only some of our "
-"content is currently included in the Library Bundle, however we hope to "
-"expand the collection as more publishers become comfortable with "
-"participating. All Bundle content is accessed via EZProxy."
-msgstr ""
-"O Pacote Biblioteca é um conjunto de recursos aos quais não é necessário "
-"candidatar-se. Se preencher os critérios descritos acima, será "
-"automaticamente autorizado a aceder-lhes quando inicia uma sessão na "
-"plataforma. Neste momento só uma parte do nosso conteúdo está incluído no "
-"Pacote Biblioteca. No entanto, esperamos expandir os recursos à medida que "
-"mais editores se sintam à vontade em participar. Todo o conteúdo incluído no "
-"pacote é acedido através de EZProxy."
+msgid "The Library Bundle is a collection of resources for which no application is required. If you meet the criteria laid out above, you will be authorized for access automatically upon logging in to the platform. Only some of our content is currently included in the Library Bundle, however we hope to expand the collection as more publishers become comfortable with participating. All Bundle content is accessed via EZProxy."
+msgstr "O Pacote Biblioteca é um conjunto de recursos aos quais não é necessário candidatar-se. Se preencher os critérios descritos acima, será automaticamente autorizado a aceder-lhes quando inicia uma sessão na plataforma. Neste momento só uma parte do nosso conteúdo está incluído no Pacote Biblioteca. No entanto, esperamos expandir os recursos à medida que mais editores se sintam à vontade em participar. Todo o conteúdo incluído no pacote é acedido através de EZProxy."
 
 #. Translators: This is the heading for a section on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:202
@@ -2534,19 +1956,8 @@ msgstr "Práticas de citação"
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:206
 #, fuzzy
-msgid ""
-"Citation practices vary by project and even by article. Generally, we "
-"support editors citing where they found information, in a form that allows "
-"others to check it for themselves. That often means providing both original "
-"source details as well as a link to the partner database in which the source "
-"was found."
-msgstr ""
-"As práticas de citação variam entre projetos e até mesmo de artigo para "
-"artigo. Regra geral, os editores devem referir onde encontraram a "
-"informação, de forma a permitir que outras pessoas a verifiquem "
-"independentemente. Isto geralmente significa fornecer detalhes da fonte "
-"original e uma hiperligação para a base de dados do parceiro na qual essa "
-"fonte foi encontrada."
+msgid "Citation practices vary by project and even by article. Generally, we support editors citing where they found information, in a form that allows others to check it for themselves. That often means providing both original source details as well as a link to the partner database in which the source was found."
+msgstr "As práticas de citação variam entre projetos e até mesmo de artigo para artigo. Regra geral, os editores devem referir onde encontraram a informação, de forma a permitir que outras pessoas a verifiquem independentemente. Isto geralmente significa fornecer detalhes da fonte original e uma hiperligação para a base de dados do parceiro na qual essa fonte foi encontrada."
 
 #. Translators: This is the heading for a section on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #. Translators: This link is at the bottom of every page and can be clicked by users to contact the wikipedia library team.
@@ -2557,12 +1968,8 @@ msgstr "Contacte-nos"
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:218
 #, python-format
-msgid ""
-"If you have questions, need help, or want to volunteer to help, please see "
-"our <a class=\"twl-links\" href=\"%(contact_url)s\">contact page</a>."
-msgstr ""
-"Se tem dúvidas, precisa de ajuda ou quer ajudar, consulte a nossa <a class="
-"\"twl-links\" href=\"%(contact_url)s\">página de contacto</a>, por favor."
+msgid "If you have questions, need help, or want to volunteer to help, please see our <a class=\"twl-links\" href=\"%(contact_url)s\">contact page</a>."
+msgstr "Se tem dúvidas, precisa de ajuda ou quer ajudar, consulte a nossa <a class=\"twl-links\" href=\"%(contact_url)s\">página de contacto</a>, por favor."
 
 #. Translators: This is the title of the panel box detailing the contact information for the Wikipedia Library team.
 #: TWLight/templates/contact.html:14
@@ -2601,12 +2008,8 @@ msgstr "Página do Twitter da Biblioteca da Wikipédia"
 #. Translators: This is the text that appears at the bottom of the contact us form directing users to the suggestions form.
 #: TWLight/templates/contact.html:48
 #, python-format
-msgid ""
-"(If you would like to suggest a partner, <a class=\"twl-links\" href="
-"\"%(suggest)s\"><strong>go here</strong></a>.)"
-msgstr ""
-"(Se gostaria de sugerir um parceiro, <a class=\"twl-links\" href="
-"\"%(suggest)s\"><strong>faça-o aqui</strong></a>.)"
+msgid "(If you would like to suggest a partner, <a class=\"twl-links\" href=\"%(suggest)s\"><strong>go here</strong></a>.)"
+msgstr "(Se gostaria de sugerir um parceiro, <a class=\"twl-links\" href=\"%(suggest)s\"><strong>faça-o aqui</strong></a>.)"
 
 #. Translators: On a special 'link to search' page, this message is shown if JavaScript is disabled.
 #: TWLight/templates/eds_search_endpoint.html:7
@@ -2662,13 +2065,8 @@ msgstr "A Biblioteca da Wikipédia"
 #. Translators: Information about The Wikipedia Library.
 #: TWLight/templates/login_partial.html:53 TWLight/templates/new_base.html:21
 #, python-format
-msgid ""
-"More than 100 of the world's top subscription-only databases, with content "
-"in %(no_of_languages)s languages, free for Wikipedians of all backgrounds"
-msgstr ""
-"Mais de 100 das melhores bases de dados do mundo de acesso exclusivo por "
-"assinatura, com conteúdo em %(no_of_languages)s línguas, disponíveis "
-"gratuitamente para todos os utilizadores da Wikipédia"
+msgid "More than 100 of the world's top subscription-only databases, with content in %(no_of_languages)s languages, free for Wikipedians of all backgrounds"
+msgstr "Mais de 100 das melhores bases de dados do mundo de acesso exclusivo por assinatura, com conteúdo em %(no_of_languages)s línguas, disponíveis gratuitamente para todos os utilizadores da Wikipédia"
 
 #. Translators: Information about The Wikipedia Library.
 #: TWLight/templates/login_partial.html:64
@@ -2676,12 +2074,8 @@ msgid "Meet these criteria for automatic access"
 msgstr "Satisfaça estes critérios para receber acesso automático"
 
 #: TWLight/templates/login_partial.html:69
-msgid ""
-"These criteria grant you access to certain collections but not all. Some "
-"collections are accessible on a per application basis only."
-msgstr ""
-"Estes critérios dão-lhe acesso a certos conjuntos de recursos, mas não a "
-"todos. Certos conjuntos de recursos só são acessíveis através de candidatura."
+msgid "These criteria grant you access to certain collections but not all. Some collections are accessible on a per application basis only."
+msgstr "Estes critérios dão-lhe acesso a certos conjuntos de recursos, mas não a todos. Certos conjuntos de recursos só são acessíveis através de candidatura."
 
 #: TWLight/templates/login_partial.html:89
 msgid "Login via Wikipedia"
@@ -2690,42 +2084,20 @@ msgstr "Entrar com a sua conta da Wikipédia"
 #. Translators: Shown if the current user doesn't have a registered email on their account. Don't translate contact_us_url or email_url.
 #: TWLight/templates/message_partial.html:15
 #, python-format
-msgid ""
-"You don't have an email on file. We can't finalize your access to partner "
-"resources, and you won't be able to <a class=\"twl-links\" href="
-"\"%(contact_us_url)s\">contact us</a> without an email. Please <a class="
-"\"twl-links\" href=\"%(email_url)s\">update your email</a>."
-msgstr ""
-"Não tem um endereço de correio eletrónico registado. Não podemos finalizar o "
-"seu acesso aos recursos de parceiros, nem poderá <a class=\"twl-links\" href="
-"\"%(contact_us_url)s\">contactar-nos</a>, sem um endereço. <a class=\"twl-"
-"links\" href=\"%(email_url)s\">Atualize o seu correio eletrónico</a>, por "
-"favor."
+msgid "You don't have an email on file. We can't finalize your access to partner resources, and you won't be able to <a class=\"twl-links\" href=\"%(contact_us_url)s\">contact us</a> without an email. Please <a class=\"twl-links\" href=\"%(email_url)s\">update your email</a>."
+msgstr "Não tem um endereço de correio eletrónico registado. Não podemos finalizar o seu acesso aos recursos de parceiros, nem poderá <a class=\"twl-links\" href=\"%(contact_us_url)s\">contactar-nos</a>, sem um endereço. <a class=\"twl-links\" href=\"%(email_url)s\">Atualize o seu correio eletrónico</a>, por favor."
 
 #. Translators: Shown if the current user has requested the processing of their data should be restricted.
 #: TWLight/templates/message_partial.html:26
 #, python-format
-msgid ""
-"You have requested a restriction on the processing of your data. Most site "
-"functionality will not be available to you until you <a class=\"twl-links\" "
-"href=\"%(restrict_url)s\">lift this restriction</a>."
-msgstr ""
-"Pediu uma restrição ao processamento dos seus dados. A maior parte da "
-"funcionalidade do ''site'' não estará disponível enquanto não <a class=\"twl-"
-"links\" href=\"%(restrict_url)s\">levantar esta restrição</a>."
+msgid "You have requested a restriction on the processing of your data. Most site functionality will not be available to you until you <a class=\"twl-links\" href=\"%(restrict_url)s\">lift this restriction</a>."
+msgstr "Pediu uma restrição ao processamento dos seus dados. A maior parte da funcionalidade do ''site'' não estará disponível enquanto não <a class=\"twl-links\" href=\"%(restrict_url)s\">levantar esta restrição</a>."
 
 #. Translators: Shown if the current user has not agreed to the terms of use.
 #: TWLight/templates/message_partial.html:37
 #, python-format
-msgid ""
-"You have not agreed to the <a class=\"twl-links\" href=\"%(terms_url)s"
-"\">terms of use</a> of this site. Your applications will not be processed "
-"and you won't be able to apply or access resources you are approved for."
-msgstr ""
-"Não concordou com as <a class=\"twl-links\" href=\"%(terms_url)s\">condições "
-"de utilização</a> deste <i>site</i>. As suas candidaturas não serão "
-"processadas e não se poderá candidatar nem aceder a recursos para os quais "
-"tenha sido aprovado."
+msgid "You have not agreed to the <a class=\"twl-links\" href=\"%(terms_url)s\">terms of use</a> of this site. Your applications will not be processed and you won't be able to apply or access resources you are approved for."
+msgstr "Não concordou com as <a class=\"twl-links\" href=\"%(terms_url)s\">condições de utilização</a> deste <i>site</i>. As suas candidaturas não serão processadas e não se poderá candidatar nem aceder a recursos para os quais tenha sido aprovado."
 
 #. Translators: This link is at the bottom of every page and links to the 'About' page (https://wikipedialibrary.wmflabs.org/about/)
 #: TWLight/templates/new_base.html:107
@@ -2771,12 +2143,8 @@ msgstr "Redefinir palavra-passe"
 
 #. Translators: If a user goes to reset their password, this message asks them to enter their email to do so.
 #: TWLight/templates/registration/password_reset_form.html:13
-msgid ""
-"Forgot your password? Enter your email address below, and we'll email "
-"instructions for setting a new one."
-msgstr ""
-"Esqueceu-se da palavra-passe? Introduza abaixo o seu endereço de correio "
-"eletrónico e enviaremos instruções para definir uma nova."
+msgid "Forgot your password? Enter your email address below, and we'll email instructions for setting a new one."
+msgstr "Esqueceu-se da palavra-passe? Introduza abaixo o seu endereço de correio eletrónico e enviaremos instruções para definir uma nova."
 
 #. Translators: This is the label for a button that users click to update their public information.
 #: TWLight/users/forms.py:36
@@ -2786,8 +2154,7 @@ msgstr "Atualizar perfil"
 #. Translators: This labels a field where users can describe their activity on Wikipedia in a small biography.
 #: TWLight/users/forms.py:45
 msgid "Describe your contributions to Wikipedia: topics edited, et cetera."
-msgstr ""
-"Descreva as suas contribuições para a Wikipédia: os assuntos editados, etc."
+msgstr "Descreva as suas contribuições para a Wikipédia: os assuntos editados, etc."
 
 #. Translators: In the preferences section (Emails) of a user profile, this text labels the checkbox users can (un)click to change if they wish to receive account renewal notices or not.
 #: TWLight/users/forms.py:98
@@ -2821,22 +2188,13 @@ msgstr "Concordo com as condições de utilização"
 
 #. Translators: This text explains how to disagree to the site's terms of use and the restrictions that will come into effect when users disagree to the terms of use.
 #: TWLight/users/forms.py:185
-msgid ""
-"By unchecking this box and clicking “Update” you may explore the site, but "
-"you will not be able to apply for access to materials or evaluate "
-"applications unless you agree with the terms of use."
-msgstr ""
-"Ao desmarcar esta caixa e clicar \"Atualizar\" poderá explorar o <i>site</"
-"i>, mas não poderá pedir acesso a materiais nem avaliar candidaturas a menos "
-"que concorde com as condições de utilização."
+msgid "By unchecking this box and clicking “Update” you may explore the site, but you will not be able to apply for access to materials or evaluate applications unless you agree with the terms of use."
+msgstr "Ao desmarcar esta caixa e clicar \"Atualizar\" poderá explorar o <i>site</i>, mas não poderá pedir acesso a materiais nem avaliar candidaturas a menos que concorde com as condições de utilização."
 
 #. Translators: Users click this button to set their website email address to the one linked to their Wikipedia account.
 #: TWLight/users/forms.py:211
-msgid ""
-"Use my Wikipedia email address (will be updated the next time you login)."
-msgstr ""
-"Usar o meu correio eletrónico da Wikipédia (será atualizado na próxima vez "
-"que se autenticar)."
+msgid "Use my Wikipedia email address (will be updated the next time you login)."
+msgstr "Usar o meu correio eletrónico da Wikipédia (será atualizado na próxima vez que se autenticar)."
 
 #. Translators: This labels a button which users click to change their email.
 #: TWLight/users/forms.py:232
@@ -2846,17 +2204,8 @@ msgstr "Atualizar correio eletrónico"
 #. Translators: Shown if the current user tried to 'favorite' a partner they can't access. Do not translate '{partner}'
 #: TWLight/users/models.py:201
 #, python-brace-format
-msgid ""
-"Cannot add partner {partner} to your favorites because you don't have access "
-"to it"
+msgid "Cannot add partner {partner} to your favorites because you don't have access to it"
 msgstr ""
-
-#. Translators: Do not translate.
-#: TWLight/users/models.py:869
-#, fuzzy, python-brace-format
-#| msgid "Username"
-msgid "{wp_username}"
-msgstr "Nome de utilizador"
 
 #. Translators: This error message is shown when there's a problem with the authenticated login process.
 #: TWLight/users/oauth.py:243
@@ -2876,12 +2225,8 @@ msgstr "O protocolo de comunicação não foi iniciado, tente entrar novamente."
 
 #. Translators: this message is displayed to users that don't have accounts and clicked on a proxied link.
 #: TWLight/users/oauth.py:388
-msgid ""
-"To view this link you need to be an eligible library user. Please login to "
-"continue."
-msgstr ""
-"Para ver esta hiperligação tem de ser um utilizador da biblioteca que reúne "
-"certos requisitos. Para continuar, inicie uma sessão."
+msgid "To view this link you need to be an eligible library user. Please login to continue."
+msgstr "Para ver esta hiperligação tem de ser um utilizador da biblioteca que reúne certos requisitos. Para continuar, inicie uma sessão."
 
 #. Translators: This warning message is shown to users when the response received from Wikimedia OAuth servers is not a valid one.
 #: TWLight/users/oauth.py:430
@@ -2917,25 +2262,13 @@ msgstr "Informação do serviço"
 
 #. Translators: If the user tries to log in, but their account does not meet certain requirements, they cannot login.
 #: TWLight/users/oauth.py:528
-msgid ""
-"Your Wikipedia account does not meet the eligibility criteria in the terms "
-"of use, so your Wikipedia Library Card Platform account cannot be activated."
-msgstr ""
-"A sua conta da Wikipédia não preenche os critérios de elegibilidade "
-"especificados nas condições de utilização, portanto, a sua conta da "
-"plataforma Cartão da Biblioteca da Wikipédia não pode ser ativada."
+msgid "Your Wikipedia account does not meet the eligibility criteria in the terms of use, so your Wikipedia Library Card Platform account cannot be activated."
+msgstr "A sua conta da Wikipédia não preenche os critérios de elegibilidade especificados nas condições de utilização, portanto, a sua conta da plataforma Cartão da Biblioteca da Wikipédia não pode ser ativada."
 
 #. Translators: If the user tries to log in, but their account does not meet certain requirements, they cannot login.
 #: TWLight/users/oauth.py:536
-msgid ""
-"Your Wikipedia account no longer meets the eligibility criteria in the terms "
-"of use, so you cannot be logged in. If you think you should be able to log "
-"in, please email wikipedialibrary@wikimedia.org."
-msgstr ""
-"A sua conta da Wikipédia deixou de preencher os critérios de elegibilidade "
-"especificados nas condições de utilização, portanto, não pode iniciar uma "
-"sessão. Se considera que devia poder entrar, envie uma mensagem de correio "
-"eletrónico para wikipedialibrary@wikimedia.org."
+msgid "Your Wikipedia account no longer meets the eligibility criteria in the terms of use, so you cannot be logged in. If you think you should be able to log in, please email wikipedialibrary@wikimedia.org."
+msgstr "A sua conta da Wikipédia deixou de preencher os critérios de elegibilidade especificados nas condições de utilização, portanto, não pode iniciar uma sessão. Se considera que devia poder entrar, envie uma mensagem de correio eletrónico para wikipedialibrary@wikimedia.org."
 
 #. Translators: this message is displayed to users with brand new accounts.
 #: TWLight/users/oauth.py:549
@@ -2945,15 +2278,8 @@ msgstr "Bem-vindo(a)! Concorde com as condições de utilização, por favor."
 #. Translators: This message is displayed on the confirmation page where users can return their access to partner collections.
 #: TWLight/users/templates/users/authorization_confirm_return.html:13
 #, python-format
-msgid ""
-"You will no longer be able to access <b>%(partner)s's</b> resources via the "
-"Library Card platform, but can request access again by clicking 'renew', if "
-"you change your mind. Are you sure you want to return your access?"
-msgstr ""
-"Deixará de poder aceder aos recursos do parceiro <b>%(partner)s</b> através "
-"da plataforma Cartão da Biblioteca, mas poderá voltar a pedir acesso "
-"clicando em 'renovar' se mudar de ideias. Tem a certeza de que deseja "
-"devolver o seu acesso?"
+msgid "You will no longer be able to access <b>%(partner)s's</b> resources via the Library Card platform, but can request access again by clicking 'renew', if you change your mind. Are you sure you want to return your access?"
+msgstr "Deixará de poder aceder aos recursos do parceiro <b>%(partner)s</b> através da plataforma Cartão da Biblioteca, mas poderá voltar a pedir acesso clicando em 'renovar' se mudar de ideias. Tem a certeza de que deseja devolver o seu acesso?"
 
 #. Translators: On the MyLibrary page (https://wikipedialibrary.wmflabs.org/users/my_library), this tab shows all favorite collections a user has.
 #: TWLight/users/templates/users/collections_section.html:9
@@ -2996,8 +2322,7 @@ msgstr "Biblioteca"
 #. Translators: Line two of two, explaining the purpose of the page in a button on users' profile page which when clicked takes users to a page with their available collections.
 #: TWLight/users/templates/users/editor_detail.html:28
 msgid "A collective list of collections you are authorized to access"
-msgstr ""
-"Uma lista coletiva dos conjuntos de recursos que está autorizado a aceder"
+msgstr "Uma lista coletiva dos conjuntos de recursos que está autorizado a aceder"
 
 #. Translators: Line one of two in a button on users' profile page which when clicked takes users to their applications page.
 #. Translators: Heading of the applications page where users can view all of their applications listed with other relevant info.
@@ -3023,14 +2348,8 @@ msgstr "Dados de editor"
 
 #. Translators: This is shown on editor profiles, in their profile page or on applications.
 #: TWLight/users/templates/users/editor_detail.html:59
-msgid ""
-"Information with an * was retrieved from Wikipedia directly. Other "
-"information was entered directly by users or site admins, in their preferred "
-"language."
-msgstr ""
-"As informações com um * foram obtidas diretamente da Wikipédia. As restantes "
-"informações foram inseridas diretamente pelos utilizadores ou pelos "
-"administradores do <i>site</i>, na língua preferida dos mesmos."
+msgid "Information with an * was retrieved from Wikipedia directly. Other information was entered directly by users or site admins, in their preferred language."
+msgstr "As informações com um * foram obtidas diretamente da Wikipédia. As restantes informações foram inseridas diretamente pelos utilizadores ou pelos administradores do <i>site</i>, na língua preferida dos mesmos."
 
 #. Translators: This distinguishes users who have been flagged as account coordinators. Don't translate username.
 #: TWLight/users/templates/users/editor_detail.html:71
@@ -3040,14 +2359,8 @@ msgstr "%(username)s tem privilégios de coordenador neste <i>site</i>."
 
 #. Translators: This is shown on editor profiles, under the heading for Wikipedia editor data.
 #: TWLight/users/templates/users/editor_detail_data.html:5
-msgid ""
-"This information is updated automatically from your Wikimedia account each "
-"time you log in, except for the Contributions field, where you can describe "
-"your Wikimedia editing history."
-msgstr ""
-"Estas informações são atualizadas automaticamente da sua conta da Wikimedia "
-"cada vez que inicia uma sessão, exceto o campo Contribuições, onde pode "
-"descrever o seu historial de editor na Wikimedia."
+msgid "This information is updated automatically from your Wikimedia account each time you log in, except for the Contributions field, where you can describe your Wikimedia editing history."
+msgstr "Estas informações são atualizadas automaticamente da sua conta da Wikimedia cada vez que inicia uma sessão, exceto o campo Contribuições, onde pode descrever o seu historial de editor na Wikimedia."
 
 #. Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this labels the user's username.
 #: TWLight/users/templates/users/editor_detail_data.html:17
@@ -3076,22 +2389,14 @@ msgstr "Satisfaz as condições de utilização?"
 
 #. Translators: when viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this question has a yes or no answer.
 #: TWLight/users/templates/users/editor_detail_data.html:57
-msgid ""
-"at their last login, did this user meet the criteria set forth in the terms "
-"of use?"
-msgstr ""
-"no seu último início de sessão, este utilizador preenchia os critérios "
-"especificados nas condições de utilização?"
+msgid "at their last login, did this user meet the criteria set forth in the terms of use?"
+msgstr "no seu último início de sessão, este utilizador preenchia os critérios especificados nas condições de utilização?"
 
 #. Translators: When viewing a user's profile in an application, this message shows if the software doesn't think that the user is eligible for access. Don't translate username.
 #: TWLight/users/templates/users/editor_detail_data.html:72
 #, python-format
-msgid ""
-"%(username)s may still be eligible for access grants at the coordinators' "
-"discretion."
-msgstr ""
-"%(username)s pode ainda assim reunir os requisitos para concessão de acesso, "
-"ficando esta à discrição do coordenador."
+msgid "%(username)s may still be eligible for access grants at the coordinators' discretion."
+msgstr "%(username)s pode ainda assim reunir os requisitos para concessão de acesso, ficando esta à discrição do coordenador."
 
 #. Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this is the heading for a Yes/No ToU question.
 #: TWLight/users/templates/users/editor_detail_data.html:83
@@ -3125,15 +2430,8 @@ msgstr ""
 #. Translators: This message is shown on a user's profile if their Wikimedia account is blocked on one or more projects. They may still be granted access to the Library Bundle, but need to contact Wikipedia Library staff to verify.
 #: TWLight/users/templates/users/editor_detail_data.html:137
 #, python-format
-msgid ""
-"It looks like you have an active block on your account. If you meet the "
-"other criteria you may still be permitted access to the library - please <a "
-"class=\"twl-links\" href=\"%(contact_url)s\">contact us</a>."
-msgstr ""
-"Aparentemente, tem um bloqueio ativo da sua conta. Se preencher os restantes "
-"critérios poderá, ainda assim, ser-lhe permitido acesso ao Pacote Biblioteca "
-"- <a class=\"twl-links\" href=\"%(contact_url)s\">contacte-nos</a>, por "
-"favor."
+msgid "It looks like you have an active block on your account. If you meet the other criteria you may still be permitted access to the library - please <a class=\"twl-links\" href=\"%(contact_url)s\">contact us</a>."
+msgstr "Aparentemente, tem um bloqueio ativo da sua conta. Se preencher os restantes critérios poderá, ainda assim, ser-lhe permitido acesso ao Pacote Biblioteca - <a class=\"twl-links\" href=\"%(contact_url)s\">contacte-nos</a>, por favor."
 
 #. Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this is the heading for a Yes/No program eligibility question.
 #: TWLight/users/templates/users/editor_detail_data.html:153
@@ -3142,14 +2440,8 @@ msgstr "Reúne os requisitos para o Pacote?"
 
 #. Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this question has a Yes or No answer.
 #: TWLight/users/templates/users/editor_detail_data.html:156
-msgid ""
-"At their last login, did this user meet the criteria set forth in the "
-"Library Bundle? Note that satisfying terms of use is a prerequisite to "
-"bundle eligibility."
-msgstr ""
-"No último início de sessão, este utilizador preenchia os critérios "
-"especificados no Pacote Biblioteca? Note que satisfazer as condições de "
-"utilização é um pré-requisito para acesso ao pacote."
+msgid "At their last login, did this user meet the criteria set forth in the Library Bundle? Note that satisfying terms of use is a prerequisite to bundle eligibility."
+msgstr "No último início de sessão, este utilizador preenchia os critérios especificados no Pacote Biblioteca? Note que satisfazer as condições de utilização é um pré-requisito para acesso ao pacote."
 
 #. Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this is the heading for a Yes/No program eligibility question.
 #: TWLight/users/templates/users/editor_detail_data.html:177
@@ -3193,25 +2485,14 @@ msgstr "Dados particulares"
 
 #. Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this text is in the 'Personal data' section. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/users/templates/users/editor_detail_data.html:262
-msgid ""
-"The following information is visible only to you, site administrators, "
-"publishing partners (where required), and volunteer Wikipedia Library "
-"coordinators (who have signed a Non-Disclosure Agreement)."
-msgstr ""
-"As seguintes informações só são visíveis por si, pelos administradores do "
-"<i>site</i>, pelas editoras parceiras (quando necessário) e pelos "
-"coordenadores voluntários da Biblioteca da Wikipédia (que assinaram um "
-"acordo de confidencialidade)."
+msgid "The following information is visible only to you, site administrators, publishing partners (where required), and volunteer Wikipedia Library coordinators (who have signed a Non-Disclosure Agreement)."
+msgstr "As seguintes informações só são visíveis por si, pelos administradores do <i>site</i>, pelas editoras parceiras (quando necessário) e pelos coordenadores voluntários da Biblioteca da Wikipédia (que assinaram um acordo de confidencialidade)."
 
 #. Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this labels a button which users can click to update or remove their personal information. Don't translate update_url.
 #: TWLight/users/templates/users/editor_detail_data.html:272
 #, python-format
-msgid ""
-"You may <a class=\"twl-links\" href=\"%(update_url)s\">update or delete</a> "
-"your data at any time."
-msgstr ""
-"Pode <a class=\"twl-links\" href=\"%(update_url)s\">atualizar ou eliminar</"
-"a> os seus dados a qualquer altura."
+msgid "You may <a class=\"twl-links\" href=\"%(update_url)s\">update or delete</a> your data at any time."
+msgstr "Pode <a class=\"twl-links\" href=\"%(update_url)s\">atualizar ou eliminar</a> os seus dados a qualquer altura."
 
 #. Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this labels the user's email. Don't remove the *.
 #: TWLight/users/templates/users/editor_detail_data.html:283
@@ -3230,33 +2511,19 @@ msgstr "Filiação em instituições"
 
 #. Translators: This message tells users that they are not eligible to access The Wikipedia Library content.
 #: TWLight/users/templates/users/eligibility_modal.html:7
-msgid ""
-"Sorry, your Wikipedia account doesn’t currently qualify to access The "
-"Wikipedia Library."
-msgstr ""
-"Lamentamos, a sua conta da Wikipédia não cumpre os critérios para aceder à "
-"Biblioteca da Wikipédia."
+msgid "Sorry, your Wikipedia account doesn’t currently qualify to access The Wikipedia Library."
+msgstr "Lamentamos, a sua conta da Wikipédia não cumpre os critérios para aceder à Biblioteca da Wikipédia."
 
 #. Translators: This message tells users that they have not agreed to the terms of use, therefore are ineligible to access the content in The Wikipedia Library.
 #: TWLight/users/templates/users/eligibility_modal.html:30
 #, python-format
-msgid ""
-"Agreed with <a href=\"%(terms)s\" class=\"text-danger\"> terms of use </a>"
-msgstr ""
-"Concordou com as <a href=\"%(terms)s\" class=\"text-danger\"> condições de "
-"utilização </a>"
+msgid "Agreed with <a href=\"%(terms)s\" class=\"text-danger\"> terms of use </a>"
+msgstr "Concordou com as <a href=\"%(terms)s\" class=\"text-danger\"> condições de utilização </a>"
 
 #: TWLight/users/templates/users/eligibility_modal.html:40
 #, python-format
-msgid ""
-"It looks like you have an active block on your account. If you meet the "
-"other criteria you may still be permitted access to the library - please <a "
-"href=\"%(contact_url)s\">contact us</a>."
-msgstr ""
-"Aparentemente, tem um bloqueio ativo da sua conta. Se preencher os restantes "
-"critérios poderá, ainda assim, ser-lhe permitido acesso ao Pacote Biblioteca "
-"- <a class=\"twl-links\" href=\"%(contact_url)s\">contacte-nos</a>, por "
-"favor."
+msgid "It looks like you have an active block on your account. If you meet the other criteria you may still be permitted access to the library - please <a href=\"%(contact_url)s\">contact us</a>."
+msgstr "Aparentemente, tem um bloqueio ativo da sua conta. Se preencher os restantes critérios poderá, ainda assim, ser-lhe permitido acesso ao Pacote Biblioteca - <a class=\"twl-links\" href=\"%(contact_url)s\">contacte-nos</a>, por favor."
 
 #. Translators: Instructions to refresh a user's data.
 #: TWLight/users/templates/users/eligibility_modal.html:50
@@ -3276,14 +2543,12 @@ msgstr "Legenda"
 #. Translators: Text that describes a search icon.
 #: TWLight/users/templates/users/filter_section.html:45
 msgid "Collection is fully searchable via the search bar"
-msgstr ""
-"O conjunto de recursos é completamente pesquisável via barra de pesquisa"
+msgstr "O conjunto de recursos é completamente pesquisável via barra de pesquisa"
 
 #. Translators: Text that describes a search icon.
 #: TWLight/users/templates/users/filter_section.html:54
 msgid "Collection is only partially searchable via the search bar"
-msgstr ""
-"O conjunto de recursos só é parcialmente pesquisável via barra de pesquisa"
+msgstr "O conjunto de recursos só é parcialmente pesquisável via barra de pesquisa"
 
 #. Translators: Text that explains when there is no search icon.
 #: TWLight/users/templates/users/filter_section.html:58
@@ -3297,14 +2562,8 @@ msgstr "Definir língua"
 
 #. Translators: This text on the user page helps users naviage to the TranslateWiki Wikipedia Library Card platform translation page.
 #: TWLight/users/templates/users/language_form.html:31
-msgid ""
-"You can help translate the tool at <a class=\"twl-links\" href=\"https://"
-"translatewiki.net/wiki/Translating:Wikipedia_Library_Card_Platform"
-"\">translatewiki.net</a>."
-msgstr ""
-"Pode ajudar a traduzir a ferramenta em <a class=\"twl-links\" href=\"https://"
-"translatewiki.net/wiki/Translating:Wikipedia_Library_Card_Platform"
-"\">translatewiki.net</a>."
+msgid "You can help translate the tool at <a class=\"twl-links\" href=\"https://translatewiki.net/wiki/Translating:Wikipedia_Library_Card_Platform\">translatewiki.net</a>."
+msgstr "Pode ajudar a traduzir a ferramenta em <a class=\"twl-links\" href=\"https://translatewiki.net/wiki/Translating:Wikipedia_Library_Card_Platform\">translatewiki.net</a>."
 
 #. Translators: When the user starts a new application and submits the application, the user can view the application and withdraw if need be. This changes the label for the Withdraw button.
 #: TWLight/users/templates/users/my_applications.html:65
@@ -3323,12 +2582,8 @@ msgstr "Pedir renovação"
 
 #. Translators: On the page listing applications, this text explains a user they cannot renew their application since they've already requested a renewal or there aren't any renewals available.
 #: TWLight/users/templates/users/my_applications.html:79
-msgid ""
-"Renewals are either not required, not available right now, or you have "
-"already requested a renewal."
-msgstr ""
-"Ou as renovações não são necessárias, ou não estão disponíveis neste momento "
-"ou você já pediu uma renovação."
+msgid "Renewals are either not required, not available right now, or you have already requested a renewal."
+msgstr "Ou as renovações não são necessárias, ou não estão disponíveis neste momento ou você já pediu uma renovação."
 
 #. Translators: This text is the heading of a section in a user's profile where they can change their preferences.
 #: TWLight/users/templates/users/preferences.html:6
@@ -3391,27 +2646,13 @@ msgstr "Restringir processamento de dados"
 
 #. Translators: This message is displayed on the page where users can request we stop processing their data.
 #: TWLight/users/templates/users/restrict_data.html:15
-msgid ""
-"Checking this box and clicking “Restrict” will pause all processing of the "
-"data you have entered into this website. You will not be able to apply for "
-"access to resources, your applications will not be further processed, and "
-"none of your data will be altered, until you return to this page and uncheck "
-"the box. This is not the same as deleting your data."
-msgstr ""
-"Marcar esta caixa e clicar em \"Restringir\" irá interromper todo o "
-"processamento dos dados que inseriu neste <i>site</i>. Não poderá candidatar-"
-"se a acesso a recursos, o processamento das suas candidaturas será "
-"interrompido e nenhum dos seus dados será alterado, até que retorne a esta "
-"página e desmarque a caixa. Isto não é o mesmo que eliminar os seus dados."
+msgid "Checking this box and clicking “Restrict” will pause all processing of the data you have entered into this website. You will not be able to apply for access to resources, your applications will not be further processed, and none of your data will be altered, until you return to this page and uncheck the box. This is not the same as deleting your data."
+msgstr "Marcar esta caixa e clicar em \"Restringir\" irá interromper todo o processamento dos dados que inseriu neste <i>site</i>. Não poderá candidatar-se a acesso a recursos, o processamento das suas candidaturas será interrompido e nenhum dos seus dados será alterado, até que retorne a esta página e desmarque a caixa. Isto não é o mesmo que eliminar os seus dados."
 
 #. Translators: This warning message is shown to coordinators who view the data restriction page.
 #: TWLight/users/templates/users/restrict_data.html:26
-msgid ""
-"You are a coordinator on this site. If you restrict the processing of your "
-"data, your coordinator flag will be removed."
-msgstr ""
-"É um coordenador neste <i>site</i>. Se restringir o processamento dos seus "
-"dados, o seu estatuto de coordenador será removido."
+msgid "You are a coordinator on this site. If you restrict the processing of your data, your coordinator flag will be removed."
+msgstr "É um coordenador neste <i>site</i>. Se restringir o processamento dos seus dados, o seu estatuto de coordenador será removido."
 
 #. Translators: use the date *when you are translating*, in a language-appropriate format.
 #: TWLight/users/templates/users/terms.html:33
@@ -3426,44 +2667,17 @@ msgstr "Normas de privacidade da Wikimedia Foundation"
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:41
 msgid "Wikipedia Library Card Terms of Use and Privacy Statement"
-msgstr ""
-"Condições de utilização e normas de privacidade do Cartão da Biblioteca da "
-"Wikipédia"
+msgstr "Condições de utilização e normas de privacidade do Cartão da Biblioteca da Wikipédia"
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:51
-msgid ""
-"<a class=\"twl-links\" href=\"https://meta.wikimedia.org/wiki/"
-"The_Wikipedia_Library\"> The Wikipedia Library </a> has partnered with "
-"publishers around the world to allow users to access otherwise paywalled "
-"resources. This website allows Wikipedia editors to search and access these "
-"resources."
-msgstr ""
-"<a class=\"twl-links\" href=\"https://meta.wikimedia.org/wiki/"
-"The_Wikipedia_Library/pt\">A Biblioteca da Wikipédia</a> estabeleceu "
-"parcerias com editoras de todo o mundo para permitir que os utilizadores "
-"acedam a recursos que, de outra forma, seriam pagos. Este <i>site</i> da "
-"Internet permite que os utilizadores da Wikipédia pesquisem e acedam a esses "
-"recursos."
+msgid "<a class=\"twl-links\" href=\"https://meta.wikimedia.org/wiki/The_Wikipedia_Library\"> The Wikipedia Library </a> has partnered with publishers around the world to allow users to access otherwise paywalled resources. This website allows Wikipedia editors to search and access these resources."
+msgstr "<a class=\"twl-links\" href=\"https://meta.wikimedia.org/wiki/The_Wikipedia_Library/pt\">A Biblioteca da Wikipédia</a> estabeleceu parcerias com editoras de todo o mundo para permitir que os utilizadores acedam a recursos que, de outra forma, seriam pagos. Este <i>site</i> da Internet permite que os utilizadores da Wikipédia pesquisem e acedam a esses recursos."
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Wikimedia Foundation should not be translated. WMF should not be translated. Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:63
-msgid ""
-"This program is administered by the Wikimedia Foundation (WMF). These terms "
-"of use and privacy notice pertain to your application for access to "
-"resources through the Wikipedia Library, your use of this website, and your "
-"access to and use of those resources. They also describe our handling of the "
-"information you provide to us in order to create and administer your "
-"Wikipedia Library account. If we make material changes to the terms, we will "
-"notify users."
-msgstr ""
-"Este programa é administrado pela Wikimedia Foundation (WMF). Estas "
-"condições de utilização e o aviso de privacidade dizem respeito à sua "
-"candidatura para acesso aos recursos da Biblioteca da Wikipédia, à sua "
-"utilização deste <i>site</i> e à sua utilização desses recursos. Também "
-"descrevem o tratamento que faremos das informações que nos fornece para "
-"criar e administrar a sua conta da Biblioteca da Wikipédia. Se fizermos "
-"alterações substanciais às condições, notificaremos os utilizadores."
+msgid "This program is administered by the Wikimedia Foundation (WMF). These terms of use and privacy notice pertain to your application for access to resources through the Wikipedia Library, your use of this website, and your access to and use of those resources. They also describe our handling of the information you provide to us in order to create and administer your Wikipedia Library account. If we make material changes to the terms, we will notify users."
+msgstr "Este programa é administrado pela Wikimedia Foundation (WMF). Estas condições de utilização e o aviso de privacidade dizem respeito à sua candidatura para acesso aos recursos da Biblioteca da Wikipédia, à sua utilização deste <i>site</i> e à sua utilização desses recursos. Também descrevem o tratamento que faremos das informações que nos fornece para criar e administrar a sua conta da Biblioteca da Wikipédia. Se fizermos alterações substanciais às condições, notificaremos os utilizadores."
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:74
@@ -3472,58 +2686,18 @@ msgstr "Requisitos para uma conta Cartão da Biblioteca da Wikipédia"
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:78
-msgid ""
-"Access to resources via The Wikipedia Library is reserved for community "
-"members who have demonstrated their commitment to the Wikimedia projects, "
-"and who will use their access to these resources to improve project content. "
-"To that end, in order to be eligible for The Wikipedia Library, we require "
-"that you be registered for a user account on the projects, with at least 500 "
-"edits, six (6) months of activity, and 10+ edits in the last month. We ask "
-"that you do not request access to any publishers with a limited number of "
-"available accounts whose resources you can already access for free through "
-"your local library or university, or another institution or organization, in "
-"order to provide that opportunity to others."
-msgstr ""
-"O acesso a recursos através da Biblioteca da Wikipédia está reservado a "
-"membros da comunidade que demonstraram o seu empenho nos projetos da "
-"Wikimedia e que usarão o acesso a estes recursos para melhorar os conteúdos "
-"do projeto. Assim, para poder candidatar-se ao programa Biblioteca da "
-"Wikipédia, é necessário que tenha uma conta de utilizador nos projetos com, "
-"pelo menos, 500 edições, seis (6) meses de atividade e mais de 10 edições no "
-"último mês. Pedimos que não solicite acesso a editoras que têm um número "
-"limitado de contas mas cujos recursos já tenha à sua disposição de forma "
-"gratuita através da sua biblioteca ou universidade local, ou de outra "
-"instituição ou organização, para dar essa oportunidade a outros."
+msgid "Access to resources via The Wikipedia Library is reserved for community members who have demonstrated their commitment to the Wikimedia projects, and who will use their access to these resources to improve project content. To that end, in order to be eligible for The Wikipedia Library, we require that you be registered for a user account on the projects, with at least 500 edits, six (6) months of activity, and 10+ edits in the last month. We ask that you do not request access to any publishers with a limited number of available accounts whose resources you can already access for free through your local library or university, or another institution or organization, in order to provide that opportunity to others."
+msgstr "O acesso a recursos através da Biblioteca da Wikipédia está reservado a membros da comunidade que demonstraram o seu empenho nos projetos da Wikimedia e que usarão o acesso a estes recursos para melhorar os conteúdos do projeto. Assim, para poder candidatar-se ao programa Biblioteca da Wikipédia, é necessário que tenha uma conta de utilizador nos projetos com, pelo menos, 500 edições, seis (6) meses de atividade e mais de 10 edições no último mês. Pedimos que não solicite acesso a editoras que têm um número limitado de contas mas cujos recursos já tenha à sua disposição de forma gratuita através da sua biblioteca ou universidade local, ou de outra instituição ou organização, para dar essa oportunidade a outros."
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:94
-msgid ""
-"Additionally, if you are currently blocked or banned from a Wikimedia "
-"project, applications to resources may be rejected or restricted. If you "
-"obtain a Wikipedia Library account, but a block or ban is subsequently "
-"instituted against you on one of the projects, you may lose access to your "
-"Wikipedia Library account."
-msgstr ""
-"Adicionalmente, se neste momento estiver bloqueado ou banido de um projeto "
-"da Wikimedia, as candidaturas aos recursos poderão ser rejeitadas ou "
-"restringidas. Se obtiver uma conta da Biblioteca da Wikipédia mas "
-"posteriormente lhe for aplicado um bloqueio ou banimento num dos projetos, "
-"poderá perder o acesso à sua conta da Biblioteca da Wikipédia."
+msgid "Additionally, if you are currently blocked or banned from a Wikimedia project, applications to resources may be rejected or restricted. If you obtain a Wikipedia Library account, but a block or ban is subsequently instituted against you on one of the projects, you may lose access to your Wikipedia Library account."
+msgstr "Adicionalmente, se neste momento estiver bloqueado ou banido de um projeto da Wikimedia, as candidaturas aos recursos poderão ser rejeitadas ou restringidas. Se obtiver uma conta da Biblioteca da Wikipédia mas posteriormente lhe for aplicado um bloqueio ou banimento num dos projetos, poderá perder o acesso à sua conta da Biblioteca da Wikipédia."
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:104
-msgid ""
-"Your eligibility to access The Wikipedia Library is assessed at each login. "
-"While more than half of the library's content is provided via this automated "
-"eligibility check, access to other publisher's content may be time limited, "
-"typically lapsing after one year, after which you will usually need to apply "
-"for renewal."
-msgstr ""
-"O seu direito de aceder à Biblioteca da Wikipédia é reavaliado cada vez que "
-"acede. Embora mais de metade do conteúdo da biblioteca seja fornecido "
-"através desta verificação automática de elegibilidade, o acesso ao conteúdo "
-"de outras editoras pode ter limites temporais que tipicamente expiram após "
-"um ano, após o qual normalmente terá de candidatar-se a uma renovação."
+msgid "Your eligibility to access The Wikipedia Library is assessed at each login. While more than half of the library's content is provided via this automated eligibility check, access to other publisher's content may be time limited, typically lapsing after one year, after which you will usually need to apply for renewal."
+msgstr "O seu direito de aceder à Biblioteca da Wikipédia é reavaliado cada vez que acede. Embora mais de metade do conteúdo da biblioteca seja fornecido através desta verificação automática de elegibilidade, o acesso ao conteúdo de outras editoras pode ter limites temporais que tipicamente expiram após um ano, após o qual normalmente terá de candidatar-se a uma renovação."
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:114
@@ -3532,71 +2706,28 @@ msgstr "Candidatar-se através da sua conta Cartão da Biblioteca da Wikipédia"
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:118
-msgid ""
-"In order to apply for access to a partner resource, you must provide us with "
-"certain information, which we will use to evaluate your application. If your "
-"application is approved, we may transfer the information you have given us "
-"to the publishers whose resources you wish to access. They will either "
-"contact you with the account information directly or we will send access "
-"information to you ourselves."
-msgstr ""
-"Para se candidatar a acesso ao recurso de um parceiro, tem de fornecer-nos "
-"certas informações, que serão usadas para avaliar a sua candidatura. Se a "
-"sua candidatura for aprovada, poderemos transferir as informações que nos "
-"forneceu para as editoras a cujos recursos pretende aceder. As editoras "
-"entrarão em contacto consigo diretamente com as informações da conta, ou "
-"então seremos nós a enviar-lhe as informações de acesso."
+msgid "In order to apply for access to a partner resource, you must provide us with certain information, which we will use to evaluate your application. If your application is approved, we may transfer the information you have given us to the publishers whose resources you wish to access. They will either contact you with the account information directly or we will send access information to you ourselves."
+msgstr "Para se candidatar a acesso ao recurso de um parceiro, tem de fornecer-nos certas informações, que serão usadas para avaliar a sua candidatura. Se a sua candidatura for aprovada, poderemos transferir as informações que nos forneceu para as editoras a cujos recursos pretende aceder. As editoras entrarão em contacto consigo diretamente com as informações da conta, ou então seremos nós a enviar-lhe as informações de acesso."
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:130
-msgid ""
-"In addition to the basic information you provide to us, our system will "
-"retrieve some information directly from the Wikimedia projects: your "
-"username, email address, edit count, registration date, user ID number, "
-"groups to which you belong, and any special user rights."
-msgstr ""
-"Além da informação básica que nos fornece, o nosso sistema obterá algumas "
-"informações sobre si diretamente dos projetos da Wikimedia: o seu nome de "
-"utilizador, endereço de correio eletrónico, número de edições, a data de "
-"registo, o identificador do utilizador, os grupos aos quais pertence e "
-"quaisquer privilégios especiais."
+msgid "In addition to the basic information you provide to us, our system will retrieve some information directly from the Wikimedia projects: your username, email address, edit count, registration date, user ID number, groups to which you belong, and any special user rights."
+msgstr "Além da informação básica que nos fornece, o nosso sistema obterá algumas informações sobre si diretamente dos projetos da Wikimedia: o seu nome de utilizador, endereço de correio eletrónico, número de edições, a data de registo, o identificador do utilizador, os grupos aos quais pertence e quaisquer privilégios especiais."
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:140
-msgid ""
-"Each time you log in to the Wikipedia Library Card Platform, this "
-"information will be automatically updated."
-msgstr ""
-"Cada vez que iniciar uma sessão na plataforma Cartão da Biblioteca da "
-"Wikipédia, estas informações serão atualizadas automaticamente."
+msgid "Each time you log in to the Wikipedia Library Card Platform, this information will be automatically updated."
+msgstr "Cada vez que iniciar uma sessão na plataforma Cartão da Biblioteca da Wikipédia, estas informações serão atualizadas automaticamente."
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:148
-msgid ""
-"We will ask you to provide us with some information about your history of "
-"contributions to the Wikimedia projects. Information on contribution history "
-"is optional, but will greatly assist us in evaluating your application."
-msgstr ""
-"Iremos pedir que nos forneça algumas informações sobre o seu historial de "
-"contribuições para os projetos da Wikimedia. As informações do historial de "
-"contribuições são opcionais, mas ajudam-nos bastante a avaliar a sua "
-"candidatura."
+msgid "We will ask you to provide us with some information about your history of contributions to the Wikimedia projects. Information on contribution history is optional, but will greatly assist us in evaluating your application."
+msgstr "Iremos pedir que nos forneça algumas informações sobre o seu historial de contribuições para os projetos da Wikimedia. As informações do historial de contribuições são opcionais, mas ajudam-nos bastante a avaliar a sua candidatura."
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). WMF should not be translated. Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:157
-msgid ""
-"The information you provide when creating your account will be visible to "
-"you while on the site but not to others unless they are approved Wikipedia "
-"Library Coordinators, WMF Staff, or WMF Contractors who need access to this "
-"data in order to carry out their work with the Wikipedia Library, all of "
-"whom are subject to non-disclosure obligations."
-msgstr ""
-"As informações que fornecer ao criar a sua conta poderão ser vistas por si "
-"enquanto estiver no <i>site</i>, mas não por outros utilizadores, a menos "
-"que estes sejam coordenadores aprovados da Biblioteca da Wikipédia, "
-"funcionários da WMF ou fornecedores externos da WMF que necessitam de acesso "
-"a estes dados para o seu trabalho na Biblioteca da Wikipédia, estando todos "
-"eles obrigados por acordos de confidencialidade."
+msgid "The information you provide when creating your account will be visible to you while on the site but not to others unless they are approved Wikipedia Library Coordinators, WMF Staff, or WMF Contractors who need access to this data in order to carry out their work with the Wikipedia Library, all of whom are subject to non-disclosure obligations."
+msgstr "As informações que fornecer ao criar a sua conta poderão ser vistas por si enquanto estiver no <i>site</i>, mas não por outros utilizadores, a menos que estes sejam coordenadores aprovados da Biblioteca da Wikipédia, funcionários da WMF ou fornecedores externos da WMF que necessitam de acesso a estes dados para o seu trabalho na Biblioteca da Wikipédia, estando todos eles obrigados por acordos de confidencialidade."
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:167
@@ -3605,64 +2736,33 @@ msgstr "O seu uso dos recursos das editoras"
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:171
-msgid ""
-"In order to access an individual publisher’s resources, you must agree to "
-"that publisher’s terms of use and privacy policy. You agree that you will "
-"not violate such terms and policies in connection with your use of the "
-"Wikipedia Library. Additionally, the following activities are prohibited "
-"while accessing publisher resources through the Wikipedia Library."
-msgstr ""
-"Para aceder aos recursos de uma editora em particular tem de concordar com "
-"as condições de utilização e as normas de privacidade dessa editora. Aceita "
-"não violar essas condições e normas no âmbito da sua utilização da "
-"Biblioteca da Wikipédia. Adicionalmente, as seguintes atividades são "
-"proibidas enquanto acede a recursos de editoras através da Biblioteca da "
-"Wikipédia."
+msgid "In order to access an individual publisher’s resources, you must agree to that publisher’s terms of use and privacy policy. You agree that you will not violate such terms and policies in connection with your use of the Wikipedia Library. Additionally, the following activities are prohibited while accessing publisher resources through the Wikipedia Library."
+msgstr "Para aceder aos recursos de uma editora em particular tem de concordar com as condições de utilização e as normas de privacidade dessa editora. Aceita não violar essas condições e normas no âmbito da sua utilização da Biblioteca da Wikipédia. Adicionalmente, as seguintes atividades são proibidas enquanto acede a recursos de editoras através da Biblioteca da Wikipédia."
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:184
-msgid ""
-"Sharing your Wikipedia account, usernames, passwords, or any access codes "
-"for publisher resources with others;"
-msgstr ""
-"Partilhar a sua conta da Wikipédia, os seus nomes de utilizador, palavras-"
-"passe ou códigos de acesso aos recursos das editoras com outras pessoas;"
+msgid "Sharing your Wikipedia account, usernames, passwords, or any access codes for publisher resources with others;"
+msgstr "Partilhar a sua conta da Wikipédia, os seus nomes de utilizador, palavras-passe ou códigos de acesso aos recursos das editoras com outras pessoas;"
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:191
-msgid ""
-"Automatically scraping or downloading restricted content from publishers;"
-msgstr ""
-"Fazer raspagens de ecrã ou descarregamentos automáticos de conteúdos "
-"restritos das editores;"
+msgid "Automatically scraping or downloading restricted content from publishers;"
+msgstr "Fazer raspagens de ecrã ou descarregamentos automáticos de conteúdos restritos das editores;"
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:197
-msgid ""
-"Systematically making printed or electronic copies of multiple extracts of "
-"restricted content available for any purpose;"
-msgstr ""
-"Disponibilizar, para qualquer finalidade e de forma sistemática, cópias "
-"impressas ou eletrónicas de vários extratos de conteúdo restrito;"
+msgid "Systematically making printed or electronic copies of multiple extracts of restricted content available for any purpose;"
+msgstr "Disponibilizar, para qualquer finalidade e de forma sistemática, cópias impressas ou eletrónicas de vários extratos de conteúdo restrito;"
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:204
-msgid ""
-"Data mining metadata without permission—for example, in order to use "
-"metadata for auto-created stub articles;"
-msgstr ""
-"Fazer a mineração não autorizada de metadados — por exemplo, para usá-los na "
-"criação automática de esboços de artigos;"
+msgid "Data mining metadata without permission—for example, in order to use metadata for auto-created stub articles;"
+msgstr "Fazer a mineração não autorizada de metadados — por exemplo, para usá-los na criação automática de esboços de artigos;"
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:211
-msgid ""
-"Using the access you receive through the Wikipedia Library for profit by "
-"selling access to your account or resources which you have through it."
-msgstr ""
-"Usar o acesso que recebe através da Biblioteca da Wikipédia para obtenção de "
-"lucros, vendendo o acesso à sua conta ou os recursos que obtenha através "
-"dela."
+msgid "Using the access you receive through the Wikipedia Library for profit by selling access to your account or resources which you have through it."
+msgstr "Usar o acesso que recebe através da Biblioteca da Wikipédia para obtenção de lucros, vendendo o acesso à sua conta ou os recursos que obtenha através dela."
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:220
@@ -3671,25 +2771,13 @@ msgstr "Serviços de pesquisa externos e de <i>proxy</i>"
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:224
-msgid ""
-"Certain resources may only be accessed using an external search service, "
-"such as the EBSCO Discovery Service, or a proxy service, such as OCLC "
-"EZProxy. If you use such external search and/or proxy services, please "
-"review the applicable terms of use and privacy policies."
-msgstr ""
-"Certos recursos só podem ser acedidos usando um serviço de pesquisa externo, "
-"como o EBSCO Discovery Service, ou um serviço de ''proxy'', como o OCLC "
-"EZProxy. Se usar serviços externos de pesquisa ou ''proxy'', reveja as "
-"condições de utilização e normas de privacidade relevantes."
+msgid "Certain resources may only be accessed using an external search service, such as the EBSCO Discovery Service, or a proxy service, such as OCLC EZProxy. If you use such external search and/or proxy services, please review the applicable terms of use and privacy policies."
+msgstr "Certos recursos só podem ser acedidos usando um serviço de pesquisa externo, como o EBSCO Discovery Service, ou um serviço de ''proxy'', como o OCLC EZProxy. Se usar serviços externos de pesquisa ou ''proxy'', reveja as condições de utilização e normas de privacidade relevantes."
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:234
-msgid ""
-"In addition, if you use OCLC EZProxy, please note that you may not use it "
-"for commercial purposes."
-msgstr ""
-"Adicionalmente, se usar o OCLC EZProxy, note que não pode usá-lo para fins "
-"comerciais, por favor."
+msgid "In addition, if you use OCLC EZProxy, please note that you may not use it for commercial purposes."
+msgstr "Adicionalmente, se usar o OCLC EZProxy, note que não pode usá-lo para fins comerciais, por favor."
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:241
@@ -3699,202 +2787,51 @@ msgstr "Retenção e tratamento de dados"
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Wikimedia Foundation should not be translated. Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:245
 #, fuzzy
-msgid ""
-"The Wikimedia Foundation and our service providers use your information for "
-"the legitimate purpose of providing Wikipedia Library services in support of "
-"our charitable mission. When you apply for a Wikipedia Library account, or "
-"use your Wikipedia Library account, we may routinely collect the following "
-"information: your username, email address, edit count, registration date, "
-"user ID number, groups to which you belong, and any special user rights; "
-"your name, country of residence, and/or affiliation, if required by a "
-"partner to which you are applying; your narrative description of your "
-"contributions and reasons for applying for access to partner resources; and "
-"the date you agree to these terms of use."
-msgstr ""
-"A Wikimedia Foundation e os nossos fornecedores de serviços usam as suas "
-"informações com a finalidade legítima de fornecer serviços da Biblioteca da "
-"Wikipédia em apoio à nossa missão caritativa. Quando se candidata a uma "
-"conta da Biblioteca da Wikipédia, ou usa a sua conta da Biblioteca da "
-"Wikipédia, podemos recolher rotineiramente as seguintes informações: o seu "
-"nome de utilizador, endereço de correio eletrónico, contagem de edições, "
-"data de registo, número de identificação de utilizador, os grupos aos quais "
-"pertence e todos os direitos de utilizador especiais; o seu nome, país de "
-"residência, profissão e afiliação, se exigido por um parceiro ao qual se "
-"esteja a candidatar; a sua descrição narrativa das suas contribuições e "
-"razões para pedir acesso aos recursos dos parceiros; e a data em que "
-"concorda com estas condições de utilização."
+msgid "The Wikimedia Foundation and our service providers use your information for the legitimate purpose of providing Wikipedia Library services in support of our charitable mission. When you apply for a Wikipedia Library account, or use your Wikipedia Library account, we may routinely collect the following information: your username, email address, edit count, registration date, user ID number, groups to which you belong, and any special user rights; your name, country of residence, and/or affiliation, if required by a partner to which you are applying; your narrative description of your contributions and reasons for applying for access to partner resources; and the date you agree to these terms of use."
+msgstr "A Wikimedia Foundation e os nossos fornecedores de serviços usam as suas informações com a finalidade legítima de fornecer serviços da Biblioteca da Wikipédia em apoio à nossa missão caritativa. Quando se candidata a uma conta da Biblioteca da Wikipédia, ou usa a sua conta da Biblioteca da Wikipédia, podemos recolher rotineiramente as seguintes informações: o seu nome de utilizador, endereço de correio eletrónico, contagem de edições, data de registo, número de identificação de utilizador, os grupos aos quais pertence e todos os direitos de utilizador especiais; o seu nome, país de residência, profissão e afiliação, se exigido por um parceiro ao qual se esteja a candidatar; a sua descrição narrativa das suas contribuições e razões para pedir acesso aos recursos dos parceiros; e a data em que concorda com estas condições de utilização."
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:262
 #, fuzzy, python-format
-msgid ""
-"Each publisher who is a member of the Wikipedia Library program requires "
-"different specific information in the application. Some publishers may "
-"request only an email address, while others request more detailed data, such "
-"as your name, location, or institutional affiliation. When you complete your "
-"application, you will only be asked to supply information required by the "
-"publishers you have chosen, and each publisher will only receive the "
-"information they require for providing you with access. Please see our <a "
-"class=\"twl-links\" href=\"%(all_partners_url)s\">partner information</a> "
-"pages to learn what information is required by each publisher to gain access "
-"to their resources."
-msgstr ""
-"Cada editora que é membro do programa Biblioteca da Wikipédia requer "
-"informação específica na candidatura. Algumas editoras podem pedir só um "
-"endereço de correio eletrónico, enquanto outras pedem dados mais detalhados, "
-"como o seu nome, localização, ocupação ou filiação em instituições. Quando "
-"preenche a sua candidatura, só lhe será pedida a informação exigida pelas "
-"editoras que escolheu, e cada editora só receberá a informação que requer "
-"para lhe conceder acesso. Consulte as nossas páginas de <a class=\"twl-links"
-"\" href=\"%(all_partners_url)s\">informações de parceiros</a> para saber que "
-"informação é exigida por cada editora para obter acesso aos recursos da "
-"mesma."
+msgid "Each publisher who is a member of the Wikipedia Library program requires different specific information in the application. Some publishers may request only an email address, while others request more detailed data, such as your name, location, or institutional affiliation. When you complete your application, you will only be asked to supply information required by the publishers you have chosen, and each publisher will only receive the information they require for providing you with access. Please see our <a class=\"twl-links\" href=\"%(all_partners_url)s\">partner information</a> pages to learn what information is required by each publisher to gain access to their resources."
+msgstr "Cada editora que é membro do programa Biblioteca da Wikipédia requer informação específica na candidatura. Algumas editoras podem pedir só um endereço de correio eletrónico, enquanto outras pedem dados mais detalhados, como o seu nome, localização, ocupação ou filiação em instituições. Quando preenche a sua candidatura, só lhe será pedida a informação exigida pelas editoras que escolheu, e cada editora só receberá a informação que requer para lhe conceder acesso. Consulte as nossas páginas de <a class=\"twl-links\" href=\"%(all_partners_url)s\">informações de parceiros</a> para saber que informação é exigida por cada editora para obter acesso aos recursos da mesma."
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Wikimedia Foundation should not be translated. Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:277
-msgid ""
-"Some Wikipedia Library pages are visible without logging in, but you will "
-"need to log in to apply or access proprietary partner resources. We use the "
-"data provided by you via OAuth and Wikimedia API calls to assess your "
-"application for access and to process approved requests."
-msgstr ""
-"Algumas páginas da Biblioteca da Wikipédia podem ser vistas sem iniciar uma "
-"sessão, mas terá de iniciá-la para se candidatar a acesso, ou aceder, aos "
-"recursos restritos dos parceiros. Usamos os dados fornecidos por si nas "
-"chamadas das API do OAuth e da Wikimedia, para avaliar os seus pedidos de "
-"acesso e para processar os pedidos aprovados."
+msgid "Some Wikipedia Library pages are visible without logging in, but you will need to log in to apply or access proprietary partner resources. We use the data provided by you via OAuth and Wikimedia API calls to assess your application for access and to process approved requests."
+msgstr "Algumas páginas da Biblioteca da Wikipédia podem ser vistas sem iniciar uma sessão, mas terá de iniciá-la para se candidatar a acesso, ou aceder, aos recursos restritos dos parceiros. Usamos os dados fornecidos por si nas chamadas das API do OAuth e da Wikimedia, para avaliar os seus pedidos de acesso e para processar os pedidos aprovados."
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:288
 #, python-format
-msgid ""
-"In order to administer the Wikipedia Library program, we will retain the "
-"application data we collect from you for three years after your most recent "
-"login, unless you delete your account, as described below. You can log in "
-"and go to <a class=\"twl-links\" href=\"%(profile_url)s\">your profile page</"
-"a> in order to see the information associated with your account, and can "
-"download it in JSON format. You may access, update, restrict, or delete this "
-"information at any time, except for the information that is automatically "
-"retrieved from the projects. If you have any questions or concerns about the "
-"handling of your data, please contact <a class=\"twl-links\" href=\"mailto:"
-"wikipedialibrary@wikimedia.org?Subject=Wikipedia%%20Library%%20Card"
-"%%20account%%20deactivation\"> wikipedialibrary@wikimedia.org </a>."
-msgstr ""
-"Para administrar o programa da Biblioteca da Wikipédia reteremos os dados de "
-"candidatura que nos forneceu, durante um período de três anos após o seu "
-"início de sessão mais recente, a menos que elimine a sua conta conforme "
-"descrito abaixo. Pode iniciar uma sessão e aceder à <a class=\"twl-links\" "
-"href=\"%(profile_url)s\">sua página de perfil</a> para ver as informações "
-"associadas à sua conta, e pode descarregá-las em formato JSON. Pode aceder, "
-"atualizar, restringir ou apagar estas informações em qualquer altura, exceto "
-"as que são obtidas automaticamente dos projetos. Se tem qualquer pergunta ou "
-"preocupação acerca do nosso tratamento dos seus dados, é favor contactar <a "
-"class=\"twl-links\" href=\"mailto:wikipedialibrary@wikimedia.org?"
-"Subject=Wikipedia%%20Library%%20Card%%20account%%20deactivation\"> "
-"wikipedialibrary@wikimedia.org </a>."
+msgid "In order to administer the Wikipedia Library program, we will retain the application data we collect from you for three years after your most recent login, unless you delete your account, as described below. You can log in and go to <a class=\"twl-links\" href=\"%(profile_url)s\">your profile page</a> in order to see the information associated with your account, and can download it in JSON format. You may access, update, restrict, or delete this information at any time, except for the information that is automatically retrieved from the projects. If you have any questions or concerns about the handling of your data, please contact <a class=\"twl-links\" href=\"mailto:wikipedialibrary@wikimedia.org?Subject=Wikipedia%%20Library%%20Card%%20account%%20deactivation\"> wikipedialibrary@wikimedia.org </a>."
+msgstr "Para administrar o programa da Biblioteca da Wikipédia reteremos os dados de candidatura que nos forneceu, durante um período de três anos após o seu início de sessão mais recente, a menos que elimine a sua conta conforme descrito abaixo. Pode iniciar uma sessão e aceder à <a class=\"twl-links\" href=\"%(profile_url)s\">sua página de perfil</a> para ver as informações associadas à sua conta, e pode descarregá-las em formato JSON. Pode aceder, atualizar, restringir ou apagar estas informações em qualquer altura, exceto as que são obtidas automaticamente dos projetos. Se tem qualquer pergunta ou preocupação acerca do nosso tratamento dos seus dados, é favor contactar <a class=\"twl-links\" href=\"mailto:wikipedialibrary@wikimedia.org?Subject=Wikipedia%%20Library%%20Card%%20account%%20deactivation\"> wikipedialibrary@wikimedia.org </a>."
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:305
 #, fuzzy
-msgid ""
-"If you decide to disable your Wikipedia Library account, you can use the "
-"delete button on your profile to delete certain personal information "
-"associated with your account. We will delete your real name, institutional "
-"affiliation, and country of residence. Please note that the system will "
-"retain a record of your username, the publishers to which you applied or had "
-"access, and the dates of that access. Note that deletion is not reversible. "
-"Deletion of your Wikipedia Library account may also correspond with the "
-"removal of any resource access to which you were eligible or approved. If "
-"you request the deletion of account information and later wish to apply for "
-"a new account, you will need to provide the necessary information again."
-msgstr ""
-"Se decidir desativar a sua conta da Biblioteca da Wikipédia, pode usar o "
-"botão 'Eliminar' no seu perfil para eliminar determinadas informações "
-"pessoais associadas à sua conta. Eliminaremos o seu nome verdadeiro, "
-"ocupação, a filiação em instituições e o país de residência. Note, por "
-"favor, que o sistema manterá um registo do seu nome de utilizador, das "
-"editoras a que se candidatou ou teve acesso e das datas desse acesso. Note "
-"também que a eliminação não pode ser revertida. A eliminação da sua conta da "
-"Biblioteca da Wikipédia pode também coincidir com a remoção de todos os "
-"acessos a recursos para que reunia as condições ou tinha sido aprovado. Se "
-"pedir a eliminação das informações da conta e mais tarde pretender "
-"candidatar-se a uma nova conta, terá de fornecer as informações necessárias "
-"outra vez."
+msgid "If you decide to disable your Wikipedia Library account, you can use the delete button on your profile to delete certain personal information associated with your account. We will delete your real name, institutional affiliation, and country of residence. Please note that the system will retain a record of your username, the publishers to which you applied or had access, and the dates of that access. Note that deletion is not reversible. Deletion of your Wikipedia Library account may also correspond with the removal of any resource access to which you were eligible or approved. If you request the deletion of account information and later wish to apply for a new account, you will need to provide the necessary information again."
+msgstr "Se decidir desativar a sua conta da Biblioteca da Wikipédia, pode usar o botão 'Eliminar' no seu perfil para eliminar determinadas informações pessoais associadas à sua conta. Eliminaremos o seu nome verdadeiro, ocupação, a filiação em instituições e o país de residência. Note, por favor, que o sistema manterá um registo do seu nome de utilizador, das editoras a que se candidatou ou teve acesso e das datas desse acesso. Note também que a eliminação não pode ser revertida. A eliminação da sua conta da Biblioteca da Wikipédia pode também coincidir com a remoção de todos os acessos a recursos para que reunia as condições ou tinha sido aprovado. Se pedir a eliminação das informações da conta e mais tarde pretender candidatar-se a uma nova conta, terá de fornecer as informações necessárias outra vez."
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). WMF should not be translated. Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:321
-msgid ""
-"The Wikipedia Library is run by WMF Staff, Contractors, and approved "
-"volunteer Coordinators. The data associated with your account will be shared "
-"with the WMF staff, contractors, service providers, and volunteer "
-"coordinators who need to process the information in connection with their "
-"work for the Wikipedia Library, and who are subject to confidentiality "
-"obligations. We will also use your data for internal Wikipedia Library "
-"purposes such as distributing user surveys and account notifications, and in "
-"a depersonalized or aggregated fashion for statistical analysis and "
-"administration. Finally, we will share your information with the publishers "
-"whom you specifically select in order to provide you with access to "
-"resources. Otherwise, your information will not be shared with third "
-"parties, with the exception of the circumstances described below."
-msgstr ""
-"A Biblioteca da Wikipédia é administrada por funcionários da WMF, "
-"fornecedores externos e coordenadores voluntários aprovados. Os dados "
-"associados à sua conta serão partilhados com a equipa da WMF, fornecedores "
-"externos, prestadores de serviços e coordenadores voluntários, que precisam "
-"de processar as informações no âmbito do seu trabalho para a Biblioteca da "
-"Wikipédia, e que estão sujeitos a obrigações de confidencialidade. Também "
-"usaremos os seus dados para fins internos da Biblioteca da Wikipédia, tais "
-"como a distribuição de inquéritos aos utilizadores e notificações de contas, "
-"e de forma despersonalizada ou agregada para análise estatística e "
-"administração. Por fim, partilharemos a sua informação com as editoras que "
-"selecionar especificamente, de forma a lhe fornecer acesso aos recursos. "
-"Caso contrário, as suas informações não serão partilhadas com terceiros, "
-"exceto nas circunstâncias descritas abaixo."
+msgid "The Wikipedia Library is run by WMF Staff, Contractors, and approved volunteer Coordinators. The data associated with your account will be shared with the WMF staff, contractors, service providers, and volunteer coordinators who need to process the information in connection with their work for the Wikipedia Library, and who are subject to confidentiality obligations. We will also use your data for internal Wikipedia Library purposes such as distributing user surveys and account notifications, and in a depersonalized or aggregated fashion for statistical analysis and administration. Finally, we will share your information with the publishers whom you specifically select in order to provide you with access to resources. Otherwise, your information will not be shared with third parties, with the exception of the circumstances described below."
+msgstr "A Biblioteca da Wikipédia é administrada por funcionários da WMF, fornecedores externos e coordenadores voluntários aprovados. Os dados associados à sua conta serão partilhados com a equipa da WMF, fornecedores externos, prestadores de serviços e coordenadores voluntários, que precisam de processar as informações no âmbito do seu trabalho para a Biblioteca da Wikipédia, e que estão sujeitos a obrigações de confidencialidade. Também usaremos os seus dados para fins internos da Biblioteca da Wikipédia, tais como a distribuição de inquéritos aos utilizadores e notificações de contas, e de forma despersonalizada ou agregada para análise estatística e administração. Por fim, partilharemos a sua informação com as editoras que selecionar especificamente, de forma a lhe fornecer acesso aos recursos. Caso contrário, as suas informações não serão partilhadas com terceiros, exceto nas circunstâncias descritas abaixo."
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). WMF should not be translated.
 #: TWLight/users/templates/users/terms.html:338
-msgid ""
-"We may disclose any collected information when required by law, when we have "
-"your permission, when needed to protect our rights, privacy, safety, users, "
-"or the general public, and when necessary to enforce these terms, WMF’s "
-"general <a class=\"twl-links\" href=\"https://foundation.wikimedia.org/wiki/"
-"Terms_of_Use\">Terms of Use</a>, or any other WMF policy."
-msgstr ""
-"Poderemos divulgar qualquer informação recolhida quando tal for exigido por "
-"lei, quando tivermos a sua autorização, quando necessário para proteger os "
-"nossos direitos, privacidade, segurança, utilizadores ou o público em geral, "
-"e quando necessário para aplicar estas condições, as <a class=\"twl-links\" "
-"href=\"https://foundation.wikimedia.org/wiki/Terms_of_Use\">condições de "
-"utilização</a> gerais da WMF ou qualquer outra norma da WMF."
+msgid "We may disclose any collected information when required by law, when we have your permission, when needed to protect our rights, privacy, safety, users, or the general public, and when necessary to enforce these terms, WMF’s general <a class=\"twl-links\" href=\"https://foundation.wikimedia.org/wiki/Terms_of_Use\">Terms of Use</a>, or any other WMF policy."
+msgstr "Poderemos divulgar qualquer informação recolhida quando tal for exigido por lei, quando tivermos a sua autorização, quando necessário para proteger os nossos direitos, privacidade, segurança, utilizadores ou o público em geral, e quando necessário para aplicar estas condições, as <a class=\"twl-links\" href=\"https://foundation.wikimedia.org/wiki/Terms_of_Use\">condições de utilização</a> gerais da WMF ou qualquer outra norma da WMF."
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:349
-msgid ""
-"We take the security of your personal data seriously, and take reasonable "
-"precautions to ensure your data is protected. These precautions include "
-"access controls to limit who has access to your data and security "
-"technologies to protect data stored on the server. However, we cannot "
-"guarantee the safety of your data as it is transmitted and stored."
-msgstr ""
-"Encaramos com seriedade a segurança dos seus dados pessoais e tomamos as "
-"precauções que são razoáveis para garantir que os seus dados estão "
-"protegidos. Estas precauções incluem controlos de acesso para limitar quem "
-"tem acesso aos seus dados e tecnologias de segurança para proteger os dados "
-"armazenados no servidor. No entanto, não podemos garantir a segurança dos "
-"seus dados quando estes são transmitidos e armazenados."
+msgid "We take the security of your personal data seriously, and take reasonable precautions to ensure your data is protected. These precautions include access controls to limit who has access to your data and security technologies to protect data stored on the server. However, we cannot guarantee the safety of your data as it is transmitted and stored."
+msgstr "Encaramos com seriedade a segurança dos seus dados pessoais e tomamos as precauções que são razoáveis para garantir que os seus dados estão protegidos. Estas precauções incluem controlos de acesso para limitar quem tem acesso aos seus dados e tecnologias de segurança para proteger os dados armazenados no servidor. No entanto, não podemos garantir a segurança dos seus dados quando estes são transmitidos e armazenados."
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:360
-msgid ""
-"Please note that these terms do not control the use and handling of your "
-"data by the publishers and service providers whose resources you access or "
-"apply to access. Please read their individual privacy policies for that "
-"information."
-msgstr ""
-"Note, por favor, que estas condições não controlam o uso e o tratamento dos "
-"seus dados pelas editoras e fornecedores de serviços a cujos recursos acede "
-"ou se candidata a aceder. Para obter essa informação leia as normas de "
-"privacidade da entidade respetiva."
+msgid "Please note that these terms do not control the use and handling of your data by the publishers and service providers whose resources you access or apply to access. Please read their individual privacy policies for that information."
+msgstr "Note, por favor, que estas condições não controlam o uso e o tratamento dos seus dados pelas editoras e fornecedores de serviços a cujos recursos acede ou se candidata a aceder. Para obter essa informação leia as normas de privacidade da entidade respetiva."
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:368
@@ -3903,53 +2840,18 @@ msgstr "Nota importante"
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Wikimedia Foundation should not be translated. Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:373
-msgid ""
-"The Wikimedia Foundation is a nonprofit organization based in San Francisco, "
-"California. The Wikipedia Library program provides access to resources held "
-"by publishers in multiple countries. If you apply for a Wikipedia Library "
-"account (whether you are inside or outside of the United States), you "
-"understand that your personal data will be collected, transferred, stored, "
-"processed, disclosed and otherwise used in the U.S. as described in this "
-"privacy policy. You also understand that your information may be transferred "
-"by us from the U.S. to other countries, which may have different or less "
-"stringent data protection laws than your country, in connection with "
-"providing services to you, including evaluating your application and "
-"securing access to your chosen publishers (locations for each publisher are "
-"outlined on their respective partner information pages)."
-msgstr ""
-"A Wikimedia Foundation é uma organização sem fins lucrativos com sede em São "
-"Francisco, na Califórnia. O programa Biblioteca da Wikipédia oferece acesso "
-"a recursos detidos por editoras em vários países. Se se candidatar a uma "
-"conta na Biblioteca da Wikipédia (quer se encontre nos Estados Unidos ou "
-"fora) compreende que os seus dados pessoais serão recolhidos, transferidos, "
-"armazenados, processados, divulgados e sofrerão outros tratamentos nos "
-"Estados Unidos tal como é descrito nestas normas de privacidade. Também "
-"compreende que as suas informações poderão ser transferidas por nós dos EUA "
-"para outros países, que podem ter uma legislação de proteção de dados "
-"diferente ou menos restritiva do que o seu país, com o objetivo de lhe "
-"prestar serviços, incluindo a avaliação da sua candidatura e a obtenção do "
-"acesso às editoras que escolheu (as localizações de cada editora são "
-"descritas nas respetivas páginas de informação do parceiro)."
+msgid "The Wikimedia Foundation is a nonprofit organization based in San Francisco, California. The Wikipedia Library program provides access to resources held by publishers in multiple countries. If you apply for a Wikipedia Library account (whether you are inside or outside of the United States), you understand that your personal data will be collected, transferred, stored, processed, disclosed and otherwise used in the U.S. as described in this privacy policy. You also understand that your information may be transferred by us from the U.S. to other countries, which may have different or less stringent data protection laws than your country, in connection with providing services to you, including evaluating your application and securing access to your chosen publishers (locations for each publisher are outlined on their respective partner information pages)."
+msgstr "A Wikimedia Foundation é uma organização sem fins lucrativos com sede em São Francisco, na Califórnia. O programa Biblioteca da Wikipédia oferece acesso a recursos detidos por editoras em vários países. Se se candidatar a uma conta na Biblioteca da Wikipédia (quer se encontre nos Estados Unidos ou fora) compreende que os seus dados pessoais serão recolhidos, transferidos, armazenados, processados, divulgados e sofrerão outros tratamentos nos Estados Unidos tal como é descrito nestas normas de privacidade. Também compreende que as suas informações poderão ser transferidas por nós dos EUA para outros países, que podem ter uma legislação de proteção de dados diferente ou menos restritiva do que o seu país, com o objetivo de lhe prestar serviços, incluindo a avaliação da sua candidatura e a obtenção do acesso às editoras que escolheu (as localizações de cada editora são descritas nas respetivas páginas de informação do parceiro)."
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:392
-msgid ""
-"Please note that in the event of any differences in meaning or "
-"interpretation between the original English version of these terms and a "
-"translation, the original English version takes precedence."
-msgstr ""
-"Note, por favor, que caso haja diferenças de significado ou interpretação "
-"entre a versão original em inglês destas condições e uma tradução, a versão "
-"original em inglês terá precedência."
+msgid "Please note that in the event of any differences in meaning or interpretation between the original English version of these terms and a translation, the original English version takes precedence."
+msgstr "Note, por favor, que caso haja diferenças de significado ou interpretação entre a versão original em inglês destas condições e uma tradução, a versão original em inglês terá precedência."
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Wikimedia Foundation should not be translated.
 #: TWLight/users/templates/users/terms.html:403
-msgid ""
-"See also the <a class=\"twl-links\" href=\"https://wikimediafoundation.org/"
-"wiki/Privacy_policy\">Wikimedia Foundation Privacy Policy</a>."
-msgstr ""
-"Consulte também as <a class=\"twl-links\" href=\"https://wikimediafoundation."
-"org/wiki/Privacy_policy\">Normas de Privacidade da Wikimedia Foundation</a>."
+msgid "See also the <a class=\"twl-links\" href=\"https://wikimediafoundation.org/wiki/Privacy_policy\">Wikimedia Foundation Privacy Policy</a>."
+msgstr "Consulte também as <a class=\"twl-links\" href=\"https://wikimediafoundation.org/wiki/Privacy_policy\">Normas de Privacidade da Wikimedia Foundation</a>."
 
 #. Translators: This is the second to last line of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:412
@@ -3968,16 +2870,8 @@ msgstr "Wikimedia Foundation"
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:426
-msgid ""
-"By checking this box and clicking “Submit”, you agree that you have read the "
-"above terms and that you will adhere to the terms of use in your application "
-"to and use of the The Wikipedia Library, and the publishers’ services to "
-"which you gain access through The Wikipedia Library program."
-msgstr ""
-"Ao marcar esta caixa e clicar em \"Enviar\", declara ter lido as condições "
-"acima e concorda em aderir às condições de utilização na sua candidatura e "
-"uso da Biblioteca da Wikipédia e dos serviços das editoras a que ganhar "
-"acesso através do programa Biblioteca da Wikipédia."
+msgid "By checking this box and clicking “Submit”, you agree that you have read the above terms and that you will adhere to the terms of use in your application to and use of the The Wikipedia Library, and the publishers’ services to which you gain access through The Wikipedia Library program."
+msgstr "Ao marcar esta caixa e clicar em \"Enviar\", declara ter lido as condições acima e concorda em aderir às condições de utilização na sua candidatura e uso da Biblioteca da Wikipédia e dos serviços das editoras a que ganhar acesso através do programa Biblioteca da Wikipédia."
 
 #: TWLight/users/templates/users/user_collection_tile.html:32
 msgid "Remove this collection from favorites"
@@ -4029,40 +2923,19 @@ msgstr "Eliminar todos os dados"
 
 #. Translators: This message is displayed on the page where users can request the deletion of their data.
 #: TWLight/users/templates/users/user_confirm_delete.html:17
-msgid ""
-"<b>Warning:</b> Performing this action will delete your Wikipedia Library "
-"Card user account and all associated applications. This process is not "
-"reversible. You may lose any partner accounts you were granted, and will not "
-"be able to renew those accounts or apply for new ones."
-msgstr ""
-"<b>Aviso:</b> Executar esta operação irá eliminar a sua conta de utilizador "
-"do Cartão da Biblioteca da Wikipédia e todas as candidaturas associadas. "
-"Este processo não é reversível. Poderá perder as contas de parceiros que "
-"recebeu e não poderá renovar essas contas nem inscrever-se para obter novas."
+msgid "<b>Warning:</b> Performing this action will delete your Wikipedia Library Card user account and all associated applications. This process is not reversible. You may lose any partner accounts you were granted, and will not be able to renew those accounts or apply for new ones."
+msgstr "<b>Aviso:</b> Executar esta operação irá eliminar a sua conta de utilizador do Cartão da Biblioteca da Wikipédia e todas as candidaturas associadas. Este processo não é reversível. Poderá perder as contas de parceiros que recebeu e não poderá renovar essas contas nem inscrever-se para obter novas."
 
 #. Translators: this should show up for people who log in with a username/password and not OAuth, so we don't know what their Wikipedia identity is.
-#.
 #: TWLight/users/templates/users/user_detail.html:12
 #, python-format
-msgid ""
-"Hi, %(username)s! You don't have a Wikipedia editor profile attached to your "
-"account here, so you are probably a site administrator."
-msgstr ""
-"Olá, %(username)s! Não tem um perfil de editor da Wikipédia anexado à sua "
-"conta aqui, portanto é provavelmente um administrador do <i>site</i>."
+msgid "Hi, %(username)s! You don't have a Wikipedia editor profile attached to your account here, so you are probably a site administrator."
+msgstr "Olá, %(username)s! Não tem um perfil de editor da Wikipédia anexado à sua conta aqui, portanto é provavelmente um administrador do <i>site</i>."
 
 #. Translators: In the unlikely scenario that someone is able to register an account without using OAuth (thus leaving us without some of the information required for applications), users will see this message, encouraging them to re-register.
 #: TWLight/users/templates/users/user_detail.html:20
-msgid ""
-"If you aren't a site administrator, something weird has happened. You won't "
-"be able to apply for access without a Wikipedia editor profile. You should "
-"log out and create a new account by logging in via OAuth, or contact a site "
-"administrator for help."
-msgstr ""
-"Se não é um administrador do <i>site</i>, aconteceu algo de estranho. Não "
-"poderá pedir acesso sem um perfil de editor da Wikipédia. Deve sair e depois "
-"criar uma conta nova entrando através do OAuth, ou contactar um "
-"administrador do <i>site</i> para obter ajuda."
+msgid "If you aren't a site administrator, something weird has happened. You won't be able to apply for access without a Wikipedia editor profile. You should log out and create a new account by logging in via OAuth, or contact a site administrator for help."
+msgstr "Se não é um administrador do <i>site</i>, aconteceu algo de estranho. Não poderá pedir acesso sem um perfil de editor da Wikipédia. Deve sair e depois criar uma conta nova entrando através do OAuth, ou contactar um administrador do <i>site</i> para obter ajuda."
 
 #. Translators: Labels a sections where coordinators can select their email preferences.
 #: TWLight/users/templates/users/user_email_preferences.html:15
@@ -4072,31 +2945,19 @@ msgstr "Só para coordenadores"
 #. Translators: This message is shown on user's own profile page, encouraging them to make sure their information is up to date, so that account coordinators can use the information to judge applications.
 #: TWLight/users/views.py:176
 #, python-brace-format
-msgid ""
-"Please <a class='twl-links' href='{url}'>update your contributions</a> to "
-"Wikipedia to help coordinators evaluate your applications."
-msgstr ""
-"<a class='twl-links' href='{url}'>Atualize as suas contribuições</a> na "
-"Wikipédia para ajudar os coordenadores a avaliarem as suas candidaturas, por "
-"favor."
+msgid "Please <a class='twl-links' href='{url}'>update your contributions</a> to Wikipedia to help coordinators evaluate your applications."
+msgstr "<a class='twl-links' href='{url}'>Atualize as suas contribuições</a> na Wikipédia para ajudar os coordenadores a avaliarem as suas candidaturas, por favor."
 
 #. Translators: Coordinators are shown this message when they unselect all three types of reminder email options under preferences.
 #: TWLight/users/views.py:288
 #, fuzzy
-msgid ""
-"You have chosen not to receive reminder emails. As a coordinator, you should "
-"receive at least one type of reminder emails, so consider changing your "
-"preferences."
-msgstr ""
-"Escolheu não receber avisos por correio eletrónico. Por ser coordenador deve "
-"receber pelo menos um tipo destes avisos, por isso, pondere alterar as suas "
-"preferências."
+msgid "You have chosen not to receive reminder emails. As a coordinator, you should receive at least one type of reminder emails, so consider changing your preferences."
+msgstr "Escolheu não receber avisos por correio eletrónico. Por ser coordenador deve receber pelo menos um tipo destes avisos, por isso, pondere alterar as suas preferências."
 
 #. Translators: Coordinators are shown this message when they make changes to their reminder email options under preferences.
 #: TWLight/users/views.py:296
 msgid "Your reminder email preferences are updated."
-msgstr ""
-"As suas preferências de avisos por correio eletrónico estão atualizadas."
+msgstr "As suas preferências de avisos por correio eletrónico estão atualizadas."
 
 #. Translators: This message is shown to users who attempt to update their personal information without being logged in.
 #. Translators: If a user tries to do something (such as updating their email) when not logged in, this message is presented.
@@ -4114,9 +2975,7 @@ msgstr "A sua informação foi atualizada."
 #. Translators: If a user tries to save the 'email change form' without entering one and checking the 'use my Wikipedia email address' checkbox, this message is presented.
 #: TWLight/users/views.py:448
 msgid "Both the values cannot be blank. Either enter a email or check the box."
-msgstr ""
-"Os valores não podem estar ambos em branco. Introduza um endereço de correio "
-"eletrónico ou marque a caixa."
+msgstr "Os valores não podem estar ambos em branco. Introduza um endereço de correio eletrónico ou marque a caixa."
 
 #. Translators: Shown to users when they successfully modify their email. Don't translate {email}.
 #: TWLight/users/views.py:476
@@ -4126,13 +2985,8 @@ msgstr "O seu correio eletrónico foi alterado para {email}."
 
 #. Translators: If the user has not filled out their email, they can browse the website but cannot apply for access to resources.
 #: TWLight/users/views.py:487
-msgid ""
-"Your email is blank. You can still explore the site, but you won't be able "
-"to apply for access to partner resources without an email."
-msgstr ""
-"O seu endereço de correio eletrónico está em branco. Isto permite-lhe "
-"explorar o <i>site</i>, mas não poderá pedir acesso a recursos de parceiros "
-"sem um correio eletrónico."
+msgid "Your email is blank. You can still explore the site, but you won't be able to apply for access to partner resources without an email."
+msgstr "O seu endereço de correio eletrónico está em branco. Isto permite-lhe explorar o <i>site</i>, mas não poderá pedir acesso a recursos de parceiros sem um correio eletrónico."
 
 #. Translators: This message is shown once the access to a partner has successfully been returned.
 #: TWLight/users/views.py:801
@@ -4164,31 +3018,3 @@ msgstr "Sem bloqueios ativos"
 msgid "10+ edits in the last 30 days"
 msgstr "Mais de 10 edições nos últimos 30 dias"
 
-#: tests/shunit/data/bad_i18n_comment_1.py:3
-#: tests/shunit/data/bad_i18n_newline_1.py:5
-msgid "1"
-msgstr ""
-
-#. Translators: Lorem ipsum dolor sit amet, consectetur adipiscing elit. Mauris vitae ipsum ut purus faucibus pretium. Proin tempus neque et aliquet consectetur. Ut egestas sapien in consectetur sagittis. Mauris neque lacus, dapibus non viverra vitae, interdum ut aenean ipsum.
-#. Translators: Lorem ipsum dolor sit amet, consectetur adipiscing elit. Mauris vitae ipsum ut purus faucibus pretium. Proin tempus neque et aliquet consectetur. Ut egestas sapien in consectetur sagittis. Mauris neque lacus, dapibus non.
-#: tests/shunit/data/bad_i18n_comment_2.py:4
-#: tests/shunit/data/bad_i18n_newline_2.py:5 tests/shunit/data/good_i18n_1.py:2
-#: tests/shunit/data/good_i18n_2.py:2
-msgid "2"
-msgstr ""
-
-#: tests/shunit/data/bad_i18n_newline_3.py:5
-msgid "3"
-msgstr ""
-
-#: tests/shunit/data/bad_i18n_newline_4.py:5
-msgid "4"
-msgstr ""
-
-#: tests/shunit/data/bad_i18n_newline_5.py:5
-msgid "5"
-msgstr ""
-
-#: tests/shunit/data/bad_i18n_newline_6.py:5
-msgid "6"
-msgstr ""

--- a/locale/pt_Br/LC_MESSAGES/django.po
+++ b/locale/pt_Br/LC_MESSAGES/django.po
@@ -24,10 +24,11 @@
 # Author: YuriNikolai
 msgid ""
 msgstr ""
+""
 "Project-Id-Version: Wikipedia Library Card Platform - Website\n"
-"Report-Msgid-Bugs-To: wikipedialibrary@wikimedia.org\n"
+"Report-Msgid-Bugs-To: translatewiki.net\n"
 "POT-Creation-Date: 2024-07-11 20:54+0000\n"
-"PO-Revision-Date: 2024-07-11 12:30:18+0000\n"
+"PO-Revision-Date: 2024-07-15 12:29:18+0000\n"
 "Language: pt_br\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
@@ -59,13 +60,8 @@ msgstr "Sobre você"
 #. Translators: This note appears in a section of a form where we ask users to enter info (like country of residence) when applying for resource access.
 #: TWLight/applications/forms.py:179
 #, python-brace-format
-msgid ""
-"<p><small><i>Your personal data will be processed according to our <a "
-"class='twl-links' href='{terms_url}'> privacy policy</a>.</i></small></p>"
-msgstr ""
-"<p><small><i>Seus dados pessoais serão processados de acordo com nossos <a "
-"class='twl-links' href='{terms_url}'>política de Privacidade</a>.</i></"
-"small></p>"
+msgid "<p><small><i>Your personal data will be processed according to our <a class='twl-links' href='{terms_url}'> privacy policy</a>.</i></small></p>"
+msgstr "<p><small><i>Seus dados pessoais serão processados de acordo com nossos <a class='twl-links' href='{terms_url}'>política de Privacidade</a>.</i></small></p>"
 
 #. Translators: This is the title of the application form page, where users enter information required for the application. It lets the user know which partner application they are entering data for. {partner}
 #: TWLight/applications/forms.py:189
@@ -106,12 +102,8 @@ msgstr "O e-mail da sua conta no site do parceiro"
 #. Translators: This labels a choice field where users will have to select the number of months they wish to have their access for as part of the application renewal confirmation.
 #. Translators: When filling out an application, users may be required to enter the length of the account (expiry) they wish to have for proxy partners.
 #: TWLight/applications/forms.py:339 TWLight/applications/helpers.py:100
-msgid ""
-"The number of months you wish to have this access for before renewal is "
-"required"
-msgstr ""
-"O número de meses que você deseja ter esse acesso antes da renovação ser "
-"necessária"
+msgid "The number of months you wish to have this access for before renewal is required"
+msgstr "O número de meses que você deseja ter esse acesso antes da renovação ser necessária"
 
 #. Translators: When filling out an application, users may need to specify their name
 #: TWLight/applications/helpers.py:81
@@ -199,12 +191,8 @@ msgstr "E-mail"
 
 #. Translators: This comment is added to pending applications when our terms of use change.
 #: TWLight/applications/management/commands/notify_applicants_tou_changes.py:54
-msgid ""
-"Our terms of use have changed. Your applications will not be processed until "
-"you log in and agree to our updated terms."
-msgstr ""
-"Nossos termos de uso foram alterados. Seus aplicativos não serão processados "
-"até você entrar e concordar com nossos termos atualizados."
+msgid "Our terms of use have changed. Your applications will not be processed until you log in and agree to our updated terms."
+msgstr "Nossos termos de uso foram alterados. Seus aplicativos não serão processados até você entrar e concordar com nossos termos atualizados."
 
 #. Translators: This is the status of an application that has not yet been reviewed.
 #: TWLight/applications/models.py:54
@@ -270,43 +258,26 @@ msgstr "URL de acesso: {access_url}"
 
 #. Translators: This text goes into account approval emails in the case that we need to send the user's details to a publisher for manual account setup.
 #: TWLight/applications/models.py:331
-msgid ""
-"You can expect to receive access details within a week or two once it has "
-"been processed."
-msgstr ""
-"Você pode esperar receber detalhes de acesso dentro de uma semana ou duas "
-"depois de processado."
+msgid "You can expect to receive access details within a week or two once it has been processed."
+msgstr "Você pode esperar receber detalhes de acesso dentro de uma semana ou duas depois de processado."
 
 #. Translators: This comment is added to open applications when a partner joins the Library Bundle, which does not require applications.
 #: TWLight/applications/signals.py:247
-msgid ""
-"This partner joined the Library Bundle, which does not require applications. "
-"This application will be marked as invalid."
-msgstr ""
-"Esse parceiro ingressou no pacote de bibliotecas, que não requer "
-"candidaturas. Essa candidatura será marcado como inválido."
+msgid "This partner joined the Library Bundle, which does not require applications. This application will be marked as invalid."
+msgstr "Esse parceiro ingressou no pacote de bibliotecas, que não requer candidaturas. Essa candidatura será marcado como inválido."
 
 #. Translators: This is shown to users if the application is to a partner for which we have run out of available accounts. The application is therefore on a 'waitlist', and will be reviewed when more accounts are available.
 #: TWLight/applications/templates/applications/application_evaluation.html:29
-msgid ""
-"This application is on the waitlist because this partner does not have any "
-"access grants available at this time."
-msgstr ""
-"Está CANDIDATURA está na lista de espera porque esse parceiro não tem nenhum "
-"subsídio de acesso disponível no momento."
+msgid "This application is on the waitlist because this partner does not have any access grants available at this time."
+msgstr "Está CANDIDATURA está na lista de espera porque esse parceiro não tem nenhum subsídio de acesso disponível no momento."
 
 #. Translators: This message is shown on pages where coordinators can see personal information about applicants.
 #: TWLight/applications/templates/applications/application_evaluation.html:36
 #: TWLight/applications/templates/applications/application_list_include.html:6
 #: TWLight/applications/templates/applications/send_partner.html:45
 #: TWLight/resources/templates/resources/partner_users.html:18
-msgid ""
-"Coordinators: This page may contain personal information such as real names "
-"and email addresses. Please remember that this information is confidential."
-msgstr ""
-"Coordenadores: esta página pode conter informações pessoais, como nomes "
-"reais e endereços de e-mail. Por favor, lembre-se que esta informação é "
-"confidencial."
+msgid "Coordinators: This page may contain personal information such as real names and email addresses. Please remember that this information is confidential."
+msgstr "Coordenadores: esta página pode conter informações pessoais, como nomes reais e endereços de e-mail. Por favor, lembre-se que esta informação é confidencial."
 
 #. Translators: This is the title of the application page shown to users who are a coordinator, and are able to accept or reject the application.
 #: TWLight/applications/templates/applications/application_evaluation.html:39
@@ -315,12 +286,8 @@ msgstr "Avaliar candidatura"
 
 #. Translators: This text is shown to coordinators on application pages if the applicant has restricted processing of their data.
 #: TWLight/applications/templates/applications/application_evaluation.html:42
-msgid ""
-"This user has requested a restriction on the processing of their data, so "
-"you cannot change the status of their application."
-msgstr ""
-"Este usuário solicitou uma restrição no processamento de seus dados, "
-"portanto, você não pode alterar o status da candidatura."
+msgid "This user has requested a restriction on the processing of their data, so you cannot change the status of their application."
+msgstr "Este usuário solicitou uma restrição no processamento de seus dados, portanto, você não pode alterar o status da candidatura."
 
 #. Translators: This is the title of the application page shown to users who are not a coordinator.
 #: TWLight/applications/templates/applications/application_evaluation.html:48
@@ -393,12 +360,8 @@ msgstr "Desconhecido"
 
 #. Translators: This is the text displayed to coordinators when an applicant has no country of residence in their profile.
 #: TWLight/applications/templates/applications/application_evaluation.html:123
-msgid ""
-"Please request the applicant add their country of residence to their profile "
-"before proceeding further."
-msgstr ""
-"Solicite ao candidato que adicione seu país de residência ao perfil antes de "
-"prosseguir."
+msgid "Please request the applicant add their country of residence to their profile before proceeding further."
+msgstr "Solicite ao candidato que adicione seu país de residência ao perfil antes de prosseguir."
 
 #. Translators: This labels the section of an application showing the total number of accounts available for a partner or their collection.
 #: TWLight/applications/templates/applications/application_evaluation.html:134
@@ -408,12 +371,8 @@ msgstr "Contas disponíveis"
 #. Translators: This labels the section of an application showing whether the user had agreed to the terms of use or not.
 #: TWLight/applications/templates/applications/application_evaluation.html:145
 #, python-format
-msgid ""
-"Has agreed to the site's <a class=\"twl-links\" href=\"%(terms_url)s\">terms "
-"of use</a>?"
-msgstr ""
-"Concordou com os <a class=\"twl-links\" href=\"%(terms_url)s\">termos de "
-"uso</a> do site?"
+msgid "Has agreed to the site's <a class=\"twl-links\" href=\"%(terms_url)s\">terms of use</a>?"
+msgstr "Concordou com os <a class=\"twl-links\" href=\"%(terms_url)s\">termos de uso</a> do site?"
 
 #. Translators: Displayed to coordinators when they've agreed to the terms of use.
 #. Translators: Displayed if the user has agreed to the terms of use.
@@ -448,12 +407,8 @@ msgstr "Não"
 
 #. Translators: This is the text displayed to coordinators when an applicant has not agreed to the terms of use.
 #: TWLight/applications/templates/applications/application_evaluation.html:159
-msgid ""
-"Please request the applicant agree to the site's terms of use before "
-"approving this application."
-msgstr ""
-"Solicite que o candidato concorde com os termos de uso do site antes de "
-"aprovar essa candidatura."
+msgid "Please request the applicant agree to the site's terms of use before approving this application."
+msgstr "Solicite que o candidato concorde com os termos de uso do site antes de aprovar essa candidatura."
 
 #. Translators: This labels the section of an application containing the user's motivation for wanting access to this resource.
 #: TWLight/applications/templates/applications/application_evaluation.html:176
@@ -473,10 +428,8 @@ msgstr "Renovação de concessão de acesso existente?"
 #. Translators: This message is shown next to the 'Renewal of existing access grant?' label if the application is a renewal. Don't translate HTML tags or parent_url.
 #: TWLight/applications/templates/applications/application_evaluation.html:195
 #, python-format
-msgid ""
-"Yes (<a class=\"twl-links\" href=\"%(parent_url)s\">previous application</a>)"
-msgstr ""
-"Sim (<a class=\"twl-links\" href=\"%(parent_url)s\">candidatura anterior</a>)"
+msgid "Yes (<a class=\"twl-links\" href=\"%(parent_url)s\">previous application</a>)"
+msgstr "Sim (<a class=\"twl-links\" href=\"%(parent_url)s\">candidatura anterior</a>)"
 
 #. Translators: This labels the section of the application showing the length of access remaining on the user's previous authorization.
 #: TWLight/applications/templates/applications/application_evaluation.html:208
@@ -510,12 +463,8 @@ msgstr "Adicionar comentário"
 
 #. Translators: On an application page, this text tells users that the comments posted on the application are visible to coordinators and the submitting user only.
 #: TWLight/applications/templates/applications/application_evaluation.html:297
-msgid ""
-"Comments are visible to all coordinators and to the editor who submitted "
-"this application."
-msgstr ""
-"Os comentários são visíveis para todos os coordenadores e para o editor que "
-"enviou esta candidatura."
+msgid "Comments are visible to all coordinators and to the editor who submitted this application."
+msgstr "Os comentários são visíveis para todos os coordenadores e para o editor que enviou esta candidatura."
 
 #. Translators: This is the title of the section of an application page which lists information about the user who submitted the application.
 #. Translators: On the page where coordinators can view data on applications to a partner they coordinate, this is a table column heading for the username.
@@ -726,18 +675,8 @@ msgstr "Definir estado"
 
 #: TWLight/applications/templates/applications/apply.html:20
 #, python-format
-msgid ""
-"If your application is successful we may share your email address with "
-"%(partner)s. This is required to set up your access to their resources. By "
-"submitting this form you agree to allow your email address to be shared with "
-"%(partner)s if your application is successful, for the purposes of account "
-"setup."
-msgstr ""
-"Se a sua candidatura for aceita, poderemos compartilhar o seu endereço de "
-"email com %(partner)s. Isto é necessário para criar o seu acesso aos "
-"recursos do parceiro. Ao submeter este formulário, você concorda em permitir "
-"que o seu endereço de email seja compartilhado com o parceiro %(partner)s se "
-"a sua candidatura for aceita, para fins de criação da sua conta."
+msgid "If your application is successful we may share your email address with %(partner)s. This is required to set up your access to their resources. By submitting this form you agree to allow your email address to be shared with %(partner)s if your application is successful, for the purposes of account setup."
+msgstr "Se a sua candidatura for aceita, poderemos compartilhar o seu endereço de email com %(partner)s. Isto é necessário para criar o seu acesso aos recursos do parceiro. Ao submeter este formulário, você concorda em permitir que o seu endereço de email seja compartilhado com o parceiro %(partner)s se a sua candidatura for aceita, para fins de criação da sua conta."
 
 #. Translators: This message is displayed on the page where users can confirm their renewal. Please do not translate partner.
 #: TWLight/applications/templates/applications/confirm_renewal.html:23
@@ -765,12 +704,8 @@ msgstr "Quais recursos você deseja acessar?"
 
 #. Translators: This text explains that Library Bundle partners are not shown in this list.
 #: TWLight/applications/templates/applications/request_for_application.html:26
-msgid ""
-"Library Bundle partners are not shown as eligibility is determined "
-"automatically."
-msgstr ""
-"Os parceiros do pacote de biblioteca não são mostrados, pois a elegibilidade "
-"é determinada automaticamente."
+msgid "Library Bundle partners are not shown as eligibility is determined automatically."
+msgstr "Os parceiros do pacote de biblioteca não são mostrados, pois a elegibilidade é determinada automaticamente."
 
 #. Translators: On the page where users can apply for multiple partners, this message shows next to the partner name, taking them to the full application page when clicked.
 #: TWLight/applications/templates/applications/request_for_application.html:48
@@ -784,15 +719,8 @@ msgstr "Nenhum dado do parceiro foi adicionado ainda."
 
 #. Translators: the HTML is so that the word 'waitlisted' will look the same as it does in the page above; please translate 'waitlisted' the same way you did elsewhere in this file.
 #: TWLight/applications/templates/applications/request_for_application.html:74
-msgid ""
-"You can apply to <span class=\"badge badge-warning\">Waitlisted</span> "
-"partners, but they don't have access grants available right now. We will "
-"process those applications when access becomes available."
-msgstr ""
-"Você pode se inscrever para parceiros <span class =\"badge badge-warning"
-"\">na lista de espera </span>, mas eles não têm concessões de acesso "
-"disponíveis no momento. Nós processaremos esses aplicativos quando o acesso "
-"estiver disponível."
+msgid "You can apply to <span class=\"badge badge-warning\">Waitlisted</span> partners, but they don't have access grants available right now. We will process those applications when access becomes available."
+msgstr "Você pode se inscrever para parceiros <span class =\"badge badge-warning\">na lista de espera </span>, mas eles não têm concessões de acesso disponíveis no momento. Nós processaremos esses aplicativos quando o acesso estiver disponível."
 
 #. Translators: On the page where coordinators can see approved applications which have not had their details sent to the partner, this message shows when there are applications ready to be processed.
 #: TWLight/applications/templates/applications/send.html:10
@@ -813,18 +741,13 @@ msgstr "Dados de candidatura para %(object)s"
 #. Translators: This message is shown when applications exceed the number of accounts available.
 #: TWLight/applications/templates/applications/send_partner.html:54
 #, python-format
-msgid ""
-"Application(s) for %(object)s, if sent, will exceed the total available "
-"accounts for the partner. Please proceed at your own discretion."
-msgstr ""
-"candidatura(s) para %(object)s, se enviado, excederá o total de contas "
-"disponíveis para o parceiro. Por favor, proceda a seu próprio critério."
+msgid "Application(s) for %(object)s, if sent, will exceed the total available accounts for the partner. Please proceed at your own discretion."
+msgstr "candidatura(s) para %(object)s, se enviado, excederá o total de contas disponíveis para o parceiro. Por favor, proceda a seu próprio critério."
 
 #. Translators: When viewing the list of applications ready to be sent for a particular partner, this is instructions for the coordinator to click the 'mark as sent' button after they have sent the information.
 #: TWLight/applications/templates/applications/send_partner.html:65
 msgid "When you've processed the data below, click the 'mark as sent' button."
-msgstr ""
-"Depois de processar os dados abaixo, clique no botão \"Marcar como enviado\"."
+msgstr "Depois de processar os dados abaixo, clique no botão \"Marcar como enviado\"."
 
 #. Translators: When viewing the list of applications ready to be sent for a particular partner, this is the title of the section containing contact information for the people applications should be sent to.
 #: TWLight/applications/templates/applications/send_partner.html:71
@@ -835,12 +758,8 @@ msgstr[1] "Contacts"
 
 #. Translators: When viewing the list of applications ready to be sent for a particular partner, this message shows if there is no information about who the applications should be sent to. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/applications/templates/applications/send_partner.html:89
-msgid ""
-"Whoops, we don't have any listed contacts. Please notify Wikipedia Library "
-"administrators."
-msgstr ""
-"Opa, não temos contatos listados. Por favor, avise os administradores da "
-"Biblioteca da Wikipédia."
+msgid "Whoops, we don't have any listed contacts. Please notify Wikipedia Library administrators."
+msgstr "Opa, não temos contatos listados. Por favor, avise os administradores da Biblioteca da Wikipédia."
 
 #. Translators: When viewing the list of applications ready to be sent for a particular partner, this is the title of the section containing the information about those applications.
 #: TWLight/applications/templates/applications/send_partner.html:94
@@ -855,12 +774,8 @@ msgstr "Marcar como enviado"
 
 #. Translators: This text guides coordinators in using the code sending interface for approved applications.
 #: TWLight/applications/templates/applications/send_partner.html:152
-msgid ""
-"Use the dropdown menus to denote which editor will receive each code. Access "
-"codes will be sent to users automatically."
-msgstr ""
-"Use os menus suspensos para indicar qual editor receberá cada código. Os "
-"códigos de acesso serão enviados automaticamente."
+msgid "Use the dropdown menus to denote which editor will receive each code. Access codes will be sent to users automatically."
+msgstr "Use os menus suspensos para indicar qual editor receberá cada código. Os códigos de acesso serão enviados automaticamente."
 
 #. Translators: This labels a drop-down selection where staff can assign an access code to a user.
 #: TWLight/applications/templates/applications/send_partner.html:173
@@ -875,24 +790,14 @@ msgstr "Não há candidaturas aprovadas e não enviadas."
 #. Translators: When a user applies for a set of resources, they receive this message if none are currently available. They are instead placed on a 'waitlist' for later approval.
 #. Translators: When a user renews their resource, they receive this message if none are currently available. They are instead placed on a 'waitlist' for later approval.
 #: TWLight/applications/views.py:140 TWLight/applications/views.py:1282
-msgid ""
-"This partner does not have any access grants available at this time. You may "
-"still apply for access; your application will be reviewed when access grants "
-"become available."
-msgstr ""
-"Este parceiro não tem nenhum subsídio de acesso disponível no momento. Você "
-"ainda pode solicitar acesso; sua inscrição será revisada quando os subsídios "
-"de acesso estiverem disponíveis."
+msgid "This partner does not have any access grants available at this time. You may still apply for access; your application will be reviewed when access grants become available."
+msgstr "Este parceiro não tem nenhum subsídio de acesso disponível no momento. Você ainda pode solicitar acesso; sua inscrição será revisada quando os subsídios de acesso estiverem disponíveis."
 
 #. Translators: This message is shown to users once they've successfully submitted their application for review.
 #: TWLight/applications/views.py:163
 #, python-brace-format
-msgid ""
-"Your application has been submitted for review. Head over to <a "
-"href='{applications_url}'>My Applications</a> to view the status."
-msgstr ""
-"Sua candidatura foi enviada para análise. Vá para <a "
-"href='{applications_url}'>minhas candidaturas</a> para visualizar o status."
+msgid "Your application has been submitted for review. Head over to <a href='{applications_url}'>My Applications</a> to view the status."
+msgstr "Sua candidatura foi enviada para análise. Vá para <a href='{applications_url}'>minhas candidaturas</a> para visualizar o status."
 
 #. Translators: This text is displayed to users when the user has chosen to restrict data and is trying to apply for multiple partners
 #: TWLight/applications/views.py:276
@@ -940,22 +845,13 @@ msgstr "Candidaturas enviadas"
 
 #. Translators: After a coordinator has changed the status of an application to APPROVED, if the corresponding partner/collection is waitlisted this message appears.
 #: TWLight/applications/views.py:756
-msgid ""
-"Cannot approve application as partner with proxy authorization method is "
-"waitlisted."
-msgstr ""
-"Não é possível aprovar o aplicativo, pois o parceiro com o método de "
-"autorização de proxy está na lista de espera."
+msgid "Cannot approve application as partner with proxy authorization method is waitlisted."
+msgstr "Não é possível aprovar o aplicativo, pois o parceiro com o método de autorização de proxy está na lista de espera."
 
 #. Translators: After a coordinator has changed the status of an application to APPROVED, if the corresponding partner/collection has no accounts for distribution, this message appears.
 #: TWLight/applications/views.py:780
-msgid ""
-"Cannot approve application as partner with proxy authorization method is "
-"waitlisted and (or) has zero accounts available for distribution."
-msgstr ""
-"Não é possível aprovar o aplicativo, pois o parceiro com o método de "
-"autorização de proxy está na lista de espera e (ou) tem zero contas "
-"disponíveis para distribuição."
+msgid "Cannot approve application as partner with proxy authorization method is waitlisted and (or) has zero accounts available for distribution."
+msgstr "Não é possível aprovar o aplicativo, pois o parceiro com o método de autorização de proxy está na lista de espera e (ou) tem zero contas disponíveis para distribuição."
 
 #. Translators: This message appears on an "access denied" screen that stops users who attempt to authorize an editor to access a resource during a time period for which they are already authorized.
 #: TWLight/applications/views.py:803
@@ -965,16 +861,8 @@ msgstr "Você tentou criar uma autorização duplicada."
 #. Translators: This message is shown to users when they access an application page of a now Bundle partner (new applications aren't allowed for Bundle partners and the status of old applications cannot be modified)
 #: TWLight/applications/views.py:857
 #, python-brace-format
-msgid ""
-"This application cannot be modified since this partner is now part of our <a "
-"href='{bundle}'>bundle access</a>. If you are eligible, you can access this "
-"resource from <a href='{library}'>your library</a>. <a "
-"href='{contact}'>Contact us</a> if you have any questions."
-msgstr ""
-"Este aplicativo não pode ser modificado, pois agora esse parceiro faz parte "
-"do nosso <a href='{bundle}'>acesso bundle</a>. Se você é elegível, pode "
-"acessar este recurso na <a href='{library}'>sua biblioteca</a>. <a "
-"href='{contact}'>Entre em contato</a> se você tiver alguma dúvida."
+msgid "This application cannot be modified since this partner is now part of our <a href='{bundle}'>bundle access</a>. If you are eligible, you can access this resource from <a href='{library}'>your library</a>. <a href='{contact}'>Contact us</a> if you have any questions."
+msgstr "Este aplicativo não pode ser modificado, pois agora esse parceiro faz parte do nosso <a href='{bundle}'>acesso bundle</a>. Se você é elegível, pode acessar este recurso na <a href='{library}'>sua biblioteca</a>. <a href='{contact}'>Entre em contato</a> se você tiver alguma dúvida."
 
 #. Translators: this lets a reviewer set the status of a single application.
 #: TWLight/applications/views.py:873
@@ -983,12 +871,8 @@ msgstr "Definir status da candidatura"
 
 #. Translators: This warning is message is shown to applicants when the number of pending applications is greater than the number of accounts available.
 #: TWLight/applications/views.py:891
-msgid ""
-"There are more pending applications than available accounts. Your "
-"application might get waitlisted."
-msgstr ""
-"Existem mais candidaturas pendentes do que as contas disponíveis. Sua "
-"candidatura pode ficar na lista de espera."
+msgid "There are more pending applications than available accounts. Your application might get waitlisted."
+msgstr "Existem mais candidaturas pendentes do que as contas disponíveis. Sua candidatura pode ficar na lista de espera."
 
 #. Translators: this message is shown to coordinators who attempt to change an application's Status from INVALID to any other Status.
 #: TWLight/applications/views.py:904
@@ -1007,17 +891,8 @@ msgstr "Atualização em lote de aplicativos {} bem-sucedida."
 
 #. Translators: After a coordinator has changed the status of a number of applications to APPROVED, if the corresponding partner(s) is/are waitlisted or has no accounts for distribution, this message appears.
 #: TWLight/applications/views.py:1051
-msgid ""
-"Cannot approve application(s) {} as partner(s) with proxy authorization "
-"method is/are waitlisted and (or) has/have not enough accounts available. If "
-"not enough accounts are available, prioritise the applications and then "
-"approve applications equal to the accounts available."
-msgstr ""
-"Não é possível aprovar aplicativos {}, pois os parceiros com o método de "
-"autorização de proxy estão/estão na lista de espera e (ou) têm/não têm "
-"contas suficientes disponíveis. Se não houver contas suficientes "
-"disponíveis, priorize os aplicativos e aprove os aplicativos iguais às "
-"contas disponíveis."
+msgid "Cannot approve application(s) {} as partner(s) with proxy authorization method is/are waitlisted and (or) has/have not enough accounts available. If not enough accounts are available, prioritise the applications and then approve applications equal to the accounts available."
+msgstr "Não é possível aprovar aplicativos {}, pois os parceiros com o método de autorização de proxy estão/estão na lista de espera e (ou) têm/não têm contas suficientes disponíveis. Se não houver contas suficientes disponíveis, priorize os aplicativos e aprove os aplicativos iguais às contas disponíveis."
 
 #. Translators: This message is shown to coordinators who attempt to assign the same access code to multiple users.
 #: TWLight/applications/views.py:1191
@@ -1031,13 +906,8 @@ msgstr "Todos as candidaturas selecionados foram marcados como enviados."
 
 #. Translators: When a user tries to renew their resource, they receive this message if the partner is not available.
 #: TWLight/applications/views.py:1272
-msgid ""
-"Cannot renew application at this time as partner is not available. Please "
-"check back later, or contact us for more information."
-msgstr ""
-"Não é possível renovar a candidatura nesta altura porque o parceiro não está "
-"disponível. Verifique novamente mais tarde, por favor, ou contacte-nos para "
-"mais informações."
+msgid "Cannot renew application at this time as partner is not available. Please check back later, or contact us for more information."
+msgstr "Não é possível renovar a candidatura nesta altura porque o parceiro não está disponível. Verifique novamente mais tarde, por favor, ou contacte-nos para mais informações."
 
 #. Translators: This message is displayed when an attempt by a user to renew an application has been denied for some reason.
 #: TWLight/applications/views.py:1308
@@ -1047,21 +917,13 @@ msgstr "A tentativa de renovar o aplicativo não aprovado #{pk} foi negada"
 
 #. Translators: If a user requests the renewal of their account, but it wasn't renewed, this message is shown to them.
 #: TWLight/applications/views.py:1385
-msgid ""
-"This object cannot be renewed. (This probably means that you have already "
-"requested that it be renewed.)"
-msgstr ""
-"Este objeto não pode ser renovado. (Isso provavelmente significa que você já "
-"solicitou que seja renovado.)"
+msgid "This object cannot be renewed. (This probably means that you have already requested that it be renewed.)"
+msgstr "Este objeto não pode ser renovado. (Isso provavelmente significa que você já solicitou que seja renovado.)"
 
 #. Translators: If a user requests the renewal of their account, this message is shown to them.
 #: TWLight/applications/views.py:1395
-msgid ""
-"Your renewal request has been received. A coordinator will review your "
-"request."
-msgstr ""
-"Sua solicitação de renovação foi recebida. Um coordenador analisará sua "
-"solicitação."
+msgid "Your renewal request has been received. A coordinator will review your request."
+msgstr "Sua solicitação de renovação foi recebida. Um coordenador analisará sua solicitação."
 
 #. Translators: This labels a textfield where users can enter their email ID.
 #: TWLight/emails/forms.py:18
@@ -1070,12 +932,8 @@ msgstr "Seu e-mail"
 
 #. Translators: This is the help text for the email field in the contact us form letting users know the field is updated by value pulled from their respective user profiles.
 #: TWLight/emails/forms.py:21
-msgid ""
-"This field is automatically updated with the email from your <a class='twl-"
-"links' href='{}'>user profile</a>."
-msgstr ""
-"Este campo é atualizado automaticamente com o e-mail do seu <a class='twl-"
-"links' href='{}'>perfil de usuário</a>."
+msgid "This field is automatically updated with the email from your <a class='twl-links' href='{}'>user profile</a>."
+msgstr "Este campo é atualizado automaticamente com o e-mail do seu <a class='twl-links' href='{}'>perfil de usuário</a>."
 
 #. Translators: This labels a textfield where users can enter their email message.
 #: TWLight/emails/forms.py:26
@@ -1098,26 +956,14 @@ msgstr "Enviar"
 #. Translators: This email is sent to users with their access code. Don't translate Jinja variables in curly braces like user or partner. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/access_code_email-body-html.html:5
 #, python-format
-msgid ""
-"<p>Your approved application to %(partner)s has now been finalised. Your "
-"access code or login details can be found below:</p> <p><b>%(access_code)s</"
-"b></p> <p>%(user_instructions)s</p>"
-msgstr ""
-"<p>A sua candidatura aprovada para o parceiro %(partner)s foi finalizada. O "
-"código de acesso ou detalhes para iniciar sessão podem ser encontrados "
-"abaixo:</p> <p><b>%(access_code)s</b></p> <p>%(user_instructions)s</p>"
+msgid "<p>Your approved application to %(partner)s has now been finalised. Your access code or login details can be found below:</p> <p><b>%(access_code)s</b></p> <p>%(user_instructions)s</p>"
+msgstr "<p>A sua candidatura aprovada para o parceiro %(partner)s foi finalizada. O código de acesso ou detalhes para iniciar sessão podem ser encontrados abaixo:</p> <p><b>%(access_code)s</b></p> <p>%(user_instructions)s</p>"
 
 #. Translators: This email is sent to users with their access code. Don't translate Jinja variables in curly braces like user or partner. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/access_code_email-body-text.html:3
 #, python-format
-msgid ""
-"Your approved application to %(partner)s has now been finalised. Your access "
-"code or login details can be found below: %(access_code)s "
-"%(user_instructions)s"
-msgstr ""
-"A sua candidatura aprovada para o parceiro %(partner)s foi finalizada. O "
-"código de acesso ou detalhes para iniciar sessão podem ser encontrados "
-"abaixo: %(access_code)s %(user_instructions)s"
+msgid "Your approved application to %(partner)s has now been finalised. Your access code or login details can be found below: %(access_code)s %(user_instructions)s"
+msgstr "A sua candidatura aprovada para o parceiro %(partner)s foi finalizada. O código de acesso ou detalhes para iniciar sessão podem ser encontrados abaixo: %(access_code)s %(user_instructions)s"
 
 #. Translators: This is the subject line of an email sent to users with their access code.
 #: TWLight/emails/templates/emails/access_code_email-subject.html:3
@@ -1127,37 +973,14 @@ msgstr "O seu código de acesso à Biblioteca da Wikipédia"
 #. Translators: This email is sent to users when their application is approved. Don't translate Jinja variables in curly braces like user or partner; don't translate html tags either. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/approval_notification-body-html.html:5
 #, python-format
-msgid ""
-"<p>Dear %(user)s,</p> <p>Thank you for applying for access to %(partner)s "
-"resources through The Wikipedia Library. We are happy to inform you that "
-"your application has been approved.</p> <p>%(user_instructions)s</p> <p>You "
-"can view the collections you're authorized to access at My Library: "
-"%(link)s</p> <p>Cheers!</p> <p>The Wikipedia Library</p>"
-msgstr ""
-"<p>{{GENDER:|Caro|Cara|Caro(a)}} %(user)s,</p> <p>agradecemos a sua "
-"candidatura de acesso aos recursos do parceiro %(partner)s através da "
-"Biblioteca da Wikipédia. Temos o prazer de informar que a sua candidatura "
-"foi aprovada.</p> <p>%(user_instructions)s</p> <p>Você pode ver as coleções "
-"às quais você está {{GENDER:|autorizado|autorizado|autorizado(a)}} a acessar "
-"em Minha Biblioteca: %(link)s</p> <p>Divirta-se</p> <p>A Biblioteca da "
-"Wikipédia</p>"
+msgid "<p>Dear %(user)s,</p> <p>Thank you for applying for access to %(partner)s resources through The Wikipedia Library. We are happy to inform you that your application has been approved.</p> <p>%(user_instructions)s</p> <p>You can view the collections you're authorized to access at My Library: %(link)s</p> <p>Cheers!</p> <p>The Wikipedia Library</p>"
+msgstr "<p>{{GENDER:|Caro|Cara|Caro(a)}} %(user)s,</p> <p>agradecemos a sua candidatura de acesso aos recursos do parceiro %(partner)s através da Biblioteca da Wikipédia. Temos o prazer de informar que a sua candidatura foi aprovada.</p> <p>%(user_instructions)s</p> <p>Você pode ver as coleções às quais você está {{GENDER:|autorizado|autorizado|autorizado(a)}} a acessar em Minha Biblioteca: %(link)s</p> <p>Divirta-se</p> <p>A Biblioteca da Wikipédia</p>"
 
 #. Translators: This email is sent to users when their application is approved. Don't translate Jinja variables in curly braces like user or partner. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/approval_notification-body-text.html:3
 #, python-format
-msgid ""
-"Dear %(user)s, Thank you for applying for access to %(partner)s resources "
-"through The Wikipedia Library. We are happy to inform you that your "
-"application has been approved. %(user_instructions)s You can view the "
-"collections you're authorized to access at My Library: %(link)s Cheers! The "
-"Wikipedia Library"
-msgstr ""
-"{{GENDER:|Caro|Cara|Caro(a)}} %(user)s, agradecemos a sua candidatura de "
-"acesso aos recursos do parceiro %(partner)s através da Biblioteca da "
-"Wikipédia. Temos o prazer de informar que a sua candidatura foi aprovada. "
-"%(user_instructions)s Você pode ver as coleções às quais você está {{GENDER:|"
-"autorizado|autorizado|autorizado(a)}} a acessar em Minha Biblioteca: "
-"%(link)s Divirta-se! A Biblioteca da Wikipédia"
+msgid "Dear %(user)s, Thank you for applying for access to %(partner)s resources through The Wikipedia Library. We are happy to inform you that your application has been approved. %(user_instructions)s You can view the collections you're authorized to access at My Library: %(link)s Cheers! The Wikipedia Library"
+msgstr "{{GENDER:|Caro|Cara|Caro(a)}} %(user)s, agradecemos a sua candidatura de acesso aos recursos do parceiro %(partner)s através da Biblioteca da Wikipédia. Temos o prazer de informar que a sua candidatura foi aprovada. %(user_instructions)s Você pode ver as coleções às quais você está {{GENDER:|autorizado|autorizado|autorizado(a)}} a acessar em Minha Biblioteca: %(link)s Divirta-se! A Biblioteca da Wikipédia"
 
 #. Translators: This is the subject of an email which is sent to users when their application has been approved. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/approval_notification-subject.html:4
@@ -1167,58 +990,31 @@ msgstr "Sua candidatura da Biblioteca da Wikipédia foi aprovada"
 #. Translators: This email is sent to coordinators when a comment is left on an application they are processing. Don't translate Jinja variables in curly braces like user or partner. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/comment_notification_coordinator-body-html.html:5
 #, python-format
-msgid ""
-"<p style=\"color: #500050\">%(submit_date)s - %(commenter)s</p> "
-"<blockquote><p>%(comment)s</p></blockquote> <p>Please reply to these at: <a "
-"href=\"%(app_url)s\">%(app_url)s</a></p> <p>Best,</p> <p>The Wikipedia "
-"Library</p>"
-msgstr ""
-"<p style=\"color: #500050\">%(submit_date)s - %(commenter)s</p> "
-"<blockquote><p>%(comment)s</p></blockquote> <p>Responda a estes comentários "
-"em: <a href=\"%(app_url)s\">%(app_url)s</a></p> <p>Cumprimentos,</p> <p>A "
-"Biblioteca da Wikipédia</p>"
+msgid "<p style=\"color: #500050\">%(submit_date)s - %(commenter)s</p> <blockquote><p>%(comment)s</p></blockquote> <p>Please reply to these at: <a href=\"%(app_url)s\">%(app_url)s</a></p> <p>Best,</p> <p>The Wikipedia Library</p>"
+msgstr "<p style=\"color: #500050\">%(submit_date)s - %(commenter)s</p> <blockquote><p>%(comment)s</p></blockquote> <p>Responda a estes comentários em: <a href=\"%(app_url)s\">%(app_url)s</a></p> <p>Cumprimentos,</p> <p>A Biblioteca da Wikipédia</p>"
 
 #. Translators: This email is sent to coordinators when a comment is left on an application they are processing. Don't translate Jinja variables in curly braces like user or partner. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/comment_notification_coordinator-body-text.html:3
 #, python-format
-msgid ""
-"%(submit_date)s - %(commenter)s %(comment)s Please reply to this at: "
-"%(app_url)s Best, The Wikipedia Library"
-msgstr ""
-"%(submit_date)s - %(commenter)s %(comment)s Responda a estes comentários em: "
-"%(app_url)s Cumprimentos, A Biblioteca da Wikipédia"
+msgid "%(submit_date)s - %(commenter)s %(comment)s Please reply to this at: %(app_url)s Best, The Wikipedia Library"
+msgstr "%(submit_date)s - %(commenter)s %(comment)s Responda a estes comentários em: %(app_url)s Cumprimentos, A Biblioteca da Wikipédia"
 
 #. Translators: This is the subject line of an email sent to coordinators when a comment is left on an application they processed.
 #: TWLight/emails/templates/emails/comment_notification_coordinator-subject.html:3
 msgid "New comment on a Wikipedia Library application you processed"
-msgstr ""
-"Novo comentário em uma candidatura da Biblioteca da Wikipedia que você "
-"processou"
+msgstr "Novo comentário em uma candidatura da Biblioteca da Wikipedia que você processou"
 
 #. Translators: This email is sent to users when they receive a comment on their application. Don't translate Jinja variables in curly braces like user or partner; don't translate html tags either. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/comment_notification_editors-body-html.html:5
 #, python-format
-msgid ""
-"<p style=\"color: #500050\">%(submit_date)s - %(commenter)s</p> "
-"<blockquote><p>%(comment)s</p></blockquote> <p>Please reply to these at <a "
-"href=\"%(app_url)s\">%(app_url)s</a> so we can evaluate your application.</"
-"p> <p>Best,</p> <p>The Wikipedia Library</p>"
-msgstr ""
-"<p style=\"color: #500050\">%(submit_date)s - %(commenter)s</p> "
-"<blockquote><p>%(comment)s</p></blockquote> <p>Responda a estes comentários "
-"em <a href=\"%(app_url)s\">%(app_url)s</a> para podermos avaliar a sua "
-"candidatura.</p> <p>Cumprimentos,</p> <p>A Biblioteca da Wikipédia</p>"
+msgid "<p style=\"color: #500050\">%(submit_date)s - %(commenter)s</p> <blockquote><p>%(comment)s</p></blockquote> <p>Please reply to these at <a href=\"%(app_url)s\">%(app_url)s</a> so we can evaluate your application.</p> <p>Best,</p> <p>The Wikipedia Library</p>"
+msgstr "<p style=\"color: #500050\">%(submit_date)s - %(commenter)s</p> <blockquote><p>%(comment)s</p></blockquote> <p>Responda a estes comentários em <a href=\"%(app_url)s\">%(app_url)s</a> para podermos avaliar a sua candidatura.</p> <p>Cumprimentos,</p> <p>A Biblioteca da Wikipédia</p>"
 
 #. Translators: This email is sent to users when they receive a comment on their application. Don't translate Jinja variables in curly braces like user or partner. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/comment_notification_editors-body-text.html:3
 #, python-format
-msgid ""
-"%(submit_date)s - %(commenter)s %(comment)s Please reply to these at: "
-"%(app_url)s so we can evaluate your application. Best, The Wikipedia Library"
-msgstr ""
-"%(submit_date)s - %(commenter)s %(comment)s Responda a estes comentários em: "
-"%(app_url)s para podermos avaliar a sua candidatura. Cumprimentos, A "
-"Biblioteca da Wikipédia"
+msgid "%(submit_date)s - %(commenter)s %(comment)s Please reply to these at: %(app_url)s so we can evaluate your application. Best, The Wikipedia Library"
+msgstr "%(submit_date)s - %(commenter)s %(comment)s Responda a estes comentários em: %(app_url)s para podermos avaliar a sua candidatura. Cumprimentos, A Biblioteca da Wikipédia"
 
 #. Translators: This is the subject line of an email sent to users who have a comment added to one of their applications. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/comment_notification_editors-subject.html:3
@@ -1228,43 +1024,25 @@ msgstr "Novo comentário no seu aplicativo da Biblioteca da Wikipédia"
 #. Translators: This email is sent to users when an application they commented on receives another comment. Don't translate Jinja variables in curly braces like app_url; don't translate html tags either. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/comment_notification_others-body-html.html:5
 #, python-format
-msgid ""
-"<p style=\"color: #500050\">%(submit_date)s - %(commenter)s</p> "
-"<blockquote><p>%(comment)s</p></blockquote> See it at <a href=\"%(app_url)s"
-"\">%(app_url)s</a>. Thanks for helping review Wikipedia Library applications!"
-msgstr ""
-"<p style=\"color: #500050\">%(submit_date)s - %(commenter)s</p> "
-"<blockquote><p>%(comment)s</p></blockquote> Pode vê-lo em <a href="
-"\"%(app_url)s\">%(app_url)s</a>. Obrigado por ajudar a rever as candidaturas "
-"da Biblioteca da Wikipédia!"
+msgid "<p style=\"color: #500050\">%(submit_date)s - %(commenter)s</p> <blockquote><p>%(comment)s</p></blockquote> See it at <a href=\"%(app_url)s\">%(app_url)s</a>. Thanks for helping review Wikipedia Library applications!"
+msgstr "<p style=\"color: #500050\">%(submit_date)s - %(commenter)s</p> <blockquote><p>%(comment)s</p></blockquote> Pode vê-lo em <a href=\"%(app_url)s\">%(app_url)s</a>. Obrigado por ajudar a rever as candidaturas da Biblioteca da Wikipédia!"
 
 #. Translators: This email is sent to users when an application they commented on receives another comment. Don't translate Jinja variables in curly braces like app_url. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/comment_notification_others-body-text.html:3
 #, python-format
-msgid ""
-"%(submit_date)s - %(commenter)s %(comment)s See it at: %(app_url)s Thanks "
-"for helping review Wikipedia Library applications!"
-msgstr ""
-"%(submit_date)s - %(commenter)s %(comment)s Veja em: %(app_url)s Obrigado "
-"por ajudar a analisar os aplicativos da biblioteca da Wikipédia!"
+msgid "%(submit_date)s - %(commenter)s %(comment)s See it at: %(app_url)s Thanks for helping review Wikipedia Library applications!"
+msgstr "%(submit_date)s - %(commenter)s %(comment)s Veja em: %(app_url)s Obrigado por ajudar a analisar os aplicativos da biblioteca da Wikipédia!"
 
 #. Translators: This is the subject line of an email sent to users who have a comment added to an application they also commented on. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/comment_notification_others-subject.html:4
 msgid "New comment on a Wikipedia Library application you commented on"
-msgstr ""
-"Novo comentário em uma candidatura da Biblioteca da Wikipédia que você "
-"comentou"
+msgstr "Novo comentário em uma candidatura da Biblioteca da Wikipédia que você comentou"
 
 #. Translators: This text is part of a scheduled reminder email sent to coordinators who have applications requiring action. Don't translate Jinja variables in curly braces like total_apps, or user.
 #: TWLight/emails/templates/emails/coordinator_reminder_notification-body-html.html:5
 #, python-format
-msgid ""
-"<p>Dear %(user)s,</p> <p>Our records indicate that you are the designated "
-"coordinator for partners that have a total of %(total_apps)s applications.</"
-"p>"
-msgstr ""
-"<p>Caro(a) %(user)s,</p> <p>Os nossos registos indicam que é o coordenador "
-"designado para parceiros que têm um total de %(total_apps)s candidaturas.</p>"
+msgid "<p>Dear %(user)s,</p> <p>Our records indicate that you are the designated coordinator for partners that have a total of %(total_apps)s applications.</p>"
+msgstr "<p>Caro(a) %(user)s,</p> <p>Os nossos registos indicam que é o coordenador designado para parceiros que têm um total de %(total_apps)s candidaturas.</p>"
 
 #. Translators: Breakdown as in 'cost breakdown'; analysis.
 #: TWLight/emails/templates/emails/coordinator_reminder_notification-body-html.html:11
@@ -1302,43 +1080,20 @@ msgstr[1] "%(counter)s candidaturas aprovadas."
 #. Translators: This text is part of a scheduled reminder email sent to coordinators who have applications requiring action. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library). Don't translate Jinja variables in curly braces like link; don't translate email addresses or html tags either.
 #: TWLight/emails/templates/emails/coordinator_reminder_notification-body-html.html:39
 #, python-format
-msgid ""
-"<p>This is a gentle reminder that you may review applications at <a href="
-"\"%(link)s\">%(link)s</a>.</p> <p>You can customise your reminders under "
-"'preferences' in your user profile.</p> <p>If you received this message in "
-"error, drop us a line at wikipedialibrary@wikimedia.org.</p> <p>Thanks for "
-"helping review Wikipedia Library applications!</p>"
-msgstr ""
-"<p>Relembramos que pode rever candidaturas em <a href=\"%(link)s\">%(link)s</"
-"a>.</p> <p>Pode personalizar os avisos em 'preferências' no seu perfil de "
-"usuário.</p> <p>Se recebeu esta mensagem em erro, contacte-nos em "
-"wikipedialibrary@wikimedia.org.</p> <p>Obrigado por ajudar a rever as "
-"candidaturas da Biblioteca da Wikipédia!</p>"
+msgid "<p>This is a gentle reminder that you may review applications at <a href=\"%(link)s\">%(link)s</a>.</p> <p>You can customise your reminders under 'preferences' in your user profile.</p> <p>If you received this message in error, drop us a line at wikipedialibrary@wikimedia.org.</p> <p>Thanks for helping review Wikipedia Library applications!</p>"
+msgstr "<p>Relembramos que pode rever candidaturas em <a href=\"%(link)s\">%(link)s</a>.</p> <p>Pode personalizar os avisos em 'preferências' no seu perfil de usuário.</p> <p>Se recebeu esta mensagem em erro, contacte-nos em wikipedialibrary@wikimedia.org.</p> <p>Obrigado por ajudar a rever as candidaturas da Biblioteca da Wikipédia!</p>"
 
 #. Translators: This text is part of a scheduled reminder email sent to coordinators who have applications requiring action. Don't translate Jinja variables in curly braces like total_apps, or user.
 #: TWLight/emails/templates/emails/coordinator_reminder_notification-body-text.html:3
 #, python-format
-msgid ""
-"Dear %(user)s, Our records indicate that you are the designated coordinator "
-"for partners that have a total of %(total_apps)s applications."
-msgstr ""
-"Caro(a) %(user)s, Os nossos registos indicam que é o coordenador designado "
-"para parceiros que têm um total de %(total_apps)s candidaturas."
+msgid "Dear %(user)s, Our records indicate that you are the designated coordinator for partners that have a total of %(total_apps)s applications."
+msgstr "Caro(a) %(user)s, Os nossos registos indicam que é o coordenador designado para parceiros que têm um total de %(total_apps)s candidaturas."
 
 #. Translators: This text is part of a scheduled reminder email sent to coordinators who have applications requiring action. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library). Don't translate Jinja variables in curly braces like link; don't translate the email address either.
 #: TWLight/emails/templates/emails/coordinator_reminder_notification-body-text.html:38
 #, python-format
-msgid ""
-"This is a gentle reminder that you may review applications at: %(link)s. You "
-"can customise your reminders under 'preferences' in your user profile. If "
-"you received this message in error, drop us a line at: "
-"wikipedialibrary@wikimedia.org Thanks for helping review Wikipedia Library "
-"applications!"
-msgstr ""
-"Relembramos que pode rever candidaturas em: %(link)s. Pode personalizar os "
-"avisos em 'preferências' no seu perfil de usuário. Se recebeu esta mensagem "
-"em erro, contacte-nos em: wikipedialibrary@wikimedia.org Obrigado por ajudar "
-"a rever as candidaturas da Biblioteca da Wikipédia!"
+msgid "This is a gentle reminder that you may review applications at: %(link)s. You can customise your reminders under 'preferences' in your user profile. If you received this message in error, drop us a line at: wikipedialibrary@wikimedia.org Thanks for helping review Wikipedia Library applications!"
+msgstr "Relembramos que pode rever candidaturas em: %(link)s. Pode personalizar os avisos em 'preferências' no seu perfil de usuário. Se recebeu esta mensagem em erro, contacte-nos em: wikipedialibrary@wikimedia.org Obrigado por ajudar a rever as candidaturas da Biblioteca da Wikipédia!"
 
 #. Translators: This is the subject line of a scheduled reminder email sent to coordinators who have applications to review. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library). Do not translate items in curly braces.
 #: TWLight/emails/templates/emails/coordinator_reminder_notification-subject.html:4
@@ -1348,33 +1103,14 @@ msgstr "As candidaturas da Biblioteca da Wikipédia aguardam seu comentário"
 #. Translators: This email is sent to users when their application is rejected. Don't translate Jinja variables in curly braces like user or partner; don't translate html tags either. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/rejection_notification-body-html.html:5
 #, python-format
-msgid ""
-"<p>Dear %(user)s,</p> <p>Thank you for applying for access to %(partner)s "
-"resources through The Wikipedia Library. Unfortunately at this time your "
-"application has not been approved. You can view your application and review "
-"comments at <a href=\"%(app_url)s\">%(app_url)s</a>.</p> <p>Best,</p> <p>The "
-"Wikipedia Library</p>"
-msgstr ""
-"<p>Caro %(user)s,</p> <p>Obrigado por solicitar acesso aos recursos do "
-"%(partner)s através da Biblioteca da Wikipédia. Infelizmente, neste momento, "
-"sua inscrição não foi aprovada. Você pode ver sua candidatura e revisar "
-"comentários em <a href=\"%(app_url)s\">%(app_url)s</a>.</p> <p>Obrigado,</p> "
-"<p>A Biblioteca da Wikipedia</p>"
+msgid "<p>Dear %(user)s,</p> <p>Thank you for applying for access to %(partner)s resources through The Wikipedia Library. Unfortunately at this time your application has not been approved. You can view your application and review comments at <a href=\"%(app_url)s\">%(app_url)s</a>.</p> <p>Best,</p> <p>The Wikipedia Library</p>"
+msgstr "<p>Caro %(user)s,</p> <p>Obrigado por solicitar acesso aos recursos do %(partner)s através da Biblioteca da Wikipédia. Infelizmente, neste momento, sua inscrição não foi aprovada. Você pode ver sua candidatura e revisar comentários em <a href=\"%(app_url)s\">%(app_url)s</a>.</p> <p>Obrigado,</p> <p>A Biblioteca da Wikipedia</p>"
 
 #. Translators: This email is sent to users when their application is rejected. Don't translate Jinja variables in curly braces like user or partner. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/rejection_notification-body-text.html:3
 #, python-format
-msgid ""
-"Dear %(user)s, Thank you for applying for access to %(partner)s resources "
-"through The Wikipedia Library. Unfortunately at this time your application "
-"has not been approved. You can view your application and review comments at: "
-"%(app_url)s Best, The Wikipedia Library"
-msgstr ""
-"Caro %(user)s, Obrigado por solicitar acesso a %(partner)s recursos através "
-"da Biblioteca da Wikipédia. Infelizmente, neste momento, sua inscrição não "
-"foi\n"
-"aprovado. Você pode visualizar seu aplicativo e revisar comentários em: "
-"%(app_url)s Obrigado, A Biblioteca da Wikipedia"
+msgid "Dear %(user)s, Thank you for applying for access to %(partner)s resources through The Wikipedia Library. Unfortunately at this time your application has not been approved. You can view your application and review comments at: %(app_url)s Best, The Wikipedia Library"
+msgstr "Caro %(user)s, Obrigado por solicitar acesso a %(partner)s recursos através da Biblioteca da Wikipédia. Infelizmente, neste momento, sua inscrição não foi\naprovado. Você pode visualizar seu aplicativo e revisar comentários em: %(app_url)s Obrigado, A Biblioteca da Wikipedia"
 
 #. Translators: This is the subject of an email which is sent to users when their application has been rejected. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/rejection_notification-subject.html:4
@@ -1384,39 +1120,14 @@ msgstr "Sua candidatura da biblioteca da Wikipédia"
 #. Translators: This email is sent to users when they have an account that is soon to expire. Don't translate Jinja variables in curly braces like partner_name or partner_link; don't translate html tags either. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/user_renewal_notice-body-html.html:5
 #, python-format
-msgid ""
-"<p>Dear %(user)s,</p> <p>According to our records, your access to "
-"%(partner_name)s will soon expire and you may lose access. If you want to "
-"continue making use of your free account, you can request renewal of your "
-"account by clicking the 'Renew' or 'Extend' button at %(partner_link)s.</p> "
-"<p>Best,</p> <p>The Wikipedia Library</p> <p>You can disable these emails in "
-"your user page preferences: https://wikipedialibrary.wmflabs.org/users/</p>"
-msgstr ""
-"<p>Caro(a) %(user)s,</p> <p>De acordo com os nossos registos, o seu acesso "
-"aos recursos do parceiro %(partner_name)s expirará em breve e poderá perdê-"
-"lo. Se quiser continuar a usar a sua conta gratuita, pode pedir a renovação "
-"da mesma clicando o botão 'Renovar' ou 'Ampliar' em %(partner_link)s.</p> "
-"<p>Cumprimentos,</p> <p>A Biblioteca da Wikipédia</p> <p>Pode desativar "
-"estas mensagens nas preferências da sua página de utilizador: https://"
-"wikipedialibrary.wmflabs.org/users/</p>"
+msgid "<p>Dear %(user)s,</p> <p>According to our records, your access to %(partner_name)s will soon expire and you may lose access. If you want to continue making use of your free account, you can request renewal of your account by clicking the 'Renew' or 'Extend' button at %(partner_link)s.</p> <p>Best,</p> <p>The Wikipedia Library</p> <p>You can disable these emails in your user page preferences: https://wikipedialibrary.wmflabs.org/users/</p>"
+msgstr "<p>Caro(a) %(user)s,</p> <p>De acordo com os nossos registos, o seu acesso aos recursos do parceiro %(partner_name)s expirará em breve e poderá perdê-lo. Se quiser continuar a usar a sua conta gratuita, pode pedir a renovação da mesma clicando o botão 'Renovar' ou 'Ampliar' em %(partner_link)s.</p> <p>Cumprimentos,</p> <p>A Biblioteca da Wikipédia</p> <p>Pode desativar estas mensagens nas preferências da sua página de utilizador: https://wikipedialibrary.wmflabs.org/users/</p>"
 
 #. Translators: This email is sent to users when they have an account that is soon to expire. Don't translate Jinja variables in curly braces like partner_name or partner_link; don't translate html tags either. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/user_renewal_notice-body-text.html:3
 #, python-format
-msgid ""
-"Dear %(user)s, According to our records, your access to %(partner_name)s "
-"will soon expire and you may lose access. If you want to continue making use "
-"of your free account, you can request renewal of your account by clicking "
-"the Renew button at %(partner_link)s. Best, The Wikipedia Library You can "
-"disable these emails in your user page preferences: https://wikipedialibrary."
-"wmflabs.org/users/"
-msgstr ""
-"Caro(a) %(user)s, De acordo com os nossos registos, o seu acesso aos "
-"recursos do parceiro %(partner_name)s expirará em breve e poderá perdê-lo. "
-"Se quiser continuar a usar a sua conta gratuita, pode pedir a renovação da "
-"mesma clicando o botão Renovar em %(partner_link)s. Cumprimentos, A "
-"Biblioteca da Wikipédia Pode desativar estas mensagens nas preferências da "
-"sua página de utilizador: https://wikipedialibrary.wmflabs.org/users/"
+msgid "Dear %(user)s, According to our records, your access to %(partner_name)s will soon expire and you may lose access. If you want to continue making use of your free account, you can request renewal of your account by clicking the Renew button at %(partner_link)s. Best, The Wikipedia Library You can disable these emails in your user page preferences: https://wikipedialibrary.wmflabs.org/users/"
+msgstr "Caro(a) %(user)s, De acordo com os nossos registos, o seu acesso aos recursos do parceiro %(partner_name)s expirará em breve e poderá perdê-lo. Se quiser continuar a usar a sua conta gratuita, pode pedir a renovação da mesma clicando o botão Renovar em %(partner_link)s. Cumprimentos, A Biblioteca da Wikipédia Pode desativar estas mensagens nas preferências da sua página de utilizador: https://wikipedialibrary.wmflabs.org/users/"
 
 #. Translators: This is the subject of an email sent to users when they have an account that is soon to expire. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/user_renewal_notice-subject.html:4
@@ -1426,43 +1137,19 @@ msgstr "Seu acesso à Biblioteca da Wikipédia pode expirar em breve"
 #. Translators: This email is sent to users when their application is waitlisted because there are no more accounts available. Don't translate Jinja variables in curly braces like user or partner; don't translate html tags either. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/waitlist_notification-body-html.html:5
 #, python-format
-msgid ""
-"<p>Dear %(user)s,</p> <p>Thank you for applying for access to %(partner)s "
-"resources through The Wikipedia Library. There are no accounts currently "
-"available so your application has been waitlisted. Your application will be "
-"evaluated if/when more accounts become available. You can see all available "
-"resources at <a href=\"%(link)s\">%(link)s</a>.</p> <p>Best,</p> <p>The "
-"Wikipedia Library</p>"
-msgstr ""
-"<p>Caro %(user)s,</p> <p>Obrigado por solicitar acesso a recurso do "
-"%(partner)s através da Biblioteca da Wikipedia. Não há contas disponíveis no "
-"momento para que seu aplicativo esteja na lista de espera. Sua inscrição "
-"será avaliada se/quando mais contas forem disponibilizadas. Você pode ver "
-"todos os recursos disponíveis em <a href=\"%(link)s\">%(link)s</a>.</p> "
-"<p>Obrigado,</p> <p>A Biblioteca da Wikipedia</p>"
+msgid "<p>Dear %(user)s,</p> <p>Thank you for applying for access to %(partner)s resources through The Wikipedia Library. There are no accounts currently available so your application has been waitlisted. Your application will be evaluated if/when more accounts become available. You can see all available resources at <a href=\"%(link)s\">%(link)s</a>.</p> <p>Best,</p> <p>The Wikipedia Library</p>"
+msgstr "<p>Caro %(user)s,</p> <p>Obrigado por solicitar acesso a recurso do %(partner)s através da Biblioteca da Wikipedia. Não há contas disponíveis no momento para que seu aplicativo esteja na lista de espera. Sua inscrição será avaliada se/quando mais contas forem disponibilizadas. Você pode ver todos os recursos disponíveis em <a href=\"%(link)s\">%(link)s</a>.</p> <p>Obrigado,</p> <p>A Biblioteca da Wikipedia</p>"
 
 #. Translators: This email is sent to users when their application is waitlisted because there are no more accounts available. Don't translate Jinja variables in curly braces like user or partner. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/waitlist_notification-body-text.html:3
 #, python-format
-msgid ""
-"Dear %(user)s, Thank you for applying for access to %(partner)s resources "
-"through The Wikipedia Library. There are no accounts currently available so "
-"your application has been waitlisted. Your application will be evaluated if/"
-"when more accounts become available. You can see all available resources at: "
-"%(link)s Best, The Wikipedia Library"
-msgstr ""
-"Caro(a) %(user)s, Agradecemos a sua candidatura de acesso aos recursos do "
-"parceiro %(partner)s através da Biblioteca da Wikipédia. Neste momento não "
-"há nenhuma conta disponível, por isso a sua candidatura foi colocada em "
-"lista de espera. A candidatura será avaliada quando houverem contas "
-"disponíveis. Pode ver todos os recursos disponíveis em: %(link)s "
-"Cumprimentos, A Biblioteca da Wikipédia"
+msgid "Dear %(user)s, Thank you for applying for access to %(partner)s resources through The Wikipedia Library. There are no accounts currently available so your application has been waitlisted. Your application will be evaluated if/when more accounts become available. You can see all available resources at: %(link)s Best, The Wikipedia Library"
+msgstr "Caro(a) %(user)s, Agradecemos a sua candidatura de acesso aos recursos do parceiro %(partner)s através da Biblioteca da Wikipédia. Neste momento não há nenhuma conta disponível, por isso a sua candidatura foi colocada em lista de espera. A candidatura será avaliada quando houverem contas disponíveis. Pode ver todos os recursos disponíveis em: %(link)s Cumprimentos, A Biblioteca da Wikipédia"
 
 #. Translators: This is the subject of an email sent to users when their application is waitlisted because there are no more accounts available. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/waitlist_notification-subject.html:4
 msgid "Your Wikipedia Library application has been waitlisted"
-msgstr ""
-"Sua candidatura da Biblioteca da Wikipédia foi colocado na lista de espera"
+msgstr "Sua candidatura da Biblioteca da Wikipédia foi colocado na lista de espera"
 
 #. Translators: Shown to users when they successfully submit a new message using the contact us form.
 #: TWLight/emails/views.py:51
@@ -1618,22 +1305,15 @@ msgstr "Indisponível"
 #: TWLight/resources/templates/resources/filter_section.html:14
 #: TWLight/templates/about.html:12
 #: TWLight/users/templates/users/filter_section.html:13
-msgid ""
-"The Wikipedia Library allows active editors to access a wide range of "
-"collections of paywalled reliable sources for free!"
-msgstr ""
-"A Biblioteca da Wikipédia permite que editores ativos acessem gratuitamente "
-"uma ampla gama de coleções de fontes confiáveis pagas!"
+msgid "The Wikipedia Library allows active editors to access a wide range of collections of paywalled reliable sources for free!"
+msgstr "A Biblioteca da Wikipédia permite que editores ativos acessem gratuitamente uma ampla gama de coleções de fontes confiáveis pagas!"
 
 #. Translators: On the Browse Partners page (https://wikipedialibrary.wmflabs.org/partners/), this introduces users to The Wikipedia Library.
 #. Translators: On the MyLibrary page (https://wikipedialibrary.wmflabs.org/users/my_library), this introduces users to The Wikipedia Library.
 #: TWLight/resources/templates/resources/filter_section.html:17
 #: TWLight/users/templates/users/filter_section.html:15
-msgid ""
-"Start with the search bar at the top or browse publisher websites directly."
-msgstr ""
-"Comece pela barra de busca no topo ou navegue pelos sites das editoras "
-"diretamente."
+msgid "Start with the search bar at the top or browse publisher websites directly."
+msgstr "Comece pela barra de busca no topo ou navegue pelos sites das editoras diretamente."
 
 #. Translators: On the Browse Partners page (https://wikipedialibrary.wmflabs.org/partners/), this appears below introductory text and links to the 'About' page (https://wikipedialibrary.wmflabs.org/about/)
 #. Translators: On the MyLibrary page (https://wikipedialibrary.wmflabs.org/users/my_library), this appears below introductory text and links to the 'About' page (https://wikipedialibrary.wmflabs.org/about/)
@@ -1706,68 +1386,39 @@ msgstr "Voltar para parceiros"
 #. Translators: If we have no available accounts for a partner, the coordinator can change the application system to a waiting list.
 #: TWLight/resources/templates/resources/partner_detail.html:36
 #: TWLight/resources/templates/resources/partner_detail_apply.html:17
-msgid ""
-"There are no access grants available for this partner at this time. You can "
-"still apply for access; applications will be processed when access is "
-"available."
-msgstr ""
-"Não há concessões de acesso disponíveis para esse parceiro no momento. Você "
-"ainda pode solicitar acesso; os aplicativos serão processados quando o "
-"acesso estiver disponível."
+msgid "There are no access grants available for this partner at this time. You can still apply for access; applications will be processed when access is available."
+msgstr "Não há concessões de acesso disponíveis para esse parceiro no momento. Você ainda pode solicitar acesso; os aplicativos serão processados quando o acesso estiver disponível."
 
 #. Translators: This text links to the minimum user requirements and terms of use on the partner page.
 #: TWLight/resources/templates/resources/partner_detail.html:48
 #: TWLight/resources/templates/resources/partner_detail_apply.html:29
 #, python-format
-msgid ""
-"Before applying, please review the <strong><a class=\"twl-links\" href="
-"\"%(about)s#req\">minimum requirements</a></strong> for access and our "
-"<strong><a class=\"twl-links\" href=\"%(terms)s\">terms of use</a></strong>."
-msgstr ""
-"Antes de se candidatar, leia os <strong><a class=\"twl-links\" href="
-"\"%(about)s#req\">requisitos mínimos</a></strong> para acesso e as nossas "
-"<strong><a class=\"twl-links\" href=\"%(terms)s\">condições de utilização</"
-"a></strong>, por favor."
+msgid "Before applying, please review the <strong><a class=\"twl-links\" href=\"%(about)s#req\">minimum requirements</a></strong> for access and our <strong><a class=\"twl-links\" href=\"%(terms)s\">terms of use</a></strong>."
+msgstr "Antes de se candidatar, leia os <strong><a class=\"twl-links\" href=\"%(about)s#req\">requisitos mínimos</a></strong> para acesso e as nossas <strong><a class=\"twl-links\" href=\"%(terms)s\">condições de utilização</a></strong>, por favor."
 
 #. Translators: This text refers to the page containing the content a user is authorized to access.
 #: TWLight/resources/templates/resources/partner_detail.html:69
 #, python-format
-msgid ""
-"View the status of your access in <strong><a class=\"twl-links\" href="
-"\"%(library_url)s\">My Library</a></strong> page."
-msgstr ""
-"Veja seus status de acesso na página <strong><a class=\"twl-links\" href="
-"\"%(library_url)s\">Minha biblioteca</a></strong>."
+msgid "View the status of your access in <strong><a class=\"twl-links\" href=\"%(library_url)s\">My Library</a></strong> page."
+msgstr "Veja seus status de acesso na página <strong><a class=\"twl-links\" href=\"%(library_url)s\">Minha biblioteca</a></strong>."
 
 #. Translators: This message is shown when a user has open applications, linking to their respective applications page.
 #: TWLight/resources/templates/resources/partner_detail.html:78
 #, python-format
-msgid ""
-"View the status of your application(s) on your <strong><a class=\"twl-links"
-"\" href=\"%(applications_url)s\">My Applications</a></strong> page."
-msgstr ""
-"Veja o status dos seus aplicativos em sua página <strong><a class=\"twl-links"
-"\" href=\"%(applications_url)s\">Meus aplicativos</a></strong>."
+msgid "View the status of your application(s) on your <strong><a class=\"twl-links\" href=\"%(applications_url)s\">My Applications</a></strong> page."
+msgstr "Veja o status dos seus aplicativos em sua página <strong><a class=\"twl-links\" href=\"%(applications_url)s\">Meus aplicativos</a></strong>."
 
 #. Translators: This message is shown when a user has authorizations, linking to their respective collections page.
 #: TWLight/resources/templates/resources/partner_detail_apply.html:50
 #, python-format
-msgid ""
-"View the status of your access on your <strong><a href=\"%(library_url)s\" "
-"class=\"twl-links\">My Library</a></strong> page."
-msgstr ""
-"Veja seu status de acesso na página <strong><a href=\"%(library_url)s"
-"\">Minha biblioteca</a></strong>."
+msgid "View the status of your access on your <strong><a href=\"%(library_url)s\" class=\"twl-links\">My Library</a></strong> page."
+msgstr "Veja seu status de acesso na página <strong><a href=\"%(library_url)s\">Minha biblioteca</a></strong>."
 
 #. Translators: This message is shown when a user has open applications, linking to their respective applications page.
 #: TWLight/resources/templates/resources/partner_detail_apply.html:60
 #, python-format
-msgid ""
-"View the status of your application(s) on your <strong><a href="
-"\"%(applications_url)s\">My Applications</a></strong> page."
-msgstr ""
-"Veja o status dos seus aplicativos em sua página <strong><a href="
-"\"%(applications_url)s\">Meus aplicativos</a></strong>."
+msgid "View the status of your application(s) on your <strong><a href=\"%(applications_url)s\">My Applications</a></strong> page."
+msgstr "Veja o status dos seus aplicativos em sua página <strong><a href=\"%(applications_url)s\">Meus aplicativos</a></strong>."
 
 #. Translators: One the partner detail page, this text labels the button which coordinators can click to remove a partner from waitlisted status.
 #: TWLight/resources/templates/resources/partner_detail_apply.html:73
@@ -1782,8 +1433,7 @@ msgstr "Definir como em lista de espera"
 #: TWLight/resources/templates/resources/partner_detail_apply.html:86
 #, python-format
 msgid "<strong>%(coordinator)s</strong> processes applications to %(partner)s."
-msgstr ""
-"<strong>%(coordinator)s</strong> processa candidaturas para %(partner)s."
+msgstr "<strong>%(coordinator)s</strong> processa candidaturas para %(partner)s."
 
 #. Translators: When a coordinator is assigned to a partner, their details are shown on the page. This text labels a link to their Talk page on Wikipedia, and should be translated to the text used for Talk pages in the language you are translating to.
 #: TWLight/resources/templates/resources/partner_detail_apply.html:95
@@ -1797,15 +1447,8 @@ msgstr "Enviar um e-mail ao usuário"
 
 #. Translators: If no account coordinator is assigned to a partner, the Wikipedia Library team will coordinate signups. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/resources/templates/resources/partner_detail_apply.html:112
-msgid ""
-"The Wikipedia Library team will process this application. Want to help? <a "
-"class=\"twl-links\" href=\"https://en.wikipedia.org/wiki/Wikipedia:"
-"The_Wikipedia_Library/Coordinators/Signup\">Sign up as a coordinator.</a>"
-msgstr ""
-"A equipe da Biblioteca da Wikipédia processará esta candidatura. Quer "
-"ajudar? <a class=\"twl-links\" href=\"https://en.wikipedia.org/wiki/"
-"Wikipedia:The_Wikipedia_Library/Coordinators/Signup\">Inscreva-se como "
-"coordenador.</a>"
+msgid "The Wikipedia Library team will process this application. Want to help? <a class=\"twl-links\" href=\"https://en.wikipedia.org/wiki/Wikipedia:The_Wikipedia_Library/Coordinators/Signup\">Sign up as a coordinator.</a>"
+msgstr "A equipe da Biblioteca da Wikipédia processará esta candidatura. Quer ajudar? <a class=\"twl-links\" href=\"https://en.wikipedia.org/wiki/Wikipedia:The_Wikipedia_Library/Coordinators/Signup\">Inscreva-se como coordenador.</a>"
 
 #. Translators: This text labels a button coordinators can click to view a list of users who have applied for access for a particular partner
 #: TWLight/resources/templates/resources/partner_detail_apply.html:121
@@ -1834,24 +1477,14 @@ msgstr "Acesso ao pacote da biblioteca"
 
 #. Translators: Text shown to authenticated, bundle eligible users when they visit a Bundle partner page.
 #: TWLight/resources/templates/resources/partner_detail_apply.html:138
-msgid ""
-"You are eligible to access Library Bundle partners. Click the button above "
-"to access the collection."
-msgstr ""
-"Você está qualificado para acessar os parceiros do pacote de bibliotecas. "
-"Clique no botão acima para acessar a coleção."
+msgid "You are eligible to access Library Bundle partners. Click the button above to access the collection."
+msgstr "Você está qualificado para acessar os parceiros do pacote de bibliotecas. Clique no botão acima para acessar a coleção."
 
 #. Translators: Text shown to authenticated, bundle ineligible users when they visit a Bundle partner page.
 #: TWLight/resources/templates/resources/partner_detail_apply.html:152
 #, python-format
-msgid ""
-"You are not eligible to access Library Bundle partners. Visit the <a class="
-"\"twl-links\" href=\"%(homepage)s\">homepage</a> to check the eligibility "
-"criteria."
-msgstr ""
-"Você não está qualificado para acessar os parceiros do pacote de "
-"bibliotecas. Visite a <a class=\"twl-links\" href=\"%(homepage)s\">página "
-"inicial</a> para verificar os critérios de elegibilidade."
+msgid "You are not eligible to access Library Bundle partners. Visit the <a class=\"twl-links\" href=\"%(homepage)s\">homepage</a> to check the eligibility criteria."
+msgstr "Você não está qualificado para acessar os parceiros do pacote de bibliotecas. Visite a <a class=\"twl-links\" href=\"%(homepage)s\">página inicial</a> para verificar os critérios de elegibilidade."
 
 #. Translators: Buttton prompting users to log in.
 #: TWLight/resources/templates/resources/partner_detail_apply.html:160
@@ -1862,14 +1495,8 @@ msgstr "Entrar"
 #. Translators: Text shown to unauthenticated users when they visit a Bundle partner page.
 #: TWLight/resources/templates/resources/partner_detail_apply.html:168
 #, python-format
-msgid ""
-"This resource is part of our <a class=\"twl-links\" href=\"%(about)s"
-"\">Library Bundle</a>, which you can access if you meet our minimum "
-"eligibility criteria. Log in to find out if you are eligible."
-msgstr ""
-"Esse recurso faz parte do nosso <a class=\"twl-links\" href=\"%(about)s"
-"\">pacote de biblioteca</a>, que você pode acessar se cumprir nossos "
-"critérios mínimos de qualificação. Entre para descobrir se você é elegível."
+msgid "This resource is part of our <a class=\"twl-links\" href=\"%(about)s\">Library Bundle</a>, which you can access if you meet our minimum eligibility criteria. Log in to find out if you are eligible."
+msgstr "Esse recurso faz parte do nosso <a class=\"twl-links\" href=\"%(about)s\">pacote de biblioteca</a>, que você pode acessar se cumprir nossos critérios mínimos de qualificação. Entre para descobrir se você é elegível."
 
 #. Translators: This is the label for a number which shows the total active accounts for one partner. (e.g. https://wikipedialibrary.wmflabs.org/partners/8/).
 #: TWLight/resources/templates/resources/partner_detail_stats.html:21
@@ -1919,34 +1546,20 @@ msgstr "Limite de trecho"
 #. Translators: If a partner has specified the excerpt limit both in words and percentage, this message will display the percentage of words and the number of words on the partner page.
 #: TWLight/resources/templates/resources/partner_detail_timeline.html:99
 #, python-format
-msgid ""
-"%(object)s allows a maximum of %(excerpt_limit)s words or "
-"%(excerpt_limit_percentage)s%% of an article be excerpted into a Wikipedia "
-"article."
-msgstr ""
-"%(object)s permite um máximo de %(excerpt_limit)s palavras ou "
-"%(excerpt_limit_percentage)s%% de um artigo seja extraído em um artigo da "
-"Wikipedia."
+msgid "%(object)s allows a maximum of %(excerpt_limit)s words or %(excerpt_limit_percentage)s%% of an article be excerpted into a Wikipedia article."
+msgstr "%(object)s permite um máximo de %(excerpt_limit)s palavras ou %(excerpt_limit_percentage)s%% de um artigo seja extraído em um artigo da Wikipedia."
 
 #. Translators: If a partner has specified the excerpt limit in words, this message will display the number of words on the partner page.
 #: TWLight/resources/templates/resources/partner_detail_timeline.html:106
 #, python-format
-msgid ""
-"%(object)s allows a maximum of %(excerpt_limit)s words be excerpted into a "
-"Wikipedia article."
-msgstr ""
-"%(object)s permite um máximo de %(excerpt_limit)s palavras ser extraídas em "
-"um artigo da Wikipedia."
+msgid "%(object)s allows a maximum of %(excerpt_limit)s words be excerpted into a Wikipedia article."
+msgstr "%(object)s permite um máximo de %(excerpt_limit)s palavras ser extraídas em um artigo da Wikipedia."
 
 #. Translators: If a partner has specified the excerpt limit in percentage, this message will display the percentage of words on the partner page.
 #: TWLight/resources/templates/resources/partner_detail_timeline.html:113
 #, python-format
-msgid ""
-"%(object)s allows a maximum of %(excerpt_limit_percentage)s%% of an article "
-"be excerpted into a Wikipedia article."
-msgstr ""
-"%(object)s permite um máximo de %(excerpt_limit_percentage)s%% de um artigo "
-"seja extraído em um artigo da Wikipedia."
+msgid "%(object)s allows a maximum of %(excerpt_limit_percentage)s%% of an article be excerpted into a Wikipedia article."
+msgstr "%(object)s permite um máximo de %(excerpt_limit_percentage)s%% de um artigo seja extraído em um artigo da Wikipedia."
 
 #. Translators: If a partner has other requirements for access, this text shows as the title for that information field. (e.g. https://wikipedialibrary.wmflabs.org/partners/10/).
 #: TWLight/resources/templates/resources/partner_detail_timeline.html:132
@@ -1956,12 +1569,8 @@ msgstr "Requisitos especiais para candidatos"
 #. Translators: If a user must agree to a Terms of Use document, they see this message, and must enter the name of the resource. Don't translate publisher or url.
 #: TWLight/resources/templates/resources/partner_detail_timeline.html:140
 #, python-format
-msgid ""
-"%(publisher)s requires that you agree with its <a href=\"%(url)s\">terms of "
-"use</a>."
-msgstr ""
-"%(publisher)s exige que você concorde com o seu <a href=\"%(url)s\">termos "
-"de uso</a>."
+msgid "%(publisher)s requires that you agree with its <a href=\"%(url)s\">terms of use</a>."
+msgstr "%(publisher)s exige que você concorde com o seu <a href=\"%(url)s\">termos de uso</a>."
 
 #. Translators: If a user must provide their real name to apply to a partner, they see this message, and must enter the name of the resource. Don't translate publisher.
 #: TWLight/resources/templates/resources/partner_detail_timeline.html:150
@@ -1984,22 +1593,14 @@ msgstr "%(publisher)s exige que você forneça sua afiliação institucional."
 #. Translators: If a user must select a specific resource to apply for, they see this message, and must enter the name of the resource. Don't translate publisher.
 #: TWLight/resources/templates/resources/partner_detail_timeline.html:177
 #, python-format
-msgid ""
-"%(publisher)s requires that you specify a particular title that you want to "
-"access."
-msgstr ""
-"%(publisher)s requer que você especifique um título específico que deseja "
-"acessar."
+msgid "%(publisher)s requires that you specify a particular title that you want to access."
+msgstr "%(publisher)s requer que você especifique um título específico que deseja acessar."
 
 #. Translators: If a user must register on the partner website before applying, they see this message. Don't translate partner.
 #: TWLight/resources/templates/resources/partner_detail_timeline.html:187
 #, python-format
-msgid ""
-"%(publisher)s requires that you sign up for an account before applying for "
-"access."
-msgstr ""
-"%(publisher)s exige que você se inscreva em uma conta antes de solicitar "
-"acesso."
+msgid "%(publisher)s requires that you sign up for an account before applying for access."
+msgstr "%(publisher)s exige que você se inscreva em uma conta antes de solicitar acesso."
 
 #. Translators: If a partner has their location listed, this message is a label for that location
 #: TWLight/resources/templates/resources/partner_detail_timeline.html:206
@@ -2125,12 +1726,8 @@ msgstr "Tem certeza de que deseja excluir <b>%(object)s</b>?"
 
 #. Translators: If multiple authorizations where returned for a collection, this message is shown to a user
 #: TWLight/resources/views.py:268
-msgid ""
-"Multiple authorizations were returned – something's wrong. Please contact us "
-"and don't forget to mention this message."
-msgstr ""
-"Várias autorizações foram retornadas - algo está errado. Entre em contato "
-"conosco e não esqueça de mencionar esta mensagem."
+msgid "Multiple authorizations were returned – something's wrong. Please contact us and don't forget to mention this message."
+msgstr "Várias autorizações foram retornadas - algo está errado. Entre em contato conosco e não esqueça de mencionar esta mensagem."
 
 #. Translators: This message is shown when user tries to access a NOT_AVAILABLE Partner
 #: TWLight/resources/views.py:316
@@ -2170,22 +1767,8 @@ msgstr "Desculpa; nós não sabemos o que fazer com isso."
 #. Translators: Shown on the website's 400 page, when a user sends a bad request. Don't translate path or Phabricator.
 #: TWLight/templates/400.html:20
 #, python-format
-msgid ""
-"If you think we should know what to do with that, please email us about this "
-"error at <a class=\"twl-links\" href=\"mailto:wikipedialibrary@wikimedia.org?"
-"Subject=Wikipedia%%20Library%%20%(path)s%%20Permission%%20denied"
-"\">wikipedialibrary@wikimedia.org</a> or report it to us on <a class=\"twl-"
-"links\" href=\"https://phabricator.wikimedia.org/maniphest/task/edit/form/1/?"
-"projectPHIDs=Library-Card-Platform&title=Wikipedia%%20Library%%20%(path)s"
-"%%20Bad%%20Request\">Phabricator</a>"
-msgstr ""
-"Se você acha que devemos saber o que fazer com isso, envie-nos um e-mail "
-"sobre esse erro em <a class=\"twl-links\" href=\"mailto:"
-"wikipedialibrary@wikimedia.org?Subject=Wikipedia%%20Library%%20%(path)s"
-"%%20Permission%%20denied\">wikipedialibrary@wikimedia.org</a> ou informe-nos "
-"no <a class=\"twl-links\" href=\"https://phabricator.wikimedia.org/maniphest/"
-"task/edit/form/1/?projectPHIDs=Library-Card-Platform&title=Wikipedia"
-"%%20Library%%20%(path)s%%20Bad%%20Request\">Phabricator</a>"
+msgid "If you think we should know what to do with that, please email us about this error at <a class=\"twl-links\" href=\"mailto:wikipedialibrary@wikimedia.org?Subject=Wikipedia%%20Library%%20%(path)s%%20Permission%%20denied\">wikipedialibrary@wikimedia.org</a> or report it to us on <a class=\"twl-links\" href=\"https://phabricator.wikimedia.org/maniphest/task/edit/form/1/?projectPHIDs=Library-Card-Platform&title=Wikipedia%%20Library%%20%(path)s%%20Bad%%20Request\">Phabricator</a>"
+msgstr "Se você acha que devemos saber o que fazer com isso, envie-nos um e-mail sobre esse erro em <a class=\"twl-links\" href=\"mailto:wikipedialibrary@wikimedia.org?Subject=Wikipedia%%20Library%%20%(path)s%%20Permission%%20denied\">wikipedialibrary@wikimedia.org</a> ou informe-nos no <a class=\"twl-links\" href=\"https://phabricator.wikimedia.org/maniphest/task/edit/form/1/?projectPHIDs=Library-Card-Platform&title=Wikipedia%%20Library%%20%(path)s%%20Bad%%20Request\">Phabricator</a>"
 
 #. Translators: Alt text for an image shown on the 400 error page.
 #. Translators: Alt text for an image shown on the 403 error page.
@@ -2206,23 +1789,8 @@ msgstr "Desculpa; você não tem permissão para fazer isso."
 #. Translators: Shown on the website's 403 page, when a user attempts to navigate to a page they don't have permission to view. Don't translate path or Phabricator.
 #: TWLight/templates/403.html:20
 #, python-format
-msgid ""
-"If you think your account should be able to do that, please email us about "
-"this error at <a class=\"twl-links\" href=\"mailto:"
-"wikipedialibrary@wikimedia.org?Subject=Wikipedia%%20Library%%20%(path)s"
-"%%20Permission%%20denied\">wikipedialibrary@wikimedia.org</a> or report it "
-"to us on <a class=\"twl-links\" href=\"https://phabricator.wikimedia.org/"
-"maniphest/task/edit/form/1/?projectPHIDs=Library-Card-"
-"Platform&title=Wikipedia%%20Library%%20%(path)s%%20Permission%%20denied"
-"\">Phabricator</a>"
-msgstr ""
-"Se você acha que sua conta deve ser capaz de fazer isso, envie-nos um e-mail "
-"sobre esse erro em <a class=\"twl-links\" href=\"mailto:"
-"wikipedialibrary@wikimedia.org?Subject=Wikipedia%%20Library%%20%(path)s"
-"%%20Permission%%20denied\">wikipedialibrary@wikimedia.org</a> ou informe-nos "
-"no <a class=\"twl-links\" href=\"https://phabricator.wikimedia.org/maniphest/"
-"task/edit/form/1/?projectPHIDs=Library-Card-Platform&title=Wikipedia"
-"%%20Library%%20%(path)s%%20Permission%%20denied\">Phabricator</a>"
+msgid "If you think your account should be able to do that, please email us about this error at <a class=\"twl-links\" href=\"mailto:wikipedialibrary@wikimedia.org?Subject=Wikipedia%%20Library%%20%(path)s%%20Permission%%20denied\">wikipedialibrary@wikimedia.org</a> or report it to us on <a class=\"twl-links\" href=\"https://phabricator.wikimedia.org/maniphest/task/edit/form/1/?projectPHIDs=Library-Card-Platform&title=Wikipedia%%20Library%%20%(path)s%%20Permission%%20denied\">Phabricator</a>"
+msgstr "Se você acha que sua conta deve ser capaz de fazer isso, envie-nos um e-mail sobre esse erro em <a class=\"twl-links\" href=\"mailto:wikipedialibrary@wikimedia.org?Subject=Wikipedia%%20Library%%20%(path)s%%20Permission%%20denied\">wikipedialibrary@wikimedia.org</a> ou informe-nos no <a class=\"twl-links\" href=\"https://phabricator.wikimedia.org/maniphest/task/edit/form/1/?projectPHIDs=Library-Card-Platform&title=Wikipedia%%20Library%%20%(path)s%%20Permission%%20denied\">Phabricator</a>"
 
 #. Translators: Shown on the website's 404 page, when a user attempts to navigate to a page that doesn't exist.
 #: TWLight/templates/404.html:11
@@ -2237,22 +1805,8 @@ msgstr "Desculpa; nós não podemos encontrar isso."
 #. Translators: Shown on the website's 404 page, when a user attempts to navigate to a page that doesn't exist. Don't translate path or Phabricator.
 #: TWLight/templates/404.html:19
 #, python-format
-msgid ""
-"If you are certain that something should be here, please email us about this "
-"error at <a class=\"twl-links\" href=\"mailto:wikipedialibrary@wikimedia.org?"
-"Subject=Wikipedia%%20Library%%20%(path)s%%20Not%%20found\"> "
-"wikipedialibrary@wikimedia.org</a> or report it to us on <a class=\"twl-links"
-"\" href=\"https://phabricator.wikimedia.org/maniphest/task/edit/form/1/?"
-"projectPHIDs=Library-Card-Platform&title=Wikipedia%%20Library%%20%(path)s"
-"%%20Not%%20found\">Phabricator</a>"
-msgstr ""
-"Se tiver certeza de que algo deveria estar aqui, envie-nos um e-mail sobre "
-"esse erro em <a class=\"twl-links\" href=\"mailto:wikipedialibrary@wikimedia."
-"org?Subject=Wikipedia%%20Library%%20%(path)s%%20Not%%20found\"> "
-"wikipedialibrary@wikimedia.org</a> ou informe-nos no <a class=\"twl-links\" "
-"href=\"https://phabricator.wikimedia.org/maniphest/task/edit/form/1/?"
-"projectPHIDs=Library-Card-Platform&title=Wikipedia%%20Library%%20%(path)s"
-"%%20Not%%20found\">Phabricator</a>"
+msgid "If you are certain that something should be here, please email us about this error at <a class=\"twl-links\" href=\"mailto:wikipedialibrary@wikimedia.org?Subject=Wikipedia%%20Library%%20%(path)s%%20Not%%20found\"> wikipedialibrary@wikimedia.org</a> or report it to us on <a class=\"twl-links\" href=\"https://phabricator.wikimedia.org/maniphest/task/edit/form/1/?projectPHIDs=Library-Card-Platform&title=Wikipedia%%20Library%%20%(path)s%%20Not%%20found\">Phabricator</a>"
+msgstr "Se tiver certeza de que algo deveria estar aqui, envie-nos um e-mail sobre esse erro em <a class=\"twl-links\" href=\"mailto:wikipedialibrary@wikimedia.org?Subject=Wikipedia%%20Library%%20%(path)s%%20Not%%20found\"> wikipedialibrary@wikimedia.org</a> ou informe-nos no <a class=\"twl-links\" href=\"https://phabricator.wikimedia.org/maniphest/task/edit/form/1/?projectPHIDs=Library-Card-Platform&title=Wikipedia%%20Library%%20%(path)s%%20Not%%20found\">Phabricator</a>"
 
 #. Translators: Alt text for an image shown on the 404 error page.
 #: TWLight/templates/404.html:32
@@ -2266,50 +1820,19 @@ msgstr "Sobre biblioteca da Wikipédia"
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:20
-msgid ""
-"This platform is our central tool for facilitating access to our available "
-"collections. Here you can see which partnerships are available, search their "
-"contents, and apply for and access the ones you’re interested in."
-msgstr ""
-"Essa plataforma é nossa ferramenta central de viabilização de acesso às "
-"coleções disponíveis. Aqui, é possível ver quais parcerias estão "
-"disponíveis, além de poder pesquisar seus conteúdos e aplicar-se para "
-"receber acesso aos que lhe interessem."
+msgid "This platform is our central tool for facilitating access to our available collections. Here you can see which partnerships are available, search their contents, and apply for and access the ones you’re interested in."
+msgstr "Essa plataforma é nossa ferramenta central de viabilização de acesso às coleções disponíveis. Aqui, é possível ver quais parcerias estão disponíveis, além de poder pesquisar seus conteúdos e aplicar-se para receber acesso aos que lhe interessem."
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/). Wikimedia Foundation should not be translated.
 #: TWLight/templates/about.html:29
-msgid ""
-"All users receive immediate access to some collections, which can be browsed "
-"by clicking the 'Access collection' buttons or using the search bar at the "
-"top of the page. Other collections require an application before access is "
-"granted, and may be accessed directly or via an individual login or access "
-"code. Volunteer coordinators, who have signed non-disclosure agreements with "
-"the Wikimedia Foundation, review these applications and work with publishers "
-"to get you your free access."
-msgstr ""
-"Todos os usuários recebem acesso imediato a algumas coleções, as quais podem "
-"ser lidas ao clicar em seus respectivos botões de “Acessar coleção”, ou "
-"utilizando-se da barra de pesquisa no topo da página. Outras coleções "
-"necessitam de pedido de registro, e podem ser acessadas diretamente ou via "
-"autenticação individual e código de acesso. Coordenadores voluntários, que "
-"assinaram termos de confidencialidade com a Fundação Wikimedia, são os "
-"responsáveis pela revisão dos pedidos de registro e trabalham junto aos "
-"periódicos para conceder o acesso livre."
+msgid "All users receive immediate access to some collections, which can be browsed by clicking the 'Access collection' buttons or using the search bar at the top of the page. Other collections require an application before access is granted, and may be accessed directly or via an individual login or access code. Volunteer coordinators, who have signed non-disclosure agreements with the Wikimedia Foundation, review these applications and work with publishers to get you your free access."
+msgstr "Todos os usuários recebem acesso imediato a algumas coleções, as quais podem ser lidas ao clicar em seus respectivos botões de “Acessar coleção”, ou utilizando-se da barra de pesquisa no topo da página. Outras coleções necessitam de pedido de registro, e podem ser acessadas diretamente ou via autenticação individual e código de acesso. Coordenadores voluntários, que assinaram termos de confidencialidade com a Fundação Wikimedia, são os responsáveis pela revisão dos pedidos de registro e trabalham junto aos periódicos para conceder o acesso livre."
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/). Don't translate terms_url.
 #: TWLight/templates/about.html:43
 #, python-format
-msgid ""
-"For more information about how your information is stored and reviewed "
-"please see our <a class=\"twl-links\" href=\"%(terms_url)s\"> terms of use "
-"and privacy policy</a>. Accounts you apply for are also subject to the Terms "
-"of Use provided by each partner’s platform; please review them."
-msgstr ""
-"Para obter mais informações sobre como suas informações são armazenadas e "
-"revisadas, consulte nosso <a class=\"twl-links\" href=\"%(terms_url)s"
-"\">termos de uso e politica de privacidade</a>. As contas solicitadas também "
-"estão sujeitas aos Termos de Uso fornecidos pela plataforma de cada "
-"parceiro. Dedique um tempo para lê-los."
+msgid "For more information about how your information is stored and reviewed please see our <a class=\"twl-links\" href=\"%(terms_url)s\"> terms of use and privacy policy</a>. Accounts you apply for are also subject to the Terms of Use provided by each partner’s platform; please review them."
+msgstr "Para obter mais informações sobre como suas informações são armazenadas e revisadas, consulte nosso <a class=\"twl-links\" href=\"%(terms_url)s\">termos de uso e politica de privacidade</a>. As contas solicitadas também estão sujeitas aos Termos de Uso fornecidos pela plataforma de cada parceiro. Dedique um tempo para lê-los."
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:51
@@ -2318,25 +1841,13 @@ msgstr "Quem pode receber acesso?"
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/). Wikimedia Foundation should not be translated.
 #: TWLight/templates/about.html:55
-msgid ""
-"Any active editor in good standing can receive access. For publishers with "
-"limited numbers of accounts, applications are reviewed based on the editor’s "
-"needs and contributions. If you think you could use access to one of our "
-"partner resources and are an active editor in any project supported by the "
-"Wikimedia Foundation, please apply."
-msgstr ""
-"Qualquer editor ativo em boas condições pode receber acesso. Para editores "
-"com um número limitado de contas, os aplicativos são revisados com base nas "
-"necessidades e contribuições do editor. Se você acha que poderia usar o "
-"acesso a um de nossos recursos de parceiros e é um editor ativo em qualquer "
-"projeto apoiado pela Fundação Wikimedia, faça o seu pedido."
+msgid "Any active editor in good standing can receive access. For publishers with limited numbers of accounts, applications are reviewed based on the editor’s needs and contributions. If you think you could use access to one of our partner resources and are an active editor in any project supported by the Wikimedia Foundation, please apply."
+msgstr "Qualquer editor ativo em boas condições pode receber acesso. Para editores com um número limitado de contas, os aplicativos são revisados com base nas necessidades e contribuições do editor. Se você acha que poderia usar o acesso a um de nossos recursos de parceiros e é um editor ativo em qualquer projeto apoiado pela Fundação Wikimedia, faça o seu pedido."
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:65
 msgid "Any editor can use the library if they meet a few basic requirements:"
-msgstr ""
-"Qualquer editor pode usar a biblioteca se atender a alguns requisitos "
-"básicos:"
+msgstr "Qualquer editor pode usar a biblioteca se atender a alguns requisitos básicos:"
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:71
@@ -2360,35 +1871,13 @@ msgstr "No momento, você não está bloqueado de editar um projeto da Wikimedia
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/)
 #: TWLight/templates/about.html:89
-msgid ""
-"If you are applying for an available collection, please first check that you "
-"don't already have access through another library or institution. If you do, "
-"please consider using that access rather than taking up a seat for this "
-"resource in The Wikipedia Library."
-msgstr ""
-"Se você estiver solicitando uma coleção disponível, verifique primeiro se "
-"ainda não tem acesso por meio de outra biblioteca ou instituição. Se "
-"possuir, considere usar esse acesso em vez de usar este recurso na "
-"Biblioteca da Wikipédia."
+msgid "If you are applying for an available collection, please first check that you don't already have access through another library or institution. If you do, please consider using that access rather than taking up a seat for this resource in The Wikipedia Library."
+msgstr "Se você estiver solicitando uma coleção disponível, verifique primeiro se ainda não tem acesso por meio de outra biblioteca ou instituição. Se possuir, considere usar esse acesso em vez de usar este recurso na Biblioteca da Wikipédia."
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/)
 #: TWLight/templates/about.html:99
-msgid ""
-"If your account is blocked on one or more Wikimedia projects, you may still "
-"be granted access to The Wikipedia Library. You will need to contact the "
-"Wikipedia Library team, who will review your blocks. If you have been "
-"blocked for content issues, most notably copyright violations, or have "
-"multiple long-term blocks, we may decline your request. Additionally, if "
-"your block status changes after being approved, you will need to request "
-"another review."
-msgstr ""
-"Se sua conta estiver bloqueada em um ou mais projetos da Wikimedia, você "
-"ainda poderá ter acesso à Biblioteca da Wikipédia. Será necessário entrar em "
-"contato com a equipe da Biblioteca, que revisará seus bloqueios. Caso seu "
-"bloqueio tenha sido feito por problemas de conteúdo, principalmente "
-"violações de direitos autorais, ou caso você possua vários bloqueios de "
-"longo prazo, sua solicitação poderá ser recusada. Além disso, se o bloqueio "
-"for desfeito após a aprovação, você precisará solicitar outra revisão."
+msgid "If your account is blocked on one or more Wikimedia projects, you may still be granted access to The Wikipedia Library. You will need to contact the Wikipedia Library team, who will review your blocks. If you have been blocked for content issues, most notably copyright violations, or have multiple long-term blocks, we may decline your request. Additionally, if your block status changes after being approved, you will need to request another review."
+msgstr "Se sua conta estiver bloqueada em um ou mais projetos da Wikimedia, você ainda poderá ter acesso à Biblioteca da Wikipédia. Será necessário entrar em contato com a equipe da Biblioteca, que revisará seus bloqueios. Caso seu bloqueio tenha sido feito por problemas de conteúdo, principalmente violações de direitos autorais, ou caso você possua vários bloqueios de longo prazo, sua solicitação poderá ser recusada. Além disso, se o bloqueio for desfeito após a aprovação, você precisará solicitar outra revisão."
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:110
@@ -2422,12 +1911,8 @@ msgstr "Editores aprovados <i>não devem</i>:"
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:136
-msgid ""
-"Share their account logins or passwords with others, or sell their access to "
-"other parties"
-msgstr ""
-"Compartilhe seus logins ou senhas de conta com outras pessoas ou venda seu "
-"acesso a outras partes"
+msgid "Share their account logins or passwords with others, or sell their access to other parties"
+msgstr "Compartilhe seus logins ou senhas de conta com outras pessoas ou venda seu acesso a outras partes"
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:140
@@ -2436,30 +1921,18 @@ msgstr "Raspe em massa ou conteúdo do parceiro de download em massa"
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:144
-msgid ""
-"Systematically make printed or electronic copies of multiple extracts of "
-"restricted content available for any purpose"
-msgstr ""
-"Faça cópias impressas ou eletrônicas de múltiplos extratos de conteúdo "
-"restrito disponíveis para qualquer finalidade."
+msgid "Systematically make printed or electronic copies of multiple extracts of restricted content available for any purpose"
+msgstr "Faça cópias impressas ou eletrônicas de múltiplos extratos de conteúdo restrito disponíveis para qualquer finalidade."
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/). Stub is a technical term for a short Wikipedia article, use the appropriate Wikipedia term in your language.
 #: TWLight/templates/about.html:148
-msgid ""
-"Datamine metadata without permission, in order, for instance, to use "
-"metadata for auto-created stub articles"
-msgstr ""
-"Metadados de dados sem permissão, para, por exemplo, usar metadados para "
-"artigos stub criados automaticamente"
+msgid "Datamine metadata without permission, in order, for instance, to use metadata for auto-created stub articles"
+msgstr "Metadados de dados sem permissão, para, por exemplo, usar metadados para artigos stub criados automaticamente"
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:154
-msgid ""
-"Respecting these agreements allows us to continue growing the partnerships "
-"available to the community."
-msgstr ""
-"Respeitar esses acordos nos permite continuar aumentando as parcerias "
-"disponíveis para a comunidade."
+msgid "Respecting these agreements allows us to continue growing the partnerships available to the community."
+msgstr "Respeitar esses acordos nos permite continuar aumentando as parcerias disponíveis para a comunidade."
 
 #. Translators: This is the heading for a section on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:160
@@ -2468,63 +1941,23 @@ msgstr "EZProxy"
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:164
-msgid ""
-"EZProxy is a proxy server used to authenticate users for many Wikipedia "
-"Library partners. Users sign into EZProxy via the Library Card platform to "
-"verify that they are authorized users, and then the server accesses "
-"requested resources using its own IP address."
-msgstr ""
-"O EZProxy é um servidor proxy usado para autenticar usuários de muitos "
-"parceiros da Biblioteca da Wikipedia. Os usuários fazem login no EZProxy "
-"através da plataforma Library Card para verificar se são usuários "
-"autorizados e, em seguida, o servidor acessa os recursos solicitados usando "
-"seu próprio endereço IP."
+msgid "EZProxy is a proxy server used to authenticate users for many Wikipedia Library partners. Users sign into EZProxy via the Library Card platform to verify that they are authorized users, and then the server accesses requested resources using its own IP address."
+msgstr "O EZProxy é um servidor proxy usado para autenticar usuários de muitos parceiros da Biblioteca da Wikipedia. Os usuários fazem login no EZProxy através da plataforma Library Card para verificar se são usuários autorizados e, em seguida, o servidor acessa os recursos solicitados usando seu próprio endereço IP."
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:173
-msgid ""
-"You may notice that when accessing resources via EZProxy that URLs are "
-"dynamically rewritten. This is why we recommend logging in via the Library "
-"Card platform rather than going directly to the unproxied partner website. "
-"When in doubt, check the URL for ‘idm.oclc’. If it’s there, then you’re "
-"connected via EZProxy."
-msgstr ""
-"Você pode perceber que, ao acessar recursos via EZProxy, os URLs são "
-"reescritos dinamicamente. É por isso que recomendamos que você faça login "
-"através da plataforma Library Card, em vez de acessar diretamente o site do "
-"parceiro não autorizado. Em caso de dúvida, verifique o URL para \"idm.oclc"
-"\". Se estiver lá, você estará conectado via EZProxy."
+msgid "You may notice that when accessing resources via EZProxy that URLs are dynamically rewritten. This is why we recommend logging in via the Library Card platform rather than going directly to the unproxied partner website. When in doubt, check the URL for ‘idm.oclc’. If it’s there, then you’re connected via EZProxy."
+msgstr "Você pode perceber que, ao acessar recursos via EZProxy, os URLs são reescritos dinamicamente. É por isso que recomendamos que você faça login através da plataforma Library Card, em vez de acessar diretamente o site do parceiro não autorizado. Em caso de dúvida, verifique o URL para \"idm.oclc\". Se estiver lá, você estará conectado via EZProxy."
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:182
-msgid ""
-"Typically once you’ve logged in your session will remain active in your "
-"browser for up to two hours after you’ve finished searching. Note that use "
-"of EZProxy requires you to enable cookies. If you are having problems you "
-"should also try clearing your cache and restarting your browser."
-msgstr ""
-"Normalmente, após a entrada, sua sessão permanece ativa no navegador por até "
-"duas horas após a conclusão da pesquisa. Observe que o uso do EZProxy requer "
-"que você ative os cookies. Se você estiver tendo problemas, tente limpar o "
-"cache e reiniciar o navegador."
+msgid "Typically once you’ve logged in your session will remain active in your browser for up to two hours after you’ve finished searching. Note that use of EZProxy requires you to enable cookies. If you are having problems you should also try clearing your cache and restarting your browser."
+msgstr "Normalmente, após a entrada, sua sessão permanece ativa no navegador por até duas horas após a conclusão da pesquisa. Observe que o uso do EZProxy requer que você ative os cookies. Se você estiver tendo problemas, tente limpar o cache e reiniciar o navegador."
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/)
 #: TWLight/templates/about.html:193
-msgid ""
-"The Library Bundle is a collection of resources for which no application is "
-"required. If you meet the criteria laid out above, you will be authorized "
-"for access automatically upon logging in to the platform. Only some of our "
-"content is currently included in the Library Bundle, however we hope to "
-"expand the collection as more publishers become comfortable with "
-"participating. All Bundle content is accessed via EZProxy."
-msgstr ""
-"O pacote de bibliotecas é uma coleção de recursos para os quais nenhum "
-"aplicativo é necessário. Se você atender aos critérios estabelecidos acima, "
-"você será autorizado a acessar automaticamente ao fazer login na plataforma. "
-"Atualmente, apenas parte de nosso conteúdo está incluído no pacote de "
-"bibliotecas. No entanto, esperamos expandir a coleção, à medida que mais "
-"editores se sintam à vontade para participar. Todo o conteúdo do pacote é "
-"acessado via EZProxy."
+msgid "The Library Bundle is a collection of resources for which no application is required. If you meet the criteria laid out above, you will be authorized for access automatically upon logging in to the platform. Only some of our content is currently included in the Library Bundle, however we hope to expand the collection as more publishers become comfortable with participating. All Bundle content is accessed via EZProxy."
+msgstr "O pacote de bibliotecas é uma coleção de recursos para os quais nenhum aplicativo é necessário. Se você atender aos critérios estabelecidos acima, você será autorizado a acessar automaticamente ao fazer login na plataforma. Atualmente, apenas parte de nosso conteúdo está incluído no pacote de bibliotecas. No entanto, esperamos expandir a coleção, à medida que mais editores se sintam à vontade para participar. Todo o conteúdo do pacote é acessado via EZProxy."
 
 #. Translators: This is the heading for a section on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:202
@@ -2533,18 +1966,8 @@ msgstr "Práticas de citação"
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:206
-msgid ""
-"Citation practices vary by project and even by article. Generally, we "
-"support editors citing where they found information, in a form that allows "
-"others to check it for themselves. That often means providing both original "
-"source details as well as a link to the partner database in which the source "
-"was found."
-msgstr ""
-"As práticas de citação variam de acordo com o projeto e até com o artigo. "
-"Geralmente, apoiamos editores que citam onde encontraram informações, de uma "
-"forma que permite que outras pessoas as verifiquem por si mesmas. Isso "
-"geralmente significa fornecer os detalhes da fonte original, bem como um "
-"link para o banco de dados do parceiro no qual a fonte foi encontrada."
+msgid "Citation practices vary by project and even by article. Generally, we support editors citing where they found information, in a form that allows others to check it for themselves. That often means providing both original source details as well as a link to the partner database in which the source was found."
+msgstr "As práticas de citação variam de acordo com o projeto e até com o artigo. Geralmente, apoiamos editores que citam onde encontraram informações, de uma forma que permite que outras pessoas as verifiquem por si mesmas. Isso geralmente significa fornecer os detalhes da fonte original, bem como um link para o banco de dados do parceiro no qual a fonte foi encontrada."
 
 #. Translators: This is the heading for a section on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #. Translators: This link is at the bottom of every page and can be clicked by users to contact the wikipedia library team.
@@ -2555,13 +1978,8 @@ msgstr "Contacte-nos"
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:218
 #, python-format
-msgid ""
-"If you have questions, need help, or want to volunteer to help, please see "
-"our <a class=\"twl-links\" href=\"%(contact_url)s\">contact page</a>."
-msgstr ""
-"Se você tiver dúvidas, precisar de ajuda ou quiser se voluntariar para "
-"ajudar, consulte nossa <a class=\"twl-links\" href=\"%(contact_url)s"
-"\">página de contato</a>."
+msgid "If you have questions, need help, or want to volunteer to help, please see our <a class=\"twl-links\" href=\"%(contact_url)s\">contact page</a>."
+msgstr "Se você tiver dúvidas, precisar de ajuda ou quiser se voluntariar para ajudar, consulte nossa <a class=\"twl-links\" href=\"%(contact_url)s\">página de contato</a>."
 
 #. Translators: This is the title of the panel box detailing the contact information for the Wikipedia Library team.
 #: TWLight/templates/contact.html:14
@@ -2600,18 +2018,13 @@ msgstr "Twitter da Biblioteca da Wikipédia"
 #. Translators: This is the text that appears at the bottom of the contact us form directing users to the suggestions form.
 #: TWLight/templates/contact.html:48
 #, python-format
-msgid ""
-"(If you would like to suggest a partner, <a class=\"twl-links\" href="
-"\"%(suggest)s\"><strong>go here</strong></a>.)"
-msgstr ""
-"(Se gostaria de sugerir um parceiro, <a class=\"twl-links\" href="
-"\"%(suggest)s\"><strong>faça-o aqui</strong></a>.)"
+msgid "(If you would like to suggest a partner, <a class=\"twl-links\" href=\"%(suggest)s\"><strong>go here</strong></a>.)"
+msgstr "(Se gostaria de sugerir um parceiro, <a class=\"twl-links\" href=\"%(suggest)s\"><strong>faça-o aqui</strong></a>.)"
 
 #. Translators: On a special 'link to search' page, this message is shown if JavaScript is disabled.
 #: TWLight/templates/eds_search_endpoint.html:7
 msgid "JavaScript is disabled; use the button below to continue."
-msgstr ""
-"O JavaScript encontra-se desativado. Utilize o botão abaixo para continuar."
+msgstr "O JavaScript encontra-se desativado. Utilize o botão abaixo para continuar."
 
 #. Translators: Alt text for the Wikipedia Library shown in the top left of all pages.
 #: TWLight/templates/header_partial_b4.html:14
@@ -2663,13 +2076,8 @@ msgstr "A biblioteca da Wikipédia"
 #. Translators: Information about The Wikipedia Library.
 #: TWLight/templates/login_partial.html:53 TWLight/templates/new_base.html:21
 #, fuzzy, python-format
-msgid ""
-"More than 100 of the world's top subscription-only databases, with content "
-"in %(no_of_languages)s languages, free for Wikipedians of all backgrounds"
-msgstr ""
-"Mais de 90 dos melhores bancos de dados do mundo, de acesso por assinatura, "
-"com conteúdo em %(no_of_languages)s idiomas, agora livres para wikipedistas "
-"de todas as origens"
+msgid "More than 100 of the world's top subscription-only databases, with content in %(no_of_languages)s languages, free for Wikipedians of all backgrounds"
+msgstr "Mais de 90 dos melhores bancos de dados do mundo, de acesso por assinatura, com conteúdo em %(no_of_languages)s idiomas, agora livres para wikipedistas de todas as origens"
 
 #. Translators: Information about The Wikipedia Library.
 #: TWLight/templates/login_partial.html:64
@@ -2677,12 +2085,8 @@ msgid "Meet these criteria for automatic access"
 msgstr "Atenda aos critérios para acesso automático"
 
 #: TWLight/templates/login_partial.html:69
-msgid ""
-"These criteria grant you access to certain collections but not all. Some "
-"collections are accessible on a per application basis only."
-msgstr ""
-"Esses critérios permitem-lhe acesso a algumas coleções, mas não todas. "
-"Certas coleções são disponibilizadas somente por pedido de acesso."
+msgid "These criteria grant you access to certain collections but not all. Some collections are accessible on a per application basis only."
+msgstr "Esses critérios permitem-lhe acesso a algumas coleções, mas não todas. Certas coleções são disponibilizadas somente por pedido de acesso."
 
 #: TWLight/templates/login_partial.html:89
 msgid "Login via Wikipedia"
@@ -2691,40 +2095,20 @@ msgstr "Entrar via Wikipédia"
 #. Translators: Shown if the current user doesn't have a registered email on their account. Don't translate contact_us_url or email_url.
 #: TWLight/templates/message_partial.html:15
 #, python-format
-msgid ""
-"You don't have an email on file. We can't finalize your access to partner "
-"resources, and you won't be able to <a class=\"twl-links\" href="
-"\"%(contact_us_url)s\">contact us</a> without an email. Please <a class="
-"\"twl-links\" href=\"%(email_url)s\">update your email</a>."
-msgstr ""
-"Não tem um endereço de e-mail registado. Não podemos finalizar o seu acesso "
-"aos recursos de parceiros, nem poderá <a class=\"twl-links\" href="
-"\"%(contact_us_url)s\">contactar-nos</a>, sem um endereço. <a class=\"twl-"
-"links\" href=\"%(email_url)s\">Atualize o seu e-mail</a>, por favor."
+msgid "You don't have an email on file. We can't finalize your access to partner resources, and you won't be able to <a class=\"twl-links\" href=\"%(contact_us_url)s\">contact us</a> without an email. Please <a class=\"twl-links\" href=\"%(email_url)s\">update your email</a>."
+msgstr "Não tem um endereço de e-mail registado. Não podemos finalizar o seu acesso aos recursos de parceiros, nem poderá <a class=\"twl-links\" href=\"%(contact_us_url)s\">contactar-nos</a>, sem um endereço. <a class=\"twl-links\" href=\"%(email_url)s\">Atualize o seu e-mail</a>, por favor."
 
 #. Translators: Shown if the current user has requested the processing of their data should be restricted.
 #: TWLight/templates/message_partial.html:26
 #, python-format
-msgid ""
-"You have requested a restriction on the processing of your data. Most site "
-"functionality will not be available to you until you <a class=\"twl-links\" "
-"href=\"%(restrict_url)s\">lift this restriction</a>."
-msgstr ""
-"Você solicitou uma restrição no processamento de seus dados. A maior parte "
-"da funcionalidade do site não estará disponível até que você <a class=\"twl-"
-"links\" href=\"%(restrict_url)s\">elimine essa restrição</a>."
+msgid "You have requested a restriction on the processing of your data. Most site functionality will not be available to you until you <a class=\"twl-links\" href=\"%(restrict_url)s\">lift this restriction</a>."
+msgstr "Você solicitou uma restrição no processamento de seus dados. A maior parte da funcionalidade do site não estará disponível até que você <a class=\"twl-links\" href=\"%(restrict_url)s\">elimine essa restrição</a>."
 
 #. Translators: Shown if the current user has not agreed to the terms of use.
 #: TWLight/templates/message_partial.html:37
 #, python-format
-msgid ""
-"You have not agreed to the <a class=\"twl-links\" href=\"%(terms_url)s"
-"\">terms of use</a> of this site. Your applications will not be processed "
-"and you won't be able to apply or access resources you are approved for."
-msgstr ""
-"Você não concordou nos the <a class=\"twl-links\" href=\"%(terms_url)s"
-"\">terms of use</a> deste site. Suas candidaturas não serão processadas e "
-"você não poderá aplicar ou acessar os recursos aprovados."
+msgid "You have not agreed to the <a class=\"twl-links\" href=\"%(terms_url)s\">terms of use</a> of this site. Your applications will not be processed and you won't be able to apply or access resources you are approved for."
+msgstr "Você não concordou nos the <a class=\"twl-links\" href=\"%(terms_url)s\">terms of use</a> deste site. Suas candidaturas não serão processadas e você não poderá aplicar ou acessar os recursos aprovados."
 
 #. Translators: This link is at the bottom of every page and links to the 'About' page (https://wikipedialibrary.wmflabs.org/about/)
 #: TWLight/templates/new_base.html:107
@@ -2770,12 +2154,8 @@ msgstr "Redefinir senha"
 
 #. Translators: If a user goes to reset their password, this message asks them to enter their email to do so.
 #: TWLight/templates/registration/password_reset_form.html:13
-msgid ""
-"Forgot your password? Enter your email address below, and we'll email "
-"instructions for setting a new one."
-msgstr ""
-"Esqueceu sua senha? Digite seu endereço de e-mail abaixo e enviaremos "
-"instruções por e-mail para configurar um novo."
+msgid "Forgot your password? Enter your email address below, and we'll email instructions for setting a new one."
+msgstr "Esqueceu sua senha? Digite seu endereço de e-mail abaixo e enviaremos instruções por e-mail para configurar um novo."
 
 #. Translators: This is the label for a button that users click to update their public information.
 #: TWLight/users/forms.py:36
@@ -2785,8 +2165,7 @@ msgstr "Atualizar perfil"
 #. Translators: This labels a field where users can describe their activity on Wikipedia in a small biography.
 #: TWLight/users/forms.py:45
 msgid "Describe your contributions to Wikipedia: topics edited, et cetera."
-msgstr ""
-"Descreva suas contribuições para a Wikipédia: tópicos editados, et cetera."
+msgstr "Descreva suas contribuições para a Wikipédia: tópicos editados, et cetera."
 
 #. Translators: In the preferences section (Emails) of a user profile, this text labels the checkbox users can (un)click to change if they wish to receive account renewal notices or not.
 #: TWLight/users/forms.py:98
@@ -2820,22 +2199,13 @@ msgstr "Eu concordo com os termos de uso"
 
 #. Translators: This text explains how to disagree to the site's terms of use and the restrictions that will come into effect when users disagree to the terms of use.
 #: TWLight/users/forms.py:185
-msgid ""
-"By unchecking this box and clicking “Update” you may explore the site, but "
-"you will not be able to apply for access to materials or evaluate "
-"applications unless you agree with the terms of use."
-msgstr ""
-"Ao desmarcar esta caixa e clicar em \"Atualizar\", você pode explorar o "
-"site, mas não poderá solicitar acesso a materiais ou avaliar aplicativos, a "
-"menos que concorde com os termos de uso."
+msgid "By unchecking this box and clicking “Update” you may explore the site, but you will not be able to apply for access to materials or evaluate applications unless you agree with the terms of use."
+msgstr "Ao desmarcar esta caixa e clicar em \"Atualizar\", você pode explorar o site, mas não poderá solicitar acesso a materiais ou avaliar aplicativos, a menos que concorde com os termos de uso."
 
 #. Translators: Users click this button to set their website email address to the one linked to their Wikipedia account.
 #: TWLight/users/forms.py:211
-msgid ""
-"Use my Wikipedia email address (will be updated the next time you login)."
-msgstr ""
-"Use meu endereço de e-mail da Wikipédia (será atualizado na próxima vez que "
-"você fizer login)."
+msgid "Use my Wikipedia email address (will be updated the next time you login)."
+msgstr "Use meu endereço de e-mail da Wikipédia (será atualizado na próxima vez que você fizer login)."
 
 #. Translators: This labels a button which users click to change their email.
 #: TWLight/users/forms.py:232
@@ -2845,19 +2215,8 @@ msgstr "Atualizar e-mail"
 #. Translators: Shown if the current user tried to 'favorite' a partner they can't access. Do not translate '{partner}'
 #: TWLight/users/models.py:201
 #, python-brace-format
-msgid ""
-"Cannot add partner {partner} to your favorites because you don't have access "
-"to it"
-msgstr ""
-"Não é possível adicionar o(a) parceiro(a) {partner} aos seus favoritos "
-"porque você não tem acesso a ele(a)"
-
-#. Translators: Do not translate.
-#: TWLight/users/models.py:869
-#, fuzzy, python-brace-format
-#| msgid "Username"
-msgid "{wp_username}"
-msgstr "Nome de usuário(a)"
+msgid "Cannot add partner {partner} to your favorites because you don't have access to it"
+msgstr "Não é possível adicionar o(a) parceiro(a) {partner} aos seus favoritos porque você não tem acesso a ele(a)"
 
 #. Translators: This error message is shown when there's a problem with the authenticated login process.
 #: TWLight/users/oauth.py:243
@@ -2877,12 +2236,8 @@ msgstr "O handshaker não foi iniciado, tente entrar novamente."
 
 #. Translators: this message is displayed to users that don't have accounts and clicked on a proxied link.
 #: TWLight/users/oauth.py:388
-msgid ""
-"To view this link you need to be an eligible library user. Please login to "
-"continue."
-msgstr ""
-"Essa ligação só pode ser visualizada por usuários elegíveis. Por favor, "
-"autentique-se para continuar."
+msgid "To view this link you need to be an eligible library user. Please login to continue."
+msgstr "Essa ligação só pode ser visualizada por usuários elegíveis. Por favor, autentique-se para continuar."
 
 #. Translators: This warning message is shown to users when the response received from Wikimedia OAuth servers is not a valid one.
 #: TWLight/users/oauth.py:430
@@ -2917,24 +2272,13 @@ msgstr "Veja {issue} para mais informações"
 
 #. Translators: If the user tries to log in, but their account does not meet certain requirements, they cannot login.
 #: TWLight/users/oauth.py:528
-msgid ""
-"Your Wikipedia account does not meet the eligibility criteria in the terms "
-"of use, so your Wikipedia Library Card Platform account cannot be activated."
-msgstr ""
-"Sua conta da Wikipédia não atende aos critérios de elegibilidade nos termos "
-"de uso, portanto, sua conta da Plataforma da Biblioteca da Wikipedia não "
-"pode ser ativada."
+msgid "Your Wikipedia account does not meet the eligibility criteria in the terms of use, so your Wikipedia Library Card Platform account cannot be activated."
+msgstr "Sua conta da Wikipédia não atende aos critérios de elegibilidade nos termos de uso, portanto, sua conta da Plataforma da Biblioteca da Wikipedia não pode ser ativada."
 
 #. Translators: If the user tries to log in, but their account does not meet certain requirements, they cannot login.
 #: TWLight/users/oauth.py:536
-msgid ""
-"Your Wikipedia account no longer meets the eligibility criteria in the terms "
-"of use, so you cannot be logged in. If you think you should be able to log "
-"in, please email wikipedialibrary@wikimedia.org."
-msgstr ""
-"Sua conta da Wikipédia não preenche mais os critérios de elegibilidade nos "
-"termos de uso, então você não pode estar logado. Se você acha que deve "
-"conseguir entrar, por favor enviar e-mail wikipedialibrary@wikimedia.org."
+msgid "Your Wikipedia account no longer meets the eligibility criteria in the terms of use, so you cannot be logged in. If you think you should be able to log in, please email wikipedialibrary@wikimedia.org."
+msgstr "Sua conta da Wikipédia não preenche mais os critérios de elegibilidade nos termos de uso, então você não pode estar logado. Se você acha que deve conseguir entrar, por favor enviar e-mail wikipedialibrary@wikimedia.org."
 
 #. Translators: this message is displayed to users with brand new accounts.
 #: TWLight/users/oauth.py:549
@@ -2944,15 +2288,8 @@ msgstr "Bem vinda! Por favor, concorde com os termos de uso."
 #. Translators: This message is displayed on the confirmation page where users can return their access to partner collections.
 #: TWLight/users/templates/users/authorization_confirm_return.html:13
 #, python-format
-msgid ""
-"You will no longer be able to access <b>%(partner)s's</b> resources via the "
-"Library Card platform, but can request access again by clicking 'renew', if "
-"you change your mind. Are you sure you want to return your access?"
-msgstr ""
-"Você não poderá mais acessar os recursos de <b>%(partner)s</b> por meio da "
-"plataforma Cartão da biblioteca, mas poderá solicitar o acesso novamente "
-"clicando em 'renovar', se mudar de ideia. Tem certeza de que deseja retornar "
-"seu acesso?"
+msgid "You will no longer be able to access <b>%(partner)s's</b> resources via the Library Card platform, but can request access again by clicking 'renew', if you change your mind. Are you sure you want to return your access?"
+msgstr "Você não poderá mais acessar os recursos de <b>%(partner)s</b> por meio da plataforma Cartão da biblioteca, mas poderá solicitar o acesso novamente clicando em 'renovar', se mudar de ideia. Tem certeza de que deseja retornar seu acesso?"
 
 #. Translators: On the MyLibrary page (https://wikipedialibrary.wmflabs.org/users/my_library), this tab shows all favorite collections a user has.
 #: TWLight/users/templates/users/collections_section.html:9
@@ -3021,14 +2358,8 @@ msgstr "Dados do editor"
 
 #. Translators: This is shown on editor profiles, in their profile page or on applications.
 #: TWLight/users/templates/users/editor_detail.html:59
-msgid ""
-"Information with an * was retrieved from Wikipedia directly. Other "
-"information was entered directly by users or site admins, in their preferred "
-"language."
-msgstr ""
-"Informações com um * foram recuperadas diretamente da Wikipedia. Outras "
-"informações foram inseridas diretamente pelos usuários ou administradores do "
-"site, em seu idioma preferido."
+msgid "Information with an * was retrieved from Wikipedia directly. Other information was entered directly by users or site admins, in their preferred language."
+msgstr "Informações com um * foram recuperadas diretamente da Wikipedia. Outras informações foram inseridas diretamente pelos usuários ou administradores do site, em seu idioma preferido."
 
 #. Translators: This distinguishes users who have been flagged as account coordinators. Don't translate username.
 #: TWLight/users/templates/users/editor_detail.html:71
@@ -3038,14 +2369,8 @@ msgstr "%(username)s tem privilégios de coordenador neste site."
 
 #. Translators: This is shown on editor profiles, under the heading for Wikipedia editor data.
 #: TWLight/users/templates/users/editor_detail_data.html:5
-msgid ""
-"This information is updated automatically from your Wikimedia account each "
-"time you log in, except for the Contributions field, where you can describe "
-"your Wikimedia editing history."
-msgstr ""
-"Essas informações são atualizadas automaticamente da sua conta da Wikimedia "
-"cada vez que você faz login, exceto no campo Contribuições, onde você pode "
-"descrever seu histórico de edição da Wikimedia."
+msgid "This information is updated automatically from your Wikimedia account each time you log in, except for the Contributions field, where you can describe your Wikimedia editing history."
+msgstr "Essas informações são atualizadas automaticamente da sua conta da Wikimedia cada vez que você faz login, exceto no campo Contribuições, onde você pode descrever seu histórico de edição da Wikimedia."
 
 #. Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this labels the user's username.
 #: TWLight/users/templates/users/editor_detail_data.html:17
@@ -3074,22 +2399,14 @@ msgstr "Satisfaz os termos de uso?"
 
 #. Translators: when viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this question has a yes or no answer.
 #: TWLight/users/templates/users/editor_detail_data.html:57
-msgid ""
-"at their last login, did this user meet the criteria set forth in the terms "
-"of use?"
-msgstr ""
-"na última entrada, esse usuário atendeu aos critérios estabelecidos nos "
-"termos de uso?"
+msgid "at their last login, did this user meet the criteria set forth in the terms of use?"
+msgstr "na última entrada, esse usuário atendeu aos critérios estabelecidos nos termos de uso?"
 
 #. Translators: When viewing a user's profile in an application, this message shows if the software doesn't think that the user is eligible for access. Don't translate username.
 #: TWLight/users/templates/users/editor_detail_data.html:72
 #, python-format
-msgid ""
-"%(username)s may still be eligible for access grants at the coordinators' "
-"discretion."
-msgstr ""
-"%(username)s pode ainda ser elegível para concessões de acesso a critério "
-"dos coordenadores."
+msgid "%(username)s may still be eligible for access grants at the coordinators' discretion."
+msgstr "%(username)s pode ainda ser elegível para concessões de acesso a critério dos coordenadores."
 
 #. Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this is the heading for a Yes/No ToU question.
 #: TWLight/users/templates/users/editor_detail_data.html:83
@@ -3123,14 +2440,8 @@ msgstr ""
 #. Translators: This message is shown on a user's profile if their Wikimedia account is blocked on one or more projects. They may still be granted access to the Library Bundle, but need to contact Wikipedia Library staff to verify.
 #: TWLight/users/templates/users/editor_detail_data.html:137
 #, python-format
-msgid ""
-"It looks like you have an active block on your account. If you meet the "
-"other criteria you may still be permitted access to the library - please <a "
-"class=\"twl-links\" href=\"%(contact_url)s\">contact us</a>."
-msgstr ""
-"Parece que você tem um bloqueio ativo em sua conta. Se você atender a outros "
-"critérios, ainda poderá ter acesso ao Pacote da Biblioteca - por favor <a "
-"class=\"twl-links\" href=\"%(contact_url)s\">contate-nos</a>."
+msgid "It looks like you have an active block on your account. If you meet the other criteria you may still be permitted access to the library - please <a class=\"twl-links\" href=\"%(contact_url)s\">contact us</a>."
+msgstr "Parece que você tem um bloqueio ativo em sua conta. Se você atender a outros critérios, ainda poderá ter acesso ao Pacote da Biblioteca - por favor <a class=\"twl-links\" href=\"%(contact_url)s\">contate-nos</a>."
 
 #. Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this is the heading for a Yes/No program eligibility question.
 #: TWLight/users/templates/users/editor_detail_data.html:153
@@ -3139,14 +2450,8 @@ msgstr "Qualificado para o pacote?"
 
 #. Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this question has a Yes or No answer.
 #: TWLight/users/templates/users/editor_detail_data.html:156
-msgid ""
-"At their last login, did this user meet the criteria set forth in the "
-"Library Bundle? Note that satisfying terms of use is a prerequisite to "
-"bundle eligibility."
-msgstr ""
-"Na última entrada, esse usuário atendeu aos critérios estabelecidos no "
-"pacote da biblioteca? Observe que satisfazer os termos de uso é um pré-"
-"requisito para agrupar a elegibilidade."
+msgid "At their last login, did this user meet the criteria set forth in the Library Bundle? Note that satisfying terms of use is a prerequisite to bundle eligibility."
+msgstr "Na última entrada, esse usuário atendeu aos critérios estabelecidos no pacote da biblioteca? Observe que satisfazer os termos de uso é um pré-requisito para agrupar a elegibilidade."
 
 #. Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this is the heading for a Yes/No program eligibility question.
 #: TWLight/users/templates/users/editor_detail_data.html:177
@@ -3190,25 +2495,14 @@ msgstr "Dados pessoais"
 
 #. Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this text is in the 'Personal data' section. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/users/templates/users/editor_detail_data.html:262
-msgid ""
-"The following information is visible only to you, site administrators, "
-"publishing partners (where required), and volunteer Wikipedia Library "
-"coordinators (who have signed a Non-Disclosure Agreement)."
-msgstr ""
-"As seguintes informações são visíveis apenas para você, administradores do "
-"site, parceiros de publicação (quando necessário) e coordenadores "
-"voluntários da Biblioteca da Wikipédia (que assinaram um Acordo de não "
-"divulgação)."
+msgid "The following information is visible only to you, site administrators, publishing partners (where required), and volunteer Wikipedia Library coordinators (who have signed a Non-Disclosure Agreement)."
+msgstr "As seguintes informações são visíveis apenas para você, administradores do site, parceiros de publicação (quando necessário) e coordenadores voluntários da Biblioteca da Wikipédia (que assinaram um Acordo de não divulgação)."
 
 #. Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this labels a button which users can click to update or remove their personal information. Don't translate update_url.
 #: TWLight/users/templates/users/editor_detail_data.html:272
 #, python-format
-msgid ""
-"You may <a class=\"twl-links\" href=\"%(update_url)s\">update or delete</a> "
-"your data at any time."
-msgstr ""
-"Você pode <a class=\"twl-links\" href=\"%(update_url)s\">atualizar ou "
-"excluir</a> seus dados a qualquer momento."
+msgid "You may <a class=\"twl-links\" href=\"%(update_url)s\">update or delete</a> your data at any time."
+msgstr "Você pode <a class=\"twl-links\" href=\"%(update_url)s\">atualizar ou excluir</a> seus dados a qualquer momento."
 
 #. Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this labels the user's email. Don't remove the *.
 #: TWLight/users/templates/users/editor_detail_data.html:283
@@ -3227,32 +2521,19 @@ msgstr "Afiliação institucional"
 
 #. Translators: This message tells users that they are not eligible to access The Wikipedia Library content.
 #: TWLight/users/templates/users/eligibility_modal.html:7
-msgid ""
-"Sorry, your Wikipedia account doesn’t currently qualify to access The "
-"Wikipedia Library."
-msgstr ""
-"Infelizmente, sua conta da Wikipédia ainda não se qualifica para acessar a "
-"Biblioteca da Wikipédia."
+msgid "Sorry, your Wikipedia account doesn’t currently qualify to access The Wikipedia Library."
+msgstr "Infelizmente, sua conta da Wikipédia ainda não se qualifica para acessar a Biblioteca da Wikipédia."
 
 #. Translators: This message tells users that they have not agreed to the terms of use, therefore are ineligible to access the content in The Wikipedia Library.
 #: TWLight/users/templates/users/eligibility_modal.html:30
 #, python-format
-msgid ""
-"Agreed with <a href=\"%(terms)s\" class=\"text-danger\"> terms of use </a>"
-msgstr ""
-"Concordou com os <a href=\"%(terms)s\" class=\"text-danger\">termos de uso</"
-"a> do site?"
+msgid "Agreed with <a href=\"%(terms)s\" class=\"text-danger\"> terms of use </a>"
+msgstr "Concordou com os <a href=\"%(terms)s\" class=\"text-danger\">termos de uso</a> do site?"
 
 #: TWLight/users/templates/users/eligibility_modal.html:40
 #, python-format
-msgid ""
-"It looks like you have an active block on your account. If you meet the "
-"other criteria you may still be permitted access to the library - please <a "
-"href=\"%(contact_url)s\">contact us</a>."
-msgstr ""
-"Parece que você tem um bloqueio ativo em sua conta. Se você atender a outros "
-"critérios, ainda poderá ter acesso ao Pacote da Biblioteca - por favor <a "
-"href=\"%(contact_url)s\">contate-nos</a>."
+msgid "It looks like you have an active block on your account. If you meet the other criteria you may still be permitted access to the library - please <a href=\"%(contact_url)s\">contact us</a>."
+msgstr "Parece que você tem um bloqueio ativo em sua conta. Se você atender a outros critérios, ainda poderá ter acesso ao Pacote da Biblioteca - por favor <a href=\"%(contact_url)s\">contate-nos</a>."
 
 #. Translators: Instructions to refresh a user's data.
 #: TWLight/users/templates/users/eligibility_modal.html:50
@@ -3277,8 +2558,7 @@ msgstr "É possível pesquisar na coleção completa pela barra de pesquisa"
 #. Translators: Text that describes a search icon.
 #: TWLight/users/templates/users/filter_section.html:54
 msgid "Collection is only partially searchable via the search bar"
-msgstr ""
-"É possível pesquisar na coleção pela barra de pesquisa apenas parcialmente"
+msgstr "É possível pesquisar na coleção pela barra de pesquisa apenas parcialmente"
 
 #. Translators: Text that explains when there is no search icon.
 #: TWLight/users/templates/users/filter_section.html:58
@@ -3292,14 +2572,8 @@ msgstr "Definir idioma"
 
 #. Translators: This text on the user page helps users naviage to the TranslateWiki Wikipedia Library Card platform translation page.
 #: TWLight/users/templates/users/language_form.html:31
-msgid ""
-"You can help translate the tool at <a class=\"twl-links\" href=\"https://"
-"translatewiki.net/wiki/Translating:Wikipedia_Library_Card_Platform"
-"\">translatewiki.net</a>."
-msgstr ""
-"Você pode ajudar a traduzir a ferramenta no <a class=\"twl-links\" href="
-"\"https://translatewiki.net/wiki/Translating:Wikipedia_Library_Card_Platform"
-"\">translatewiki.net</a>."
+msgid "You can help translate the tool at <a class=\"twl-links\" href=\"https://translatewiki.net/wiki/Translating:Wikipedia_Library_Card_Platform\">translatewiki.net</a>."
+msgstr "Você pode ajudar a traduzir a ferramenta no <a class=\"twl-links\" href=\"https://translatewiki.net/wiki/Translating:Wikipedia_Library_Card_Platform\">translatewiki.net</a>."
 
 #. Translators: When the user starts a new application and submits the application, the user can view the application and withdraw if need be. This changes the label for the Withdraw button.
 #: TWLight/users/templates/users/my_applications.html:65
@@ -3318,12 +2592,8 @@ msgstr "Solicitar renovação"
 
 #. Translators: On the page listing applications, this text explains a user they cannot renew their application since they've already requested a renewal or there aren't any renewals available.
 #: TWLight/users/templates/users/my_applications.html:79
-msgid ""
-"Renewals are either not required, not available right now, or you have "
-"already requested a renewal."
-msgstr ""
-"Renovações não são necessárias, não estão disponíveis no momento, ou você já "
-"solicitou uma renovação."
+msgid "Renewals are either not required, not available right now, or you have already requested a renewal."
+msgstr "Renovações não são necessárias, não estão disponíveis no momento, ou você já solicitou uma renovação."
 
 #. Translators: This text is the heading of a section in a user's profile where they can change their preferences.
 #: TWLight/users/templates/users/preferences.html:6
@@ -3386,27 +2656,13 @@ msgstr "Restringir processamento de dados"
 
 #. Translators: This message is displayed on the page where users can request we stop processing their data.
 #: TWLight/users/templates/users/restrict_data.html:15
-msgid ""
-"Checking this box and clicking “Restrict” will pause all processing of the "
-"data you have entered into this website. You will not be able to apply for "
-"access to resources, your applications will not be further processed, and "
-"none of your data will be altered, until you return to this page and uncheck "
-"the box. This is not the same as deleting your data."
-msgstr ""
-"Marcar esta caixa e clicar em \"Restringir\" interromperá todo o "
-"processamento dos dados inseridos neste site. Você não poderá solicitar "
-"acesso a recursos, seus aplicativos não serão processados posteriormente e "
-"nenhum dos seus dados será alterado até que você retorne a esta página e "
-"desmarque a caixa. Isso não é o mesmo que excluir seus dados."
+msgid "Checking this box and clicking “Restrict” will pause all processing of the data you have entered into this website. You will not be able to apply for access to resources, your applications will not be further processed, and none of your data will be altered, until you return to this page and uncheck the box. This is not the same as deleting your data."
+msgstr "Marcar esta caixa e clicar em \"Restringir\" interromperá todo o processamento dos dados inseridos neste site. Você não poderá solicitar acesso a recursos, seus aplicativos não serão processados posteriormente e nenhum dos seus dados será alterado até que você retorne a esta página e desmarque a caixa. Isso não é o mesmo que excluir seus dados."
 
 #. Translators: This warning message is shown to coordinators who view the data restriction page.
 #: TWLight/users/templates/users/restrict_data.html:26
-msgid ""
-"You are a coordinator on this site. If you restrict the processing of your "
-"data, your coordinator flag will be removed."
-msgstr ""
-"Você é um coordenador neste site. Se você restringir o processamento de seus "
-"dados, o sinalizador de coordenador será removido."
+msgid "You are a coordinator on this site. If you restrict the processing of your data, your coordinator flag will be removed."
+msgstr "Você é um coordenador neste site. Se você restringir o processamento de seus dados, o sinalizador de coordenador será removido."
 
 #. Translators: use the date *when you are translating*, in a language-appropriate format.
 #: TWLight/users/templates/users/terms.html:33
@@ -3421,45 +2677,17 @@ msgstr "Política de privacidade da Fundação Wikimedia"
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:41
 msgid "Wikipedia Library Card Terms of Use and Privacy Statement"
-msgstr ""
-"Termos de Uso e Declaração de Privacidade do Cartão de Biblioteca da "
-"Wikipédia"
+msgstr "Termos de Uso e Declaração de Privacidade do Cartão de Biblioteca da Wikipédia"
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:51
-msgid ""
-"<a class=\"twl-links\" href=\"https://meta.wikimedia.org/wiki/"
-"The_Wikipedia_Library\"> The Wikipedia Library </a> has partnered with "
-"publishers around the world to allow users to access otherwise paywalled "
-"resources. This website allows Wikipedia editors to search and access these "
-"resources."
-msgstr ""
-"<a class=\"twl-links\" href=\"https://meta.wikimedia.org/wiki/"
-"The_Wikipedia_Library/pt-br\">A Biblioteca da Wikipédia</a> estabeleceu "
-"parcerias com editoras de todo o mundo para permitir que os usuários acessem "
-"a recursos que, de outra forma, seriam pagos. Este <i>site</i> da Internet "
-"permite que os usuários se candidatem simultaneamente a acesso ao conteúdo "
-"de várias editoras e torna fácil e eficiente a administração de contas da "
-"Biblioteca da Wikipédia, e o acesso às mesmas."
+msgid "<a class=\"twl-links\" href=\"https://meta.wikimedia.org/wiki/The_Wikipedia_Library\"> The Wikipedia Library </a> has partnered with publishers around the world to allow users to access otherwise paywalled resources. This website allows Wikipedia editors to search and access these resources."
+msgstr "<a class=\"twl-links\" href=\"https://meta.wikimedia.org/wiki/The_Wikipedia_Library/pt-br\">A Biblioteca da Wikipédia</a> estabeleceu parcerias com editoras de todo o mundo para permitir que os usuários acessem a recursos que, de outra forma, seriam pagos. Este <i>site</i> da Internet permite que os usuários se candidatem simultaneamente a acesso ao conteúdo de várias editoras e torna fácil e eficiente a administração de contas da Biblioteca da Wikipédia, e o acesso às mesmas."
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Wikimedia Foundation should not be translated. WMF should not be translated. Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:63
-msgid ""
-"This program is administered by the Wikimedia Foundation (WMF). These terms "
-"of use and privacy notice pertain to your application for access to "
-"resources through the Wikipedia Library, your use of this website, and your "
-"access to and use of those resources. They also describe our handling of the "
-"information you provide to us in order to create and administer your "
-"Wikipedia Library account. If we make material changes to the terms, we will "
-"notify users."
-msgstr ""
-"Este programa é administrado pela Fundação Wikimedia (WMF). Estes termos de "
-"uso e aviso de privacidade referem-se ao seu aplicativo para acesso a "
-"recursos através da Biblioteca da Wikipédia, seu uso deste site e seu acesso "
-"e uso desses recursos. Eles também descrevem nosso tratamento das "
-"informações que você nos fornece para criar e administrar sua conta da "
-"Biblioteca da Wikipédia. Se fizermos alterações materiais nos termos, "
-"notificaremos os usuários."
+msgid "This program is administered by the Wikimedia Foundation (WMF). These terms of use and privacy notice pertain to your application for access to resources through the Wikipedia Library, your use of this website, and your access to and use of those resources. They also describe our handling of the information you provide to us in order to create and administer your Wikipedia Library account. If we make material changes to the terms, we will notify users."
+msgstr "Este programa é administrado pela Fundação Wikimedia (WMF). Estes termos de uso e aviso de privacidade referem-se ao seu aplicativo para acesso a recursos através da Biblioteca da Wikipédia, seu uso deste site e seu acesso e uso desses recursos. Eles também descrevem nosso tratamento das informações que você nos fornece para criar e administrar sua conta da Biblioteca da Wikipédia. Se fizermos alterações materiais nos termos, notificaremos os usuários."
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:74
@@ -3468,59 +2696,18 @@ msgstr "Requisitos para uma conta de cartão da biblioteca da Wikipédia"
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:78
-msgid ""
-"Access to resources via The Wikipedia Library is reserved for community "
-"members who have demonstrated their commitment to the Wikimedia projects, "
-"and who will use their access to these resources to improve project content. "
-"To that end, in order to be eligible for The Wikipedia Library, we require "
-"that you be registered for a user account on the projects, with at least 500 "
-"edits, six (6) months of activity, and 10+ edits in the last month. We ask "
-"that you do not request access to any publishers with a limited number of "
-"available accounts whose resources you can already access for free through "
-"your local library or university, or another institution or organization, in "
-"order to provide that opportunity to others."
-msgstr ""
-"O acesso aos recursos através da Biblioteca da Wikipédia são reservados para "
-"membros da comunidade que demonstraram seu compromisso com os projetos da "
-"Wikimedia e usarão seu acesso a esses recursos para melhorar o conteúdo do "
-"projeto. Para esse fim, para ser elegível para o programa Biblioteca da "
-"Wikipédia, exigimos que você possua uma conta de usuário nos projetos com "
-"pelo menos 500 edições, seis (6) meses de atividade e mais de 10 edições no "
-"último mês. Solicitamos que você não solicite acesso a periódicos cujos "
-"recursos você já tenha acesso gratuitamente por meio de sua biblioteca ou "
-"universidade local, ou de outra instituição ou organização, a fim de "
-"fornecer essa oportunidade a outras pessoas."
+msgid "Access to resources via The Wikipedia Library is reserved for community members who have demonstrated their commitment to the Wikimedia projects, and who will use their access to these resources to improve project content. To that end, in order to be eligible for The Wikipedia Library, we require that you be registered for a user account on the projects, with at least 500 edits, six (6) months of activity, and 10+ edits in the last month. We ask that you do not request access to any publishers with a limited number of available accounts whose resources you can already access for free through your local library or university, or another institution or organization, in order to provide that opportunity to others."
+msgstr "O acesso aos recursos através da Biblioteca da Wikipédia são reservados para membros da comunidade que demonstraram seu compromisso com os projetos da Wikimedia e usarão seu acesso a esses recursos para melhorar o conteúdo do projeto. Para esse fim, para ser elegível para o programa Biblioteca da Wikipédia, exigimos que você possua uma conta de usuário nos projetos com pelo menos 500 edições, seis (6) meses de atividade e mais de 10 edições no último mês. Solicitamos que você não solicite acesso a periódicos cujos recursos você já tenha acesso gratuitamente por meio de sua biblioteca ou universidade local, ou de outra instituição ou organização, a fim de fornecer essa oportunidade a outras pessoas."
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:94
-msgid ""
-"Additionally, if you are currently blocked or banned from a Wikimedia "
-"project, applications to resources may be rejected or restricted. If you "
-"obtain a Wikipedia Library account, but a block or ban is subsequently "
-"instituted against you on one of the projects, you may lose access to your "
-"Wikipedia Library account."
-msgstr ""
-"Além disso, se sua conta encontra-se bloqueada ou banida de um projeto da "
-"Wikimedia, seus pedidos de acesso aos recursos podem ser rejeitados ou "
-"restringidos. Se você obtiver uma conta na Biblioteca da Wikipédia, mas um "
-"bloqueio ou proibição de longo prazo for posteriormente instituído contra "
-"você em um dos projetos, você poderá perder o acesso à sua conta da "
-"Biblioteca."
+msgid "Additionally, if you are currently blocked or banned from a Wikimedia project, applications to resources may be rejected or restricted. If you obtain a Wikipedia Library account, but a block or ban is subsequently instituted against you on one of the projects, you may lose access to your Wikipedia Library account."
+msgstr "Além disso, se sua conta encontra-se bloqueada ou banida de um projeto da Wikimedia, seus pedidos de acesso aos recursos podem ser rejeitados ou restringidos. Se você obtiver uma conta na Biblioteca da Wikipédia, mas um bloqueio ou proibição de longo prazo for posteriormente instituído contra você em um dos projetos, você poderá perder o acesso à sua conta da Biblioteca."
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:104
-msgid ""
-"Your eligibility to access The Wikipedia Library is assessed at each login. "
-"While more than half of the library's content is provided via this automated "
-"eligibility check, access to other publisher's content may be time limited, "
-"typically lapsing after one year, after which you will usually need to apply "
-"for renewal."
-msgstr ""
-"Sua elegibilidade de acesso à Biblioteca da Wikipédia será avaliada a cada "
-"vez que você se autenticar. Ao passo que mais da metade do conteúdo da "
-"biblioteca é fornecido através da verificação automática de elegibilidade, o "
-"acesso aos conteúdos de outros periódicos pode necessitar de renovação "
-"geralmente anual. Nesse caso, será necessário um pedido de renovação."
+msgid "Your eligibility to access The Wikipedia Library is assessed at each login. While more than half of the library's content is provided via this automated eligibility check, access to other publisher's content may be time limited, typically lapsing after one year, after which you will usually need to apply for renewal."
+msgstr "Sua elegibilidade de acesso à Biblioteca da Wikipédia será avaliada a cada vez que você se autenticar. Ao passo que mais da metade do conteúdo da biblioteca é fornecido através da verificação automática de elegibilidade, o acesso aos conteúdos de outros periódicos pode necessitar de renovação geralmente anual. Nesse caso, será necessário um pedido de renovação."
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:114
@@ -3529,71 +2716,28 @@ msgstr "Candidatando-se pela sua conta da Biblioteca da Wikipédia"
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:118
-msgid ""
-"In order to apply for access to a partner resource, you must provide us with "
-"certain information, which we will use to evaluate your application. If your "
-"application is approved, we may transfer the information you have given us "
-"to the publishers whose resources you wish to access. They will either "
-"contact you with the account information directly or we will send access "
-"information to you ourselves."
-msgstr ""
-"Para solicitar acesso a um recurso de parceiro, você deve nos fornecer "
-"determinadas informações, que usaremos para avaliar seu aplicativo. Se sua "
-"inscrição for aprovada, poderemos transferir as informações que você nos "
-"forneceu aos editores cujos recursos você deseja acessar. Eles entrarão em "
-"contato diretamente com você com as informações da conta ou enviaremos "
-"informações de acesso a você."
+msgid "In order to apply for access to a partner resource, you must provide us with certain information, which we will use to evaluate your application. If your application is approved, we may transfer the information you have given us to the publishers whose resources you wish to access. They will either contact you with the account information directly or we will send access information to you ourselves."
+msgstr "Para solicitar acesso a um recurso de parceiro, você deve nos fornecer determinadas informações, que usaremos para avaliar seu aplicativo. Se sua inscrição for aprovada, poderemos transferir as informações que você nos forneceu aos editores cujos recursos você deseja acessar. Eles entrarão em contato diretamente com você com as informações da conta ou enviaremos informações de acesso a você."
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:130
-msgid ""
-"In addition to the basic information you provide to us, our system will "
-"retrieve some information directly from the Wikimedia projects: your "
-"username, email address, edit count, registration date, user ID number, "
-"groups to which you belong, and any special user rights."
-msgstr ""
-"Além das informações básicas que você nos fornece, nosso sistema recuperará "
-"algumas informações diretamente dos projetos da Wikimedia: seu nome de "
-"usuário, endereço de e-mail, número de edição, data de registro, número de "
-"usuário, grupos aos quais você pertence e quaisquer direitos especiais de "
-"usuário."
+msgid "In addition to the basic information you provide to us, our system will retrieve some information directly from the Wikimedia projects: your username, email address, edit count, registration date, user ID number, groups to which you belong, and any special user rights."
+msgstr "Além das informações básicas que você nos fornece, nosso sistema recuperará algumas informações diretamente dos projetos da Wikimedia: seu nome de usuário, endereço de e-mail, número de edição, data de registro, número de usuário, grupos aos quais você pertence e quaisquer direitos especiais de usuário."
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:140
-msgid ""
-"Each time you log in to the Wikipedia Library Card Platform, this "
-"information will be automatically updated."
-msgstr ""
-"Sempre que você fizer login na plataforma Cartão da Biblioteca da Wikipédia, "
-"essas informações serão atualizadas automaticamente."
+msgid "Each time you log in to the Wikipedia Library Card Platform, this information will be automatically updated."
+msgstr "Sempre que você fizer login na plataforma Cartão da Biblioteca da Wikipédia, essas informações serão atualizadas automaticamente."
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:148
-msgid ""
-"We will ask you to provide us with some information about your history of "
-"contributions to the Wikimedia projects. Information on contribution history "
-"is optional, but will greatly assist us in evaluating your application."
-msgstr ""
-"Solicitaremos que você forneça algumas informações sobre seu histórico de "
-"contribuições para os projetos da Wikimedia. As informações sobre o "
-"histórico de contribuições são opcionais, mas ajudarão bastante na avaliação "
-"de sua inscrição."
+msgid "We will ask you to provide us with some information about your history of contributions to the Wikimedia projects. Information on contribution history is optional, but will greatly assist us in evaluating your application."
+msgstr "Solicitaremos que você forneça algumas informações sobre seu histórico de contribuições para os projetos da Wikimedia. As informações sobre o histórico de contribuições são opcionais, mas ajudarão bastante na avaliação de sua inscrição."
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). WMF should not be translated. Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:157
-msgid ""
-"The information you provide when creating your account will be visible to "
-"you while on the site but not to others unless they are approved Wikipedia "
-"Library Coordinators, WMF Staff, or WMF Contractors who need access to this "
-"data in order to carry out their work with the Wikipedia Library, all of "
-"whom are subject to non-disclosure obligations."
-msgstr ""
-"As informações que você fornecer ao criar sua conta estarão visíveis para "
-"você enquanto estiver no site, mas não para outras pessoas, a menos que "
-"sejam coordenadores de bibliotecas da Wikipédia aprovados, funcionários da "
-"WMF ou contratados da WMF que precisem acessar esses dados para realizar seu "
-"trabalho com o Biblioteca da Wikipédia, todos sujeitos a obrigações de não "
-"divulgação."
+msgid "The information you provide when creating your account will be visible to you while on the site but not to others unless they are approved Wikipedia Library Coordinators, WMF Staff, or WMF Contractors who need access to this data in order to carry out their work with the Wikipedia Library, all of whom are subject to non-disclosure obligations."
+msgstr "As informações que você fornecer ao criar sua conta estarão visíveis para você enquanto estiver no site, mas não para outras pessoas, a menos que sejam coordenadores de bibliotecas da Wikipédia aprovados, funcionários da WMF ou contratados da WMF que precisem acessar esses dados para realizar seu trabalho com o Biblioteca da Wikipédia, todos sujeitos a obrigações de não divulgação."
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:167
@@ -3602,61 +2746,33 @@ msgstr "Seu uso de recursos do editor"
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:171
-msgid ""
-"In order to access an individual publisher’s resources, you must agree to "
-"that publisher’s terms of use and privacy policy. You agree that you will "
-"not violate such terms and policies in connection with your use of the "
-"Wikipedia Library. Additionally, the following activities are prohibited "
-"while accessing publisher resources through the Wikipedia Library."
-msgstr ""
-"Para acessar os recursos de um editor individual, você deve concordar com os "
-"termos de uso e a política de privacidade desse editor. Você concorda que "
-"não violará esses termos e políticas em conexão com o uso da Biblioteca da "
-"Wikipedia. Além disso, as atividades a seguir são proibidas ao acessar os "
-"recursos do editor através da Biblioteca da Wikipédia."
+msgid "In order to access an individual publisher’s resources, you must agree to that publisher’s terms of use and privacy policy. You agree that you will not violate such terms and policies in connection with your use of the Wikipedia Library. Additionally, the following activities are prohibited while accessing publisher resources through the Wikipedia Library."
+msgstr "Para acessar os recursos de um editor individual, você deve concordar com os termos de uso e a política de privacidade desse editor. Você concorda que não violará esses termos e políticas em conexão com o uso da Biblioteca da Wikipedia. Além disso, as atividades a seguir são proibidas ao acessar os recursos do editor através da Biblioteca da Wikipédia."
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:184
-msgid ""
-"Sharing your Wikipedia account, usernames, passwords, or any access codes "
-"for publisher resources with others;"
-msgstr ""
-"Compartilhar suas contas da Wikipédia, senhas ou códigos de acesso para "
-"recursos do periódico com outras pessoas;"
+msgid "Sharing your Wikipedia account, usernames, passwords, or any access codes for publisher resources with others;"
+msgstr "Compartilhar suas contas da Wikipédia, senhas ou códigos de acesso para recursos do periódico com outras pessoas;"
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:191
-msgid ""
-"Automatically scraping or downloading restricted content from publishers;"
+msgid "Automatically scraping or downloading restricted content from publishers;"
 msgstr "Raspagem ou download automático de conteúdo restrito de editores;"
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:197
-msgid ""
-"Systematically making printed or electronic copies of multiple extracts of "
-"restricted content available for any purpose;"
-msgstr ""
-"Disponibilizar sistematicamente cópias impressas ou eletrônicas de vários "
-"extratos de conteúdo restrito para qualquer finalidade;"
+msgid "Systematically making printed or electronic copies of multiple extracts of restricted content available for any purpose;"
+msgstr "Disponibilizar sistematicamente cópias impressas ou eletrônicas de vários extratos de conteúdo restrito para qualquer finalidade;"
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:204
-msgid ""
-"Data mining metadata without permission—for example, in order to use "
-"metadata for auto-created stub articles;"
-msgstr ""
-"Minerar metadados sem permissão, para, por exemplo, usá-los em esboços de "
-"artigos criados automaticamente;"
+msgid "Data mining metadata without permission—for example, in order to use metadata for auto-created stub articles;"
+msgstr "Minerar metadados sem permissão, para, por exemplo, usá-los em esboços de artigos criados automaticamente;"
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:211
-msgid ""
-"Using the access you receive through the Wikipedia Library for profit by "
-"selling access to your account or resources which you have through it."
-msgstr ""
-"Usando o acesso que você recebe através da Biblioteca da Wikipédia para "
-"obter lucro vendendo acesso à sua conta ou recursos que você possui através "
-"dela."
+msgid "Using the access you receive through the Wikipedia Library for profit by selling access to your account or resources which you have through it."
+msgstr "Usando o acesso que você recebe através da Biblioteca da Wikipédia para obter lucro vendendo acesso à sua conta ou recursos que você possui através dela."
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:220
@@ -3665,25 +2781,13 @@ msgstr "Serviços de pesquisa e proxy externos"
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:224
-msgid ""
-"Certain resources may only be accessed using an external search service, "
-"such as the EBSCO Discovery Service, or a proxy service, such as OCLC "
-"EZProxy. If you use such external search and/or proxy services, please "
-"review the applicable terms of use and privacy policies."
-msgstr ""
-"Certos recursos podem ser acessados apenas usando um serviço de pesquisa "
-"externo, como o EBSCO Discovery Service, ou um serviço de proxy, como o OCLC "
-"EZProxy. Se você usar esses serviços externos de pesquisa e/ou proxy, revise "
-"os termos de uso aplicáveis e as políticas de privacidade."
+msgid "Certain resources may only be accessed using an external search service, such as the EBSCO Discovery Service, or a proxy service, such as OCLC EZProxy. If you use such external search and/or proxy services, please review the applicable terms of use and privacy policies."
+msgstr "Certos recursos podem ser acessados apenas usando um serviço de pesquisa externo, como o EBSCO Discovery Service, ou um serviço de proxy, como o OCLC EZProxy. Se você usar esses serviços externos de pesquisa e/ou proxy, revise os termos de uso aplicáveis e as políticas de privacidade."
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:234
-msgid ""
-"In addition, if you use OCLC EZProxy, please note that you may not use it "
-"for commercial purposes."
-msgstr ""
-"Além disso, se você usar o OCLC EZProxy, observe que não poderá usá-lo para "
-"fins comerciais."
+msgid "In addition, if you use OCLC EZProxy, please note that you may not use it for commercial purposes."
+msgstr "Além disso, se você usar o OCLC EZProxy, observe que não poderá usá-lo para fins comerciais."
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:241
@@ -3693,198 +2797,51 @@ msgstr "Retenção e Manipulação de Dados"
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Wikimedia Foundation should not be translated. Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:245
 #, fuzzy
-msgid ""
-"The Wikimedia Foundation and our service providers use your information for "
-"the legitimate purpose of providing Wikipedia Library services in support of "
-"our charitable mission. When you apply for a Wikipedia Library account, or "
-"use your Wikipedia Library account, we may routinely collect the following "
-"information: your username, email address, edit count, registration date, "
-"user ID number, groups to which you belong, and any special user rights; "
-"your name, country of residence, and/or affiliation, if required by a "
-"partner to which you are applying; your narrative description of your "
-"contributions and reasons for applying for access to partner resources; and "
-"the date you agree to these terms of use."
-msgstr ""
-"A Fundação Wikimedia e seus provedores de serviços usam suas informações com "
-"a finalidade de fornecer serviços da Biblioteca Wikipedia em apoio à nossa "
-"missão de caridade. Quando você solicita uma conta nesta/ou usa sua conta da "
-"Biblioteca, coletaremos as seguintes informações: nome de usuário, endereço "
-"de e-mail, contagem de edições, data de registro, número de identificação do "
-"usuário, grupos aos quais você pertence e qualquer nível especial de "
-"usuário; seu nome, país de residência, ocupação e/ou afiliação (se exigido "
-"por um parceiro ao qual você está se candidatando); descrição de suas "
-"contribuições e razões para solicitar acesso aos recursos do parceiro, e; a "
-"data em que você concorda com estes termos de uso."
+msgid "The Wikimedia Foundation and our service providers use your information for the legitimate purpose of providing Wikipedia Library services in support of our charitable mission. When you apply for a Wikipedia Library account, or use your Wikipedia Library account, we may routinely collect the following information: your username, email address, edit count, registration date, user ID number, groups to which you belong, and any special user rights; your name, country of residence, and/or affiliation, if required by a partner to which you are applying; your narrative description of your contributions and reasons for applying for access to partner resources; and the date you agree to these terms of use."
+msgstr "A Fundação Wikimedia e seus provedores de serviços usam suas informações com a finalidade de fornecer serviços da Biblioteca Wikipedia em apoio à nossa missão de caridade. Quando você solicita uma conta nesta/ou usa sua conta da Biblioteca, coletaremos as seguintes informações: nome de usuário, endereço de e-mail, contagem de edições, data de registro, número de identificação do usuário, grupos aos quais você pertence e qualquer nível especial de usuário; seu nome, país de residência, ocupação e/ou afiliação (se exigido por um parceiro ao qual você está se candidatando); descrição de suas contribuições e razões para solicitar acesso aos recursos do parceiro, e; a data em que você concorda com estes termos de uso."
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:262
 #, fuzzy, python-format
-msgid ""
-"Each publisher who is a member of the Wikipedia Library program requires "
-"different specific information in the application. Some publishers may "
-"request only an email address, while others request more detailed data, such "
-"as your name, location, or institutional affiliation. When you complete your "
-"application, you will only be asked to supply information required by the "
-"publishers you have chosen, and each publisher will only receive the "
-"information they require for providing you with access. Please see our <a "
-"class=\"twl-links\" href=\"%(all_partners_url)s\">partner information</a> "
-"pages to learn what information is required by each publisher to gain access "
-"to their resources."
-msgstr ""
-"Cada editora que é membro do programa Biblioteca da Wikipédia requer "
-"informação específica na candidatura, algumas podem pedir só um endereço de "
-"e-mail, enquanto outras pedem dados mais detalhados, como o seu nome, "
-"localização, ocupação ou filiação em instituições. Será pedida a informação "
-"exigida de acordo com as editoras que escolheu, e cada só receberá a "
-"informação que requereu para lhe conceder acesso. Consulte as nossas páginas "
-"de <a class=\"twl-links\" href=\"%(all_partners_url)s\">informações de "
-"parceiros</a> para saber que informação é exigida por cada editora para "
-"obter acesso aos recursos da mesma."
+msgid "Each publisher who is a member of the Wikipedia Library program requires different specific information in the application. Some publishers may request only an email address, while others request more detailed data, such as your name, location, or institutional affiliation. When you complete your application, you will only be asked to supply information required by the publishers you have chosen, and each publisher will only receive the information they require for providing you with access. Please see our <a class=\"twl-links\" href=\"%(all_partners_url)s\">partner information</a> pages to learn what information is required by each publisher to gain access to their resources."
+msgstr "Cada editora que é membro do programa Biblioteca da Wikipédia requer informação específica na candidatura, algumas podem pedir só um endereço de e-mail, enquanto outras pedem dados mais detalhados, como o seu nome, localização, ocupação ou filiação em instituições. Será pedida a informação exigida de acordo com as editoras que escolheu, e cada só receberá a informação que requereu para lhe conceder acesso. Consulte as nossas páginas de <a class=\"twl-links\" href=\"%(all_partners_url)s\">informações de parceiros</a> para saber que informação é exigida por cada editora para obter acesso aos recursos da mesma."
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Wikimedia Foundation should not be translated. Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:277
-msgid ""
-"Some Wikipedia Library pages are visible without logging in, but you will "
-"need to log in to apply or access proprietary partner resources. We use the "
-"data provided by you via OAuth and Wikimedia API calls to assess your "
-"application for access and to process approved requests."
-msgstr ""
-"Você pode navegar no site da Biblioteca da Wikipédia sem autenticação "
-"(login), mas para acessar recursos de parceiros proprietários precisará "
-"autenticar-se. Usamos os dados fornecidos por você por meio de chamadas da "
-"API OAuth e Wikimedia para avaliar seu pedido de acesso e processar "
-"solicitações aprovadas."
+msgid "Some Wikipedia Library pages are visible without logging in, but you will need to log in to apply or access proprietary partner resources. We use the data provided by you via OAuth and Wikimedia API calls to assess your application for access and to process approved requests."
+msgstr "Você pode navegar no site da Biblioteca da Wikipédia sem autenticação (login), mas para acessar recursos de parceiros proprietários precisará autenticar-se. Usamos os dados fornecidos por você por meio de chamadas da API OAuth e Wikimedia para avaliar seu pedido de acesso e processar solicitações aprovadas."
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:288
 #, python-format
-msgid ""
-"In order to administer the Wikipedia Library program, we will retain the "
-"application data we collect from you for three years after your most recent "
-"login, unless you delete your account, as described below. You can log in "
-"and go to <a class=\"twl-links\" href=\"%(profile_url)s\">your profile page</"
-"a> in order to see the information associated with your account, and can "
-"download it in JSON format. You may access, update, restrict, or delete this "
-"information at any time, except for the information that is automatically "
-"retrieved from the projects. If you have any questions or concerns about the "
-"handling of your data, please contact <a class=\"twl-links\" href=\"mailto:"
-"wikipedialibrary@wikimedia.org?Subject=Wikipedia%%20Library%%20Card"
-"%%20account%%20deactivation\"> wikipedialibrary@wikimedia.org </a>."
-msgstr ""
-"Para administrar o programa da Biblioteca da Wikipédia reteremos os dados de "
-"candidatura que nos forneceu, durante um período de três anos após o seu "
-"início de sessão mais recente, a menos que elimine a sua conta conforme "
-"descrito abaixo. Pode iniciar uma sessão e aceder à <a class=\"twl-links\" "
-"href=\"%(profile_url)s\">sua página de perfil</a> para ver as informações "
-"associadas à sua conta, onde pode baixar-las em formato JSON, atualizar, "
-"restringir, ou apagar estas informações em qualquer momento, exceto as que "
-"são obtidas automaticamente dos projetos. Se tem qualquer pergunta ou "
-"preocupação acerca do nosso tratamento dos seus dados, por favor fale "
-"conosco <a class=\"twl-links\" href=\"mailto:wikipedialibrary@wikimedia.org?"
-"Subject=Wikipedia%%20Library%%20Card%%20account%%20deactivation"
-"\">wikipedialibrary@wikimedia.org</a>."
+msgid "In order to administer the Wikipedia Library program, we will retain the application data we collect from you for three years after your most recent login, unless you delete your account, as described below. You can log in and go to <a class=\"twl-links\" href=\"%(profile_url)s\">your profile page</a> in order to see the information associated with your account, and can download it in JSON format. You may access, update, restrict, or delete this information at any time, except for the information that is automatically retrieved from the projects. If you have any questions or concerns about the handling of your data, please contact <a class=\"twl-links\" href=\"mailto:wikipedialibrary@wikimedia.org?Subject=Wikipedia%%20Library%%20Card%%20account%%20deactivation\"> wikipedialibrary@wikimedia.org </a>."
+msgstr "Para administrar o programa da Biblioteca da Wikipédia reteremos os dados de candidatura que nos forneceu, durante um período de três anos após o seu início de sessão mais recente, a menos que elimine a sua conta conforme descrito abaixo. Pode iniciar uma sessão e aceder à <a class=\"twl-links\" href=\"%(profile_url)s\">sua página de perfil</a> para ver as informações associadas à sua conta, onde pode baixar-las em formato JSON, atualizar, restringir, ou apagar estas informações em qualquer momento, exceto as que são obtidas automaticamente dos projetos. Se tem qualquer pergunta ou preocupação acerca do nosso tratamento dos seus dados, por favor fale conosco <a class=\"twl-links\" href=\"mailto:wikipedialibrary@wikimedia.org?Subject=Wikipedia%%20Library%%20Card%%20account%%20deactivation\">wikipedialibrary@wikimedia.org</a>."
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:305
 #, fuzzy
-msgid ""
-"If you decide to disable your Wikipedia Library account, you can use the "
-"delete button on your profile to delete certain personal information "
-"associated with your account. We will delete your real name, institutional "
-"affiliation, and country of residence. Please note that the system will "
-"retain a record of your username, the publishers to which you applied or had "
-"access, and the dates of that access. Note that deletion is not reversible. "
-"Deletion of your Wikipedia Library account may also correspond with the "
-"removal of any resource access to which you were eligible or approved. If "
-"you request the deletion of account information and later wish to apply for "
-"a new account, you will need to provide the necessary information again."
-msgstr ""
-"Se você decidir desativar sua conta da Biblioteca da Wikipédia, poderá usar "
-"o botão Excluir no seu perfil para excluir determinadas informações pessoais "
-"associadas à sua conta. Excluiremos seu nome real, profissão, afiliação "
-"institucional e país de residência. Observe que o sistema manterá um "
-"registro do seu nome de usuário, dos editores aos quais você aplicou ou teve "
-"acesso e as datas desse acesso. Observe que a exclusão não é reversível. A "
-"exclusão da sua conta da Biblioteca da Wikipédia também pode corresponder à "
-"remoção de qualquer acesso a recursos aos quais você foi elegível ou "
-"aprovado. Se você solicitar a exclusão de informações da conta e "
-"posteriormente desejar solicitar uma nova conta, precisará fornecer as "
-"informações necessárias novamente."
+msgid "If you decide to disable your Wikipedia Library account, you can use the delete button on your profile to delete certain personal information associated with your account. We will delete your real name, institutional affiliation, and country of residence. Please note that the system will retain a record of your username, the publishers to which you applied or had access, and the dates of that access. Note that deletion is not reversible. Deletion of your Wikipedia Library account may also correspond with the removal of any resource access to which you were eligible or approved. If you request the deletion of account information and later wish to apply for a new account, you will need to provide the necessary information again."
+msgstr "Se você decidir desativar sua conta da Biblioteca da Wikipédia, poderá usar o botão Excluir no seu perfil para excluir determinadas informações pessoais associadas à sua conta. Excluiremos seu nome real, profissão, afiliação institucional e país de residência. Observe que o sistema manterá um registro do seu nome de usuário, dos editores aos quais você aplicou ou teve acesso e as datas desse acesso. Observe que a exclusão não é reversível. A exclusão da sua conta da Biblioteca da Wikipédia também pode corresponder à remoção de qualquer acesso a recursos aos quais você foi elegível ou aprovado. Se você solicitar a exclusão de informações da conta e posteriormente desejar solicitar uma nova conta, precisará fornecer as informações necessárias novamente."
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). WMF should not be translated. Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:321
-msgid ""
-"The Wikipedia Library is run by WMF Staff, Contractors, and approved "
-"volunteer Coordinators. The data associated with your account will be shared "
-"with the WMF staff, contractors, service providers, and volunteer "
-"coordinators who need to process the information in connection with their "
-"work for the Wikipedia Library, and who are subject to confidentiality "
-"obligations. We will also use your data for internal Wikipedia Library "
-"purposes such as distributing user surveys and account notifications, and in "
-"a depersonalized or aggregated fashion for statistical analysis and "
-"administration. Finally, we will share your information with the publishers "
-"whom you specifically select in order to provide you with access to "
-"resources. Otherwise, your information will not be shared with third "
-"parties, with the exception of the circumstances described below."
-msgstr ""
-"A Biblioteca da Wikipédia é administrada por funcionários da WMF, "
-"contratados e coordenadores voluntários aprovados. Os dados associados à sua "
-"conta serão compartilhados com a equipe da WMF, prestadores de serviços, "
-"prestadores de serviços e coordenadores voluntários que precisam processar "
-"as informações em conexão com seu trabalho na Biblioteca Wikipédia e que "
-"estão sujeitos a obrigações de confidencialidade. Também usaremos seus dados "
-"para fins internos da Biblioteca Wikipédia, como distribuir pesquisas de "
-"usuários e notificações de contas e de forma despersonalizada ou agregada "
-"para análise e administração estatística. Por fim, compartilharemos suas "
-"informações com os editores que você selecionar especificamente para "
-"fornecer acesso a recursos. Caso contrário, suas informações não serão "
-"compartilhadas com terceiros, com exceção das circunstâncias descritas "
-"abaixo."
+msgid "The Wikipedia Library is run by WMF Staff, Contractors, and approved volunteer Coordinators. The data associated with your account will be shared with the WMF staff, contractors, service providers, and volunteer coordinators who need to process the information in connection with their work for the Wikipedia Library, and who are subject to confidentiality obligations. We will also use your data for internal Wikipedia Library purposes such as distributing user surveys and account notifications, and in a depersonalized or aggregated fashion for statistical analysis and administration. Finally, we will share your information with the publishers whom you specifically select in order to provide you with access to resources. Otherwise, your information will not be shared with third parties, with the exception of the circumstances described below."
+msgstr "A Biblioteca da Wikipédia é administrada por funcionários da WMF, contratados e coordenadores voluntários aprovados. Os dados associados à sua conta serão compartilhados com a equipe da WMF, prestadores de serviços, prestadores de serviços e coordenadores voluntários que precisam processar as informações em conexão com seu trabalho na Biblioteca Wikipédia e que estão sujeitos a obrigações de confidencialidade. Também usaremos seus dados para fins internos da Biblioteca Wikipédia, como distribuir pesquisas de usuários e notificações de contas e de forma despersonalizada ou agregada para análise e administração estatística. Por fim, compartilharemos suas informações com os editores que você selecionar especificamente para fornecer acesso a recursos. Caso contrário, suas informações não serão compartilhadas com terceiros, com exceção das circunstâncias descritas abaixo."
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). WMF should not be translated.
 #: TWLight/users/templates/users/terms.html:338
-msgid ""
-"We may disclose any collected information when required by law, when we have "
-"your permission, when needed to protect our rights, privacy, safety, users, "
-"or the general public, and when necessary to enforce these terms, WMF’s "
-"general <a class=\"twl-links\" href=\"https://foundation.wikimedia.org/wiki/"
-"Terms_of_Use\">Terms of Use</a>, or any other WMF policy."
-msgstr ""
-"Podemos divulgar qualquer informação coletada quando: exigido por lei, "
-"quando tivermos sua permissão, quando necessário para proteger nossos "
-"direitos, privacidade, segurança, usuários ou o público em geral e, quando "
-"necessário, para fazer cumprir os termos e as diretrizes gerais da WMF. <a "
-"class=\"twl-links\" href=\"https://foundation.wikimedia.org/wiki/Terms_of_Use"
-"\">Termos de uso</a>, ou qualquer outra política do WMF."
+msgid "We may disclose any collected information when required by law, when we have your permission, when needed to protect our rights, privacy, safety, users, or the general public, and when necessary to enforce these terms, WMF’s general <a class=\"twl-links\" href=\"https://foundation.wikimedia.org/wiki/Terms_of_Use\">Terms of Use</a>, or any other WMF policy."
+msgstr "Podemos divulgar qualquer informação coletada quando: exigido por lei, quando tivermos sua permissão, quando necessário para proteger nossos direitos, privacidade, segurança, usuários ou o público em geral e, quando necessário, para fazer cumprir os termos e as diretrizes gerais da WMF. <a class=\"twl-links\" href=\"https://foundation.wikimedia.org/wiki/Terms_of_Use\">Termos de uso</a>, ou qualquer outra política do WMF."
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:349
-msgid ""
-"We take the security of your personal data seriously, and take reasonable "
-"precautions to ensure your data is protected. These precautions include "
-"access controls to limit who has access to your data and security "
-"technologies to protect data stored on the server. However, we cannot "
-"guarantee the safety of your data as it is transmitted and stored."
-msgstr ""
-"Levamos a sério a segurança de seus dados pessoais e tomamos as devidas "
-"precauções para garantir que seus dados sejam protegidos. Essas precauções "
-"incluem controles de acesso para limitar quem tem acesso aos seus dados e "
-"tecnologias de segurança para proteger os dados armazenados no servidor. No "
-"entanto, não podemos garantir a segurança dos seus dados à medida que são "
-"transmitidos e armazenados."
+msgid "We take the security of your personal data seriously, and take reasonable precautions to ensure your data is protected. These precautions include access controls to limit who has access to your data and security technologies to protect data stored on the server. However, we cannot guarantee the safety of your data as it is transmitted and stored."
+msgstr "Levamos a sério a segurança de seus dados pessoais e tomamos as devidas precauções para garantir que seus dados sejam protegidos. Essas precauções incluem controles de acesso para limitar quem tem acesso aos seus dados e tecnologias de segurança para proteger os dados armazenados no servidor. No entanto, não podemos garantir a segurança dos seus dados à medida que são transmitidos e armazenados."
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:360
-msgid ""
-"Please note that these terms do not control the use and handling of your "
-"data by the publishers and service providers whose resources you access or "
-"apply to access. Please read their individual privacy policies for that "
-"information."
-msgstr ""
-"Observe que esses termos não controlam o uso e o manuseio de seus dados "
-"pelos editores e provedores de serviços cujos recursos você acessa ou "
-"aplica. Leia suas políticas de privacidade individuais para essas "
-"informações."
+msgid "Please note that these terms do not control the use and handling of your data by the publishers and service providers whose resources you access or apply to access. Please read their individual privacy policies for that information."
+msgstr "Observe que esses termos não controlam o uso e o manuseio de seus dados pelos editores e provedores de serviços cujos recursos você acessa ou aplica. Leia suas políticas de privacidade individuais para essas informações."
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:368
@@ -3893,52 +2850,18 @@ msgstr "Nota importante"
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Wikimedia Foundation should not be translated. Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:373
-msgid ""
-"The Wikimedia Foundation is a nonprofit organization based in San Francisco, "
-"California. The Wikipedia Library program provides access to resources held "
-"by publishers in multiple countries. If you apply for a Wikipedia Library "
-"account (whether you are inside or outside of the United States), you "
-"understand that your personal data will be collected, transferred, stored, "
-"processed, disclosed and otherwise used in the U.S. as described in this "
-"privacy policy. You also understand that your information may be transferred "
-"by us from the U.S. to other countries, which may have different or less "
-"stringent data protection laws than your country, in connection with "
-"providing services to you, including evaluating your application and "
-"securing access to your chosen publishers (locations for each publisher are "
-"outlined on their respective partner information pages)."
-msgstr ""
-"A Fundação Wikimedia é uma organização sem fins lucrativos com sede em San "
-"Francisco, Califórnia. O programa Biblioteca da Wikipédia fornece acesso a "
-"recursos mantidos por editores em vários países. Se você solicitar uma conta "
-"da Biblioteca da Wikipedia (dentro ou fora dos Estados Unidos), entende que "
-"seus dados pessoais serão coletados, transferidos, armazenados, processados, "
-"divulgados e usados nos EUA, conforme descrito nesta política de "
-"privacidade . Você também entende que suas informações podem ser "
-"transferidas por nós dos EUA para outros países, que podem ter leis de "
-"proteção de dados diferentes ou menos rigorosas que o seu país, em conexão "
-"com a prestação de serviços, incluindo a avaliação de sua inscrição e a "
-"garantia de acesso ao país escolhido. editores (os locais de cada editor "
-"estão descritos em suas respectivas páginas de informações de parceiros)."
+msgid "The Wikimedia Foundation is a nonprofit organization based in San Francisco, California. The Wikipedia Library program provides access to resources held by publishers in multiple countries. If you apply for a Wikipedia Library account (whether you are inside or outside of the United States), you understand that your personal data will be collected, transferred, stored, processed, disclosed and otherwise used in the U.S. as described in this privacy policy. You also understand that your information may be transferred by us from the U.S. to other countries, which may have different or less stringent data protection laws than your country, in connection with providing services to you, including evaluating your application and securing access to your chosen publishers (locations for each publisher are outlined on their respective partner information pages)."
+msgstr "A Fundação Wikimedia é uma organização sem fins lucrativos com sede em San Francisco, Califórnia. O programa Biblioteca da Wikipédia fornece acesso a recursos mantidos por editores em vários países. Se você solicitar uma conta da Biblioteca da Wikipedia (dentro ou fora dos Estados Unidos), entende que seus dados pessoais serão coletados, transferidos, armazenados, processados, divulgados e usados nos EUA, conforme descrito nesta política de privacidade . Você também entende que suas informações podem ser transferidas por nós dos EUA para outros países, que podem ter leis de proteção de dados diferentes ou menos rigorosas que o seu país, em conexão com a prestação de serviços, incluindo a avaliação de sua inscrição e a garantia de acesso ao país escolhido. editores (os locais de cada editor estão descritos em suas respectivas páginas de informações de parceiros)."
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:392
-msgid ""
-"Please note that in the event of any differences in meaning or "
-"interpretation between the original English version of these terms and a "
-"translation, the original English version takes precedence."
-msgstr ""
-"Observe que, no caso de haver diferenças de significado ou interpretação "
-"entre a versão original em inglês desses termos e uma tradução, a versão "
-"original em inglês terá precedência."
+msgid "Please note that in the event of any differences in meaning or interpretation between the original English version of these terms and a translation, the original English version takes precedence."
+msgstr "Observe que, no caso de haver diferenças de significado ou interpretação entre a versão original em inglês desses termos e uma tradução, a versão original em inglês terá precedência."
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Wikimedia Foundation should not be translated.
 #: TWLight/users/templates/users/terms.html:403
-msgid ""
-"See also the <a class=\"twl-links\" href=\"https://wikimediafoundation.org/"
-"wiki/Privacy_policy\">Wikimedia Foundation Privacy Policy</a>."
-msgstr ""
-"Veja também a <a class=\"twl-links\" href=\"https://wikimediafoundation.org/"
-"wiki/Privacy_policy\">Política de Privacidade da WMF</a>."
+msgid "See also the <a class=\"twl-links\" href=\"https://wikimediafoundation.org/wiki/Privacy_policy\">Wikimedia Foundation Privacy Policy</a>."
+msgstr "Veja também a <a class=\"twl-links\" href=\"https://wikimediafoundation.org/wiki/Privacy_policy\">Política de Privacidade da WMF</a>."
 
 #. Translators: This is the second to last line of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:412
@@ -3957,16 +2880,8 @@ msgstr "Fundação Wikimedia"
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:426
-msgid ""
-"By checking this box and clicking “Submit”, you agree that you have read the "
-"above terms and that you will adhere to the terms of use in your application "
-"to and use of the The Wikipedia Library, and the publishers’ services to "
-"which you gain access through The Wikipedia Library program."
-msgstr ""
-"Ao marcar esta caixa e clicar em \"Enviar\", declara ter lido as condições "
-"acima e concorda em aderir às condições de utilização na sua candidatura e "
-"uso da Biblioteca da Wikipédia e dos serviços das editoras a que ganhar "
-"acesso através do programa Biblioteca da Wikipédia."
+msgid "By checking this box and clicking “Submit”, you agree that you have read the above terms and that you will adhere to the terms of use in your application to and use of the The Wikipedia Library, and the publishers’ services to which you gain access through The Wikipedia Library program."
+msgstr "Ao marcar esta caixa e clicar em \"Enviar\", declara ter lido as condições acima e concorda em aderir às condições de utilização na sua candidatura e uso da Biblioteca da Wikipédia e dos serviços das editoras a que ganhar acesso através do programa Biblioteca da Wikipédia."
 
 #: TWLight/users/templates/users/user_collection_tile.html:32
 msgid "Remove this collection from favorites"
@@ -4018,40 +2933,19 @@ msgstr "Excluir todos os dados"
 
 #. Translators: This message is displayed on the page where users can request the deletion of their data.
 #: TWLight/users/templates/users/user_confirm_delete.html:17
-msgid ""
-"<b>Warning:</b> Performing this action will delete your Wikipedia Library "
-"Card user account and all associated applications. This process is not "
-"reversible. You may lose any partner accounts you were granted, and will not "
-"be able to renew those accounts or apply for new ones."
-msgstr ""
-"<b>Atenção:</b> A execução dessa ação excluirá sua conta de usuário do "
-"cartão da Biblioteca da Wikipédia e todos as candidaturas associadas. Este "
-"processo não é reversível. Você pode perder as contas de parceiros que "
-"recebeu e não poderá renovar essas contas nem solicitar novas."
+msgid "<b>Warning:</b> Performing this action will delete your Wikipedia Library Card user account and all associated applications. This process is not reversible. You may lose any partner accounts you were granted, and will not be able to renew those accounts or apply for new ones."
+msgstr "<b>Atenção:</b> A execução dessa ação excluirá sua conta de usuário do cartão da Biblioteca da Wikipédia e todos as candidaturas associadas. Este processo não é reversível. Você pode perder as contas de parceiros que recebeu e não poderá renovar essas contas nem solicitar novas."
 
 #. Translators: this should show up for people who log in with a username/password and not OAuth, so we don't know what their Wikipedia identity is.
-#.
 #: TWLight/users/templates/users/user_detail.html:12
 #, python-format
-msgid ""
-"Hi, %(username)s! You don't have a Wikipedia editor profile attached to your "
-"account here, so you are probably a site administrator."
-msgstr ""
-"Olá, %(username)s! Você não tem um perfil de editor da Wikipédia anexado à "
-"sua conta aqui, então você provavelmente é um administrador do site."
+msgid "Hi, %(username)s! You don't have a Wikipedia editor profile attached to your account here, so you are probably a site administrator."
+msgstr "Olá, %(username)s! Você não tem um perfil de editor da Wikipédia anexado à sua conta aqui, então você provavelmente é um administrador do site."
 
 #. Translators: In the unlikely scenario that someone is able to register an account without using OAuth (thus leaving us without some of the information required for applications), users will see this message, encouraging them to re-register.
 #: TWLight/users/templates/users/user_detail.html:20
-msgid ""
-"If you aren't a site administrator, something weird has happened. You won't "
-"be able to apply for access without a Wikipedia editor profile. You should "
-"log out and create a new account by logging in via OAuth, or contact a site "
-"administrator for help."
-msgstr ""
-"Se você não é um administrador do site, algo estranho aconteceu. Você não "
-"poderá solicitar acesso sem um perfil do editor da Wikipedia. Você deve "
-"fazer logout e criar uma nova conta autenticando-se via OAuth ou entrar em "
-"contato com um administrador do site para obter ajuda."
+msgid "If you aren't a site administrator, something weird has happened. You won't be able to apply for access without a Wikipedia editor profile. You should log out and create a new account by logging in via OAuth, or contact a site administrator for help."
+msgstr "Se você não é um administrador do site, algo estranho aconteceu. Você não poderá solicitar acesso sem um perfil do editor da Wikipedia. Você deve fazer logout e criar uma nova conta autenticando-se via OAuth ou entrar em contato com um administrador do site para obter ajuda."
 
 #. Translators: Labels a sections where coordinators can select their email preferences.
 #: TWLight/users/templates/users/user_email_preferences.html:15
@@ -4061,23 +2955,13 @@ msgstr "Apenas coordenadores"
 #. Translators: This message is shown on user's own profile page, encouraging them to make sure their information is up to date, so that account coordinators can use the information to judge applications.
 #: TWLight/users/views.py:176
 #, python-brace-format
-msgid ""
-"Please <a class='twl-links' href='{url}'>update your contributions</a> to "
-"Wikipedia to help coordinators evaluate your applications."
-msgstr ""
-"Por favor <a class='twl-links' href='{url}'>atualize suas contribuições</a> "
-"à Wikipédia para ajudar os coordenadores a avaliar seus aplicativos."
+msgid "Please <a class='twl-links' href='{url}'>update your contributions</a> to Wikipedia to help coordinators evaluate your applications."
+msgstr "Por favor <a class='twl-links' href='{url}'>atualize suas contribuições</a> à Wikipédia para ajudar os coordenadores a avaliar seus aplicativos."
 
 #. Translators: Coordinators are shown this message when they unselect all three types of reminder email options under preferences.
 #: TWLight/users/views.py:288
-msgid ""
-"You have chosen not to receive reminder emails. As a coordinator, you should "
-"receive at least one type of reminder emails, so consider changing your "
-"preferences."
-msgstr ""
-"Você optou por não receber e-mails de lembrete. Como coordenador, você deve "
-"receber pelo menos um tipo de e-mail de lembrete, então considere alterar "
-"suas preferências."
+msgid "You have chosen not to receive reminder emails. As a coordinator, you should receive at least one type of reminder emails, so consider changing your preferences."
+msgstr "Você optou por não receber e-mails de lembrete. Como coordenador, você deve receber pelo menos um tipo de e-mail de lembrete, então considere alterar suas preferências."
 
 #. Translators: Coordinators are shown this message when they make changes to their reminder email options under preferences.
 #: TWLight/users/views.py:296
@@ -4100,9 +2984,7 @@ msgstr "Suas informações foram atualizadas."
 #. Translators: If a user tries to save the 'email change form' without entering one and checking the 'use my Wikipedia email address' checkbox, this message is presented.
 #: TWLight/users/views.py:448
 msgid "Both the values cannot be blank. Either enter a email or check the box."
-msgstr ""
-"Os valores não podem estar ambos em branco. Introduza um endereço de e-mail "
-"ou marque a caixa."
+msgstr "Os valores não podem estar ambos em branco. Introduza um endereço de e-mail ou marque a caixa."
 
 #. Translators: Shown to users when they successfully modify their email. Don't translate {email}.
 #: TWLight/users/views.py:476
@@ -4112,12 +2994,8 @@ msgstr "Seu email foi alterado para {email}."
 
 #. Translators: If the user has not filled out their email, they can browse the website but cannot apply for access to resources.
 #: TWLight/users/views.py:487
-msgid ""
-"Your email is blank. You can still explore the site, but you won't be able "
-"to apply for access to partner resources without an email."
-msgstr ""
-"Seu email está em branco. Ainda é possível explorar o site, mas você não "
-"poderá solicitar acesso a recursos de parceiros sem um e-mail."
+msgid "Your email is blank. You can still explore the site, but you won't be able to apply for access to partner resources without an email."
+msgstr "Seu email está em branco. Ainda é possível explorar o site, mas você não poderá solicitar acesso a recursos de parceiros sem um e-mail."
 
 #. Translators: This message is shown once the access to a partner has successfully been returned.
 #: TWLight/users/views.py:801
@@ -4150,31 +3028,3 @@ msgstr "Nenhum bloqueio ativo"
 msgid "10+ edits in the last 30 days"
 msgstr "10+ edições no ultimo mês"
 
-#: tests/shunit/data/bad_i18n_comment_1.py:3
-#: tests/shunit/data/bad_i18n_newline_1.py:5
-msgid "1"
-msgstr ""
-
-#. Translators: Lorem ipsum dolor sit amet, consectetur adipiscing elit. Mauris vitae ipsum ut purus faucibus pretium. Proin tempus neque et aliquet consectetur. Ut egestas sapien in consectetur sagittis. Mauris neque lacus, dapibus non viverra vitae, interdum ut aenean ipsum.
-#. Translators: Lorem ipsum dolor sit amet, consectetur adipiscing elit. Mauris vitae ipsum ut purus faucibus pretium. Proin tempus neque et aliquet consectetur. Ut egestas sapien in consectetur sagittis. Mauris neque lacus, dapibus non.
-#: tests/shunit/data/bad_i18n_comment_2.py:4
-#: tests/shunit/data/bad_i18n_newline_2.py:5 tests/shunit/data/good_i18n_1.py:2
-#: tests/shunit/data/good_i18n_2.py:2
-msgid "2"
-msgstr ""
-
-#: tests/shunit/data/bad_i18n_newline_3.py:5
-msgid "3"
-msgstr ""
-
-#: tests/shunit/data/bad_i18n_newline_4.py:5
-msgid "4"
-msgstr ""
-
-#: tests/shunit/data/bad_i18n_newline_5.py:5
-msgid "5"
-msgstr ""
-
-#: tests/shunit/data/bad_i18n_newline_6.py:5
-msgid "6"
-msgstr ""

--- a/locale/qqq/LC_MESSAGES/django.po
+++ b/locale/qqq/LC_MESSAGES/django.po
@@ -14,10 +14,11 @@
 # Author: عمر العنزي
 msgid ""
 msgstr ""
+""
 "Project-Id-Version: Wikipedia Library Card Platform - Website\n"
-"Report-Msgid-Bugs-To: wikipedialibrary@wikimedia.org\n"
+"Report-Msgid-Bugs-To: translatewiki.net\n"
 "POT-Creation-Date: 2024-07-11 20:54+0000\n"
-"PO-Revision-Date: 2024-07-11 12:30:18+0000\n"
+"PO-Revision-Date: 2024-07-15 12:29:18+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
 "Language: qqq\n"
@@ -42,10 +43,7 @@ msgstr ""
 #: TWLight/resources/templates/resources/partner_detail_apply.html:42
 #: TWLight/users/templates/users/available_collection_tile.html:89
 msgid "Apply"
-msgstr ""
-"{{doc-important|This means \"Apply for a library card\", \"Start submitting "
-"an application\". This doesn't mean what \"Apply\" often means in other "
-"buttons.}}"
+msgstr "{{doc-important|This means \"Apply for a library card\", \"Start submitting an application\". This doesn't mean what \"Apply\" often means in other buttons.}}"
 
 #. Translators: This labels a section of a form where we ask users to enter personal information (such as their country of residence) when making an application.
 #: TWLight/applications/forms.py:170
@@ -55,18 +53,14 @@ msgstr ""
 #. Translators: This note appears in a section of a form where we ask users to enter info (like country of residence) when applying for resource access.
 #: TWLight/applications/forms.py:179
 #, python-brace-format
-msgid ""
-"<p><small><i>Your personal data will be processed according to our <a "
-"class='twl-links' href='{terms_url}'> privacy policy</a>.</i></small></p>"
+msgid "<p><small><i>Your personal data will be processed according to our <a class='twl-links' href='{terms_url}'> privacy policy</a>.</i></small></p>"
 msgstr ""
 
 #. Translators: This is the title of the application form page, where users enter information required for the application. It lets the user know which partner application they are entering data for. {partner}
 #: TWLight/applications/forms.py:189
 #, python-brace-format
 msgid "Your application to {partner}"
-msgstr ""
-"{{Doc-important|\"Application\" here means \"request\" or \"candidacy\". "
-"This doesn't mean \"software application\" or \"app\".}}"
+msgstr "{{Doc-important|\"Application\" here means \"request\" or \"candidacy\". This doesn't mean \"software application\" or \"app\".}}"
 
 #. Translators: For some applications, users must register at another website before finishing the application form, and must then enter their email address used when registering. Don't translate {url}.
 #: TWLight/applications/forms.py:220
@@ -101,9 +95,7 @@ msgstr ""
 #. Translators: This labels a choice field where users will have to select the number of months they wish to have their access for as part of the application renewal confirmation.
 #. Translators: When filling out an application, users may be required to enter the length of the account (expiry) they wish to have for proxy partners.
 #: TWLight/applications/forms.py:339 TWLight/applications/helpers.py:100
-msgid ""
-"The number of months you wish to have this access for before renewal is "
-"required"
+msgid "The number of months you wish to have this access for before renewal is required"
 msgstr ""
 
 #. Translators: When filling out an application, users may need to specify their name
@@ -192,12 +184,8 @@ msgstr ""
 
 #. Translators: This comment is added to pending applications when our terms of use change.
 #: TWLight/applications/management/commands/notify_applicants_tou_changes.py:54
-msgid ""
-"Our terms of use have changed. Your applications will not be processed until "
-"you log in and agree to our updated terms."
-msgstr ""
-"{{Doc-important|\"Application\" here means \"request\" or \"candidacy\". "
-"This doesn't mean \"software application\" or \"app\".}}"
+msgid "Our terms of use have changed. Your applications will not be processed until you log in and agree to our updated terms."
+msgstr "{{Doc-important|\"Application\" here means \"request\" or \"candidacy\". This doesn't mean \"software application\" or \"app\".}}"
 
 #. Translators: This is the status of an application that has not yet been reviewed.
 #: TWLight/applications/models.py:54
@@ -263,75 +251,51 @@ msgstr ""
 
 #. Translators: This text goes into account approval emails in the case that we need to send the user's details to a publisher for manual account setup.
 #: TWLight/applications/models.py:331
-msgid ""
-"You can expect to receive access details within a week or two once it has "
-"been processed."
+msgid "You can expect to receive access details within a week or two once it has been processed."
 msgstr ""
 
 #. Translators: This comment is added to open applications when a partner joins the Library Bundle, which does not require applications.
 #: TWLight/applications/signals.py:247
-msgid ""
-"This partner joined the Library Bundle, which does not require applications. "
-"This application will be marked as invalid."
-msgstr ""
-"{{Doc-important|\"Application\" here means \"request\" or \"candidacy\". "
-"This doesn't mean \"software application\" or \"app\".}}"
+msgid "This partner joined the Library Bundle, which does not require applications. This application will be marked as invalid."
+msgstr "{{Doc-important|\"Application\" here means \"request\" or \"candidacy\". This doesn't mean \"software application\" or \"app\".}}"
 
 #. Translators: This is shown to users if the application is to a partner for which we have run out of available accounts. The application is therefore on a 'waitlist', and will be reviewed when more accounts are available.
 #: TWLight/applications/templates/applications/application_evaluation.html:29
-msgid ""
-"This application is on the waitlist because this partner does not have any "
-"access grants available at this time."
-msgstr ""
-"{{Doc-important|\"Application\" here means \"request\" or \"candidacy\". "
-"This doesn't mean \"software application\" or \"app\".}}"
+msgid "This application is on the waitlist because this partner does not have any access grants available at this time."
+msgstr "{{Doc-important|\"Application\" here means \"request\" or \"candidacy\". This doesn't mean \"software application\" or \"app\".}}"
 
 #. Translators: This message is shown on pages where coordinators can see personal information about applicants.
 #: TWLight/applications/templates/applications/application_evaluation.html:36
 #: TWLight/applications/templates/applications/application_list_include.html:6
 #: TWLight/applications/templates/applications/send_partner.html:45
 #: TWLight/resources/templates/resources/partner_users.html:18
-msgid ""
-"Coordinators: This page may contain personal information such as real names "
-"and email addresses. Please remember that this information is confidential."
+msgid "Coordinators: This page may contain personal information such as real names and email addresses. Please remember that this information is confidential."
 msgstr ""
 
 #. Translators: This is the title of the application page shown to users who are a coordinator, and are able to accept or reject the application.
 #: TWLight/applications/templates/applications/application_evaluation.html:39
 msgid "Evaluate application"
-msgstr ""
-"{{Doc-important|\"Application\" here means \"request\" or \"candidacy\". "
-"This doesn't mean \"software application\" or \"app\".}}"
+msgstr "{{Doc-important|\"Application\" here means \"request\" or \"candidacy\". This doesn't mean \"software application\" or \"app\".}}"
 
 #. Translators: This text is shown to coordinators on application pages if the applicant has restricted processing of their data.
 #: TWLight/applications/templates/applications/application_evaluation.html:42
-msgid ""
-"This user has requested a restriction on the processing of their data, so "
-"you cannot change the status of their application."
-msgstr ""
-"{{Doc-important|\"Application\" here means \"request\" or \"candidacy\". "
-"This doesn't mean \"software application\" or \"app\".}}"
+msgid "This user has requested a restriction on the processing of their data, so you cannot change the status of their application."
+msgstr "{{Doc-important|\"Application\" here means \"request\" or \"candidacy\". This doesn't mean \"software application\" or \"app\".}}"
 
 #. Translators: This is the title of the application page shown to users who are not a coordinator.
 #: TWLight/applications/templates/applications/application_evaluation.html:48
 msgid "Application history"
-msgstr ""
-"{{Doc-important|\"Application\" here means \"request\" or \"candidacy\". "
-"This doesn't mean \"software application\" or \"app\".}}"
+msgstr "{{Doc-important|\"Application\" here means \"request\" or \"candidacy\". This doesn't mean \"software application\" or \"app\".}}"
 
 #. Translators: This is the title of the section of an application page containing information about the request.
 #: TWLight/applications/templates/applications/application_evaluation.html:51
 msgid "Application"
-msgstr ""
-"{{Doc-important|\"Application\" here means \"request\" or \"candidacy\". "
-"This doesn't mean \"software application\" or \"app\".}}"
+msgstr "{{Doc-important|\"Application\" here means \"request\" or \"candidacy\". This doesn't mean \"software application\" or \"app\".}}"
 
 #. Translators: This labels the section of an application showing the date the application was submitted.
 #: TWLight/applications/templates/applications/application_evaluation.html:56
 msgid "Date of application"
-msgstr ""
-"{{Doc-important|\"Application\" here means \"request\" or \"candidacy\". "
-"This doesn't mean \"software application\" or \"app\".}}"
+msgstr "{{Doc-important|\"Application\" here means \"request\" or \"candidacy\". This doesn't mean \"software application\" or \"app\".}}"
 
 #. Translators: This labels the section of an application showing how many days it has been since the application was opened.
 #: TWLight/applications/templates/applications/application_evaluation.html:65
@@ -341,9 +305,7 @@ msgstr ""
 #. Translators: This labels the section of an application showing how many days it has been since the application was closed.
 #: TWLight/applications/templates/applications/application_evaluation.html:73
 msgid "Days since application was closed"
-msgstr ""
-"{{Doc-important|\"Application\" here means \"request\" or \"candidacy\". "
-"This doesn't mean \"software application\" or \"app\".}}"
+msgstr "{{Doc-important|\"Application\" here means \"request\" or \"candidacy\". This doesn't mean \"software application\" or \"app\".}}"
 
 #. Translators: This labels the section of an application showing the current status of the application ('Pending', 'Approved', etc.)
 #. Translators: This labels the column description indicating the status of the listed applications.
@@ -391,12 +353,8 @@ msgstr "{{Identical|Unknown}}"
 
 #. Translators: This is the text displayed to coordinators when an applicant has no country of residence in their profile.
 #: TWLight/applications/templates/applications/application_evaluation.html:123
-msgid ""
-"Please request the applicant add their country of residence to their profile "
-"before proceeding further."
-msgstr ""
-"{{Doc-important|\"Application\" here means \"request\" or \"candidacy\". "
-"This doesn't mean \"software application\" or \"app\".}}"
+msgid "Please request the applicant add their country of residence to their profile before proceeding further."
+msgstr "{{Doc-important|\"Application\" here means \"request\" or \"candidacy\". This doesn't mean \"software application\" or \"app\".}}"
 
 #. Translators: This labels the section of an application showing the total number of accounts available for a partner or their collection.
 #: TWLight/applications/templates/applications/application_evaluation.html:134
@@ -406,9 +364,7 @@ msgstr ""
 #. Translators: This labels the section of an application showing whether the user had agreed to the terms of use or not.
 #: TWLight/applications/templates/applications/application_evaluation.html:145
 #, python-format
-msgid ""
-"Has agreed to the site's <a class=\"twl-links\" href=\"%(terms_url)s\">terms "
-"of use</a>?"
+msgid "Has agreed to the site's <a class=\"twl-links\" href=\"%(terms_url)s\">terms of use</a>?"
 msgstr ""
 
 #. Translators: Displayed to coordinators when they've agreed to the terms of use.
@@ -444,12 +400,8 @@ msgstr "{{Identical|No}}"
 
 #. Translators: This is the text displayed to coordinators when an applicant has not agreed to the terms of use.
 #: TWLight/applications/templates/applications/application_evaluation.html:159
-msgid ""
-"Please request the applicant agree to the site's terms of use before "
-"approving this application."
-msgstr ""
-"{{Doc-important|\"Application\" here means \"request\" or \"candidacy\". "
-"This doesn't mean \"software application\" or \"app\".}}"
+msgid "Please request the applicant agree to the site's terms of use before approving this application."
+msgstr "{{Doc-important|\"Application\" here means \"request\" or \"candidacy\". This doesn't mean \"software application\" or \"app\".}}"
 
 #. Translators: This labels the section of an application containing the user's motivation for wanting access to this resource.
 #: TWLight/applications/templates/applications/application_evaluation.html:176
@@ -469,11 +421,8 @@ msgstr ""
 #. Translators: This message is shown next to the 'Renewal of existing access grant?' label if the application is a renewal. Don't translate HTML tags or parent_url.
 #: TWLight/applications/templates/applications/application_evaluation.html:195
 #, python-format
-msgid ""
-"Yes (<a class=\"twl-links\" href=\"%(parent_url)s\">previous application</a>)"
-msgstr ""
-"{{Doc-important|\"Application\" here means \"request\" or \"candidacy\". "
-"This doesn't mean \"software application\" or \"app\".}}"
+msgid "Yes (<a class=\"twl-links\" href=\"%(parent_url)s\">previous application</a>)"
+msgstr "{{Doc-important|\"Application\" here means \"request\" or \"candidacy\". This doesn't mean \"software application\" or \"app\".}}"
 
 #. Translators: This labels the section of the application showing the length of access remaining on the user's previous authorization.
 #: TWLight/applications/templates/applications/application_evaluation.html:208
@@ -488,16 +437,12 @@ msgstr ""
 #. Translators: This is the title of the section of an application page which contains the Recent Applications made by the applicant in the last 90 days.
 #: TWLight/applications/templates/applications/application_evaluation.html:227
 msgid "Recent Applications (last 90 days)"
-msgstr ""
-"{{Doc-important|\"Application\" here means \"request\" or \"candidacy\". "
-"This doesn't mean \"software application\" or \"app\".}}"
+msgstr "{{Doc-important|\"Application\" here means \"request\" or \"candidacy\". This doesn't mean \"software application\" or \"app\".}}"
 
 #. Translators: This text is shown to Coordinators when applicant has not made any application in the last 90 days.
 #: TWLight/applications/templates/applications/application_evaluation.html:264
 msgid "No applications were made in last 90 days by the applicant"
-msgstr ""
-"{{Doc-important|\"Application\" here means \"request\" or \"candidacy\". "
-"This doesn't mean \"software application\" or \"app\".}}"
+msgstr "{{Doc-important|\"Application\" here means \"request\" or \"candidacy\". This doesn't mean \"software application\" or \"app\".}}"
 
 #. Translators: This is the title of the section of an application page which contains the comment thread between the user and account coordinator.
 #: TWLight/applications/templates/applications/application_evaluation.html:268
@@ -511,12 +456,8 @@ msgstr ""
 
 #. Translators: On an application page, this text tells users that the comments posted on the application are visible to coordinators and the submitting user only.
 #: TWLight/applications/templates/applications/application_evaluation.html:297
-msgid ""
-"Comments are visible to all coordinators and to the editor who submitted "
-"this application."
-msgstr ""
-"{{Doc-important|\"Application\" here means \"request\" or \"candidacy\". "
-"This doesn't mean \"software application\" or \"app\".}}"
+msgid "Comments are visible to all coordinators and to the editor who submitted this application."
+msgstr "{{Doc-important|\"Application\" here means \"request\" or \"candidacy\". This doesn't mean \"software application\" or \"app\".}}"
 
 #. Translators: This is the title of the section of an application page which lists information about the user who submitted the application.
 #. Translators: On the page where coordinators can view data on applications to a partner they coordinate, this is a table column heading for the username.
@@ -562,9 +503,7 @@ msgstr ""
 
 #: TWLight/applications/templates/applications/application_list.html:37
 msgid "View applications which are..."
-msgstr ""
-"{{Doc-important|\"Application\" here means \"request\" or \"candidacy\". "
-"This doesn't mean \"software application\" or \"app\".}}"
+msgstr "{{Doc-important|\"Application\" here means \"request\" or \"candidacy\". This doesn't mean \"software application\" or \"app\".}}"
 
 #: TWLight/applications/templates/applications/application_list.html:43
 msgid "Pending review"
@@ -641,9 +580,7 @@ msgstr ""
 #: TWLight/applications/templates/applications/application_list_include.html:33
 #: TWLight/users/templates/users/my_applications.html:43
 msgid "Imported application"
-msgstr ""
-"{{Doc-important|\"Application\" here means \"request\" or \"candidacy\". "
-"This doesn't mean \"software application\" or \"app\".}}"
+msgstr "{{Doc-important|\"Application\" here means \"request\" or \"candidacy\". This doesn't mean \"software application\" or \"app\".}}"
 
 #. Translators: On the page listing applications, this shows next to an application which was previously reviewed. Don't translate reviewer or review_date.
 #. Translators: If an application was previously reviewed by a coordinator, this text displays the date and the name of the coordinator.
@@ -681,9 +618,7 @@ msgstr ""
 #: TWLight/applications/templates/applications/application_list_reviewable_include.html:102
 #: TWLight/users/templates/users/my_applications.html:92
 msgid "No applications right now."
-msgstr ""
-"{{Doc-important|\"Application\" here means \"request\" or \"candidacy\". "
-"This doesn't mean \"software application\" or \"app\".}}"
+msgstr "{{Doc-important|\"Application\" here means \"request\" or \"candidacy\". This doesn't mean \"software application\" or \"app\".}}"
 
 #. Translators: This labels the column description that lists the partner (and the corresponding collection, if any) of the listed applications.
 #: TWLight/applications/templates/applications/application_list_reviewable_include.html:13
@@ -724,9 +659,7 @@ msgstr ""
 #. Translators: Coordinators can change the status of multiple applications at one time. This text is shown above the drop-down menu for the status they want to set.
 #: TWLight/applications/templates/applications/application_list_reviewable_include.html:83
 msgid "Status for all selected applications"
-msgstr ""
-"{{Doc-important|\"Application\" here means \"request\" or \"candidacy\". "
-"This doesn't mean \"software application\" or \"app\".}}"
+msgstr "{{Doc-important|\"Application\" here means \"request\" or \"candidacy\". This doesn't mean \"software application\" or \"app\".}}"
 
 #. Translators: Coordinators can change the status of multiple applications at one time. This text is found on a button that users click after selecting multiple applications and a status change.
 #: TWLight/applications/templates/applications/application_list_reviewable_include.html:97
@@ -735,22 +668,14 @@ msgstr ""
 
 #: TWLight/applications/templates/applications/apply.html:20
 #, python-format
-msgid ""
-"If your application is successful we may share your email address with "
-"%(partner)s. This is required to set up your access to their resources. By "
-"submitting this form you agree to allow your email address to be shared with "
-"%(partner)s if your application is successful, for the purposes of account "
-"setup."
+msgid "If your application is successful we may share your email address with %(partner)s. This is required to set up your access to their resources. By submitting this form you agree to allow your email address to be shared with %(partner)s if your application is successful, for the purposes of account setup."
 msgstr ""
 
 #. Translators: This message is displayed on the page where users can confirm their renewal. Please do not translate partner.
 #: TWLight/applications/templates/applications/confirm_renewal.html:23
 #, python-format
 msgid "Click 'confirm' to renew your application for %(partner)s"
-msgstr ""
-"{{Doc-important|\"Application\" here means \"request\" or \"candidacy\". "
-"This doesn't mean \"software application\" or \"app\".}}\n"
-"\"Confirm\" is {{msg-wm|Wikipedia-library-04a212-Confirm}}"
+msgstr "{{Doc-important|\"Application\" here means \"request\" or \"candidacy\". This doesn't mean \"software application\" or \"app\".}}\n\"Confirm\" is {{msg-wm|Wikipedia-library-04a212-Confirm}}"
 
 #. Translators: Labels the submit button requesting confirmation of application renewal.
 #. Translators: This is the button coordinators click to confirm deletion of a suggestion.
@@ -772,9 +697,7 @@ msgstr ""
 
 #. Translators: This text explains that Library Bundle partners are not shown in this list.
 #: TWLight/applications/templates/applications/request_for_application.html:26
-msgid ""
-"Library Bundle partners are not shown as eligibility is determined "
-"automatically."
+msgid "Library Bundle partners are not shown as eligibility is determined automatically."
 msgstr ""
 
 #. Translators: On the page where users can apply for multiple partners, this message shows next to the partner name, taking them to the full application page when clicked.
@@ -789,45 +712,30 @@ msgstr ""
 
 #. Translators: the HTML is so that the word 'waitlisted' will look the same as it does in the page above; please translate 'waitlisted' the same way you did elsewhere in this file.
 #: TWLight/applications/templates/applications/request_for_application.html:74
-msgid ""
-"You can apply to <span class=\"badge badge-warning\">Waitlisted</span> "
-"partners, but they don't have access grants available right now. We will "
-"process those applications when access becomes available."
-msgstr ""
-"{{Doc-important|\"Application\" here means \"request\" or \"candidacy\". "
-"This doesn't mean \"software application\" or \"app\".}}"
+msgid "You can apply to <span class=\"badge badge-warning\">Waitlisted</span> partners, but they don't have access grants available right now. We will process those applications when access becomes available."
+msgstr "{{Doc-important|\"Application\" here means \"request\" or \"candidacy\". This doesn't mean \"software application\" or \"app\".}}"
 
 #. Translators: On the page where coordinators can see approved applications which have not had their details sent to the partner, this message shows when there are applications ready to be processed.
 #: TWLight/applications/templates/applications/send.html:10
 msgid "Partners with approved, unsent applications"
-msgstr ""
-"{{Doc-important|\"Application\" here means \"request\" or \"candidacy\". "
-"This doesn't mean \"software application\" or \"app\".}}"
+msgstr "{{Doc-important|\"Application\" here means \"request\" or \"candidacy\". This doesn't mean \"software application\" or \"app\".}}"
 
 #. Translators: On the page where coordinators can see approved applications which have not had their details sent to the partner, this message shows when no such applications exist or all have already been sent.
 #: TWLight/applications/templates/applications/send.html:23
 msgid "There are no partners with applications ready to send."
-msgstr ""
-"{{Doc-important|\"Application\" here means \"request\" or \"candidacy\". "
-"This doesn't mean \"software application\" or \"app\".}}"
+msgstr "{{Doc-important|\"Application\" here means \"request\" or \"candidacy\". This doesn't mean \"software application\" or \"app\".}}"
 
 #. Translators: When viewing the list of applications ready to be sent for a particular partner, this is the title of the page, where object will be the name of the partner. Don't translate object.
 #: TWLight/applications/templates/applications/send_partner.html:40
 #, python-format
 msgid "Application data for %(object)s"
-msgstr ""
-"{{Doc-important|\"Application\" here means \"request\" or \"candidacy\". "
-"This doesn't mean \"software application\" or \"app\".}}"
+msgstr "{{Doc-important|\"Application\" here means \"request\" or \"candidacy\". This doesn't mean \"software application\" or \"app\".}}"
 
 #. Translators: This message is shown when applications exceed the number of accounts available.
 #: TWLight/applications/templates/applications/send_partner.html:54
 #, python-format
-msgid ""
-"Application(s) for %(object)s, if sent, will exceed the total available "
-"accounts for the partner. Please proceed at your own discretion."
-msgstr ""
-"{{Doc-important|\"Application\" here means \"request\" or \"candidacy\". "
-"This doesn't mean \"software application\" or \"app\".}}"
+msgid "Application(s) for %(object)s, if sent, will exceed the total available accounts for the partner. Please proceed at your own discretion."
+msgstr "{{Doc-important|\"Application\" here means \"request\" or \"candidacy\". This doesn't mean \"software application\" or \"app\".}}"
 
 #. Translators: When viewing the list of applications ready to be sent for a particular partner, this is instructions for the coordinator to click the 'mark as sent' button after they have sent the information.
 #: TWLight/applications/templates/applications/send_partner.html:65
@@ -842,17 +750,13 @@ msgstr[0] ""
 
 #. Translators: When viewing the list of applications ready to be sent for a particular partner, this message shows if there is no information about who the applications should be sent to. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/applications/templates/applications/send_partner.html:89
-msgid ""
-"Whoops, we don't have any listed contacts. Please notify Wikipedia Library "
-"administrators."
+msgid "Whoops, we don't have any listed contacts. Please notify Wikipedia Library administrators."
 msgstr ""
 
 #. Translators: When viewing the list of applications ready to be sent for a particular partner, this is the title of the section containing the information about those applications.
 #: TWLight/applications/templates/applications/send_partner.html:94
 msgid "Application data"
-msgstr ""
-"{{Doc-important|\"Application\" here means \"request\" or \"candidacy\". "
-"This doesn't mean \"software application\" or \"app\".}}"
+msgstr "{{Doc-important|\"Application\" here means \"request\" or \"candidacy\". This doesn't mean \"software application\" or \"app\".}}"
 
 #. Translators: When viewing the list of applications ready to be sent for a particular partner, this labels the button coordinators press to change the status of applications to 'sent'.
 #: TWLight/applications/templates/applications/send_partner.html:147
@@ -862,9 +766,7 @@ msgstr ""
 
 #. Translators: This text guides coordinators in using the code sending interface for approved applications.
 #: TWLight/applications/templates/applications/send_partner.html:152
-msgid ""
-"Use the dropdown menus to denote which editor will receive each code. Access "
-"codes will be sent to users automatically."
+msgid "Use the dropdown menus to denote which editor will receive each code. Access codes will be sent to users automatically."
 msgstr ""
 
 #. Translators: This labels a drop-down selection where staff can assign an access code to a user.
@@ -875,31 +777,19 @@ msgstr ""
 #. Translators: When viewing the list of applications ready to be sent for a particular partner, this message shows when there are none to show the coordinator.
 #: TWLight/applications/templates/applications/send_partner.html:192
 msgid "There are no approved, unsent applications."
-msgstr ""
-"{{Doc-important|\"Application\" here means \"request\" or \"candidacy\". "
-"This doesn't mean \"software application\" or \"app\".}}"
+msgstr "{{Doc-important|\"Application\" here means \"request\" or \"candidacy\". This doesn't mean \"software application\" or \"app\".}}"
 
 #. Translators: When a user applies for a set of resources, they receive this message if none are currently available. They are instead placed on a 'waitlist' for later approval.
 #. Translators: When a user renews their resource, they receive this message if none are currently available. They are instead placed on a 'waitlist' for later approval.
 #: TWLight/applications/views.py:140 TWLight/applications/views.py:1282
-msgid ""
-"This partner does not have any access grants available at this time. You may "
-"still apply for access; your application will be reviewed when access grants "
-"become available."
-msgstr ""
-"{{Doc-important|\"Application\" here means \"request\" or \"candidacy\". "
-"This doesn't mean \"software application\" or \"app\".}}"
+msgid "This partner does not have any access grants available at this time. You may still apply for access; your application will be reviewed when access grants become available."
+msgstr "{{Doc-important|\"Application\" here means \"request\" or \"candidacy\". This doesn't mean \"software application\" or \"app\".}}"
 
 #. Translators: This message is shown to users once they've successfully submitted their application for review.
 #: TWLight/applications/views.py:163
 #, python-brace-format
-msgid ""
-"Your application has been submitted for review. Head over to <a "
-"href='{applications_url}'>My Applications</a> to view the status."
-msgstr ""
-"{{Doc-important|\"Application\" here means \"request\" or \"candidacy\". "
-"This doesn't mean \"software application\" or \"app\".}}\n"
-"\"My Applications\" is {{msg-wm|Wikipedia-library-c46eb7-My Applications}}."
+msgid "Your application has been submitted for review. Head over to <a href='{applications_url}'>My Applications</a> to view the status."
+msgstr "{{Doc-important|\"Application\" here means \"request\" or \"candidacy\". This doesn't mean \"software application\" or \"app\".}}\n\"My Applications\" is {{msg-wm|Wikipedia-library-c46eb7-My Applications}}."
 
 #. Translators: This text is displayed to users when the user has chosen to restrict data and is trying to apply for multiple partners
 #: TWLight/applications/views.py:276
@@ -909,9 +799,7 @@ msgstr ""
 #. Translators: This message is shown to user when he tries to apply to same partner more than once
 #: TWLight/applications/views.py:372
 msgid "You already have an application for this Partner."
-msgstr ""
-"{{Doc-important|\"Application\" here means \"request\" or \"candidacy\". "
-"This doesn't mean \"software application\" or \"app\".}}"
+msgstr "{{Doc-important|\"Application\" here means \"request\" or \"candidacy\". This doesn't mean \"software application\" or \"app\".}}"
 
 #. Translators: Editor = wikipedia editor, gender unknown.
 #: TWLight/applications/views.py:469 TWLight/applications/views.py:548
@@ -921,25 +809,19 @@ msgstr ""
 #. Translators: On the page listing applications, this is the page title if the coordinator has selected the list of 'Pending' applications.
 #: TWLight/applications/views.py:594
 msgid "Applications to review"
-msgstr ""
-"{{Doc-important|\"Application\" here means \"request\" or \"candidacy\". "
-"This doesn't mean \"software application\" or \"app\".}}"
+msgstr "{{Doc-important|\"Application\" here means \"request\" or \"candidacy\". This doesn't mean \"software application\" or \"app\".}}"
 
 #. Translators: On the page listing applications, this is the page title if the coordinator has selected the list of 'Approved' applications.
 #. Translators: On the page listing approved users for a partner, this is the title of the section listing applications with the 'approved' status
 #: TWLight/applications/views.py:635
 #: TWLight/resources/templates/resources/partner_users.html:23
 msgid "Approved applications"
-msgstr ""
-"{{Doc-important|\"Application\" here means \"request\" or \"candidacy\". "
-"This doesn't mean \"software application\" or \"app\".}}"
+msgstr "{{Doc-important|\"Application\" here means \"request\" or \"candidacy\". This doesn't mean \"software application\" or \"app\".}}"
 
 #. Translators: On the page listing applications, this is the page title if the coordinator has selected the list of 'Rejected' applications.
 #: TWLight/applications/views.py:661
 msgid "Rejected applications"
-msgstr ""
-"{{Doc-important|\"Application\" here means \"request\" or \"candidacy\". "
-"This doesn't mean \"software application\" or \"app\".}}"
+msgstr "{{Doc-important|\"Application\" here means \"request\" or \"candidacy\". This doesn't mean \"software application\" or \"app\".}}"
 
 #. Translators: On the page listing applications, this is the page title if the coordinator has selected the list of 'Up for renewal' applications.
 #: TWLight/applications/views.py:695
@@ -951,27 +833,17 @@ msgstr ""
 #: TWLight/applications/views.py:721
 #: TWLight/resources/templates/resources/partner_users.html:63
 msgid "Sent applications"
-msgstr ""
-"{{Doc-important|\"Application\" here means \"request\" or \"candidacy\". "
-"This doesn't mean \"software application\" or \"app\".}}"
+msgstr "{{Doc-important|\"Application\" here means \"request\" or \"candidacy\". This doesn't mean \"software application\" or \"app\".}}"
 
 #. Translators: After a coordinator has changed the status of an application to APPROVED, if the corresponding partner/collection is waitlisted this message appears.
 #: TWLight/applications/views.py:756
-msgid ""
-"Cannot approve application as partner with proxy authorization method is "
-"waitlisted."
-msgstr ""
-"{{Doc-important|\"Application\" here means \"request\" or \"candidacy\". "
-"This doesn't mean \"software application\" or \"app\".}}"
+msgid "Cannot approve application as partner with proxy authorization method is waitlisted."
+msgstr "{{Doc-important|\"Application\" here means \"request\" or \"candidacy\". This doesn't mean \"software application\" or \"app\".}}"
 
 #. Translators: After a coordinator has changed the status of an application to APPROVED, if the corresponding partner/collection has no accounts for distribution, this message appears.
 #: TWLight/applications/views.py:780
-msgid ""
-"Cannot approve application as partner with proxy authorization method is "
-"waitlisted and (or) has zero accounts available for distribution."
-msgstr ""
-"{{Doc-important|\"Application\" here means \"request\" or \"candidacy\". "
-"This doesn't mean \"software application\" or \"app\".}}"
+msgid "Cannot approve application as partner with proxy authorization method is waitlisted and (or) has zero accounts available for distribution."
+msgstr "{{Doc-important|\"Application\" here means \"request\" or \"candidacy\". This doesn't mean \"software application\" or \"app\".}}"
 
 #. Translators: This message appears on an "access denied" screen that stops users who attempt to authorize an editor to access a resource during a time period for which they are already authorized.
 #: TWLight/applications/views.py:803
@@ -981,68 +853,38 @@ msgstr ""
 #. Translators: This message is shown to users when they access an application page of a now Bundle partner (new applications aren't allowed for Bundle partners and the status of old applications cannot be modified)
 #: TWLight/applications/views.py:857
 #, python-brace-format
-msgid ""
-"This application cannot be modified since this partner is now part of our <a "
-"href='{bundle}'>bundle access</a>. If you are eligible, you can access this "
-"resource from <a href='{library}'>your library</a>. <a "
-"href='{contact}'>Contact us</a> if you have any questions."
-msgstr ""
-"{{Doc-important|\"Application\" here means \"request\" or \"candidacy\". "
-"This doesn't mean \"software application\" or \"app\".}}"
+msgid "This application cannot be modified since this partner is now part of our <a href='{bundle}'>bundle access</a>. If you are eligible, you can access this resource from <a href='{library}'>your library</a>. <a href='{contact}'>Contact us</a> if you have any questions."
+msgstr "{{Doc-important|\"Application\" here means \"request\" or \"candidacy\". This doesn't mean \"software application\" or \"app\".}}"
 
 #. Translators: this lets a reviewer set the status of a single application.
 #: TWLight/applications/views.py:873
 msgid "Set application status"
-msgstr ""
-"{{Doc-important|\"Application\" here means \"request\" or \"candidacy\". "
-"This doesn't mean \"software application\" or \"app\".}}"
+msgstr "{{Doc-important|\"Application\" here means \"request\" or \"candidacy\". This doesn't mean \"software application\" or \"app\".}}"
 
 #. Translators: This warning is message is shown to applicants when the number of pending applications is greater than the number of accounts available.
 #: TWLight/applications/views.py:891
-msgid ""
-"There are more pending applications than available accounts. Your "
-"application might get waitlisted."
-msgstr ""
-"{{Doc-important|\"Application\" here means \"request\" or \"candidacy\". "
-"This doesn't mean \"software application\" or \"app\".}}"
+msgid "There are more pending applications than available accounts. Your application might get waitlisted."
+msgstr "{{Doc-important|\"Application\" here means \"request\" or \"candidacy\". This doesn't mean \"software application\" or \"app\".}}"
 
 #. Translators: this message is shown to coordinators who attempt to change an application's Status from INVALID to any other Status.
 #: TWLight/applications/views.py:904
 msgid "Status of INVALID applications cannot be changed."
-msgstr ""
-"{{Doc-important|\"Application\" here means \"request\" or \"candidacy\". "
-"This doesn't mean \"software application\" or \"app\".}}"
+msgstr "{{Doc-important|\"Application\" here means \"request\" or \"candidacy\". This doesn't mean \"software application\" or \"app\".}}"
 
 #. Translators: When a coordinator is batch editing (https://wikipedialibrary.wmflabs.org/applications/list/), they receive this message if they click Set Status without selecting any applications.
 #: TWLight/applications/views.py:940
 msgid "Please select at least one application."
-msgstr ""
-"{{Doc-important|\"Application\" here means \"request\" or \"candidacy\". "
-"This doesn't mean \"software application\" or \"app\".}}"
+msgstr "{{Doc-important|\"Application\" here means \"request\" or \"candidacy\". This doesn't mean \"software application\" or \"app\".}}"
 
 #. Translators: After a coordinator has changed the status of a number of applications, this message appears.
 #: TWLight/applications/views.py:1042
 msgid "Batch update of application(s) {} successful."
-msgstr ""
-"{{Doc-important|\"Application\" here means \"request\" or \"candidacy\". "
-"This doesn't mean \"software application\" or \"app\".}}\n"
-"\n"
-"Please preserve <code>{}</code> litteraly as a placeholder that will be "
-"replaced by a list of applications."
+msgstr "{{Doc-important|\"Application\" here means \"request\" or \"candidacy\". This doesn't mean \"software application\" or \"app\".}}\n\nPlease preserve <code>{}</code> litteraly as a placeholder that will be replaced by a list of applications."
 
 #. Translators: After a coordinator has changed the status of a number of applications to APPROVED, if the corresponding partner(s) is/are waitlisted or has no accounts for distribution, this message appears.
 #: TWLight/applications/views.py:1051
-msgid ""
-"Cannot approve application(s) {} as partner(s) with proxy authorization "
-"method is/are waitlisted and (or) has/have not enough accounts available. If "
-"not enough accounts are available, prioritise the applications and then "
-"approve applications equal to the accounts available."
-msgstr ""
-"{{Doc-important|\"Application\" here means \"request\" or \"candidacy\". "
-"This doesn't mean \"software application\" or \"app\".}}\n"
-"\n"
-"Please preserve <code>{}</code> litteraly as a placeholder that will be "
-"replaced by a list of applications."
+msgid "Cannot approve application(s) {} as partner(s) with proxy authorization method is/are waitlisted and (or) has/have not enough accounts available. If not enough accounts are available, prioritise the applications and then approve applications equal to the accounts available."
+msgstr "{{Doc-important|\"Application\" here means \"request\" or \"candidacy\". This doesn't mean \"software application\" or \"app\".}}\n\nPlease preserve <code>{}</code> litteraly as a placeholder that will be replaced by a list of applications."
 
 #. Translators: This message is shown to coordinators who attempt to assign the same access code to multiple users.
 #: TWLight/applications/views.py:1191
@@ -1052,39 +894,27 @@ msgstr ""
 #. Translators: After a coordinator has marked a number of applications as 'sent', this message appears.
 #: TWLight/applications/views.py:1241
 msgid "All selected applications have been marked as sent."
-msgstr ""
-"{{Doc-important|\"Application\" here means \"request\" or \"candidacy\". "
-"This doesn't mean \"software application\" or \"app\".}}"
+msgstr "{{Doc-important|\"Application\" here means \"request\" or \"candidacy\". This doesn't mean \"software application\" or \"app\".}}"
 
 #. Translators: When a user tries to renew their resource, they receive this message if the partner is not available.
 #: TWLight/applications/views.py:1272
-msgid ""
-"Cannot renew application at this time as partner is not available. Please "
-"check back later, or contact us for more information."
-msgstr ""
-"{{Doc-important|\"Application\" here means \"request\" or \"candidacy\". "
-"This doesn't mean \"software application\" or \"app\".}}"
+msgid "Cannot renew application at this time as partner is not available. Please check back later, or contact us for more information."
+msgstr "{{Doc-important|\"Application\" here means \"request\" or \"candidacy\". This doesn't mean \"software application\" or \"app\".}}"
 
 #. Translators: This message is displayed when an attempt by a user to renew an application has been denied for some reason.
 #: TWLight/applications/views.py:1308
 #, python-brace-format
 msgid "Attempt to renew unapproved application #{pk} has been denied"
-msgstr ""
-"{{Doc-important|\"Application\" here means \"request\" or \"candidacy\". "
-"This doesn't mean \"software application\" or \"app\".}}"
+msgstr "{{Doc-important|\"Application\" here means \"request\" or \"candidacy\". This doesn't mean \"software application\" or \"app\".}}"
 
 #. Translators: If a user requests the renewal of their account, but it wasn't renewed, this message is shown to them.
 #: TWLight/applications/views.py:1385
-msgid ""
-"This object cannot be renewed. (This probably means that you have already "
-"requested that it be renewed.)"
+msgid "This object cannot be renewed. (This probably means that you have already requested that it be renewed.)"
 msgstr ""
 
 #. Translators: If a user requests the renewal of their account, this message is shown to them.
 #: TWLight/applications/views.py:1395
-msgid ""
-"Your renewal request has been received. A coordinator will review your "
-"request."
+msgid "Your renewal request has been received. A coordinator will review your request."
 msgstr ""
 
 #. Translators: This labels a textfield where users can enter their email ID.
@@ -1094,9 +924,7 @@ msgstr ""
 
 #. Translators: This is the help text for the email field in the contact us form letting users know the field is updated by value pulled from their respective user profiles.
 #: TWLight/emails/forms.py:21
-msgid ""
-"This field is automatically updated with the email from your <a class='twl-"
-"links' href='{}'>user profile</a>."
+msgid "This field is automatically updated with the email from your <a class='twl-links' href='{}'>user profile</a>."
 msgstr ""
 
 #. Translators: This labels a textfield where users can enter their email message.
@@ -1120,24 +948,14 @@ msgstr ""
 #. Translators: This email is sent to users with their access code. Don't translate Jinja variables in curly braces like user or partner. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/access_code_email-body-html.html:5
 #, python-format
-msgid ""
-"<p>Your approved application to %(partner)s has now been finalised. Your "
-"access code or login details can be found below:</p> <p><b>%(access_code)s</"
-"b></p> <p>%(user_instructions)s</p>"
-msgstr ""
-"{{Doc-important|\"Application\" here means \"request\" or \"candidacy\". "
-"This doesn't mean \"software application\" or \"app\".}}"
+msgid "<p>Your approved application to %(partner)s has now been finalised. Your access code or login details can be found below:</p> <p><b>%(access_code)s</b></p> <p>%(user_instructions)s</p>"
+msgstr "{{Doc-important|\"Application\" here means \"request\" or \"candidacy\". This doesn't mean \"software application\" or \"app\".}}"
 
 #. Translators: This email is sent to users with their access code. Don't translate Jinja variables in curly braces like user or partner. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/access_code_email-body-text.html:3
 #, fuzzy, python-format
-msgid ""
-"Your approved application to %(partner)s has now been finalised. Your access "
-"code or login details can be found below: %(access_code)s "
-"%(user_instructions)s"
-msgstr ""
-"{{Doc-important|\"Application\" here means \"request\" or \"candidacy\". "
-"This doesn't mean \"software application\" or \"app\".}}"
+msgid "Your approved application to %(partner)s has now been finalised. Your access code or login details can be found below: %(access_code)s %(user_instructions)s"
+msgstr "{{Doc-important|\"Application\" here means \"request\" or \"candidacy\". This doesn't mean \"software application\" or \"app\".}}"
 
 #. Translators: This is the subject line of an email sent to users with their access code.
 #: TWLight/emails/templates/emails/access_code_email-subject.html:3
@@ -1147,128 +965,76 @@ msgstr ""
 #. Translators: This email is sent to users when their application is approved. Don't translate Jinja variables in curly braces like user or partner; don't translate html tags either. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/approval_notification-body-html.html:5
 #, python-format
-msgid ""
-"<p>Dear %(user)s,</p> <p>Thank you for applying for access to %(partner)s "
-"resources through The Wikipedia Library. We are happy to inform you that "
-"your application has been approved.</p> <p>%(user_instructions)s</p> <p>You "
-"can view the collections you're authorized to access at My Library: "
-"%(link)s</p> <p>Cheers!</p> <p>The Wikipedia Library</p>"
-msgstr ""
-"{{Doc-important|\"Application\" here means \"request\" or \"candidacy\". "
-"This doesn't mean \"software application\" or \"app\".}}"
+msgid "<p>Dear %(user)s,</p> <p>Thank you for applying for access to %(partner)s resources through The Wikipedia Library. We are happy to inform you that your application has been approved.</p> <p>%(user_instructions)s</p> <p>You can view the collections you're authorized to access at My Library: %(link)s</p> <p>Cheers!</p> <p>The Wikipedia Library</p>"
+msgstr "{{Doc-important|\"Application\" here means \"request\" or \"candidacy\". This doesn't mean \"software application\" or \"app\".}}"
 
 #. Translators: This email is sent to users when their application is approved. Don't translate Jinja variables in curly braces like user or partner. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/approval_notification-body-text.html:3
 #, python-format
-msgid ""
-"Dear %(user)s, Thank you for applying for access to %(partner)s resources "
-"through The Wikipedia Library. We are happy to inform you that your "
-"application has been approved. %(user_instructions)s You can view the "
-"collections you're authorized to access at My Library: %(link)s Cheers! The "
-"Wikipedia Library"
-msgstr ""
-"{{Doc-important|\"Application\" here means \"request\" or \"candidacy\". "
-"This doesn't mean \"software application\" or \"app\".}}"
+msgid "Dear %(user)s, Thank you for applying for access to %(partner)s resources through The Wikipedia Library. We are happy to inform you that your application has been approved. %(user_instructions)s You can view the collections you're authorized to access at My Library: %(link)s Cheers! The Wikipedia Library"
+msgstr "{{Doc-important|\"Application\" here means \"request\" or \"candidacy\". This doesn't mean \"software application\" or \"app\".}}"
 
 #. Translators: This is the subject of an email which is sent to users when their application has been approved. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/approval_notification-subject.html:4
 msgid "Your Wikipedia Library application has been approved"
-msgstr ""
-"{{Doc-important|\"Application\" here means \"request\" or \"candidacy\". "
-"This doesn't mean \"software application\" or \"app\".}}"
+msgstr "{{Doc-important|\"Application\" here means \"request\" or \"candidacy\". This doesn't mean \"software application\" or \"app\".}}"
 
 #. Translators: This email is sent to coordinators when a comment is left on an application they are processing. Don't translate Jinja variables in curly braces like user or partner. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/comment_notification_coordinator-body-html.html:5
 #, python-format
-msgid ""
-"<p style=\"color: #500050\">%(submit_date)s - %(commenter)s</p> "
-"<blockquote><p>%(comment)s</p></blockquote> <p>Please reply to these at: <a "
-"href=\"%(app_url)s\">%(app_url)s</a></p> <p>Best,</p> <p>The Wikipedia "
-"Library</p>"
+msgid "<p style=\"color: #500050\">%(submit_date)s - %(commenter)s</p> <blockquote><p>%(comment)s</p></blockquote> <p>Please reply to these at: <a href=\"%(app_url)s\">%(app_url)s</a></p> <p>Best,</p> <p>The Wikipedia Library</p>"
 msgstr ""
 
 #. Translators: This email is sent to coordinators when a comment is left on an application they are processing. Don't translate Jinja variables in curly braces like user or partner. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/comment_notification_coordinator-body-text.html:3
 #, python-format
-msgid ""
-"%(submit_date)s - %(commenter)s %(comment)s Please reply to this at: "
-"%(app_url)s Best, The Wikipedia Library"
+msgid "%(submit_date)s - %(commenter)s %(comment)s Please reply to this at: %(app_url)s Best, The Wikipedia Library"
 msgstr ""
 
 #. Translators: This is the subject line of an email sent to coordinators when a comment is left on an application they processed.
 #: TWLight/emails/templates/emails/comment_notification_coordinator-subject.html:3
 msgid "New comment on a Wikipedia Library application you processed"
-msgstr ""
-"{{Doc-important|\"Application\" here means \"request\" or \"candidacy\". "
-"This doesn't mean \"software application\" or \"app\".}}"
+msgstr "{{Doc-important|\"Application\" here means \"request\" or \"candidacy\". This doesn't mean \"software application\" or \"app\".}}"
 
 #. Translators: This email is sent to users when they receive a comment on their application. Don't translate Jinja variables in curly braces like user or partner; don't translate html tags either. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/comment_notification_editors-body-html.html:5
 #, python-format
-msgid ""
-"<p style=\"color: #500050\">%(submit_date)s - %(commenter)s</p> "
-"<blockquote><p>%(comment)s</p></blockquote> <p>Please reply to these at <a "
-"href=\"%(app_url)s\">%(app_url)s</a> so we can evaluate your application.</"
-"p> <p>Best,</p> <p>The Wikipedia Library</p>"
-msgstr ""
-"{{Doc-important|\"Application\" here means \"request\" or \"candidacy\". "
-"This doesn't mean \"software application\" or \"app\".}}"
+msgid "<p style=\"color: #500050\">%(submit_date)s - %(commenter)s</p> <blockquote><p>%(comment)s</p></blockquote> <p>Please reply to these at <a href=\"%(app_url)s\">%(app_url)s</a> so we can evaluate your application.</p> <p>Best,</p> <p>The Wikipedia Library</p>"
+msgstr "{{Doc-important|\"Application\" here means \"request\" or \"candidacy\". This doesn't mean \"software application\" or \"app\".}}"
 
 #. Translators: This email is sent to users when they receive a comment on their application. Don't translate Jinja variables in curly braces like user or partner. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/comment_notification_editors-body-text.html:3
 #, python-format
-msgid ""
-"%(submit_date)s - %(commenter)s %(comment)s Please reply to these at: "
-"%(app_url)s so we can evaluate your application. Best, The Wikipedia Library"
-msgstr ""
-"{{Doc-important|\"Application\" here means \"request\" or \"candidacy\". "
-"This doesn't mean \"software application\" or \"app\".}}"
+msgid "%(submit_date)s - %(commenter)s %(comment)s Please reply to these at: %(app_url)s so we can evaluate your application. Best, The Wikipedia Library"
+msgstr "{{Doc-important|\"Application\" here means \"request\" or \"candidacy\". This doesn't mean \"software application\" or \"app\".}}"
 
 #. Translators: This is the subject line of an email sent to users who have a comment added to one of their applications. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/comment_notification_editors-subject.html:3
 msgid "New comment on your Wikipedia Library application"
-msgstr ""
-"{{Doc-important|\"Application\" here means \"request\" or \"candidacy\". "
-"This doesn't mean \"software application\" or \"app\".}}"
+msgstr "{{Doc-important|\"Application\" here means \"request\" or \"candidacy\". This doesn't mean \"software application\" or \"app\".}}"
 
 #. Translators: This email is sent to users when an application they commented on receives another comment. Don't translate Jinja variables in curly braces like app_url; don't translate html tags either. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/comment_notification_others-body-html.html:5
 #, python-format
-msgid ""
-"<p style=\"color: #500050\">%(submit_date)s - %(commenter)s</p> "
-"<blockquote><p>%(comment)s</p></blockquote> See it at <a href=\"%(app_url)s"
-"\">%(app_url)s</a>. Thanks for helping review Wikipedia Library applications!"
-msgstr ""
-"{{Doc-important|\"Application\" here means \"request\" or \"candidacy\". "
-"This doesn't mean \"software application\" or \"app\".}}"
+msgid "<p style=\"color: #500050\">%(submit_date)s - %(commenter)s</p> <blockquote><p>%(comment)s</p></blockquote> See it at <a href=\"%(app_url)s\">%(app_url)s</a>. Thanks for helping review Wikipedia Library applications!"
+msgstr "{{Doc-important|\"Application\" here means \"request\" or \"candidacy\". This doesn't mean \"software application\" or \"app\".}}"
 
 #. Translators: This email is sent to users when an application they commented on receives another comment. Don't translate Jinja variables in curly braces like app_url. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/comment_notification_others-body-text.html:3
 #, python-format
-msgid ""
-"%(submit_date)s - %(commenter)s %(comment)s See it at: %(app_url)s Thanks "
-"for helping review Wikipedia Library applications!"
-msgstr ""
-"{{Doc-important|\"Application\" here means \"request\" or \"candidacy\". "
-"This doesn't mean \"software application\" or \"app\".}}"
+msgid "%(submit_date)s - %(commenter)s %(comment)s See it at: %(app_url)s Thanks for helping review Wikipedia Library applications!"
+msgstr "{{Doc-important|\"Application\" here means \"request\" or \"candidacy\". This doesn't mean \"software application\" or \"app\".}}"
 
 #. Translators: This is the subject line of an email sent to users who have a comment added to an application they also commented on. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/comment_notification_others-subject.html:4
 msgid "New comment on a Wikipedia Library application you commented on"
-msgstr ""
-"{{Doc-important|\"Application\" here means \"request\" or \"candidacy\". "
-"This doesn't mean \"software application\" or \"app\".}}"
+msgstr "{{Doc-important|\"Application\" here means \"request\" or \"candidacy\". This doesn't mean \"software application\" or \"app\".}}"
 
 #. Translators: This text is part of a scheduled reminder email sent to coordinators who have applications requiring action. Don't translate Jinja variables in curly braces like total_apps, or user.
 #: TWLight/emails/templates/emails/coordinator_reminder_notification-body-html.html:5
 #, python-format
-msgid ""
-"<p>Dear %(user)s,</p> <p>Our records indicate that you are the designated "
-"coordinator for partners that have a total of %(total_apps)s applications.</"
-"p>"
-msgstr ""
-"{{Doc-important|\"Application\" here means \"request\" or \"candidacy\". "
-"This doesn't mean \"software application\" or \"app\".}}"
+msgid "<p>Dear %(user)s,</p> <p>Our records indicate that you are the designated coordinator for partners that have a total of %(total_apps)s applications.</p>"
+msgstr "{{Doc-important|\"Application\" here means \"request\" or \"candidacy\". This doesn't mean \"software application\" or \"app\".}}"
 
 #. Translators: Breakdown as in 'cost breakdown'; analysis.
 #: TWLight/emails/templates/emails/coordinator_reminder_notification-body-html.html:11
@@ -1282,9 +1048,7 @@ msgstr ""
 #, python-format
 msgid "%(counter)s pending application."
 msgid_plural "%(counter)s pending applications."
-msgstr[0] ""
-"{{Doc-important|\"Application\" here means \"request\" or \"candidacy\". "
-"This doesn't mean \"software application\" or \"app\".}}"
+msgstr[0] "{{Doc-important|\"Application\" here means \"request\" or \"candidacy\". This doesn't mean \"software application\" or \"app\".}}"
 
 #. Translators: This text is part of a scheduled reminder email sent to coordinators who have applications requiring action. Don't translate Jinja variables in curly braces like counter.
 #: TWLight/emails/templates/emails/coordinator_reminder_notification-body-html.html:24
@@ -1292,9 +1056,7 @@ msgstr[0] ""
 #, python-format
 msgid "%(counter)s under discussion application."
 msgid_plural "%(counter)s under discussion applications."
-msgstr[0] ""
-"{{Doc-important|\"Application\" here means \"request\" or \"candidacy\". "
-"This doesn't mean \"software application\" or \"app\".}}"
+msgstr[0] "{{Doc-important|\"Application\" here means \"request\" or \"candidacy\". This doesn't mean \"software application\" or \"app\".}}"
 
 #. Translators: This text is part of a scheduled reminder email sent to coordinators who have applications requiring action. Don't translate Jinja variables in curly braces like counter.
 #: TWLight/emails/templates/emails/coordinator_reminder_notification-body-html.html:32
@@ -1302,107 +1064,58 @@ msgstr[0] ""
 #, python-format
 msgid "%(counter)s approved application."
 msgid_plural "%(counter)s approved applications."
-msgstr[0] ""
-"{{Doc-important|\"Application\" here means \"request\" or \"candidacy\". "
-"This doesn't mean \"software application\" or \"app\".}}"
+msgstr[0] "{{Doc-important|\"Application\" here means \"request\" or \"candidacy\". This doesn't mean \"software application\" or \"app\".}}"
 
 #. Translators: This text is part of a scheduled reminder email sent to coordinators who have applications requiring action. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library). Don't translate Jinja variables in curly braces like link; don't translate email addresses or html tags either.
 #: TWLight/emails/templates/emails/coordinator_reminder_notification-body-html.html:39
 #, python-format
-msgid ""
-"<p>This is a gentle reminder that you may review applications at <a href="
-"\"%(link)s\">%(link)s</a>.</p> <p>You can customise your reminders under "
-"'preferences' in your user profile.</p> <p>If you received this message in "
-"error, drop us a line at wikipedialibrary@wikimedia.org.</p> <p>Thanks for "
-"helping review Wikipedia Library applications!</p>"
-msgstr ""
-"{{Doc-important|\"Application\" here means \"request\" or \"candidacy\". "
-"This doesn't mean \"software application\" or \"app\".}}"
+msgid "<p>This is a gentle reminder that you may review applications at <a href=\"%(link)s\">%(link)s</a>.</p> <p>You can customise your reminders under 'preferences' in your user profile.</p> <p>If you received this message in error, drop us a line at wikipedialibrary@wikimedia.org.</p> <p>Thanks for helping review Wikipedia Library applications!</p>"
+msgstr "{{Doc-important|\"Application\" here means \"request\" or \"candidacy\". This doesn't mean \"software application\" or \"app\".}}"
 
 #. Translators: This text is part of a scheduled reminder email sent to coordinators who have applications requiring action. Don't translate Jinja variables in curly braces like total_apps, or user.
 #: TWLight/emails/templates/emails/coordinator_reminder_notification-body-text.html:3
 #, python-format
-msgid ""
-"Dear %(user)s, Our records indicate that you are the designated coordinator "
-"for partners that have a total of %(total_apps)s applications."
-msgstr ""
-"{{Doc-important|\"Application\" here means \"request\" or \"candidacy\". "
-"This doesn't mean \"software application\" or \"app\".}}"
+msgid "Dear %(user)s, Our records indicate that you are the designated coordinator for partners that have a total of %(total_apps)s applications."
+msgstr "{{Doc-important|\"Application\" here means \"request\" or \"candidacy\". This doesn't mean \"software application\" or \"app\".}}"
 
 #. Translators: This text is part of a scheduled reminder email sent to coordinators who have applications requiring action. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library). Don't translate Jinja variables in curly braces like link; don't translate the email address either.
 #: TWLight/emails/templates/emails/coordinator_reminder_notification-body-text.html:38
 #, python-format
-msgid ""
-"This is a gentle reminder that you may review applications at: %(link)s. You "
-"can customise your reminders under 'preferences' in your user profile. If "
-"you received this message in error, drop us a line at: "
-"wikipedialibrary@wikimedia.org Thanks for helping review Wikipedia Library "
-"applications!"
-msgstr ""
-"{{Doc-important|\"Application\" here means \"request\" or \"candidacy\". "
-"This doesn't mean \"software application\" or \"app\".}}"
+msgid "This is a gentle reminder that you may review applications at: %(link)s. You can customise your reminders under 'preferences' in your user profile. If you received this message in error, drop us a line at: wikipedialibrary@wikimedia.org Thanks for helping review Wikipedia Library applications!"
+msgstr "{{Doc-important|\"Application\" here means \"request\" or \"candidacy\". This doesn't mean \"software application\" or \"app\".}}"
 
 #. Translators: This is the subject line of a scheduled reminder email sent to coordinators who have applications to review. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library). Do not translate items in curly braces.
 #: TWLight/emails/templates/emails/coordinator_reminder_notification-subject.html:4
 msgid "Wikipedia Library applications await your review"
-msgstr ""
-"{{Doc-important|\"Application\" here means \"request\" or \"candidacy\". "
-"This doesn't mean \"software application\" or \"app\".}}"
+msgstr "{{Doc-important|\"Application\" here means \"request\" or \"candidacy\". This doesn't mean \"software application\" or \"app\".}}"
 
 #. Translators: This email is sent to users when their application is rejected. Don't translate Jinja variables in curly braces like user or partner; don't translate html tags either. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/rejection_notification-body-html.html:5
 #, python-format
-msgid ""
-"<p>Dear %(user)s,</p> <p>Thank you for applying for access to %(partner)s "
-"resources through The Wikipedia Library. Unfortunately at this time your "
-"application has not been approved. You can view your application and review "
-"comments at <a href=\"%(app_url)s\">%(app_url)s</a>.</p> <p>Best,</p> <p>The "
-"Wikipedia Library</p>"
-msgstr ""
-"{{Doc-important|\"Application\" here means \"request\" or \"candidacy\". "
-"This doesn't mean \"software application\" or \"app\".}}"
+msgid "<p>Dear %(user)s,</p> <p>Thank you for applying for access to %(partner)s resources through The Wikipedia Library. Unfortunately at this time your application has not been approved. You can view your application and review comments at <a href=\"%(app_url)s\">%(app_url)s</a>.</p> <p>Best,</p> <p>The Wikipedia Library</p>"
+msgstr "{{Doc-important|\"Application\" here means \"request\" or \"candidacy\". This doesn't mean \"software application\" or \"app\".}}"
 
 #. Translators: This email is sent to users when their application is rejected. Don't translate Jinja variables in curly braces like user or partner. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/rejection_notification-body-text.html:3
 #, python-format
-msgid ""
-"Dear %(user)s, Thank you for applying for access to %(partner)s resources "
-"through The Wikipedia Library. Unfortunately at this time your application "
-"has not been approved. You can view your application and review comments at: "
-"%(app_url)s Best, The Wikipedia Library"
-msgstr ""
-"{{Doc-important|\"Application\" here means \"request\" or \"candidacy\". "
-"This doesn't mean \"software application\" or \"app\".}}"
+msgid "Dear %(user)s, Thank you for applying for access to %(partner)s resources through The Wikipedia Library. Unfortunately at this time your application has not been approved. You can view your application and review comments at: %(app_url)s Best, The Wikipedia Library"
+msgstr "{{Doc-important|\"Application\" here means \"request\" or \"candidacy\". This doesn't mean \"software application\" or \"app\".}}"
 
 #. Translators: This is the subject of an email which is sent to users when their application has been rejected. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/rejection_notification-subject.html:4
 msgid "Your Wikipedia Library application"
-msgstr ""
-"{{Doc-important|\"Application\" here means \"request\" or \"candidacy\". "
-"This doesn't mean \"software application\" or \"app\".}}"
+msgstr "{{Doc-important|\"Application\" here means \"request\" or \"candidacy\". This doesn't mean \"software application\" or \"app\".}}"
 
 #. Translators: This email is sent to users when they have an account that is soon to expire. Don't translate Jinja variables in curly braces like partner_name or partner_link; don't translate html tags either. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/user_renewal_notice-body-html.html:5
 #, python-format
-msgid ""
-"<p>Dear %(user)s,</p> <p>According to our records, your access to "
-"%(partner_name)s will soon expire and you may lose access. If you want to "
-"continue making use of your free account, you can request renewal of your "
-"account by clicking the 'Renew' or 'Extend' button at %(partner_link)s.</p> "
-"<p>Best,</p> <p>The Wikipedia Library</p> <p>You can disable these emails in "
-"your user page preferences: https://wikipedialibrary.wmflabs.org/users/</p>"
+msgid "<p>Dear %(user)s,</p> <p>According to our records, your access to %(partner_name)s will soon expire and you may lose access. If you want to continue making use of your free account, you can request renewal of your account by clicking the 'Renew' or 'Extend' button at %(partner_link)s.</p> <p>Best,</p> <p>The Wikipedia Library</p> <p>You can disable these emails in your user page preferences: https://wikipedialibrary.wmflabs.org/users/</p>"
 msgstr ""
 
 #. Translators: This email is sent to users when they have an account that is soon to expire. Don't translate Jinja variables in curly braces like partner_name or partner_link; don't translate html tags either. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/user_renewal_notice-body-text.html:3
 #, python-format
-msgid ""
-"Dear %(user)s, According to our records, your access to %(partner_name)s "
-"will soon expire and you may lose access. If you want to continue making use "
-"of your free account, you can request renewal of your account by clicking "
-"the Renew button at %(partner_link)s. Best, The Wikipedia Library You can "
-"disable these emails in your user page preferences: https://wikipedialibrary."
-"wmflabs.org/users/"
+msgid "Dear %(user)s, According to our records, your access to %(partner_name)s will soon expire and you may lose access. If you want to continue making use of your free account, you can request renewal of your account by clicking the Renew button at %(partner_link)s. Best, The Wikipedia Library You can disable these emails in your user page preferences: https://wikipedialibrary.wmflabs.org/users/"
 msgstr ""
 
 #. Translators: This is the subject of an email sent to users when they have an account that is soon to expire. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
@@ -1413,36 +1126,19 @@ msgstr ""
 #. Translators: This email is sent to users when their application is waitlisted because there are no more accounts available. Don't translate Jinja variables in curly braces like user or partner; don't translate html tags either. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/waitlist_notification-body-html.html:5
 #, python-format
-msgid ""
-"<p>Dear %(user)s,</p> <p>Thank you for applying for access to %(partner)s "
-"resources through The Wikipedia Library. There are no accounts currently "
-"available so your application has been waitlisted. Your application will be "
-"evaluated if/when more accounts become available. You can see all available "
-"resources at <a href=\"%(link)s\">%(link)s</a>.</p> <p>Best,</p> <p>The "
-"Wikipedia Library</p>"
-msgstr ""
-"{{Doc-important|\"Application\" here means \"request\" or \"candidacy\". "
-"This doesn't mean \"software application\" or \"app\".}}"
+msgid "<p>Dear %(user)s,</p> <p>Thank you for applying for access to %(partner)s resources through The Wikipedia Library. There are no accounts currently available so your application has been waitlisted. Your application will be evaluated if/when more accounts become available. You can see all available resources at <a href=\"%(link)s\">%(link)s</a>.</p> <p>Best,</p> <p>The Wikipedia Library</p>"
+msgstr "{{Doc-important|\"Application\" here means \"request\" or \"candidacy\". This doesn't mean \"software application\" or \"app\".}}"
 
 #. Translators: This email is sent to users when their application is waitlisted because there are no more accounts available. Don't translate Jinja variables in curly braces like user or partner. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/waitlist_notification-body-text.html:3
 #, python-format
-msgid ""
-"Dear %(user)s, Thank you for applying for access to %(partner)s resources "
-"through The Wikipedia Library. There are no accounts currently available so "
-"your application has been waitlisted. Your application will be evaluated if/"
-"when more accounts become available. You can see all available resources at: "
-"%(link)s Best, The Wikipedia Library"
-msgstr ""
-"{{Doc-important|\"Application\" here means \"request\" or \"candidacy\". "
-"This doesn't mean \"software application\" or \"app\".}}"
+msgid "Dear %(user)s, Thank you for applying for access to %(partner)s resources through The Wikipedia Library. There are no accounts currently available so your application has been waitlisted. Your application will be evaluated if/when more accounts become available. You can see all available resources at: %(link)s Best, The Wikipedia Library"
+msgstr "{{Doc-important|\"Application\" here means \"request\" or \"candidacy\". This doesn't mean \"software application\" or \"app\".}}"
 
 #. Translators: This is the subject of an email sent to users when their application is waitlisted because there are no more accounts available. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/waitlist_notification-subject.html:4
 msgid "Your Wikipedia Library application has been waitlisted"
-msgstr ""
-"{{Doc-important|\"Application\" here means \"request\" or \"candidacy\". "
-"This doesn't mean \"software application\" or \"app\".}}"
+msgstr "{{Doc-important|\"Application\" here means \"request\" or \"candidacy\". This doesn't mean \"software application\" or \"app\".}}"
 
 #. Translators: Shown to users when they successfully submit a new message using the contact us form.
 #: TWLight/emails/views.py:51
@@ -1598,17 +1294,14 @@ msgstr ""
 #: TWLight/resources/templates/resources/filter_section.html:14
 #: TWLight/templates/about.html:12
 #: TWLight/users/templates/users/filter_section.html:13
-msgid ""
-"The Wikipedia Library allows active editors to access a wide range of "
-"collections of paywalled reliable sources for free!"
+msgid "The Wikipedia Library allows active editors to access a wide range of collections of paywalled reliable sources for free!"
 msgstr ""
 
 #. Translators: On the Browse Partners page (https://wikipedialibrary.wmflabs.org/partners/), this introduces users to The Wikipedia Library.
 #. Translators: On the MyLibrary page (https://wikipedialibrary.wmflabs.org/users/my_library), this introduces users to The Wikipedia Library.
 #: TWLight/resources/templates/resources/filter_section.html:17
 #: TWLight/users/templates/users/filter_section.html:15
-msgid ""
-"Start with the search bar at the top or browse publisher websites directly."
+msgid "Start with the search bar at the top or browse publisher websites directly."
 msgstr ""
 
 #. Translators: On the Browse Partners page (https://wikipedialibrary.wmflabs.org/partners/), this appears below introductory text and links to the 'About' page (https://wikipedialibrary.wmflabs.org/about/)
@@ -1649,10 +1342,7 @@ msgstr ""
 #: TWLight/resources/templates/resources/filter_section.html:54
 #: TWLight/users/templates/users/filter_section.html:82
 msgid "Filter collections"
-msgstr ""
-"Translators: On the Browse Partners page (https://wikipedialibrary.wmflabs."
-"org/partners/), this is a placeholder for an input that helps users filter "
-"collections."
+msgstr "Translators: On the Browse Partners page (https://wikipedialibrary.wmflabs.org/partners/), this is a placeholder for an input that helps users filter collections."
 
 #. Translators: This is the title of the form where coordiantors can merge partner suggestions.
 #: TWLight/resources/templates/resources/merge_suggestion.html:34
@@ -1680,68 +1370,44 @@ msgstr ""
 
 #: TWLight/resources/templates/resources/partner_detail.html:22
 msgid "Back to partners"
-msgstr ""
-"Translators: This text is located on individual partner pages, and when "
-"clicked takes unauthenticated users back to the list of publishers."
+msgstr "Translators: This text is located on individual partner pages, and when clicked takes unauthenticated users back to the list of publishers."
 
 #. Translators: If we have no available accounts for a partner, the coordinator can change the application system to a waiting list.
 #: TWLight/resources/templates/resources/partner_detail.html:36
 #: TWLight/resources/templates/resources/partner_detail_apply.html:17
-msgid ""
-"There are no access grants available for this partner at this time. You can "
-"still apply for access; applications will be processed when access is "
-"available."
-msgstr ""
-"{{Doc-important|\"Application\" here means \"request\" or \"candidacy\". "
-"This doesn't mean \"software application\" or \"app\".}}"
+msgid "There are no access grants available for this partner at this time. You can still apply for access; applications will be processed when access is available."
+msgstr "{{Doc-important|\"Application\" here means \"request\" or \"candidacy\". This doesn't mean \"software application\" or \"app\".}}"
 
 #. Translators: This text links to the minimum user requirements and terms of use on the partner page.
 #: TWLight/resources/templates/resources/partner_detail.html:48
 #: TWLight/resources/templates/resources/partner_detail_apply.html:29
 #, python-format
-msgid ""
-"Before applying, please review the <strong><a class=\"twl-links\" href="
-"\"%(about)s#req\">minimum requirements</a></strong> for access and our "
-"<strong><a class=\"twl-links\" href=\"%(terms)s\">terms of use</a></strong>."
+msgid "Before applying, please review the <strong><a class=\"twl-links\" href=\"%(about)s#req\">minimum requirements</a></strong> for access and our <strong><a class=\"twl-links\" href=\"%(terms)s\">terms of use</a></strong>."
 msgstr ""
 
 #. Translators: This text refers to the page containing the content a user is authorized to access.
 #: TWLight/resources/templates/resources/partner_detail.html:69
 #, fuzzy, python-format
-msgid ""
-"View the status of your access in <strong><a class=\"twl-links\" href="
-"\"%(library_url)s\">My Library</a></strong> page."
+msgid "View the status of your access in <strong><a class=\"twl-links\" href=\"%(library_url)s\">My Library</a></strong> page."
 msgstr "“My Library” is {{msg-wm|Wikipedia-library-7996cc-My Library}}."
 
 #. Translators: This message is shown when a user has open applications, linking to their respective applications page.
 #: TWLight/resources/templates/resources/partner_detail.html:78
 #, python-format
-msgid ""
-"View the status of your application(s) on your <strong><a class=\"twl-links"
-"\" href=\"%(applications_url)s\">My Applications</a></strong> page."
-msgstr ""
-"{{Doc-important|\"Application\" here means \"request\" or \"candidacy\". "
-"This doesn't mean \"software application\" or \"app\".}}\n"
-"\"My Applications\" is {{msg-wm|Wikipedia-library-c46eb7-My Applications}}."
+msgid "View the status of your application(s) on your <strong><a class=\"twl-links\" href=\"%(applications_url)s\">My Applications</a></strong> page."
+msgstr "{{Doc-important|\"Application\" here means \"request\" or \"candidacy\". This doesn't mean \"software application\" or \"app\".}}\n\"My Applications\" is {{msg-wm|Wikipedia-library-c46eb7-My Applications}}."
 
 #. Translators: This message is shown when a user has authorizations, linking to their respective collections page.
 #: TWLight/resources/templates/resources/partner_detail_apply.html:50
 #, python-format
-msgid ""
-"View the status of your access on your <strong><a href=\"%(library_url)s\" "
-"class=\"twl-links\">My Library</a></strong> page."
+msgid "View the status of your access on your <strong><a href=\"%(library_url)s\" class=\"twl-links\">My Library</a></strong> page."
 msgstr "“My Library” is {{msg-wm|Wikipedia-library-7996cc-My Library}}."
 
 #. Translators: This message is shown when a user has open applications, linking to their respective applications page.
 #: TWLight/resources/templates/resources/partner_detail_apply.html:60
 #, python-format
-msgid ""
-"View the status of your application(s) on your <strong><a href="
-"\"%(applications_url)s\">My Applications</a></strong> page."
-msgstr ""
-"{{Doc-important|\"Application\" here means \"request\" or \"candidacy\". "
-"This doesn't mean \"software application\" or \"app\".}}\n"
-"\"My Applications\" is {{msg-wm|Wikipedia-library-c46eb7-My Applications}}."
+msgid "View the status of your application(s) on your <strong><a href=\"%(applications_url)s\">My Applications</a></strong> page."
+msgstr "{{Doc-important|\"Application\" here means \"request\" or \"candidacy\". This doesn't mean \"software application\" or \"app\".}}\n\"My Applications\" is {{msg-wm|Wikipedia-library-c46eb7-My Applications}}."
 
 #. Translators: One the partner detail page, this text labels the button which coordinators can click to remove a partner from waitlisted status.
 #: TWLight/resources/templates/resources/partner_detail_apply.html:73
@@ -1756,9 +1422,7 @@ msgstr ""
 #: TWLight/resources/templates/resources/partner_detail_apply.html:86
 #, python-format
 msgid "<strong>%(coordinator)s</strong> processes applications to %(partner)s."
-msgstr ""
-"{{Doc-important|\"Application\" here means \"request\" or \"candidacy\". "
-"This doesn't mean \"software application\" or \"app\".}}"
+msgstr "{{Doc-important|\"Application\" here means \"request\" or \"candidacy\". This doesn't mean \"software application\" or \"app\".}}"
 
 #. Translators: When a coordinator is assigned to a partner, their details are shown on the page. This text labels a link to their Talk page on Wikipedia, and should be translated to the text used for Talk pages in the language you are translating to.
 #: TWLight/resources/templates/resources/partner_detail_apply.html:95
@@ -1772,20 +1436,13 @@ msgstr ""
 
 #. Translators: If no account coordinator is assigned to a partner, the Wikipedia Library team will coordinate signups. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/resources/templates/resources/partner_detail_apply.html:112
-msgid ""
-"The Wikipedia Library team will process this application. Want to help? <a "
-"class=\"twl-links\" href=\"https://en.wikipedia.org/wiki/Wikipedia:"
-"The_Wikipedia_Library/Coordinators/Signup\">Sign up as a coordinator.</a>"
-msgstr ""
-"{{Doc-important|\"Application\" here means \"request\" or \"candidacy\". "
-"This doesn't mean \"software application\" or \"app\".}}"
+msgid "The Wikipedia Library team will process this application. Want to help? <a class=\"twl-links\" href=\"https://en.wikipedia.org/wiki/Wikipedia:The_Wikipedia_Library/Coordinators/Signup\">Sign up as a coordinator.</a>"
+msgstr "{{Doc-important|\"Application\" here means \"request\" or \"candidacy\". This doesn't mean \"software application\" or \"app\".}}"
 
 #. Translators: This text labels a button coordinators can click to view a list of users who have applied for access for a particular partner
 #: TWLight/resources/templates/resources/partner_detail_apply.html:121
 msgid "List applications"
-msgstr ""
-"{{Doc-important|\"Application\" here means \"request\" or \"candidacy\". "
-"This doesn't mean \"software application\" or \"app\".}}"
+msgstr "{{Doc-important|\"Application\" here means \"request\" or \"candidacy\". This doesn't mean \"software application\" or \"app\".}}"
 
 #. Translators: This text labels a button authenticated, bundle eligible users can click to access the proxied resource.
 #: TWLight/resources/templates/resources/partner_detail_apply.html:130
@@ -1809,18 +1466,13 @@ msgstr ""
 
 #. Translators: Text shown to authenticated, bundle eligible users when they visit a Bundle partner page.
 #: TWLight/resources/templates/resources/partner_detail_apply.html:138
-msgid ""
-"You are eligible to access Library Bundle partners. Click the button above "
-"to access the collection."
+msgid "You are eligible to access Library Bundle partners. Click the button above to access the collection."
 msgstr ""
 
 #. Translators: Text shown to authenticated, bundle ineligible users when they visit a Bundle partner page.
 #: TWLight/resources/templates/resources/partner_detail_apply.html:152
 #, python-format
-msgid ""
-"You are not eligible to access Library Bundle partners. Visit the <a class="
-"\"twl-links\" href=\"%(homepage)s\">homepage</a> to check the eligibility "
-"criteria."
+msgid "You are not eligible to access Library Bundle partners. Visit the <a class=\"twl-links\" href=\"%(homepage)s\">homepage</a> to check the eligibility criteria."
 msgstr ""
 
 #. Translators: Buttton prompting users to log in.
@@ -1832,10 +1484,7 @@ msgstr ""
 #. Translators: Text shown to unauthenticated users when they visit a Bundle partner page.
 #: TWLight/resources/templates/resources/partner_detail_apply.html:168
 #, python-format
-msgid ""
-"This resource is part of our <a class=\"twl-links\" href=\"%(about)s"
-"\">Library Bundle</a>, which you can access if you meet our minimum "
-"eligibility criteria. Log in to find out if you are eligible."
+msgid "This resource is part of our <a class=\"twl-links\" href=\"%(about)s\">Library Bundle</a>, which you can access if you meet our minimum eligibility criteria. Log in to find out if you are eligible."
 msgstr ""
 
 #. Translators: This is the label for a number which shows the total active accounts for one partner. (e.g. https://wikipedialibrary.wmflabs.org/partners/8/).
@@ -1851,9 +1500,7 @@ msgstr ""
 #. Translators: This is the label for a number which shows the median (not mean) number of days between users applying and a coordinator making a decision on their application. (e.g. https://wikipedialibrary.wmflabs.org/partners/8/).
 #: TWLight/resources/templates/resources/partner_detail_stats.html:59
 msgid "Median days from application to decision"
-msgstr ""
-"{{Doc-important|\"Application\" here means \"request\" or \"candidacy\". "
-"This doesn't mean \"software application\" or \"app\".}}"
+msgstr "{{Doc-important|\"Application\" here means \"request\" or \"candidacy\". This doesn't mean \"software application\" or \"app\".}}"
 
 #. Translators: If a partner has no description written, this message is shown in the Description field on the partner page.
 #: TWLight/resources/templates/resources/partner_detail_timeline.html:22
@@ -1888,41 +1535,30 @@ msgstr ""
 #. Translators: If a partner has specified the excerpt limit both in words and percentage, this message will display the percentage of words and the number of words on the partner page.
 #: TWLight/resources/templates/resources/partner_detail_timeline.html:99
 #, python-format
-msgid ""
-"%(object)s allows a maximum of %(excerpt_limit)s words or "
-"%(excerpt_limit_percentage)s%% of an article be excerpted into a Wikipedia "
-"article."
+msgid "%(object)s allows a maximum of %(excerpt_limit)s words or %(excerpt_limit_percentage)s%% of an article be excerpted into a Wikipedia article."
 msgstr ""
 
 #. Translators: If a partner has specified the excerpt limit in words, this message will display the number of words on the partner page.
 #: TWLight/resources/templates/resources/partner_detail_timeline.html:106
 #, python-format
-msgid ""
-"%(object)s allows a maximum of %(excerpt_limit)s words be excerpted into a "
-"Wikipedia article."
+msgid "%(object)s allows a maximum of %(excerpt_limit)s words be excerpted into a Wikipedia article."
 msgstr ""
 
 #. Translators: If a partner has specified the excerpt limit in percentage, this message will display the percentage of words on the partner page.
 #: TWLight/resources/templates/resources/partner_detail_timeline.html:113
 #, python-format
-msgid ""
-"%(object)s allows a maximum of %(excerpt_limit_percentage)s%% of an article "
-"be excerpted into a Wikipedia article."
+msgid "%(object)s allows a maximum of %(excerpt_limit_percentage)s%% of an article be excerpted into a Wikipedia article."
 msgstr ""
 
 #. Translators: If a partner has other requirements for access, this text shows as the title for that information field. (e.g. https://wikipedialibrary.wmflabs.org/partners/10/).
 #: TWLight/resources/templates/resources/partner_detail_timeline.html:132
 msgid "Special requirements for applicants"
-msgstr ""
-"{{Doc-important|\"Application\" here means \"request\" or \"candidacy\". "
-"This doesn't mean \"software application\" or \"app\".}}"
+msgstr "{{Doc-important|\"Application\" here means \"request\" or \"candidacy\". This doesn't mean \"software application\" or \"app\".}}"
 
 #. Translators: If a user must agree to a Terms of Use document, they see this message, and must enter the name of the resource. Don't translate publisher or url.
 #: TWLight/resources/templates/resources/partner_detail_timeline.html:140
 #, python-format
-msgid ""
-"%(publisher)s requires that you agree with its <a href=\"%(url)s\">terms of "
-"use</a>."
+msgid "%(publisher)s requires that you agree with its <a href=\"%(url)s\">terms of use</a>."
 msgstr ""
 
 #. Translators: If a user must provide their real name to apply to a partner, they see this message, and must enter the name of the resource. Don't translate publisher.
@@ -1946,17 +1582,13 @@ msgstr ""
 #. Translators: If a user must select a specific resource to apply for, they see this message, and must enter the name of the resource. Don't translate publisher.
 #: TWLight/resources/templates/resources/partner_detail_timeline.html:177
 #, python-format
-msgid ""
-"%(publisher)s requires that you specify a particular title that you want to "
-"access."
+msgid "%(publisher)s requires that you specify a particular title that you want to access."
 msgstr ""
 
 #. Translators: If a user must register on the partner website before applying, they see this message. Don't translate partner.
 #: TWLight/resources/templates/resources/partner_detail_timeline.html:187
 #, python-format
-msgid ""
-"%(publisher)s requires that you sign up for an account before applying for "
-"access."
+msgid "%(publisher)s requires that you sign up for an account before applying for access."
 msgstr ""
 
 #. Translators: If a partner has their location listed, this message is a label for that location
@@ -2007,17 +1639,13 @@ msgstr ""
 #: TWLight/resources/templates/resources/partner_users.html:33
 #: TWLight/resources/templates/resources/partner_users.html:73
 msgid "Application date"
-msgstr ""
-"{{Doc-important|\"Application\" here means \"request\" or \"candidacy\". "
-"This doesn't mean \"software application\" or \"app\".}}"
+msgstr "{{Doc-important|\"Application\" here means \"request\" or \"candidacy\". This doesn't mean \"software application\" or \"app\".}}"
 
 #. Translators: On the page where coordinators can view data on applications to a partner they coordinate, this is a table column heading for date an application was approved by a coordinator.
 #: TWLight/resources/templates/resources/partner_users.html:35
 #: TWLight/resources/templates/resources/partner_users.html:75
 msgid "Application approved"
-msgstr ""
-"{{Doc-important|\"Application\" here means \"request\" or \"candidacy\". "
-"This doesn't mean \"software application\" or \"app\".}}"
+msgstr "{{Doc-important|\"Application\" here means \"request\" or \"candidacy\". This doesn't mean \"software application\" or \"app\".}}"
 
 #. Translators: On the page where coordinators can view data on applications to a partner they coordinate, this is a table column heading denoting whether an application was a renewal.
 #: TWLight/resources/templates/resources/partner_users.html:37
@@ -2043,10 +1671,7 @@ msgstr ""
 
 #: TWLight/resources/templates/resources/suggest.html:43
 msgid "Filter suggestions"
-msgstr ""
-"On the Browse Partners page (https://wikipedialibrary.wmflabs.org/"
-"partners/), this is a placeholder for an input that helps users filter "
-"collections."
+msgstr "On the Browse Partners page (https://wikipedialibrary.wmflabs.org/partners/), this is a placeholder for an input that helps users filter collections."
 
 #. Translators: This is the title of the panel where user suggestions are displayed.
 #: TWLight/resources/templates/resources/suggest.html:47
@@ -2090,17 +1715,13 @@ msgstr ""
 
 #. Translators: If multiple authorizations where returned for a collection, this message is shown to a user
 #: TWLight/resources/views.py:268
-msgid ""
-"Multiple authorizations were returned – something's wrong. Please contact us "
-"and don't forget to mention this message."
+msgid "Multiple authorizations were returned – something's wrong. Please contact us and don't forget to mention this message."
 msgstr ""
 
 #. Translators: This message is shown when user tries to access a NOT_AVAILABLE Partner
 #: TWLight/resources/views.py:316
 msgid "This partner is currently not open for applications"
-msgstr ""
-"{{Doc-important|\"Application\" here means \"request\" or \"candidacy\". "
-"This doesn't mean \"software application\" or \"app\".}}"
+msgstr "{{Doc-important|\"Application\" here means \"request\" or \"candidacy\". This doesn't mean \"software application\" or \"app\".}}"
 
 #. Translators: When an account coordinator changes a partner from being open to applications to having a 'waitlist', they are shown this message.
 #: TWLight/resources/views.py:408
@@ -2110,9 +1731,7 @@ msgstr ""
 #. Translators: When an account coordinator changes a partner from having a 'waitlist' to being open for applications, they are shown this message.
 #: TWLight/resources/views.py:421
 msgid "This partner is now available for applications"
-msgstr ""
-"{{Doc-important|\"Application\" here means \"request\" or \"candidacy\". "
-"This doesn't mean \"software application\" or \"app\".}}"
+msgstr "{{Doc-important|\"Application\" here means \"request\" or \"candidacy\". This doesn't mean \"software application\" or \"app\".}}"
 
 #. Translators: Shown to users when they successfully add a new partner suggestion.
 #: TWLight/resources/views.py:547
@@ -2137,14 +1756,7 @@ msgstr ""
 #. Translators: Shown on the website's 400 page, when a user sends a bad request. Don't translate path or Phabricator.
 #: TWLight/templates/400.html:20
 #, python-format
-msgid ""
-"If you think we should know what to do with that, please email us about this "
-"error at <a class=\"twl-links\" href=\"mailto:wikipedialibrary@wikimedia.org?"
-"Subject=Wikipedia%%20Library%%20%(path)s%%20Permission%%20denied"
-"\">wikipedialibrary@wikimedia.org</a> or report it to us on <a class=\"twl-"
-"links\" href=\"https://phabricator.wikimedia.org/maniphest/task/edit/form/1/?"
-"projectPHIDs=Library-Card-Platform&title=Wikipedia%%20Library%%20%(path)s"
-"%%20Bad%%20Request\">Phabricator</a>"
+msgid "If you think we should know what to do with that, please email us about this error at <a class=\"twl-links\" href=\"mailto:wikipedialibrary@wikimedia.org?Subject=Wikipedia%%20Library%%20%(path)s%%20Permission%%20denied\">wikipedialibrary@wikimedia.org</a> or report it to us on <a class=\"twl-links\" href=\"https://phabricator.wikimedia.org/maniphest/task/edit/form/1/?projectPHIDs=Library-Card-Platform&title=Wikipedia%%20Library%%20%(path)s%%20Bad%%20Request\">Phabricator</a>"
 msgstr ""
 
 #. Translators: Alt text for an image shown on the 400 error page.
@@ -2166,15 +1778,7 @@ msgstr ""
 #. Translators: Shown on the website's 403 page, when a user attempts to navigate to a page they don't have permission to view. Don't translate path or Phabricator.
 #: TWLight/templates/403.html:20
 #, python-format
-msgid ""
-"If you think your account should be able to do that, please email us about "
-"this error at <a class=\"twl-links\" href=\"mailto:"
-"wikipedialibrary@wikimedia.org?Subject=Wikipedia%%20Library%%20%(path)s"
-"%%20Permission%%20denied\">wikipedialibrary@wikimedia.org</a> or report it "
-"to us on <a class=\"twl-links\" href=\"https://phabricator.wikimedia.org/"
-"maniphest/task/edit/form/1/?projectPHIDs=Library-Card-"
-"Platform&title=Wikipedia%%20Library%%20%(path)s%%20Permission%%20denied"
-"\">Phabricator</a>"
+msgid "If you think your account should be able to do that, please email us about this error at <a class=\"twl-links\" href=\"mailto:wikipedialibrary@wikimedia.org?Subject=Wikipedia%%20Library%%20%(path)s%%20Permission%%20denied\">wikipedialibrary@wikimedia.org</a> or report it to us on <a class=\"twl-links\" href=\"https://phabricator.wikimedia.org/maniphest/task/edit/form/1/?projectPHIDs=Library-Card-Platform&title=Wikipedia%%20Library%%20%(path)s%%20Permission%%20denied\">Phabricator</a>"
 msgstr ""
 
 #. Translators: Shown on the website's 404 page, when a user attempts to navigate to a page that doesn't exist.
@@ -2190,14 +1794,7 @@ msgstr ""
 #. Translators: Shown on the website's 404 page, when a user attempts to navigate to a page that doesn't exist. Don't translate path or Phabricator.
 #: TWLight/templates/404.html:19
 #, python-format
-msgid ""
-"If you are certain that something should be here, please email us about this "
-"error at <a class=\"twl-links\" href=\"mailto:wikipedialibrary@wikimedia.org?"
-"Subject=Wikipedia%%20Library%%20%(path)s%%20Not%%20found\"> "
-"wikipedialibrary@wikimedia.org</a> or report it to us on <a class=\"twl-links"
-"\" href=\"https://phabricator.wikimedia.org/maniphest/task/edit/form/1/?"
-"projectPHIDs=Library-Card-Platform&title=Wikipedia%%20Library%%20%(path)s"
-"%%20Not%%20found\">Phabricator</a>"
+msgid "If you are certain that something should be here, please email us about this error at <a class=\"twl-links\" href=\"mailto:wikipedialibrary@wikimedia.org?Subject=Wikipedia%%20Library%%20%(path)s%%20Not%%20found\"> wikipedialibrary@wikimedia.org</a> or report it to us on <a class=\"twl-links\" href=\"https://phabricator.wikimedia.org/maniphest/task/edit/form/1/?projectPHIDs=Library-Card-Platform&title=Wikipedia%%20Library%%20%(path)s%%20Not%%20found\">Phabricator</a>"
 msgstr ""
 
 #. Translators: Alt text for an image shown on the 404 error page.
@@ -2212,34 +1809,18 @@ msgstr ""
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:20
-msgid ""
-"This platform is our central tool for facilitating access to our available "
-"collections. Here you can see which partnerships are available, search their "
-"contents, and apply for and access the ones you’re interested in."
+msgid "This platform is our central tool for facilitating access to our available collections. Here you can see which partnerships are available, search their contents, and apply for and access the ones you’re interested in."
 msgstr ""
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/). Wikimedia Foundation should not be translated.
 #: TWLight/templates/about.html:29
-msgid ""
-"All users receive immediate access to some collections, which can be browsed "
-"by clicking the 'Access collection' buttons or using the search bar at the "
-"top of the page. Other collections require an application before access is "
-"granted, and may be accessed directly or via an individual login or access "
-"code. Volunteer coordinators, who have signed non-disclosure agreements with "
-"the Wikimedia Foundation, review these applications and work with publishers "
-"to get you your free access."
-msgstr ""
-"{{Doc-important|\"Application\" here means \"request\" or \"candidacy\". "
-"This doesn't mean \"software application\" or \"app\".}}"
+msgid "All users receive immediate access to some collections, which can be browsed by clicking the 'Access collection' buttons or using the search bar at the top of the page. Other collections require an application before access is granted, and may be accessed directly or via an individual login or access code. Volunteer coordinators, who have signed non-disclosure agreements with the Wikimedia Foundation, review these applications and work with publishers to get you your free access."
+msgstr "{{Doc-important|\"Application\" here means \"request\" or \"candidacy\". This doesn't mean \"software application\" or \"app\".}}"
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/). Don't translate terms_url.
 #: TWLight/templates/about.html:43
 #, python-format
-msgid ""
-"For more information about how your information is stored and reviewed "
-"please see our <a class=\"twl-links\" href=\"%(terms_url)s\"> terms of use "
-"and privacy policy</a>. Accounts you apply for are also subject to the Terms "
-"of Use provided by each partner’s platform; please review them."
+msgid "For more information about how your information is stored and reviewed please see our <a class=\"twl-links\" href=\"%(terms_url)s\"> terms of use and privacy policy</a>. Accounts you apply for are also subject to the Terms of Use provided by each partner’s platform; please review them."
 msgstr ""
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
@@ -2249,15 +1830,8 @@ msgstr ""
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/). Wikimedia Foundation should not be translated.
 #: TWLight/templates/about.html:55
-msgid ""
-"Any active editor in good standing can receive access. For publishers with "
-"limited numbers of accounts, applications are reviewed based on the editor’s "
-"needs and contributions. If you think you could use access to one of our "
-"partner resources and are an active editor in any project supported by the "
-"Wikimedia Foundation, please apply."
-msgstr ""
-"{{Doc-important|\"Application\" here means \"request\" or \"candidacy\". "
-"This doesn't mean \"software application\" or \"app\".}}"
+msgid "Any active editor in good standing can receive access. For publishers with limited numbers of accounts, applications are reviewed based on the editor’s needs and contributions. If you think you could use access to one of our partner resources and are an active editor in any project supported by the Wikimedia Foundation, please apply."
+msgstr "{{Doc-important|\"Application\" here means \"request\" or \"candidacy\". This doesn't mean \"software application\" or \"app\".}}"
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:65
@@ -2286,23 +1860,12 @@ msgstr ""
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/)
 #: TWLight/templates/about.html:89
-msgid ""
-"If you are applying for an available collection, please first check that you "
-"don't already have access through another library or institution. If you do, "
-"please consider using that access rather than taking up a seat for this "
-"resource in The Wikipedia Library."
+msgid "If you are applying for an available collection, please first check that you don't already have access through another library or institution. If you do, please consider using that access rather than taking up a seat for this resource in The Wikipedia Library."
 msgstr ""
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/)
 #: TWLight/templates/about.html:99
-msgid ""
-"If your account is blocked on one or more Wikimedia projects, you may still "
-"be granted access to The Wikipedia Library. You will need to contact the "
-"Wikipedia Library team, who will review your blocks. If you have been "
-"blocked for content issues, most notably copyright violations, or have "
-"multiple long-term blocks, we may decline your request. Additionally, if "
-"your block status changes after being approved, you will need to request "
-"another review."
+msgid "If your account is blocked on one or more Wikimedia projects, you may still be granted access to The Wikipedia Library. You will need to contact the Wikipedia Library team, who will review your blocks. If you have been blocked for content issues, most notably copyright violations, or have multiple long-term blocks, we may decline your request. Additionally, if your block status changes after being approved, you will need to request another review."
 msgstr ""
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
@@ -2337,9 +1900,7 @@ msgstr ""
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:136
-msgid ""
-"Share their account logins or passwords with others, or sell their access to "
-"other parties"
+msgid "Share their account logins or passwords with others, or sell their access to other parties"
 msgstr ""
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
@@ -2349,23 +1910,17 @@ msgstr ""
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:144
-msgid ""
-"Systematically make printed or electronic copies of multiple extracts of "
-"restricted content available for any purpose"
+msgid "Systematically make printed or electronic copies of multiple extracts of restricted content available for any purpose"
 msgstr ""
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/). Stub is a technical term for a short Wikipedia article, use the appropriate Wikipedia term in your language.
 #: TWLight/templates/about.html:148
-msgid ""
-"Datamine metadata without permission, in order, for instance, to use "
-"metadata for auto-created stub articles"
+msgid "Datamine metadata without permission, in order, for instance, to use metadata for auto-created stub articles"
 msgstr ""
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:154
-msgid ""
-"Respecting these agreements allows us to continue growing the partnerships "
-"available to the community."
+msgid "Respecting these agreements allows us to continue growing the partnerships available to the community."
 msgstr ""
 
 #. Translators: This is the heading for a section on the About page (https://wikipedialibrary.wmflabs.org/about/).
@@ -2375,41 +1930,22 @@ msgstr ""
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:164
-msgid ""
-"EZProxy is a proxy server used to authenticate users for many Wikipedia "
-"Library partners. Users sign into EZProxy via the Library Card platform to "
-"verify that they are authorized users, and then the server accesses "
-"requested resources using its own IP address."
+msgid "EZProxy is a proxy server used to authenticate users for many Wikipedia Library partners. Users sign into EZProxy via the Library Card platform to verify that they are authorized users, and then the server accesses requested resources using its own IP address."
 msgstr ""
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:173
-msgid ""
-"You may notice that when accessing resources via EZProxy that URLs are "
-"dynamically rewritten. This is why we recommend logging in via the Library "
-"Card platform rather than going directly to the unproxied partner website. "
-"When in doubt, check the URL for ‘idm.oclc’. If it’s there, then you’re "
-"connected via EZProxy."
+msgid "You may notice that when accessing resources via EZProxy that URLs are dynamically rewritten. This is why we recommend logging in via the Library Card platform rather than going directly to the unproxied partner website. When in doubt, check the URL for ‘idm.oclc’. If it’s there, then you’re connected via EZProxy."
 msgstr ""
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:182
-msgid ""
-"Typically once you’ve logged in your session will remain active in your "
-"browser for up to two hours after you’ve finished searching. Note that use "
-"of EZProxy requires you to enable cookies. If you are having problems you "
-"should also try clearing your cache and restarting your browser."
+msgid "Typically once you’ve logged in your session will remain active in your browser for up to two hours after you’ve finished searching. Note that use of EZProxy requires you to enable cookies. If you are having problems you should also try clearing your cache and restarting your browser."
 msgstr ""
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/)
 #: TWLight/templates/about.html:193
-msgid ""
-"The Library Bundle is a collection of resources for which no application is "
-"required. If you meet the criteria laid out above, you will be authorized "
-"for access automatically upon logging in to the platform. Only some of our "
-"content is currently included in the Library Bundle, however we hope to "
-"expand the collection as more publishers become comfortable with "
-"participating. All Bundle content is accessed via EZProxy."
+msgid "The Library Bundle is a collection of resources for which no application is required. If you meet the criteria laid out above, you will be authorized for access automatically upon logging in to the platform. Only some of our content is currently included in the Library Bundle, however we hope to expand the collection as more publishers become comfortable with participating. All Bundle content is accessed via EZProxy."
 msgstr ""
 
 #. Translators: This is the heading for a section on the About page (https://wikipedialibrary.wmflabs.org/about/).
@@ -2419,12 +1955,7 @@ msgstr ""
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:206
-msgid ""
-"Citation practices vary by project and even by article. Generally, we "
-"support editors citing where they found information, in a form that allows "
-"others to check it for themselves. That often means providing both original "
-"source details as well as a link to the partner database in which the source "
-"was found."
+msgid "Citation practices vary by project and even by article. Generally, we support editors citing where they found information, in a form that allows others to check it for themselves. That often means providing both original source details as well as a link to the partner database in which the source was found."
 msgstr ""
 
 #. Translators: This is the heading for a section on the About page (https://wikipedialibrary.wmflabs.org/about/).
@@ -2436,9 +1967,7 @@ msgstr ""
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:218
 #, python-format
-msgid ""
-"If you have questions, need help, or want to volunteer to help, please see "
-"our <a class=\"twl-links\" href=\"%(contact_url)s\">contact page</a>."
+msgid "If you have questions, need help, or want to volunteer to help, please see our <a class=\"twl-links\" href=\"%(contact_url)s\">contact page</a>."
 msgstr ""
 
 #. Translators: This is the title of the panel box detailing the contact information for the Wikipedia Library team.
@@ -2478,9 +2007,7 @@ msgstr ""
 #. Translators: This is the text that appears at the bottom of the contact us form directing users to the suggestions form.
 #: TWLight/templates/contact.html:48
 #, python-format
-msgid ""
-"(If you would like to suggest a partner, <a class=\"twl-links\" href="
-"\"%(suggest)s\"><strong>go here</strong></a>.)"
+msgid "(If you would like to suggest a partner, <a class=\"twl-links\" href=\"%(suggest)s\"><strong>go here</strong></a>.)"
 msgstr ""
 
 #. Translators: On a special 'link to search' page, this message is shown if JavaScript is disabled.
@@ -2537,15 +2064,8 @@ msgstr ""
 #. Translators: Information about The Wikipedia Library.
 #: TWLight/templates/login_partial.html:53 TWLight/templates/new_base.html:21
 #, fuzzy, python-format
-msgid ""
-"More than 100 of the world's top subscription-only databases, with content "
-"in %(no_of_languages)s languages, free for Wikipedians of all backgrounds"
-msgstr ""
-"Note that the \"free\" term does not mean freedom of use: the contents are "
-"still protected and subject to the usage policies defined by publishers of "
-"the collections granting accesses via The Wikipedia Library. It means an "
-"access provided with \"no cost\" (no paid subscription or billing for "
-"allowed users), as long that access and usage conditions are met."
+msgid "More than 100 of the world's top subscription-only databases, with content in %(no_of_languages)s languages, free for Wikipedians of all backgrounds"
+msgstr "Note that the \"free\" term does not mean freedom of use: the contents are still protected and subject to the usage policies defined by publishers of the collections granting accesses via The Wikipedia Library. It means an access provided with \"no cost\" (no paid subscription or billing for allowed users), as long that access and usage conditions are met."
 
 #. Translators: Information about The Wikipedia Library.
 #: TWLight/templates/login_partial.html:64
@@ -2553,14 +2073,8 @@ msgid "Meet these criteria for automatic access"
 msgstr ""
 
 #: TWLight/templates/login_partial.html:69
-msgid ""
-"These criteria grant you access to certain collections but not all. Some "
-"collections are accessible on a per application basis only."
-msgstr ""
-"{{Doc-important|\"Application\" here means \"request\" or \"candidacy\". "
-"This doesn't mean \"software application\" or \"app\".}}\n"
-"Tooltip message accompanying {{msg-wm|Wikipedia-library-68267b-Meet these "
-"criteria for automa}}"
+msgid "These criteria grant you access to certain collections but not all. Some collections are accessible on a per application basis only."
+msgstr "{{Doc-important|\"Application\" here means \"request\" or \"candidacy\". This doesn't mean \"software application\" or \"app\".}}\nTooltip message accompanying {{msg-wm|Wikipedia-library-68267b-Meet these criteria for automa}}"
 
 #: TWLight/templates/login_partial.html:89
 msgid "Login via Wikipedia"
@@ -2569,32 +2083,20 @@ msgstr ""
 #. Translators: Shown if the current user doesn't have a registered email on their account. Don't translate contact_us_url or email_url.
 #: TWLight/templates/message_partial.html:15
 #, python-format
-msgid ""
-"You don't have an email on file. We can't finalize your access to partner "
-"resources, and you won't be able to <a class=\"twl-links\" href="
-"\"%(contact_us_url)s\">contact us</a> without an email. Please <a class="
-"\"twl-links\" href=\"%(email_url)s\">update your email</a>."
+msgid "You don't have an email on file. We can't finalize your access to partner resources, and you won't be able to <a class=\"twl-links\" href=\"%(contact_us_url)s\">contact us</a> without an email. Please <a class=\"twl-links\" href=\"%(email_url)s\">update your email</a>."
 msgstr ""
 
 #. Translators: Shown if the current user has requested the processing of their data should be restricted.
 #: TWLight/templates/message_partial.html:26
 #, python-format
-msgid ""
-"You have requested a restriction on the processing of your data. Most site "
-"functionality will not be available to you until you <a class=\"twl-links\" "
-"href=\"%(restrict_url)s\">lift this restriction</a>."
+msgid "You have requested a restriction on the processing of your data. Most site functionality will not be available to you until you <a class=\"twl-links\" href=\"%(restrict_url)s\">lift this restriction</a>."
 msgstr ""
 
 #. Translators: Shown if the current user has not agreed to the terms of use.
 #: TWLight/templates/message_partial.html:37
 #, python-format
-msgid ""
-"You have not agreed to the <a class=\"twl-links\" href=\"%(terms_url)s"
-"\">terms of use</a> of this site. Your applications will not be processed "
-"and you won't be able to apply or access resources you are approved for."
-msgstr ""
-"{{Doc-important|\"Application\" here means \"request\" or \"candidacy\". "
-"This doesn't mean \"software application\" or \"app\".}}"
+msgid "You have not agreed to the <a class=\"twl-links\" href=\"%(terms_url)s\">terms of use</a> of this site. Your applications will not be processed and you won't be able to apply or access resources you are approved for."
+msgstr "{{Doc-important|\"Application\" here means \"request\" or \"candidacy\". This doesn't mean \"software application\" or \"app\".}}"
 
 #. Translators: This link is at the bottom of every page and links to the 'About' page (https://wikipedialibrary.wmflabs.org/about/)
 #: TWLight/templates/new_base.html:107
@@ -2640,9 +2142,7 @@ msgstr ""
 
 #. Translators: If a user goes to reset their password, this message asks them to enter their email to do so.
 #: TWLight/templates/registration/password_reset_form.html:13
-msgid ""
-"Forgot your password? Enter your email address below, and we'll email "
-"instructions for setting a new one."
+msgid "Forgot your password? Enter your email address below, and we'll email instructions for setting a new one."
 msgstr ""
 
 #. Translators: This is the label for a button that users click to update their public information.
@@ -2663,23 +2163,17 @@ msgstr ""
 #. Translators: In the preferences section (Emails) of a user profile, this text labels the checkbox coordinators can (un)click to change if they wish to receive pending application reminders or not.
 #: TWLight/users/forms.py:121
 msgid "Send pending application reminders"
-msgstr ""
-"{{Doc-important|\"Application\" here means \"request\" or \"candidacy\". "
-"This doesn't mean \"software application\" or \"app\".}}"
+msgstr "{{Doc-important|\"Application\" here means \"request\" or \"candidacy\". This doesn't mean \"software application\" or \"app\".}}"
 
 #. Translators: In the preferences section (Emails) of a user profile, this text labels the checkbox coordinators can (un)click to change if they wish to receive application reminders that are under discussion or not.
 #: TWLight/users/forms.py:129
 msgid "Send discussion application reminders"
-msgstr ""
-"{{Doc-important|\"Application\" here means \"request\" or \"candidacy\". "
-"This doesn't mean \"software application\" or \"app\".}}"
+msgstr "{{Doc-important|\"Application\" here means \"request\" or \"candidacy\". This doesn't mean \"software application\" or \"app\".}}"
 
 #. Translators: In the preferences section (Emails) of a user profile, this text labels the checkbox coordinators can (un)click to change if they wish to receive approved application reminders or not.
 #: TWLight/users/forms.py:137
 msgid "Send approved application reminders"
-msgstr ""
-"{{Doc-important|\"Application\" here means \"request\" or \"candidacy\". "
-"This doesn't mean \"software application\" or \"app\".}}"
+msgstr "{{Doc-important|\"Application\" here means \"request\" or \"candidacy\". This doesn't mean \"software application\" or \"app\".}}"
 
 #. Translators: Labels the button users click to request a restriction on the processing of their data.
 #: TWLight/users/forms.py:152
@@ -2693,19 +2187,12 @@ msgstr ""
 
 #. Translators: This text explains how to disagree to the site's terms of use and the restrictions that will come into effect when users disagree to the terms of use.
 #: TWLight/users/forms.py:185
-msgid ""
-"By unchecking this box and clicking “Update” you may explore the site, but "
-"you will not be able to apply for access to materials or evaluate "
-"applications unless you agree with the terms of use."
-msgstr ""
-"{{Doc-important|\"Application\" here means \"request\" or \"candidacy\". "
-"This doesn't mean \"software application\" or \"app\".}}\n"
-"\"Update\" is {{msg-wm|Wikipedia-library-fb91e2-Update}}."
+msgid "By unchecking this box and clicking “Update” you may explore the site, but you will not be able to apply for access to materials or evaluate applications unless you agree with the terms of use."
+msgstr "{{Doc-important|\"Application\" here means \"request\" or \"candidacy\". This doesn't mean \"software application\" or \"app\".}}\n\"Update\" is {{msg-wm|Wikipedia-library-fb91e2-Update}}."
 
 #. Translators: Users click this button to set their website email address to the one linked to their Wikipedia account.
 #: TWLight/users/forms.py:211
-msgid ""
-"Use my Wikipedia email address (will be updated the next time you login)."
+msgid "Use my Wikipedia email address (will be updated the next time you login)."
 msgstr ""
 
 #. Translators: This labels a button which users click to change their email.
@@ -2716,14 +2203,12 @@ msgstr ""
 #. Translators: Shown if the current user tried to 'favorite' a partner they can't access. Do not translate '{partner}'
 #: TWLight/users/models.py:201
 #, python-brace-format
-msgid ""
-"Cannot add partner {partner} to your favorites because you don't have access "
-"to it"
+msgid "Cannot add partner {partner} to your favorites because you don't have access to it"
 msgstr ""
 
 #. Translators: Do not translate.
 #: TWLight/users/models.py:869
-#, python-brace-format
+#, ignored, python-brace-format
 msgid "{wp_username}"
 msgstr "{{Ignored}}"
 
@@ -2745,9 +2230,7 @@ msgstr ""
 
 #. Translators: this message is displayed to users that don't have accounts and clicked on a proxied link.
 #: TWLight/users/oauth.py:388
-msgid ""
-"To view this link you need to be an eligible library user. Please login to "
-"continue."
+msgid "To view this link you need to be an eligible library user. Please login to continue."
 msgstr ""
 
 #. Translators: This warning message is shown to users when the response received from Wikimedia OAuth servers is not a valid one.
@@ -2783,17 +2266,12 @@ msgstr ""
 
 #. Translators: If the user tries to log in, but their account does not meet certain requirements, they cannot login.
 #: TWLight/users/oauth.py:528
-msgid ""
-"Your Wikipedia account does not meet the eligibility criteria in the terms "
-"of use, so your Wikipedia Library Card Platform account cannot be activated."
+msgid "Your Wikipedia account does not meet the eligibility criteria in the terms of use, so your Wikipedia Library Card Platform account cannot be activated."
 msgstr ""
 
 #. Translators: If the user tries to log in, but their account does not meet certain requirements, they cannot login.
 #: TWLight/users/oauth.py:536
-msgid ""
-"Your Wikipedia account no longer meets the eligibility criteria in the terms "
-"of use, so you cannot be logged in. If you think you should be able to log "
-"in, please email wikipedialibrary@wikimedia.org."
+msgid "Your Wikipedia account no longer meets the eligibility criteria in the terms of use, so you cannot be logged in. If you think you should be able to log in, please email wikipedialibrary@wikimedia.org."
 msgstr ""
 
 #. Translators: this message is displayed to users with brand new accounts.
@@ -2804,10 +2282,7 @@ msgstr ""
 #. Translators: This message is displayed on the confirmation page where users can return their access to partner collections.
 #: TWLight/users/templates/users/authorization_confirm_return.html:13
 #, python-format
-msgid ""
-"You will no longer be able to access <b>%(partner)s's</b> resources via the "
-"Library Card platform, but can request access again by clicking 'renew', if "
-"you change your mind. Are you sure you want to return your access?"
+msgid "You will no longer be able to access <b>%(partner)s's</b> resources via the Library Card platform, but can request access again by clicking 'renew', if you change your mind. Are you sure you want to return your access?"
 msgstr ""
 
 #. Translators: On the MyLibrary page (https://wikipedialibrary.wmflabs.org/users/my_library), this tab shows all favorite collections a user has.
@@ -2828,9 +2303,7 @@ msgstr ""
 #. Translators: On the MyLibrary page (https://wikipedialibrary.wmflabs.org/users/my_library), a link that will take you to the applications.
 #: TWLight/users/templates/users/collections_section.html:31
 msgid "View my applications >"
-msgstr ""
-"{{Doc-important|\"Application\" here means \"request\" or \"candidacy\". "
-"This doesn't mean \"software application\" or \"app\".}}"
+msgstr "{{Doc-important|\"Application\" here means \"request\" or \"candidacy\". This doesn't mean \"software application\" or \"app\".}}"
 
 #. Translators: On the MyLibrary page (https://wikipedialibrary.wmflabs.org/users/my_library), a title that indicates the start of the expired collections section.
 #: TWLight/users/templates/users/collections_section.html:54
@@ -2841,9 +2314,7 @@ msgstr ""
 #. Translators: Users viewing their own profile can click this button to go to the browse partners page.
 #: TWLight/users/templates/users/editor_detail.html:15
 msgid "Start new application"
-msgstr ""
-"{{Doc-important|\"Application\" here means \"request\" or \"candidacy\". "
-"This doesn't mean \"software application\" or \"app\".}}"
+msgstr "{{Doc-important|\"Application\" here means \"request\" or \"candidacy\". This doesn't mean \"software application\" or \"app\".}}"
 
 #. Translators: Line one of two in a button on users' profile page which when clicked takes users to their collection page.
 #. Translators: A button on the 'your applications' page which when clicked takes users their collection page.
@@ -2862,9 +2333,7 @@ msgstr ""
 #: TWLight/users/templates/users/editor_detail.html:36
 #: TWLight/users/templates/users/my_applications.html:10
 msgid "My applications"
-msgstr ""
-"{{Doc-important|\"Application\" here means \"request\" or \"candidacy\". "
-"This doesn't mean \"software application\" or \"app\".}}"
+msgstr "{{Doc-important|\"Application\" here means \"request\" or \"candidacy\". This doesn't mean \"software application\" or \"app\".}}"
 
 #. Translators: Line two of two, explaining the purpose of the page in a button on users' profile page which when clicked takes users to a page with their collection.
 #: TWLight/users/templates/users/editor_detail.html:40
@@ -2883,10 +2352,7 @@ msgstr ""
 
 #. Translators: This is shown on editor profiles, in their profile page or on applications.
 #: TWLight/users/templates/users/editor_detail.html:59
-msgid ""
-"Information with an * was retrieved from Wikipedia directly. Other "
-"information was entered directly by users or site admins, in their preferred "
-"language."
+msgid "Information with an * was retrieved from Wikipedia directly. Other information was entered directly by users or site admins, in their preferred language."
 msgstr ""
 
 #. Translators: This distinguishes users who have been flagged as account coordinators. Don't translate username.
@@ -2897,10 +2363,7 @@ msgstr ""
 
 #. Translators: This is shown on editor profiles, under the heading for Wikipedia editor data.
 #: TWLight/users/templates/users/editor_detail_data.html:5
-msgid ""
-"This information is updated automatically from your Wikimedia account each "
-"time you log in, except for the Contributions field, where you can describe "
-"your Wikimedia editing history."
+msgid "This information is updated automatically from your Wikimedia account each time you log in, except for the Contributions field, where you can describe your Wikimedia editing history."
 msgstr ""
 
 #. Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this labels the user's username.
@@ -2930,17 +2393,13 @@ msgstr ""
 
 #. Translators: when viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this question has a yes or no answer.
 #: TWLight/users/templates/users/editor_detail_data.html:57
-msgid ""
-"at their last login, did this user meet the criteria set forth in the terms "
-"of use?"
+msgid "at their last login, did this user meet the criteria set forth in the terms of use?"
 msgstr ""
 
 #. Translators: When viewing a user's profile in an application, this message shows if the software doesn't think that the user is eligible for access. Don't translate username.
 #: TWLight/users/templates/users/editor_detail_data.html:72
 #, python-format
-msgid ""
-"%(username)s may still be eligible for access grants at the coordinators' "
-"discretion."
+msgid "%(username)s may still be eligible for access grants at the coordinators' discretion."
 msgstr ""
 
 #. Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this is the heading for a Yes/No ToU question.
@@ -2975,10 +2434,7 @@ msgstr ""
 #. Translators: This message is shown on a user's profile if their Wikimedia account is blocked on one or more projects. They may still be granted access to the Library Bundle, but need to contact Wikipedia Library staff to verify.
 #: TWLight/users/templates/users/editor_detail_data.html:137
 #, python-format
-msgid ""
-"It looks like you have an active block on your account. If you meet the "
-"other criteria you may still be permitted access to the library - please <a "
-"class=\"twl-links\" href=\"%(contact_url)s\">contact us</a>."
+msgid "It looks like you have an active block on your account. If you meet the other criteria you may still be permitted access to the library - please <a class=\"twl-links\" href=\"%(contact_url)s\">contact us</a>."
 msgstr ""
 
 #. Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this is the heading for a Yes/No program eligibility question.
@@ -2988,10 +2444,7 @@ msgstr ""
 
 #. Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this question has a Yes or No answer.
 #: TWLight/users/templates/users/editor_detail_data.html:156
-msgid ""
-"At their last login, did this user meet the criteria set forth in the "
-"Library Bundle? Note that satisfying terms of use is a prerequisite to "
-"bundle eligibility."
+msgid "At their last login, did this user meet the criteria set forth in the Library Bundle? Note that satisfying terms of use is a prerequisite to bundle eligibility."
 msgstr ""
 
 #. Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this is the heading for a Yes/No program eligibility question.
@@ -3036,18 +2489,13 @@ msgstr ""
 
 #. Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this text is in the 'Personal data' section. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/users/templates/users/editor_detail_data.html:262
-msgid ""
-"The following information is visible only to you, site administrators, "
-"publishing partners (where required), and volunteer Wikipedia Library "
-"coordinators (who have signed a Non-Disclosure Agreement)."
+msgid "The following information is visible only to you, site administrators, publishing partners (where required), and volunteer Wikipedia Library coordinators (who have signed a Non-Disclosure Agreement)."
 msgstr ""
 
 #. Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this labels a button which users can click to update or remove their personal information. Don't translate update_url.
 #: TWLight/users/templates/users/editor_detail_data.html:272
 #, python-format
-msgid ""
-"You may <a class=\"twl-links\" href=\"%(update_url)s\">update or delete</a> "
-"your data at any time."
+msgid "You may <a class=\"twl-links\" href=\"%(update_url)s\">update or delete</a> your data at any time."
 msgstr ""
 
 #. Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this labels the user's email. Don't remove the *.
@@ -3067,24 +2515,18 @@ msgstr ""
 
 #. Translators: This message tells users that they are not eligible to access The Wikipedia Library content.
 #: TWLight/users/templates/users/eligibility_modal.html:7
-msgid ""
-"Sorry, your Wikipedia account doesn’t currently qualify to access The "
-"Wikipedia Library."
+msgid "Sorry, your Wikipedia account doesn’t currently qualify to access The Wikipedia Library."
 msgstr ""
 
 #. Translators: This message tells users that they have not agreed to the terms of use, therefore are ineligible to access the content in The Wikipedia Library.
 #: TWLight/users/templates/users/eligibility_modal.html:30
 #, python-format
-msgid ""
-"Agreed with <a href=\"%(terms)s\" class=\"text-danger\"> terms of use </a>"
+msgid "Agreed with <a href=\"%(terms)s\" class=\"text-danger\"> terms of use </a>"
 msgstr ""
 
 #: TWLight/users/templates/users/eligibility_modal.html:40
 #, python-format
-msgid ""
-"It looks like you have an active block on your account. If you meet the "
-"other criteria you may still be permitted access to the library - please <a "
-"href=\"%(contact_url)s\">contact us</a>."
+msgid "It looks like you have an active block on your account. If you meet the other criteria you may still be permitted access to the library - please <a href=\"%(contact_url)s\">contact us</a>."
 msgstr ""
 
 #. Translators: Instructions to refresh a user's data.
@@ -3124,10 +2566,7 @@ msgstr ""
 
 #. Translators: This text on the user page helps users naviage to the TranslateWiki Wikipedia Library Card platform translation page.
 #: TWLight/users/templates/users/language_form.html:31
-msgid ""
-"You can help translate the tool at <a class=\"twl-links\" href=\"https://"
-"translatewiki.net/wiki/Translating:Wikipedia_Library_Card_Platform"
-"\">translatewiki.net</a>."
+msgid "You can help translate the tool at <a class=\"twl-links\" href=\"https://translatewiki.net/wiki/Translating:Wikipedia_Library_Card_Platform\">translatewiki.net</a>."
 msgstr ""
 
 #. Translators: When the user starts a new application and submits the application, the user can view the application and withdraw if need be. This changes the label for the Withdraw button.
@@ -3147,9 +2586,7 @@ msgstr ""
 
 #. Translators: On the page listing applications, this text explains a user they cannot renew their application since they've already requested a renewal or there aren't any renewals available.
 #: TWLight/users/templates/users/my_applications.html:79
-msgid ""
-"Renewals are either not required, not available right now, or you have "
-"already requested a renewal."
+msgid "Renewals are either not required, not available right now, or you have already requested a renewal."
 msgstr ""
 
 #. Translators: This text is the heading of a section in a user's profile where they can change their preferences.
@@ -3213,22 +2650,12 @@ msgstr ""
 
 #. Translators: This message is displayed on the page where users can request we stop processing their data.
 #: TWLight/users/templates/users/restrict_data.html:15
-msgid ""
-"Checking this box and clicking “Restrict” will pause all processing of the "
-"data you have entered into this website. You will not be able to apply for "
-"access to resources, your applications will not be further processed, and "
-"none of your data will be altered, until you return to this page and uncheck "
-"the box. This is not the same as deleting your data."
-msgstr ""
-"{{Doc-important|\"Application\" here means \"request\" or \"candidacy\". "
-"This doesn't mean \"software application\" or \"app\".}}\n"
-"\"Restrict\" is {{msg-wm|Wikipedia-library-a66b50-Restrict}}."
+msgid "Checking this box and clicking “Restrict” will pause all processing of the data you have entered into this website. You will not be able to apply for access to resources, your applications will not be further processed, and none of your data will be altered, until you return to this page and uncheck the box. This is not the same as deleting your data."
+msgstr "{{Doc-important|\"Application\" here means \"request\" or \"candidacy\". This doesn't mean \"software application\" or \"app\".}}\n\"Restrict\" is {{msg-wm|Wikipedia-library-a66b50-Restrict}}."
 
 #. Translators: This warning message is shown to coordinators who view the data restriction page.
 #: TWLight/users/templates/users/restrict_data.html:26
-msgid ""
-"You are a coordinator on this site. If you restrict the processing of your "
-"data, your coordinator flag will be removed."
+msgid "You are a coordinator on this site. If you restrict the processing of your data, your coordinator flag will be removed."
 msgstr ""
 
 #. Translators: use the date *when you are translating*, in a language-appropriate format.
@@ -3248,27 +2675,13 @@ msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:51
-msgid ""
-"<a class=\"twl-links\" href=\"https://meta.wikimedia.org/wiki/"
-"The_Wikipedia_Library\"> The Wikipedia Library </a> has partnered with "
-"publishers around the world to allow users to access otherwise paywalled "
-"resources. This website allows Wikipedia editors to search and access these "
-"resources."
+msgid "<a class=\"twl-links\" href=\"https://meta.wikimedia.org/wiki/The_Wikipedia_Library\"> The Wikipedia Library </a> has partnered with publishers around the world to allow users to access otherwise paywalled resources. This website allows Wikipedia editors to search and access these resources."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Wikimedia Foundation should not be translated. WMF should not be translated. Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:63
-msgid ""
-"This program is administered by the Wikimedia Foundation (WMF). These terms "
-"of use and privacy notice pertain to your application for access to "
-"resources through the Wikipedia Library, your use of this website, and your "
-"access to and use of those resources. They also describe our handling of the "
-"information you provide to us in order to create and administer your "
-"Wikipedia Library account. If we make material changes to the terms, we will "
-"notify users."
-msgstr ""
-"{{Doc-important|\"Application\" here means \"request\" or \"candidacy\". "
-"This doesn't mean \"software application\" or \"app\".}}"
+msgid "This program is administered by the Wikimedia Foundation (WMF). These terms of use and privacy notice pertain to your application for access to resources through the Wikipedia Library, your use of this website, and your access to and use of those resources. They also describe our handling of the information you provide to us in order to create and administer your Wikipedia Library account. If we make material changes to the terms, we will notify users."
+msgstr "{{Doc-important|\"Application\" here means \"request\" or \"candidacy\". This doesn't mean \"software application\" or \"app\".}}"
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:74
@@ -3277,39 +2690,17 @@ msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:78
-msgid ""
-"Access to resources via The Wikipedia Library is reserved for community "
-"members who have demonstrated their commitment to the Wikimedia projects, "
-"and who will use their access to these resources to improve project content. "
-"To that end, in order to be eligible for The Wikipedia Library, we require "
-"that you be registered for a user account on the projects, with at least 500 "
-"edits, six (6) months of activity, and 10+ edits in the last month. We ask "
-"that you do not request access to any publishers with a limited number of "
-"available accounts whose resources you can already access for free through "
-"your local library or university, or another institution or organization, in "
-"order to provide that opportunity to others."
+msgid "Access to resources via The Wikipedia Library is reserved for community members who have demonstrated their commitment to the Wikimedia projects, and who will use their access to these resources to improve project content. To that end, in order to be eligible for The Wikipedia Library, we require that you be registered for a user account on the projects, with at least 500 edits, six (6) months of activity, and 10+ edits in the last month. We ask that you do not request access to any publishers with a limited number of available accounts whose resources you can already access for free through your local library or university, or another institution or organization, in order to provide that opportunity to others."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:94
-msgid ""
-"Additionally, if you are currently blocked or banned from a Wikimedia "
-"project, applications to resources may be rejected or restricted. If you "
-"obtain a Wikipedia Library account, but a block or ban is subsequently "
-"instituted against you on one of the projects, you may lose access to your "
-"Wikipedia Library account."
-msgstr ""
-"{{Doc-important|\"Application\" here means \"request\" or \"candidacy\". "
-"This doesn't mean \"software application\" or \"app\".}}"
+msgid "Additionally, if you are currently blocked or banned from a Wikimedia project, applications to resources may be rejected or restricted. If you obtain a Wikipedia Library account, but a block or ban is subsequently instituted against you on one of the projects, you may lose access to your Wikipedia Library account."
+msgstr "{{Doc-important|\"Application\" here means \"request\" or \"candidacy\". This doesn't mean \"software application\" or \"app\".}}"
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:104
-msgid ""
-"Your eligibility to access The Wikipedia Library is assessed at each login. "
-"While more than half of the library's content is provided via this automated "
-"eligibility check, access to other publisher's content may be time limited, "
-"typically lapsing after one year, after which you will usually need to apply "
-"for renewal."
+msgid "Your eligibility to access The Wikipedia Library is assessed at each login. While more than half of the library's content is provided via this automated eligibility check, access to other publisher's content may be time limited, typically lapsing after one year, after which you will usually need to apply for renewal."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
@@ -3319,51 +2710,27 @@ msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:118
-msgid ""
-"In order to apply for access to a partner resource, you must provide us with "
-"certain information, which we will use to evaluate your application. If your "
-"application is approved, we may transfer the information you have given us "
-"to the publishers whose resources you wish to access. They will either "
-"contact you with the account information directly or we will send access "
-"information to you ourselves."
-msgstr ""
-"{{Doc-important|\"Application\" here means \"request\" or \"candidacy\". "
-"This doesn't mean \"software application\" or \"app\".}}"
+msgid "In order to apply for access to a partner resource, you must provide us with certain information, which we will use to evaluate your application. If your application is approved, we may transfer the information you have given us to the publishers whose resources you wish to access. They will either contact you with the account information directly or we will send access information to you ourselves."
+msgstr "{{Doc-important|\"Application\" here means \"request\" or \"candidacy\". This doesn't mean \"software application\" or \"app\".}}"
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:130
-msgid ""
-"In addition to the basic information you provide to us, our system will "
-"retrieve some information directly from the Wikimedia projects: your "
-"username, email address, edit count, registration date, user ID number, "
-"groups to which you belong, and any special user rights."
+msgid "In addition to the basic information you provide to us, our system will retrieve some information directly from the Wikimedia projects: your username, email address, edit count, registration date, user ID number, groups to which you belong, and any special user rights."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:140
-msgid ""
-"Each time you log in to the Wikipedia Library Card Platform, this "
-"information will be automatically updated."
+msgid "Each time you log in to the Wikipedia Library Card Platform, this information will be automatically updated."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:148
-msgid ""
-"We will ask you to provide us with some information about your history of "
-"contributions to the Wikimedia projects. Information on contribution history "
-"is optional, but will greatly assist us in evaluating your application."
-msgstr ""
-"{{Doc-important|\"Application\" here means \"request\" or \"candidacy\". "
-"This doesn't mean \"software application\" or \"app\".}}"
+msgid "We will ask you to provide us with some information about your history of contributions to the Wikimedia projects. Information on contribution history is optional, but will greatly assist us in evaluating your application."
+msgstr "{{Doc-important|\"Application\" here means \"request\" or \"candidacy\". This doesn't mean \"software application\" or \"app\".}}"
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). WMF should not be translated. Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:157
-msgid ""
-"The information you provide when creating your account will be visible to "
-"you while on the site but not to others unless they are approved Wikipedia "
-"Library Coordinators, WMF Staff, or WMF Contractors who need access to this "
-"data in order to carry out their work with the Wikipedia Library, all of "
-"whom are subject to non-disclosure obligations."
+msgid "The information you provide when creating your account will be visible to you while on the site but not to others unless they are approved Wikipedia Library Coordinators, WMF Staff, or WMF Contractors who need access to this data in order to carry out their work with the Wikipedia Library, all of whom are subject to non-disclosure obligations."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
@@ -3373,46 +2740,32 @@ msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:171
-msgid ""
-"In order to access an individual publisher’s resources, you must agree to "
-"that publisher’s terms of use and privacy policy. You agree that you will "
-"not violate such terms and policies in connection with your use of the "
-"Wikipedia Library. Additionally, the following activities are prohibited "
-"while accessing publisher resources through the Wikipedia Library."
+msgid "In order to access an individual publisher’s resources, you must agree to that publisher’s terms of use and privacy policy. You agree that you will not violate such terms and policies in connection with your use of the Wikipedia Library. Additionally, the following activities are prohibited while accessing publisher resources through the Wikipedia Library."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:184
-msgid ""
-"Sharing your Wikipedia account, usernames, passwords, or any access codes "
-"for publisher resources with others;"
+msgid "Sharing your Wikipedia account, usernames, passwords, or any access codes for publisher resources with others;"
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:191
-msgid ""
-"Automatically scraping or downloading restricted content from publishers;"
+msgid "Automatically scraping or downloading restricted content from publishers;"
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:197
-msgid ""
-"Systematically making printed or electronic copies of multiple extracts of "
-"restricted content available for any purpose;"
+msgid "Systematically making printed or electronic copies of multiple extracts of restricted content available for any purpose;"
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:204
-msgid ""
-"Data mining metadata without permission—for example, in order to use "
-"metadata for auto-created stub articles;"
+msgid "Data mining metadata without permission—for example, in order to use metadata for auto-created stub articles;"
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:211
-msgid ""
-"Using the access you receive through the Wikipedia Library for profit by "
-"selling access to your account or resources which you have through it."
+msgid "Using the access you receive through the Wikipedia Library for profit by selling access to your account or resources which you have through it."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
@@ -3422,18 +2775,12 @@ msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:224
-msgid ""
-"Certain resources may only be accessed using an external search service, "
-"such as the EBSCO Discovery Service, or a proxy service, such as OCLC "
-"EZProxy. If you use such external search and/or proxy services, please "
-"review the applicable terms of use and privacy policies."
+msgid "Certain resources may only be accessed using an external search service, such as the EBSCO Discovery Service, or a proxy service, such as OCLC EZProxy. If you use such external search and/or proxy services, please review the applicable terms of use and privacy policies."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:234
-msgid ""
-"In addition, if you use OCLC EZProxy, please note that you may not use it "
-"for commercial purposes."
+msgid "In addition, if you use OCLC EZProxy, please note that you may not use it for commercial purposes."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
@@ -3443,122 +2790,49 @@ msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Wikimedia Foundation should not be translated. Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:245
-msgid ""
-"The Wikimedia Foundation and our service providers use your information for "
-"the legitimate purpose of providing Wikipedia Library services in support of "
-"our charitable mission. When you apply for a Wikipedia Library account, or "
-"use your Wikipedia Library account, we may routinely collect the following "
-"information: your username, email address, edit count, registration date, "
-"user ID number, groups to which you belong, and any special user rights; "
-"your name, country of residence, and/or affiliation, if required by a "
-"partner to which you are applying; your narrative description of your "
-"contributions and reasons for applying for access to partner resources; and "
-"the date you agree to these terms of use."
+msgid "The Wikimedia Foundation and our service providers use your information for the legitimate purpose of providing Wikipedia Library services in support of our charitable mission. When you apply for a Wikipedia Library account, or use your Wikipedia Library account, we may routinely collect the following information: your username, email address, edit count, registration date, user ID number, groups to which you belong, and any special user rights; your name, country of residence, and/or affiliation, if required by a partner to which you are applying; your narrative description of your contributions and reasons for applying for access to partner resources; and the date you agree to these terms of use."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:262
 #, fuzzy, python-format
-msgid ""
-"Each publisher who is a member of the Wikipedia Library program requires "
-"different specific information in the application. Some publishers may "
-"request only an email address, while others request more detailed data, such "
-"as your name, location, or institutional affiliation. When you complete your "
-"application, you will only be asked to supply information required by the "
-"publishers you have chosen, and each publisher will only receive the "
-"information they require for providing you with access. Please see our <a "
-"class=\"twl-links\" href=\"%(all_partners_url)s\">partner information</a> "
-"pages to learn what information is required by each publisher to gain access "
-"to their resources."
-msgstr ""
-"{{Doc-important|\"Application\" here means \"request\" or \"candidacy\". "
-"This doesn't mean \"software application\" or \"app\".}}"
+msgid "Each publisher who is a member of the Wikipedia Library program requires different specific information in the application. Some publishers may request only an email address, while others request more detailed data, such as your name, location, or institutional affiliation. When you complete your application, you will only be asked to supply information required by the publishers you have chosen, and each publisher will only receive the information they require for providing you with access. Please see our <a class=\"twl-links\" href=\"%(all_partners_url)s\">partner information</a> pages to learn what information is required by each publisher to gain access to their resources."
+msgstr "{{Doc-important|\"Application\" here means \"request\" or \"candidacy\". This doesn't mean \"software application\" or \"app\".}}"
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Wikimedia Foundation should not be translated. Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:277
-msgid ""
-"Some Wikipedia Library pages are visible without logging in, but you will "
-"need to log in to apply or access proprietary partner resources. We use the "
-"data provided by you via OAuth and Wikimedia API calls to assess your "
-"application for access and to process approved requests."
+msgid "Some Wikipedia Library pages are visible without logging in, but you will need to log in to apply or access proprietary partner resources. We use the data provided by you via OAuth and Wikimedia API calls to assess your application for access and to process approved requests."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:288
 #, python-format
-msgid ""
-"In order to administer the Wikipedia Library program, we will retain the "
-"application data we collect from you for three years after your most recent "
-"login, unless you delete your account, as described below. You can log in "
-"and go to <a class=\"twl-links\" href=\"%(profile_url)s\">your profile page</"
-"a> in order to see the information associated with your account, and can "
-"download it in JSON format. You may access, update, restrict, or delete this "
-"information at any time, except for the information that is automatically "
-"retrieved from the projects. If you have any questions or concerns about the "
-"handling of your data, please contact <a class=\"twl-links\" href=\"mailto:"
-"wikipedialibrary@wikimedia.org?Subject=Wikipedia%%20Library%%20Card"
-"%%20account%%20deactivation\"> wikipedialibrary@wikimedia.org </a>."
+msgid "In order to administer the Wikipedia Library program, we will retain the application data we collect from you for three years after your most recent login, unless you delete your account, as described below. You can log in and go to <a class=\"twl-links\" href=\"%(profile_url)s\">your profile page</a> in order to see the information associated with your account, and can download it in JSON format. You may access, update, restrict, or delete this information at any time, except for the information that is automatically retrieved from the projects. If you have any questions or concerns about the handling of your data, please contact <a class=\"twl-links\" href=\"mailto:wikipedialibrary@wikimedia.org?Subject=Wikipedia%%20Library%%20Card%%20account%%20deactivation\"> wikipedialibrary@wikimedia.org </a>."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:305
-msgid ""
-"If you decide to disable your Wikipedia Library account, you can use the "
-"delete button on your profile to delete certain personal information "
-"associated with your account. We will delete your real name, institutional "
-"affiliation, and country of residence. Please note that the system will "
-"retain a record of your username, the publishers to which you applied or had "
-"access, and the dates of that access. Note that deletion is not reversible. "
-"Deletion of your Wikipedia Library account may also correspond with the "
-"removal of any resource access to which you were eligible or approved. If "
-"you request the deletion of account information and later wish to apply for "
-"a new account, you will need to provide the necessary information again."
+msgid "If you decide to disable your Wikipedia Library account, you can use the delete button on your profile to delete certain personal information associated with your account. We will delete your real name, institutional affiliation, and country of residence. Please note that the system will retain a record of your username, the publishers to which you applied or had access, and the dates of that access. Note that deletion is not reversible. Deletion of your Wikipedia Library account may also correspond with the removal of any resource access to which you were eligible or approved. If you request the deletion of account information and later wish to apply for a new account, you will need to provide the necessary information again."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). WMF should not be translated. Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:321
-msgid ""
-"The Wikipedia Library is run by WMF Staff, Contractors, and approved "
-"volunteer Coordinators. The data associated with your account will be shared "
-"with the WMF staff, contractors, service providers, and volunteer "
-"coordinators who need to process the information in connection with their "
-"work for the Wikipedia Library, and who are subject to confidentiality "
-"obligations. We will also use your data for internal Wikipedia Library "
-"purposes such as distributing user surveys and account notifications, and in "
-"a depersonalized or aggregated fashion for statistical analysis and "
-"administration. Finally, we will share your information with the publishers "
-"whom you specifically select in order to provide you with access to "
-"resources. Otherwise, your information will not be shared with third "
-"parties, with the exception of the circumstances described below."
+msgid "The Wikipedia Library is run by WMF Staff, Contractors, and approved volunteer Coordinators. The data associated with your account will be shared with the WMF staff, contractors, service providers, and volunteer coordinators who need to process the information in connection with their work for the Wikipedia Library, and who are subject to confidentiality obligations. We will also use your data for internal Wikipedia Library purposes such as distributing user surveys and account notifications, and in a depersonalized or aggregated fashion for statistical analysis and administration. Finally, we will share your information with the publishers whom you specifically select in order to provide you with access to resources. Otherwise, your information will not be shared with third parties, with the exception of the circumstances described below."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). WMF should not be translated.
 #: TWLight/users/templates/users/terms.html:338
-msgid ""
-"We may disclose any collected information when required by law, when we have "
-"your permission, when needed to protect our rights, privacy, safety, users, "
-"or the general public, and when necessary to enforce these terms, WMF’s "
-"general <a class=\"twl-links\" href=\"https://foundation.wikimedia.org/wiki/"
-"Terms_of_Use\">Terms of Use</a>, or any other WMF policy."
+msgid "We may disclose any collected information when required by law, when we have your permission, when needed to protect our rights, privacy, safety, users, or the general public, and when necessary to enforce these terms, WMF’s general <a class=\"twl-links\" href=\"https://foundation.wikimedia.org/wiki/Terms_of_Use\">Terms of Use</a>, or any other WMF policy."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:349
-msgid ""
-"We take the security of your personal data seriously, and take reasonable "
-"precautions to ensure your data is protected. These precautions include "
-"access controls to limit who has access to your data and security "
-"technologies to protect data stored on the server. However, we cannot "
-"guarantee the safety of your data as it is transmitted and stored."
+msgid "We take the security of your personal data seriously, and take reasonable precautions to ensure your data is protected. These precautions include access controls to limit who has access to your data and security technologies to protect data stored on the server. However, we cannot guarantee the safety of your data as it is transmitted and stored."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:360
-msgid ""
-"Please note that these terms do not control the use and handling of your "
-"data by the publishers and service providers whose resources you access or "
-"apply to access. Please read their individual privacy policies for that "
-"information."
+msgid "Please note that these terms do not control the use and handling of your data by the publishers and service providers whose resources you access or apply to access. Please read their individual privacy policies for that information."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
@@ -3568,34 +2842,17 @@ msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Wikimedia Foundation should not be translated. Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:373
-msgid ""
-"The Wikimedia Foundation is a nonprofit organization based in San Francisco, "
-"California. The Wikipedia Library program provides access to resources held "
-"by publishers in multiple countries. If you apply for a Wikipedia Library "
-"account (whether you are inside or outside of the United States), you "
-"understand that your personal data will be collected, transferred, stored, "
-"processed, disclosed and otherwise used in the U.S. as described in this "
-"privacy policy. You also understand that your information may be transferred "
-"by us from the U.S. to other countries, which may have different or less "
-"stringent data protection laws than your country, in connection with "
-"providing services to you, including evaluating your application and "
-"securing access to your chosen publishers (locations for each publisher are "
-"outlined on their respective partner information pages)."
+msgid "The Wikimedia Foundation is a nonprofit organization based in San Francisco, California. The Wikipedia Library program provides access to resources held by publishers in multiple countries. If you apply for a Wikipedia Library account (whether you are inside or outside of the United States), you understand that your personal data will be collected, transferred, stored, processed, disclosed and otherwise used in the U.S. as described in this privacy policy. You also understand that your information may be transferred by us from the U.S. to other countries, which may have different or less stringent data protection laws than your country, in connection with providing services to you, including evaluating your application and securing access to your chosen publishers (locations for each publisher are outlined on their respective partner information pages)."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:392
-msgid ""
-"Please note that in the event of any differences in meaning or "
-"interpretation between the original English version of these terms and a "
-"translation, the original English version takes precedence."
+msgid "Please note that in the event of any differences in meaning or interpretation between the original English version of these terms and a translation, the original English version takes precedence."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Wikimedia Foundation should not be translated.
 #: TWLight/users/templates/users/terms.html:403
-msgid ""
-"See also the <a class=\"twl-links\" href=\"https://wikimediafoundation.org/"
-"wiki/Privacy_policy\">Wikimedia Foundation Privacy Policy</a>."
+msgid "See also the <a class=\"twl-links\" href=\"https://wikimediafoundation.org/wiki/Privacy_policy\">Wikimedia Foundation Privacy Policy</a>."
 msgstr ""
 
 #. Translators: This is the second to last line of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
@@ -3615,11 +2872,7 @@ msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:426
-msgid ""
-"By checking this box and clicking “Submit”, you agree that you have read the "
-"above terms and that you will adhere to the terms of use in your application "
-"to and use of the The Wikipedia Library, and the publishers’ services to "
-"which you gain access through The Wikipedia Library program."
+msgid "By checking this box and clicking “Submit”, you agree that you have read the above terms and that you will adhere to the terms of use in your application to and use of the The Wikipedia Library, and the publishers’ services to which you gain access through The Wikipedia Library program."
 msgstr "\"Submit\" is {{msg-wm|Wikipedia-library-2dacf6-Submit}}."
 
 #: TWLight/users/templates/users/user_collection_tile.html:32
@@ -3643,9 +2896,7 @@ msgstr ""
 #: TWLight/users/templates/users/user_collection_tile.html:117
 #, fuzzy
 msgid "Go to application"
-msgstr ""
-"{{doc-important|This means \"request\". This doesn't mean \"software "
-"application\" or \"app\".}}"
+msgstr "{{doc-important|This means \"request\". This doesn't mean \"software application\" or \"app\".}}"
 
 #. Translators: On the My Library page (https://wikipedialibrary.wmflabs.org/users/my_library), this labels the text on a button which takes the user to the partner's site.
 #: TWLight/users/templates/users/user_collection_tile.html:131
@@ -3675,29 +2926,18 @@ msgstr ""
 
 #. Translators: This message is displayed on the page where users can request the deletion of their data.
 #: TWLight/users/templates/users/user_confirm_delete.html:17
-msgid ""
-"<b>Warning:</b> Performing this action will delete your Wikipedia Library "
-"Card user account and all associated applications. This process is not "
-"reversible. You may lose any partner accounts you were granted, and will not "
-"be able to renew those accounts or apply for new ones."
+msgid "<b>Warning:</b> Performing this action will delete your Wikipedia Library Card user account and all associated applications. This process is not reversible. You may lose any partner accounts you were granted, and will not be able to renew those accounts or apply for new ones."
 msgstr ""
 
 #. Translators: this should show up for people who log in with a username/password and not OAuth, so we don't know what their Wikipedia identity is.
-#.
 #: TWLight/users/templates/users/user_detail.html:12
 #, python-format
-msgid ""
-"Hi, %(username)s! You don't have a Wikipedia editor profile attached to your "
-"account here, so you are probably a site administrator."
+msgid "Hi, %(username)s! You don't have a Wikipedia editor profile attached to your account here, so you are probably a site administrator."
 msgstr ""
 
 #. Translators: In the unlikely scenario that someone is able to register an account without using OAuth (thus leaving us without some of the information required for applications), users will see this message, encouraging them to re-register.
 #: TWLight/users/templates/users/user_detail.html:20
-msgid ""
-"If you aren't a site administrator, something weird has happened. You won't "
-"be able to apply for access without a Wikipedia editor profile. You should "
-"log out and create a new account by logging in via OAuth, or contact a site "
-"administrator for help."
+msgid "If you aren't a site administrator, something weird has happened. You won't be able to apply for access without a Wikipedia editor profile. You should log out and create a new account by logging in via OAuth, or contact a site administrator for help."
 msgstr ""
 
 #. Translators: Labels a sections where coordinators can select their email preferences.
@@ -3708,17 +2948,12 @@ msgstr ""
 #. Translators: This message is shown on user's own profile page, encouraging them to make sure their information is up to date, so that account coordinators can use the information to judge applications.
 #: TWLight/users/views.py:176
 #, python-brace-format
-msgid ""
-"Please <a class='twl-links' href='{url}'>update your contributions</a> to "
-"Wikipedia to help coordinators evaluate your applications."
+msgid "Please <a class='twl-links' href='{url}'>update your contributions</a> to Wikipedia to help coordinators evaluate your applications."
 msgstr ""
 
 #. Translators: Coordinators are shown this message when they unselect all three types of reminder email options under preferences.
 #: TWLight/users/views.py:288
-msgid ""
-"You have chosen not to receive reminder emails. As a coordinator, you should "
-"receive at least one type of reminder emails, so consider changing your "
-"preferences."
+msgid "You have chosen not to receive reminder emails. As a coordinator, you should receive at least one type of reminder emails, so consider changing your preferences."
 msgstr ""
 
 #. Translators: Coordinators are shown this message when they make changes to their reminder email options under preferences.
@@ -3752,9 +2987,7 @@ msgstr ""
 
 #. Translators: If the user has not filled out their email, they can browse the website but cannot apply for access to resources.
 #: TWLight/users/views.py:487
-msgid ""
-"Your email is blank. You can still explore the site, but you won't be able "
-"to apply for access to partner resources without an email."
+msgid "Your email is blank. You can still explore the site, but you won't be able to apply for access to partner resources without an email."
 msgstr ""
 
 #. Translators: This message is shown once the access to a partner has successfully been returned.
@@ -3789,6 +3022,7 @@ msgstr ""
 
 #: tests/shunit/data/bad_i18n_comment_1.py:3
 #: tests/shunit/data/bad_i18n_newline_1.py:5
+#, ignored
 msgid "1"
 msgstr ""
 
@@ -3797,21 +3031,27 @@ msgstr ""
 #: tests/shunit/data/bad_i18n_comment_2.py:4
 #: tests/shunit/data/bad_i18n_newline_2.py:5 tests/shunit/data/good_i18n_1.py:2
 #: tests/shunit/data/good_i18n_2.py:2
+#, ignored
 msgid "2"
 msgstr ""
 
 #: tests/shunit/data/bad_i18n_newline_3.py:5
+#, ignored
 msgid "3"
 msgstr ""
 
 #: tests/shunit/data/bad_i18n_newline_4.py:5
+#, ignored
 msgid "4"
 msgstr ""
 
 #: tests/shunit/data/bad_i18n_newline_5.py:5
+#, ignored
 msgid "5"
 msgstr ""
 
 #: tests/shunit/data/bad_i18n_newline_6.py:5
+#, ignored
 msgid "6"
 msgstr ""
+

--- a/locale/ro/LC_MESSAGES/django.po
+++ b/locale/ro/LC_MESSAGES/django.po
@@ -16,17 +16,17 @@
 # Author: WebSourceContentRO
 msgid ""
 msgstr ""
+""
 "Project-Id-Version: Wikipedia Library Card Platform - Website\n"
-"Report-Msgid-Bugs-To: wikipedialibrary@wikimedia.org\n"
+"Report-Msgid-Bugs-To: translatewiki.net\n"
 "POT-Creation-Date: 2024-07-11 20:54+0000\n"
-"PO-Revision-Date: 2024-07-11 12:30:18+0000\n"
+"PO-Revision-Date: 2024-07-15 12:29:19+0000\n"
 "Language: ro\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "X-POT-Import-Date: 2024-06-25 18:44:08+0000\n"
 "X-Generator: MediaWiki 1.43.0-alpha; Translate 2024-07-16\n"
-"Plural-Forms: nplurals=3; plural=(n == 1) ? 0 : ( (n == 0 || (n%100 > 0 && n"
-"%100 < 20)) ? 1 : 2 );\n"
+"Plural-Forms: nplurals=3; plural=(n == 1) ? 0 : ( (n == 0 || (n%100 > 0 && n%100 < 20)) ? 1 : 2 );\n"
 "X-Translation-Project: translatewiki.net <https://translatewiki.net>\n"
 
 #. Translators: Labels the button users click to apply for a partner's resources.
@@ -52,12 +52,8 @@ msgstr "Despre tine"
 #. Translators: This note appears in a section of a form where we ask users to enter info (like country of residence) when applying for resource access.
 #: TWLight/applications/forms.py:179
 #, python-brace-format
-msgid ""
-"<p><small><i>Your personal data will be processed according to our <a "
-"class='twl-links' href='{terms_url}'> privacy policy</a>.</i></small></p>"
-msgstr ""
-"<p><small><i>Datele dvs. personale vor fi procesate conform <a class='twl-"
-"links' href='{terms_url}'>politicii de confidențialitate</a>.</i></small></p>"
+msgid "<p><small><i>Your personal data will be processed according to our <a class='twl-links' href='{terms_url}'> privacy policy</a>.</i></small></p>"
+msgstr "<p><small><i>Datele dvs. personale vor fi procesate conform <a class='twl-links' href='{terms_url}'>politicii de confidențialitate</a>.</i></small></p>"
 
 #. Translators: This is the title of the application form page, where users enter information required for the application. It lets the user know which partner application they are entering data for. {partner}
 #: TWLight/applications/forms.py:189
@@ -98,12 +94,8 @@ msgstr "Adresa de e-mail pentru contul dvs. pe site-ul partenerului"
 #. Translators: This labels a choice field where users will have to select the number of months they wish to have their access for as part of the application renewal confirmation.
 #. Translators: When filling out an application, users may be required to enter the length of the account (expiry) they wish to have for proxy partners.
 #: TWLight/applications/forms.py:339 TWLight/applications/helpers.py:100
-msgid ""
-"The number of months you wish to have this access for before renewal is "
-"required"
-msgstr ""
-"Numărul de luni pentru care doriți să aveți acest acces înainte ca "
-"reînnoirea să fie necesară"
+msgid "The number of months you wish to have this access for before renewal is required"
+msgstr "Numărul de luni pentru care doriți să aveți acest acces înainte ca reînnoirea să fie necesară"
 
 #. Translators: When filling out an application, users may need to specify their name
 #: TWLight/applications/helpers.py:81
@@ -191,13 +183,8 @@ msgstr "Email"
 
 #. Translators: This comment is added to pending applications when our terms of use change.
 #: TWLight/applications/management/commands/notify_applicants_tou_changes.py:54
-msgid ""
-"Our terms of use have changed. Your applications will not be processed until "
-"you log in and agree to our updated terms."
-msgstr ""
-"Termenii noaștri de utilizare s-au schimbat. Aplicațiile dvs. nu vor fi "
-"procesate până când vă autentificați și sunteți de acord cu termenii "
-"actualizați."
+msgid "Our terms of use have changed. Your applications will not be processed until you log in and agree to our updated terms."
+msgstr "Termenii noaștri de utilizare s-au schimbat. Aplicațiile dvs. nu vor fi procesate până când vă autentificați și sunteți de acord cu termenii actualizați."
 
 #. Translators: This is the status of an application that has not yet been reviewed.
 #: TWLight/applications/models.py:54
@@ -263,43 +250,26 @@ msgstr "URL de acces: {access_url}"
 
 #. Translators: This text goes into account approval emails in the case that we need to send the user's details to a publisher for manual account setup.
 #: TWLight/applications/models.py:331
-msgid ""
-"You can expect to receive access details within a week or two once it has "
-"been processed."
-msgstr ""
-"Vă puteți aștepta să primiți detalii de acces într-o săptămână sau două "
-"odată ce a fost procesat."
+msgid "You can expect to receive access details within a week or two once it has been processed."
+msgstr "Vă puteți aștepta să primiți detalii de acces într-o săptămână sau două odată ce a fost procesat."
 
 #. Translators: This comment is added to open applications when a partner joins the Library Bundle, which does not require applications.
 #: TWLight/applications/signals.py:247
-msgid ""
-"This partner joined the Library Bundle, which does not require applications. "
-"This application will be marked as invalid."
-msgstr ""
-"Acest partener s-a alăturat Library Bundle, care nu necesită aplicație. "
-"Această aplicație va fi marcată ca nevalidă."
+msgid "This partner joined the Library Bundle, which does not require applications. This application will be marked as invalid."
+msgstr "Acest partener s-a alăturat Library Bundle, care nu necesită aplicație. Această aplicație va fi marcată ca nevalidă."
 
 #. Translators: This is shown to users if the application is to a partner for which we have run out of available accounts. The application is therefore on a 'waitlist', and will be reviewed when more accounts are available.
 #: TWLight/applications/templates/applications/application_evaluation.html:29
-msgid ""
-"This application is on the waitlist because this partner does not have any "
-"access grants available at this time."
-msgstr ""
-"Această solicitare este pe lista de așteptare, deoarece acest partener nu "
-"are nicio permisiune de acces disponibilă în acest moment."
+msgid "This application is on the waitlist because this partner does not have any access grants available at this time."
+msgstr "Această solicitare este pe lista de așteptare, deoarece acest partener nu are nicio permisiune de acces disponibilă în acest moment."
 
 #. Translators: This message is shown on pages where coordinators can see personal information about applicants.
 #: TWLight/applications/templates/applications/application_evaluation.html:36
 #: TWLight/applications/templates/applications/application_list_include.html:6
 #: TWLight/applications/templates/applications/send_partner.html:45
 #: TWLight/resources/templates/resources/partner_users.html:18
-msgid ""
-"Coordinators: This page may contain personal information such as real names "
-"and email addresses. Please remember that this information is confidential."
-msgstr ""
-"Coordonatori: Această pagină poate conține informații personale, cum ar fi "
-"nume reale și adrese de e-mail. Vă rugăm să vă amintiți că aceste informații "
-"sunt confidențiale."
+msgid "Coordinators: This page may contain personal information such as real names and email addresses. Please remember that this information is confidential."
+msgstr "Coordonatori: Această pagină poate conține informații personale, cum ar fi nume reale și adrese de e-mail. Vă rugăm să vă amintiți că aceste informații sunt confidențiale."
 
 #. Translators: This is the title of the application page shown to users who are a coordinator, and are able to accept or reject the application.
 #: TWLight/applications/templates/applications/application_evaluation.html:39
@@ -308,12 +278,8 @@ msgstr "Evaluează solicitarea"
 
 #. Translators: This text is shown to coordinators on application pages if the applicant has restricted processing of their data.
 #: TWLight/applications/templates/applications/application_evaluation.html:42
-msgid ""
-"This user has requested a restriction on the processing of their data, so "
-"you cannot change the status of their application."
-msgstr ""
-"Acest utilizator a solicitat o restricție cu privire la procesarea datelor "
-"sale, astfel încât nu puteți schimba starea solicitării sale."
+msgid "This user has requested a restriction on the processing of their data, so you cannot change the status of their application."
+msgstr "Acest utilizator a solicitat o restricție cu privire la procesarea datelor sale, astfel încât nu puteți schimba starea solicitării sale."
 
 #. Translators: This is the title of the application page shown to users who are not a coordinator.
 #: TWLight/applications/templates/applications/application_evaluation.html:48
@@ -386,12 +352,8 @@ msgstr "Necunoscut"
 
 #. Translators: This is the text displayed to coordinators when an applicant has no country of residence in their profile.
 #: TWLight/applications/templates/applications/application_evaluation.html:123
-msgid ""
-"Please request the applicant add their country of residence to their profile "
-"before proceeding further."
-msgstr ""
-"Vă rugăm să solicitați solicitantului adăugarea țării de reședință la "
-"profilul său înainte de a continua."
+msgid "Please request the applicant add their country of residence to their profile before proceeding further."
+msgstr "Vă rugăm să solicitați solicitantului adăugarea țării de reședință la profilul său înainte de a continua."
 
 #. Translators: This labels the section of an application showing the total number of accounts available for a partner or their collection.
 #: TWLight/applications/templates/applications/application_evaluation.html:134
@@ -401,12 +363,8 @@ msgstr "Conturi disponibile"
 #. Translators: This labels the section of an application showing whether the user had agreed to the terms of use or not.
 #: TWLight/applications/templates/applications/application_evaluation.html:145
 #, python-format
-msgid ""
-"Has agreed to the site's <a class=\"twl-links\" href=\"%(terms_url)s\">terms "
-"of use</a>?"
-msgstr ""
-"A fost de acord cu <a class=\"twl-links\" href=\"%(terms_url)s\">termenii de "
-"utilizare</a>?"
+msgid "Has agreed to the site's <a class=\"twl-links\" href=\"%(terms_url)s\">terms of use</a>?"
+msgstr "A fost de acord cu <a class=\"twl-links\" href=\"%(terms_url)s\">termenii de utilizare</a>?"
 
 #. Translators: Displayed to coordinators when they've agreed to the terms of use.
 #. Translators: Displayed if the user has agreed to the terms of use.
@@ -441,12 +399,8 @@ msgstr "Nu"
 
 #. Translators: This is the text displayed to coordinators when an applicant has not agreed to the terms of use.
 #: TWLight/applications/templates/applications/application_evaluation.html:159
-msgid ""
-"Please request the applicant agree to the site's terms of use before "
-"approving this application."
-msgstr ""
-"Vă rugăm să solicitați solicitantului să accepte condițiile de utilizare a "
-"site-ului înainte de a aproba această cerere."
+msgid "Please request the applicant agree to the site's terms of use before approving this application."
+msgstr "Vă rugăm să solicitați solicitantului să accepte condițiile de utilizare a site-ului înainte de a aproba această cerere."
 
 #. Translators: This labels the section of an application containing the user's motivation for wanting access to this resource.
 #: TWLight/applications/templates/applications/application_evaluation.html:176
@@ -466,10 +420,8 @@ msgstr "Reînnoirea permisiunii de acces existente?"
 #. Translators: This message is shown next to the 'Renewal of existing access grant?' label if the application is a renewal. Don't translate HTML tags or parent_url.
 #: TWLight/applications/templates/applications/application_evaluation.html:195
 #, python-format
-msgid ""
-"Yes (<a class=\"twl-links\" href=\"%(parent_url)s\">previous application</a>)"
-msgstr ""
-"Da (<a class=\"twl-links\" href=\"%(parent_url)s\">aplicația precedentă</a>)"
+msgid "Yes (<a class=\"twl-links\" href=\"%(parent_url)s\">previous application</a>)"
+msgstr "Da (<a class=\"twl-links\" href=\"%(parent_url)s\">aplicația precedentă</a>)"
 
 #. Translators: This labels the section of the application showing the length of access remaining on the user's previous authorization.
 #: TWLight/applications/templates/applications/application_evaluation.html:208
@@ -503,12 +455,8 @@ msgstr "Adaugă comentariu"
 
 #. Translators: On an application page, this text tells users that the comments posted on the application are visible to coordinators and the submitting user only.
 #: TWLight/applications/templates/applications/application_evaluation.html:297
-msgid ""
-"Comments are visible to all coordinators and to the editor who submitted "
-"this application."
-msgstr ""
-"Comentariile sunt vizibile pentru toți coordonatorii și editorul care a "
-"depus această cerere."
+msgid "Comments are visible to all coordinators and to the editor who submitted this application."
+msgstr "Comentariile sunt vizibile pentru toți coordonatorii și editorul care a depus această cerere."
 
 #. Translators: This is the title of the section of an application page which lists information about the user who submitted the application.
 #. Translators: On the page where coordinators can view data on applications to a partner they coordinate, this is a table column heading for the username.
@@ -570,9 +518,7 @@ msgstr "Trimis"
 
 #: TWLight/applications/templates/applications/application_list.html:63
 msgid "Up for renewal"
-msgstr ""
-"\n"
-"În curs de reînnoire"
+msgstr "\nÎn curs de reînnoire"
 
 #. Translators: Coordinators can filter the page which shows a list of applications. This is the heading for the box where filters are selected.
 #: TWLight/applications/templates/applications/application_list.html:78
@@ -721,25 +667,14 @@ msgstr "Stabilește stare"
 
 #: TWLight/applications/templates/applications/apply.html:20
 #, python-format
-msgid ""
-"If your application is successful we may share your email address with "
-"%(partner)s. This is required to set up your access to their resources. By "
-"submitting this form you agree to allow your email address to be shared with "
-"%(partner)s if your application is successful, for the purposes of account "
-"setup."
-msgstr ""
-"Dacă cererea dvs. are succes, este posibil să vă împărtășim adresa de e-mail "
-"cu %(partner)s. Acest lucru este necesar pentru a vă configura accesul la "
-"resursele lor. Prin trimiterea acestui formular, sunteți de acord să "
-"permiteți accesul la adresa dvs. de e-mail cu %(partner)s dacă cererea dvs. "
-"are succes, în scopul configurării contului."
+msgid "If your application is successful we may share your email address with %(partner)s. This is required to set up your access to their resources. By submitting this form you agree to allow your email address to be shared with %(partner)s if your application is successful, for the purposes of account setup."
+msgstr "Dacă cererea dvs. are succes, este posibil să vă împărtășim adresa de e-mail cu %(partner)s. Acest lucru este necesar pentru a vă configura accesul la resursele lor. Prin trimiterea acestui formular, sunteți de acord să permiteți accesul la adresa dvs. de e-mail cu %(partner)s dacă cererea dvs. are succes, în scopul configurării contului."
 
 #. Translators: This message is displayed on the page where users can confirm their renewal. Please do not translate partner.
 #: TWLight/applications/templates/applications/confirm_renewal.html:23
 #, python-format
 msgid "Click 'confirm' to renew your application for %(partner)s"
-msgstr ""
-"Faceți click pe 'confirmare' pentru a reînnoi cererea pentru %(partner)s"
+msgstr "Faceți click pe 'confirmare' pentru a reînnoi cererea pentru %(partner)s"
 
 #. Translators: Labels the submit button requesting confirmation of application renewal.
 #. Translators: This is the button coordinators click to confirm deletion of a suggestion.
@@ -761,12 +696,8 @@ msgstr "Ce resurse doriți să accesați?"
 
 #. Translators: This text explains that Library Bundle partners are not shown in this list.
 #: TWLight/applications/templates/applications/request_for_application.html:26
-msgid ""
-"Library Bundle partners are not shown as eligibility is determined "
-"automatically."
-msgstr ""
-"Partenerii din Library Bundle nu sunt afișați, deoarece eligibilitatea este "
-"determinată automat."
+msgid "Library Bundle partners are not shown as eligibility is determined automatically."
+msgstr "Partenerii din Library Bundle nu sunt afișați, deoarece eligibilitatea este determinată automat."
 
 #. Translators: On the page where users can apply for multiple partners, this message shows next to the partner name, taking them to the full application page when clicked.
 #: TWLight/applications/templates/applications/request_for_application.html:48
@@ -780,14 +711,8 @@ msgstr "Nu s-au adăugat încă date despre partener."
 
 #. Translators: the HTML is so that the word 'waitlisted' will look the same as it does in the page above; please translate 'waitlisted' the same way you did elsewhere in this file.
 #: TWLight/applications/templates/applications/request_for_application.html:74
-msgid ""
-"You can apply to <span class=\"badge badge-warning\">Waitlisted</span> "
-"partners, but they don't have access grants available right now. We will "
-"process those applications when access becomes available."
-msgstr ""
-"Puteți aplica la <span class=\"badge badge-warning\">Lista de așteptare</"
-"span> parteneri, dar nu au subvenții de acces disponibile în acest moment. "
-"Vom prelucra acele aplicații atunci când accesul devine disponibil."
+msgid "You can apply to <span class=\"badge badge-warning\">Waitlisted</span> partners, but they don't have access grants available right now. We will process those applications when access becomes available."
+msgstr "Puteți aplica la <span class=\"badge badge-warning\">Lista de așteptare</span> parteneri, dar nu au subvenții de acces disponibile în acest moment. Vom prelucra acele aplicații atunci când accesul devine disponibil."
 
 #. Translators: On the page where coordinators can see approved applications which have not had their details sent to the partner, this message shows when there are applications ready to be processed.
 #: TWLight/applications/templates/applications/send.html:10
@@ -808,19 +733,13 @@ msgstr "Date aplicație pentru %(object)s"
 #. Translators: This message is shown when applications exceed the number of accounts available.
 #: TWLight/applications/templates/applications/send_partner.html:54
 #, python-format
-msgid ""
-"Application(s) for %(object)s, if sent, will exceed the total available "
-"accounts for the partner. Please proceed at your own discretion."
-msgstr ""
-"Cererea (cererile) pentru %(object)s, dacă este trimisă, va depăși totalul "
-"conturilor disponibile pentru partener. Vă rugăm să continuați la discreție."
+msgid "Application(s) for %(object)s, if sent, will exceed the total available accounts for the partner. Please proceed at your own discretion."
+msgstr "Cererea (cererile) pentru %(object)s, dacă este trimisă, va depăși totalul conturilor disponibile pentru partener. Vă rugăm să continuați la discreție."
 
 #. Translators: When viewing the list of applications ready to be sent for a particular partner, this is instructions for the coordinator to click the 'mark as sent' button after they have sent the information.
 #: TWLight/applications/templates/applications/send_partner.html:65
 msgid "When you've processed the data below, click the 'mark as sent' button."
-msgstr ""
-"Când ați procesat datele de mai jos, faceți click pe butonul 'marcați ca "
-"trimis'."
+msgstr "Când ați procesat datele de mai jos, faceți click pe butonul 'marcați ca trimis'."
 
 #. Translators: When viewing the list of applications ready to be sent for a particular partner, this is the title of the section containing contact information for the people applications should be sent to.
 #: TWLight/applications/templates/applications/send_partner.html:71
@@ -832,12 +751,8 @@ msgstr[2] ""
 
 #. Translators: When viewing the list of applications ready to be sent for a particular partner, this message shows if there is no information about who the applications should be sent to. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/applications/templates/applications/send_partner.html:89
-msgid ""
-"Whoops, we don't have any listed contacts. Please notify Wikipedia Library "
-"administrators."
-msgstr ""
-"Ups, nu avem contactele listate. Vă rugăm să anunțați administratorii "
-"Bibliotecii Wikipedia."
+msgid "Whoops, we don't have any listed contacts. Please notify Wikipedia Library administrators."
+msgstr "Ups, nu avem contactele listate. Vă rugăm să anunțați administratorii Bibliotecii Wikipedia."
 
 #. Translators: When viewing the list of applications ready to be sent for a particular partner, this is the title of the section containing the information about those applications.
 #: TWLight/applications/templates/applications/send_partner.html:94
@@ -852,12 +767,8 @@ msgstr "Marchează ca trimisă"
 
 #. Translators: This text guides coordinators in using the code sending interface for approved applications.
 #: TWLight/applications/templates/applications/send_partner.html:152
-msgid ""
-"Use the dropdown menus to denote which editor will receive each code. Access "
-"codes will be sent to users automatically."
-msgstr ""
-"Utilizați meniurile derulante pentru a indica ce editor va primi fiecare "
-"cod. Codurile de acces vor fi trimise utilizatorilor automat."
+msgid "Use the dropdown menus to denote which editor will receive each code. Access codes will be sent to users automatically."
+msgstr "Utilizați meniurile derulante pentru a indica ce editor va primi fiecare cod. Codurile de acces vor fi trimise utilizatorilor automat."
 
 #. Translators: This labels a drop-down selection where staff can assign an access code to a user.
 #: TWLight/applications/templates/applications/send_partner.html:173
@@ -872,24 +783,14 @@ msgstr "Nu există solicitări aprobate sau neexpediate."
 #. Translators: When a user applies for a set of resources, they receive this message if none are currently available. They are instead placed on a 'waitlist' for later approval.
 #. Translators: When a user renews their resource, they receive this message if none are currently available. They are instead placed on a 'waitlist' for later approval.
 #: TWLight/applications/views.py:140 TWLight/applications/views.py:1282
-msgid ""
-"This partner does not have any access grants available at this time. You may "
-"still apply for access; your application will be reviewed when access grants "
-"become available."
-msgstr ""
-"Acest partener nu are momentan niciun fel de permisiuni de acces "
-"disponibile. Puteți să solicitați în continuare acces; cererea dvs. va fi "
-"revizuită atunci când permisiunile de acces vor fi disponibile."
+msgid "This partner does not have any access grants available at this time. You may still apply for access; your application will be reviewed when access grants become available."
+msgstr "Acest partener nu are momentan niciun fel de permisiuni de acces disponibile. Puteți să solicitați în continuare acces; cererea dvs. va fi revizuită atunci când permisiunile de acces vor fi disponibile."
 
 #. Translators: This message is shown to users once they've successfully submitted their application for review.
 #: TWLight/applications/views.py:163
 #, python-brace-format
-msgid ""
-"Your application has been submitted for review. Head over to <a "
-"href='{applications_url}'>My Applications</a> to view the status."
-msgstr ""
-"Solicitarea dvs. a fost trimisă spre examinare. Mergi spre <a "
-"href='{applications_url}'>Aplicațiile mele</a> pentru a vedea starea."
+msgid "Your application has been submitted for review. Head over to <a href='{applications_url}'>My Applications</a> to view the status."
+msgstr "Solicitarea dvs. a fost trimisă spre examinare. Mergi spre <a href='{applications_url}'>Aplicațiile mele</a> pentru a vedea starea."
 
 #. Translators: This text is displayed to users when the user has chosen to restrict data and is trying to apply for multiple partners
 #: TWLight/applications/views.py:276
@@ -937,22 +838,13 @@ msgstr "Solicitări trimise"
 
 #. Translators: After a coordinator has changed the status of an application to APPROVED, if the corresponding partner/collection is waitlisted this message appears.
 #: TWLight/applications/views.py:756
-msgid ""
-"Cannot approve application as partner with proxy authorization method is "
-"waitlisted."
-msgstr ""
-"Nu se poate aproba solicitarea ca partener cu metoda de autorizare proxy "
-"este pe lista de așteptare."
+msgid "Cannot approve application as partner with proxy authorization method is waitlisted."
+msgstr "Nu se poate aproba solicitarea ca partener cu metoda de autorizare proxy este pe lista de așteptare."
 
 #. Translators: After a coordinator has changed the status of an application to APPROVED, if the corresponding partner/collection has no accounts for distribution, this message appears.
 #: TWLight/applications/views.py:780
-msgid ""
-"Cannot approve application as partner with proxy authorization method is "
-"waitlisted and (or) has zero accounts available for distribution."
-msgstr ""
-"Nu se poate aproba solicitarea ca partener cu metoda de autorizare proxy "
-"este pe lista de așteptare și (sau) are zero conturi disponibile pentru "
-"distribuire."
+msgid "Cannot approve application as partner with proxy authorization method is waitlisted and (or) has zero accounts available for distribution."
+msgstr "Nu se poate aproba solicitarea ca partener cu metoda de autorizare proxy este pe lista de așteptare și (sau) are zero conturi disponibile pentru distribuire."
 
 #. Translators: This message appears on an "access denied" screen that stops users who attempt to authorize an editor to access a resource during a time period for which they are already authorized.
 #: TWLight/applications/views.py:803
@@ -962,16 +854,8 @@ msgstr "Ați încercat să creați o autorizație duplicată."
 #. Translators: This message is shown to users when they access an application page of a now Bundle partner (new applications aren't allowed for Bundle partners and the status of old applications cannot be modified)
 #: TWLight/applications/views.py:857
 #, python-brace-format
-msgid ""
-"This application cannot be modified since this partner is now part of our <a "
-"href='{bundle}'>bundle access</a>. If you are eligible, you can access this "
-"resource from <a href='{library}'>your library</a>. <a "
-"href='{contact}'>Contact us</a> if you have any questions."
-msgstr ""
-"Această solicitare nu poate fi modificată, deoarece acest partener face "
-"parte acum din <a href='{bundle}'>acces la pachet</a>. Dacă sunteți "
-"eligibil, puteți accesa această resursă din <a href='{library}'>biblioteca "
-"dvs.</a>. <a href='{contact}'>Contactați-ne</a>  dacă aveți întrebări."
+msgid "This application cannot be modified since this partner is now part of our <a href='{bundle}'>bundle access</a>. If you are eligible, you can access this resource from <a href='{library}'>your library</a>. <a href='{contact}'>Contact us</a> if you have any questions."
+msgstr "Această solicitare nu poate fi modificată, deoarece acest partener face parte acum din <a href='{bundle}'>acces la pachet</a>. Dacă sunteți eligibil, puteți accesa această resursă din <a href='{library}'>biblioteca dvs.</a>. <a href='{contact}'>Contactați-ne</a>  dacă aveți întrebări."
 
 #. Translators: this lets a reviewer set the status of a single application.
 #: TWLight/applications/views.py:873
@@ -980,12 +864,8 @@ msgstr "Setați starea aplicației"
 
 #. Translators: This warning is message is shown to applicants when the number of pending applications is greater than the number of accounts available.
 #: TWLight/applications/views.py:891
-msgid ""
-"There are more pending applications than available accounts. Your "
-"application might get waitlisted."
-msgstr ""
-"Există mai multe aplicații în așteptare decât conturi disponibile. Aplicația "
-"dvs. ar putea fi pe lista de așteptare."
+msgid "There are more pending applications than available accounts. Your application might get waitlisted."
+msgstr "Există mai multe aplicații în așteptare decât conturi disponibile. Aplicația dvs. ar putea fi pe lista de așteptare."
 
 #. Translators: this message is shown to coordinators who attempt to change an application's Status from INVALID to any other Status.
 #: TWLight/applications/views.py:904
@@ -1004,17 +884,8 @@ msgstr "Actualizare în grup a solicităr(ilor) {} succes."
 
 #. Translators: After a coordinator has changed the status of a number of applications to APPROVED, if the corresponding partner(s) is/are waitlisted or has no accounts for distribution, this message appears.
 #: TWLight/applications/views.py:1051
-msgid ""
-"Cannot approve application(s) {} as partner(s) with proxy authorization "
-"method is/are waitlisted and (or) has/have not enough accounts available. If "
-"not enough accounts are available, prioritise the applications and then "
-"approve applications equal to the accounts available."
-msgstr ""
-"Nu se pot aproba solcitarea (solicitările) {} ca partener(i) cu metoda de "
-"autorizare proxy este/sunt listate și (sau) au/nu au suficiente conturi "
-"disponibile. Dacă nu sunt disponibile suficiente conturi, acordați "
-"prioritate solicitărilor și apoi aprobați solicitărilor egale cu numărul de "
-"conturi disponibile."
+msgid "Cannot approve application(s) {} as partner(s) with proxy authorization method is/are waitlisted and (or) has/have not enough accounts available. If not enough accounts are available, prioritise the applications and then approve applications equal to the accounts available."
+msgstr "Nu se pot aproba solcitarea (solicitările) {} ca partener(i) cu metoda de autorizare proxy este/sunt listate și (sau) au/nu au suficiente conturi disponibile. Dacă nu sunt disponibile suficiente conturi, acordați prioritate solicitărilor și apoi aprobați solicitărilor egale cu numărul de conturi disponibile."
 
 #. Translators: This message is shown to coordinators who attempt to assign the same access code to multiple users.
 #: TWLight/applications/views.py:1191
@@ -1028,13 +899,8 @@ msgstr "Toate solicitările selectate au fost marcate ca trimise."
 
 #. Translators: When a user tries to renew their resource, they receive this message if the partner is not available.
 #: TWLight/applications/views.py:1272
-msgid ""
-"Cannot renew application at this time as partner is not available. Please "
-"check back later, or contact us for more information."
-msgstr ""
-"Nu se poate reînnoi solicitarea în acest moment deoarece partenerul nu este "
-"disponibil. Vă rugăm să verificați mai târziu sau să ne contactați pentru "
-"mai multe informații."
+msgid "Cannot renew application at this time as partner is not available. Please check back later, or contact us for more information."
+msgstr "Nu se poate reînnoi solicitarea în acest moment deoarece partenerul nu este disponibil. Vă rugăm să verificați mai târziu sau să ne contactați pentru mai multe informații."
 
 #. Translators: This message is displayed when an attempt by a user to renew an application has been denied for some reason.
 #: TWLight/applications/views.py:1308
@@ -1044,21 +910,13 @@ msgstr "Încercarea de a reînnoi aplicația neaprobată #{pk} a fost refuzată"
 
 #. Translators: If a user requests the renewal of their account, but it wasn't renewed, this message is shown to them.
 #: TWLight/applications/views.py:1385
-msgid ""
-"This object cannot be renewed. (This probably means that you have already "
-"requested that it be renewed.)"
-msgstr ""
-"Acest obiect nu poate fi reînnoit. (Acest lucru înseamnă probabil că ați "
-"solicitat deja reînnoirea.)"
+msgid "This object cannot be renewed. (This probably means that you have already requested that it be renewed.)"
+msgstr "Acest obiect nu poate fi reînnoit. (Acest lucru înseamnă probabil că ați solicitat deja reînnoirea.)"
 
 #. Translators: If a user requests the renewal of their account, this message is shown to them.
 #: TWLight/applications/views.py:1395
-msgid ""
-"Your renewal request has been received. A coordinator will review your "
-"request."
-msgstr ""
-"Cererea dvs. de reînnoire a fost primită. Un coordonator va examina "
-"solicitarea dvs."
+msgid "Your renewal request has been received. A coordinator will review your request."
+msgstr "Cererea dvs. de reînnoire a fost primită. Un coordonator va examina solicitarea dvs."
 
 #. Translators: This labels a textfield where users can enter their email ID.
 #: TWLight/emails/forms.py:18
@@ -1067,12 +925,8 @@ msgstr "Email-ul tău"
 
 #. Translators: This is the help text for the email field in the contact us form letting users know the field is updated by value pulled from their respective user profiles.
 #: TWLight/emails/forms.py:21
-msgid ""
-"This field is automatically updated with the email from your <a class='twl-"
-"links' href='{}'>user profile</a>."
-msgstr ""
-"Acest câmp este actualizat automat odată cu e-mailul din <a class='twl-"
-"links' href='{}'>profilul utilizator</a>."
+msgid "This field is automatically updated with the email from your <a class='twl-links' href='{}'>user profile</a>."
+msgstr "Acest câmp este actualizat automat odată cu e-mailul din <a class='twl-links' href='{}'>profilul utilizator</a>."
 
 #. Translators: This labels a textfield where users can enter their email message.
 #: TWLight/emails/forms.py:26
@@ -1095,26 +949,14 @@ msgstr "Trimite"
 #. Translators: This email is sent to users with their access code. Don't translate Jinja variables in curly braces like user or partner. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/access_code_email-body-html.html:5
 #, python-format
-msgid ""
-"<p>Your approved application to %(partner)s has now been finalised. Your "
-"access code or login details can be found below:</p> <p><b>%(access_code)s</"
-"b></p> <p>%(user_instructions)s</p>"
-msgstr ""
-"<p>Solicitarea dvs. aprobată pentru %(partner)s acum a fost finalizată. "
-"Codul de acces sau detaliile de conectare pot fi găsite mai jos:</p> <p><b>"
-"%(access_code)s</b></p> <p>%(user_instructions)s</p>"
+msgid "<p>Your approved application to %(partner)s has now been finalised. Your access code or login details can be found below:</p> <p><b>%(access_code)s</b></p> <p>%(user_instructions)s</p>"
+msgstr "<p>Solicitarea dvs. aprobată pentru %(partner)s acum a fost finalizată. Codul de acces sau detaliile de conectare pot fi găsite mai jos:</p> <p><b>%(access_code)s</b></p> <p>%(user_instructions)s</p>"
 
 #. Translators: This email is sent to users with their access code. Don't translate Jinja variables in curly braces like user or partner. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/access_code_email-body-text.html:3
 #, python-format
-msgid ""
-"Your approved application to %(partner)s has now been finalised. Your access "
-"code or login details can be found below: %(access_code)s "
-"%(user_instructions)s"
-msgstr ""
-"Solcitarea dvs. aprobată pentru %(partner)s a fost finalizată. Codul de "
-"acces sau detaliile de conectare pot fi găsite mai jos: %(access_code)s "
-"%(user_instructions)s"
+msgid "Your approved application to %(partner)s has now been finalised. Your access code or login details can be found below: %(access_code)s %(user_instructions)s"
+msgstr "Solcitarea dvs. aprobată pentru %(partner)s a fost finalizată. Codul de acces sau detaliile de conectare pot fi găsite mai jos: %(access_code)s %(user_instructions)s"
 
 #. Translators: This is the subject line of an email sent to users with their access code.
 #: TWLight/emails/templates/emails/access_code_email-subject.html:3
@@ -1124,34 +966,14 @@ msgstr "Codul tău de acces la Wikipedia Library"
 #. Translators: This email is sent to users when their application is approved. Don't translate Jinja variables in curly braces like user or partner; don't translate html tags either. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/approval_notification-body-html.html:5
 #, python-format
-msgid ""
-"<p>Dear %(user)s,</p> <p>Thank you for applying for access to %(partner)s "
-"resources through The Wikipedia Library. We are happy to inform you that "
-"your application has been approved.</p> <p>%(user_instructions)s</p> <p>You "
-"can view the collections you're authorized to access at My Library: "
-"%(link)s</p> <p>Cheers!</p> <p>The Wikipedia Library</p>"
-msgstr ""
-"<p>Dragă %(user)s,</p> <p>Vă mulțumim că ați aplicat pentru acces la "
-"resursele %(partner)s prin Biblioteca Wikipedia. Suntem bucuroși să vă "
-"informăm că cererea dvs. a fost aprobată.</p> <p>%(user_instructions)s</p> "
-"<p>Puteți vedea colecțiile pe care sunteți autorizat să le accesați la "
-"Biblioteca mea: %(link)s</p> <p>Noroc!</p> <p>Biblioteca Wikipedia</p>"
+msgid "<p>Dear %(user)s,</p> <p>Thank you for applying for access to %(partner)s resources through The Wikipedia Library. We are happy to inform you that your application has been approved.</p> <p>%(user_instructions)s</p> <p>You can view the collections you're authorized to access at My Library: %(link)s</p> <p>Cheers!</p> <p>The Wikipedia Library</p>"
+msgstr "<p>Dragă %(user)s,</p> <p>Vă mulțumim că ați aplicat pentru acces la resursele %(partner)s prin Biblioteca Wikipedia. Suntem bucuroși să vă informăm că cererea dvs. a fost aprobată.</p> <p>%(user_instructions)s</p> <p>Puteți vedea colecțiile pe care sunteți autorizat să le accesați la Biblioteca mea: %(link)s</p> <p>Noroc!</p> <p>Biblioteca Wikipedia</p>"
 
 #. Translators: This email is sent to users when their application is approved. Don't translate Jinja variables in curly braces like user or partner. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/approval_notification-body-text.html:3
 #, python-format
-msgid ""
-"Dear %(user)s, Thank you for applying for access to %(partner)s resources "
-"through The Wikipedia Library. We are happy to inform you that your "
-"application has been approved. %(user_instructions)s You can view the "
-"collections you're authorized to access at My Library: %(link)s Cheers! The "
-"Wikipedia Library"
-msgstr ""
-"Dragă %(user)s, Vă mulțumim că ați aplicat pentru acces la resursele "
-"%(partner)s prin Biblioteca Wikipedia. Suntem bucuroși să vă informăm că "
-"cererea dumneavoastră a fost aprobată. %(user_instructions)s Puteți "
-"vizualiza colecțiile pe care sunteți autorizat să le accesați la Biblioteca "
-"mea: %(link)s Noroc! Biblioteca Wikipedia"
+msgid "Dear %(user)s, Thank you for applying for access to %(partner)s resources through The Wikipedia Library. We are happy to inform you that your application has been approved. %(user_instructions)s You can view the collections you're authorized to access at My Library: %(link)s Cheers! The Wikipedia Library"
+msgstr "Dragă %(user)s, Vă mulțumim că ați aplicat pentru acces la resursele %(partner)s prin Biblioteca Wikipedia. Suntem bucuroși să vă informăm că cererea dumneavoastră a fost aprobată. %(user_instructions)s Puteți vizualiza colecțiile pe care sunteți autorizat să le accesați la Biblioteca mea: %(link)s Noroc! Biblioteca Wikipedia"
 
 #. Translators: This is the subject of an email which is sent to users when their application has been approved. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/approval_notification-subject.html:4
@@ -1161,57 +983,31 @@ msgstr "Solicitarea dvs. pentru Biblioteca Wikipedia a fost aprobată"
 #. Translators: This email is sent to coordinators when a comment is left on an application they are processing. Don't translate Jinja variables in curly braces like user or partner. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/comment_notification_coordinator-body-html.html:5
 #, python-format
-msgid ""
-"<p style=\"color: #500050\">%(submit_date)s - %(commenter)s</p> "
-"<blockquote><p>%(comment)s</p></blockquote> <p>Please reply to these at: <a "
-"href=\"%(app_url)s\">%(app_url)s</a></p> <p>Best,</p> <p>The Wikipedia "
-"Library</p>"
-msgstr ""
-"<p style=\"color: #500050\">%(submit_date)s - %(commenter)s</p> "
-"<blockquote><p>%(comment)s</p></blockquote> <p>Vă rugăm să răspundeți la "
-"acestea la: <a href=\"%(app_url)s\">%(app_url)s</a></p> <p>Cele bune,</p> "
-"<p>Biblioteca Wikipedia</p>"
+msgid "<p style=\"color: #500050\">%(submit_date)s - %(commenter)s</p> <blockquote><p>%(comment)s</p></blockquote> <p>Please reply to these at: <a href=\"%(app_url)s\">%(app_url)s</a></p> <p>Best,</p> <p>The Wikipedia Library</p>"
+msgstr "<p style=\"color: #500050\">%(submit_date)s - %(commenter)s</p> <blockquote><p>%(comment)s</p></blockquote> <p>Vă rugăm să răspundeți la acestea la: <a href=\"%(app_url)s\">%(app_url)s</a></p> <p>Cele bune,</p> <p>Biblioteca Wikipedia</p>"
 
 #. Translators: This email is sent to coordinators when a comment is left on an application they are processing. Don't translate Jinja variables in curly braces like user or partner. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/comment_notification_coordinator-body-text.html:3
 #, python-format
-msgid ""
-"%(submit_date)s - %(commenter)s %(comment)s Please reply to this at: "
-"%(app_url)s Best, The Wikipedia Library"
-msgstr ""
-"%(submit_date)s - %(commenter)s %(comment)s Vă rugăm să răspundeți la "
-"aceasta la: %(app_url)s Cele bune, Biblioteca Wikipedia"
+msgid "%(submit_date)s - %(commenter)s %(comment)s Please reply to this at: %(app_url)s Best, The Wikipedia Library"
+msgstr "%(submit_date)s - %(commenter)s %(comment)s Vă rugăm să răspundeți la aceasta la: %(app_url)s Cele bune, Biblioteca Wikipedia"
 
 #. Translators: This is the subject line of an email sent to coordinators when a comment is left on an application they processed.
 #: TWLight/emails/templates/emails/comment_notification_coordinator-subject.html:3
 msgid "New comment on a Wikipedia Library application you processed"
-msgstr ""
-"Un nou comentariu la o solicitare Biblioteca Wikipedia pe care ați procesat-o"
+msgstr "Un nou comentariu la o solicitare Biblioteca Wikipedia pe care ați procesat-o"
 
 #. Translators: This email is sent to users when they receive a comment on their application. Don't translate Jinja variables in curly braces like user or partner; don't translate html tags either. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/comment_notification_editors-body-html.html:5
 #, python-format
-msgid ""
-"<p style=\"color: #500050\">%(submit_date)s - %(commenter)s</p> "
-"<blockquote><p>%(comment)s</p></blockquote> <p>Please reply to these at <a "
-"href=\"%(app_url)s\">%(app_url)s</a> so we can evaluate your application.</"
-"p> <p>Best,</p> <p>The Wikipedia Library</p>"
-msgstr ""
-"<p style=\"color: #500050\">%(submit_date)s - %(commenter)s</p> "
-"<blockquote><p>%(comment)s</p></blockquote> <p>Vă rugăm să răspundeți la "
-"acestea la <a href=\"%(app_url)s\">%(app_url)s</a> astfel încât să putem "
-"evalua solicitarea dvs.</p> <p>Cele bune,</p> <p>Biblioteca Wikipedia</p>"
+msgid "<p style=\"color: #500050\">%(submit_date)s - %(commenter)s</p> <blockquote><p>%(comment)s</p></blockquote> <p>Please reply to these at <a href=\"%(app_url)s\">%(app_url)s</a> so we can evaluate your application.</p> <p>Best,</p> <p>The Wikipedia Library</p>"
+msgstr "<p style=\"color: #500050\">%(submit_date)s - %(commenter)s</p> <blockquote><p>%(comment)s</p></blockquote> <p>Vă rugăm să răspundeți la acestea la <a href=\"%(app_url)s\">%(app_url)s</a> astfel încât să putem evalua solicitarea dvs.</p> <p>Cele bune,</p> <p>Biblioteca Wikipedia</p>"
 
 #. Translators: This email is sent to users when they receive a comment on their application. Don't translate Jinja variables in curly braces like user or partner. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/comment_notification_editors-body-text.html:3
 #, python-format
-msgid ""
-"%(submit_date)s - %(commenter)s %(comment)s Please reply to these at: "
-"%(app_url)s so we can evaluate your application. Best, The Wikipedia Library"
-msgstr ""
-"%(submit_date)s - %(commenter)s %(comment)s Vă rugăm să răspundeți la "
-"acestea la: %(app_url)s astfel încât să putem evalua solicitarea dvs. Cele "
-"bune, Biblioteca Wikipedia"
+msgid "%(submit_date)s - %(commenter)s %(comment)s Please reply to these at: %(app_url)s so we can evaluate your application. Best, The Wikipedia Library"
+msgstr "%(submit_date)s - %(commenter)s %(comment)s Vă rugăm să răspundeți la acestea la: %(app_url)s astfel încât să putem evalua solicitarea dvs. Cele bune, Biblioteca Wikipedia"
 
 #. Translators: This is the subject line of an email sent to users who have a comment added to one of their applications. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/comment_notification_editors-subject.html:3
@@ -1221,44 +1017,25 @@ msgstr "Un nou comentariu la solicitarea dvs. pentru Biblioteca Wikipedia"
 #. Translators: This email is sent to users when an application they commented on receives another comment. Don't translate Jinja variables in curly braces like app_url; don't translate html tags either. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/comment_notification_others-body-html.html:5
 #, python-format
-msgid ""
-"<p style=\"color: #500050\">%(submit_date)s - %(commenter)s</p> "
-"<blockquote><p>%(comment)s</p></blockquote> See it at <a href=\"%(app_url)s"
-"\">%(app_url)s</a>. Thanks for helping review Wikipedia Library applications!"
-msgstr ""
-"<p style=\"color: #500050\">%(submit_date)s - %(commenter)s</p> "
-"<blockquote><p>%(comment)s</p></blockquote> Vezi-l la <a href=\"%(app_url)s"
-"\">%(app_url)s</a>. Vă mulțumim pentru că ați ajutat la examinarea "
-"solicitărilor la Biblioteca Wikipedia!"
+msgid "<p style=\"color: #500050\">%(submit_date)s - %(commenter)s</p> <blockquote><p>%(comment)s</p></blockquote> See it at <a href=\"%(app_url)s\">%(app_url)s</a>. Thanks for helping review Wikipedia Library applications!"
+msgstr "<p style=\"color: #500050\">%(submit_date)s - %(commenter)s</p> <blockquote><p>%(comment)s</p></blockquote> Vezi-l la <a href=\"%(app_url)s\">%(app_url)s</a>. Vă mulțumim pentru că ați ajutat la examinarea solicitărilor la Biblioteca Wikipedia!"
 
 #. Translators: This email is sent to users when an application they commented on receives another comment. Don't translate Jinja variables in curly braces like app_url. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/comment_notification_others-body-text.html:3
 #, python-format
-msgid ""
-"%(submit_date)s - %(commenter)s %(comment)s See it at: %(app_url)s Thanks "
-"for helping review Wikipedia Library applications!"
-msgstr ""
-"%(submit_date)s - %(commenter)s %(comment)s Vedeți-l la: %(app_url)s "
-"Mulțumesc pentru că ați ajutat la revizuirea solicitărilor din Biblioteca "
-"Wikipedia!"
+msgid "%(submit_date)s - %(commenter)s %(comment)s See it at: %(app_url)s Thanks for helping review Wikipedia Library applications!"
+msgstr "%(submit_date)s - %(commenter)s %(comment)s Vedeți-l la: %(app_url)s Mulțumesc pentru că ați ajutat la revizuirea solicitărilor din Biblioteca Wikipedia!"
 
 #. Translators: This is the subject line of an email sent to users who have a comment added to an application they also commented on. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/comment_notification_others-subject.html:4
 msgid "New comment on a Wikipedia Library application you commented on"
-msgstr ""
-"Comentariu nou la o solicitare la Biblioteca Wikipedia la care ai comentat"
+msgstr "Comentariu nou la o solicitare la Biblioteca Wikipedia la care ai comentat"
 
 #. Translators: This text is part of a scheduled reminder email sent to coordinators who have applications requiring action. Don't translate Jinja variables in curly braces like total_apps, or user.
 #: TWLight/emails/templates/emails/coordinator_reminder_notification-body-html.html:5
 #, python-format
-msgid ""
-"<p>Dear %(user)s,</p> <p>Our records indicate that you are the designated "
-"coordinator for partners that have a total of %(total_apps)s applications.</"
-"p>"
-msgstr ""
-"<p>Dragă %(user)s,</p> <p>Înregistrările noastre indică faptul că sunteți "
-"coordonatorul desemnat pentru partenerii care au un total de %(total_apps)s "
-"aplicații.</p>"
+msgid "<p>Dear %(user)s,</p> <p>Our records indicate that you are the designated coordinator for partners that have a total of %(total_apps)s applications.</p>"
+msgstr "<p>Dragă %(user)s,</p> <p>Înregistrările noastre indică faptul că sunteți coordonatorul desemnat pentru partenerii care au un total de %(total_apps)s aplicații.</p>"
 
 #. Translators: Breakdown as in 'cost breakdown'; analysis.
 #: TWLight/emails/templates/emails/coordinator_reminder_notification-body-html.html:11
@@ -1299,46 +1076,20 @@ msgstr[2] ""
 #. Translators: This text is part of a scheduled reminder email sent to coordinators who have applications requiring action. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library). Don't translate Jinja variables in curly braces like link; don't translate email addresses or html tags either.
 #: TWLight/emails/templates/emails/coordinator_reminder_notification-body-html.html:39
 #, python-format
-msgid ""
-"<p>This is a gentle reminder that you may review applications at <a href="
-"\"%(link)s\">%(link)s</a>.</p> <p>You can customise your reminders under "
-"'preferences' in your user profile.</p> <p>If you received this message in "
-"error, drop us a line at wikipedialibrary@wikimedia.org.</p> <p>Thanks for "
-"helping review Wikipedia Library applications!</p>"
-msgstr ""
-"<p>Acesta este un memento blând la care puteți consulta solicitările la <a "
-"href=\"%(link)s\">%(link)s</a>.</p> <p>Puteți personaliza mementourile dvs. "
-"în 'preferințe' din profilul dvs. de utilizator.</p> <p>Dacă ați primit "
-"acest mesaj din greșeală, aruncați-ne un rând la wikipedialibrary@wikimedia."
-"org.</p> <p>Vă mulțumim pentru că ați ajutat la examinarea solicitărilor "
-"pentru Biblioteca Wikipedia!</p>"
+msgid "<p>This is a gentle reminder that you may review applications at <a href=\"%(link)s\">%(link)s</a>.</p> <p>You can customise your reminders under 'preferences' in your user profile.</p> <p>If you received this message in error, drop us a line at wikipedialibrary@wikimedia.org.</p> <p>Thanks for helping review Wikipedia Library applications!</p>"
+msgstr "<p>Acesta este un memento blând la care puteți consulta solicitările la <a href=\"%(link)s\">%(link)s</a>.</p> <p>Puteți personaliza mementourile dvs. în 'preferințe' din profilul dvs. de utilizator.</p> <p>Dacă ați primit acest mesaj din greșeală, aruncați-ne un rând la wikipedialibrary@wikimedia.org.</p> <p>Vă mulțumim pentru că ați ajutat la examinarea solicitărilor pentru Biblioteca Wikipedia!</p>"
 
 #. Translators: This text is part of a scheduled reminder email sent to coordinators who have applications requiring action. Don't translate Jinja variables in curly braces like total_apps, or user.
 #: TWLight/emails/templates/emails/coordinator_reminder_notification-body-text.html:3
 #, python-format
-msgid ""
-"Dear %(user)s, Our records indicate that you are the designated coordinator "
-"for partners that have a total of %(total_apps)s applications."
-msgstr ""
-"Dragă %(user)s, Înregistrările noastre indică faptul că sunteți "
-"coordonatorul desemnat pentru partenerii care au un total de %(total_apps)s "
-"solicitări."
+msgid "Dear %(user)s, Our records indicate that you are the designated coordinator for partners that have a total of %(total_apps)s applications."
+msgstr "Dragă %(user)s, Înregistrările noastre indică faptul că sunteți coordonatorul desemnat pentru partenerii care au un total de %(total_apps)s solicitări."
 
 #. Translators: This text is part of a scheduled reminder email sent to coordinators who have applications requiring action. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library). Don't translate Jinja variables in curly braces like link; don't translate the email address either.
 #: TWLight/emails/templates/emails/coordinator_reminder_notification-body-text.html:38
 #, python-format
-msgid ""
-"This is a gentle reminder that you may review applications at: %(link)s. You "
-"can customise your reminders under 'preferences' in your user profile. If "
-"you received this message in error, drop us a line at: "
-"wikipedialibrary@wikimedia.org Thanks for helping review Wikipedia Library "
-"applications!"
-msgstr ""
-"Acesta este un memento blând că puteți examina solicitările la: %(link)s. "
-"Puteți personaliza mementourile dvs. în 'preferințe' din profilul dvs. de "
-"utilizator. Dacă ați primit acest mesaj greșit, aruncați-ne un rând la: "
-"wikipedialibrary@wikimedia.org Vă mulțumim că ați ajutat la revizuirea "
-"aplicațiilor pentru Biblioteca Wikipedia!"
+msgid "This is a gentle reminder that you may review applications at: %(link)s. You can customise your reminders under 'preferences' in your user profile. If you received this message in error, drop us a line at: wikipedialibrary@wikimedia.org Thanks for helping review Wikipedia Library applications!"
+msgstr "Acesta este un memento blând că puteți examina solicitările la: %(link)s. Puteți personaliza mementourile dvs. în 'preferințe' din profilul dvs. de utilizator. Dacă ați primit acest mesaj greșit, aruncați-ne un rând la: wikipedialibrary@wikimedia.org Vă mulțumim că ați ajutat la revizuirea aplicațiilor pentru Biblioteca Wikipedia!"
 
 #. Translators: This is the subject line of a scheduled reminder email sent to coordinators who have applications to review. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library). Do not translate items in curly braces.
 #: TWLight/emails/templates/emails/coordinator_reminder_notification-subject.html:4
@@ -1348,32 +1099,14 @@ msgstr "Solicitările Bibliotecii Wikipedia își așteaptă recenzia"
 #. Translators: This email is sent to users when their application is rejected. Don't translate Jinja variables in curly braces like user or partner; don't translate html tags either. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/rejection_notification-body-html.html:5
 #, python-format
-msgid ""
-"<p>Dear %(user)s,</p> <p>Thank you for applying for access to %(partner)s "
-"resources through The Wikipedia Library. Unfortunately at this time your "
-"application has not been approved. You can view your application and review "
-"comments at <a href=\"%(app_url)s\">%(app_url)s</a>.</p> <p>Best,</p> <p>The "
-"Wikipedia Library</p>"
-msgstr ""
-"<p>Dragă %(user)s,</p> <p>Vă mulțumim că ați solicitat accesul la resursele "
-"%(partner)s prin Biblioteca Wikipedia. Din păcate, în acest moment, "
-"solicitarea dvs. nu a fost aprobată. Puteți vedea solicitarea dvs. și puteți "
-"consulta comentariile la <a href=\"%(app_url)s\">%(app_url)s</a>.</p> "
-"<p>Cele bune,</p> <p>Biblioteca Wikipedia</p>"
+msgid "<p>Dear %(user)s,</p> <p>Thank you for applying for access to %(partner)s resources through The Wikipedia Library. Unfortunately at this time your application has not been approved. You can view your application and review comments at <a href=\"%(app_url)s\">%(app_url)s</a>.</p> <p>Best,</p> <p>The Wikipedia Library</p>"
+msgstr "<p>Dragă %(user)s,</p> <p>Vă mulțumim că ați solicitat accesul la resursele %(partner)s prin Biblioteca Wikipedia. Din păcate, în acest moment, solicitarea dvs. nu a fost aprobată. Puteți vedea solicitarea dvs. și puteți consulta comentariile la <a href=\"%(app_url)s\">%(app_url)s</a>.</p> <p>Cele bune,</p> <p>Biblioteca Wikipedia</p>"
 
 #. Translators: This email is sent to users when their application is rejected. Don't translate Jinja variables in curly braces like user or partner. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/rejection_notification-body-text.html:3
 #, python-format
-msgid ""
-"Dear %(user)s, Thank you for applying for access to %(partner)s resources "
-"through The Wikipedia Library. Unfortunately at this time your application "
-"has not been approved. You can view your application and review comments at: "
-"%(app_url)s Best, The Wikipedia Library"
-msgstr ""
-"Dragă %(user)s, Vă mulțumim că ați solicitat accesul la resursele  "
-"%(partner)s prin Biblioteca Wikipedia. Din păcate, în acest moment, "
-"solicitarea dvs. nu a fost aprobată. Puteți vedea solicitarea dvs. și puteți "
-"consulta comentariile la: %(app_url)s Cele bune, Biblioteca Wikipedia"
+msgid "Dear %(user)s, Thank you for applying for access to %(partner)s resources through The Wikipedia Library. Unfortunately at this time your application has not been approved. You can view your application and review comments at: %(app_url)s Best, The Wikipedia Library"
+msgstr "Dragă %(user)s, Vă mulțumim că ați solicitat accesul la resursele  %(partner)s prin Biblioteca Wikipedia. Din păcate, în acest moment, solicitarea dvs. nu a fost aprobată. Puteți vedea solicitarea dvs. și puteți consulta comentariile la: %(app_url)s Cele bune, Biblioteca Wikipedia"
 
 #. Translators: This is the subject of an email which is sent to users when their application has been rejected. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/rejection_notification-subject.html:4
@@ -1383,40 +1116,14 @@ msgstr "Aplicația dvs. pentru Biblioteca Wikipedia"
 #. Translators: This email is sent to users when they have an account that is soon to expire. Don't translate Jinja variables in curly braces like partner_name or partner_link; don't translate html tags either. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/user_renewal_notice-body-html.html:5
 #, python-format
-msgid ""
-"<p>Dear %(user)s,</p> <p>According to our records, your access to "
-"%(partner_name)s will soon expire and you may lose access. If you want to "
-"continue making use of your free account, you can request renewal of your "
-"account by clicking the 'Renew' or 'Extend' button at %(partner_link)s.</p> "
-"<p>Best,</p> <p>The Wikipedia Library</p> <p>You can disable these emails in "
-"your user page preferences: https://wikipedialibrary.wmflabs.org/users/</p>"
-msgstr ""
-"<p>Dragă %(user)s,</p> <p>Conform înregistrărilor noastre, accesul dvs. la "
-"%(partner_name)s va expira în curând și este posibil să pierdeți accesul. "
-"Dacă doriți să utilizați în continuare contul dvs. gratuit, puteți solicita "
-"reînnoirea contului dvs. făcând click pe butonul Reînnoire la "
-"%(partner_link)s.</p> <p>Toate cele bune,</p> <p>Biblioteca Wikipedia</p> "
-"<p>Puteți dezactiva aceste e-mailuri în preferințele paginii de utilizator: "
-"https://wikipedialibrary.wmflabs.org/users/</p>"
+msgid "<p>Dear %(user)s,</p> <p>According to our records, your access to %(partner_name)s will soon expire and you may lose access. If you want to continue making use of your free account, you can request renewal of your account by clicking the 'Renew' or 'Extend' button at %(partner_link)s.</p> <p>Best,</p> <p>The Wikipedia Library</p> <p>You can disable these emails in your user page preferences: https://wikipedialibrary.wmflabs.org/users/</p>"
+msgstr "<p>Dragă %(user)s,</p> <p>Conform înregistrărilor noastre, accesul dvs. la %(partner_name)s va expira în curând și este posibil să pierdeți accesul. Dacă doriți să utilizați în continuare contul dvs. gratuit, puteți solicita reînnoirea contului dvs. făcând click pe butonul Reînnoire la %(partner_link)s.</p> <p>Toate cele bune,</p> <p>Biblioteca Wikipedia</p> <p>Puteți dezactiva aceste e-mailuri în preferințele paginii de utilizator: https://wikipedialibrary.wmflabs.org/users/</p>"
 
 #. Translators: This email is sent to users when they have an account that is soon to expire. Don't translate Jinja variables in curly braces like partner_name or partner_link; don't translate html tags either. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/user_renewal_notice-body-text.html:3
 #, python-format
-msgid ""
-"Dear %(user)s, According to our records, your access to %(partner_name)s "
-"will soon expire and you may lose access. If you want to continue making use "
-"of your free account, you can request renewal of your account by clicking "
-"the Renew button at %(partner_link)s. Best, The Wikipedia Library You can "
-"disable these emails in your user page preferences: https://wikipedialibrary."
-"wmflabs.org/users/"
-msgstr ""
-"Dragă %(user)s, Conform înregistrărilor noastre, accesul dvs. la "
-"%(partner_name)s va expira în curând și este posibil să pierdeți accesul. "
-"Dacă doriți să utilizați în continuare contul dvs. gratuit, puteți solicita "
-"reînnoirea contului dvs. făcând click pe butonul Reînnoire la "
-"%(partner_link)s. Cele bune, Biblioteca Wikipedia Puteți dezactiva aceste e-"
-"mailuri în preferințele paginii dvs. de utilizator: https://wikipedialibrary."
-"wmflabs.org/users/"
+msgid "Dear %(user)s, According to our records, your access to %(partner_name)s will soon expire and you may lose access. If you want to continue making use of your free account, you can request renewal of your account by clicking the Renew button at %(partner_link)s. Best, The Wikipedia Library You can disable these emails in your user page preferences: https://wikipedialibrary.wmflabs.org/users/"
+msgstr "Dragă %(user)s, Conform înregistrărilor noastre, accesul dvs. la %(partner_name)s va expira în curând și este posibil să pierdeți accesul. Dacă doriți să utilizați în continuare contul dvs. gratuit, puteți solicita reînnoirea contului dvs. făcând click pe butonul Reînnoire la %(partner_link)s. Cele bune, Biblioteca Wikipedia Puteți dezactiva aceste e-mailuri în preferințele paginii dvs. de utilizator: https://wikipedialibrary.wmflabs.org/users/"
 
 #. Translators: This is the subject of an email sent to users when they have an account that is soon to expire. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/user_renewal_notice-subject.html:4
@@ -1426,43 +1133,19 @@ msgstr "Accesul dvs. la Biblioteca Wikipedia poate expira curând"
 #. Translators: This email is sent to users when their application is waitlisted because there are no more accounts available. Don't translate Jinja variables in curly braces like user or partner; don't translate html tags either. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/waitlist_notification-body-html.html:5
 #, python-format
-msgid ""
-"<p>Dear %(user)s,</p> <p>Thank you for applying for access to %(partner)s "
-"resources through The Wikipedia Library. There are no accounts currently "
-"available so your application has been waitlisted. Your application will be "
-"evaluated if/when more accounts become available. You can see all available "
-"resources at <a href=\"%(link)s\">%(link)s</a>.</p> <p>Best,</p> <p>The "
-"Wikipedia Library</p>"
-msgstr ""
-"<p>Dragă %(user)s,</p> <p>Vă mulțumim că ați solicitat accesul la resursele "
-"%(partner)s prin Biblioteca Wikipedia. În prezent, nu există conturi "
-"disponibile, astfel încât cererea dvs. a fost listată. Aplicația dvs. va fi "
-"evaluată dacă/când vor fi disponibile mai multe conturi. Puteți vedea toate "
-"resursele disponibile la <a href=\"%(link)s\">%(link)s</a>.</p> <p>Cele bune,"
-"</p> <p>Biblioteca Wikipedia</p>"
+msgid "<p>Dear %(user)s,</p> <p>Thank you for applying for access to %(partner)s resources through The Wikipedia Library. There are no accounts currently available so your application has been waitlisted. Your application will be evaluated if/when more accounts become available. You can see all available resources at <a href=\"%(link)s\">%(link)s</a>.</p> <p>Best,</p> <p>The Wikipedia Library</p>"
+msgstr "<p>Dragă %(user)s,</p> <p>Vă mulțumim că ați solicitat accesul la resursele %(partner)s prin Biblioteca Wikipedia. În prezent, nu există conturi disponibile, astfel încât cererea dvs. a fost listată. Aplicația dvs. va fi evaluată dacă/când vor fi disponibile mai multe conturi. Puteți vedea toate resursele disponibile la <a href=\"%(link)s\">%(link)s</a>.</p> <p>Cele bune,</p> <p>Biblioteca Wikipedia</p>"
 
 #. Translators: This email is sent to users when their application is waitlisted because there are no more accounts available. Don't translate Jinja variables in curly braces like user or partner. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/waitlist_notification-body-text.html:3
 #, python-format
-msgid ""
-"Dear %(user)s, Thank you for applying for access to %(partner)s resources "
-"through The Wikipedia Library. There are no accounts currently available so "
-"your application has been waitlisted. Your application will be evaluated if/"
-"when more accounts become available. You can see all available resources at: "
-"%(link)s Best, The Wikipedia Library"
-msgstr ""
-"Dragă %(user)s, Vă mulțumim că ați solicitat accesul la resursele "
-"%(partner)s prin Biblioteca Wikipedia. În prezent, nu există conturi "
-"disponibile, astfel încât cererea dvs. a fost listată. Aplicația dvs. va fi "
-"evaluată dacă/când vor fi disponibile mai multe conturi. Puteți vedea toate "
-"resursele disponibile la: %(link)s Cele bune, Biblioteca Wikipedia"
+msgid "Dear %(user)s, Thank you for applying for access to %(partner)s resources through The Wikipedia Library. There are no accounts currently available so your application has been waitlisted. Your application will be evaluated if/when more accounts become available. You can see all available resources at: %(link)s Best, The Wikipedia Library"
+msgstr "Dragă %(user)s, Vă mulțumim că ați solicitat accesul la resursele %(partner)s prin Biblioteca Wikipedia. În prezent, nu există conturi disponibile, astfel încât cererea dvs. a fost listată. Aplicația dvs. va fi evaluată dacă/când vor fi disponibile mai multe conturi. Puteți vedea toate resursele disponibile la: %(link)s Cele bune, Biblioteca Wikipedia"
 
 #. Translators: This is the subject of an email sent to users when their application is waitlisted because there are no more accounts available. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/waitlist_notification-subject.html:4
 msgid "Your Wikipedia Library application has been waitlisted"
-msgstr ""
-"Solicitarea dvs. pentru Biblioteca Wikipedia a fost trecută pe lista de "
-"așteptare"
+msgstr "Solicitarea dvs. pentru Biblioteca Wikipedia a fost trecută pe lista de așteptare"
 
 #. Translators: Shown to users when they successfully submit a new message using the contact us form.
 #: TWLight/emails/views.py:51
@@ -1618,22 +1301,15 @@ msgstr "Nu Este Disponibil"
 #: TWLight/resources/templates/resources/filter_section.html:14
 #: TWLight/templates/about.html:12
 #: TWLight/users/templates/users/filter_section.html:13
-msgid ""
-"The Wikipedia Library allows active editors to access a wide range of "
-"collections of paywalled reliable sources for free!"
-msgstr ""
-"Biblioteca Wikipedia permite editorilor activi să acceseze gratuit o gamă "
-"largă de colecții de surse de încredere cu plată!"
+msgid "The Wikipedia Library allows active editors to access a wide range of collections of paywalled reliable sources for free!"
+msgstr "Biblioteca Wikipedia permite editorilor activi să acceseze gratuit o gamă largă de colecții de surse de încredere cu plată!"
 
 #. Translators: On the Browse Partners page (https://wikipedialibrary.wmflabs.org/partners/), this introduces users to The Wikipedia Library.
 #. Translators: On the MyLibrary page (https://wikipedialibrary.wmflabs.org/users/my_library), this introduces users to The Wikipedia Library.
 #: TWLight/resources/templates/resources/filter_section.html:17
 #: TWLight/users/templates/users/filter_section.html:15
-msgid ""
-"Start with the search bar at the top or browse publisher websites directly."
-msgstr ""
-"Începeți cu bara de căutare din partea de sus sau răsfoiți direct site-urile "
-"web ale editorilor."
+msgid "Start with the search bar at the top or browse publisher websites directly."
+msgstr "Începeți cu bara de căutare din partea de sus sau răsfoiți direct site-urile web ale editorilor."
 
 #. Translators: On the Browse Partners page (https://wikipedialibrary.wmflabs.org/partners/), this appears below introductory text and links to the 'About' page (https://wikipedialibrary.wmflabs.org/about/)
 #. Translators: On the MyLibrary page (https://wikipedialibrary.wmflabs.org/users/my_library), this appears below introductory text and links to the 'About' page (https://wikipedialibrary.wmflabs.org/about/)
@@ -1706,68 +1382,39 @@ msgstr "Înapoi la parteneri"
 #. Translators: If we have no available accounts for a partner, the coordinator can change the application system to a waiting list.
 #: TWLight/resources/templates/resources/partner_detail.html:36
 #: TWLight/resources/templates/resources/partner_detail_apply.html:17
-msgid ""
-"There are no access grants available for this partner at this time. You can "
-"still apply for access; applications will be processed when access is "
-"available."
-msgstr ""
-"Nu există permisiuni de acces disponibile pentru acest partener în acest "
-"moment. Puteți să solicitați în continuare acces; cererile vor fi procesate "
-"atunci când accesul va fi disponibil."
+msgid "There are no access grants available for this partner at this time. You can still apply for access; applications will be processed when access is available."
+msgstr "Nu există permisiuni de acces disponibile pentru acest partener în acest moment. Puteți să solicitați în continuare acces; cererile vor fi procesate atunci când accesul va fi disponibil."
 
 #. Translators: This text links to the minimum user requirements and terms of use on the partner page.
 #: TWLight/resources/templates/resources/partner_detail.html:48
 #: TWLight/resources/templates/resources/partner_detail_apply.html:29
 #, python-format
-msgid ""
-"Before applying, please review the <strong><a class=\"twl-links\" href="
-"\"%(about)s#req\">minimum requirements</a></strong> for access and our "
-"<strong><a class=\"twl-links\" href=\"%(terms)s\">terms of use</a></strong>."
-msgstr ""
-"Înainte de a aplica, consultați <strong><a class=\"twl-links\" href="
-"\"%(about)s#req\">cerințele minime</a></strong> pentru acces și <strong><a "
-"class=\"twl-links\" href=\"%(terms)s\">termenii de utilizare</a></strong>."
+msgid "Before applying, please review the <strong><a class=\"twl-links\" href=\"%(about)s#req\">minimum requirements</a></strong> for access and our <strong><a class=\"twl-links\" href=\"%(terms)s\">terms of use</a></strong>."
+msgstr "Înainte de a aplica, consultați <strong><a class=\"twl-links\" href=\"%(about)s#req\">cerințele minime</a></strong> pentru acces și <strong><a class=\"twl-links\" href=\"%(terms)s\">termenii de utilizare</a></strong>."
 
 #. Translators: This text refers to the page containing the content a user is authorized to access.
 #: TWLight/resources/templates/resources/partner_detail.html:69
 #, python-format
-msgid ""
-"View the status of your access in <strong><a class=\"twl-links\" href="
-"\"%(library_url)s\">My Library</a></strong> page."
-msgstr ""
-"Vizualizați starea accesului (acceselor) dvs. în pagina <strong><a class="
-"\"twl-links\" href=\"%(library_url)s\">Biblioteca mea</a></strong>."
+msgid "View the status of your access in <strong><a class=\"twl-links\" href=\"%(library_url)s\">My Library</a></strong> page."
+msgstr "Vizualizați starea accesului (acceselor) dvs. în pagina <strong><a class=\"twl-links\" href=\"%(library_url)s\">Biblioteca mea</a></strong>."
 
 #. Translators: This message is shown when a user has open applications, linking to their respective applications page.
 #: TWLight/resources/templates/resources/partner_detail.html:78
 #, python-format
-msgid ""
-"View the status of your application(s) on your <strong><a class=\"twl-links"
-"\" href=\"%(applications_url)s\">My Applications</a></strong> page."
-msgstr ""
-"Vizualizați starea solicitării (solicitărilor) dvs. în pagina <strong><a "
-"class=\"twl-links\" href=\"%(applications_url)s\">Solicitarea mea</a></"
-"strong>."
+msgid "View the status of your application(s) on your <strong><a class=\"twl-links\" href=\"%(applications_url)s\">My Applications</a></strong> page."
+msgstr "Vizualizați starea solicitării (solicitărilor) dvs. în pagina <strong><a class=\"twl-links\" href=\"%(applications_url)s\">Solicitarea mea</a></strong>."
 
 #. Translators: This message is shown when a user has authorizations, linking to their respective collections page.
 #: TWLight/resources/templates/resources/partner_detail_apply.html:50
 #, python-format
-msgid ""
-"View the status of your access on your <strong><a href=\"%(library_url)s\" "
-"class=\"twl-links\">My Library</a></strong> page."
-msgstr ""
-"Vedeți starea accesului dvs. pe pagina <strong><a href=\"%(library_url)s\" "
-"class=\"twl-links\">Biblioteca mea</a></strong> page."
+msgid "View the status of your access on your <strong><a href=\"%(library_url)s\" class=\"twl-links\">My Library</a></strong> page."
+msgstr "Vedeți starea accesului dvs. pe pagina <strong><a href=\"%(library_url)s\" class=\"twl-links\">Biblioteca mea</a></strong> page."
 
 #. Translators: This message is shown when a user has open applications, linking to their respective applications page.
 #: TWLight/resources/templates/resources/partner_detail_apply.html:60
 #, python-format
-msgid ""
-"View the status of your application(s) on your <strong><a href="
-"\"%(applications_url)s\">My Applications</a></strong> page."
-msgstr ""
-"Vizualizați starea solicitării (solicitărilor) dvs. în pagina <strong><a "
-"href=\"%(applications_url)s\">Solicitarea mea</a></strong>."
+msgid "View the status of your application(s) on your <strong><a href=\"%(applications_url)s\">My Applications</a></strong> page."
+msgstr "Vizualizați starea solicitării (solicitărilor) dvs. în pagina <strong><a href=\"%(applications_url)s\">Solicitarea mea</a></strong>."
 
 #. Translators: One the partner detail page, this text labels the button which coordinators can click to remove a partner from waitlisted status.
 #: TWLight/resources/templates/resources/partner_detail_apply.html:73
@@ -1782,8 +1429,7 @@ msgstr "Setează pe lista de așteptare"
 #: TWLight/resources/templates/resources/partner_detail_apply.html:86
 #, python-format
 msgid "<strong>%(coordinator)s</strong> processes applications to %(partner)s."
-msgstr ""
-"<strong>%(coordinator)s</strong> procesează aplicațiile pentru %(partner)s."
+msgstr "<strong>%(coordinator)s</strong> procesează aplicațiile pentru %(partner)s."
 
 #. Translators: When a coordinator is assigned to a partner, their details are shown on the page. This text labels a link to their Talk page on Wikipedia, and should be translated to the text used for Talk pages in the language you are translating to.
 #: TWLight/resources/templates/resources/partner_detail_apply.html:95
@@ -1797,14 +1443,8 @@ msgstr "Pagina Special:EmailUser"
 
 #. Translators: If no account coordinator is assigned to a partner, the Wikipedia Library team will coordinate signups. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/resources/templates/resources/partner_detail_apply.html:112
-msgid ""
-"The Wikipedia Library team will process this application. Want to help? <a "
-"class=\"twl-links\" href=\"https://en.wikipedia.org/wiki/Wikipedia:"
-"The_Wikipedia_Library/Coordinators/Signup\">Sign up as a coordinator.</a>"
-msgstr ""
-"Echipa Bibliotecii Wikipedia va prelucra această solicitare. Vrei să ajuți? "
-"<a class=\"twl-links\" href=\"https://en.wikipedia.org/wiki/Wikipedia:"
-"The_Wikipedia_Library/Coordinators/Signup\">Înscrie-te ca coordonator.</a>"
+msgid "The Wikipedia Library team will process this application. Want to help? <a class=\"twl-links\" href=\"https://en.wikipedia.org/wiki/Wikipedia:The_Wikipedia_Library/Coordinators/Signup\">Sign up as a coordinator.</a>"
+msgstr "Echipa Bibliotecii Wikipedia va prelucra această solicitare. Vrei să ajuți? <a class=\"twl-links\" href=\"https://en.wikipedia.org/wiki/Wikipedia:The_Wikipedia_Library/Coordinators/Signup\">Înscrie-te ca coordonator.</a>"
 
 #. Translators: This text labels a button coordinators can click to view a list of users who have applied for access for a particular partner
 #: TWLight/resources/templates/resources/partner_detail_apply.html:121
@@ -1833,24 +1473,14 @@ msgstr "Acces pachet bibliotecă"
 
 #. Translators: Text shown to authenticated, bundle eligible users when they visit a Bundle partner page.
 #: TWLight/resources/templates/resources/partner_detail_apply.html:138
-msgid ""
-"You are eligible to access Library Bundle partners. Click the button above "
-"to access the collection."
-msgstr ""
-"Sunteți eligibil pentru a accesa partenerii Bundle Library. Faceți click pe "
-"butonul de mai sus pentru a accesa colecția."
+msgid "You are eligible to access Library Bundle partners. Click the button above to access the collection."
+msgstr "Sunteți eligibil pentru a accesa partenerii Bundle Library. Faceți click pe butonul de mai sus pentru a accesa colecția."
 
 #. Translators: Text shown to authenticated, bundle ineligible users when they visit a Bundle partner page.
 #: TWLight/resources/templates/resources/partner_detail_apply.html:152
 #, python-format
-msgid ""
-"You are not eligible to access Library Bundle partners. Visit the <a class="
-"\"twl-links\" href=\"%(homepage)s\">homepage</a> to check the eligibility "
-"criteria."
-msgstr ""
-"Nu sunteți eligibil pentru a accesa partenerii Bundle Library. Accesați <a "
-"class=\"twl-links\" href=\"%(homepage)s\">pagina principală</a> pentru a "
-"verifica criteriile de eligibilitate."
+msgid "You are not eligible to access Library Bundle partners. Visit the <a class=\"twl-links\" href=\"%(homepage)s\">homepage</a> to check the eligibility criteria."
+msgstr "Nu sunteți eligibil pentru a accesa partenerii Bundle Library. Accesați <a class=\"twl-links\" href=\"%(homepage)s\">pagina principală</a> pentru a verifica criteriile de eligibilitate."
 
 #. Translators: Buttton prompting users to log in.
 #: TWLight/resources/templates/resources/partner_detail_apply.html:160
@@ -1861,15 +1491,8 @@ msgstr "Autentificare"
 #. Translators: Text shown to unauthenticated users when they visit a Bundle partner page.
 #: TWLight/resources/templates/resources/partner_detail_apply.html:168
 #, python-format
-msgid ""
-"This resource is part of our <a class=\"twl-links\" href=\"%(about)s"
-"\">Library Bundle</a>, which you can access if you meet our minimum "
-"eligibility criteria. Log in to find out if you are eligible."
-msgstr ""
-"Această resursă face parte din <a class=\"twl-links\" href=\"%(about)s"
-"\">Library Bundle</a>, pe care îl puteți accesa dacă îndepliniți criteriile "
-"noastre minime de eligibilitate. Conectați-vă pentru a afla dacă sunteți "
-"eligibil."
+msgid "This resource is part of our <a class=\"twl-links\" href=\"%(about)s\">Library Bundle</a>, which you can access if you meet our minimum eligibility criteria. Log in to find out if you are eligible."
+msgstr "Această resursă face parte din <a class=\"twl-links\" href=\"%(about)s\">Library Bundle</a>, pe care îl puteți accesa dacă îndepliniți criteriile noastre minime de eligibilitate. Conectați-vă pentru a afla dacă sunteți eligibil."
 
 #. Translators: This is the label for a number which shows the total active accounts for one partner. (e.g. https://wikipedialibrary.wmflabs.org/partners/8/).
 #: TWLight/resources/templates/resources/partner_detail_stats.html:21
@@ -1919,34 +1542,20 @@ msgstr "Limita extrasului"
 #. Translators: If a partner has specified the excerpt limit both in words and percentage, this message will display the percentage of words and the number of words on the partner page.
 #: TWLight/resources/templates/resources/partner_detail_timeline.html:99
 #, python-format
-msgid ""
-"%(object)s allows a maximum of %(excerpt_limit)s words or "
-"%(excerpt_limit_percentage)s%% of an article be excerpted into a Wikipedia "
-"article."
-msgstr ""
-"%(object)s permite maximum %(excerpt_limit)s de cuvinte sau "
-"%(excerpt_limit_percentage)s%% dintr-un articol să fie extras într-un "
-"articol Wikipedia."
+msgid "%(object)s allows a maximum of %(excerpt_limit)s words or %(excerpt_limit_percentage)s%% of an article be excerpted into a Wikipedia article."
+msgstr "%(object)s permite maximum %(excerpt_limit)s de cuvinte sau %(excerpt_limit_percentage)s%% dintr-un articol să fie extras într-un articol Wikipedia."
 
 #. Translators: If a partner has specified the excerpt limit in words, this message will display the number of words on the partner page.
 #: TWLight/resources/templates/resources/partner_detail_timeline.html:106
 #, python-format
-msgid ""
-"%(object)s allows a maximum of %(excerpt_limit)s words be excerpted into a "
-"Wikipedia article."
-msgstr ""
-"%(object)s permite extragerea unui număr maxim de %(excerpt_limit)s cuvinte "
-"într-un articol Wikipedia."
+msgid "%(object)s allows a maximum of %(excerpt_limit)s words be excerpted into a Wikipedia article."
+msgstr "%(object)s permite extragerea unui număr maxim de %(excerpt_limit)s cuvinte într-un articol Wikipedia."
 
 #. Translators: If a partner has specified the excerpt limit in percentage, this message will display the percentage of words on the partner page.
 #: TWLight/resources/templates/resources/partner_detail_timeline.html:113
 #, python-format
-msgid ""
-"%(object)s allows a maximum of %(excerpt_limit_percentage)s%% of an article "
-"be excerpted into a Wikipedia article."
-msgstr ""
-"%(object)s permite ca un maxim de %(excerpt_limit_percentage)s%% dintr-un "
-"articol să fie extras într-un articol Wikipedia."
+msgid "%(object)s allows a maximum of %(excerpt_limit_percentage)s%% of an article be excerpted into a Wikipedia article."
+msgstr "%(object)s permite ca un maxim de %(excerpt_limit_percentage)s%% dintr-un articol să fie extras într-un articol Wikipedia."
 
 #. Translators: If a partner has other requirements for access, this text shows as the title for that information field. (e.g. https://wikipedialibrary.wmflabs.org/partners/10/).
 #: TWLight/resources/templates/resources/partner_detail_timeline.html:132
@@ -1956,12 +1565,8 @@ msgstr "Cerințe speciale pentru solicitanți"
 #. Translators: If a user must agree to a Terms of Use document, they see this message, and must enter the name of the resource. Don't translate publisher or url.
 #: TWLight/resources/templates/resources/partner_detail_timeline.html:140
 #, python-format
-msgid ""
-"%(publisher)s requires that you agree with its <a href=\"%(url)s\">terms of "
-"use</a>."
-msgstr ""
-"%(publisher)s solicită să fiți de acord cu <a href=\"%(url)s\">termenii de "
-"utilizare</a>."
+msgid "%(publisher)s requires that you agree with its <a href=\"%(url)s\">terms of use</a>."
+msgstr "%(publisher)s solicită să fiți de acord cu <a href=\"%(url)s\">termenii de utilizare</a>."
 
 #. Translators: If a user must provide their real name to apply to a partner, they see this message, and must enter the name of the resource. Don't translate publisher.
 #: TWLight/resources/templates/resources/partner_detail_timeline.html:150
@@ -1984,22 +1589,14 @@ msgstr "%(publisher)s impune să vă oferiți afilierea instituțională."
 #. Translators: If a user must select a specific resource to apply for, they see this message, and must enter the name of the resource. Don't translate publisher.
 #: TWLight/resources/templates/resources/partner_detail_timeline.html:177
 #, python-format
-msgid ""
-"%(publisher)s requires that you specify a particular title that you want to "
-"access."
-msgstr ""
-"%(publisher)s necesită să specificați un anumit titlu pe care doriți să "
-"accesați."
+msgid "%(publisher)s requires that you specify a particular title that you want to access."
+msgstr "%(publisher)s necesită să specificați un anumit titlu pe care doriți să accesați."
 
 #. Translators: If a user must register on the partner website before applying, they see this message. Don't translate partner.
 #: TWLight/resources/templates/resources/partner_detail_timeline.html:187
 #, python-format
-msgid ""
-"%(publisher)s requires that you sign up for an account before applying for "
-"access."
-msgstr ""
-"%(publisher)s necesită să vă înscrieți pentru un cont înainte de a solicita "
-"accesul."
+msgid "%(publisher)s requires that you sign up for an account before applying for access."
+msgstr "%(publisher)s necesită să vă înscrieți pentru un cont înainte de a solicita accesul."
 
 #. Translators: If a partner has their location listed, this message is a label for that location
 #: TWLight/resources/templates/resources/partner_detail_timeline.html:206
@@ -2125,12 +1722,8 @@ msgstr "Sunteți sigur că vreți să ștergeți <b>%(object)s</b>?"
 
 #. Translators: If multiple authorizations where returned for a collection, this message is shown to a user
 #: TWLight/resources/views.py:268
-msgid ""
-"Multiple authorizations were returned – something's wrong. Please contact us "
-"and don't forget to mention this message."
-msgstr ""
-"Au fost returnate mai multe autorizații - ceva nu este în regulă. Vă rugăm "
-"să ne contactați și nu uitați să menționați acest mesaj."
+msgid "Multiple authorizations were returned – something's wrong. Please contact us and don't forget to mention this message."
+msgstr "Au fost returnate mai multe autorizații - ceva nu este în regulă. Vă rugăm să ne contactați și nu uitați să menționați acest mesaj."
 
 #. Translators: This message is shown when user tries to access a NOT_AVAILABLE Partner
 #: TWLight/resources/views.py:316
@@ -2170,23 +1763,8 @@ msgstr "Ne pare rău; nu știm ce să facem cu asta."
 #. Translators: Shown on the website's 400 page, when a user sends a bad request. Don't translate path or Phabricator.
 #: TWLight/templates/400.html:20
 #, python-format
-msgid ""
-"If you think we should know what to do with that, please email us about this "
-"error at <a class=\"twl-links\" href=\"mailto:wikipedialibrary@wikimedia.org?"
-"Subject=Wikipedia%%20Library%%20%(path)s%%20Permission%%20denied"
-"\">wikipedialibrary@wikimedia.org</a> or report it to us on <a class=\"twl-"
-"links\" href=\"https://phabricator.wikimedia.org/maniphest/task/edit/form/1/?"
-"projectPHIDs=Library-Card-Platform&title=Wikipedia%%20Library%%20%(path)s"
-"%%20Bad%%20Request\">Phabricator</a>"
-msgstr ""
-"Dacă credeți că ar trebui să știm ce să facem cu asta, vă rugăm să ne "
-"trimiteți un e-mail despre această eroare la <a class=\"twl-links\" href="
-"\"mailto:wikipedialibrary@wikimedia.org?Subject=Wikipedia%%20Library"
-"%%20%(path)s%%20Permission%%20denied\">wikipedialibrary@wikimedia.org</a> "
-"sau raportați-ne la <a class=\"twl-links\" href=\"https://phabricator."
-"wikimedia.org/maniphest/task/edit/form/1/?projectPHIDs=Library-Card-"
-"Platform&title=Wikipedia%%20Library%%20%(path)s%%20Bad%%20Request"
-"\">Phabricator</a>"
+msgid "If you think we should know what to do with that, please email us about this error at <a class=\"twl-links\" href=\"mailto:wikipedialibrary@wikimedia.org?Subject=Wikipedia%%20Library%%20%(path)s%%20Permission%%20denied\">wikipedialibrary@wikimedia.org</a> or report it to us on <a class=\"twl-links\" href=\"https://phabricator.wikimedia.org/maniphest/task/edit/form/1/?projectPHIDs=Library-Card-Platform&title=Wikipedia%%20Library%%20%(path)s%%20Bad%%20Request\">Phabricator</a>"
+msgstr "Dacă credeți că ar trebui să știm ce să facem cu asta, vă rugăm să ne trimiteți un e-mail despre această eroare la <a class=\"twl-links\" href=\"mailto:wikipedialibrary@wikimedia.org?Subject=Wikipedia%%20Library%%20%(path)s%%20Permission%%20denied\">wikipedialibrary@wikimedia.org</a> sau raportați-ne la <a class=\"twl-links\" href=\"https://phabricator.wikimedia.org/maniphest/task/edit/form/1/?projectPHIDs=Library-Card-Platform&title=Wikipedia%%20Library%%20%(path)s%%20Bad%%20Request\">Phabricator</a>"
 
 #. Translators: Alt text for an image shown on the 400 error page.
 #. Translators: Alt text for an image shown on the 403 error page.
@@ -2207,24 +1785,8 @@ msgstr "Ne pare rău; nu ai voie să faci asta."
 #. Translators: Shown on the website's 403 page, when a user attempts to navigate to a page they don't have permission to view. Don't translate path or Phabricator.
 #: TWLight/templates/403.html:20
 #, python-format
-msgid ""
-"If you think your account should be able to do that, please email us about "
-"this error at <a class=\"twl-links\" href=\"mailto:"
-"wikipedialibrary@wikimedia.org?Subject=Wikipedia%%20Library%%20%(path)s"
-"%%20Permission%%20denied\">wikipedialibrary@wikimedia.org</a> or report it "
-"to us on <a class=\"twl-links\" href=\"https://phabricator.wikimedia.org/"
-"maniphest/task/edit/form/1/?projectPHIDs=Library-Card-"
-"Platform&title=Wikipedia%%20Library%%20%(path)s%%20Permission%%20denied"
-"\">Phabricator</a>"
-msgstr ""
-"Dacă credeți că contul dvs. ar trebui să poată face asta, vă rugăm să ne "
-"trimiteți un e-mail despre această eroare la <a class=\"twl-links\" href="
-"\"mailto:wikipedialibrary@wikimedia.org?Subject=Wikipedia%%20Library"
-"%%20%(path)s%%20Permission%%20denied\">wikipedialibrary@wikimedia.org</a> "
-"sau raportați-ne la <a class=\"twl-links\" href=\"https://phabricator."
-"wikimedia.org/maniphest/task/edit/form/1/?projectPHIDs=Library-Card-"
-"Platform&title=Wikipedia%%20Library%%20%(path)s%%20Permission%%20denied"
-"\">Phabricator</a>"
+msgid "If you think your account should be able to do that, please email us about this error at <a class=\"twl-links\" href=\"mailto:wikipedialibrary@wikimedia.org?Subject=Wikipedia%%20Library%%20%(path)s%%20Permission%%20denied\">wikipedialibrary@wikimedia.org</a> or report it to us on <a class=\"twl-links\" href=\"https://phabricator.wikimedia.org/maniphest/task/edit/form/1/?projectPHIDs=Library-Card-Platform&title=Wikipedia%%20Library%%20%(path)s%%20Permission%%20denied\">Phabricator</a>"
+msgstr "Dacă credeți că contul dvs. ar trebui să poată face asta, vă rugăm să ne trimiteți un e-mail despre această eroare la <a class=\"twl-links\" href=\"mailto:wikipedialibrary@wikimedia.org?Subject=Wikipedia%%20Library%%20%(path)s%%20Permission%%20denied\">wikipedialibrary@wikimedia.org</a> sau raportați-ne la <a class=\"twl-links\" href=\"https://phabricator.wikimedia.org/maniphest/task/edit/form/1/?projectPHIDs=Library-Card-Platform&title=Wikipedia%%20Library%%20%(path)s%%20Permission%%20denied\">Phabricator</a>"
 
 #. Translators: Shown on the website's 404 page, when a user attempts to navigate to a page that doesn't exist.
 #: TWLight/templates/404.html:11
@@ -2239,22 +1801,8 @@ msgstr "Ne pare rău; nu putem găsi asta."
 #. Translators: Shown on the website's 404 page, when a user attempts to navigate to a page that doesn't exist. Don't translate path or Phabricator.
 #: TWLight/templates/404.html:19
 #, python-format
-msgid ""
-"If you are certain that something should be here, please email us about this "
-"error at <a class=\"twl-links\" href=\"mailto:wikipedialibrary@wikimedia.org?"
-"Subject=Wikipedia%%20Library%%20%(path)s%%20Not%%20found\"> "
-"wikipedialibrary@wikimedia.org</a> or report it to us on <a class=\"twl-links"
-"\" href=\"https://phabricator.wikimedia.org/maniphest/task/edit/form/1/?"
-"projectPHIDs=Library-Card-Platform&title=Wikipedia%%20Library%%20%(path)s"
-"%%20Not%%20found\">Phabricator</a>"
-msgstr ""
-"Dacă sunteți sigur că ceva ar trebui să fie aici, vă rugăm să ne trimiteți "
-"un e-mail despre această eroare la <a class=\"twl-links\" href=\"mailto:"
-"wikipedialibrary@wikimedia.org?Subject=Wikipedia%%20Library%%20%(path)s"
-"%%20Not%%20found\"> wikipedialibrary@wikimedia.org</a> sau raportați-ne la "
-"<a class=\"twl-links\" href=\"https://phabricator.wikimedia.org/maniphest/"
-"task/edit/form/1/?projectPHIDs=Library-Card-Platform&title=Wikipedia"
-"%%20Library%%20%(path)s%%20Not%%20found\">Phabricator</a>"
+msgid "If you are certain that something should be here, please email us about this error at <a class=\"twl-links\" href=\"mailto:wikipedialibrary@wikimedia.org?Subject=Wikipedia%%20Library%%20%(path)s%%20Not%%20found\"> wikipedialibrary@wikimedia.org</a> or report it to us on <a class=\"twl-links\" href=\"https://phabricator.wikimedia.org/maniphest/task/edit/form/1/?projectPHIDs=Library-Card-Platform&title=Wikipedia%%20Library%%20%(path)s%%20Not%%20found\">Phabricator</a>"
+msgstr "Dacă sunteți sigur că ceva ar trebui să fie aici, vă rugăm să ne trimiteți un e-mail despre această eroare la <a class=\"twl-links\" href=\"mailto:wikipedialibrary@wikimedia.org?Subject=Wikipedia%%20Library%%20%(path)s%%20Not%%20found\"> wikipedialibrary@wikimedia.org</a> sau raportați-ne la <a class=\"twl-links\" href=\"https://phabricator.wikimedia.org/maniphest/task/edit/form/1/?projectPHIDs=Library-Card-Platform&title=Wikipedia%%20Library%%20%(path)s%%20Not%%20found\">Phabricator</a>"
 
 #. Translators: Alt text for an image shown on the 404 error page.
 #: TWLight/templates/404.html:32
@@ -2268,49 +1816,19 @@ msgstr "Despre Biblioteca Wikipedia"
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:20
-msgid ""
-"This platform is our central tool for facilitating access to our available "
-"collections. Here you can see which partnerships are available, search their "
-"contents, and apply for and access the ones you’re interested in."
-msgstr ""
-"Această platformă este instrumentul nostru central pentru a facilita accesul "
-"la colecțiile noastre disponibile. Aici puteți vedea ce parteneriate sunt "
-"disponibile, puteți căuta conținutul acestora și puteți aplica și accesa "
-"cele care vă interesează."
+msgid "This platform is our central tool for facilitating access to our available collections. Here you can see which partnerships are available, search their contents, and apply for and access the ones you’re interested in."
+msgstr "Această platformă este instrumentul nostru central pentru a facilita accesul la colecțiile noastre disponibile. Aici puteți vedea ce parteneriate sunt disponibile, puteți căuta conținutul acestora și puteți aplica și accesa cele care vă interesează."
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/). Wikimedia Foundation should not be translated.
 #: TWLight/templates/about.html:29
-msgid ""
-"All users receive immediate access to some collections, which can be browsed "
-"by clicking the 'Access collection' buttons or using the search bar at the "
-"top of the page. Other collections require an application before access is "
-"granted, and may be accessed directly or via an individual login or access "
-"code. Volunteer coordinators, who have signed non-disclosure agreements with "
-"the Wikimedia Foundation, review these applications and work with publishers "
-"to get you your free access."
-msgstr ""
-"Toți utilizatorii primesc acces imediat la unele colecții, care pot fi "
-"răsfoite făcând clic pe butoanele 'Acces colecție' sau folosind bara de "
-"căutare din partea de sus a paginii. Alte colecții necesită o aplicație "
-"înainte de a se acorda accesul și pot fi accesate direct sau printr-un cod "
-"individual de conectare sau de acces. Coordonatorii voluntari, care au "
-"semnat acorduri de confidențialitate cu Fundația Wikimedia, examinează "
-"aceste aplicații și lucrează cu editorii pentru a vă obține accesul gratuit."
+msgid "All users receive immediate access to some collections, which can be browsed by clicking the 'Access collection' buttons or using the search bar at the top of the page. Other collections require an application before access is granted, and may be accessed directly or via an individual login or access code. Volunteer coordinators, who have signed non-disclosure agreements with the Wikimedia Foundation, review these applications and work with publishers to get you your free access."
+msgstr "Toți utilizatorii primesc acces imediat la unele colecții, care pot fi răsfoite făcând clic pe butoanele 'Acces colecție' sau folosind bara de căutare din partea de sus a paginii. Alte colecții necesită o aplicație înainte de a se acorda accesul și pot fi accesate direct sau printr-un cod individual de conectare sau de acces. Coordonatorii voluntari, care au semnat acorduri de confidențialitate cu Fundația Wikimedia, examinează aceste aplicații și lucrează cu editorii pentru a vă obține accesul gratuit."
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/). Don't translate terms_url.
 #: TWLight/templates/about.html:43
 #, python-format
-msgid ""
-"For more information about how your information is stored and reviewed "
-"please see our <a class=\"twl-links\" href=\"%(terms_url)s\"> terms of use "
-"and privacy policy</a>. Accounts you apply for are also subject to the Terms "
-"of Use provided by each partner’s platform; please review them."
-msgstr ""
-"Pentru mai multe informații despre modul în care informațiile dvs. sunt "
-"stocate și revizuite, consultați <a class=\"twl-links\" href=\"%(terms_url)s"
-"\"> termenii de utilizare și politica de confidențialitate </a>. Conturile "
-"pe care le solicitați sunt, de asemenea, supuse Termenilor de utilizare "
-"furnizați de platforma fiecărui partener; vă rugăm să le revizuiți."
+msgid "For more information about how your information is stored and reviewed please see our <a class=\"twl-links\" href=\"%(terms_url)s\"> terms of use and privacy policy</a>. Accounts you apply for are also subject to the Terms of Use provided by each partner’s platform; please review them."
+msgstr "Pentru mai multe informații despre modul în care informațiile dvs. sunt stocate și revizuite, consultați <a class=\"twl-links\" href=\"%(terms_url)s\"> termenii de utilizare și politica de confidențialitate </a>. Conturile pe care le solicitați sunt, de asemenea, supuse Termenilor de utilizare furnizați de platforma fiecărui partener; vă rugăm să le revizuiți."
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:51
@@ -2319,25 +1837,13 @@ msgstr "Cine poate primi acces?"
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/). Wikimedia Foundation should not be translated.
 #: TWLight/templates/about.html:55
-msgid ""
-"Any active editor in good standing can receive access. For publishers with "
-"limited numbers of accounts, applications are reviewed based on the editor’s "
-"needs and contributions. If you think you could use access to one of our "
-"partner resources and are an active editor in any project supported by the "
-"Wikimedia Foundation, please apply."
-msgstr ""
-"Orice editor activ în stare bună poate primi acces. Pentru editorii cu un "
-"număr limitat de conturi, cererile sunt examinate în funcție de nevoile și "
-"contribuțiile editorului. Dacă credeți că puteți utiliza accesul la una "
-"dintre resursele partenere și sunteți redactor activ în orice proiect "
-"susținut de Fundația Wikimedia, vă rugăm să aplicați."
+msgid "Any active editor in good standing can receive access. For publishers with limited numbers of accounts, applications are reviewed based on the editor’s needs and contributions. If you think you could use access to one of our partner resources and are an active editor in any project supported by the Wikimedia Foundation, please apply."
+msgstr "Orice editor activ în stare bună poate primi acces. Pentru editorii cu un număr limitat de conturi, cererile sunt examinate în funcție de nevoile și contribuțiile editorului. Dacă credeți că puteți utiliza accesul la una dintre resursele partenere și sunteți redactor activ în orice proiect susținut de Fundația Wikimedia, vă rugăm să aplicați."
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:65
 msgid "Any editor can use the library if they meet a few basic requirements:"
-msgstr ""
-"Orice editor poate folosi biblioteca dacă îndeplinește câteva cerințe de "
-"bază:"
+msgstr "Orice editor poate folosi biblioteca dacă îndeplinește câteva cerințe de bază:"
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:71
@@ -2352,8 +1858,7 @@ msgstr "Ați făcut minim 500 de editări proiectelor Wikimedia"
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:79
 msgid "You have made at least 10 edits to Wikimedia projects in the last month"
-msgstr ""
-"Ați făcut cel puțin 10 modificări în proiectele Wikimedia în ultima lună"
+msgstr "Ați făcut cel puțin 10 modificări în proiectele Wikimedia în ultima lună"
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:83
@@ -2362,36 +1867,13 @@ msgstr "În prezent, nu sunteți blocat să editați un proiect Wikimedia"
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/)
 #: TWLight/templates/about.html:89
-msgid ""
-"If you are applying for an available collection, please first check that you "
-"don't already have access through another library or institution. If you do, "
-"please consider using that access rather than taking up a seat for this "
-"resource in The Wikipedia Library."
-msgstr ""
-"Dacă aplicați pentru o colecție disponibilă, vă rugăm să verificați mai "
-"întâi că nu aveți deja acces printr-o altă bibliotecă sau instituție. Dacă o "
-"faceți, vă rugăm să luați în considerare utilizarea acestui acces în loc să "
-"vă ocupați de această resursă în Biblioteca Wikipedia."
+msgid "If you are applying for an available collection, please first check that you don't already have access through another library or institution. If you do, please consider using that access rather than taking up a seat for this resource in The Wikipedia Library."
+msgstr "Dacă aplicați pentru o colecție disponibilă, vă rugăm să verificați mai întâi că nu aveți deja acces printr-o altă bibliotecă sau instituție. Dacă o faceți, vă rugăm să luați în considerare utilizarea acestui acces în loc să vă ocupați de această resursă în Biblioteca Wikipedia."
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/)
 #: TWLight/templates/about.html:99
-msgid ""
-"If your account is blocked on one or more Wikimedia projects, you may still "
-"be granted access to The Wikipedia Library. You will need to contact the "
-"Wikipedia Library team, who will review your blocks. If you have been "
-"blocked for content issues, most notably copyright violations, or have "
-"multiple long-term blocks, we may decline your request. Additionally, if "
-"your block status changes after being approved, you will need to request "
-"another review."
-msgstr ""
-"Dacă contul dvs. este blocat pentru unul sau mai multe proiecte Wikimedia, "
-"este posibil să vi se acorde în continuare acces la Biblioteca Wikipedia. Va "
-"trebui să contactați echipa Bibliotecii Wikipedia, care vă va examina "
-"blocurile. Dacă ați fost blocat din cauza unor probleme de conținut, în "
-"special încălcări ale drepturilor de autor sau dacă aveți mai multe blocări "
-"pe termen lung, este posibil să vă refuzăm solicitarea. În plus, dacă starea "
-"de blocare se schimbă după aprobare, va trebui să solicitați o altă "
-"examinare."
+msgid "If your account is blocked on one or more Wikimedia projects, you may still be granted access to The Wikipedia Library. You will need to contact the Wikipedia Library team, who will review your blocks. If you have been blocked for content issues, most notably copyright violations, or have multiple long-term blocks, we may decline your request. Additionally, if your block status changes after being approved, you will need to request another review."
+msgstr "Dacă contul dvs. este blocat pentru unul sau mai multe proiecte Wikimedia, este posibil să vi se acorde în continuare acces la Biblioteca Wikipedia. Va trebui să contactați echipa Bibliotecii Wikipedia, care vă va examina blocurile. Dacă ați fost blocat din cauza unor probleme de conținut, în special încălcări ale drepturilor de autor sau dacă aveți mai multe blocări pe termen lung, este posibil să vă refuzăm solicitarea. În plus, dacă starea de blocare se schimbă după aprobare, va trebui să solicitați o altă examinare."
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:110
@@ -2425,12 +1907,8 @@ msgstr "Editorii aprobați <i>nu ar trebui să</i>:"
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:136
-msgid ""
-"Share their account logins or passwords with others, or sell their access to "
-"other parties"
-msgstr ""
-"Împărtășiți autentificările sau parolele contului cu alții sau să vindeți "
-"accesul altor părți"
+msgid "Share their account logins or passwords with others, or sell their access to other parties"
+msgstr "Împărtășiți autentificările sau parolele contului cu alții sau să vindeți accesul altor părți"
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:140
@@ -2439,30 +1917,18 @@ msgstr "Răzuire în masă sau descărcare în masă conținut partener"
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:144
-msgid ""
-"Systematically make printed or electronic copies of multiple extracts of "
-"restricted content available for any purpose"
-msgstr ""
-"Faceți sistematic copii tipărite sau electronice ale mai multor extracte de "
-"conținut restricționat pentru orice scop"
+msgid "Systematically make printed or electronic copies of multiple extracts of restricted content available for any purpose"
+msgstr "Faceți sistematic copii tipărite sau electronice ale mai multor extracte de conținut restricționat pentru orice scop"
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/). Stub is a technical term for a short Wikipedia article, use the appropriate Wikipedia term in your language.
 #: TWLight/templates/about.html:148
-msgid ""
-"Datamine metadata without permission, in order, for instance, to use "
-"metadata for auto-created stub articles"
-msgstr ""
-"Căutați metadate fără permisiune, de exemplu pentru crearea automată a "
-"articolelor de proiect"
+msgid "Datamine metadata without permission, in order, for instance, to use metadata for auto-created stub articles"
+msgstr "Căutați metadate fără permisiune, de exemplu pentru crearea automată a articolelor de proiect"
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:154
-msgid ""
-"Respecting these agreements allows us to continue growing the partnerships "
-"available to the community."
-msgstr ""
-"Respectarea acestor acorduri ne permite să continuăm creșterea "
-"parteneriatelor disponibile comunității."
+msgid "Respecting these agreements allows us to continue growing the partnerships available to the community."
+msgstr "Respectarea acestor acorduri ne permite să continuăm creșterea parteneriatelor disponibile comunității."
 
 #. Translators: This is the heading for a section on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:160
@@ -2471,64 +1937,23 @@ msgstr "EZProxy"
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:164
-msgid ""
-"EZProxy is a proxy server used to authenticate users for many Wikipedia "
-"Library partners. Users sign into EZProxy via the Library Card platform to "
-"verify that they are authorized users, and then the server accesses "
-"requested resources using its own IP address."
-msgstr ""
-"EZProxy este un server proxy utilizat pentru autentificarea utilizatorilor "
-"pentru mulți parteneri ai Bibliotecii Wikipedia. Utilizatorii se conectează "
-"la EZProxy prin intermediul Platformei Biblioteca Card pentru a verifica "
-"dacă sunt utilizatori autorizați, iar apoi serverul accesează resursele "
-"solicitate folosind propria sa adresă IP."
+msgid "EZProxy is a proxy server used to authenticate users for many Wikipedia Library partners. Users sign into EZProxy via the Library Card platform to verify that they are authorized users, and then the server accesses requested resources using its own IP address."
+msgstr "EZProxy este un server proxy utilizat pentru autentificarea utilizatorilor pentru mulți parteneri ai Bibliotecii Wikipedia. Utilizatorii se conectează la EZProxy prin intermediul Platformei Biblioteca Card pentru a verifica dacă sunt utilizatori autorizați, iar apoi serverul accesează resursele solicitate folosind propria sa adresă IP."
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:173
-msgid ""
-"You may notice that when accessing resources via EZProxy that URLs are "
-"dynamically rewritten. This is why we recommend logging in via the Library "
-"Card platform rather than going directly to the unproxied partner website. "
-"When in doubt, check the URL for ‘idm.oclc’. If it’s there, then you’re "
-"connected via EZProxy."
-msgstr ""
-"Puteți observa că atunci când accesați resurse prin EZProxy, URL-urile sunt "
-"rescrise dinamic. Acesta este motivul pentru care vă recomandăm să vă "
-"conectați prin intermediul platformei Library Card, mai degrabă decât să "
-"mergeți direct pe site-ul partenerului fără proxy. Când aveți îndoieli, "
-"verificați adresa URL pentru ‘idm.oclc’ Dacă este acolo, atunci sunteți "
-"conectat prin EZProxy."
+msgid "You may notice that when accessing resources via EZProxy that URLs are dynamically rewritten. This is why we recommend logging in via the Library Card platform rather than going directly to the unproxied partner website. When in doubt, check the URL for ‘idm.oclc’. If it’s there, then you’re connected via EZProxy."
+msgstr "Puteți observa că atunci când accesați resurse prin EZProxy, URL-urile sunt rescrise dinamic. Acesta este motivul pentru care vă recomandăm să vă conectați prin intermediul platformei Library Card, mai degrabă decât să mergeți direct pe site-ul partenerului fără proxy. Când aveți îndoieli, verificați adresa URL pentru ‘idm.oclc’ Dacă este acolo, atunci sunteți conectat prin EZProxy."
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:182
-msgid ""
-"Typically once you’ve logged in your session will remain active in your "
-"browser for up to two hours after you’ve finished searching. Note that use "
-"of EZProxy requires you to enable cookies. If you are having problems you "
-"should also try clearing your cache and restarting your browser."
-msgstr ""
-"În mod obișnuit, după ce v-ați autentificat în sesiune, va rămâne activ în "
-"browserul dvs. până la două ore după ce ați terminat căutarea. Rețineți că "
-"utilizarea EZProxy necesită activarea cookie-urilor. Dacă aveți probleme, "
-"trebuie să încercați, de asemenea, să vă ștergeți memoria cache și să "
-"reporniți browserul."
+msgid "Typically once you’ve logged in your session will remain active in your browser for up to two hours after you’ve finished searching. Note that use of EZProxy requires you to enable cookies. If you are having problems you should also try clearing your cache and restarting your browser."
+msgstr "În mod obișnuit, după ce v-ați autentificat în sesiune, va rămâne activ în browserul dvs. până la două ore după ce ați terminat căutarea. Rețineți că utilizarea EZProxy necesită activarea cookie-urilor. Dacă aveți probleme, trebuie să încercați, de asemenea, să vă ștergeți memoria cache și să reporniți browserul."
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/)
 #: TWLight/templates/about.html:193
-msgid ""
-"The Library Bundle is a collection of resources for which no application is "
-"required. If you meet the criteria laid out above, you will be authorized "
-"for access automatically upon logging in to the platform. Only some of our "
-"content is currently included in the Library Bundle, however we hope to "
-"expand the collection as more publishers become comfortable with "
-"participating. All Bundle content is accessed via EZProxy."
-msgstr ""
-"Library Bundle este o colecție de resurse pentru care nu este necesară nicio "
-"solicitare. Dacă îndepliniți criteriile expuse mai sus, veți fi autorizat "
-"pentru acces automat la conectarea la platformă. Doar o parte din conținutul "
-"nostru este inclus în prezent în Library Bundle, cu toate acestea sperăm să "
-"extindem colecția, deoarece mai mulți editori devin confortabili cu "
-"participarea. Tot conținutul pachetului este accesat prin EZProxy."
+msgid "The Library Bundle is a collection of resources for which no application is required. If you meet the criteria laid out above, you will be authorized for access automatically upon logging in to the platform. Only some of our content is currently included in the Library Bundle, however we hope to expand the collection as more publishers become comfortable with participating. All Bundle content is accessed via EZProxy."
+msgstr "Library Bundle este o colecție de resurse pentru care nu este necesară nicio solicitare. Dacă îndepliniți criteriile expuse mai sus, veți fi autorizat pentru acces automat la conectarea la platformă. Doar o parte din conținutul nostru este inclus în prezent în Library Bundle, cu toate acestea sperăm să extindem colecția, deoarece mai mulți editori devin confortabili cu participarea. Tot conținutul pachetului este accesat prin EZProxy."
 
 #. Translators: This is the heading for a section on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:202
@@ -2537,18 +1962,8 @@ msgstr "Practici de citare"
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:206
-msgid ""
-"Citation practices vary by project and even by article. Generally, we "
-"support editors citing where they found information, in a form that allows "
-"others to check it for themselves. That often means providing both original "
-"source details as well as a link to the partner database in which the source "
-"was found."
-msgstr ""
-"Practicile de citare variază în funcție de proiect și chiar de articol. În "
-"general, acceptăm editorii care menționează unde au găsit informații, într-"
-"un formular care permite altor persoane să le verifice de la sine. Acest "
-"lucru înseamnă adesea furnizarea atât a detaliilor sursei originale, cât și "
-"a unui link către baza de date parteneră în care s-a găsit sursa."
+msgid "Citation practices vary by project and even by article. Generally, we support editors citing where they found information, in a form that allows others to check it for themselves. That often means providing both original source details as well as a link to the partner database in which the source was found."
+msgstr "Practicile de citare variază în funcție de proiect și chiar de articol. În general, acceptăm editorii care menționează unde au găsit informații, într-un formular care permite altor persoane să le verifice de la sine. Acest lucru înseamnă adesea furnizarea atât a detaliilor sursei originale, cât și a unui link către baza de date parteneră în care s-a găsit sursa."
 
 #. Translators: This is the heading for a section on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #. Translators: This link is at the bottom of every page and can be clicked by users to contact the wikipedia library team.
@@ -2559,13 +1974,8 @@ msgstr "Contactează-ne"
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:218
 #, python-format
-msgid ""
-"If you have questions, need help, or want to volunteer to help, please see "
-"our <a class=\"twl-links\" href=\"%(contact_url)s\">contact page</a>."
-msgstr ""
-"Dacă aveți întrebări, aveți nevoie de ajutor sau doriți să vă oferiți "
-"voluntar, vă rugăm să consultați <a class=\"twl-links\" href="
-"\"%(contact_url)s\">pagina de contact </a>."
+msgid "If you have questions, need help, or want to volunteer to help, please see our <a class=\"twl-links\" href=\"%(contact_url)s\">contact page</a>."
+msgstr "Dacă aveți întrebări, aveți nevoie de ajutor sau doriți să vă oferiți voluntar, vă rugăm să consultați <a class=\"twl-links\" href=\"%(contact_url)s\">pagina de contact </a>."
 
 #. Translators: This is the title of the panel box detailing the contact information for the Wikipedia Library team.
 #: TWLight/templates/contact.html:14
@@ -2604,18 +2014,13 @@ msgstr "Pagina de Twitter a Bibliotecii Wikipedia"
 #. Translators: This is the text that appears at the bottom of the contact us form directing users to the suggestions form.
 #: TWLight/templates/contact.html:48
 #, python-format
-msgid ""
-"(If you would like to suggest a partner, <a class=\"twl-links\" href="
-"\"%(suggest)s\"><strong>go here</strong></a>.)"
-msgstr ""
-"(Dacă doriți să sugerați un partener, <a class=\"twl-links\" href="
-"\"%(suggest)s\"><strong>mergi aici</strong></a>.)"
+msgid "(If you would like to suggest a partner, <a class=\"twl-links\" href=\"%(suggest)s\"><strong>go here</strong></a>.)"
+msgstr "(Dacă doriți să sugerați un partener, <a class=\"twl-links\" href=\"%(suggest)s\"><strong>mergi aici</strong></a>.)"
 
 #. Translators: On a special 'link to search' page, this message is shown if JavaScript is disabled.
 #: TWLight/templates/eds_search_endpoint.html:7
 msgid "JavaScript is disabled; use the button below to continue."
-msgstr ""
-"JavaScript este dezactivat; utilizați butonul de mai jos pentru a continua."
+msgstr "JavaScript este dezactivat; utilizați butonul de mai jos pentru a continua."
 
 #. Translators: Alt text for the Wikipedia Library shown in the top left of all pages.
 #: TWLight/templates/header_partial_b4.html:14
@@ -2667,12 +2072,8 @@ msgstr "Biblioteca Wikipedia"
 #. Translators: Information about The Wikipedia Library.
 #: TWLight/templates/login_partial.html:53 TWLight/templates/new_base.html:21
 #, fuzzy, python-format
-msgid ""
-"More than 100 of the world's top subscription-only databases, with content "
-"in %(no_of_languages)s languages, free for Wikipedians of all backgrounds"
-msgstr ""
-"Peste 90 dintre cele mai bune baze de date din lume numai cu abonament, cu "
-"conținut în %(no_of_languages)s de limbi, gratuit pentru toți wikipediștii"
+msgid "More than 100 of the world's top subscription-only databases, with content in %(no_of_languages)s languages, free for Wikipedians of all backgrounds"
+msgstr "Peste 90 dintre cele mai bune baze de date din lume numai cu abonament, cu conținut în %(no_of_languages)s de limbi, gratuit pentru toți wikipediștii"
 
 #. Translators: Information about The Wikipedia Library.
 #: TWLight/templates/login_partial.html:64
@@ -2680,12 +2081,8 @@ msgid "Meet these criteria for automatic access"
 msgstr "Îndeplinește aceste criterii pentru acces automat"
 
 #: TWLight/templates/login_partial.html:69
-msgid ""
-"These criteria grant you access to certain collections but not all. Some "
-"collections are accessible on a per application basis only."
-msgstr ""
-"Aceste criterii vă oferă acces la anumite colecții, dar nu la toate. Unele "
-"colecții sunt accesibile numai pe bază de aplicație."
+msgid "These criteria grant you access to certain collections but not all. Some collections are accessible on a per application basis only."
+msgstr "Aceste criterii vă oferă acces la anumite colecții, dar nu la toate. Unele colecții sunt accesibile numai pe bază de aplicație."
 
 #: TWLight/templates/login_partial.html:89
 msgid "Login via Wikipedia"
@@ -2694,40 +2091,20 @@ msgstr "Conectați-vă cu contul dvs. Wikipedia"
 #. Translators: Shown if the current user doesn't have a registered email on their account. Don't translate contact_us_url or email_url.
 #: TWLight/templates/message_partial.html:15
 #, python-format
-msgid ""
-"You don't have an email on file. We can't finalize your access to partner "
-"resources, and you won't be able to <a class=\"twl-links\" href="
-"\"%(contact_us_url)s\">contact us</a> without an email. Please <a class="
-"\"twl-links\" href=\"%(email_url)s\">update your email</a>."
-msgstr ""
-"Nu aveți un e-mail în fișier. Nu vă putem finaliza accesul la resursele "
-"partenere și nu veți putea <a class=\"twl-links\" href=\"%(contact_us_url)s"
-"\">contactați-ne </a> fără un e-mail. Vă rugăm să <a class=\"twl-links\" "
-"href=\"%(email_url)s\"> actualizați e-mailul</a>."
+msgid "You don't have an email on file. We can't finalize your access to partner resources, and you won't be able to <a class=\"twl-links\" href=\"%(contact_us_url)s\">contact us</a> without an email. Please <a class=\"twl-links\" href=\"%(email_url)s\">update your email</a>."
+msgstr "Nu aveți un e-mail în fișier. Nu vă putem finaliza accesul la resursele partenere și nu veți putea <a class=\"twl-links\" href=\"%(contact_us_url)s\">contactați-ne </a> fără un e-mail. Vă rugăm să <a class=\"twl-links\" href=\"%(email_url)s\"> actualizați e-mailul</a>."
 
 #. Translators: Shown if the current user has requested the processing of their data should be restricted.
 #: TWLight/templates/message_partial.html:26
 #, python-format
-msgid ""
-"You have requested a restriction on the processing of your data. Most site "
-"functionality will not be available to you until you <a class=\"twl-links\" "
-"href=\"%(restrict_url)s\">lift this restriction</a>."
-msgstr ""
-"Ați solicitat o restricție cu privire la procesarea datelor dvs. Majoritatea "
-"funcționalității site-ului nu vă vor fi disponibile până când <a class=\"twl-"
-"links\" href=\"%(restrict_url)s\">ridicați această restricție</a>."
+msgid "You have requested a restriction on the processing of your data. Most site functionality will not be available to you until you <a class=\"twl-links\" href=\"%(restrict_url)s\">lift this restriction</a>."
+msgstr "Ați solicitat o restricție cu privire la procesarea datelor dvs. Majoritatea funcționalității site-ului nu vă vor fi disponibile până când <a class=\"twl-links\" href=\"%(restrict_url)s\">ridicați această restricție</a>."
 
 #. Translators: Shown if the current user has not agreed to the terms of use.
 #: TWLight/templates/message_partial.html:37
 #, python-format
-msgid ""
-"You have not agreed to the <a class=\"twl-links\" href=\"%(terms_url)s"
-"\">terms of use</a> of this site. Your applications will not be processed "
-"and you won't be able to apply or access resources you are approved for."
-msgstr ""
-"Nu ați acceptat <a class=\"twl-links\" href=\"%(terms_url)s\">termenii de "
-"utilizare</a> ale acestui site. Solicitările dvs. nu vor fi procesate și nu "
-"veți putea solicita sau accesa resurse pentru care sunteți aprobat."
+msgid "You have not agreed to the <a class=\"twl-links\" href=\"%(terms_url)s\">terms of use</a> of this site. Your applications will not be processed and you won't be able to apply or access resources you are approved for."
+msgstr "Nu ați acceptat <a class=\"twl-links\" href=\"%(terms_url)s\">termenii de utilizare</a> ale acestui site. Solicitările dvs. nu vor fi procesate și nu veți putea solicita sau accesa resurse pentru care sunteți aprobat."
 
 #. Translators: This link is at the bottom of every page and links to the 'About' page (https://wikipedialibrary.wmflabs.org/about/)
 #: TWLight/templates/new_base.html:107
@@ -2773,12 +2150,8 @@ msgstr "Resetează parola"
 
 #. Translators: If a user goes to reset their password, this message asks them to enter their email to do so.
 #: TWLight/templates/registration/password_reset_form.html:13
-msgid ""
-"Forgot your password? Enter your email address below, and we'll email "
-"instructions for setting a new one."
-msgstr ""
-"Ti-ai uitat parola? Introdu adresa de e-mail de mai jos și vom primi "
-"instrucțiuni de e-mail pentru setarea unei noi parole."
+msgid "Forgot your password? Enter your email address below, and we'll email instructions for setting a new one."
+msgstr "Ti-ai uitat parola? Introdu adresa de e-mail de mai jos și vom primi instrucțiuni de e-mail pentru setarea unei noi parole."
 
 #. Translators: This is the label for a button that users click to update their public information.
 #: TWLight/users/forms.py:36
@@ -2822,22 +2195,13 @@ msgstr "Sunt de acord cu termenii de utilizare"
 
 #. Translators: This text explains how to disagree to the site's terms of use and the restrictions that will come into effect when users disagree to the terms of use.
 #: TWLight/users/forms.py:185
-msgid ""
-"By unchecking this box and clicking “Update” you may explore the site, but "
-"you will not be able to apply for access to materials or evaluate "
-"applications unless you agree with the terms of use."
-msgstr ""
-"Debifând această casetă și făcând clic pe „Actualizare”, puteți explora site-"
-"ul, dar nu veți putea aplica pentru acces la materiale sau evalua aplicații "
-"decât dacă sunteți de acord cu termenii de utilizare."
+msgid "By unchecking this box and clicking “Update” you may explore the site, but you will not be able to apply for access to materials or evaluate applications unless you agree with the terms of use."
+msgstr "Debifând această casetă și făcând clic pe „Actualizare”, puteți explora site-ul, dar nu veți putea aplica pentru acces la materiale sau evalua aplicații decât dacă sunteți de acord cu termenii de utilizare."
 
 #. Translators: Users click this button to set their website email address to the one linked to their Wikipedia account.
 #: TWLight/users/forms.py:211
-msgid ""
-"Use my Wikipedia email address (will be updated the next time you login)."
-msgstr ""
-"Folosiți adresa mea de e-mail Wikipedia (va fi actualizată data următoare "
-"când vă conectați)."
+msgid "Use my Wikipedia email address (will be updated the next time you login)."
+msgstr "Folosiți adresa mea de e-mail Wikipedia (va fi actualizată data următoare când vă conectați)."
 
 #. Translators: This labels a button which users click to change their email.
 #: TWLight/users/forms.py:232
@@ -2847,26 +2211,13 @@ msgstr "Actualizați email"
 #. Translators: Shown if the current user tried to 'favorite' a partner they can't access. Do not translate '{partner}'
 #: TWLight/users/models.py:201
 #, python-brace-format
-msgid ""
-"Cannot add partner {partner} to your favorites because you don't have access "
-"to it"
-msgstr ""
-"Nu puteți adăuga partenerul {partner} la favorite deoarece nu aveți acces la "
-"acesta"
-
-#. Translators: Do not translate.
-#: TWLight/users/models.py:869
-#, fuzzy, python-brace-format
-#| msgid "Username"
-msgid "{wp_username}"
-msgstr "Nume de utilizator"
+msgid "Cannot add partner {partner} to your favorites because you don't have access to it"
+msgstr "Nu puteți adăuga partenerul {partner} la favorite deoarece nu aveți acces la acesta"
 
 #. Translators: This error message is shown when there's a problem with the authenticated login process.
 #: TWLight/users/oauth.py:243
 msgid "You tried to log in but presented an invalid access token."
-msgstr ""
-"Ați încercat să vă autentificați, dar ați prezentat un jeton de acces "
-"nevalid."
+msgstr "Ați încercat să vă autentificați, dar ați prezentat un jeton de acces nevalid."
 
 #. Translators: This message is shown when the OAuth login process fails because the request came from the wrong website. Don't translate {domain}.
 #: TWLight/users/oauth.py:298 TWLight/users/oauth.py:444
@@ -2877,18 +2228,12 @@ msgstr "{domain} nu este o gazdă permisă."
 #. Translators: This warning message is shown to users when OAuth handshaker can't be initiated.
 #: TWLight/users/oauth.py:364
 msgid "Handshaker not initiated, please try logging in again."
-msgstr ""
-"Strângere de mână nu a fost inițializată, vă rugăm să încercați să vă "
-"conectați din nou."
+msgstr "Strângere de mână nu a fost inițializată, vă rugăm să încercați să vă conectați din nou."
 
 #. Translators: this message is displayed to users that don't have accounts and clicked on a proxied link.
 #: TWLight/users/oauth.py:388
-msgid ""
-"To view this link you need to be an eligible library user. Please login to "
-"continue."
-msgstr ""
-"Pentru a vizualiza acest link, trebuie să fii un utilizator eligibil al "
-"bibliotecii. Vă rugăm să vă conectați pentru a continua."
+msgid "To view this link you need to be an eligible library user. Please login to continue."
+msgstr "Pentru a vizualiza acest link, trebuie să fii un utilizator eligibil al bibliotecii. Vă rugăm să vă conectați pentru a continua."
 
 #. Translators: This warning message is shown to users when the response received from Wikimedia OAuth servers is not a valid one.
 #: TWLight/users/oauth.py:430
@@ -2913,9 +2258,7 @@ msgstr "Fără cerere jeton."
 #. Translators: This message is shown when the OAuth login process fails.
 #: TWLight/users/oauth.py:498
 msgid "Access token generation failed, please try logging in again."
-msgstr ""
-"Generarea tokenului de acces a eșuat, vă rog încercați să vă conectați din "
-"nou."
+msgstr "Generarea tokenului de acces a eșuat, vă rog încercați să vă conectați din nou."
 
 #. Translators: This message is shown when more information is available on another page. Do not translate {issue}
 #: TWLight/users/oauth.py:507
@@ -2925,25 +2268,13 @@ msgstr "Consultați {issue} pentru mai multe informații"
 
 #. Translators: If the user tries to log in, but their account does not meet certain requirements, they cannot login.
 #: TWLight/users/oauth.py:528
-msgid ""
-"Your Wikipedia account does not meet the eligibility criteria in the terms "
-"of use, so your Wikipedia Library Card Platform account cannot be activated."
-msgstr ""
-"Contul dvs. Wikipedia nu îndeplinește criteriile de eligibilitate din "
-"termenii de utilizare, astfel încât contul dvs. Platforma de carte de "
-"Bibliotecă Wikipedia nu poate fi activat."
+msgid "Your Wikipedia account does not meet the eligibility criteria in the terms of use, so your Wikipedia Library Card Platform account cannot be activated."
+msgstr "Contul dvs. Wikipedia nu îndeplinește criteriile de eligibilitate din termenii de utilizare, astfel încât contul dvs. Platforma de carte de Bibliotecă Wikipedia nu poate fi activat."
 
 #. Translators: If the user tries to log in, but their account does not meet certain requirements, they cannot login.
 #: TWLight/users/oauth.py:536
-msgid ""
-"Your Wikipedia account no longer meets the eligibility criteria in the terms "
-"of use, so you cannot be logged in. If you think you should be able to log "
-"in, please email wikipedialibrary@wikimedia.org."
-msgstr ""
-"Contul dvs. Wikipedia nu mai îndeplinește criteriile de eligibilitate în "
-"termenii de utilizare, deci nu vă puteți autentifica. Dacă credeți că ar "
-"trebui să vă puteți autentifica, vă rugăm să trimiteți un e-mail la "
-"wikipedialibrary@wikimedia.org."
+msgid "Your Wikipedia account no longer meets the eligibility criteria in the terms of use, so you cannot be logged in. If you think you should be able to log in, please email wikipedialibrary@wikimedia.org."
+msgstr "Contul dvs. Wikipedia nu mai îndeplinește criteriile de eligibilitate în termenii de utilizare, deci nu vă puteți autentifica. Dacă credeți că ar trebui să vă puteți autentifica, vă rugăm să trimiteți un e-mail la wikipedialibrary@wikimedia.org."
 
 #. Translators: this message is displayed to users with brand new accounts.
 #: TWLight/users/oauth.py:549
@@ -2953,14 +2284,8 @@ msgstr "Bine ați venit! Vă rugăm să fiți de acord cu termenii de utilizare.
 #. Translators: This message is displayed on the confirmation page where users can return their access to partner collections.
 #: TWLight/users/templates/users/authorization_confirm_return.html:13
 #, python-format
-msgid ""
-"You will no longer be able to access <b>%(partner)s's</b> resources via the "
-"Library Card platform, but can request access again by clicking 'renew', if "
-"you change your mind. Are you sure you want to return your access?"
-msgstr ""
-"Nu veți mai putea accesa resursele <b>%(partner)s's</b> prin intermediul "
-"platformei Library Card, dar puteți solicita acces din nou făcând click pe "
-"'reînnoire', dacă vă răzgândiți. Sigur doriți să vă returnați accesul?"
+msgid "You will no longer be able to access <b>%(partner)s's</b> resources via the Library Card platform, but can request access again by clicking 'renew', if you change your mind. Are you sure you want to return your access?"
+msgstr "Nu veți mai putea accesa resursele <b>%(partner)s's</b> prin intermediul platformei Library Card, dar puteți solicita acces din nou făcând click pe 'reînnoire', dacă vă răzgândiți. Sigur doriți să vă returnați accesul?"
 
 #. Translators: On the MyLibrary page (https://wikipedialibrary.wmflabs.org/users/my_library), this tab shows all favorite collections a user has.
 #: TWLight/users/templates/users/collections_section.html:9
@@ -3029,14 +2354,8 @@ msgstr "Date editor"
 
 #. Translators: This is shown on editor profiles, in their profile page or on applications.
 #: TWLight/users/templates/users/editor_detail.html:59
-msgid ""
-"Information with an * was retrieved from Wikipedia directly. Other "
-"information was entered directly by users or site admins, in their preferred "
-"language."
-msgstr ""
-"Informațiile cu un * au fost preluate direct de pe Wikipedia. Alte "
-"informații au fost introduse direct de utilizatori sau administratorii site-"
-"ului, în limba lor preferată."
+msgid "Information with an * was retrieved from Wikipedia directly. Other information was entered directly by users or site admins, in their preferred language."
+msgstr "Informațiile cu un * au fost preluate direct de pe Wikipedia. Alte informații au fost introduse direct de utilizatori sau administratorii site-ului, în limba lor preferată."
 
 #. Translators: This distinguishes users who have been flagged as account coordinators. Don't translate username.
 #: TWLight/users/templates/users/editor_detail.html:71
@@ -3046,14 +2365,8 @@ msgstr "%(username)s are privilegii de coordonator pe acest site."
 
 #. Translators: This is shown on editor profiles, under the heading for Wikipedia editor data.
 #: TWLight/users/templates/users/editor_detail_data.html:5
-msgid ""
-"This information is updated automatically from your Wikimedia account each "
-"time you log in, except for the Contributions field, where you can describe "
-"your Wikimedia editing history."
-msgstr ""
-"Aceste informații sunt actualizate automat din contul dvs. Wikimedia de "
-"fiecare dată când vă conectați, cu excepția câmpului Contribuții, unde "
-"puteți descrie istoricul editării Wikimedia."
+msgid "This information is updated automatically from your Wikimedia account each time you log in, except for the Contributions field, where you can describe your Wikimedia editing history."
+msgstr "Aceste informații sunt actualizate automat din contul dvs. Wikimedia de fiecare dată când vă conectați, cu excepția câmpului Contribuții, unde puteți descrie istoricul editării Wikimedia."
 
 #. Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this labels the user's username.
 #: TWLight/users/templates/users/editor_detail_data.html:17
@@ -3082,22 +2395,14 @@ msgstr "Satisface termenii de utilizare?"
 
 #. Translators: when viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this question has a yes or no answer.
 #: TWLight/users/templates/users/editor_detail_data.html:57
-msgid ""
-"at their last login, did this user meet the criteria set forth in the terms "
-"of use?"
-msgstr ""
-"la ultima conectare, acest utilizator a îndeplinit criteriile stabilite în "
-"termenii de utilizare?"
+msgid "at their last login, did this user meet the criteria set forth in the terms of use?"
+msgstr "la ultima conectare, acest utilizator a îndeplinit criteriile stabilite în termenii de utilizare?"
 
 #. Translators: When viewing a user's profile in an application, this message shows if the software doesn't think that the user is eligible for access. Don't translate username.
 #: TWLight/users/templates/users/editor_detail_data.html:72
 #, python-format
-msgid ""
-"%(username)s may still be eligible for access grants at the coordinators' "
-"discretion."
-msgstr ""
-"%(username)s poate fi în continuare eligibil pentru permisiuni de acces la "
-"discreția coordonatorilor."
+msgid "%(username)s may still be eligible for access grants at the coordinators' discretion."
+msgstr "%(username)s poate fi în continuare eligibil pentru permisiuni de acces la discreția coordonatorilor."
 
 #. Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this is the heading for a Yes/No ToU question.
 #: TWLight/users/templates/users/editor_detail_data.html:83
@@ -3131,14 +2436,8 @@ msgstr ""
 #. Translators: This message is shown on a user's profile if their Wikimedia account is blocked on one or more projects. They may still be granted access to the Library Bundle, but need to contact Wikipedia Library staff to verify.
 #: TWLight/users/templates/users/editor_detail_data.html:137
 #, python-format
-msgid ""
-"It looks like you have an active block on your account. If you meet the "
-"other criteria you may still be permitted access to the library - please <a "
-"class=\"twl-links\" href=\"%(contact_url)s\">contact us</a>."
-msgstr ""
-"Se pare că aveți o blocare activă în cont. Dacă îndepliniți celelalte "
-"criterii, vi se poate permite accesul la Library Bundle - vă rugăm să <a "
-"class=\"twl-links\" href=\"%(contact_url)s\">contactați-ne</a>."
+msgid "It looks like you have an active block on your account. If you meet the other criteria you may still be permitted access to the library - please <a class=\"twl-links\" href=\"%(contact_url)s\">contact us</a>."
+msgstr "Se pare că aveți o blocare activă în cont. Dacă îndepliniți celelalte criterii, vi se poate permite accesul la Library Bundle - vă rugăm să <a class=\"twl-links\" href=\"%(contact_url)s\">contactați-ne</a>."
 
 #. Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this is the heading for a Yes/No program eligibility question.
 #: TWLight/users/templates/users/editor_detail_data.html:153
@@ -3147,14 +2446,8 @@ msgstr "Potrivit pentru Bundle?"
 
 #. Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this question has a Yes or No answer.
 #: TWLight/users/templates/users/editor_detail_data.html:156
-msgid ""
-"At their last login, did this user meet the criteria set forth in the "
-"Library Bundle? Note that satisfying terms of use is a prerequisite to "
-"bundle eligibility."
-msgstr ""
-"La ultima conectare, acest utilizator a îndeplinit criteriile stabilite în "
-"Library Bundle? Rețineți că condițiile de utilizare satisfăcătoare "
-"reprezintă o condiție prealabilă pentru eligibilitatea bundle."
+msgid "At their last login, did this user meet the criteria set forth in the Library Bundle? Note that satisfying terms of use is a prerequisite to bundle eligibility."
+msgstr "La ultima conectare, acest utilizator a îndeplinit criteriile stabilite în Library Bundle? Rețineți că condițiile de utilizare satisfăcătoare reprezintă o condiție prealabilă pentru eligibilitatea bundle."
 
 #. Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this is the heading for a Yes/No program eligibility question.
 #: TWLight/users/templates/users/editor_detail_data.html:177
@@ -3179,9 +2472,7 @@ msgstr "Număr recent de editare globală *"
 #. Translators: This text is shown next to a user's recent global edit count if less than 30 days has passed since they first logged in to the Library Card. In this case, we don't yet know if they're eligible.
 #: TWLight/users/templates/users/editor_detail_data.html:220
 msgid "Unknown (requires 30 days from initial user login)"
-msgstr ""
-"Necunoscut (necesită 30 de zile de la autentificarea inițială a "
-"utilizatorului)"
+msgstr "Necunoscut (necesită 30 de zile de la autentificarea inițială a utilizatorului)"
 
 #. Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this labels the date the user registered their Meta-wiki account or the date their account was merged by the SUL merge process. Don't remove the *
 #: TWLight/users/templates/users/editor_detail_data.html:232
@@ -3200,25 +2491,14 @@ msgstr "Date personale"
 
 #. Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this text is in the 'Personal data' section. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/users/templates/users/editor_detail_data.html:262
-msgid ""
-"The following information is visible only to you, site administrators, "
-"publishing partners (where required), and volunteer Wikipedia Library "
-"coordinators (who have signed a Non-Disclosure Agreement)."
-msgstr ""
-"Următoarele informații sunt vizibile numai dvs., administratorilor site-"
-"ului, partenerilor de publicare (acolo unde este necesar) și coordonatorilor "
-"voluntari ai Bibliotecii Wikipedia (care au semnat un Acord de non-"
-"divulgare)."
+msgid "The following information is visible only to you, site administrators, publishing partners (where required), and volunteer Wikipedia Library coordinators (who have signed a Non-Disclosure Agreement)."
+msgstr "Următoarele informații sunt vizibile numai dvs., administratorilor site-ului, partenerilor de publicare (acolo unde este necesar) și coordonatorilor voluntari ai Bibliotecii Wikipedia (care au semnat un Acord de non-divulgare)."
 
 #. Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this labels a button which users can click to update or remove their personal information. Don't translate update_url.
 #: TWLight/users/templates/users/editor_detail_data.html:272
 #, python-format
-msgid ""
-"You may <a class=\"twl-links\" href=\"%(update_url)s\">update or delete</a> "
-"your data at any time."
-msgstr ""
-"Poți <a class=\"twl-links\" href=\"%(update_url)s\">actualiza sau șterge</a> "
-"datele dvs. în orice moment."
+msgid "You may <a class=\"twl-links\" href=\"%(update_url)s\">update or delete</a> your data at any time."
+msgstr "Poți <a class=\"twl-links\" href=\"%(update_url)s\">actualiza sau șterge</a> datele dvs. în orice moment."
 
 #. Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this labels the user's email. Don't remove the *.
 #: TWLight/users/templates/users/editor_detail_data.html:283
@@ -3237,39 +2517,24 @@ msgstr "Afiliere instituțională"
 
 #. Translators: This message tells users that they are not eligible to access The Wikipedia Library content.
 #: TWLight/users/templates/users/eligibility_modal.html:7
-msgid ""
-"Sorry, your Wikipedia account doesn’t currently qualify to access The "
-"Wikipedia Library."
-msgstr ""
-"Ne pare rău, contul dvs. Wikipedia nu se califică în prezent pentru a accesa "
-"Biblioteca Wikipedia."
+msgid "Sorry, your Wikipedia account doesn’t currently qualify to access The Wikipedia Library."
+msgstr "Ne pare rău, contul dvs. Wikipedia nu se califică în prezent pentru a accesa Biblioteca Wikipedia."
 
 #. Translators: This message tells users that they have not agreed to the terms of use, therefore are ineligible to access the content in The Wikipedia Library.
 #: TWLight/users/templates/users/eligibility_modal.html:30
 #, python-format
-msgid ""
-"Agreed with <a href=\"%(terms)s\" class=\"text-danger\"> terms of use </a>"
-msgstr ""
-"A fost de acord cu <a href=\"%(terms)s\" class=\"text-danger\">termenii de "
-"utilizare</a>?"
+msgid "Agreed with <a href=\"%(terms)s\" class=\"text-danger\"> terms of use </a>"
+msgstr "A fost de acord cu <a href=\"%(terms)s\" class=\"text-danger\">termenii de utilizare</a>?"
 
 #: TWLight/users/templates/users/eligibility_modal.html:40
 #, python-format
-msgid ""
-"It looks like you have an active block on your account. If you meet the "
-"other criteria you may still be permitted access to the library - please <a "
-"href=\"%(contact_url)s\">contact us</a>."
-msgstr ""
-"Se pare că aveți o blocare activă în cont. Dacă îndepliniți celelalte "
-"criterii, vi se poate permite accesul la Library Bundle - vă rugăm să <a "
-"href=\"%(contact_url)s\">contactați-ne</a>."
+msgid "It looks like you have an active block on your account. If you meet the other criteria you may still be permitted access to the library - please <a href=\"%(contact_url)s\">contact us</a>."
+msgstr "Se pare că aveți o blocare activă în cont. Dacă îndepliniți celelalte criterii, vi se poate permite accesul la Library Bundle - vă rugăm să <a href=\"%(contact_url)s\">contactați-ne</a>."
 
 #. Translators: Instructions to refresh a user's data.
 #: TWLight/users/templates/users/eligibility_modal.html:50
 msgid "To refresh your data, please log out and back in."
-msgstr ""
-"Pentru a vă reîmprospăta datele, vă rugăm să vă deconectați și să vă "
-"reconectați."
+msgstr "Pentru a vă reîmprospăta datele, vă rugăm să vă deconectați și să vă reconectați."
 
 #. Translators: A button that takes users to their profile.
 #: TWLight/users/templates/users/eligibility_modal.html:58
@@ -3303,14 +2568,8 @@ msgstr "Selectare limbă"
 
 #. Translators: This text on the user page helps users naviage to the TranslateWiki Wikipedia Library Card platform translation page.
 #: TWLight/users/templates/users/language_form.html:31
-msgid ""
-"You can help translate the tool at <a class=\"twl-links\" href=\"https://"
-"translatewiki.net/wiki/Translating:Wikipedia_Library_Card_Platform"
-"\">translatewiki.net</a>."
-msgstr ""
-"Puteți ajuta să traduceți instrumentul la <a class=\"twl-links\" href="
-"\"https://translatewiki.net/wiki/Translating:Wikipedia_Library_Card_Platform"
-"\">translatewiki.net</a>."
+msgid "You can help translate the tool at <a class=\"twl-links\" href=\"https://translatewiki.net/wiki/Translating:Wikipedia_Library_Card_Platform\">translatewiki.net</a>."
+msgstr "Puteți ajuta să traduceți instrumentul la <a class=\"twl-links\" href=\"https://translatewiki.net/wiki/Translating:Wikipedia_Library_Card_Platform\">translatewiki.net</a>."
 
 #. Translators: When the user starts a new application and submits the application, the user can view the application and withdraw if need be. This changes the label for the Withdraw button.
 #: TWLight/users/templates/users/my_applications.html:65
@@ -3329,12 +2588,8 @@ msgstr "Solicită reînnoire"
 
 #. Translators: On the page listing applications, this text explains a user they cannot renew their application since they've already requested a renewal or there aren't any renewals available.
 #: TWLight/users/templates/users/my_applications.html:79
-msgid ""
-"Renewals are either not required, not available right now, or you have "
-"already requested a renewal."
-msgstr ""
-"Reînnoirile nu sunt necesare, nu sunt disponibile în acest moment sau ați "
-"solicitat deja o reînnoire."
+msgid "Renewals are either not required, not available right now, or you have already requested a renewal."
+msgstr "Reînnoirile nu sunt necesare, nu sunt disponibile în acest moment sau ați solicitat deja o reînnoire."
 
 #. Translators: This text is the heading of a section in a user's profile where they can change their preferences.
 #: TWLight/users/templates/users/preferences.html:6
@@ -3397,28 +2652,13 @@ msgstr "Restricționează procesarea datelor"
 
 #. Translators: This message is displayed on the page where users can request we stop processing their data.
 #: TWLight/users/templates/users/restrict_data.html:15
-msgid ""
-"Checking this box and clicking “Restrict” will pause all processing of the "
-"data you have entered into this website. You will not be able to apply for "
-"access to resources, your applications will not be further processed, and "
-"none of your data will be altered, until you return to this page and uncheck "
-"the box. This is not the same as deleting your data."
-msgstr ""
-"Dacă bifează această casetă și faceți clic pe “Restricționare” va întrerupe "
-"procesarea datelor introduse pe acest site web. Nu veți putea solicita "
-"accesul la resurse, cererile dvs. nu vor fi procesate în continuare și "
-"niciuna dintre datele dvs. nu va fi modificată, până când nu reveniți la "
-"această pagină și debifați caseta. Nu este același lucru cu ștergerea "
-"datelor."
+msgid "Checking this box and clicking “Restrict” will pause all processing of the data you have entered into this website. You will not be able to apply for access to resources, your applications will not be further processed, and none of your data will be altered, until you return to this page and uncheck the box. This is not the same as deleting your data."
+msgstr "Dacă bifează această casetă și faceți clic pe “Restricționare” va întrerupe procesarea datelor introduse pe acest site web. Nu veți putea solicita accesul la resurse, cererile dvs. nu vor fi procesate în continuare și niciuna dintre datele dvs. nu va fi modificată, până când nu reveniți la această pagină și debifați caseta. Nu este același lucru cu ștergerea datelor."
 
 #. Translators: This warning message is shown to coordinators who view the data restriction page.
 #: TWLight/users/templates/users/restrict_data.html:26
-msgid ""
-"You are a coordinator on this site. If you restrict the processing of your "
-"data, your coordinator flag will be removed."
-msgstr ""
-"Sunteți un coordonator al acestui site. Dacă limitați procesarea datelor "
-"dvs., statutul dvs. de coordonator va fi retras."
+msgid "You are a coordinator on this site. If you restrict the processing of your data, your coordinator flag will be removed."
+msgstr "Sunteți un coordonator al acestui site. Dacă limitați procesarea datelor dvs., statutul dvs. de coordonator va fi retras."
 
 #. Translators: use the date *when you are translating*, in a language-appropriate format.
 #: TWLight/users/templates/users/terms.html:33
@@ -3433,44 +2673,17 @@ msgstr "Politica de confidențialitate a Fundației Wikimedia"
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:41
 msgid "Wikipedia Library Card Terms of Use and Privacy Statement"
-msgstr ""
-"Wikipedia Biblioteca Card Termeni de utilizare și Declarație de "
-"confidențialitate"
+msgstr "Wikipedia Biblioteca Card Termeni de utilizare și Declarație de confidențialitate"
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:51
-msgid ""
-"<a class=\"twl-links\" href=\"https://meta.wikimedia.org/wiki/"
-"The_Wikipedia_Library\"> The Wikipedia Library </a> has partnered with "
-"publishers around the world to allow users to access otherwise paywalled "
-"resources. This website allows Wikipedia editors to search and access these "
-"resources."
-msgstr ""
-"<a class=\"twl-links\" href=\"https://meta.wikimedia.org/wiki/"
-"The_Wikipedia_Library/ro\">Biblioteca Wikipedia</a> a făcut parteneriat cu "
-"editorii din întreaga lume pentru a permite utilizatorilor să acceseze "
-"resurse cu alte pachete. Acest site web permite utilizatorilor să aplice "
-"simultan pentru acces la mai multe materiale de editori și face "
-"administrarea și accesul la conturile Bibliotecii Wikipedia ușor și eficient."
+msgid "<a class=\"twl-links\" href=\"https://meta.wikimedia.org/wiki/The_Wikipedia_Library\"> The Wikipedia Library </a> has partnered with publishers around the world to allow users to access otherwise paywalled resources. This website allows Wikipedia editors to search and access these resources."
+msgstr "<a class=\"twl-links\" href=\"https://meta.wikimedia.org/wiki/The_Wikipedia_Library/ro\">Biblioteca Wikipedia</a> a făcut parteneriat cu editorii din întreaga lume pentru a permite utilizatorilor să acceseze resurse cu alte pachete. Acest site web permite utilizatorilor să aplice simultan pentru acces la mai multe materiale de editori și face administrarea și accesul la conturile Bibliotecii Wikipedia ușor și eficient."
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Wikimedia Foundation should not be translated. WMF should not be translated. Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:63
-msgid ""
-"This program is administered by the Wikimedia Foundation (WMF). These terms "
-"of use and privacy notice pertain to your application for access to "
-"resources through the Wikipedia Library, your use of this website, and your "
-"access to and use of those resources. They also describe our handling of the "
-"information you provide to us in order to create and administer your "
-"Wikipedia Library account. If we make material changes to the terms, we will "
-"notify users."
-msgstr ""
-"Acest program este administrat de Fundația Wikimedia (WMF). Acești termeni "
-"de utilizare și notificare de confidențialitate se referă la solicitarea "
-"dvs. pentru accesul la resurse prin intermediul bibliotecii Wikipedia, a "
-"utilizării dvs. de acest site și a accesului și la utilizarea acestor "
-"resurse. Ele descriu, de asemenea, gestionarea informațiilor pe care ni le "
-"furnizați pentru a crea și administra contul dvs. de Bibliotecă Wikipedia. "
-"Dacă facem modificări materiale ale termenilor, vom anunța utilizatorii."
+msgid "This program is administered by the Wikimedia Foundation (WMF). These terms of use and privacy notice pertain to your application for access to resources through the Wikipedia Library, your use of this website, and your access to and use of those resources. They also describe our handling of the information you provide to us in order to create and administer your Wikipedia Library account. If we make material changes to the terms, we will notify users."
+msgstr "Acest program este administrat de Fundația Wikimedia (WMF). Acești termeni de utilizare și notificare de confidențialitate se referă la solicitarea dvs. pentru accesul la resurse prin intermediul bibliotecii Wikipedia, a utilizării dvs. de acest site și a accesului și la utilizarea acestor resurse. Ele descriu, de asemenea, gestionarea informațiilor pe care ni le furnizați pentru a crea și administra contul dvs. de Bibliotecă Wikipedia. Dacă facem modificări materiale ale termenilor, vom anunța utilizatorii."
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:74
@@ -3479,133 +2692,48 @@ msgstr "Cerințe pentru un cont de card de Bibliotecă Wikipedia"
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:78
-msgid ""
-"Access to resources via The Wikipedia Library is reserved for community "
-"members who have demonstrated their commitment to the Wikimedia projects, "
-"and who will use their access to these resources to improve project content. "
-"To that end, in order to be eligible for The Wikipedia Library, we require "
-"that you be registered for a user account on the projects, with at least 500 "
-"edits, six (6) months of activity, and 10+ edits in the last month. We ask "
-"that you do not request access to any publishers with a limited number of "
-"available accounts whose resources you can already access for free through "
-"your local library or university, or another institution or organization, in "
-"order to provide that opportunity to others."
-msgstr ""
-"Accesul la resurse prin Biblioteca Wikipedia este rezervat membrilor "
-"comunității care și-au demonstrat angajamentul față de proiectele Wikimedia "
-"și care își vor folosi accesul la aceste resurse pentru a îmbunătăți "
-"conținutul proiectului. În acest scop, pentru a fi eligibil pentru "
-"Biblioteca Wikipedia, vă solicităm să fiți înregistrat pentru un cont de "
-"utilizator pe proiecte, cu cel puțin 500 de editări, șase (6) luni de "
-"activitate și peste 10 editări în ultima lună. . Vă rugăm să nu solicitați "
-"acces la niciun editor cu un număr limitat de conturi disponibile ale căror "
-"resurse le puteți accesa deja gratuit prin biblioteca sau universitatea "
-"locală, sau altă instituție sau organizație, pentru a oferi această "
-"oportunitate altora."
+msgid "Access to resources via The Wikipedia Library is reserved for community members who have demonstrated their commitment to the Wikimedia projects, and who will use their access to these resources to improve project content. To that end, in order to be eligible for The Wikipedia Library, we require that you be registered for a user account on the projects, with at least 500 edits, six (6) months of activity, and 10+ edits in the last month. We ask that you do not request access to any publishers with a limited number of available accounts whose resources you can already access for free through your local library or university, or another institution or organization, in order to provide that opportunity to others."
+msgstr "Accesul la resurse prin Biblioteca Wikipedia este rezervat membrilor comunității care și-au demonstrat angajamentul față de proiectele Wikimedia și care își vor folosi accesul la aceste resurse pentru a îmbunătăți conținutul proiectului. În acest scop, pentru a fi eligibil pentru Biblioteca Wikipedia, vă solicităm să fiți înregistrat pentru un cont de utilizator pe proiecte, cu cel puțin 500 de editări, șase (6) luni de activitate și peste 10 editări în ultima lună. . Vă rugăm să nu solicitați acces la niciun editor cu un număr limitat de conturi disponibile ale căror resurse le puteți accesa deja gratuit prin biblioteca sau universitatea locală, sau altă instituție sau organizație, pentru a oferi această oportunitate altora."
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:94
-msgid ""
-"Additionally, if you are currently blocked or banned from a Wikimedia "
-"project, applications to resources may be rejected or restricted. If you "
-"obtain a Wikipedia Library account, but a block or ban is subsequently "
-"instituted against you on one of the projects, you may lose access to your "
-"Wikipedia Library account."
-msgstr ""
-"În plus, dacă în prezent sunteți blocat sau interzis dintr-un proiect "
-"Wikimedia, aplicațiile la resurse pot fi respinse sau restricționate. Dacă "
-"obțineți un cont de Biblioteca Wikipedia, dar ulterior este instituită o "
-"blocare sau o interdicție împotriva dvs. pentru unul dintre proiecte, este "
-"posibil să pierdeți accesul la contul dvs. Biblioteca Wikipedia."
+msgid "Additionally, if you are currently blocked or banned from a Wikimedia project, applications to resources may be rejected or restricted. If you obtain a Wikipedia Library account, but a block or ban is subsequently instituted against you on one of the projects, you may lose access to your Wikipedia Library account."
+msgstr "În plus, dacă în prezent sunteți blocat sau interzis dintr-un proiect Wikimedia, aplicațiile la resurse pot fi respinse sau restricționate. Dacă obțineți un cont de Biblioteca Wikipedia, dar ulterior este instituită o blocare sau o interdicție împotriva dvs. pentru unul dintre proiecte, este posibil să pierdeți accesul la contul dvs. Biblioteca Wikipedia."
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:104
-msgid ""
-"Your eligibility to access The Wikipedia Library is assessed at each login. "
-"While more than half of the library's content is provided via this automated "
-"eligibility check, access to other publisher's content may be time limited, "
-"typically lapsing after one year, after which you will usually need to apply "
-"for renewal."
-msgstr ""
-"Eligibilitatea dvs. de a accesa Biblioteca Wikipedia este evaluată la "
-"fiecare conectare. Deși mai mult de jumătate din conținutul bibliotecii este "
-"furnizat prin această verificare automată a eligibilității, accesul la "
-"conținutul altor editori poate fi limitat în timp, de obicei expirând după "
-"un an, după care va trebui de obicei să solicitați reînnoire."
+msgid "Your eligibility to access The Wikipedia Library is assessed at each login. While more than half of the library's content is provided via this automated eligibility check, access to other publisher's content may be time limited, typically lapsing after one year, after which you will usually need to apply for renewal."
+msgstr "Eligibilitatea dvs. de a accesa Biblioteca Wikipedia este evaluată la fiecare conectare. Deși mai mult de jumătate din conținutul bibliotecii este furnizat prin această verificare automată a eligibilității, accesul la conținutul altor editori poate fi limitat în timp, de obicei expirând după un an, după care va trebui de obicei să solicitați reînnoire."
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:114
 msgid "Applying via Your Wikipedia Library Card Account"
-msgstr ""
-"Solicitarea prin intermediul contului dvs. de carte de bibliotecă Wikipedia"
+msgstr "Solicitarea prin intermediul contului dvs. de carte de bibliotecă Wikipedia"
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:118
-msgid ""
-"In order to apply for access to a partner resource, you must provide us with "
-"certain information, which we will use to evaluate your application. If your "
-"application is approved, we may transfer the information you have given us "
-"to the publishers whose resources you wish to access. They will either "
-"contact you with the account information directly or we will send access "
-"information to you ourselves."
-msgstr ""
-"Pentru a solicita accesul la o resursă parteneră, trebuie să ne oferiți "
-"anumite informații, pe care le vom folosi pentru a evalua solicitarea dvs. "
-"Dacă cererea dvs. este aprobată, putem transfera informațiile pe care ni le-"
-"ați oferit editorilor ale căror resurse doriți să accesați. Vă vor contacta "
-"direct cu informațiile contului sau vă vom trimite informațiile de acces "
-"către dvs. înșine."
+msgid "In order to apply for access to a partner resource, you must provide us with certain information, which we will use to evaluate your application. If your application is approved, we may transfer the information you have given us to the publishers whose resources you wish to access. They will either contact you with the account information directly or we will send access information to you ourselves."
+msgstr "Pentru a solicita accesul la o resursă parteneră, trebuie să ne oferiți anumite informații, pe care le vom folosi pentru a evalua solicitarea dvs. Dacă cererea dvs. este aprobată, putem transfera informațiile pe care ni le-ați oferit editorilor ale căror resurse doriți să accesați. Vă vor contacta direct cu informațiile contului sau vă vom trimite informațiile de acces către dvs. înșine."
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:130
-msgid ""
-"In addition to the basic information you provide to us, our system will "
-"retrieve some information directly from the Wikimedia projects: your "
-"username, email address, edit count, registration date, user ID number, "
-"groups to which you belong, and any special user rights."
-msgstr ""
-"Pe lângă informațiile de bază pe care ni le furnizați, sistemul nostru va "
-"prelua unele informații direct din proiectele Wikimedia: numele dvs. de "
-"utilizator, adresa de e-mail, numărul de editare, data înregistrării, "
-"numărul de identificare al utilizatorului, grupurile din care faceți parte "
-"și orice drepturi speciale ale utilizatorului."
+msgid "In addition to the basic information you provide to us, our system will retrieve some information directly from the Wikimedia projects: your username, email address, edit count, registration date, user ID number, groups to which you belong, and any special user rights."
+msgstr "Pe lângă informațiile de bază pe care ni le furnizați, sistemul nostru va prelua unele informații direct din proiectele Wikimedia: numele dvs. de utilizator, adresa de e-mail, numărul de editare, data înregistrării, numărul de identificare al utilizatorului, grupurile din care faceți parte și orice drepturi speciale ale utilizatorului."
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:140
-msgid ""
-"Each time you log in to the Wikipedia Library Card Platform, this "
-"information will be automatically updated."
-msgstr ""
-"De fiecare dată când vă conectați la Platforma de carduri pentru "
-"Bibliotecile Wikipedia, aceste informații vor fi actualizate automat."
+msgid "Each time you log in to the Wikipedia Library Card Platform, this information will be automatically updated."
+msgstr "De fiecare dată când vă conectați la Platforma de carduri pentru Bibliotecile Wikipedia, aceste informații vor fi actualizate automat."
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:148
-msgid ""
-"We will ask you to provide us with some information about your history of "
-"contributions to the Wikimedia projects. Information on contribution history "
-"is optional, but will greatly assist us in evaluating your application."
-msgstr ""
-"Vă vom solicita să ne furnizați câteva informații despre istoricul "
-"contribuțiilor dvs. la proiectele Wikimedia. Informațiile privind istoricul "
-"contribuțiilor sunt opționale, dar ne vor ajuta foarte mult în evaluarea "
-"cererii dvs."
+msgid "We will ask you to provide us with some information about your history of contributions to the Wikimedia projects. Information on contribution history is optional, but will greatly assist us in evaluating your application."
+msgstr "Vă vom solicita să ne furnizați câteva informații despre istoricul contribuțiilor dvs. la proiectele Wikimedia. Informațiile privind istoricul contribuțiilor sunt opționale, dar ne vor ajuta foarte mult în evaluarea cererii dvs."
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). WMF should not be translated. Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:157
-msgid ""
-"The information you provide when creating your account will be visible to "
-"you while on the site but not to others unless they are approved Wikipedia "
-"Library Coordinators, WMF Staff, or WMF Contractors who need access to this "
-"data in order to carry out their work with the Wikipedia Library, all of "
-"whom are subject to non-disclosure obligations."
-msgstr ""
-"Informațiile pe care le furnizați la crearea contului dvs. vă vor fi "
-"vizibile în timp ce pe site, dar nu și altora, cu excepția cazului în care "
-"sunt autorizați Coordonatorii Bibliotecii Wikipedia, personalul WMF sau "
-"contractanții WMF care au nevoie de acces la aceste date pentru a-și "
-"desfășura activitatea cu Biblioteca Wikipedia, toate care fac obiectul "
-"obligațiilor de nedivulgare."
+msgid "The information you provide when creating your account will be visible to you while on the site but not to others unless they are approved Wikipedia Library Coordinators, WMF Staff, or WMF Contractors who need access to this data in order to carry out their work with the Wikipedia Library, all of whom are subject to non-disclosure obligations."
+msgstr "Informațiile pe care le furnizați la crearea contului dvs. vă vor fi vizibile în timp ce pe site, dar nu și altora, cu excepția cazului în care sunt autorizați Coordonatorii Bibliotecii Wikipedia, personalul WMF sau contractanții WMF care au nevoie de acces la aceste date pentru a-și desfășura activitatea cu Biblioteca Wikipedia, toate care fac obiectul obligațiilor de nedivulgare."
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:167
@@ -3614,64 +2742,33 @@ msgstr "Utilizarea dvs. de resurse pentru editori"
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:171
-msgid ""
-"In order to access an individual publisher’s resources, you must agree to "
-"that publisher’s terms of use and privacy policy. You agree that you will "
-"not violate such terms and policies in connection with your use of the "
-"Wikipedia Library. Additionally, the following activities are prohibited "
-"while accessing publisher resources through the Wikipedia Library."
-msgstr ""
-"Pentru a accesa resursele unui editor individual, trebuie să fiți de acord "
-"cu condițiile de utilizare și politica de confidențialitate ale editorului. "
-"Sunteți de acord că nu veți încălca acești termeni și politici în legătură "
-"cu utilizarea dvs. de la Biblioteca Wikipedia. În plus, următoarele "
-"activități sunt interzise în timp ce accesați resursele editorilor prin "
-"intermediul Bibliotecii Wikipedia."
+msgid "In order to access an individual publisher’s resources, you must agree to that publisher’s terms of use and privacy policy. You agree that you will not violate such terms and policies in connection with your use of the Wikipedia Library. Additionally, the following activities are prohibited while accessing publisher resources through the Wikipedia Library."
+msgstr "Pentru a accesa resursele unui editor individual, trebuie să fiți de acord cu condițiile de utilizare și politica de confidențialitate ale editorului. Sunteți de acord că nu veți încălca acești termeni și politici în legătură cu utilizarea dvs. de la Biblioteca Wikipedia. În plus, următoarele activități sunt interzise în timp ce accesați resursele editorilor prin intermediul Bibliotecii Wikipedia."
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:184
-msgid ""
-"Sharing your Wikipedia account, usernames, passwords, or any access codes "
-"for publisher resources with others;"
-msgstr ""
-"Partajarea contului dvs. Wikipedia, a numelor de utilizator, a parolelor sau "
-"a oricăror coduri de acces pentru resursele editorilor cu alții;"
+msgid "Sharing your Wikipedia account, usernames, passwords, or any access codes for publisher resources with others;"
+msgstr "Partajarea contului dvs. Wikipedia, a numelor de utilizator, a parolelor sau a oricăror coduri de acces pentru resursele editorilor cu alții;"
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:191
-msgid ""
-"Automatically scraping or downloading restricted content from publishers;"
-msgstr ""
-"Răspândirea sau descărcarea automată a conținutului restricționat de la "
-"editori;"
+msgid "Automatically scraping or downloading restricted content from publishers;"
+msgstr "Răspândirea sau descărcarea automată a conținutului restricționat de la editori;"
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:197
-msgid ""
-"Systematically making printed or electronic copies of multiple extracts of "
-"restricted content available for any purpose;"
-msgstr ""
-"Punerea la dispoziție sistematic a copiilor tipărite sau electronice ale mai "
-"multor extracte de conținut restricționat pentru orice scop"
+msgid "Systematically making printed or electronic copies of multiple extracts of restricted content available for any purpose;"
+msgstr "Punerea la dispoziție sistematic a copiilor tipărite sau electronice ale mai multor extracte de conținut restricționat pentru orice scop"
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:204
-msgid ""
-"Data mining metadata without permission—for example, in order to use "
-"metadata for auto-created stub articles;"
-msgstr ""
-"Extragerea datelor metadata fără permisiune - de exemplu, pentru a utiliza "
-"metadate pentru articole ciot create automat;"
+msgid "Data mining metadata without permission—for example, in order to use metadata for auto-created stub articles;"
+msgstr "Extragerea datelor metadata fără permisiune - de exemplu, pentru a utiliza metadate pentru articole ciot create automat;"
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:211
-msgid ""
-"Using the access you receive through the Wikipedia Library for profit by "
-"selling access to your account or resources which you have through it."
-msgstr ""
-"Utilizarea accesului pe care îl primiți prin intermediul Bibliotecii "
-"Wikipedia pentru a face profit, prin vânzarea accesului la contul sau la "
-"resursele pe care le aveți prin intermediul acestuia."
+msgid "Using the access you receive through the Wikipedia Library for profit by selling access to your account or resources which you have through it."
+msgstr "Utilizarea accesului pe care îl primiți prin intermediul Bibliotecii Wikipedia pentru a face profit, prin vânzarea accesului la contul sau la resursele pe care le aveți prin intermediul acestuia."
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:220
@@ -3680,26 +2777,13 @@ msgstr "Servicii externe de căutare și proxy"
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:224
-msgid ""
-"Certain resources may only be accessed using an external search service, "
-"such as the EBSCO Discovery Service, or a proxy service, such as OCLC "
-"EZProxy. If you use such external search and/or proxy services, please "
-"review the applicable terms of use and privacy policies."
-msgstr ""
-"Anumite resurse pot fi accesate numai folosind un serviciu de căutare "
-"extern, cum ar fi Serviciul de descoperire EBSCO sau un serviciu proxy, cum "
-"ar fi OCLC EZProxy. Dacă utilizați astfel de servicii de căutare și/sau "
-"proxy externe, consultați termenii de utilizare și politicile de "
-"confidențialitate."
+msgid "Certain resources may only be accessed using an external search service, such as the EBSCO Discovery Service, or a proxy service, such as OCLC EZProxy. If you use such external search and/or proxy services, please review the applicable terms of use and privacy policies."
+msgstr "Anumite resurse pot fi accesate numai folosind un serviciu de căutare extern, cum ar fi Serviciul de descoperire EBSCO sau un serviciu proxy, cum ar fi OCLC EZProxy. Dacă utilizați astfel de servicii de căutare și/sau proxy externe, consultați termenii de utilizare și politicile de confidențialitate."
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:234
-msgid ""
-"In addition, if you use OCLC EZProxy, please note that you may not use it "
-"for commercial purposes."
-msgstr ""
-"În plus, dacă utilizați OCLC EZProxy, rețineți că este posibil să nu îl "
-"utilizați în scopuri comerciale."
+msgid "In addition, if you use OCLC EZProxy, please note that you may not use it for commercial purposes."
+msgstr "În plus, dacă utilizați OCLC EZProxy, rețineți că este posibil să nu îl utilizați în scopuri comerciale."
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:241
@@ -3709,202 +2793,51 @@ msgstr "Păstrarea și manipularea datelor"
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Wikimedia Foundation should not be translated. Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:245
 #, fuzzy
-msgid ""
-"The Wikimedia Foundation and our service providers use your information for "
-"the legitimate purpose of providing Wikipedia Library services in support of "
-"our charitable mission. When you apply for a Wikipedia Library account, or "
-"use your Wikipedia Library account, we may routinely collect the following "
-"information: your username, email address, edit count, registration date, "
-"user ID number, groups to which you belong, and any special user rights; "
-"your name, country of residence, and/or affiliation, if required by a "
-"partner to which you are applying; your narrative description of your "
-"contributions and reasons for applying for access to partner resources; and "
-"the date you agree to these terms of use."
-msgstr ""
-"Fundația Wikimedia și furnizorii noștri de servicii utilizează informațiile "
-"dvs. în scopul legitim de a furniza servicii Biblioteca Wikipedia în "
-"sprijinul misiunii noastre caritabile. Când solicitați un cont Biblioteca "
-"Wikipedia sau folosiți contul Biblioteca Wikipedia, este posibil să colectăm "
-"în mod obișnuit următoarele informații: numele dvs. de utilizator, adresa de "
-"e-mail, numărul de editări, data înregistrării, numărul ID utilizator, "
-"grupurile din care faceți parte și orice utilizator special. drepturi; "
-"numele, țara de reședință, ocupația și/sau afilierea dvs., dacă este "
-"solicitat de un partener la care aplicați; descrierea dumneavoastră narativă "
-"a contribuțiilor dumneavoastră și motivele pentru care solicitați acces la "
-"resursele partenerilor; și data la care sunteți de acord cu acești termeni "
-"de utilizare."
+msgid "The Wikimedia Foundation and our service providers use your information for the legitimate purpose of providing Wikipedia Library services in support of our charitable mission. When you apply for a Wikipedia Library account, or use your Wikipedia Library account, we may routinely collect the following information: your username, email address, edit count, registration date, user ID number, groups to which you belong, and any special user rights; your name, country of residence, and/or affiliation, if required by a partner to which you are applying; your narrative description of your contributions and reasons for applying for access to partner resources; and the date you agree to these terms of use."
+msgstr "Fundația Wikimedia și furnizorii noștri de servicii utilizează informațiile dvs. în scopul legitim de a furniza servicii Biblioteca Wikipedia în sprijinul misiunii noastre caritabile. Când solicitați un cont Biblioteca Wikipedia sau folosiți contul Biblioteca Wikipedia, este posibil să colectăm în mod obișnuit următoarele informații: numele dvs. de utilizator, adresa de e-mail, numărul de editări, data înregistrării, numărul ID utilizator, grupurile din care faceți parte și orice utilizator special. drepturi; numele, țara de reședință, ocupația și/sau afilierea dvs., dacă este solicitat de un partener la care aplicați; descrierea dumneavoastră narativă a contribuțiilor dumneavoastră și motivele pentru care solicitați acces la resursele partenerilor; și data la care sunteți de acord cu acești termeni de utilizare."
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:262
 #, fuzzy, python-format
-msgid ""
-"Each publisher who is a member of the Wikipedia Library program requires "
-"different specific information in the application. Some publishers may "
-"request only an email address, while others request more detailed data, such "
-"as your name, location, or institutional affiliation. When you complete your "
-"application, you will only be asked to supply information required by the "
-"publishers you have chosen, and each publisher will only receive the "
-"information they require for providing you with access. Please see our <a "
-"class=\"twl-links\" href=\"%(all_partners_url)s\">partner information</a> "
-"pages to learn what information is required by each publisher to gain access "
-"to their resources."
-msgstr ""
-"Fiecare editor care este membru al programului Bibliotecii Wikipedia "
-"necesită diferite informații specifice în aplicație. Unii editori pot "
-"solicita doar o adresă de e-mail, în timp ce alții solicită date mai "
-"detaliate, cum ar fi numele dvs., locația, ocupația sau afilierea "
-"instituțională. Când completați cererea, vi se va solicita să furnizați "
-"numai informațiile solicitate de editorii pe care i-ați ales și fiecare "
-"editor va primi doar informațiile pe care le solicită pentru a vă oferi "
-"acces. Vă rugăm să consultați paginile noastre <a class=\"twl-links\" href="
-"\"%(all_partners_url)s\">informații despre parteneri</a> pentru a afla ce "
-"informații sunt necesare de ls fiecare editor pentru a avea acces la "
-"resursele sale."
+msgid "Each publisher who is a member of the Wikipedia Library program requires different specific information in the application. Some publishers may request only an email address, while others request more detailed data, such as your name, location, or institutional affiliation. When you complete your application, you will only be asked to supply information required by the publishers you have chosen, and each publisher will only receive the information they require for providing you with access. Please see our <a class=\"twl-links\" href=\"%(all_partners_url)s\">partner information</a> pages to learn what information is required by each publisher to gain access to their resources."
+msgstr "Fiecare editor care este membru al programului Bibliotecii Wikipedia necesită diferite informații specifice în aplicație. Unii editori pot solicita doar o adresă de e-mail, în timp ce alții solicită date mai detaliate, cum ar fi numele dvs., locația, ocupația sau afilierea instituțională. Când completați cererea, vi se va solicita să furnizați numai informațiile solicitate de editorii pe care i-ați ales și fiecare editor va primi doar informațiile pe care le solicită pentru a vă oferi acces. Vă rugăm să consultați paginile noastre <a class=\"twl-links\" href=\"%(all_partners_url)s\">informații despre parteneri</a> pentru a afla ce informații sunt necesare de ls fiecare editor pentru a avea acces la resursele sale."
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Wikimedia Foundation should not be translated. Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:277
-msgid ""
-"Some Wikipedia Library pages are visible without logging in, but you will "
-"need to log in to apply or access proprietary partner resources. We use the "
-"data provided by you via OAuth and Wikimedia API calls to assess your "
-"application for access and to process approved requests."
-msgstr ""
-"Unele pagini ale Bibliotecii Wikipedia sunt vizibile fără a vă autentifica, "
-"dar va trebui să vă autentificați pentru a aplica sau pentru a accesa "
-"resursele proprietare ale partenerilor. Folosim datele furnizate de dvs. "
-"prin apeluri OAuth și Wikimedia API pentru a vă evalua cererea de acces și "
-"pentru a procesa cererile aprobate."
+msgid "Some Wikipedia Library pages are visible without logging in, but you will need to log in to apply or access proprietary partner resources. We use the data provided by you via OAuth and Wikimedia API calls to assess your application for access and to process approved requests."
+msgstr "Unele pagini ale Bibliotecii Wikipedia sunt vizibile fără a vă autentifica, dar va trebui să vă autentificați pentru a aplica sau pentru a accesa resursele proprietare ale partenerilor. Folosim datele furnizate de dvs. prin apeluri OAuth și Wikimedia API pentru a vă evalua cererea de acces și pentru a procesa cererile aprobate."
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:288
 #, python-format
-msgid ""
-"In order to administer the Wikipedia Library program, we will retain the "
-"application data we collect from you for three years after your most recent "
-"login, unless you delete your account, as described below. You can log in "
-"and go to <a class=\"twl-links\" href=\"%(profile_url)s\">your profile page</"
-"a> in order to see the information associated with your account, and can "
-"download it in JSON format. You may access, update, restrict, or delete this "
-"information at any time, except for the information that is automatically "
-"retrieved from the projects. If you have any questions or concerns about the "
-"handling of your data, please contact <a class=\"twl-links\" href=\"mailto:"
-"wikipedialibrary@wikimedia.org?Subject=Wikipedia%%20Library%%20Card"
-"%%20account%%20deactivation\"> wikipedialibrary@wikimedia.org </a>."
-msgstr ""
-"Pentru a administra programul Bibliotecii Wikipedia, vom păstra datele "
-"aplicației pe care le colectăm de la dvs. timp de trei ani după "
-"autentificarea dvs. cea mai recentă, cu excepția cazului în care vă ștergeți "
-"contul, așa cum este descris mai jos. Vă puteți autentifica și accesa <a "
-"class=\"twl-links\" href=\"%(profile_url)s\">pagina de profil</a> pentru a "
-"vedea informațiile asociate contului dvs. și le puteți descărca în format "
-"JSON. Puteți accesa, actualiza, restricționa sau șterge aceste informații în "
-"orice moment, cu excepția informațiilor care sunt preluate automat din "
-"proiecte. Dacă aveți întrebări sau nelămuriri cu privire la manipularea "
-"datelor dvs., vă rugăm să contactați <a class=\"twl-links\" href=\"mailto:"
-"wikipedialibrary@wikimedia.org?Subject=Wikipedia%%20Library%%20Card"
-"%%20account%%20deactivation\">wikipedialibrary@wikimedia.org</a>."
+msgid "In order to administer the Wikipedia Library program, we will retain the application data we collect from you for three years after your most recent login, unless you delete your account, as described below. You can log in and go to <a class=\"twl-links\" href=\"%(profile_url)s\">your profile page</a> in order to see the information associated with your account, and can download it in JSON format. You may access, update, restrict, or delete this information at any time, except for the information that is automatically retrieved from the projects. If you have any questions or concerns about the handling of your data, please contact <a class=\"twl-links\" href=\"mailto:wikipedialibrary@wikimedia.org?Subject=Wikipedia%%20Library%%20Card%%20account%%20deactivation\"> wikipedialibrary@wikimedia.org </a>."
+msgstr "Pentru a administra programul Bibliotecii Wikipedia, vom păstra datele aplicației pe care le colectăm de la dvs. timp de trei ani după autentificarea dvs. cea mai recentă, cu excepția cazului în care vă ștergeți contul, așa cum este descris mai jos. Vă puteți autentifica și accesa <a class=\"twl-links\" href=\"%(profile_url)s\">pagina de profil</a> pentru a vedea informațiile asociate contului dvs. și le puteți descărca în format JSON. Puteți accesa, actualiza, restricționa sau șterge aceste informații în orice moment, cu excepția informațiilor care sunt preluate automat din proiecte. Dacă aveți întrebări sau nelămuriri cu privire la manipularea datelor dvs., vă rugăm să contactați <a class=\"twl-links\" href=\"mailto:wikipedialibrary@wikimedia.org?Subject=Wikipedia%%20Library%%20Card%%20account%%20deactivation\">wikipedialibrary@wikimedia.org</a>."
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:305
 #, fuzzy
-msgid ""
-"If you decide to disable your Wikipedia Library account, you can use the "
-"delete button on your profile to delete certain personal information "
-"associated with your account. We will delete your real name, institutional "
-"affiliation, and country of residence. Please note that the system will "
-"retain a record of your username, the publishers to which you applied or had "
-"access, and the dates of that access. Note that deletion is not reversible. "
-"Deletion of your Wikipedia Library account may also correspond with the "
-"removal of any resource access to which you were eligible or approved. If "
-"you request the deletion of account information and later wish to apply for "
-"a new account, you will need to provide the necessary information again."
-msgstr ""
-"Dacă decideți să vă dezactivați contul de bibliotecă Wikipedia, puteți "
-"utiliza butonul de ștergere din profilul dvs. pentru a șterge anumite "
-"informații personale asociate contului dvs. Vom șterge numele dvs. real, "
-"ocupația, apartenența instituțională și țara de reședință. Vă rugăm să "
-"rețineți că sistemul va păstra o înregistrare a numelui dvs. de utilizator, "
-"a editorilor la care ați solicitat sau ați avut acces, precum și datele "
-"acestui acces. Rețineți că ștergerea nu este reversibilă. Ștergerea contului "
-"dvs. de bibliotecă Wikipedia poate corespunde, de asemenea, cu eliminarea "
-"oricărui acces la resurse pentru care ați fost eligibil sau aprobat. Dacă "
-"solicitați ștergerea informațiilor despre cont și ulterior doriți să "
-"solicitați un cont nou, va trebui să furnizați informațiile necesare din nou."
+msgid "If you decide to disable your Wikipedia Library account, you can use the delete button on your profile to delete certain personal information associated with your account. We will delete your real name, institutional affiliation, and country of residence. Please note that the system will retain a record of your username, the publishers to which you applied or had access, and the dates of that access. Note that deletion is not reversible. Deletion of your Wikipedia Library account may also correspond with the removal of any resource access to which you were eligible or approved. If you request the deletion of account information and later wish to apply for a new account, you will need to provide the necessary information again."
+msgstr "Dacă decideți să vă dezactivați contul de bibliotecă Wikipedia, puteți utiliza butonul de ștergere din profilul dvs. pentru a șterge anumite informații personale asociate contului dvs. Vom șterge numele dvs. real, ocupația, apartenența instituțională și țara de reședință. Vă rugăm să rețineți că sistemul va păstra o înregistrare a numelui dvs. de utilizator, a editorilor la care ați solicitat sau ați avut acces, precum și datele acestui acces. Rețineți că ștergerea nu este reversibilă. Ștergerea contului dvs. de bibliotecă Wikipedia poate corespunde, de asemenea, cu eliminarea oricărui acces la resurse pentru care ați fost eligibil sau aprobat. Dacă solicitați ștergerea informațiilor despre cont și ulterior doriți să solicitați un cont nou, va trebui să furnizați informațiile necesare din nou."
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). WMF should not be translated. Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:321
-msgid ""
-"The Wikipedia Library is run by WMF Staff, Contractors, and approved "
-"volunteer Coordinators. The data associated with your account will be shared "
-"with the WMF staff, contractors, service providers, and volunteer "
-"coordinators who need to process the information in connection with their "
-"work for the Wikipedia Library, and who are subject to confidentiality "
-"obligations. We will also use your data for internal Wikipedia Library "
-"purposes such as distributing user surveys and account notifications, and in "
-"a depersonalized or aggregated fashion for statistical analysis and "
-"administration. Finally, we will share your information with the publishers "
-"whom you specifically select in order to provide you with access to "
-"resources. Otherwise, your information will not be shared with third "
-"parties, with the exception of the circumstances described below."
-msgstr ""
-"Biblioteca Wikipedia este condusă de personalul WMF, contractori și "
-"coordonatori voluntari aprobați. Datele asociate contului dvs. vor fi "
-"distribuite personalului WMF, contractanților, furnizorilor de servicii și "
-"coordonatorilor voluntari care au nevoie să prelucreze informațiile în "
-"legătură cu activitatea lor pentru Biblioteca Wikipedia și care sunt supuse "
-"obligațiilor de confidențialitate. Vom folosi, de asemenea, datele dvs. în "
-"scopuri interne ale Bibliotecii Wikipedia, cum ar fi distribuirea sondajelor "
-"pentru utilizatori și notificări ale conturilor și într-un mod "
-"depersonalizat sau agregat pentru analiză și administrare statistică. În "
-"sfârșit, vom împărtăși informațiile dvs. cu editorii pe care îi selectați "
-"special pentru a vă oferi acces la resurse. În caz contrar, informațiile "
-"dvs. nu vor fi partajate terților, cu excepția circumstanțelor descrise mai "
-"jos."
+msgid "The Wikipedia Library is run by WMF Staff, Contractors, and approved volunteer Coordinators. The data associated with your account will be shared with the WMF staff, contractors, service providers, and volunteer coordinators who need to process the information in connection with their work for the Wikipedia Library, and who are subject to confidentiality obligations. We will also use your data for internal Wikipedia Library purposes such as distributing user surveys and account notifications, and in a depersonalized or aggregated fashion for statistical analysis and administration. Finally, we will share your information with the publishers whom you specifically select in order to provide you with access to resources. Otherwise, your information will not be shared with third parties, with the exception of the circumstances described below."
+msgstr "Biblioteca Wikipedia este condusă de personalul WMF, contractori și coordonatori voluntari aprobați. Datele asociate contului dvs. vor fi distribuite personalului WMF, contractanților, furnizorilor de servicii și coordonatorilor voluntari care au nevoie să prelucreze informațiile în legătură cu activitatea lor pentru Biblioteca Wikipedia și care sunt supuse obligațiilor de confidențialitate. Vom folosi, de asemenea, datele dvs. în scopuri interne ale Bibliotecii Wikipedia, cum ar fi distribuirea sondajelor pentru utilizatori și notificări ale conturilor și într-un mod depersonalizat sau agregat pentru analiză și administrare statistică. În sfârșit, vom împărtăși informațiile dvs. cu editorii pe care îi selectați special pentru a vă oferi acces la resurse. În caz contrar, informațiile dvs. nu vor fi partajate terților, cu excepția circumstanțelor descrise mai jos."
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). WMF should not be translated.
 #: TWLight/users/templates/users/terms.html:338
-msgid ""
-"We may disclose any collected information when required by law, when we have "
-"your permission, when needed to protect our rights, privacy, safety, users, "
-"or the general public, and when necessary to enforce these terms, WMF’s "
-"general <a class=\"twl-links\" href=\"https://foundation.wikimedia.org/wiki/"
-"Terms_of_Use\">Terms of Use</a>, or any other WMF policy."
-msgstr ""
-"Putem dezvălui orice informație colectată atunci când este cerut de lege, "
-"atunci când avem permisiunea dvs., atunci când este necesar pentru a ne "
-"proteja drepturile, confidențialitatea, siguranța, utilizatorii sau publicul "
-"larg, și atunci când este necesar pentru a aplica aceste condiții, WMF "
-"generale <a class=\"twl-links\" href=\"https://foundation.wikimedia.org/wiki/"
-"Terms_of_Use\">Termenii de utilizare</a>, sau orice altă politică WMF."
+msgid "We may disclose any collected information when required by law, when we have your permission, when needed to protect our rights, privacy, safety, users, or the general public, and when necessary to enforce these terms, WMF’s general <a class=\"twl-links\" href=\"https://foundation.wikimedia.org/wiki/Terms_of_Use\">Terms of Use</a>, or any other WMF policy."
+msgstr "Putem dezvălui orice informație colectată atunci când este cerut de lege, atunci când avem permisiunea dvs., atunci când este necesar pentru a ne proteja drepturile, confidențialitatea, siguranța, utilizatorii sau publicul larg, și atunci când este necesar pentru a aplica aceste condiții, WMF generale <a class=\"twl-links\" href=\"https://foundation.wikimedia.org/wiki/Terms_of_Use\">Termenii de utilizare</a>, sau orice altă politică WMF."
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:349
-msgid ""
-"We take the security of your personal data seriously, and take reasonable "
-"precautions to ensure your data is protected. These precautions include "
-"access controls to limit who has access to your data and security "
-"technologies to protect data stored on the server. However, we cannot "
-"guarantee the safety of your data as it is transmitted and stored."
-msgstr ""
-"Luăm în serios datele dvs. cu caracter personal și luăm măsuri de precauție "
-"rezonabile pentru a vă asigura că datele dvs. sunt protejate. Aceste "
-"precauții includ controale de acces pentru a limita cine are acces la datele "
-"dvs. și la tehnologiile de securitate pentru a proteja datele stocate pe "
-"server. Cu toate acestea, nu putem garanta siguranța datelor dvs. deoarece "
-"acestea sunt transmise și stocate."
+msgid "We take the security of your personal data seriously, and take reasonable precautions to ensure your data is protected. These precautions include access controls to limit who has access to your data and security technologies to protect data stored on the server. However, we cannot guarantee the safety of your data as it is transmitted and stored."
+msgstr "Luăm în serios datele dvs. cu caracter personal și luăm măsuri de precauție rezonabile pentru a vă asigura că datele dvs. sunt protejate. Aceste precauții includ controale de acces pentru a limita cine are acces la datele dvs. și la tehnologiile de securitate pentru a proteja datele stocate pe server. Cu toate acestea, nu putem garanta siguranța datelor dvs. deoarece acestea sunt transmise și stocate."
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:360
-msgid ""
-"Please note that these terms do not control the use and handling of your "
-"data by the publishers and service providers whose resources you access or "
-"apply to access. Please read their individual privacy policies for that "
-"information."
-msgstr ""
-"Vă rugăm să rețineți că acești termeni nu controlează utilizarea și "
-"manipularea datelor dvs. de către editorii și furnizorii de servicii ale "
-"căror resurse accesați sau aplicați la acces. Vă rugăm să citiți politicile "
-"individuale de confidențialitate pentru aceste informații."
+msgid "Please note that these terms do not control the use and handling of your data by the publishers and service providers whose resources you access or apply to access. Please read their individual privacy policies for that information."
+msgstr "Vă rugăm să rețineți că acești termeni nu controlează utilizarea și manipularea datelor dvs. de către editorii și furnizorii de servicii ale căror resurse accesați sau aplicați la acces. Vă rugăm să citiți politicile individuale de confidențialitate pentru aceste informații."
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:368
@@ -3913,54 +2846,18 @@ msgstr "Notă importantă"
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Wikimedia Foundation should not be translated. Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:373
-msgid ""
-"The Wikimedia Foundation is a nonprofit organization based in San Francisco, "
-"California. The Wikipedia Library program provides access to resources held "
-"by publishers in multiple countries. If you apply for a Wikipedia Library "
-"account (whether you are inside or outside of the United States), you "
-"understand that your personal data will be collected, transferred, stored, "
-"processed, disclosed and otherwise used in the U.S. as described in this "
-"privacy policy. You also understand that your information may be transferred "
-"by us from the U.S. to other countries, which may have different or less "
-"stringent data protection laws than your country, in connection with "
-"providing services to you, including evaluating your application and "
-"securing access to your chosen publishers (locations for each publisher are "
-"outlined on their respective partner information pages)."
-msgstr ""
-"Fundația Wikimedia este o organizație nonprofit cu sediul în San Francisco, "
-"California. Programul Biblioteca Wikipedia oferă acces la resurse deținute "
-"de editori în mai multe țări. Dacă solicitați un cont al Bibliotecii "
-"Wikipedia (indiferent dacă vă aflați în interiorul sau în afara Statelor "
-"Unite ale Americii), înțelegeți că datele dvs. personale vor fi colectate, "
-"transferate, stocate, procesate, dezvăluite și utilizate altfel în SUA așa "
-"cum este descris în această politică de confidențialitate . De asemenea, "
-"înțelegeți că informațiile dvs. pot fi transferate de noi din SUA către alte "
-"țări, care pot avea legi diferite sau mai puțin stricte de protecție a "
-"datelor decât țara dvs., în legătură cu furnizarea de servicii dvs., "
-"inclusiv evaluarea aplicației dvs. și asigurarea accesului la alegerea dvs. "
-"editori (locațiile pentru fiecare editor sunt prezentate pe paginile de "
-"informații ale partenerilor)."
+msgid "The Wikimedia Foundation is a nonprofit organization based in San Francisco, California. The Wikipedia Library program provides access to resources held by publishers in multiple countries. If you apply for a Wikipedia Library account (whether you are inside or outside of the United States), you understand that your personal data will be collected, transferred, stored, processed, disclosed and otherwise used in the U.S. as described in this privacy policy. You also understand that your information may be transferred by us from the U.S. to other countries, which may have different or less stringent data protection laws than your country, in connection with providing services to you, including evaluating your application and securing access to your chosen publishers (locations for each publisher are outlined on their respective partner information pages)."
+msgstr "Fundația Wikimedia este o organizație nonprofit cu sediul în San Francisco, California. Programul Biblioteca Wikipedia oferă acces la resurse deținute de editori în mai multe țări. Dacă solicitați un cont al Bibliotecii Wikipedia (indiferent dacă vă aflați în interiorul sau în afara Statelor Unite ale Americii), înțelegeți că datele dvs. personale vor fi colectate, transferate, stocate, procesate, dezvăluite și utilizate altfel în SUA așa cum este descris în această politică de confidențialitate . De asemenea, înțelegeți că informațiile dvs. pot fi transferate de noi din SUA către alte țări, care pot avea legi diferite sau mai puțin stricte de protecție a datelor decât țara dvs., în legătură cu furnizarea de servicii dvs., inclusiv evaluarea aplicației dvs. și asigurarea accesului la alegerea dvs. editori (locațiile pentru fiecare editor sunt prezentate pe paginile de informații ale partenerilor)."
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:392
-msgid ""
-"Please note that in the event of any differences in meaning or "
-"interpretation between the original English version of these terms and a "
-"translation, the original English version takes precedence."
-msgstr ""
-"Vă rugăm să rețineți că, în cazul unor diferențe de sens sau de interpretare "
-"între versiunea inițială în limba engleză a acestor termeni și o traducere, "
-"versiunea inițială în limba engleză are prioritate."
+msgid "Please note that in the event of any differences in meaning or interpretation between the original English version of these terms and a translation, the original English version takes precedence."
+msgstr "Vă rugăm să rețineți că, în cazul unor diferențe de sens sau de interpretare între versiunea inițială în limba engleză a acestor termeni și o traducere, versiunea inițială în limba engleză are prioritate."
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Wikimedia Foundation should not be translated.
 #: TWLight/users/templates/users/terms.html:403
-msgid ""
-"See also the <a class=\"twl-links\" href=\"https://wikimediafoundation.org/"
-"wiki/Privacy_policy\">Wikimedia Foundation Privacy Policy</a>."
-msgstr ""
-"Consultați și <a class=\"twl-links\" href=\"https://wikimediafoundation.org/"
-"wiki/Privacy_policy\">Politica de confidențialitate a Fundației Wikimedia</"
-"a>."
+msgid "See also the <a class=\"twl-links\" href=\"https://wikimediafoundation.org/wiki/Privacy_policy\">Wikimedia Foundation Privacy Policy</a>."
+msgstr "Consultați și <a class=\"twl-links\" href=\"https://wikimediafoundation.org/wiki/Privacy_policy\">Politica de confidențialitate a Fundației Wikimedia</a>."
 
 #. Translators: This is the second to last line of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:412
@@ -3979,16 +2876,8 @@ msgstr "Fundația Wikimedia"
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:426
-msgid ""
-"By checking this box and clicking “Submit”, you agree that you have read the "
-"above terms and that you will adhere to the terms of use in your application "
-"to and use of the The Wikipedia Library, and the publishers’ services to "
-"which you gain access through The Wikipedia Library program."
-msgstr ""
-"Bifând această casetă și făcând clic pe „Trimite”, sunteți de acord că ați "
-"citit termenii de mai sus și că veți respecta termenii de utilizare în "
-"aplicația și utilizarea Bibliotecii Wikipedia și a serviciilor editorilor la "
-"care beneficiați acces prin programul Biblioteca Wikipedia."
+msgid "By checking this box and clicking “Submit”, you agree that you have read the above terms and that you will adhere to the terms of use in your application to and use of the The Wikipedia Library, and the publishers’ services to which you gain access through The Wikipedia Library program."
+msgstr "Bifând această casetă și făcând clic pe „Trimite”, sunteți de acord că ați citit termenii de mai sus și că veți respecta termenii de utilizare în aplicația și utilizarea Bibliotecii Wikipedia și a serviciilor editorilor la care beneficiați acces prin programul Biblioteca Wikipedia."
 
 #: TWLight/users/templates/users/user_collection_tile.html:32
 msgid "Remove this collection from favorites"
@@ -4040,41 +2929,19 @@ msgstr "Ștergeți toate datele"
 
 #. Translators: This message is displayed on the page where users can request the deletion of their data.
 #: TWLight/users/templates/users/user_confirm_delete.html:17
-msgid ""
-"<b>Warning:</b> Performing this action will delete your Wikipedia Library "
-"Card user account and all associated applications. This process is not "
-"reversible. You may lose any partner accounts you were granted, and will not "
-"be able to renew those accounts or apply for new ones."
-msgstr ""
-"<b>Avertisment:</b> Efectuarea acestei acțiuni va șterge contul de "
-"utilizator la Biblioteca Wikipedia și toate solicitările asociate. Acest "
-"proces nu este reversibil. Puteți pierde orice cont de partener care vi s-a "
-"acordat și nu veți putea reînnoi aceste conturi și nu puteți aplica pentru "
-"noi conturi."
+msgid "<b>Warning:</b> Performing this action will delete your Wikipedia Library Card user account and all associated applications. This process is not reversible. You may lose any partner accounts you were granted, and will not be able to renew those accounts or apply for new ones."
+msgstr "<b>Avertisment:</b> Efectuarea acestei acțiuni va șterge contul de utilizator la Biblioteca Wikipedia și toate solicitările asociate. Acest proces nu este reversibil. Puteți pierde orice cont de partener care vi s-a acordat și nu veți putea reînnoi aceste conturi și nu puteți aplica pentru noi conturi."
 
 #. Translators: this should show up for people who log in with a username/password and not OAuth, so we don't know what their Wikipedia identity is.
-#.
 #: TWLight/users/templates/users/user_detail.html:12
 #, python-format
-msgid ""
-"Hi, %(username)s! You don't have a Wikipedia editor profile attached to your "
-"account here, so you are probably a site administrator."
-msgstr ""
-"Salut, %(username)s! Nu aveți un profil de editor Wikipedia atașat contului "
-"dvs. aici, deci sunteți probabil administrator de site."
+msgid "Hi, %(username)s! You don't have a Wikipedia editor profile attached to your account here, so you are probably a site administrator."
+msgstr "Salut, %(username)s! Nu aveți un profil de editor Wikipedia atașat contului dvs. aici, deci sunteți probabil administrator de site."
 
 #. Translators: In the unlikely scenario that someone is able to register an account without using OAuth (thus leaving us without some of the information required for applications), users will see this message, encouraging them to re-register.
 #: TWLight/users/templates/users/user_detail.html:20
-msgid ""
-"If you aren't a site administrator, something weird has happened. You won't "
-"be able to apply for access without a Wikipedia editor profile. You should "
-"log out and create a new account by logging in via OAuth, or contact a site "
-"administrator for help."
-msgstr ""
-"Dacă nu sunteți administrator de site, s-a întâmplat ceva ciudat. Nu veți "
-"putea solicita accesul fără un profil de editor Wikipedia. Ar trebui să vă "
-"deconectați și să creați un cont nou prin logare prin OAuth sau să "
-"contactați un administrator de site pentru ajutor."
+msgid "If you aren't a site administrator, something weird has happened. You won't be able to apply for access without a Wikipedia editor profile. You should log out and create a new account by logging in via OAuth, or contact a site administrator for help."
+msgstr "Dacă nu sunteți administrator de site, s-a întâmplat ceva ciudat. Nu veți putea solicita accesul fără un profil de editor Wikipedia. Ar trebui să vă deconectați și să creați un cont nou prin logare prin OAuth sau să contactați un administrator de site pentru ajutor."
 
 #. Translators: Labels a sections where coordinators can select their email preferences.
 #: TWLight/users/templates/users/user_email_preferences.html:15
@@ -4084,23 +2951,13 @@ msgstr "Doar coordonatori"
 #. Translators: This message is shown on user's own profile page, encouraging them to make sure their information is up to date, so that account coordinators can use the information to judge applications.
 #: TWLight/users/views.py:176
 #, python-brace-format
-msgid ""
-"Please <a class='twl-links' href='{url}'>update your contributions</a> to "
-"Wikipedia to help coordinators evaluate your applications."
-msgstr ""
-"Vă rugăm <a class='twl-links' href='{url}'>actualizați-vă contribuțiile</a> "
-"la Wikipedia pentru a ajuta coordonatorii să vă evalueze solicitările."
+msgid "Please <a class='twl-links' href='{url}'>update your contributions</a> to Wikipedia to help coordinators evaluate your applications."
+msgstr "Vă rugăm <a class='twl-links' href='{url}'>actualizați-vă contribuțiile</a> la Wikipedia pentru a ajuta coordonatorii să vă evalueze solicitările."
 
 #. Translators: Coordinators are shown this message when they unselect all three types of reminder email options under preferences.
 #: TWLight/users/views.py:288
-msgid ""
-"You have chosen not to receive reminder emails. As a coordinator, you should "
-"receive at least one type of reminder emails, so consider changing your "
-"preferences."
-msgstr ""
-"Ați ales să nu primiți e-mailuri de memento. În calitate de coordonator, ar "
-"trebui să primiți cel puțin un tip de e-mailuri de memento, așa că luați în "
-"considerare schimbarea preferințelor."
+msgid "You have chosen not to receive reminder emails. As a coordinator, you should receive at least one type of reminder emails, so consider changing your preferences."
+msgstr "Ați ales să nu primiți e-mailuri de memento. În calitate de coordonator, ar trebui să primiți cel puțin un tip de e-mailuri de memento, așa că luați în considerare schimbarea preferințelor."
 
 #. Translators: Coordinators are shown this message when they make changes to their reminder email options under preferences.
 #: TWLight/users/views.py:296
@@ -4123,9 +2980,7 @@ msgstr "Informațiile dvs. au fost actualizate."
 #. Translators: If a user tries to save the 'email change form' without entering one and checking the 'use my Wikipedia email address' checkbox, this message is presented.
 #: TWLight/users/views.py:448
 msgid "Both the values cannot be blank. Either enter a email or check the box."
-msgstr ""
-"Ambele valori nu pot fi necompletate. Fie introduceți un e-mail, fie bifați "
-"caseta."
+msgstr "Ambele valori nu pot fi necompletate. Fie introduceți un e-mail, fie bifați caseta."
 
 #. Translators: Shown to users when they successfully modify their email. Don't translate {email}.
 #: TWLight/users/views.py:476
@@ -4135,12 +2990,8 @@ msgstr "E-mailul dvs. a fost schimbat în {email}."
 
 #. Translators: If the user has not filled out their email, they can browse the website but cannot apply for access to resources.
 #: TWLight/users/views.py:487
-msgid ""
-"Your email is blank. You can still explore the site, but you won't be able "
-"to apply for access to partner resources without an email."
-msgstr ""
-"E-mailul dvs. este necompletat. Încă puteți explora site-ul, dar nu veți "
-"putea solicita accesul la resursele partenere fără un e-mail."
+msgid "Your email is blank. You can still explore the site, but you won't be able to apply for access to partner resources without an email."
+msgstr "E-mailul dvs. este necompletat. Încă puteți explora site-ul, dar nu veți putea solicita accesul la resursele partenere fără un e-mail."
 
 #. Translators: This message is shown once the access to a partner has successfully been returned.
 #: TWLight/users/views.py:801
@@ -4172,31 +3023,3 @@ msgstr "Nu există blocări active"
 msgid "10+ edits in the last 30 days"
 msgstr "Peste 10 modificări în ultimele 30 de zile"
 
-#: tests/shunit/data/bad_i18n_comment_1.py:3
-#: tests/shunit/data/bad_i18n_newline_1.py:5
-msgid "1"
-msgstr ""
-
-#. Translators: Lorem ipsum dolor sit amet, consectetur adipiscing elit. Mauris vitae ipsum ut purus faucibus pretium. Proin tempus neque et aliquet consectetur. Ut egestas sapien in consectetur sagittis. Mauris neque lacus, dapibus non viverra vitae, interdum ut aenean ipsum.
-#. Translators: Lorem ipsum dolor sit amet, consectetur adipiscing elit. Mauris vitae ipsum ut purus faucibus pretium. Proin tempus neque et aliquet consectetur. Ut egestas sapien in consectetur sagittis. Mauris neque lacus, dapibus non.
-#: tests/shunit/data/bad_i18n_comment_2.py:4
-#: tests/shunit/data/bad_i18n_newline_2.py:5 tests/shunit/data/good_i18n_1.py:2
-#: tests/shunit/data/good_i18n_2.py:2
-msgid "2"
-msgstr ""
-
-#: tests/shunit/data/bad_i18n_newline_3.py:5
-msgid "3"
-msgstr ""
-
-#: tests/shunit/data/bad_i18n_newline_4.py:5
-msgid "4"
-msgstr ""
-
-#: tests/shunit/data/bad_i18n_newline_5.py:5
-msgid "5"
-msgstr ""
-
-#: tests/shunit/data/bad_i18n_newline_6.py:5
-msgid "6"
-msgstr ""

--- a/locale/ru/LC_MESSAGES/django.po
+++ b/locale/ru/LC_MESSAGES/django.po
@@ -44,17 +44,17 @@
 # Author: Евгения
 msgid ""
 msgstr ""
+""
 "Project-Id-Version: Wikipedia Library Card Platform - Website\n"
-"Report-Msgid-Bugs-To: wikipedialibrary@wikimedia.org\n"
+"Report-Msgid-Bugs-To: translatewiki.net\n"
 "POT-Creation-Date: 2024-07-11 20:54+0000\n"
-"PO-Revision-Date: 2024-07-11 12:30:18+0000\n"
+"PO-Revision-Date: 2024-07-15 12:29:19+0000\n"
 "Language: ru\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "X-POT-Import-Date: 2024-06-25 18:44:08+0000\n"
 "X-Generator: MediaWiki 1.43.0-alpha; Translate 2024-07-16\n"
-"Plural-Forms: nplurals=3; plural=(n%10 == 1 && n%100 != 11) ? 0 : ( (n%10 >= "
-"2 && n%10 <= 4 && (n%100 < 10 || n%100 >= 20)) ? 1 : 2 );\n"
+"Plural-Forms: nplurals=3; plural=(n%10 == 1 && n%100 != 11) ? 0 : ( (n%10 >= 2 && n%10 <= 4 && (n%100 < 10 || n%100 >= 20)) ? 1 : 2 );\n"
 "X-Translation-Project: translatewiki.net <https://translatewiki.net>\n"
 
 #. Translators: Labels the button users click to apply for a partner's resources.
@@ -80,13 +80,8 @@ msgstr "О вас"
 #. Translators: This note appears in a section of a form where we ask users to enter info (like country of residence) when applying for resource access.
 #: TWLight/applications/forms.py:179
 #, python-brace-format
-msgid ""
-"<p><small><i>Your personal data will be processed according to our <a "
-"class='twl-links' href='{terms_url}'> privacy policy</a>.</i></small></p>"
-msgstr ""
-"<p><small><i>Ваши персональные данные будут обрабатываться в соответствии с "
-"нашей <a class='twl-links' href='{terms_url}'> политикой конфиденциальности</"
-"a>.</i></small></p>"
+msgid "<p><small><i>Your personal data will be processed according to our <a class='twl-links' href='{terms_url}'> privacy policy</a>.</i></small></p>"
+msgstr "<p><small><i>Ваши персональные данные будут обрабатываться в соответствии с нашей <a class='twl-links' href='{terms_url}'> политикой конфиденциальности</a>.</i></small></p>"
 
 #. Translators: This is the title of the application form page, where users enter information required for the application. It lets the user know which partner application they are entering data for. {partner}
 #: TWLight/applications/forms.py:189
@@ -127,12 +122,8 @@ msgstr "Адрес эл. почты к вашей учётной записи н
 #. Translators: This labels a choice field where users will have to select the number of months they wish to have their access for as part of the application renewal confirmation.
 #. Translators: When filling out an application, users may be required to enter the length of the account (expiry) they wish to have for proxy partners.
 #: TWLight/applications/forms.py:339 TWLight/applications/helpers.py:100
-msgid ""
-"The number of months you wish to have this access for before renewal is "
-"required"
-msgstr ""
-"Количество месяцев, на которое вы хотите получить доступ, прежде чем "
-"потребуется продление срока действия"
+msgid "The number of months you wish to have this access for before renewal is required"
+msgstr "Количество месяцев, на которое вы хотите получить доступ, прежде чем потребуется продление срока действия"
 
 #. Translators: When filling out an application, users may need to specify their name
 #: TWLight/applications/helpers.py:81
@@ -220,12 +211,8 @@ msgstr "Эл. почта"
 
 #. Translators: This comment is added to pending applications when our terms of use change.
 #: TWLight/applications/management/commands/notify_applicants_tou_changes.py:54
-msgid ""
-"Our terms of use have changed. Your applications will not be processed until "
-"you log in and agree to our updated terms."
-msgstr ""
-"Наши условия использования изменились. Ваши заявки будут обработаны после "
-"того, как вы войдёте в систему и согласитесь с нашими обновлёнными условиями."
+msgid "Our terms of use have changed. Your applications will not be processed until you log in and agree to our updated terms."
+msgstr "Наши условия использования изменились. Ваши заявки будут обработаны после того, как вы войдёте в систему и согласитесь с нашими обновлёнными условиями."
 
 #. Translators: This is the status of an application that has not yet been reviewed.
 #: TWLight/applications/models.py:54
@@ -291,43 +278,26 @@ msgstr "Ссылка для доступа: {access_url}"
 
 #. Translators: This text goes into account approval emails in the case that we need to send the user's details to a publisher for manual account setup.
 #: TWLight/applications/models.py:331
-msgid ""
-"You can expect to receive access details within a week or two once it has "
-"been processed."
-msgstr ""
-"Вы можете рассчитывать на получение сведений о доступе в течение 1—2 недель "
-"после обработки заявки."
+msgid "You can expect to receive access details within a week or two once it has been processed."
+msgstr "Вы можете рассчитывать на получение сведений о доступе в течение 1—2 недель после обработки заявки."
 
 #. Translators: This comment is added to open applications when a partner joins the Library Bundle, which does not require applications.
 #: TWLight/applications/signals.py:247
-msgid ""
-"This partner joined the Library Bundle, which does not require applications. "
-"This application will be marked as invalid."
-msgstr ""
-"Этот партнер присоединился к Набору Библиотеки, который не требует подачи "
-"заявок. Данная заявка будет помечена как недействительная."
+msgid "This partner joined the Library Bundle, which does not require applications. This application will be marked as invalid."
+msgstr "Этот партнер присоединился к Набору Библиотеки, который не требует подачи заявок. Данная заявка будет помечена как недействительная."
 
 #. Translators: This is shown to users if the application is to a partner for which we have run out of available accounts. The application is therefore on a 'waitlist', and will be reviewed when more accounts are available.
 #: TWLight/applications/templates/applications/application_evaluation.html:29
-msgid ""
-"This application is on the waitlist because this partner does not have any "
-"access grants available at this time."
-msgstr ""
-"Эта заявка находится в списке ожидания, потому что этот партнёр на данный "
-"момент превысил лимит предоставления прав доступа."
+msgid "This application is on the waitlist because this partner does not have any access grants available at this time."
+msgstr "Эта заявка находится в списке ожидания, потому что этот партнёр на данный момент превысил лимит предоставления прав доступа."
 
 #. Translators: This message is shown on pages where coordinators can see personal information about applicants.
 #: TWLight/applications/templates/applications/application_evaluation.html:36
 #: TWLight/applications/templates/applications/application_list_include.html:6
 #: TWLight/applications/templates/applications/send_partner.html:45
 #: TWLight/resources/templates/resources/partner_users.html:18
-msgid ""
-"Coordinators: This page may contain personal information such as real names "
-"and email addresses. Please remember that this information is confidential."
-msgstr ""
-"Координаторы: Эта страница может содержать личную информацию, такую как "
-"реальные имена и адреса эл. почты. Пожалуйста, помните, что эта информация "
-"является конфиденциальной."
+msgid "Coordinators: This page may contain personal information such as real names and email addresses. Please remember that this information is confidential."
+msgstr "Координаторы: Эта страница может содержать личную информацию, такую как реальные имена и адреса эл. почты. Пожалуйста, помните, что эта информация является конфиденциальной."
 
 #. Translators: This is the title of the application page shown to users who are a coordinator, and are able to accept or reject the application.
 #: TWLight/applications/templates/applications/application_evaluation.html:39
@@ -336,12 +306,8 @@ msgstr "Оценить заявку"
 
 #. Translators: This text is shown to coordinators on application pages if the applicant has restricted processing of their data.
 #: TWLight/applications/templates/applications/application_evaluation.html:42
-msgid ""
-"This user has requested a restriction on the processing of their data, so "
-"you cannot change the status of their application."
-msgstr ""
-"Этот пользователь запросил ограничение на обработку своих данных, поэтому вы "
-"не можете изменить статус его заявки."
+msgid "This user has requested a restriction on the processing of their data, so you cannot change the status of their application."
+msgstr "Этот пользователь запросил ограничение на обработку своих данных, поэтому вы не можете изменить статус его заявки."
 
 #. Translators: This is the title of the application page shown to users who are not a coordinator.
 #: TWLight/applications/templates/applications/application_evaluation.html:48
@@ -414,12 +380,8 @@ msgstr "Неизвестно"
 
 #. Translators: This is the text displayed to coordinators when an applicant has no country of residence in their profile.
 #: TWLight/applications/templates/applications/application_evaluation.html:123
-msgid ""
-"Please request the applicant add their country of residence to their profile "
-"before proceeding further."
-msgstr ""
-"Пожалуйста, попросите заявителя добавить страну проживания в свой профиль, "
-"прежде чем продолжить рассмотрение дела."
+msgid "Please request the applicant add their country of residence to their profile before proceeding further."
+msgstr "Пожалуйста, попросите заявителя добавить страну проживания в свой профиль, прежде чем продолжить рассмотрение дела."
 
 #. Translators: This labels the section of an application showing the total number of accounts available for a partner or their collection.
 #: TWLight/applications/templates/applications/application_evaluation.html:134
@@ -430,12 +392,8 @@ msgstr "Доступные аккаунты:"
 #. Translators: This labels the section of an application showing whether the user had agreed to the terms of use or not.
 #: TWLight/applications/templates/applications/application_evaluation.html:145
 #, python-format
-msgid ""
-"Has agreed to the site's <a class=\"twl-links\" href=\"%(terms_url)s\">terms "
-"of use</a>?"
-msgstr ""
-"Получено соглашение с <a class=\"twl-links\" href=\"%(terms_url)s"
-"\">условиями использования сайта</a>?"
+msgid "Has agreed to the site's <a class=\"twl-links\" href=\"%(terms_url)s\">terms of use</a>?"
+msgstr "Получено соглашение с <a class=\"twl-links\" href=\"%(terms_url)s\">условиями использования сайта</a>?"
 
 #. Translators: Displayed to coordinators when they've agreed to the terms of use.
 #. Translators: Displayed if the user has agreed to the terms of use.
@@ -470,12 +428,8 @@ msgstr "Нет"
 
 #. Translators: This is the text displayed to coordinators when an applicant has not agreed to the terms of use.
 #: TWLight/applications/templates/applications/application_evaluation.html:159
-msgid ""
-"Please request the applicant agree to the site's terms of use before "
-"approving this application."
-msgstr ""
-"Пожалуйста, попросите заявителя согласиться с условиями использования сайта, "
-"прежде чем утверждать данную заявку."
+msgid "Please request the applicant agree to the site's terms of use before approving this application."
+msgstr "Пожалуйста, попросите заявителя согласиться с условиями использования сайта, прежде чем утверждать данную заявку."
 
 #. Translators: This labels the section of an application containing the user's motivation for wanting access to this resource.
 #: TWLight/applications/templates/applications/application_evaluation.html:176
@@ -495,10 +449,8 @@ msgstr "Продление существующего права доступа?
 #. Translators: This message is shown next to the 'Renewal of existing access grant?' label if the application is a renewal. Don't translate HTML tags or parent_url.
 #: TWLight/applications/templates/applications/application_evaluation.html:195
 #, python-format
-msgid ""
-"Yes (<a class=\"twl-links\" href=\"%(parent_url)s\">previous application</a>)"
-msgstr ""
-"Да (<a class=\"twl-links\" href=\"%(parent_url)s\">предыдущая заявка</a>)"
+msgid "Yes (<a class=\"twl-links\" href=\"%(parent_url)s\">previous application</a>)"
+msgstr "Да (<a class=\"twl-links\" href=\"%(parent_url)s\">предыдущая заявка</a>)"
 
 #. Translators: This labels the section of the application showing the length of access remaining on the user's previous authorization.
 #: TWLight/applications/templates/applications/application_evaluation.html:208
@@ -532,9 +484,7 @@ msgstr "Добавить комментарий"
 
 #. Translators: On an application page, this text tells users that the comments posted on the application are visible to coordinators and the submitting user only.
 #: TWLight/applications/templates/applications/application_evaluation.html:297
-msgid ""
-"Comments are visible to all coordinators and to the editor who submitted "
-"this application."
+msgid "Comments are visible to all coordinators and to the editor who submitted this application."
 msgstr "Комментарии видны всем координаторам и участнику, подавшему заявку."
 
 #. Translators: This is the title of the section of an application page which lists information about the user who submitted the application.
@@ -747,18 +697,8 @@ msgstr "Установить статус"
 
 #: TWLight/applications/templates/applications/apply.html:20
 #, python-format
-msgid ""
-"If your application is successful we may share your email address with "
-"%(partner)s. This is required to set up your access to their resources. By "
-"submitting this form you agree to allow your email address to be shared with "
-"%(partner)s if your application is successful, for the purposes of account "
-"setup."
-msgstr ""
-"Если ваша заявка одобрена, вероятно, мы поделимся вашей эл. почтой с "
-"%(partner)s. Это необходимо для настройки вашего доступа к их ресурсам. "
-"Подтверждая и отправляя эту форму, вы соглашаетесь предоставить разрешение "
-"на распространение вашей эл. почты среди %(partner)s в случае одобрения "
-"вашей заявки с целями, касающимися настройки вашего аккаунта."
+msgid "If your application is successful we may share your email address with %(partner)s. This is required to set up your access to their resources. By submitting this form you agree to allow your email address to be shared with %(partner)s if your application is successful, for the purposes of account setup."
+msgstr "Если ваша заявка одобрена, вероятно, мы поделимся вашей эл. почтой с %(partner)s. Это необходимо для настройки вашего доступа к их ресурсам. Подтверждая и отправляя эту форму, вы соглашаетесь предоставить разрешение на распространение вашей эл. почты среди %(partner)s в случае одобрения вашей заявки с целями, касающимися настройки вашего аккаунта."
 
 #. Translators: This message is displayed on the page where users can confirm their renewal. Please do not translate partner.
 #: TWLight/applications/templates/applications/confirm_renewal.html:23
@@ -786,12 +726,8 @@ msgstr "К каким ресурсам вы хотите получить дос
 
 #. Translators: This text explains that Library Bundle partners are not shown in this list.
 #: TWLight/applications/templates/applications/request_for_application.html:26
-msgid ""
-"Library Bundle partners are not shown as eligibility is determined "
-"automatically."
-msgstr ""
-"Партнеры Library Bundle не отображаются, так как право на участие "
-"определяется автоматически."
+msgid "Library Bundle partners are not shown as eligibility is determined automatically."
+msgstr "Партнеры Library Bundle не отображаются, так как право на участие определяется автоматически."
 
 #. Translators: On the page where users can apply for multiple partners, this message shows next to the partner name, taking them to the full application page when clicked.
 #: TWLight/applications/templates/applications/request_for_application.html:48
@@ -805,14 +741,8 @@ msgstr "Партнёрские данные пока отсутствуют."
 
 #. Translators: the HTML is so that the word 'waitlisted' will look the same as it does in the page above; please translate 'waitlisted' the same way you did elsewhere in this file.
 #: TWLight/applications/templates/applications/request_for_application.html:74
-msgid ""
-"You can apply to <span class=\"badge badge-warning\">Waitlisted</span> "
-"partners, but they don't have access grants available right now. We will "
-"process those applications when access becomes available."
-msgstr ""
-"Вы можете подать заявку партнёрам <span class=\"badge badge-warning\">из "
-"списка ожидания</span>, однако они не предоставляют доступ в данный момент. "
-"Мы обработаем эти заявки, как только раздача доступа возобновится."
+msgid "You can apply to <span class=\"badge badge-warning\">Waitlisted</span> partners, but they don't have access grants available right now. We will process those applications when access becomes available."
+msgstr "Вы можете подать заявку партнёрам <span class=\"badge badge-warning\">из списка ожидания</span>, однако они не предоставляют доступ в данный момент. Мы обработаем эти заявки, как только раздача доступа возобновится."
 
 #. Translators: On the page where coordinators can see approved applications which have not had their details sent to the partner, this message shows when there are applications ready to be processed.
 #: TWLight/applications/templates/applications/send.html:10
@@ -833,20 +763,13 @@ msgstr "Данные о заявках для %(object)s"
 #. Translators: This message is shown when applications exceed the number of accounts available.
 #: TWLight/applications/templates/applications/send_partner.html:54
 #, python-format
-msgid ""
-"Application(s) for %(object)s, if sent, will exceed the total available "
-"accounts for the partner. Please proceed at your own discretion."
-msgstr ""
-"Если на %(object)s отправить ещё заявки, их число превысит общее количество "
-"доступных учётных записей для партнёра. Пожалуйста, действуйте по своему "
-"усмотрению."
+msgid "Application(s) for %(object)s, if sent, will exceed the total available accounts for the partner. Please proceed at your own discretion."
+msgstr "Если на %(object)s отправить ещё заявки, их число превысит общее количество доступных учётных записей для партнёра. Пожалуйста, действуйте по своему усмотрению."
 
 #. Translators: When viewing the list of applications ready to be sent for a particular partner, this is instructions for the coordinator to click the 'mark as sent' button after they have sent the information.
 #: TWLight/applications/templates/applications/send_partner.html:65
 msgid "When you've processed the data below, click the 'mark as sent' button."
-msgstr ""
-"Когда вы закончите вводить данные, нажмите на кнопку «Пометить как "
-"посланное»."
+msgstr "Когда вы закончите вводить данные, нажмите на кнопку «Пометить как посланное»."
 
 #. Translators: When viewing the list of applications ready to be sent for a particular partner, this is the title of the section containing contact information for the people applications should be sent to.
 #: TWLight/applications/templates/applications/send_partner.html:71
@@ -858,12 +781,8 @@ msgstr[2] "Контактная информация"
 
 #. Translators: When viewing the list of applications ready to be sent for a particular partner, this message shows if there is no information about who the applications should be sent to. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/applications/templates/applications/send_partner.html:89
-msgid ""
-"Whoops, we don't have any listed contacts. Please notify Wikipedia Library "
-"administrators."
-msgstr ""
-"Упс, мы не указали контактов. Пожалуйста, уведомите администраторов "
-"Библиотеки Википедии."
+msgid "Whoops, we don't have any listed contacts. Please notify Wikipedia Library administrators."
+msgstr "Упс, мы не указали контактов. Пожалуйста, уведомите администраторов Библиотеки Википедии."
 
 #. Translators: When viewing the list of applications ready to be sent for a particular partner, this is the title of the section containing the information about those applications.
 #: TWLight/applications/templates/applications/send_partner.html:94
@@ -878,12 +797,8 @@ msgstr "Пометить как посланное"
 
 #. Translators: This text guides coordinators in using the code sending interface for approved applications.
 #: TWLight/applications/templates/applications/send_partner.html:152
-msgid ""
-"Use the dropdown menus to denote which editor will receive each code. Access "
-"codes will be sent to users automatically."
-msgstr ""
-"Используйте раскрывающиеся меню, чтобы указать, какой редактор получит "
-"каждый код. Коды доступа будут отправлены пользователям автоматически."
+msgid "Use the dropdown menus to denote which editor will receive each code. Access codes will be sent to users automatically."
+msgstr "Используйте раскрывающиеся меню, чтобы указать, какой редактор получит каждый код. Коды доступа будут отправлены пользователям автоматически."
 
 #. Translators: This labels a drop-down selection where staff can assign an access code to a user.
 #: TWLight/applications/templates/applications/send_partner.html:173
@@ -898,23 +813,14 @@ msgstr "Нет одобренных или неотправленных заяв
 #. Translators: When a user applies for a set of resources, they receive this message if none are currently available. They are instead placed on a 'waitlist' for later approval.
 #. Translators: When a user renews their resource, they receive this message if none are currently available. They are instead placed on a 'waitlist' for later approval.
 #: TWLight/applications/views.py:140 TWLight/applications/views.py:1282
-msgid ""
-"This partner does not have any access grants available at this time. You may "
-"still apply for access; your application will be reviewed when access grants "
-"become available."
-msgstr ""
-"Данный партнёр не раздаёт доступ в данный момент. Вы всё равно можете подать "
-"заявку; она будет обработана, как только раздача доступа возобновится."
+msgid "This partner does not have any access grants available at this time. You may still apply for access; your application will be reviewed when access grants become available."
+msgstr "Данный партнёр не раздаёт доступ в данный момент. Вы всё равно можете подать заявку; она будет обработана, как только раздача доступа возобновится."
 
 #. Translators: This message is shown to users once they've successfully submitted their application for review.
 #: TWLight/applications/views.py:163
 #, python-brace-format
-msgid ""
-"Your application has been submitted for review. Head over to <a "
-"href='{applications_url}'>My Applications</a> to view the status."
-msgstr ""
-"Ваша заявка была отправлена на рассмотрение. Перейдите в <a "
-"href='{applications_url}'>Мои заявки</a>, чтобы проверить их статус."
+msgid "Your application has been submitted for review. Head over to <a href='{applications_url}'>My Applications</a> to view the status."
+msgstr "Ваша заявка была отправлена на рассмотрение. Перейдите в <a href='{applications_url}'>Мои заявки</a>, чтобы проверить их статус."
 
 #. Translators: This text is displayed to users when the user has chosen to restrict data and is trying to apply for multiple partners
 #: TWLight/applications/views.py:276
@@ -962,22 +868,13 @@ msgstr "Отправленные заявки"
 
 #. Translators: After a coordinator has changed the status of an application to APPROVED, if the corresponding partner/collection is waitlisted this message appears.
 #: TWLight/applications/views.py:756
-msgid ""
-"Cannot approve application as partner with proxy authorization method is "
-"waitlisted."
-msgstr ""
-"Не удаётся подтвердить заявку, поскольку партнёр с прокси-методом "
-"авторизации находится в списке ожидания."
+msgid "Cannot approve application as partner with proxy authorization method is waitlisted."
+msgstr "Не удаётся подтвердить заявку, поскольку партнёр с прокси-методом авторизации находится в списке ожидания."
 
 #. Translators: After a coordinator has changed the status of an application to APPROVED, if the corresponding partner/collection has no accounts for distribution, this message appears.
 #: TWLight/applications/views.py:780
-msgid ""
-"Cannot approve application as partner with proxy authorization method is "
-"waitlisted and (or) has zero accounts available for distribution."
-msgstr ""
-"Не удаётся подтвердить заявку, поскольку партнёр с прокси-методом "
-"авторизации находится в списке ожидания и/или исчерпал лимит имеющих доступ "
-"учётных записей."
+msgid "Cannot approve application as partner with proxy authorization method is waitlisted and (or) has zero accounts available for distribution."
+msgstr "Не удаётся подтвердить заявку, поскольку партнёр с прокси-методом авторизации находится в списке ожидания и/или исчерпал лимит имеющих доступ учётных записей."
 
 #. Translators: This message appears on an "access denied" screen that stops users who attempt to authorize an editor to access a resource during a time period for which they are already authorized.
 #: TWLight/applications/views.py:803
@@ -987,17 +884,8 @@ msgstr "Вы попытались провести повторную автор
 #. Translators: This message is shown to users when they access an application page of a now Bundle partner (new applications aren't allowed for Bundle partners and the status of old applications cannot be modified)
 #: TWLight/applications/views.py:857
 #, python-brace-format
-msgid ""
-"This application cannot be modified since this partner is now part of our <a "
-"href='{bundle}'>bundle access</a>. If you are eligible, you can access this "
-"resource from <a href='{library}'>your library</a>. <a "
-"href='{contact}'>Contact us</a> if you have any questions."
-msgstr ""
-"Данная заявка не может быть изменена, поскольку партнёр теперь является "
-"частью <a href='{bundle}'>Набора Библиотеки</a>. Если вы соответствуете "
-"критериям, вы можете получить доступ к этому ресурсу из <a "
-"href='{library}'>вашей библиотеки</a>. <a href='{contact}'>Свяжитесь с нами</"
-"a>, если у вас есть какие-либо вопросы."
+msgid "This application cannot be modified since this partner is now part of our <a href='{bundle}'>bundle access</a>. If you are eligible, you can access this resource from <a href='{library}'>your library</a>. <a href='{contact}'>Contact us</a> if you have any questions."
+msgstr "Данная заявка не может быть изменена, поскольку партнёр теперь является частью <a href='{bundle}'>Набора Библиотеки</a>. Если вы соответствуете критериям, вы можете получить доступ к этому ресурсу из <a href='{library}'>вашей библиотеки</a>. <a href='{contact}'>Свяжитесь с нами</a>, если у вас есть какие-либо вопросы."
 
 #. Translators: this lets a reviewer set the status of a single application.
 #: TWLight/applications/views.py:873
@@ -1006,12 +894,8 @@ msgstr "Установить статус заявки"
 
 #. Translators: This warning is message is shown to applicants when the number of pending applications is greater than the number of accounts available.
 #: TWLight/applications/views.py:891
-msgid ""
-"There are more pending applications than available accounts. Your "
-"application might get waitlisted."
-msgstr ""
-"Число необработанных заявок превышает количество доступных учётных записей. "
-"Ваша заявка может быть добавлена в список ожидания."
+msgid "There are more pending applications than available accounts. Your application might get waitlisted."
+msgstr "Число необработанных заявок превышает количество доступных учётных записей. Ваша заявка может быть добавлена в список ожидания."
 
 #. Translators: this message is shown to coordinators who attempt to change an application's Status from INVALID to any other Status.
 #: TWLight/applications/views.py:904
@@ -1030,16 +914,8 @@ msgstr "Групповое обновление заявок {} прошло у�
 
 #. Translators: After a coordinator has changed the status of a number of applications to APPROVED, if the corresponding partner(s) is/are waitlisted or has no accounts for distribution, this message appears.
 #: TWLight/applications/views.py:1051
-msgid ""
-"Cannot approve application(s) {} as partner(s) with proxy authorization "
-"method is/are waitlisted and (or) has/have not enough accounts available. If "
-"not enough accounts are available, prioritise the applications and then "
-"approve applications equal to the accounts available."
-msgstr ""
-"Не удаётся подтвердить заявки {}, так как партнёр(ы) с прокси-методом "
-"авторизации находятся в списке ожидания и/или исчерпали лимит имеющих доступ "
-"учётных записей. Если лимит учётных записей был исчерпан, расставьте "
-"приоритеты заявкам и подтвердите число заявок, не превышающее лимит."
+msgid "Cannot approve application(s) {} as partner(s) with proxy authorization method is/are waitlisted and (or) has/have not enough accounts available. If not enough accounts are available, prioritise the applications and then approve applications equal to the accounts available."
+msgstr "Не удаётся подтвердить заявки {}, так как партнёр(ы) с прокси-методом авторизации находятся в списке ожидания и/или исчерпали лимит имеющих доступ учётных записей. Если лимит учётных записей был исчерпан, расставьте приоритеты заявкам и подтвердите число заявок, не превышающее лимит."
 
 #. Translators: This message is shown to coordinators who attempt to assign the same access code to multiple users.
 #: TWLight/applications/views.py:1191
@@ -1053,13 +929,8 @@ msgstr "Все выбранные заявки отмечены отправле
 
 #. Translators: When a user tries to renew their resource, they receive this message if the partner is not available.
 #: TWLight/applications/views.py:1272
-msgid ""
-"Cannot renew application at this time as partner is not available. Please "
-"check back later, or contact us for more information."
-msgstr ""
-"Вы не можете продлить заявку в данный момент, так как партнёр недоступен. "
-"Пожалуйста, попробуйте позже, или свяжитесь с нами для получения дальнейшей "
-"информации."
+msgid "Cannot renew application at this time as partner is not available. Please check back later, or contact us for more information."
+msgstr "Вы не можете продлить заявку в данный момент, так как партнёр недоступен. Пожалуйста, попробуйте позже, или свяжитесь с нами для получения дальнейшей информации."
 
 #. Translators: This message is displayed when an attempt by a user to renew an application has been denied for some reason.
 #: TWLight/applications/views.py:1308
@@ -1069,21 +940,13 @@ msgstr "Попытка продлить неподтверждённую зая�
 
 #. Translators: If a user requests the renewal of their account, but it wasn't renewed, this message is shown to them.
 #: TWLight/applications/views.py:1385
-msgid ""
-"This object cannot be renewed. (This probably means that you have already "
-"requested that it be renewed.)"
-msgstr ""
-"Этот объект не может быть продлён (возможно, это означает, что вы уже "
-"запросили его продление)."
+msgid "This object cannot be renewed. (This probably means that you have already requested that it be renewed.)"
+msgstr "Этот объект не может быть продлён (возможно, это означает, что вы уже запросили его продление)."
 
 #. Translators: If a user requests the renewal of their account, this message is shown to them.
 #: TWLight/applications/views.py:1395
-msgid ""
-"Your renewal request has been received. A coordinator will review your "
-"request."
-msgstr ""
-"Ваша заявка на продление доступа получена. Координатор обработает вашу "
-"заявку."
+msgid "Your renewal request has been received. A coordinator will review your request."
+msgstr "Ваша заявка на продление доступа получена. Координатор обработает вашу заявку."
 
 #. Translators: This labels a textfield where users can enter their email ID.
 #: TWLight/emails/forms.py:18
@@ -1092,12 +955,8 @@ msgstr "Ваш адрес эл. почты"
 
 #. Translators: This is the help text for the email field in the contact us form letting users know the field is updated by value pulled from their respective user profiles.
 #: TWLight/emails/forms.py:21
-msgid ""
-"This field is automatically updated with the email from your <a class='twl-"
-"links' href='{}'>user profile</a>."
-msgstr ""
-"Это поле было автоматически заполнено электронным адресом из вашего <a "
-"class='twl-links' href='{}'>профиля</a>."
+msgid "This field is automatically updated with the email from your <a class='twl-links' href='{}'>user profile</a>."
+msgstr "Это поле было автоматически заполнено электронным адресом из вашего <a class='twl-links' href='{}'>профиля</a>."
 
 #. Translators: This labels a textfield where users can enter their email message.
 #: TWLight/emails/forms.py:26
@@ -1120,25 +979,14 @@ msgstr "Отправить"
 #. Translators: This email is sent to users with their access code. Don't translate Jinja variables in curly braces like user or partner. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/access_code_email-body-html.html:5
 #, python-format
-msgid ""
-"<p>Your approved application to %(partner)s has now been finalised. Your "
-"access code or login details can be found below:</p> <p><b>%(access_code)s</"
-"b></p> <p>%(user_instructions)s</p>"
-msgstr ""
-"<p>Ваша подтверждённая заявка к %(partner)s была закрыта. Ваш код доступа "
-"или данные для авторизации прописаны ниже:</p> <p><b>%(access_code)s</b></p> "
-"<p>%(user_instructions)s</p>"
+msgid "<p>Your approved application to %(partner)s has now been finalised. Your access code or login details can be found below:</p> <p><b>%(access_code)s</b></p> <p>%(user_instructions)s</p>"
+msgstr "<p>Ваша подтверждённая заявка к %(partner)s была закрыта. Ваш код доступа или данные для авторизации прописаны ниже:</p> <p><b>%(access_code)s</b></p> <p>%(user_instructions)s</p>"
 
 #. Translators: This email is sent to users with their access code. Don't translate Jinja variables in curly braces like user or partner. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/access_code_email-body-text.html:3
 #, python-format
-msgid ""
-"Your approved application to %(partner)s has now been finalised. Your access "
-"code or login details can be found below: %(access_code)s "
-"%(user_instructions)s"
-msgstr ""
-"Ваша подтверждённая заявка к %(partner)s была закрыта. Ваш код доступа или "
-"данные для авторизации прописаны ниже: %(access_code)s %(user_instructions)s"
+msgid "Your approved application to %(partner)s has now been finalised. Your access code or login details can be found below: %(access_code)s %(user_instructions)s"
+msgstr "Ваша подтверждённая заявка к %(partner)s была закрыта. Ваш код доступа или данные для авторизации прописаны ниже: %(access_code)s %(user_instructions)s"
 
 #. Translators: This is the subject line of an email sent to users with their access code.
 #: TWLight/emails/templates/emails/access_code_email-subject.html:3
@@ -1148,33 +996,14 @@ msgstr "Ваш код доступа к Библиотеке Википедии"
 #. Translators: This email is sent to users when their application is approved. Don't translate Jinja variables in curly braces like user or partner; don't translate html tags either. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/approval_notification-body-html.html:5
 #, python-format
-msgid ""
-"<p>Dear %(user)s,</p> <p>Thank you for applying for access to %(partner)s "
-"resources through The Wikipedia Library. We are happy to inform you that "
-"your application has been approved.</p> <p>%(user_instructions)s</p> <p>You "
-"can view the collections you're authorized to access at My Library: "
-"%(link)s</p> <p>Cheers!</p> <p>The Wikipedia Library</p>"
-msgstr ""
-"<p>Ув. %(user)s,</p> <p>Спасибо за подачу заявки на доступ к ресурсам "
-"%(partner)s через Библиотеку Википедии. Мы рады сообщить, что ваша заявка "
-"была одобрена.</p> <p>%(user_instructions)s</p> <p>Вы можете просмотреть "
-"доступные коллекции в Моей библиотеке: %(link)s</p> <p>Пока!</p> "
-"<p>Библиотека Википедии</p>"
+msgid "<p>Dear %(user)s,</p> <p>Thank you for applying for access to %(partner)s resources through The Wikipedia Library. We are happy to inform you that your application has been approved.</p> <p>%(user_instructions)s</p> <p>You can view the collections you're authorized to access at My Library: %(link)s</p> <p>Cheers!</p> <p>The Wikipedia Library</p>"
+msgstr "<p>Ув. %(user)s,</p> <p>Спасибо за подачу заявки на доступ к ресурсам %(partner)s через Библиотеку Википедии. Мы рады сообщить, что ваша заявка была одобрена.</p> <p>%(user_instructions)s</p> <p>Вы можете просмотреть доступные коллекции в Моей библиотеке: %(link)s</p> <p>Пока!</p> <p>Библиотека Википедии</p>"
 
 #. Translators: This email is sent to users when their application is approved. Don't translate Jinja variables in curly braces like user or partner. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/approval_notification-body-text.html:3
 #, python-format
-msgid ""
-"Dear %(user)s, Thank you for applying for access to %(partner)s resources "
-"through The Wikipedia Library. We are happy to inform you that your "
-"application has been approved. %(user_instructions)s You can view the "
-"collections you're authorized to access at My Library: %(link)s Cheers! The "
-"Wikipedia Library"
-msgstr ""
-"Ув. %(user)s, Спасибо за подачу заявки на доступ к ресурсам %(partner)s "
-"через Библиотеку Википедии. Мы рады сообщить, что ваша заявка была одобрена. "
-"%(user_instructions)s Вы можете просмотреть доступные коллекции в Моей "
-"библиотеке: %(link)s Пока! Библиотека Википедии"
+msgid "Dear %(user)s, Thank you for applying for access to %(partner)s resources through The Wikipedia Library. We are happy to inform you that your application has been approved. %(user_instructions)s You can view the collections you're authorized to access at My Library: %(link)s Cheers! The Wikipedia Library"
+msgstr "Ув. %(user)s, Спасибо за подачу заявки на доступ к ресурсам %(partner)s через Библиотеку Википедии. Мы рады сообщить, что ваша заявка была одобрена. %(user_instructions)s Вы можете просмотреть доступные коллекции в Моей библиотеке: %(link)s Пока! Библиотека Википедии"
 
 #. Translators: This is the subject of an email which is sent to users when their application has been approved. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/approval_notification-subject.html:4
@@ -1184,26 +1013,14 @@ msgstr "Ваша заявка в Библиотеку Википедии был�
 #. Translators: This email is sent to coordinators when a comment is left on an application they are processing. Don't translate Jinja variables in curly braces like user or partner. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/comment_notification_coordinator-body-html.html:5
 #, python-format
-msgid ""
-"<p style=\"color: #500050\">%(submit_date)s - %(commenter)s</p> "
-"<blockquote><p>%(comment)s</p></blockquote> <p>Please reply to these at: <a "
-"href=\"%(app_url)s\">%(app_url)s</a></p> <p>Best,</p> <p>The Wikipedia "
-"Library</p>"
-msgstr ""
-"<p style=\"color: #500050\">%(submit_date)s — %(commenter)s</p> "
-"<blockquote><p>%(comment)s</p></blockquote> <p>Пожалуйста, отвечайте здесь: "
-"<a href=\"%(app_url)s\">%(app_url)s</a></p> <p>С наилучшими пожеланиями,</p> "
-"<p>Библиотека Википедии</p>"
+msgid "<p style=\"color: #500050\">%(submit_date)s - %(commenter)s</p> <blockquote><p>%(comment)s</p></blockquote> <p>Please reply to these at: <a href=\"%(app_url)s\">%(app_url)s</a></p> <p>Best,</p> <p>The Wikipedia Library</p>"
+msgstr "<p style=\"color: #500050\">%(submit_date)s — %(commenter)s</p> <blockquote><p>%(comment)s</p></blockquote> <p>Пожалуйста, отвечайте здесь: <a href=\"%(app_url)s\">%(app_url)s</a></p> <p>С наилучшими пожеланиями,</p> <p>Библиотека Википедии</p>"
 
 #. Translators: This email is sent to coordinators when a comment is left on an application they are processing. Don't translate Jinja variables in curly braces like user or partner. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/comment_notification_coordinator-body-text.html:3
 #, python-format
-msgid ""
-"%(submit_date)s - %(commenter)s %(comment)s Please reply to this at: "
-"%(app_url)s Best, The Wikipedia Library"
-msgstr ""
-"%(submit_date)s — %(commenter)s %(comment)s Пожалуйста, отвечайте здесь: "
-"%(app_url)s С наилучшими пожеланиями, Библиотека Википедии"
+msgid "%(submit_date)s - %(commenter)s %(comment)s Please reply to this at: %(app_url)s Best, The Wikipedia Library"
+msgstr "%(submit_date)s — %(commenter)s %(comment)s Пожалуйста, отвечайте здесь: %(app_url)s С наилучшими пожеланиями, Библиотека Википедии"
 
 #. Translators: This is the subject line of an email sent to coordinators when a comment is left on an application they processed.
 #: TWLight/emails/templates/emails/comment_notification_coordinator-subject.html:3
@@ -1213,28 +1030,14 @@ msgstr "Новый комментарий к обработанной вами �
 #. Translators: This email is sent to users when they receive a comment on their application. Don't translate Jinja variables in curly braces like user or partner; don't translate html tags either. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/comment_notification_editors-body-html.html:5
 #, python-format
-msgid ""
-"<p style=\"color: #500050\">%(submit_date)s - %(commenter)s</p> "
-"<blockquote><p>%(comment)s</p></blockquote> <p>Please reply to these at <a "
-"href=\"%(app_url)s\">%(app_url)s</a> so we can evaluate your application.</"
-"p> <p>Best,</p> <p>The Wikipedia Library</p>"
-msgstr ""
-"<p style=\"color: #500050\">%(submit_date)s — %(commenter)s</p> "
-"<blockquote><p>%(comment)s</p></blockquote> <p>Пожалуйста, ответьте на эти "
-"сообщения по ссылке <a href=\"%(app_url)s\">%(app_url)s</a> — так мы сможем "
-"оценить вашу заявку.</p> <p>С наилучшими пожеланиями,</p> <p>Библиотека "
-"Википедии</p>"
+msgid "<p style=\"color: #500050\">%(submit_date)s - %(commenter)s</p> <blockquote><p>%(comment)s</p></blockquote> <p>Please reply to these at <a href=\"%(app_url)s\">%(app_url)s</a> so we can evaluate your application.</p> <p>Best,</p> <p>The Wikipedia Library</p>"
+msgstr "<p style=\"color: #500050\">%(submit_date)s — %(commenter)s</p> <blockquote><p>%(comment)s</p></blockquote> <p>Пожалуйста, ответьте на эти сообщения по ссылке <a href=\"%(app_url)s\">%(app_url)s</a> — так мы сможем оценить вашу заявку.</p> <p>С наилучшими пожеланиями,</p> <p>Библиотека Википедии</p>"
 
 #. Translators: This email is sent to users when they receive a comment on their application. Don't translate Jinja variables in curly braces like user or partner. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/comment_notification_editors-body-text.html:3
 #, python-format
-msgid ""
-"%(submit_date)s - %(commenter)s %(comment)s Please reply to these at: "
-"%(app_url)s so we can evaluate your application. Best, The Wikipedia Library"
-msgstr ""
-"%(submit_date)s — %(commenter)s %(comment)s Пожалуйста, напишите ответ "
-"здесь: %(app_url)s — чтобы мы могли оценить вашу заявку. С наилучшими "
-"пожеланиями, Библиотека Википедии"
+msgid "%(submit_date)s - %(commenter)s %(comment)s Please reply to these at: %(app_url)s so we can evaluate your application. Best, The Wikipedia Library"
+msgstr "%(submit_date)s — %(commenter)s %(comment)s Пожалуйста, напишите ответ здесь: %(app_url)s — чтобы мы могли оценить вашу заявку. С наилучшими пожеланиями, Библиотека Википедии"
 
 #. Translators: This is the subject line of an email sent to users who have a comment added to one of their applications. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/comment_notification_editors-subject.html:3
@@ -1244,42 +1047,25 @@ msgstr "Новый комментарий к вашей заявке в Библ
 #. Translators: This email is sent to users when an application they commented on receives another comment. Don't translate Jinja variables in curly braces like app_url; don't translate html tags either. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/comment_notification_others-body-html.html:5
 #, python-format
-msgid ""
-"<p style=\"color: #500050\">%(submit_date)s - %(commenter)s</p> "
-"<blockquote><p>%(comment)s</p></blockquote> See it at <a href=\"%(app_url)s"
-"\">%(app_url)s</a>. Thanks for helping review Wikipedia Library applications!"
-msgstr ""
-"<p style=\"color: #500050\">%(submit_date)s — %(commenter)s</p> "
-"<blockquote><p>%(comment)s</p></blockquote> См. в <a href=\"%(app_url)s\">"
-"%(app_url)s</a>. Спасибо за помощь в обработке заявок в Библиотеку Википедии!"
+msgid "<p style=\"color: #500050\">%(submit_date)s - %(commenter)s</p> <blockquote><p>%(comment)s</p></blockquote> See it at <a href=\"%(app_url)s\">%(app_url)s</a>. Thanks for helping review Wikipedia Library applications!"
+msgstr "<p style=\"color: #500050\">%(submit_date)s — %(commenter)s</p> <blockquote><p>%(comment)s</p></blockquote> См. в <a href=\"%(app_url)s\">%(app_url)s</a>. Спасибо за помощь в обработке заявок в Библиотеку Википедии!"
 
 #. Translators: This email is sent to users when an application they commented on receives another comment. Don't translate Jinja variables in curly braces like app_url. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/comment_notification_others-body-text.html:3
 #, python-format
-msgid ""
-"%(submit_date)s - %(commenter)s %(comment)s See it at: %(app_url)s Thanks "
-"for helping review Wikipedia Library applications!"
-msgstr ""
-"%(submit_date)s — %(commenter)s %(comment)s См. в %(app_url)s. Спасибо за "
-"помощь в обработке заявок в Библиотеку Википедии!"
+msgid "%(submit_date)s - %(commenter)s %(comment)s See it at: %(app_url)s Thanks for helping review Wikipedia Library applications!"
+msgstr "%(submit_date)s — %(commenter)s %(comment)s См. в %(app_url)s. Спасибо за помощь в обработке заявок в Библиотеку Википедии!"
 
 #. Translators: This is the subject line of an email sent to users who have a comment added to an application they also commented on. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/comment_notification_others-subject.html:4
 msgid "New comment on a Wikipedia Library application you commented on"
-msgstr ""
-"Новый комментарий к заявке в Библиотеку Википедии, которую вы комментировали "
-"ранее"
+msgstr "Новый комментарий к заявке в Библиотеку Википедии, которую вы комментировали ранее"
 
 #. Translators: This text is part of a scheduled reminder email sent to coordinators who have applications requiring action. Don't translate Jinja variables in curly braces like total_apps, or user.
 #: TWLight/emails/templates/emails/coordinator_reminder_notification-body-html.html:5
 #, python-format
-msgid ""
-"<p>Dear %(user)s,</p> <p>Our records indicate that you are the designated "
-"coordinator for partners that have a total of %(total_apps)s applications.</"
-"p>"
-msgstr ""
-"<p>Ув. %(user)s,</p> <p>По нашим данным, вы являетесь проверенным "
-"координатором для партнёров, которым подано %(total_apps)s заявок.</p>"
+msgid "<p>Dear %(user)s,</p> <p>Our records indicate that you are the designated coordinator for partners that have a total of %(total_apps)s applications.</p>"
+msgstr "<p>Ув. %(user)s,</p> <p>По нашим данным, вы являетесь проверенным координатором для партнёров, которым подано %(total_apps)s заявок.</p>"
 
 #. Translators: Breakdown as in 'cost breakdown'; analysis.
 #: TWLight/emails/templates/emails/coordinator_reminder_notification-body-html.html:11
@@ -1320,43 +1106,20 @@ msgstr[2] "%(counter)s подтверждённых заявок."
 #. Translators: This text is part of a scheduled reminder email sent to coordinators who have applications requiring action. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library). Don't translate Jinja variables in curly braces like link; don't translate email addresses or html tags either.
 #: TWLight/emails/templates/emails/coordinator_reminder_notification-body-html.html:39
 #, python-format
-msgid ""
-"<p>This is a gentle reminder that you may review applications at <a href="
-"\"%(link)s\">%(link)s</a>.</p> <p>You can customise your reminders under "
-"'preferences' in your user profile.</p> <p>If you received this message in "
-"error, drop us a line at wikipedialibrary@wikimedia.org.</p> <p>Thanks for "
-"helping review Wikipedia Library applications!</p>"
-msgstr ""
-"<p>Напоминаем о том, что вы можете рассмотреть заявки здесь: <a href="
-"\"%(link)s\">%(link)s</a>.</p> <p>Вы можете настроить напоминания в "
-"«Настройках» вашего профиля.</p> <p>Если вы получили это сообщение по "
-"ошибке, напишите нам об этом: wikipedialibrary@wikimedia.org</p> <p>Спасибо "
-"за помощь в рассмотрении заявок в Библиотеку Википедии!</p>"
+msgid "<p>This is a gentle reminder that you may review applications at <a href=\"%(link)s\">%(link)s</a>.</p> <p>You can customise your reminders under 'preferences' in your user profile.</p> <p>If you received this message in error, drop us a line at wikipedialibrary@wikimedia.org.</p> <p>Thanks for helping review Wikipedia Library applications!</p>"
+msgstr "<p>Напоминаем о том, что вы можете рассмотреть заявки здесь: <a href=\"%(link)s\">%(link)s</a>.</p> <p>Вы можете настроить напоминания в «Настройках» вашего профиля.</p> <p>Если вы получили это сообщение по ошибке, напишите нам об этом: wikipedialibrary@wikimedia.org</p> <p>Спасибо за помощь в рассмотрении заявок в Библиотеку Википедии!</p>"
 
 #. Translators: This text is part of a scheduled reminder email sent to coordinators who have applications requiring action. Don't translate Jinja variables in curly braces like total_apps, or user.
 #: TWLight/emails/templates/emails/coordinator_reminder_notification-body-text.html:3
 #, python-format
-msgid ""
-"Dear %(user)s, Our records indicate that you are the designated coordinator "
-"for partners that have a total of %(total_apps)s applications."
-msgstr ""
-"Ув. %(user)s, По нашим данным, вы являетесь проверенным координатором для "
-"партнёров, которым подано %(total_apps)s заявок."
+msgid "Dear %(user)s, Our records indicate that you are the designated coordinator for partners that have a total of %(total_apps)s applications."
+msgstr "Ув. %(user)s, По нашим данным, вы являетесь проверенным координатором для партнёров, которым подано %(total_apps)s заявок."
 
 #. Translators: This text is part of a scheduled reminder email sent to coordinators who have applications requiring action. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library). Don't translate Jinja variables in curly braces like link; don't translate the email address either.
 #: TWLight/emails/templates/emails/coordinator_reminder_notification-body-text.html:38
 #, python-format
-msgid ""
-"This is a gentle reminder that you may review applications at: %(link)s. You "
-"can customise your reminders under 'preferences' in your user profile. If "
-"you received this message in error, drop us a line at: "
-"wikipedialibrary@wikimedia.org Thanks for helping review Wikipedia Library "
-"applications!"
-msgstr ""
-"Напоминаем о том, что вы можете рассмотреть заявки здесь: %(link)s. Вы "
-"можете настроить напоминания в «Настройках» вашего профиля. Если вы получили "
-"это сообщение по ошибке, напишите нам об этом: wikipedialibrary@wikimedia."
-"org Спасибо за помощь в рассмотрении заявок в Библиотеку Википедии!"
+msgid "This is a gentle reminder that you may review applications at: %(link)s. You can customise your reminders under 'preferences' in your user profile. If you received this message in error, drop us a line at: wikipedialibrary@wikimedia.org Thanks for helping review Wikipedia Library applications!"
+msgstr "Напоминаем о том, что вы можете рассмотреть заявки здесь: %(link)s. Вы можете настроить напоминания в «Настройках» вашего профиля. Если вы получили это сообщение по ошибке, напишите нам об этом: wikipedialibrary@wikimedia.org Спасибо за помощь в рассмотрении заявок в Библиотеку Википедии!"
 
 #. Translators: This is the subject line of a scheduled reminder email sent to coordinators who have applications to review. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library). Do not translate items in curly braces.
 #: TWLight/emails/templates/emails/coordinator_reminder_notification-subject.html:4
@@ -1366,32 +1129,14 @@ msgstr "Заявки к Библиотеке Википедии ждут ваш�
 #. Translators: This email is sent to users when their application is rejected. Don't translate Jinja variables in curly braces like user or partner; don't translate html tags either. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/rejection_notification-body-html.html:5
 #, python-format
-msgid ""
-"<p>Dear %(user)s,</p> <p>Thank you for applying for access to %(partner)s "
-"resources through The Wikipedia Library. Unfortunately at this time your "
-"application has not been approved. You can view your application and review "
-"comments at <a href=\"%(app_url)s\">%(app_url)s</a>.</p> <p>Best,</p> <p>The "
-"Wikipedia Library</p>"
-msgstr ""
-"<p>Ув. %(user)s,</p> <p>Спасибо за подачу заявки на доступ к ресурсам "
-"%(partner)s через Библиотеку Википедии. К сожалению, на этот раз ваша заявка "
-"не была одобрена. Вы можете посмотреть вашу заявку и комментарии проверяющих "
-"по ссылке <a href=\"%(app_url)s\">%(app_url)s</a>.</p> <p>С наилучшими "
-"пожеланиями,</p> <p>Библиотека Википедии</p>"
+msgid "<p>Dear %(user)s,</p> <p>Thank you for applying for access to %(partner)s resources through The Wikipedia Library. Unfortunately at this time your application has not been approved. You can view your application and review comments at <a href=\"%(app_url)s\">%(app_url)s</a>.</p> <p>Best,</p> <p>The Wikipedia Library</p>"
+msgstr "<p>Ув. %(user)s,</p> <p>Спасибо за подачу заявки на доступ к ресурсам %(partner)s через Библиотеку Википедии. К сожалению, на этот раз ваша заявка не была одобрена. Вы можете посмотреть вашу заявку и комментарии проверяющих по ссылке <a href=\"%(app_url)s\">%(app_url)s</a>.</p> <p>С наилучшими пожеланиями,</p> <p>Библиотека Википедии</p>"
 
 #. Translators: This email is sent to users when their application is rejected. Don't translate Jinja variables in curly braces like user or partner. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/rejection_notification-body-text.html:3
 #, python-format
-msgid ""
-"Dear %(user)s, Thank you for applying for access to %(partner)s resources "
-"through The Wikipedia Library. Unfortunately at this time your application "
-"has not been approved. You can view your application and review comments at: "
-"%(app_url)s Best, The Wikipedia Library"
-msgstr ""
-"Ув. %(user)s, Спасибо за подачу заявки на доступ к ресурсам %(partner)s "
-"через Библиотеку Википедии. К сожалению, на этот раз ваша заявка не была "
-"одобрена. Вы можете посмотреть вашу заявку и комментарии проверяющих по "
-"ссылке: %(app_url)s С наилучшими пожеланиями, Библиотека Википедии"
+msgid "Dear %(user)s, Thank you for applying for access to %(partner)s resources through The Wikipedia Library. Unfortunately at this time your application has not been approved. You can view your application and review comments at: %(app_url)s Best, The Wikipedia Library"
+msgstr "Ув. %(user)s, Спасибо за подачу заявки на доступ к ресурсам %(partner)s через Библиотеку Википедии. К сожалению, на этот раз ваша заявка не была одобрена. Вы можете посмотреть вашу заявку и комментарии проверяющих по ссылке: %(app_url)s С наилучшими пожеланиями, Библиотека Википедии"
 
 #. Translators: This is the subject of an email which is sent to users when their application has been rejected. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/rejection_notification-subject.html:4
@@ -1401,39 +1146,14 @@ msgstr "Ваша заявка в Библиотеку Википедии"
 #. Translators: This email is sent to users when they have an account that is soon to expire. Don't translate Jinja variables in curly braces like partner_name or partner_link; don't translate html tags either. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/user_renewal_notice-body-html.html:5
 #, python-format
-msgid ""
-"<p>Dear %(user)s,</p> <p>According to our records, your access to "
-"%(partner_name)s will soon expire and you may lose access. If you want to "
-"continue making use of your free account, you can request renewal of your "
-"account by clicking the 'Renew' or 'Extend' button at %(partner_link)s.</p> "
-"<p>Best,</p> <p>The Wikipedia Library</p> <p>You can disable these emails in "
-"your user page preferences: https://wikipedialibrary.wmflabs.org/users/</p>"
-msgstr ""
-"<p>Ув. %(user)s,</p> <p>По нашим данным, время вашего доступа к "
-"%(partner_name)s скоро истечёт. Если вы хотите продолжить пользоваться своей "
-"бесплатной учётной записью, можно запросить продление доступа к учётной "
-"записи путём нажатия на кнопку «Обновить» или «Продлить» в %(partner_link)s."
-"</p> <p>С наилучшими пожеланиями,</p> <p>Библиотека Википедии</p> <p>Эти "
-"письма можно отключить в настройках учётной записи: https://wikipedialibrary."
-"wmflabs.org/users/</p>"
+msgid "<p>Dear %(user)s,</p> <p>According to our records, your access to %(partner_name)s will soon expire and you may lose access. If you want to continue making use of your free account, you can request renewal of your account by clicking the 'Renew' or 'Extend' button at %(partner_link)s.</p> <p>Best,</p> <p>The Wikipedia Library</p> <p>You can disable these emails in your user page preferences: https://wikipedialibrary.wmflabs.org/users/</p>"
+msgstr "<p>Ув. %(user)s,</p> <p>По нашим данным, время вашего доступа к %(partner_name)s скоро истечёт. Если вы хотите продолжить пользоваться своей бесплатной учётной записью, можно запросить продление доступа к учётной записи путём нажатия на кнопку «Обновить» или «Продлить» в %(partner_link)s.</p> <p>С наилучшими пожеланиями,</p> <p>Библиотека Википедии</p> <p>Эти письма можно отключить в настройках учётной записи: https://wikipedialibrary.wmflabs.org/users/</p>"
 
 #. Translators: This email is sent to users when they have an account that is soon to expire. Don't translate Jinja variables in curly braces like partner_name or partner_link; don't translate html tags either. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/user_renewal_notice-body-text.html:3
 #, python-format
-msgid ""
-"Dear %(user)s, According to our records, your access to %(partner_name)s "
-"will soon expire and you may lose access. If you want to continue making use "
-"of your free account, you can request renewal of your account by clicking "
-"the Renew button at %(partner_link)s. Best, The Wikipedia Library You can "
-"disable these emails in your user page preferences: https://wikipedialibrary."
-"wmflabs.org/users/"
-msgstr ""
-"Ув. %(user)s, По нашим данным, ваш доступ к %(partner_name)s скоро истечёт. "
-"Если вы хотите продолжить пользоваться бесплатной учётной записью, вы можете "
-"запросить продление доступа нажатием на кнопку «Обновить» в "
-"%(partner_link)s. С наилучшими пожеланиями, Библиотека Википедии. Вы можете "
-"отключить эти письма в настройках учётной записи: https://wikipedialibrary."
-"wmflabs.org/users/"
+msgid "Dear %(user)s, According to our records, your access to %(partner_name)s will soon expire and you may lose access. If you want to continue making use of your free account, you can request renewal of your account by clicking the Renew button at %(partner_link)s. Best, The Wikipedia Library You can disable these emails in your user page preferences: https://wikipedialibrary.wmflabs.org/users/"
+msgstr "Ув. %(user)s, По нашим данным, ваш доступ к %(partner_name)s скоро истечёт. Если вы хотите продолжить пользоваться бесплатной учётной записью, вы можете запросить продление доступа нажатием на кнопку «Обновить» в %(partner_link)s. С наилучшими пожеланиями, Библиотека Википедии. Вы можете отключить эти письма в настройках учётной записи: https://wikipedialibrary.wmflabs.org/users/"
 
 #. Translators: This is the subject of an email sent to users when they have an account that is soon to expire. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/user_renewal_notice-subject.html:4
@@ -1443,36 +1163,14 @@ msgstr "Ваш доступ к Библиотеке Википедии може�
 #. Translators: This email is sent to users when their application is waitlisted because there are no more accounts available. Don't translate Jinja variables in curly braces like user or partner; don't translate html tags either. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/waitlist_notification-body-html.html:5
 #, python-format
-msgid ""
-"<p>Dear %(user)s,</p> <p>Thank you for applying for access to %(partner)s "
-"resources through The Wikipedia Library. There are no accounts currently "
-"available so your application has been waitlisted. Your application will be "
-"evaluated if/when more accounts become available. You can see all available "
-"resources at <a href=\"%(link)s\">%(link)s</a>.</p> <p>Best,</p> <p>The "
-"Wikipedia Library</p>"
-msgstr ""
-"<p>Ув. %(user)s,</p> <p>Спасибо за подачу заявки на доступ к ресурсам "
-"%(partner)s через Библиотеку Википедии. В данный момент исчерпан лимит "
-"доступных аккаунтов, поэтому ваша заявка была добавлена в список ожидания. "
-"Она будет обработана, когда появятся свободные аккаунты. Вы можете "
-"посмотреть доступные ресурсы на <a href=\"%(link)s\">%(link)s</a>.</p> <p>С "
-"наилучшими пожеланиями,</p> <p>Библиотека Википедии</p>"
+msgid "<p>Dear %(user)s,</p> <p>Thank you for applying for access to %(partner)s resources through The Wikipedia Library. There are no accounts currently available so your application has been waitlisted. Your application will be evaluated if/when more accounts become available. You can see all available resources at <a href=\"%(link)s\">%(link)s</a>.</p> <p>Best,</p> <p>The Wikipedia Library</p>"
+msgstr "<p>Ув. %(user)s,</p> <p>Спасибо за подачу заявки на доступ к ресурсам %(partner)s через Библиотеку Википедии. В данный момент исчерпан лимит доступных аккаунтов, поэтому ваша заявка была добавлена в список ожидания. Она будет обработана, когда появятся свободные аккаунты. Вы можете посмотреть доступные ресурсы на <a href=\"%(link)s\">%(link)s</a>.</p> <p>С наилучшими пожеланиями,</p> <p>Библиотека Википедии</p>"
 
 #. Translators: This email is sent to users when their application is waitlisted because there are no more accounts available. Don't translate Jinja variables in curly braces like user or partner. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/waitlist_notification-body-text.html:3
 #, python-format
-msgid ""
-"Dear %(user)s, Thank you for applying for access to %(partner)s resources "
-"through The Wikipedia Library. There are no accounts currently available so "
-"your application has been waitlisted. Your application will be evaluated if/"
-"when more accounts become available. You can see all available resources at: "
-"%(link)s Best, The Wikipedia Library"
-msgstr ""
-"Ув. %(user)s, Спасибо за подачу заявки на доступ к ресурсам %(partner)s "
-"через Библиотеку Википедии. В данный момент исчерпан лимит доступных "
-"аккаунтов, поэтому ваша заявка была добавлена в список ожидания. Она будет "
-"обработана, когда появятся доступные аккаунты. Вы можете посмотреть "
-"доступные ресурсы на %(link)s С наилучшими пожеланиями, Библиотека Википедии"
+msgid "Dear %(user)s, Thank you for applying for access to %(partner)s resources through The Wikipedia Library. There are no accounts currently available so your application has been waitlisted. Your application will be evaluated if/when more accounts become available. You can see all available resources at: %(link)s Best, The Wikipedia Library"
+msgstr "Ув. %(user)s, Спасибо за подачу заявки на доступ к ресурсам %(partner)s через Библиотеку Википедии. В данный момент исчерпан лимит доступных аккаунтов, поэтому ваша заявка была добавлена в список ожидания. Она будет обработана, когда появятся доступные аккаунты. Вы можете посмотреть доступные ресурсы на %(link)s С наилучшими пожеланиями, Библиотека Википедии"
 
 #. Translators: This is the subject of an email sent to users when their application is waitlisted because there are no more accounts available. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/waitlist_notification-subject.html:4
@@ -1633,22 +1331,15 @@ msgstr "Недоступно"
 #: TWLight/resources/templates/resources/filter_section.html:14
 #: TWLight/templates/about.html:12
 #: TWLight/users/templates/users/filter_section.html:13
-msgid ""
-"The Wikipedia Library allows active editors to access a wide range of "
-"collections of paywalled reliable sources for free!"
-msgstr ""
-"Библиотека Википедии позволяет активным редакторам получить бесплатный "
-"доступ к обширной коллекции платных авторитетных источников!"
+msgid "The Wikipedia Library allows active editors to access a wide range of collections of paywalled reliable sources for free!"
+msgstr "Библиотека Википедии позволяет активным редакторам получить бесплатный доступ к обширной коллекции платных авторитетных источников!"
 
 #. Translators: On the Browse Partners page (https://wikipedialibrary.wmflabs.org/partners/), this introduces users to The Wikipedia Library.
 #. Translators: On the MyLibrary page (https://wikipedialibrary.wmflabs.org/users/my_library), this introduces users to The Wikipedia Library.
 #: TWLight/resources/templates/resources/filter_section.html:17
 #: TWLight/users/templates/users/filter_section.html:15
-msgid ""
-"Start with the search bar at the top or browse publisher websites directly."
-msgstr ""
-"Начните с поисковой строки в верхней части сайта или совершите поиск прямо "
-"на сайте издателя."
+msgid "Start with the search bar at the top or browse publisher websites directly."
+msgstr "Начните с поисковой строки в верхней части сайта или совершите поиск прямо на сайте издателя."
 
 #. Translators: On the Browse Partners page (https://wikipedialibrary.wmflabs.org/partners/), this appears below introductory text and links to the 'About' page (https://wikipedialibrary.wmflabs.org/about/)
 #. Translators: On the MyLibrary page (https://wikipedialibrary.wmflabs.org/users/my_library), this appears below introductory text and links to the 'About' page (https://wikipedialibrary.wmflabs.org/about/)
@@ -1721,68 +1412,39 @@ msgstr "Назад к партнёрам"
 #. Translators: If we have no available accounts for a partner, the coordinator can change the application system to a waiting list.
 #: TWLight/resources/templates/resources/partner_detail.html:36
 #: TWLight/resources/templates/resources/partner_detail_apply.html:17
-msgid ""
-"There are no access grants available for this partner at this time. You can "
-"still apply for access; applications will be processed when access is "
-"available."
-msgstr ""
-"В данный момент этот партнёр превысил лимит предоставления прав доступа. Вы "
-"всё равно можете подать заявку, её обработают как только появятся свободные "
-"места."
+msgid "There are no access grants available for this partner at this time. You can still apply for access; applications will be processed when access is available."
+msgstr "В данный момент этот партнёр превысил лимит предоставления прав доступа. Вы всё равно можете подать заявку, её обработают как только появятся свободные места."
 
 #. Translators: This text links to the minimum user requirements and terms of use on the partner page.
 #: TWLight/resources/templates/resources/partner_detail.html:48
 #: TWLight/resources/templates/resources/partner_detail_apply.html:29
 #, python-format
-msgid ""
-"Before applying, please review the <strong><a class=\"twl-links\" href="
-"\"%(about)s#req\">minimum requirements</a></strong> for access and our "
-"<strong><a class=\"twl-links\" href=\"%(terms)s\">terms of use</a></strong>."
-msgstr ""
-"Перед подачей заявки, пожалуйста, просмотрите <strong><a class=\"twl-links\" "
-"href=\"%(about)s#req\">минимальные требования</a></strong> для доступа и "
-"наши <strong><a class=\"twl-links\" href=\"%(terms)s\">условия "
-"использования</a></strong>."
+msgid "Before applying, please review the <strong><a class=\"twl-links\" href=\"%(about)s#req\">minimum requirements</a></strong> for access and our <strong><a class=\"twl-links\" href=\"%(terms)s\">terms of use</a></strong>."
+msgstr "Перед подачей заявки, пожалуйста, просмотрите <strong><a class=\"twl-links\" href=\"%(about)s#req\">минимальные требования</a></strong> для доступа и наши <strong><a class=\"twl-links\" href=\"%(terms)s\">условия использования</a></strong>."
 
 #. Translators: This text refers to the page containing the content a user is authorized to access.
 #: TWLight/resources/templates/resources/partner_detail.html:69
 #, python-format
-msgid ""
-"View the status of your access in <strong><a class=\"twl-links\" href="
-"\"%(library_url)s\">My Library</a></strong> page."
-msgstr ""
-"Посмотрите статус вашего доступа на странице <strong><a class=\"twl-links\" "
-"href=\"%(library_url)s\">Моя библиотека</a></strong>."
+msgid "View the status of your access in <strong><a class=\"twl-links\" href=\"%(library_url)s\">My Library</a></strong> page."
+msgstr "Посмотрите статус вашего доступа на странице <strong><a class=\"twl-links\" href=\"%(library_url)s\">Моя библиотека</a></strong>."
 
 #. Translators: This message is shown when a user has open applications, linking to their respective applications page.
 #: TWLight/resources/templates/resources/partner_detail.html:78
 #, python-format
-msgid ""
-"View the status of your application(s) on your <strong><a class=\"twl-links"
-"\" href=\"%(applications_url)s\">My Applications</a></strong> page."
-msgstr ""
-"Посмотрите статус ваших заявок на странице <strong><a class=\"twl-links\" "
-"href=\"%(applications_url)s\">Мои заявки</a></strong>."
+msgid "View the status of your application(s) on your <strong><a class=\"twl-links\" href=\"%(applications_url)s\">My Applications</a></strong> page."
+msgstr "Посмотрите статус ваших заявок на странице <strong><a class=\"twl-links\" href=\"%(applications_url)s\">Мои заявки</a></strong>."
 
 #. Translators: This message is shown when a user has authorizations, linking to their respective collections page.
 #: TWLight/resources/templates/resources/partner_detail_apply.html:50
 #, python-format
-msgid ""
-"View the status of your access on your <strong><a href=\"%(library_url)s\" "
-"class=\"twl-links\">My Library</a></strong> page."
-msgstr ""
-"Посмотрите статус вашего доступа на странице <strong><a href="
-"\"%(library_url)s\" class=\"twl-links\">Моя библиотека</a></strong>."
+msgid "View the status of your access on your <strong><a href=\"%(library_url)s\" class=\"twl-links\">My Library</a></strong> page."
+msgstr "Посмотрите статус вашего доступа на странице <strong><a href=\"%(library_url)s\" class=\"twl-links\">Моя библиотека</a></strong>."
 
 #. Translators: This message is shown when a user has open applications, linking to their respective applications page.
 #: TWLight/resources/templates/resources/partner_detail_apply.html:60
 #, python-format
-msgid ""
-"View the status of your application(s) on your <strong><a href="
-"\"%(applications_url)s\">My Applications</a></strong> page."
-msgstr ""
-"Посмотрите статус ваших заявок на странице <strong><a href="
-"\"%(applications_url)s\">Мои заявки</a></strong>."
+msgid "View the status of your application(s) on your <strong><a href=\"%(applications_url)s\">My Applications</a></strong> page."
+msgstr "Посмотрите статус ваших заявок на странице <strong><a href=\"%(applications_url)s\">Мои заявки</a></strong>."
 
 #. Translators: One the partner detail page, this text labels the button which coordinators can click to remove a partner from waitlisted status.
 #: TWLight/resources/templates/resources/partner_detail_apply.html:73
@@ -1811,14 +1473,8 @@ msgstr "Написать электронное письмо участнику"
 
 #. Translators: If no account coordinator is assigned to a partner, the Wikipedia Library team will coordinate signups. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/resources/templates/resources/partner_detail_apply.html:112
-msgid ""
-"The Wikipedia Library team will process this application. Want to help? <a "
-"class=\"twl-links\" href=\"https://en.wikipedia.org/wiki/Wikipedia:"
-"The_Wikipedia_Library/Coordinators/Signup\">Sign up as a coordinator.</a>"
-msgstr ""
-"Команда Библиотеки Википедии обработает эту заявку. Желаете помочь? <a class="
-"\"twl-links\" href=\"https://en.wikipedia.org/wiki/Wikipedia:"
-"The_Wikipedia_Library/Coordinators/Signup\">Запишитесь координатором.</a>"
+msgid "The Wikipedia Library team will process this application. Want to help? <a class=\"twl-links\" href=\"https://en.wikipedia.org/wiki/Wikipedia:The_Wikipedia_Library/Coordinators/Signup\">Sign up as a coordinator.</a>"
+msgstr "Команда Библиотеки Википедии обработает эту заявку. Желаете помочь? <a class=\"twl-links\" href=\"https://en.wikipedia.org/wiki/Wikipedia:The_Wikipedia_Library/Coordinators/Signup\">Запишитесь координатором.</a>"
 
 #. Translators: This text labels a button coordinators can click to view a list of users who have applied for access for a particular partner
 #: TWLight/resources/templates/resources/partner_detail_apply.html:121
@@ -1847,24 +1503,14 @@ msgstr "Доступ к Набору Библиотеки"
 
 #. Translators: Text shown to authenticated, bundle eligible users when they visit a Bundle partner page.
 #: TWLight/resources/templates/resources/partner_detail_apply.html:138
-msgid ""
-"You are eligible to access Library Bundle partners. Click the button above "
-"to access the collection."
-msgstr ""
-"Вы отвечаете требованиям для доступа к партнёрам из Набора Библиотеки. "
-"Нажмите на кнопку наверху чтобы получить доступ к коллекции."
+msgid "You are eligible to access Library Bundle partners. Click the button above to access the collection."
+msgstr "Вы отвечаете требованиям для доступа к партнёрам из Набора Библиотеки. Нажмите на кнопку наверху чтобы получить доступ к коллекции."
 
 #. Translators: Text shown to authenticated, bundle ineligible users when they visit a Bundle partner page.
 #: TWLight/resources/templates/resources/partner_detail_apply.html:152
 #, python-format
-msgid ""
-"You are not eligible to access Library Bundle partners. Visit the <a class="
-"\"twl-links\" href=\"%(homepage)s\">homepage</a> to check the eligibility "
-"criteria."
-msgstr ""
-"Вы не соответствуете критериям для доступа к партнёрам из Набора Библиотеки. "
-"Посетите <a class=\"twl-links\" href=\"%(homepage)s\">заглавную страницу</"
-"a>, чтобы узнать критерии."
+msgid "You are not eligible to access Library Bundle partners. Visit the <a class=\"twl-links\" href=\"%(homepage)s\">homepage</a> to check the eligibility criteria."
+msgstr "Вы не соответствуете критериям для доступа к партнёрам из Набора Библиотеки. Посетите <a class=\"twl-links\" href=\"%(homepage)s\">заглавную страницу</a>, чтобы узнать критерии."
 
 #. Translators: Buttton prompting users to log in.
 #: TWLight/resources/templates/resources/partner_detail_apply.html:160
@@ -1875,15 +1521,8 @@ msgstr "Войти"
 #. Translators: Text shown to unauthenticated users when they visit a Bundle partner page.
 #: TWLight/resources/templates/resources/partner_detail_apply.html:168
 #, python-format
-msgid ""
-"This resource is part of our <a class=\"twl-links\" href=\"%(about)s"
-"\">Library Bundle</a>, which you can access if you meet our minimum "
-"eligibility criteria. Log in to find out if you are eligible."
-msgstr ""
-"Этот ресурс является частью нашего <a class=\"twl-links\" href=\"%(about)s"
-"\">Набора Библиотеки</a>, к которому вы можете получить доступ, если "
-"удовлетворяете минимальным критериям. Авторизуйтесь, чтобы выяснить, "
-"удовлетворяете ли вы критериям."
+msgid "This resource is part of our <a class=\"twl-links\" href=\"%(about)s\">Library Bundle</a>, which you can access if you meet our minimum eligibility criteria. Log in to find out if you are eligible."
+msgstr "Этот ресурс является частью нашего <a class=\"twl-links\" href=\"%(about)s\">Набора Библиотеки</a>, к которому вы можете получить доступ, если удовлетворяете минимальным критериям. Авторизуйтесь, чтобы выяснить, удовлетворяете ли вы критериям."
 
 #. Translators: This is the label for a number which shows the total active accounts for one partner. (e.g. https://wikipedialibrary.wmflabs.org/partners/8/).
 #: TWLight/resources/templates/resources/partner_detail_stats.html:21
@@ -1933,33 +1572,20 @@ msgstr "Лимиты выписки"
 #. Translators: If a partner has specified the excerpt limit both in words and percentage, this message will display the percentage of words and the number of words on the partner page.
 #: TWLight/resources/templates/resources/partner_detail_timeline.html:99
 #, python-format
-msgid ""
-"%(object)s allows a maximum of %(excerpt_limit)s words or "
-"%(excerpt_limit_percentage)s%% of an article be excerpted into a Wikipedia "
-"article."
-msgstr ""
-"%(object)s разрешает перепечатать в статью Википедии максимум "
-"%(excerpt_limit)s слов, или %(excerpt_limit_percentage)s%% статьи."
+msgid "%(object)s allows a maximum of %(excerpt_limit)s words or %(excerpt_limit_percentage)s%% of an article be excerpted into a Wikipedia article."
+msgstr "%(object)s разрешает перепечатать в статью Википедии максимум %(excerpt_limit)s слов, или %(excerpt_limit_percentage)s%% статьи."
 
 #. Translators: If a partner has specified the excerpt limit in words, this message will display the number of words on the partner page.
 #: TWLight/resources/templates/resources/partner_detail_timeline.html:106
 #, python-format
-msgid ""
-"%(object)s allows a maximum of %(excerpt_limit)s words be excerpted into a "
-"Wikipedia article."
-msgstr ""
-"%(object)s разрешает перепечатать в статью Википедии максимум "
-"%(excerpt_limit)s слов."
+msgid "%(object)s allows a maximum of %(excerpt_limit)s words be excerpted into a Wikipedia article."
+msgstr "%(object)s разрешает перепечатать в статью Википедии максимум %(excerpt_limit)s слов."
 
 #. Translators: If a partner has specified the excerpt limit in percentage, this message will display the percentage of words on the partner page.
 #: TWLight/resources/templates/resources/partner_detail_timeline.html:113
 #, python-format
-msgid ""
-"%(object)s allows a maximum of %(excerpt_limit_percentage)s%% of an article "
-"be excerpted into a Wikipedia article."
-msgstr ""
-"%(object)s разрешает перепечатать в статью Википедии максимум "
-"%(excerpt_limit_percentage)s%% статьи."
+msgid "%(object)s allows a maximum of %(excerpt_limit_percentage)s%% of an article be excerpted into a Wikipedia article."
+msgstr "%(object)s разрешает перепечатать в статью Википедии максимум %(excerpt_limit_percentage)s%% статьи."
 
 #. Translators: If a partner has other requirements for access, this text shows as the title for that information field. (e.g. https://wikipedialibrary.wmflabs.org/partners/10/).
 #: TWLight/resources/templates/resources/partner_detail_timeline.html:132
@@ -1969,12 +1595,8 @@ msgstr "Особые требования к подающим заявки"
 #. Translators: If a user must agree to a Terms of Use document, they see this message, and must enter the name of the resource. Don't translate publisher or url.
 #: TWLight/resources/templates/resources/partner_detail_timeline.html:140
 #, python-format
-msgid ""
-"%(publisher)s requires that you agree with its <a href=\"%(url)s\">terms of "
-"use</a>."
-msgstr ""
-"%(publisher)s требует согласия с <a href=\"%(url)s\">условиями "
-"использования</a>."
+msgid "%(publisher)s requires that you agree with its <a href=\"%(url)s\">terms of use</a>."
+msgstr "%(publisher)s требует согласия с <a href=\"%(url)s\">условиями использования</a>."
 
 #. Translators: If a user must provide their real name to apply to a partner, they see this message, and must enter the name of the resource. Don't translate publisher.
 #: TWLight/resources/templates/resources/partner_detail_timeline.html:150
@@ -1992,28 +1614,19 @@ msgstr "%(publisher)s требует предоставления страны �
 #: TWLight/resources/templates/resources/partner_detail_timeline.html:168
 #, python-format
 msgid "%(publisher)s requires that you provide your institutional affiliation."
-msgstr ""
-"%(publisher)s требует указать учреждение, где вы работаете или учитесь."
+msgstr "%(publisher)s требует указать учреждение, где вы работаете или учитесь."
 
 #. Translators: If a user must select a specific resource to apply for, they see this message, and must enter the name of the resource. Don't translate publisher.
 #: TWLight/resources/templates/resources/partner_detail_timeline.html:177
 #, python-format
-msgid ""
-"%(publisher)s requires that you specify a particular title that you want to "
-"access."
-msgstr ""
-"%(publisher)s требует указания конкретных разделов, к которым вы хотите "
-"получить доступ."
+msgid "%(publisher)s requires that you specify a particular title that you want to access."
+msgstr "%(publisher)s требует указания конкретных разделов, к которым вы хотите получить доступ."
 
 #. Translators: If a user must register on the partner website before applying, they see this message. Don't translate partner.
 #: TWLight/resources/templates/resources/partner_detail_timeline.html:187
 #, python-format
-msgid ""
-"%(publisher)s requires that you sign up for an account before applying for "
-"access."
-msgstr ""
-"%(publisher)s требует авторизации в учётную запись перед подачей заявки на "
-"доступ."
+msgid "%(publisher)s requires that you sign up for an account before applying for access."
+msgstr "%(publisher)s требует авторизации в учётную запись перед подачей заявки на доступ."
 
 #. Translators: If a partner has their location listed, this message is a label for that location
 #: TWLight/resources/templates/resources/partner_detail_timeline.html:206
@@ -2139,12 +1752,8 @@ msgstr "Вы уверены, что хотите удалить <b>%(object)s</b
 
 #. Translators: If multiple authorizations where returned for a collection, this message is shown to a user
 #: TWLight/resources/views.py:268
-msgid ""
-"Multiple authorizations were returned – something's wrong. Please contact us "
-"and don't forget to mention this message."
-msgstr ""
-"Было получено несколько авторизаций — что-то пошло не так. Пожалуйста, "
-"свяжитесь с нами и не забудьте упомянуть про это сообщение."
+msgid "Multiple authorizations were returned – something's wrong. Please contact us and don't forget to mention this message."
+msgstr "Было получено несколько авторизаций — что-то пошло не так. Пожалуйста, свяжитесь с нами и не забудьте упомянуть про это сообщение."
 
 #. Translators: This message is shown when user tries to access a NOT_AVAILABLE Partner
 #: TWLight/resources/views.py:316
@@ -2184,23 +1793,8 @@ msgstr "Извините, мы не знаем, что с этим делать.
 #. Translators: Shown on the website's 400 page, when a user sends a bad request. Don't translate path or Phabricator.
 #: TWLight/templates/400.html:20
 #, python-format
-msgid ""
-"If you think we should know what to do with that, please email us about this "
-"error at <a class=\"twl-links\" href=\"mailto:wikipedialibrary@wikimedia.org?"
-"Subject=Wikipedia%%20Library%%20%(path)s%%20Permission%%20denied"
-"\">wikipedialibrary@wikimedia.org</a> or report it to us on <a class=\"twl-"
-"links\" href=\"https://phabricator.wikimedia.org/maniphest/task/edit/form/1/?"
-"projectPHIDs=Library-Card-Platform&title=Wikipedia%%20Library%%20%(path)s"
-"%%20Bad%%20Request\">Phabricator</a>"
-msgstr ""
-"Если вы считаете, что мы понимаем, что с этим делать, пожалуйста, напишите "
-"об этой ошибке по адресу <a class=\"twl-links\" href=\"mailto:"
-"wikipedialibrary@wikimedia.org?Subject=Wikipedia%%20Library%%20%(path)s"
-"%%20Permission%%20denied\">wikipedialibrary@wikimedia.org</a> или сообщите "
-"нам на <a class=\"twl-links\" href=\"https://phabricator.wikimedia.org/"
-"maniphest/task/edit/form/1/?projectPHIDs=Library-Card-"
-"Platform&title=Wikipedia%%20Library%%20%(path)s%%20Bad%%20Request"
-"\">Фабрикатор</a>"
+msgid "If you think we should know what to do with that, please email us about this error at <a class=\"twl-links\" href=\"mailto:wikipedialibrary@wikimedia.org?Subject=Wikipedia%%20Library%%20%(path)s%%20Permission%%20denied\">wikipedialibrary@wikimedia.org</a> or report it to us on <a class=\"twl-links\" href=\"https://phabricator.wikimedia.org/maniphest/task/edit/form/1/?projectPHIDs=Library-Card-Platform&title=Wikipedia%%20Library%%20%(path)s%%20Bad%%20Request\">Phabricator</a>"
+msgstr "Если вы считаете, что мы понимаем, что с этим делать, пожалуйста, напишите об этой ошибке по адресу <a class=\"twl-links\" href=\"mailto:wikipedialibrary@wikimedia.org?Subject=Wikipedia%%20Library%%20%(path)s%%20Permission%%20denied\">wikipedialibrary@wikimedia.org</a> или сообщите нам на <a class=\"twl-links\" href=\"https://phabricator.wikimedia.org/maniphest/task/edit/form/1/?projectPHIDs=Library-Card-Platform&title=Wikipedia%%20Library%%20%(path)s%%20Bad%%20Request\">Фабрикатор</a>"
 
 #. Translators: Alt text for an image shown on the 400 error page.
 #. Translators: Alt text for an image shown on the 403 error page.
@@ -2221,23 +1815,8 @@ msgstr "Извините, вам сюда нельзя."
 #. Translators: Shown on the website's 403 page, when a user attempts to navigate to a page they don't have permission to view. Don't translate path or Phabricator.
 #: TWLight/templates/403.html:20
 #, python-format
-msgid ""
-"If you think your account should be able to do that, please email us about "
-"this error at <a class=\"twl-links\" href=\"mailto:"
-"wikipedialibrary@wikimedia.org?Subject=Wikipedia%%20Library%%20%(path)s"
-"%%20Permission%%20denied\">wikipedialibrary@wikimedia.org</a> or report it "
-"to us on <a class=\"twl-links\" href=\"https://phabricator.wikimedia.org/"
-"maniphest/task/edit/form/1/?projectPHIDs=Library-Card-"
-"Platform&title=Wikipedia%%20Library%%20%(path)s%%20Permission%%20denied"
-"\">Phabricator</a>"
-msgstr ""
-"Если вы считаете, что ваша учётная запись должна иметь такое право, напишите "
-"нам об этой ошибке по адресу <a class=\"twl-links\" href=\"mailto:"
-"wikipedialibrary@wikimedia.org?Subject=Wikipedia%%20Library%%20%(path)s"
-"%%20Permission%%20denied\">wikipedialibrary@wikimedia.org</a> или на <a "
-"class=\"twl-links\" href=\"https://phabricator.wikimedia.org/maniphest/task/"
-"edit/form/1/?projectPHIDs=Library-Card-Platform&title=Wikipedia%%20Library"
-"%%20%(path)s%%20Permission%%20denied\">Фабрикатор</a>"
+msgid "If you think your account should be able to do that, please email us about this error at <a class=\"twl-links\" href=\"mailto:wikipedialibrary@wikimedia.org?Subject=Wikipedia%%20Library%%20%(path)s%%20Permission%%20denied\">wikipedialibrary@wikimedia.org</a> or report it to us on <a class=\"twl-links\" href=\"https://phabricator.wikimedia.org/maniphest/task/edit/form/1/?projectPHIDs=Library-Card-Platform&title=Wikipedia%%20Library%%20%(path)s%%20Permission%%20denied\">Phabricator</a>"
+msgstr "Если вы считаете, что ваша учётная запись должна иметь такое право, напишите нам об этой ошибке по адресу <a class=\"twl-links\" href=\"mailto:wikipedialibrary@wikimedia.org?Subject=Wikipedia%%20Library%%20%(path)s%%20Permission%%20denied\">wikipedialibrary@wikimedia.org</a> или на <a class=\"twl-links\" href=\"https://phabricator.wikimedia.org/maniphest/task/edit/form/1/?projectPHIDs=Library-Card-Platform&title=Wikipedia%%20Library%%20%(path)s%%20Permission%%20denied\">Фабрикатор</a>"
 
 #. Translators: Shown on the website's 404 page, when a user attempts to navigate to a page that doesn't exist.
 #: TWLight/templates/404.html:11
@@ -2252,22 +1831,8 @@ msgstr "Извините, мы не можем найти это."
 #. Translators: Shown on the website's 404 page, when a user attempts to navigate to a page that doesn't exist. Don't translate path or Phabricator.
 #: TWLight/templates/404.html:19
 #, python-format
-msgid ""
-"If you are certain that something should be here, please email us about this "
-"error at <a class=\"twl-links\" href=\"mailto:wikipedialibrary@wikimedia.org?"
-"Subject=Wikipedia%%20Library%%20%(path)s%%20Not%%20found\"> "
-"wikipedialibrary@wikimedia.org</a> or report it to us on <a class=\"twl-links"
-"\" href=\"https://phabricator.wikimedia.org/maniphest/task/edit/form/1/?"
-"projectPHIDs=Library-Card-Platform&title=Wikipedia%%20Library%%20%(path)s"
-"%%20Not%%20found\">Phabricator</a>"
-msgstr ""
-"Если вы уверены, что на этой странице должно что-то быть, сообщите нам на "
-"почту <a class=\"twl-links\" href=\"mailto:wikipedialibrary@wikimedia.org?"
-"Subject=Wikipedia%%20Library%%20%(path)s%%20Not%%20found\"> "
-"wikipedialibrary@wikimedia.org</a> или на <a class=\"twl-links\" href="
-"\"https://phabricator.wikimedia.org/maniphest/task/edit/form/1/?"
-"projectPHIDs=Library-Card-Platform&title=Wikipedia%%20Library%%20%(path)s"
-"%%20Not%%20found\">Фабрикатор</a>"
+msgid "If you are certain that something should be here, please email us about this error at <a class=\"twl-links\" href=\"mailto:wikipedialibrary@wikimedia.org?Subject=Wikipedia%%20Library%%20%(path)s%%20Not%%20found\"> wikipedialibrary@wikimedia.org</a> or report it to us on <a class=\"twl-links\" href=\"https://phabricator.wikimedia.org/maniphest/task/edit/form/1/?projectPHIDs=Library-Card-Platform&title=Wikipedia%%20Library%%20%(path)s%%20Not%%20found\">Phabricator</a>"
+msgstr "Если вы уверены, что на этой странице должно что-то быть, сообщите нам на почту <a class=\"twl-links\" href=\"mailto:wikipedialibrary@wikimedia.org?Subject=Wikipedia%%20Library%%20%(path)s%%20Not%%20found\"> wikipedialibrary@wikimedia.org</a> или на <a class=\"twl-links\" href=\"https://phabricator.wikimedia.org/maniphest/task/edit/form/1/?projectPHIDs=Library-Card-Platform&title=Wikipedia%%20Library%%20%(path)s%%20Not%%20found\">Фабрикатор</a>"
 
 #. Translators: Alt text for an image shown on the 404 error page.
 #: TWLight/templates/404.html:32
@@ -2281,50 +1846,19 @@ msgstr "О Библиотеке Википедии"
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:20
-msgid ""
-"This platform is our central tool for facilitating access to our available "
-"collections. Here you can see which partnerships are available, search their "
-"contents, and apply for and access the ones you’re interested in."
-msgstr ""
-"Данная платформа — место, где предоставляется доступ к источникам из нашей "
-"коллекции и принимаются решения по заявкам. Здесь вы можете просмотреть "
-"доступные источники, ознакомиться с их содержимым и подать заявки на доступ "
-"в те из них, которые вам интересны."
+msgid "This platform is our central tool for facilitating access to our available collections. Here you can see which partnerships are available, search their contents, and apply for and access the ones you’re interested in."
+msgstr "Данная платформа — место, где предоставляется доступ к источникам из нашей коллекции и принимаются решения по заявкам. Здесь вы можете просмотреть доступные источники, ознакомиться с их содержимым и подать заявки на доступ в те из них, которые вам интересны."
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/). Wikimedia Foundation should not be translated.
 #: TWLight/templates/about.html:29
-msgid ""
-"All users receive immediate access to some collections, which can be browsed "
-"by clicking the 'Access collection' buttons or using the search bar at the "
-"top of the page. Other collections require an application before access is "
-"granted, and may be accessed directly or via an individual login or access "
-"code. Volunteer coordinators, who have signed non-disclosure agreements with "
-"the Wikimedia Foundation, review these applications and work with publishers "
-"to get you your free access."
-msgstr ""
-"Все пользователи сразу же получают доступ к некоторым коллекциям, которые вы "
-"можете изучать при нажатии на кнопку «Доступ к коллекции» или используя "
-"строку поиска в верхней части страницы. Для получения доступа к другим "
-"коллекциям необходимо подать заявку, и доступ к ним осуществляется напрямую "
-"или с помощью индивидуального логина или кода доступа. Координаторы-"
-"волонтёры, подписавшие соглашения о неразглашении информации с Фондом "
-"Викимедиа, рассматривают эти заявки и работают с издателями, чтобы "
-"предоставить вам бесплатный доступ."
+msgid "All users receive immediate access to some collections, which can be browsed by clicking the 'Access collection' buttons or using the search bar at the top of the page. Other collections require an application before access is granted, and may be accessed directly or via an individual login or access code. Volunteer coordinators, who have signed non-disclosure agreements with the Wikimedia Foundation, review these applications and work with publishers to get you your free access."
+msgstr "Все пользователи сразу же получают доступ к некоторым коллекциям, которые вы можете изучать при нажатии на кнопку «Доступ к коллекции» или используя строку поиска в верхней части страницы. Для получения доступа к другим коллекциям необходимо подать заявку, и доступ к ним осуществляется напрямую или с помощью индивидуального логина или кода доступа. Координаторы-волонтёры, подписавшие соглашения о неразглашении информации с Фондом Викимедиа, рассматривают эти заявки и работают с издателями, чтобы предоставить вам бесплатный доступ."
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/). Don't translate terms_url.
 #: TWLight/templates/about.html:43
 #, python-format
-msgid ""
-"For more information about how your information is stored and reviewed "
-"please see our <a class=\"twl-links\" href=\"%(terms_url)s\"> terms of use "
-"and privacy policy</a>. Accounts you apply for are also subject to the Terms "
-"of Use provided by each partner’s platform; please review them."
-msgstr ""
-"Узнать больше о том, как ваши данные хранятся и используются, можно в <a "
-"class=\"twl-links\" href=\"%(terms_url)s\"> Условиях использования и "
-"политике приватности</a>. Аккаунты, к которым вы получаете доступ, также "
-"должны следовать Условиям использования каждой конкретной партнёрской "
-"платформы. Просим их также изучать."
+msgid "For more information about how your information is stored and reviewed please see our <a class=\"twl-links\" href=\"%(terms_url)s\"> terms of use and privacy policy</a>. Accounts you apply for are also subject to the Terms of Use provided by each partner’s platform; please review them."
+msgstr "Узнать больше о том, как ваши данные хранятся и используются, можно в <a class=\"twl-links\" href=\"%(terms_url)s\"> Условиях использования и политике приватности</a>. Аккаунты, к которым вы получаете доступ, также должны следовать Условиям использования каждой конкретной партнёрской платформы. Просим их также изучать."
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:51
@@ -2333,25 +1867,13 @@ msgstr "Кто может получить доступ?"
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/). Wikimedia Foundation should not be translated.
 #: TWLight/templates/about.html:55
-msgid ""
-"Any active editor in good standing can receive access. For publishers with "
-"limited numbers of accounts, applications are reviewed based on the editor’s "
-"needs and contributions. If you think you could use access to one of our "
-"partner resources and are an active editor in any project supported by the "
-"Wikimedia Foundation, please apply."
-msgstr ""
-"Любой активный участник с хорошей репутацией может получить доступ. Для "
-"издателей с ограниченным количеством учетных записей заявки рассматриваются "
-"в зависимости от потребностей редактора и его вклада. Если вы считаете, что "
-"можете использовать доступ к одному из наших партнёрских ресурсов и активным "
-"в любом проекте, поддерживаемом Фондом Викимедиа, пожалуйста, подайте заявку."
+msgid "Any active editor in good standing can receive access. For publishers with limited numbers of accounts, applications are reviewed based on the editor’s needs and contributions. If you think you could use access to one of our partner resources and are an active editor in any project supported by the Wikimedia Foundation, please apply."
+msgstr "Любой активный участник с хорошей репутацией может получить доступ. Для издателей с ограниченным количеством учетных записей заявки рассматриваются в зависимости от потребностей редактора и его вклада. Если вы считаете, что можете использовать доступ к одному из наших партнёрских ресурсов и активным в любом проекте, поддерживаемом Фондом Викимедиа, пожалуйста, подайте заявку."
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:65
 msgid "Any editor can use the library if they meet a few basic requirements:"
-msgstr ""
-"Любой редактор может использовать библиотеку, если он отвечает нескольким "
-"основным требованиям:"
+msgstr "Любой редактор может использовать библиотеку, если он отвечает нескольким основным требованиям:"
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:71
@@ -2375,35 +1897,13 @@ msgstr "Вы не заблокированы в Проекте Фонда Вик
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/)
 #: TWLight/templates/about.html:89
-msgid ""
-"If you are applying for an available collection, please first check that you "
-"don't already have access through another library or institution. If you do, "
-"please consider using that access rather than taking up a seat for this "
-"resource in The Wikipedia Library."
-msgstr ""
-"При подаче заявки на имеющуюся в наличии коллекцию, сначала убедитесь, что у "
-"вас уже нет доступа к ней в другой библиотеке или учреждении. Если доступ "
-"есть, рассмотрите возможность его использования вместо того, чтобы занимать "
-"место для этого ресурса в Библиотеке Википедии."
+msgid "If you are applying for an available collection, please first check that you don't already have access through another library or institution. If you do, please consider using that access rather than taking up a seat for this resource in The Wikipedia Library."
+msgstr "При подаче заявки на имеющуюся в наличии коллекцию, сначала убедитесь, что у вас уже нет доступа к ней в другой библиотеке или учреждении. Если доступ есть, рассмотрите возможность его использования вместо того, чтобы занимать место для этого ресурса в Библиотеке Википедии."
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/)
 #: TWLight/templates/about.html:99
-msgid ""
-"If your account is blocked on one or more Wikimedia projects, you may still "
-"be granted access to The Wikipedia Library. You will need to contact the "
-"Wikipedia Library team, who will review your blocks. If you have been "
-"blocked for content issues, most notably copyright violations, or have "
-"multiple long-term blocks, we may decline your request. Additionally, if "
-"your block status changes after being approved, you will need to request "
-"another review."
-msgstr ""
-"Если ваш аккаунт заблокирован в одном или более проекте Викимедиа, вы по-"
-"прежнему можете получить доступ к Библиотеке Википедии. Вам будет необходимо "
-"связаться с командой Библиотеки Википедии, которая проверит ваши блокировки. "
-"Если вы были заблокированы за проблемы со статьями, в особенности — за "
-"нарушения авторских прав, или же у вас было много длительных блокировок, мы "
-"можем отклонить ваш запрос. Кроме того, если статус вашей блокировки был "
-"изменён после подтверждения, вам придётся запросить новую проверку."
+msgid "If your account is blocked on one or more Wikimedia projects, you may still be granted access to The Wikipedia Library. You will need to contact the Wikipedia Library team, who will review your blocks. If you have been blocked for content issues, most notably copyright violations, or have multiple long-term blocks, we may decline your request. Additionally, if your block status changes after being approved, you will need to request another review."
+msgstr "Если ваш аккаунт заблокирован в одном или более проекте Викимедиа, вы по-прежнему можете получить доступ к Библиотеке Википедии. Вам будет необходимо связаться с командой Библиотеки Википедии, которая проверит ваши блокировки. Если вы были заблокированы за проблемы со статьями, в особенности — за нарушения авторских прав, или же у вас было много длительных блокировок, мы можем отклонить ваш запрос. Кроме того, если статус вашей блокировки был изменён после подтверждения, вам придётся запросить новую проверку."
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:110
@@ -2437,11 +1937,8 @@ msgstr "Одобренные редакторы <i>не должны</i>:"
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:136
-msgid ""
-"Share their account logins or passwords with others, or sell their access to "
-"other parties"
-msgstr ""
-"Делиться с другими логинами и паролями, или продавать доступ сторонним лицам"
+msgid "Share their account logins or passwords with others, or sell their access to other parties"
+msgstr "Делиться с другими логинами и паролями, или продавать доступ сторонним лицам"
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:140
@@ -2450,31 +1947,18 @@ msgstr "Массово скрейпить или загружать партнё
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:144
-msgid ""
-"Systematically make printed or electronic copies of multiple extracts of "
-"restricted content available for any purpose"
-msgstr ""
-"Систематически создавать печатные или электронные копии нескольких "
-"фрагментов защищённого содержимого для любых целей"
+msgid "Systematically make printed or electronic copies of multiple extracts of restricted content available for any purpose"
+msgstr "Систематически создавать печатные или электронные копии нескольких фрагментов защищённого содержимого для любых целей"
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/). Stub is a technical term for a short Wikipedia article, use the appropriate Wikipedia term in your language.
 #: TWLight/templates/about.html:148
-msgid ""
-"Datamine metadata without permission, in order, for instance, to use "
-"metadata for auto-created stub articles"
-msgstr ""
-"Заниматься интеллектуальным анализом данных без разрешения, например, "
-"используя полученные обобщённые данные для автоматической заливки статей-"
-"заготовок"
+msgid "Datamine metadata without permission, in order, for instance, to use metadata for auto-created stub articles"
+msgstr "Заниматься интеллектуальным анализом данных без разрешения, например, используя полученные обобщённые данные для автоматической заливки статей-заготовок"
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:154
-msgid ""
-"Respecting these agreements allows us to continue growing the partnerships "
-"available to the community."
-msgstr ""
-"Уважительное отношение к данному соглашению позволяет нам продолжать "
-"расширять количество партнёров, доступных сообществу."
+msgid "Respecting these agreements allows us to continue growing the partnerships available to the community."
+msgstr "Уважительное отношение к данному соглашению позволяет нам продолжать расширять количество партнёров, доступных сообществу."
 
 #. Translators: This is the heading for a section on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:160
@@ -2483,62 +1967,23 @@ msgstr "EZProxy"
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:164
-msgid ""
-"EZProxy is a proxy server used to authenticate users for many Wikipedia "
-"Library partners. Users sign into EZProxy via the Library Card platform to "
-"verify that they are authorized users, and then the server accesses "
-"requested resources using its own IP address."
-msgstr ""
-"EZProxy — прокси-сервер, используемый для аутентификации участников для "
-"многих партнёров Библиотеки Википедии. Участники заходят в EZProxy через "
-"Платформу карточек Библиотеки, подтверждая, что они авторизованные "
-"пользователи, а затем сервер обращается к запрошенным ресурсам, используя "
-"собственный IP-адрес."
+msgid "EZProxy is a proxy server used to authenticate users for many Wikipedia Library partners. Users sign into EZProxy via the Library Card platform to verify that they are authorized users, and then the server accesses requested resources using its own IP address."
+msgstr "EZProxy — прокси-сервер, используемый для аутентификации участников для многих партнёров Библиотеки Википедии. Участники заходят в EZProxy через Платформу карточек Библиотеки, подтверждая, что они авторизованные пользователи, а затем сервер обращается к запрошенным ресурсам, используя собственный IP-адрес."
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:173
-msgid ""
-"You may notice that when accessing resources via EZProxy that URLs are "
-"dynamically rewritten. This is why we recommend logging in via the Library "
-"Card platform rather than going directly to the unproxied partner website. "
-"When in doubt, check the URL for ‘idm.oclc’. If it’s there, then you’re "
-"connected via EZProxy."
-msgstr ""
-"При обращении к ресурсам через EZProxy, вы можете заметить, что веб-адреса "
-"динамически переписываются. Поэтому мы рекомендуем авторизоваться через "
-"Платформу карточек Библиотеки, а не переходить напрямую на сайт партнёра. В "
-"случае сомнений проверьте веб-адрес «idm.oclc». Если он доступен, вы "
-"подключены через EZProxy."
+msgid "You may notice that when accessing resources via EZProxy that URLs are dynamically rewritten. This is why we recommend logging in via the Library Card platform rather than going directly to the unproxied partner website. When in doubt, check the URL for ‘idm.oclc’. If it’s there, then you’re connected via EZProxy."
+msgstr "При обращении к ресурсам через EZProxy, вы можете заметить, что веб-адреса динамически переписываются. Поэтому мы рекомендуем авторизоваться через Платформу карточек Библиотеки, а не переходить напрямую на сайт партнёра. В случае сомнений проверьте веб-адрес «idm.oclc». Если он доступен, вы подключены через EZProxy."
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:182
-msgid ""
-"Typically once you’ve logged in your session will remain active in your "
-"browser for up to two hours after you’ve finished searching. Note that use "
-"of EZProxy requires you to enable cookies. If you are having problems you "
-"should also try clearing your cache and restarting your browser."
-msgstr ""
-"Как правило, после авторизации ваша сессия будет оставаться активной в вашем "
-"браузере до двух часов после окончания поиска. Обратите внимание: "
-"использование EZProxy требует включения файлов куки. При возникновении "
-"проблем вам также следует попробовать очистить кэш и перезапустить браузер."
+msgid "Typically once you’ve logged in your session will remain active in your browser for up to two hours after you’ve finished searching. Note that use of EZProxy requires you to enable cookies. If you are having problems you should also try clearing your cache and restarting your browser."
+msgstr "Как правило, после авторизации ваша сессия будет оставаться активной в вашем браузере до двух часов после окончания поиска. Обратите внимание: использование EZProxy требует включения файлов куки. При возникновении проблем вам также следует попробовать очистить кэш и перезапустить браузер."
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/)
 #: TWLight/templates/about.html:193
-msgid ""
-"The Library Bundle is a collection of resources for which no application is "
-"required. If you meet the criteria laid out above, you will be authorized "
-"for access automatically upon logging in to the platform. Only some of our "
-"content is currently included in the Library Bundle, however we hope to "
-"expand the collection as more publishers become comfortable with "
-"participating. All Bundle content is accessed via EZProxy."
-msgstr ""
-"Набор Библиотеки — сборник ресурсов, к которым не нужно подавать заявки. "
-"Если вы удовлетворяете критериям, перечисленным выше, вы получите доступ к "
-"ресурсам сразу после авторизации на платформе. Сейчас лишь небольшая часть "
-"наших материалов включена в Набор Библиотеки, однако мы надеемся расширять "
-"его по мере того, как издателям станет комфортно в нём участвовать. Все "
-"материалы из набора просматриваются через EZProxy."
+msgid "The Library Bundle is a collection of resources for which no application is required. If you meet the criteria laid out above, you will be authorized for access automatically upon logging in to the platform. Only some of our content is currently included in the Library Bundle, however we hope to expand the collection as more publishers become comfortable with participating. All Bundle content is accessed via EZProxy."
+msgstr "Набор Библиотеки — сборник ресурсов, к которым не нужно подавать заявки. Если вы удовлетворяете критериям, перечисленным выше, вы получите доступ к ресурсам сразу после авторизации на платформе. Сейчас лишь небольшая часть наших материалов включена в Набор Библиотеки, однако мы надеемся расширять его по мере того, как издателям станет комфортно в нём участвовать. Все материалы из набора просматриваются через EZProxy."
 
 #. Translators: This is the heading for a section on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:202
@@ -2547,18 +1992,8 @@ msgstr "Политика сносок"
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:206
-msgid ""
-"Citation practices vary by project and even by article. Generally, we "
-"support editors citing where they found information, in a form that allows "
-"others to check it for themselves. That often means providing both original "
-"source details as well as a link to the partner database in which the source "
-"was found."
-msgstr ""
-"Политика сносок разнится в зависимости от проекта и даже от статьи. В целом, "
-"мы поддерживаем указание редакторами, где была найдена информация, в той "
-"форме, которая позволит другим проверить информацию самостоятельно. Обычно "
-"это предполагает как указание информации о первоисточнике, так и ссылки на "
-"базу данных партнёра, в которой этот источник был найден."
+msgid "Citation practices vary by project and even by article. Generally, we support editors citing where they found information, in a form that allows others to check it for themselves. That often means providing both original source details as well as a link to the partner database in which the source was found."
+msgstr "Политика сносок разнится в зависимости от проекта и даже от статьи. В целом, мы поддерживаем указание редакторами, где была найдена информация, в той форме, которая позволит другим проверить информацию самостоятельно. Обычно это предполагает как указание информации о первоисточнике, так и ссылки на базу данных партнёра, в которой этот источник был найден."
 
 #. Translators: This is the heading for a section on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #. Translators: This link is at the bottom of every page and can be clicked by users to contact the wikipedia library team.
@@ -2569,13 +2004,8 @@ msgstr "Свяжитесь с нами"
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:218
 #, python-format
-msgid ""
-"If you have questions, need help, or want to volunteer to help, please see "
-"our <a class=\"twl-links\" href=\"%(contact_url)s\">contact page</a>."
-msgstr ""
-"Если у вас есть вопросы, вам нужна помощь или вы хотите помочь, пожалуйста, "
-"посетите <a class=\"twl-links\" href=\"%(contact_url)s\">страницу контактов</"
-"a>."
+msgid "If you have questions, need help, or want to volunteer to help, please see our <a class=\"twl-links\" href=\"%(contact_url)s\">contact page</a>."
+msgstr "Если у вас есть вопросы, вам нужна помощь или вы хотите помочь, пожалуйста, посетите <a class=\"twl-links\" href=\"%(contact_url)s\">страницу контактов</a>."
 
 #. Translators: This is the title of the panel box detailing the contact information for the Wikipedia Library team.
 #: TWLight/templates/contact.html:14
@@ -2614,12 +2044,8 @@ msgstr "Twitter Библиотеки Википедии"
 #. Translators: This is the text that appears at the bottom of the contact us form directing users to the suggestions form.
 #: TWLight/templates/contact.html:48
 #, python-format
-msgid ""
-"(If you would like to suggest a partner, <a class=\"twl-links\" href="
-"\"%(suggest)s\"><strong>go here</strong></a>.)"
-msgstr ""
-"(Если вы хотите предложить партнёра, <a class=\"twl-links\" href="
-"\"%(suggest)s\"><strong>перейдите сюда</strong></a>.)"
+msgid "(If you would like to suggest a partner, <a class=\"twl-links\" href=\"%(suggest)s\"><strong>go here</strong></a>.)"
+msgstr "(Если вы хотите предложить партнёра, <a class=\"twl-links\" href=\"%(suggest)s\"><strong>перейдите сюда</strong></a>.)"
 
 #. Translators: On a special 'link to search' page, this message is shown if JavaScript is disabled.
 #: TWLight/templates/eds_search_endpoint.html:7
@@ -2675,13 +2101,8 @@ msgstr "Библиотека Википедии"
 #. Translators: Information about The Wikipedia Library.
 #: TWLight/templates/login_partial.html:53 TWLight/templates/new_base.html:21
 #, python-format
-msgid ""
-"More than 100 of the world's top subscription-only databases, with content "
-"in %(no_of_languages)s languages, free for Wikipedians of all backgrounds"
-msgstr ""
-"Более 100 лучших в мире баз данных, доступных только по подписке, с "
-"контентом на %(no_of_languages)s языках, бесплатны для Википедистов любого "
-"уровня подготовки"
+msgid "More than 100 of the world's top subscription-only databases, with content in %(no_of_languages)s languages, free for Wikipedians of all backgrounds"
+msgstr "Более 100 лучших в мире баз данных, доступных только по подписке, с контентом на %(no_of_languages)s языках, бесплатны для Википедистов любого уровня подготовки"
 
 #. Translators: Information about The Wikipedia Library.
 #: TWLight/templates/login_partial.html:64
@@ -2689,12 +2110,8 @@ msgid "Meet these criteria for automatic access"
 msgstr "Вы должны соответствовать этим критериям автоматического доступа"
 
 #: TWLight/templates/login_partial.html:69
-msgid ""
-"These criteria grant you access to certain collections but not all. Some "
-"collections are accessible on a per application basis only."
-msgstr ""
-"Эти критерии не гарантируют доступа ко всем коллекциям. Некоторые коллекции "
-"доступны только по заявке."
+msgid "These criteria grant you access to certain collections but not all. Some collections are accessible on a per application basis only."
+msgstr "Эти критерии не гарантируют доступа ко всем коллекциям. Некоторые коллекции доступны только по заявке."
 
 #: TWLight/templates/login_partial.html:89
 msgid "Login via Wikipedia"
@@ -2703,42 +2120,20 @@ msgstr "Войти через учётную запись в Википедии"
 #. Translators: Shown if the current user doesn't have a registered email on their account. Don't translate contact_us_url or email_url.
 #: TWLight/templates/message_partial.html:15
 #, python-format
-msgid ""
-"You don't have an email on file. We can't finalize your access to partner "
-"resources, and you won't be able to <a class=\"twl-links\" href="
-"\"%(contact_us_url)s\">contact us</a> without an email. Please <a class="
-"\"twl-links\" href=\"%(email_url)s\">update your email</a>."
-msgstr ""
-"У вас не указан электронный адрес. Мы не сможем обеспечить вам доступ к "
-"ресурсам партнёров, и вы не сможете <a class=\"twl-links\" href="
-"\"%(contact_us_url)s\">связаться с нами</a> без адреса электронной почты. "
-"Пожалуйста, <a class=\"twl-links\" href=\"%(email_url)s\">укажите свой "
-"электронный адрес</a>."
+msgid "You don't have an email on file. We can't finalize your access to partner resources, and you won't be able to <a class=\"twl-links\" href=\"%(contact_us_url)s\">contact us</a> without an email. Please <a class=\"twl-links\" href=\"%(email_url)s\">update your email</a>."
+msgstr "У вас не указан электронный адрес. Мы не сможем обеспечить вам доступ к ресурсам партнёров, и вы не сможете <a class=\"twl-links\" href=\"%(contact_us_url)s\">связаться с нами</a> без адреса электронной почты. Пожалуйста, <a class=\"twl-links\" href=\"%(email_url)s\">укажите свой электронный адрес</a>."
 
 #. Translators: Shown if the current user has requested the processing of their data should be restricted.
 #: TWLight/templates/message_partial.html:26
 #, python-format
-msgid ""
-"You have requested a restriction on the processing of your data. Most site "
-"functionality will not be available to you until you <a class=\"twl-links\" "
-"href=\"%(restrict_url)s\">lift this restriction</a>."
-msgstr ""
-"Вы запросили ограничение на обработку ваших данных. Большая часть "
-"функционала сайта не будет доступна вам до тех пор, пока вы не <a class="
-"\"twl-links\" href=\"%(restrict_url)s\">снимете это ограничение</a>."
+msgid "You have requested a restriction on the processing of your data. Most site functionality will not be available to you until you <a class=\"twl-links\" href=\"%(restrict_url)s\">lift this restriction</a>."
+msgstr "Вы запросили ограничение на обработку ваших данных. Большая часть функционала сайта не будет доступна вам до тех пор, пока вы не <a class=\"twl-links\" href=\"%(restrict_url)s\">снимете это ограничение</a>."
 
 #. Translators: Shown if the current user has not agreed to the terms of use.
 #: TWLight/templates/message_partial.html:37
 #, python-format
-msgid ""
-"You have not agreed to the <a class=\"twl-links\" href=\"%(terms_url)s"
-"\">terms of use</a> of this site. Your applications will not be processed "
-"and you won't be able to apply or access resources you are approved for."
-msgstr ""
-"Вы не согласились с <a class=\"twl-links\" href=\"%(terms_url)s\">условиями "
-"использования</a> этого сайта. Ваши заявки не будут обрабатываться, у вас не "
-"будет возможности подавать новые заявки или обращаться к сайтам, к которым "
-"вы уже получали доступ."
+msgid "You have not agreed to the <a class=\"twl-links\" href=\"%(terms_url)s\">terms of use</a> of this site. Your applications will not be processed and you won't be able to apply or access resources you are approved for."
+msgstr "Вы не согласились с <a class=\"twl-links\" href=\"%(terms_url)s\">условиями использования</a> этого сайта. Ваши заявки не будут обрабатываться, у вас не будет возможности подавать новые заявки или обращаться к сайтам, к которым вы уже получали доступ."
 
 #. Translators: This link is at the bottom of every page and links to the 'About' page (https://wikipedialibrary.wmflabs.org/about/)
 #: TWLight/templates/new_base.html:107
@@ -2784,12 +2179,8 @@ msgstr "Сбросить пароль"
 
 #. Translators: If a user goes to reset their password, this message asks them to enter their email to do so.
 #: TWLight/templates/registration/password_reset_form.html:13
-msgid ""
-"Forgot your password? Enter your email address below, and we'll email "
-"instructions for setting a new one."
-msgstr ""
-"Забыли пароль? Введите свой электронный адрес, и мы отошлём на него "
-"инструкции по смене пароля."
+msgid "Forgot your password? Enter your email address below, and we'll email instructions for setting a new one."
+msgstr "Забыли пароль? Введите свой электронный адрес, и мы отошлём на него инструкции по смене пароля."
 
 #. Translators: This is the label for a button that users click to update their public information.
 #: TWLight/users/forms.py:36
@@ -2799,8 +2190,7 @@ msgstr "Обновить профиль"
 #. Translators: This labels a field where users can describe their activity on Wikipedia in a small biography.
 #: TWLight/users/forms.py:45
 msgid "Describe your contributions to Wikipedia: topics edited, et cetera."
-msgstr ""
-"Опишите ваш вклад в Википедию: тематики, в которых вы работаете, и т. п."
+msgstr "Опишите ваш вклад в Википедию: тематики, в которых вы работаете, и т. п."
 
 #. Translators: In the preferences section (Emails) of a user profile, this text labels the checkbox users can (un)click to change if they wish to receive account renewal notices or not.
 #: TWLight/users/forms.py:98
@@ -2834,23 +2224,13 @@ msgstr "Я соглашаюсь с условиями использования
 
 #. Translators: This text explains how to disagree to the site's terms of use and the restrictions that will come into effect when users disagree to the terms of use.
 #: TWLight/users/forms.py:185
-msgid ""
-"By unchecking this box and clicking “Update” you may explore the site, but "
-"you will not be able to apply for access to materials or evaluate "
-"applications unless you agree with the terms of use."
-msgstr ""
-"Сняв здесь галочку и нажав на «Обновить», вы не потеряете возможности "
-"исследовать сайт, однако у вас не будет возможности подать заявку на доступ "
-"к материалам или оценивать заявки, пока вы не согласитесь с условиями "
-"использования."
+msgid "By unchecking this box and clicking “Update” you may explore the site, but you will not be able to apply for access to materials or evaluate applications unless you agree with the terms of use."
+msgstr "Сняв здесь галочку и нажав на «Обновить», вы не потеряете возможности исследовать сайт, однако у вас не будет возможности подать заявку на доступ к материалам или оценивать заявки, пока вы не согласитесь с условиями использования."
 
 #. Translators: Users click this button to set their website email address to the one linked to their Wikipedia account.
 #: TWLight/users/forms.py:211
-msgid ""
-"Use my Wikipedia email address (will be updated the next time you login)."
-msgstr ""
-"Использовать мой адрес электронной почты в Википедии (будет обновлено при "
-"следующем входе в аккаунт)."
+msgid "Use my Wikipedia email address (will be updated the next time you login)."
+msgstr "Использовать мой адрес электронной почты в Википедии (будет обновлено при следующем входе в аккаунт)."
 
 #. Translators: This labels a button which users click to change their email.
 #: TWLight/users/forms.py:232
@@ -2860,23 +2240,13 @@ msgstr "Обновить эл. почту"
 #. Translators: Shown if the current user tried to 'favorite' a partner they can't access. Do not translate '{partner}'
 #: TWLight/users/models.py:201
 #, python-brace-format
-msgid ""
-"Cannot add partner {partner} to your favorites because you don't have access "
-"to it"
+msgid "Cannot add partner {partner} to your favorites because you don't have access to it"
 msgstr "Невозможно добавить {partner} в избранное: у вас нет доступа"
-
-#. Translators: Do not translate.
-#: TWLight/users/models.py:869
-#, fuzzy, python-brace-format
-#| msgid "Username"
-msgid "{wp_username}"
-msgstr "Имя участника"
 
 #. Translators: This error message is shown when there's a problem with the authenticated login process.
 #: TWLight/users/oauth.py:243
 msgid "You tried to log in but presented an invalid access token."
-msgstr ""
-"Вы попытались авторизоваться, однако предоставили некорректный токен доступа."
+msgstr "Вы попытались авторизоваться, однако предоставили некорректный токен доступа."
 
 #. Translators: This message is shown when the OAuth login process fails because the request came from the wrong website. Don't translate {domain}.
 #: TWLight/users/oauth.py:298 TWLight/users/oauth.py:444
@@ -2891,12 +2261,8 @@ msgstr "Рукопожатие не инициировано, попробуйт
 
 #. Translators: this message is displayed to users that don't have accounts and clicked on a proxied link.
 #: TWLight/users/oauth.py:388
-msgid ""
-"To view this link you need to be an eligible library user. Please login to "
-"continue."
-msgstr ""
-"Для просмотра этой ссылки нужно быть одобренным редактором и иметь доступ в "
-"библиотеку. Пожалуйста, войдите, чтобы продолжить."
+msgid "To view this link you need to be an eligible library user. Please login to continue."
+msgstr "Для просмотра этой ссылки нужно быть одобренным редактором и иметь доступ в библиотеку. Пожалуйста, войдите, чтобы продолжить."
 
 #. Translators: This warning message is shown to users when the response received from Wikimedia OAuth servers is not a valid one.
 #: TWLight/users/oauth.py:430
@@ -2931,25 +2297,13 @@ msgstr "Смотрите {issue} для дополнительной инфор�
 
 #. Translators: If the user tries to log in, but their account does not meet certain requirements, they cannot login.
 #: TWLight/users/oauth.py:528
-msgid ""
-"Your Wikipedia account does not meet the eligibility criteria in the terms "
-"of use, so your Wikipedia Library Card Platform account cannot be activated."
-msgstr ""
-"Ваша учётная запись Википедии не удовлетворяет критериям, приведённым в "
-"условиях использования, поэтому ваша учётная запись Платформы карточек "
-"Библиотеки Википедии не может быть активирована."
+msgid "Your Wikipedia account does not meet the eligibility criteria in the terms of use, so your Wikipedia Library Card Platform account cannot be activated."
+msgstr "Ваша учётная запись Википедии не удовлетворяет критериям, приведённым в условиях использования, поэтому ваша учётная запись Платформы карточек Библиотеки Википедии не может быть активирована."
 
 #. Translators: If the user tries to log in, but their account does not meet certain requirements, they cannot login.
 #: TWLight/users/oauth.py:536
-msgid ""
-"Your Wikipedia account no longer meets the eligibility criteria in the terms "
-"of use, so you cannot be logged in. If you think you should be able to log "
-"in, please email wikipedialibrary@wikimedia.org."
-msgstr ""
-"Ваша учётная запись Википедии больше не удовлетворяет критериям, приведённым "
-"в условиях использования, поэтому вы не можете быть авторизованы. Если вы "
-"считаете, что должны иметь возможность авторизоваться, пожалуйста, оправьте "
-"письмо на wikipedialibrary@wikimedia.org."
+msgid "Your Wikipedia account no longer meets the eligibility criteria in the terms of use, so you cannot be logged in. If you think you should be able to log in, please email wikipedialibrary@wikimedia.org."
+msgstr "Ваша учётная запись Википедии больше не удовлетворяет критериям, приведённым в условиях использования, поэтому вы не можете быть авторизованы. Если вы считаете, что должны иметь возможность авторизоваться, пожалуйста, оправьте письмо на wikipedialibrary@wikimedia.org."
 
 #. Translators: this message is displayed to users with brand new accounts.
 #: TWLight/users/oauth.py:549
@@ -2959,14 +2313,8 @@ msgstr "Добро пожаловать ! Пожалуйста, согласит
 #. Translators: This message is displayed on the confirmation page where users can return their access to partner collections.
 #: TWLight/users/templates/users/authorization_confirm_return.html:13
 #, python-format
-msgid ""
-"You will no longer be able to access <b>%(partner)s's</b> resources via the "
-"Library Card platform, but can request access again by clicking 'renew', if "
-"you change your mind. Are you sure you want to return your access?"
-msgstr ""
-"Вы больше не сможете обращаться к ресурсам <b>%(partner)s</b> через "
-"Платформу карточек Библиотеки, однако сможете снова запросить доступ, нажав "
-"«Продлить», если вы передумаете. Вы уверены, что хотите вернуть доступ?"
+msgid "You will no longer be able to access <b>%(partner)s's</b> resources via the Library Card platform, but can request access again by clicking 'renew', if you change your mind. Are you sure you want to return your access?"
+msgstr "Вы больше не сможете обращаться к ресурсам <b>%(partner)s</b> через Платформу карточек Библиотеки, однако сможете снова запросить доступ, нажав «Продлить», если вы передумаете. Вы уверены, что хотите вернуть доступ?"
 
 #. Translators: On the MyLibrary page (https://wikipedialibrary.wmflabs.org/users/my_library), this tab shows all favorite collections a user has.
 #: TWLight/users/templates/users/collections_section.html:9
@@ -3035,14 +2383,8 @@ msgstr "Данные о редакторе"
 
 #. Translators: This is shown on editor profiles, in their profile page or on applications.
 #: TWLight/users/templates/users/editor_detail.html:59
-msgid ""
-"Information with an * was retrieved from Wikipedia directly. Other "
-"information was entered directly by users or site admins, in their preferred "
-"language."
-msgstr ""
-"Информация, помеченная *, была напрямую получена из Википедии. Оставшаяся "
-"информация была введена непосредственно участником или администратором сайта "
-"на предпочитаемом языке."
+msgid "Information with an * was retrieved from Wikipedia directly. Other information was entered directly by users or site admins, in their preferred language."
+msgstr "Информация, помеченная *, была напрямую получена из Википедии. Оставшаяся информация была введена непосредственно участником или администратором сайта на предпочитаемом языке."
 
 #. Translators: This distinguishes users who have been flagged as account coordinators. Don't translate username.
 #: TWLight/users/templates/users/editor_detail.html:71
@@ -3052,14 +2394,8 @@ msgstr "%(username)s имеет права координатора на это�
 
 #. Translators: This is shown on editor profiles, under the heading for Wikipedia editor data.
 #: TWLight/users/templates/users/editor_detail_data.html:5
-msgid ""
-"This information is updated automatically from your Wikimedia account each "
-"time you log in, except for the Contributions field, where you can describe "
-"your Wikimedia editing history."
-msgstr ""
-"Информация автоматически обновляется по вашему аккаунту Викимедиа при каждой "
-"вашей авторизации, за исключением поля «Вклад», в котором вы можете описать "
-"свой прошлый вклад в проекты Викимедиа."
+msgid "This information is updated automatically from your Wikimedia account each time you log in, except for the Contributions field, where you can describe your Wikimedia editing history."
+msgstr "Информация автоматически обновляется по вашему аккаунту Викимедиа при каждой вашей авторизации, за исключением поля «Вклад», в котором вы можете описать свой прошлый вклад в проекты Викимедиа."
 
 #. Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this labels the user's username.
 #: TWLight/users/templates/users/editor_detail_data.html:17
@@ -3088,21 +2424,14 @@ msgstr "Удовлетворяет условиям использования?"
 
 #. Translators: when viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this question has a yes or no answer.
 #: TWLight/users/templates/users/editor_detail_data.html:57
-msgid ""
-"at their last login, did this user meet the criteria set forth in the terms "
-"of use?"
-msgstr ""
-"удовлетворял ли этот участник критериям, обозначенным в условиях "
-"использования, в момент последней авторизации?"
+msgid "at their last login, did this user meet the criteria set forth in the terms of use?"
+msgstr "удовлетворял ли этот участник критериям, обозначенным в условиях использования, в момент последней авторизации?"
 
 #. Translators: When viewing a user's profile in an application, this message shows if the software doesn't think that the user is eligible for access. Don't translate username.
 #: TWLight/users/templates/users/editor_detail_data.html:72
 #, python-format
-msgid ""
-"%(username)s may still be eligible for access grants at the coordinators' "
-"discretion."
-msgstr ""
-"%(username)s может по-прежнему получить доступ на усмотрение координатора."
+msgid "%(username)s may still be eligible for access grants at the coordinators' discretion."
+msgstr "%(username)s может по-прежнему получить доступ на усмотрение координатора."
 
 #. Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this is the heading for a Yes/No ToU question.
 #: TWLight/users/templates/users/editor_detail_data.html:83
@@ -3136,15 +2465,8 @@ msgstr ""
 #. Translators: This message is shown on a user's profile if their Wikimedia account is blocked on one or more projects. They may still be granted access to the Library Bundle, but need to contact Wikipedia Library staff to verify.
 #: TWLight/users/templates/users/editor_detail_data.html:137
 #, python-format
-msgid ""
-"It looks like you have an active block on your account. If you meet the "
-"other criteria you may still be permitted access to the library - please <a "
-"class=\"twl-links\" href=\"%(contact_url)s\">contact us</a>."
-msgstr ""
-"Похоже, что на вашу учётную запись наложена активная блокировка. Если вы "
-"удовлетворяете остальным критериям, вам по-прежнему может быть разрешён "
-"доступ к Набору Библиотеки — пожалуйста, <a class=\"twl-links\" href="
-"\"%(contact_url)s\">свяжитесь с нами</a>."
+msgid "It looks like you have an active block on your account. If you meet the other criteria you may still be permitted access to the library - please <a class=\"twl-links\" href=\"%(contact_url)s\">contact us</a>."
+msgstr "Похоже, что на вашу учётную запись наложена активная блокировка. Если вы удовлетворяете остальным критериям, вам по-прежнему может быть разрешён доступ к Набору Библиотеки — пожалуйста, <a class=\"twl-links\" href=\"%(contact_url)s\">свяжитесь с нами</a>."
 
 #. Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this is the heading for a Yes/No program eligibility question.
 #: TWLight/users/templates/users/editor_detail_data.html:153
@@ -3153,14 +2475,8 @@ msgstr "Может получить доступ к Набору Библиот�
 
 #. Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this question has a Yes or No answer.
 #: TWLight/users/templates/users/editor_detail_data.html:156
-msgid ""
-"At their last login, did this user meet the criteria set forth in the "
-"Library Bundle? Note that satisfying terms of use is a prerequisite to "
-"bundle eligibility."
-msgstr ""
-"Удовлетворял ли этот участник критериям Набора Библиотеки на момент "
-"последней авторизации? Обратите внимание, что соответствие этим требованиям "
-"— необходимое условия для доступа к набору."
+msgid "At their last login, did this user meet the criteria set forth in the Library Bundle? Note that satisfying terms of use is a prerequisite to bundle eligibility."
+msgstr "Удовлетворял ли этот участник критериям Набора Библиотеки на момент последней авторизации? Обратите внимание, что соответствие этим требованиям — необходимое условия для доступа к набору."
 
 #. Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this is the heading for a Yes/No program eligibility question.
 #: TWLight/users/templates/users/editor_detail_data.html:177
@@ -3190,8 +2506,7 @@ msgstr "Неизвестно (требуется 30 дней с первой а�
 #. Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this labels the date the user registered their Meta-wiki account or the date their account was merged by the SUL merge process. Don't remove the *
 #: TWLight/users/templates/users/editor_detail_data.html:232
 msgid "Meta-Wiki registration or SUL merge date *"
-msgstr ""
-"Дата регистрации на MediaWiki или объединения в eдиную учётную запись *"
+msgstr "Дата регистрации на MediaWiki или объединения в eдиную учётную запись *"
 
 #. Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this labels the user's Wikipedia User ID. Don't remove the *
 #: TWLight/users/templates/users/editor_detail_data.html:244
@@ -3205,24 +2520,14 @@ msgstr "Личные данные"
 
 #. Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this text is in the 'Personal data' section. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/users/templates/users/editor_detail_data.html:262
-msgid ""
-"The following information is visible only to you, site administrators, "
-"publishing partners (where required), and volunteer Wikipedia Library "
-"coordinators (who have signed a Non-Disclosure Agreement)."
-msgstr ""
-"Следующая информация доступна только вам, администраторам сайта, издателям-"
-"партнёрам (по требованию), и волонтёрам-координаторам Библиотеки Википедии "
-"(подписавшим соглашение о неразглашении)."
+msgid "The following information is visible only to you, site administrators, publishing partners (where required), and volunteer Wikipedia Library coordinators (who have signed a Non-Disclosure Agreement)."
+msgstr "Следующая информация доступна только вам, администраторам сайта, издателям-партнёрам (по требованию), и волонтёрам-координаторам Библиотеки Википедии (подписавшим соглашение о неразглашении)."
 
 #. Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this labels a button which users can click to update or remove their personal information. Don't translate update_url.
 #: TWLight/users/templates/users/editor_detail_data.html:272
 #, python-format
-msgid ""
-"You may <a class=\"twl-links\" href=\"%(update_url)s\">update or delete</a> "
-"your data at any time."
-msgstr ""
-"Вы можете <a class=\"twl-links\" href=\"%(update_url)s\">обновить или "
-"удалить</a> свои данные в любое время."
+msgid "You may <a class=\"twl-links\" href=\"%(update_url)s\">update or delete</a> your data at any time."
+msgstr "Вы можете <a class=\"twl-links\" href=\"%(update_url)s\">обновить или удалить</a> свои данные в любое время."
 
 #. Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this labels the user's email. Don't remove the *.
 #: TWLight/users/templates/users/editor_detail_data.html:283
@@ -3241,33 +2546,19 @@ msgstr "Аффиляция с учреждением"
 
 #. Translators: This message tells users that they are not eligible to access The Wikipedia Library content.
 #: TWLight/users/templates/users/eligibility_modal.html:7
-msgid ""
-"Sorry, your Wikipedia account doesn’t currently qualify to access The "
-"Wikipedia Library."
-msgstr ""
-"К сожалению, ваш аккаунт Википедии в настоящее время не имеет права доступа "
-"к Библиотеке Википедии."
+msgid "Sorry, your Wikipedia account doesn’t currently qualify to access The Wikipedia Library."
+msgstr "К сожалению, ваш аккаунт Википедии в настоящее время не имеет права доступа к Библиотеке Википедии."
 
 #. Translators: This message tells users that they have not agreed to the terms of use, therefore are ineligible to access the content in The Wikipedia Library.
 #: TWLight/users/templates/users/eligibility_modal.html:30
 #, python-format
-msgid ""
-"Agreed with <a href=\"%(terms)s\" class=\"text-danger\"> terms of use </a>"
-msgstr ""
-"Согласен с <a href=\"%(terms)s\" class=\"text-danger\">условиями "
-"использования</a>"
+msgid "Agreed with <a href=\"%(terms)s\" class=\"text-danger\"> terms of use </a>"
+msgstr "Согласен с <a href=\"%(terms)s\" class=\"text-danger\">условиями использования</a>"
 
 #: TWLight/users/templates/users/eligibility_modal.html:40
 #, python-format
-msgid ""
-"It looks like you have an active block on your account. If you meet the "
-"other criteria you may still be permitted access to the library - please <a "
-"href=\"%(contact_url)s\">contact us</a>."
-msgstr ""
-"Похоже, что на вашу учётную запись наложена активная блокировка. Если вы "
-"удовлетворяете остальным критериям, вам по-прежнему может быть разрешён "
-"доступ к Набору Библиотеки — пожалуйста, <a href=\"%(contact_url)s"
-"\">свяжитесь с нами</a>."
+msgid "It looks like you have an active block on your account. If you meet the other criteria you may still be permitted access to the library - please <a href=\"%(contact_url)s\">contact us</a>."
+msgstr "Похоже, что на вашу учётную запись наложена активная блокировка. Если вы удовлетворяете остальным критериям, вам по-прежнему может быть разрешён доступ к Набору Библиотеки — пожалуйста, <a href=\"%(contact_url)s\">свяжитесь с нами</a>."
 
 #. Translators: Instructions to refresh a user's data.
 #: TWLight/users/templates/users/eligibility_modal.html:50
@@ -3306,14 +2597,8 @@ msgstr "Выбрать язык"
 
 #. Translators: This text on the user page helps users naviage to the TranslateWiki Wikipedia Library Card platform translation page.
 #: TWLight/users/templates/users/language_form.html:31
-msgid ""
-"You can help translate the tool at <a class=\"twl-links\" href=\"https://"
-"translatewiki.net/wiki/Translating:Wikipedia_Library_Card_Platform"
-"\">translatewiki.net</a>."
-msgstr ""
-"Вы можете помочь перевести этот инструмент на <a class=\"twl-links\" href="
-"\"https://translatewiki.net/wiki/Translating:Wikipedia_Library_Card_Platform"
-"\">translatewiki.net</a>."
+msgid "You can help translate the tool at <a class=\"twl-links\" href=\"https://translatewiki.net/wiki/Translating:Wikipedia_Library_Card_Platform\">translatewiki.net</a>."
+msgstr "Вы можете помочь перевести этот инструмент на <a class=\"twl-links\" href=\"https://translatewiki.net/wiki/Translating:Wikipedia_Library_Card_Platform\">translatewiki.net</a>."
 
 #. Translators: When the user starts a new application and submits the application, the user can view the application and withdraw if need be. This changes the label for the Withdraw button.
 #: TWLight/users/templates/users/my_applications.html:65
@@ -3332,12 +2617,8 @@ msgstr "Запросить продление"
 
 #. Translators: On the page listing applications, this text explains a user they cannot renew their application since they've already requested a renewal or there aren't any renewals available.
 #: TWLight/users/templates/users/my_applications.html:79
-msgid ""
-"Renewals are either not required, not available right now, or you have "
-"already requested a renewal."
-msgstr ""
-"Продления либо не требуются, либо недоступны сейчас, или вы уже запросили "
-"продление."
+msgid "Renewals are either not required, not available right now, or you have already requested a renewal."
+msgstr "Продления либо не требуются, либо недоступны сейчас, или вы уже запросили продление."
 
 #. Translators: This text is the heading of a section in a user's profile where they can change their preferences.
 #: TWLight/users/templates/users/preferences.html:6
@@ -3400,27 +2681,13 @@ msgstr "Ограничить обработку данных"
 
 #. Translators: This message is displayed on the page where users can request we stop processing their data.
 #: TWLight/users/templates/users/restrict_data.html:15
-msgid ""
-"Checking this box and clicking “Restrict” will pause all processing of the "
-"data you have entered into this website. You will not be able to apply for "
-"access to resources, your applications will not be further processed, and "
-"none of your data will be altered, until you return to this page and uncheck "
-"the box. This is not the same as deleting your data."
-msgstr ""
-"Галочка здесь и нажатие на «Ограничить» приостановит обработку введённых "
-"вами данных. Вы не сможете подавать заявки на доступ к ресурсам, уже "
-"поданные заявки не будут обрабатываться, а ваши данные не будут меняться до "
-"тех пор, пока вы не вернётесь на эту страницу и не снимете галочку. Это не "
-"то же самое, что удаление данных."
+msgid "Checking this box and clicking “Restrict” will pause all processing of the data you have entered into this website. You will not be able to apply for access to resources, your applications will not be further processed, and none of your data will be altered, until you return to this page and uncheck the box. This is not the same as deleting your data."
+msgstr "Галочка здесь и нажатие на «Ограничить» приостановит обработку введённых вами данных. Вы не сможете подавать заявки на доступ к ресурсам, уже поданные заявки не будут обрабатываться, а ваши данные не будут меняться до тех пор, пока вы не вернётесь на эту страницу и не снимете галочку. Это не то же самое, что удаление данных."
 
 #. Translators: This warning message is shown to coordinators who view the data restriction page.
 #: TWLight/users/templates/users/restrict_data.html:26
-msgid ""
-"You are a coordinator on this site. If you restrict the processing of your "
-"data, your coordinator flag will be removed."
-msgstr ""
-"Вы — координатор этого сайта. Если вы ограничите обработку ваших данных, ваш "
-"флаг координатора пропадёт."
+msgid "You are a coordinator on this site. If you restrict the processing of your data, your coordinator flag will be removed."
+msgstr "Вы — координатор этого сайта. Если вы ограничите обработку ваших данных, ваш флаг координатора пропадёт."
 
 #. Translators: use the date *when you are translating*, in a language-appropriate format.
 #: TWLight/users/templates/users/terms.html:33
@@ -3435,44 +2702,17 @@ msgstr "Политика конфиденциальности Фонда Вик�
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:41
 msgid "Wikipedia Library Card Terms of Use and Privacy Statement"
-msgstr ""
-"Условия использования и политика конфиденциальности Платформы карточек "
-"Библиотеки Википедии"
+msgstr "Условия использования и политика конфиденциальности Платформы карточек Библиотеки Википедии"
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:51
-msgid ""
-"<a class=\"twl-links\" href=\"https://meta.wikimedia.org/wiki/"
-"The_Wikipedia_Library\"> The Wikipedia Library </a> has partnered with "
-"publishers around the world to allow users to access otherwise paywalled "
-"resources. This website allows Wikipedia editors to search and access these "
-"resources."
-msgstr ""
-"<a class=\"twl-links\" href=\"https://meta.wikimedia.org/wiki/"
-"The_Wikipedia_Library/ru\">Библиотека Википедии</a> заключила партнёрские "
-"соглашения с издателями по всему миру, чтобы позволить участникам "
-"просматривать ресурсы, которые в противном случае оставались бы платными. "
-"Этот веб-сайт позволяет редакторам Википедии искать и получать доступ к этим "
-"ресурсам."
+msgid "<a class=\"twl-links\" href=\"https://meta.wikimedia.org/wiki/The_Wikipedia_Library\"> The Wikipedia Library </a> has partnered with publishers around the world to allow users to access otherwise paywalled resources. This website allows Wikipedia editors to search and access these resources."
+msgstr "<a class=\"twl-links\" href=\"https://meta.wikimedia.org/wiki/The_Wikipedia_Library/ru\">Библиотека Википедии</a> заключила партнёрские соглашения с издателями по всему миру, чтобы позволить участникам просматривать ресурсы, которые в противном случае оставались бы платными. Этот веб-сайт позволяет редакторам Википедии искать и получать доступ к этим ресурсам."
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Wikimedia Foundation should not be translated. WMF should not be translated. Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:63
-msgid ""
-"This program is administered by the Wikimedia Foundation (WMF). These terms "
-"of use and privacy notice pertain to your application for access to "
-"resources through the Wikipedia Library, your use of this website, and your "
-"access to and use of those resources. They also describe our handling of the "
-"information you provide to us in order to create and administer your "
-"Wikipedia Library account. If we make material changes to the terms, we will "
-"notify users."
-msgstr ""
-"Эта программа администрируется Фондом Викимедиа. Эти условия использования и "
-"уведомление о конфиденциальности относятся к вашим заявкам на доступ к "
-"ресурсам через Библиотеку Википедии, использованию веб-сайта и вашему "
-"доступу и использованию данных ресурсов. Они также описывают, как мы "
-"обрабатываем информацию, которую вы нам сообщаете при создании и управлении "
-"учётной записью Библиотеки Википедии. Если мы внесём существенные изменения "
-"в условия, мы уведомим участников."
+msgid "This program is administered by the Wikimedia Foundation (WMF). These terms of use and privacy notice pertain to your application for access to resources through the Wikipedia Library, your use of this website, and your access to and use of those resources. They also describe our handling of the information you provide to us in order to create and administer your Wikipedia Library account. If we make material changes to the terms, we will notify users."
+msgstr "Эта программа администрируется Фондом Викимедиа. Эти условия использования и уведомление о конфиденциальности относятся к вашим заявкам на доступ к ресурсам через Библиотеку Википедии, использованию веб-сайта и вашему доступу и использованию данных ресурсов. Они также описывают, как мы обрабатываем информацию, которую вы нам сообщаете при создании и управлении учётной записью Библиотеки Википедии. Если мы внесём существенные изменения в условия, мы уведомим участников."
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:74
@@ -3481,59 +2721,18 @@ msgstr "Требования к учётной записи Платформы �
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:78
-msgid ""
-"Access to resources via The Wikipedia Library is reserved for community "
-"members who have demonstrated their commitment to the Wikimedia projects, "
-"and who will use their access to these resources to improve project content. "
-"To that end, in order to be eligible for The Wikipedia Library, we require "
-"that you be registered for a user account on the projects, with at least 500 "
-"edits, six (6) months of activity, and 10+ edits in the last month. We ask "
-"that you do not request access to any publishers with a limited number of "
-"available accounts whose resources you can already access for free through "
-"your local library or university, or another institution or organization, in "
-"order to provide that opportunity to others."
-msgstr ""
-"Доступ к ресурсам Библиотеки Википедии предоставляется только тем участникам "
-"сообщества, которые продемонстрировали свою приверженность проектам "
-"Викимедиа, и которые будут использовать свой доступ к этим ресурсам для "
-"улучшения содержания проектов. Для того чтобы получить право на доступ к "
-"Библиотеке Википедии, мы требуем, чтобы вы были зарегистрированы в качестве "
-"участника проектов, имели не менее 500 правок, шесть месяцев активности и "
-"больше 10 правок за последний месяц. Мы просим вас не запрашивать доступ к "
-"каким-либо издательствам с ограниченным количеством доступных аккаунтов, к "
-"ресурсам которых вы уже можете получить бесплатный доступ через местную "
-"библиотеку или университет, или другое учреждение или организацию, чтобы "
-"отсавить такую возможность для других участиков сообщества."
+msgid "Access to resources via The Wikipedia Library is reserved for community members who have demonstrated their commitment to the Wikimedia projects, and who will use their access to these resources to improve project content. To that end, in order to be eligible for The Wikipedia Library, we require that you be registered for a user account on the projects, with at least 500 edits, six (6) months of activity, and 10+ edits in the last month. We ask that you do not request access to any publishers with a limited number of available accounts whose resources you can already access for free through your local library or university, or another institution or organization, in order to provide that opportunity to others."
+msgstr "Доступ к ресурсам Библиотеки Википедии предоставляется только тем участникам сообщества, которые продемонстрировали свою приверженность проектам Викимедиа, и которые будут использовать свой доступ к этим ресурсам для улучшения содержания проектов. Для того чтобы получить право на доступ к Библиотеке Википедии, мы требуем, чтобы вы были зарегистрированы в качестве участника проектов, имели не менее 500 правок, шесть месяцев активности и больше 10 правок за последний месяц. Мы просим вас не запрашивать доступ к каким-либо издательствам с ограниченным количеством доступных аккаунтов, к ресурсам которых вы уже можете получить бесплатный доступ через местную библиотеку или университет, или другое учреждение или организацию, чтобы отсавить такую возможность для других участиков сообщества."
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:94
-msgid ""
-"Additionally, if you are currently blocked or banned from a Wikimedia "
-"project, applications to resources may be rejected or restricted. If you "
-"obtain a Wikipedia Library account, but a block or ban is subsequently "
-"instituted against you on one of the projects, you may lose access to your "
-"Wikipedia Library account."
-msgstr ""
-"Кроме того, если вы в данный момент заблокированы в проекте Викимедиа, "
-"заявки на доступ к ресурсам могут быть отклонены или ограничены. Если у вас "
-"есть учётная запись Библиотеки Википедии, однако впоследствии вами была "
-"получена бессрочная блокировка в одном из проектов, вы можете потерять "
-"доступ к вашей учётной записи Библиотеки Википедии."
+msgid "Additionally, if you are currently blocked or banned from a Wikimedia project, applications to resources may be rejected or restricted. If you obtain a Wikipedia Library account, but a block or ban is subsequently instituted against you on one of the projects, you may lose access to your Wikipedia Library account."
+msgstr "Кроме того, если вы в данный момент заблокированы в проекте Викимедиа, заявки на доступ к ресурсам могут быть отклонены или ограничены. Если у вас есть учётная запись Библиотеки Википедии, однако впоследствии вами была получена бессрочная блокировка в одном из проектов, вы можете потерять доступ к вашей учётной записи Библиотеки Википедии."
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:104
-msgid ""
-"Your eligibility to access The Wikipedia Library is assessed at each login. "
-"While more than half of the library's content is provided via this automated "
-"eligibility check, access to other publisher's content may be time limited, "
-"typically lapsing after one year, after which you will usually need to apply "
-"for renewal."
-msgstr ""
-"Ваше право на доступ к библиотеке Википедии проверяется при каждом входе в "
-"систему. Хотя более половины содержимого библиотеки предоставляется с "
-"помощью этой автоматической проверки, доступ к содержимому других "
-"издательств может быть ограничен по времени, обычно заканчиваясь через год, "
-"после чего вам обычно требуется подавать заявку на продление."
+msgid "Your eligibility to access The Wikipedia Library is assessed at each login. While more than half of the library's content is provided via this automated eligibility check, access to other publisher's content may be time limited, typically lapsing after one year, after which you will usually need to apply for renewal."
+msgstr "Ваше право на доступ к библиотеке Википедии проверяется при каждом входе в систему. Хотя более половины содержимого библиотеки предоставляется с помощью этой автоматической проверки, доступ к содержимому других издательств может быть ограничен по времени, обычно заканчиваясь через год, после чего вам обычно требуется подавать заявку на продление."
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:114
@@ -3542,67 +2741,28 @@ msgstr "Подача заявки через вашу учётную запис�
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:118
-msgid ""
-"In order to apply for access to a partner resource, you must provide us with "
-"certain information, which we will use to evaluate your application. If your "
-"application is approved, we may transfer the information you have given us "
-"to the publishers whose resources you wish to access. They will either "
-"contact you with the account information directly or we will send access "
-"information to you ourselves."
-msgstr ""
-"Перед подачей заявки на доступ к ресурсам партнёров вы должны будете "
-"предоставить нам определённую информацию, которую мы будем использовать для "
-"оценки ваших заявок. Если ваша заявка будет подтверждена, мы можем передать "
-"предоставленную информацию издателям, к ресурсам которых вы хотите получить "
-"доступ. Они либо напрямую свяжутся с вами, используя информацию учётной "
-"записи, или же мы перешлём нужную для доступа информацию самостоятельно."
+msgid "In order to apply for access to a partner resource, you must provide us with certain information, which we will use to evaluate your application. If your application is approved, we may transfer the information you have given us to the publishers whose resources you wish to access. They will either contact you with the account information directly or we will send access information to you ourselves."
+msgstr "Перед подачей заявки на доступ к ресурсам партнёров вы должны будете предоставить нам определённую информацию, которую мы будем использовать для оценки ваших заявок. Если ваша заявка будет подтверждена, мы можем передать предоставленную информацию издателям, к ресурсам которых вы хотите получить доступ. Они либо напрямую свяжутся с вами, используя информацию учётной записи, или же мы перешлём нужную для доступа информацию самостоятельно."
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:130
-msgid ""
-"In addition to the basic information you provide to us, our system will "
-"retrieve some information directly from the Wikimedia projects: your "
-"username, email address, edit count, registration date, user ID number, "
-"groups to which you belong, and any special user rights."
-msgstr ""
-"Помимо основной информации, которую вы нам предоставили, наша система будет "
-"собирать некоторую информацию напрямую из проектов Викимедиа: ваш ник, адрес "
-"электронной почты, число правок, дату регистрации, идентификатор участника, "
-"группы, в которые вы входите, и все особые права учётной записи."
+msgid "In addition to the basic information you provide to us, our system will retrieve some information directly from the Wikimedia projects: your username, email address, edit count, registration date, user ID number, groups to which you belong, and any special user rights."
+msgstr "Помимо основной информации, которую вы нам предоставили, наша система будет собирать некоторую информацию напрямую из проектов Викимедиа: ваш ник, адрес электронной почты, число правок, дату регистрации, идентификатор участника, группы, в которые вы входите, и все особые права учётной записи."
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:140
-msgid ""
-"Each time you log in to the Wikipedia Library Card Platform, this "
-"information will be automatically updated."
-msgstr ""
-"Каждый раз, когда вы авторизуетесь на Платформе карточек Библиотеки "
-"Википедии, эта информация будет автоматически обновляться."
+msgid "Each time you log in to the Wikipedia Library Card Platform, this information will be automatically updated."
+msgstr "Каждый раз, когда вы авторизуетесь на Платформе карточек Библиотеки Википедии, эта информация будет автоматически обновляться."
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:148
-msgid ""
-"We will ask you to provide us with some information about your history of "
-"contributions to the Wikimedia projects. Information on contribution history "
-"is optional, but will greatly assist us in evaluating your application."
-msgstr ""
-"Мы попросим вас предоставить немного информации о вашем прежнем вкладе в "
-"проекты Викимедиа. Эту информацию предоставлять не обязательно, но она "
-"сильно поможет нам оценивать ваши заявки."
+msgid "We will ask you to provide us with some information about your history of contributions to the Wikimedia projects. Information on contribution history is optional, but will greatly assist us in evaluating your application."
+msgstr "Мы попросим вас предоставить немного информации о вашем прежнем вкладе в проекты Викимедиа. Эту информацию предоставлять не обязательно, но она сильно поможет нам оценивать ваши заявки."
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). WMF should not be translated. Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:157
-msgid ""
-"The information you provide when creating your account will be visible to "
-"you while on the site but not to others unless they are approved Wikipedia "
-"Library Coordinators, WMF Staff, or WMF Contractors who need access to this "
-"data in order to carry out their work with the Wikipedia Library, all of "
-"whom are subject to non-disclosure obligations."
-msgstr ""
-"Предоставляемая вами при создании учётной записи информация будет видна вам, "
-"но не другим пользователям сайта, за исключением координаторов Библиотеки "
-"Википедии и штатных или нештатных сотрудников Фонда Викимедиа — все они "
-"связаны соглашением о неразглашении."
+msgid "The information you provide when creating your account will be visible to you while on the site but not to others unless they are approved Wikipedia Library Coordinators, WMF Staff, or WMF Contractors who need access to this data in order to carry out their work with the Wikipedia Library, all of whom are subject to non-disclosure obligations."
+msgstr "Предоставляемая вами при создании учётной записи информация будет видна вам, но не другим пользователям сайта, за исключением координаторов Библиотеки Википедии и штатных или нештатных сотрудников Фонда Викимедиа — все они связаны соглашением о неразглашении."
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:167
@@ -3611,61 +2771,33 @@ msgstr "Использование ресурсов издателей"
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:171
-msgid ""
-"In order to access an individual publisher’s resources, you must agree to "
-"that publisher’s terms of use and privacy policy. You agree that you will "
-"not violate such terms and policies in connection with your use of the "
-"Wikipedia Library. Additionally, the following activities are prohibited "
-"while accessing publisher resources through the Wikipedia Library."
-msgstr ""
-"Чтобы получить доступ к отдельным ресурсам издателей, вы также должны будете "
-"согласиться с условиями использования и политикой приватности этих "
-"издателей. Пользуясь Библиотекой Википедии, вы обязуетесь не нарушать эти "
-"условия и политики. Кроме того, следующие действия запрещены при "
-"использовании ресурсов издателей через Библиотеку Википедии."
+msgid "In order to access an individual publisher’s resources, you must agree to that publisher’s terms of use and privacy policy. You agree that you will not violate such terms and policies in connection with your use of the Wikipedia Library. Additionally, the following activities are prohibited while accessing publisher resources through the Wikipedia Library."
+msgstr "Чтобы получить доступ к отдельным ресурсам издателей, вы также должны будете согласиться с условиями использования и политикой приватности этих издателей. Пользуясь Библиотекой Википедии, вы обязуетесь не нарушать эти условия и политики. Кроме того, следующие действия запрещены при использовании ресурсов издателей через Библиотеку Википедии."
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:184
-msgid ""
-"Sharing your Wikipedia account, usernames, passwords, or any access codes "
-"for publisher resources with others;"
-msgstr ""
-"Делиться логином, паролем или доступом к ресурсам издателя с другими людьми;"
+msgid "Sharing your Wikipedia account, usernames, passwords, or any access codes for publisher resources with others;"
+msgstr "Делиться логином, паролем или доступом к ресурсам издателя с другими людьми;"
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:191
-msgid ""
-"Automatically scraping or downloading restricted content from publishers;"
-msgstr ""
-"Автоматический скрейпинг или загрузка защищённого содержимого издателей;"
+msgid "Automatically scraping or downloading restricted content from publishers;"
+msgstr "Автоматический скрейпинг или загрузка защищённого содержимого издателей;"
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:197
-msgid ""
-"Systematically making printed or electronic copies of multiple extracts of "
-"restricted content available for any purpose;"
-msgstr ""
-"Систематическое создание печатных или электронных копий нескольких "
-"фрагментов защищённого содержимого для любых целей;"
+msgid "Systematically making printed or electronic copies of multiple extracts of restricted content available for any purpose;"
+msgstr "Систематическое создание печатных или электронных копий нескольких фрагментов защищённого содержимого для любых целей;"
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:204
-msgid ""
-"Data mining metadata without permission—for example, in order to use "
-"metadata for auto-created stub articles;"
-msgstr ""
-"Занятие интеллектуальным анализом данных без разрешения — например, "
-"использовать полученные метаданные для автоматической заливки статей-"
-"заготовок;"
+msgid "Data mining metadata without permission—for example, in order to use metadata for auto-created stub articles;"
+msgstr "Занятие интеллектуальным анализом данных без разрешения — например, использовать полученные метаданные для автоматической заливки статей-заготовок;"
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:211
-msgid ""
-"Using the access you receive through the Wikipedia Library for profit by "
-"selling access to your account or resources which you have through it."
-msgstr ""
-"Использовать доступ, предоставляемый Библиотекой Википедии, для извлечения "
-"выгоды путём продажи доступа к полученной учётной записи."
+msgid "Using the access you receive through the Wikipedia Library for profit by selling access to your account or resources which you have through it."
+msgstr "Использовать доступ, предоставляемый Библиотекой Википедии, для извлечения выгоды путём продажи доступа к полученной учётной записи."
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:220
@@ -3674,26 +2806,13 @@ msgstr "Внешний поиск и прокси-сервисы"
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:224
-msgid ""
-"Certain resources may only be accessed using an external search service, "
-"such as the EBSCO Discovery Service, or a proxy service, such as OCLC "
-"EZProxy. If you use such external search and/or proxy services, please "
-"review the applicable terms of use and privacy policies."
-msgstr ""
-"Ряд ресурсов можно просматривать только с использованием сторонних поисковых "
-"систем, таких как EBSCO Discovery Service, или прокси-серверов, таких как "
-"OCLC EZProxy. Перед использованием прокси и поисковых сервисов такого рода, "
-"пожалуйста, ознакомьтесь с соответствующими условиями использования и "
-"политиками конфиденциальности."
+msgid "Certain resources may only be accessed using an external search service, such as the EBSCO Discovery Service, or a proxy service, such as OCLC EZProxy. If you use such external search and/or proxy services, please review the applicable terms of use and privacy policies."
+msgstr "Ряд ресурсов можно просматривать только с использованием сторонних поисковых систем, таких как EBSCO Discovery Service, или прокси-серверов, таких как OCLC EZProxy. Перед использованием прокси и поисковых сервисов такого рода, пожалуйста, ознакомьтесь с соответствующими условиями использования и политиками конфиденциальности."
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:234
-msgid ""
-"In addition, if you use OCLC EZProxy, please note that you may not use it "
-"for commercial purposes."
-msgstr ""
-"Кроме того, если вы используете OCLC EZProxy, пожалуйста, имейте в виду, что "
-"вы не должны использовать его в коммерческих целях."
+msgid "In addition, if you use OCLC EZProxy, please note that you may not use it for commercial purposes."
+msgstr "Кроме того, если вы используете OCLC EZProxy, пожалуйста, имейте в виду, что вы не должны использовать его в коммерческих целях."
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:241
@@ -3703,201 +2822,51 @@ msgstr "Хранение и обработка данных"
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Wikimedia Foundation should not be translated. Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:245
 #, fuzzy
-msgid ""
-"The Wikimedia Foundation and our service providers use your information for "
-"the legitimate purpose of providing Wikipedia Library services in support of "
-"our charitable mission. When you apply for a Wikipedia Library account, or "
-"use your Wikipedia Library account, we may routinely collect the following "
-"information: your username, email address, edit count, registration date, "
-"user ID number, groups to which you belong, and any special user rights; "
-"your name, country of residence, and/or affiliation, if required by a "
-"partner to which you are applying; your narrative description of your "
-"contributions and reasons for applying for access to partner resources; and "
-"the date you agree to these terms of use."
-msgstr ""
-"Фонд Викимедиа и наш сервис законно используют вашу информацию для "
-"предоставления доступа к сервисам Библиотеки Википедии в целях поддержки "
-"нашей благотворительной миссии. Когда вы создаёте или используете учётную "
-"запись Библиотеки Википедии, мы можем регулярно собирать следующую "
-"информацию: ваш ник, адрес электронной почты, число правок, дату "
-"регистрации, идентификатор участника, группы, в которые вы входите, и любые "
-"особые права вашей учётной записи; ваше имя, страну проживания, род занятий "
-"и/или место обучения, если это требуется для партнёра, которому вы подаёте "
-"заявку; ваше описание собственного вклада и причины подачи заявки на доступ "
-"к ресурсам партнёров; а также дату, когда вы согласились с данными условиями "
-"использования."
+msgid "The Wikimedia Foundation and our service providers use your information for the legitimate purpose of providing Wikipedia Library services in support of our charitable mission. When you apply for a Wikipedia Library account, or use your Wikipedia Library account, we may routinely collect the following information: your username, email address, edit count, registration date, user ID number, groups to which you belong, and any special user rights; your name, country of residence, and/or affiliation, if required by a partner to which you are applying; your narrative description of your contributions and reasons for applying for access to partner resources; and the date you agree to these terms of use."
+msgstr "Фонд Викимедиа и наш сервис законно используют вашу информацию для предоставления доступа к сервисам Библиотеки Википедии в целях поддержки нашей благотворительной миссии. Когда вы создаёте или используете учётную запись Библиотеки Википедии, мы можем регулярно собирать следующую информацию: ваш ник, адрес электронной почты, число правок, дату регистрации, идентификатор участника, группы, в которые вы входите, и любые особые права вашей учётной записи; ваше имя, страну проживания, род занятий и/или место обучения, если это требуется для партнёра, которому вы подаёте заявку; ваше описание собственного вклада и причины подачи заявки на доступ к ресурсам партнёров; а также дату, когда вы согласились с данными условиями использования."
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:262
 #, fuzzy, python-format
-msgid ""
-"Each publisher who is a member of the Wikipedia Library program requires "
-"different specific information in the application. Some publishers may "
-"request only an email address, while others request more detailed data, such "
-"as your name, location, or institutional affiliation. When you complete your "
-"application, you will only be asked to supply information required by the "
-"publishers you have chosen, and each publisher will only receive the "
-"information they require for providing you with access. Please see our <a "
-"class=\"twl-links\" href=\"%(all_partners_url)s\">partner information</a> "
-"pages to learn what information is required by each publisher to gain access "
-"to their resources."
-msgstr ""
-"Каждый издатель, являющийся членом программы Библиотеки Википедии, требует "
-"особый набор информации в заявках. Некоторые издатели могут запрашивать "
-"только адрес электронной почты, в то время как другие запрашивают более "
-"подробную информацию, такую как ваше имя, местоположение, род занятий или "
-"учреждение, где вы учитесь или работаете. При заполнении заявки вас попросят "
-"заполнить только ту информацию, которую выбрал издатель, и каждый издатель "
-"будет получать только ту информацию, которую они требуют при предоставлении "
-"доступа. Пожалуйста, посетите страницу с <a class=\"twl-links\" href="
-"\"%(all_partners_url)s\">партнёрской информацией</a>, чтобы узнать больше о "
-"том, какая информация нужна каждому издателю для предоставления доступа к "
-"своим ресурсам."
+msgid "Each publisher who is a member of the Wikipedia Library program requires different specific information in the application. Some publishers may request only an email address, while others request more detailed data, such as your name, location, or institutional affiliation. When you complete your application, you will only be asked to supply information required by the publishers you have chosen, and each publisher will only receive the information they require for providing you with access. Please see our <a class=\"twl-links\" href=\"%(all_partners_url)s\">partner information</a> pages to learn what information is required by each publisher to gain access to their resources."
+msgstr "Каждый издатель, являющийся членом программы Библиотеки Википедии, требует особый набор информации в заявках. Некоторые издатели могут запрашивать только адрес электронной почты, в то время как другие запрашивают более подробную информацию, такую как ваше имя, местоположение, род занятий или учреждение, где вы учитесь или работаете. При заполнении заявки вас попросят заполнить только ту информацию, которую выбрал издатель, и каждый издатель будет получать только ту информацию, которую они требуют при предоставлении доступа. Пожалуйста, посетите страницу с <a class=\"twl-links\" href=\"%(all_partners_url)s\">партнёрской информацией</a>, чтобы узнать больше о том, какая информация нужна каждому издателю для предоставления доступа к своим ресурсам."
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Wikimedia Foundation should not be translated. Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:277
-msgid ""
-"Some Wikipedia Library pages are visible without logging in, but you will "
-"need to log in to apply or access proprietary partner resources. We use the "
-"data provided by you via OAuth and Wikimedia API calls to assess your "
-"application for access and to process approved requests."
-msgstr ""
-"Некоторые страницы Библиотеки Википедии можно просматривать без авторизации, "
-"однако чтобы подавать заявки на доступ к частным ресурсам партнёров, вам "
-"придётся авторизоваться. При создании и обработке заявок на доступ мы "
-"используем данные, предоставляемые OAuth, и вызовы API Викимедиа."
+msgid "Some Wikipedia Library pages are visible without logging in, but you will need to log in to apply or access proprietary partner resources. We use the data provided by you via OAuth and Wikimedia API calls to assess your application for access and to process approved requests."
+msgstr "Некоторые страницы Библиотеки Википедии можно просматривать без авторизации, однако чтобы подавать заявки на доступ к частным ресурсам партнёров, вам придётся авторизоваться. При создании и обработке заявок на доступ мы используем данные, предоставляемые OAuth, и вызовы API Викимедиа."
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:288
 #, python-format
-msgid ""
-"In order to administer the Wikipedia Library program, we will retain the "
-"application data we collect from you for three years after your most recent "
-"login, unless you delete your account, as described below. You can log in "
-"and go to <a class=\"twl-links\" href=\"%(profile_url)s\">your profile page</"
-"a> in order to see the information associated with your account, and can "
-"download it in JSON format. You may access, update, restrict, or delete this "
-"information at any time, except for the information that is automatically "
-"retrieved from the projects. If you have any questions or concerns about the "
-"handling of your data, please contact <a class=\"twl-links\" href=\"mailto:"
-"wikipedialibrary@wikimedia.org?Subject=Wikipedia%%20Library%%20Card"
-"%%20account%%20deactivation\"> wikipedialibrary@wikimedia.org </a>."
-msgstr ""
-"Мы будем хранить информацию из поданных вами заявок в течение трёх лет с "
-"момента вашей последней авторизации, если вы не удалите учётную запись "
-"вручную, как описано ниже. Это делается для административных нужд программы "
-"Библиотеки Википедии. Вы можете авторизоваться и перейти на <a class=\"twl-"
-"links\" href=\"%(profile_url)s\">страницу вашего профиля</a>, чтобы увидеть "
-"информацию, связанную с вашей учётной записью, а также вы можете скачать её "
-"в формате JSON. Вы можете обратиться к ней, обновить, ограничить или удалить "
-"эту информацию в любой момент времени, за исключением той информации, что "
-"была автоматически получена из проектов. Если у вас есть любые вопросы или "
-"сомнения по поводу обработки ваших данных, пожалуйста, свяжитесь с нами по "
-"адресу <a class=\"twl-links\" href=\"mailto:wikipedialibrary@wikimedia.org?"
-"Subject=Wikipedia%%20Library%%20Card%%20account%%20deactivation"
-"\">wikipedialibrary@wikimedia.org</a>."
+msgid "In order to administer the Wikipedia Library program, we will retain the application data we collect from you for three years after your most recent login, unless you delete your account, as described below. You can log in and go to <a class=\"twl-links\" href=\"%(profile_url)s\">your profile page</a> in order to see the information associated with your account, and can download it in JSON format. You may access, update, restrict, or delete this information at any time, except for the information that is automatically retrieved from the projects. If you have any questions or concerns about the handling of your data, please contact <a class=\"twl-links\" href=\"mailto:wikipedialibrary@wikimedia.org?Subject=Wikipedia%%20Library%%20Card%%20account%%20deactivation\"> wikipedialibrary@wikimedia.org </a>."
+msgstr "Мы будем хранить информацию из поданных вами заявок в течение трёх лет с момента вашей последней авторизации, если вы не удалите учётную запись вручную, как описано ниже. Это делается для административных нужд программы Библиотеки Википедии. Вы можете авторизоваться и перейти на <a class=\"twl-links\" href=\"%(profile_url)s\">страницу вашего профиля</a>, чтобы увидеть информацию, связанную с вашей учётной записью, а также вы можете скачать её в формате JSON. Вы можете обратиться к ней, обновить, ограничить или удалить эту информацию в любой момент времени, за исключением той информации, что была автоматически получена из проектов. Если у вас есть любые вопросы или сомнения по поводу обработки ваших данных, пожалуйста, свяжитесь с нами по адресу <a class=\"twl-links\" href=\"mailto:wikipedialibrary@wikimedia.org?Subject=Wikipedia%%20Library%%20Card%%20account%%20deactivation\">wikipedialibrary@wikimedia.org</a>."
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:305
 #, fuzzy
-msgid ""
-"If you decide to disable your Wikipedia Library account, you can use the "
-"delete button on your profile to delete certain personal information "
-"associated with your account. We will delete your real name, institutional "
-"affiliation, and country of residence. Please note that the system will "
-"retain a record of your username, the publishers to which you applied or had "
-"access, and the dates of that access. Note that deletion is not reversible. "
-"Deletion of your Wikipedia Library account may also correspond with the "
-"removal of any resource access to which you were eligible or approved. If "
-"you request the deletion of account information and later wish to apply for "
-"a new account, you will need to provide the necessary information again."
-msgstr ""
-"Если вы решите отключить вашу учётную запись Библиотеки Википедии, нажмите "
-"кнопку «удалить» в профиле. Мы удалим ваше настоящее имя, род занятий, "
-"учебное заведение и страну проживания. Пожалуйста, имейте в виду, что "
-"система будет хранить ваш ник, список издателей, к которым вы подавали "
-"заявки или имели доступ, и все даты доступа. Обратите внимание на то, что "
-"удаление учётной записи необратимо. Удаление вашей учётной записи может "
-"также привести к потере доступа к любым ресурсам, к которым у вас было право "
-"обращаться. Если вы запросите удаление информации учётной записи, а затем "
-"захотите зарегистрировать новую учётную запись, вам придётся снова "
-"предоставить всю необходимую информацию."
+msgid "If you decide to disable your Wikipedia Library account, you can use the delete button on your profile to delete certain personal information associated with your account. We will delete your real name, institutional affiliation, and country of residence. Please note that the system will retain a record of your username, the publishers to which you applied or had access, and the dates of that access. Note that deletion is not reversible. Deletion of your Wikipedia Library account may also correspond with the removal of any resource access to which you were eligible or approved. If you request the deletion of account information and later wish to apply for a new account, you will need to provide the necessary information again."
+msgstr "Если вы решите отключить вашу учётную запись Библиотеки Википедии, нажмите кнопку «удалить» в профиле. Мы удалим ваше настоящее имя, род занятий, учебное заведение и страну проживания. Пожалуйста, имейте в виду, что система будет хранить ваш ник, список издателей, к которым вы подавали заявки или имели доступ, и все даты доступа. Обратите внимание на то, что удаление учётной записи необратимо. Удаление вашей учётной записи может также привести к потере доступа к любым ресурсам, к которым у вас было право обращаться. Если вы запросите удаление информации учётной записи, а затем захотите зарегистрировать новую учётную запись, вам придётся снова предоставить всю необходимую информацию."
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). WMF should not be translated. Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:321
-msgid ""
-"The Wikipedia Library is run by WMF Staff, Contractors, and approved "
-"volunteer Coordinators. The data associated with your account will be shared "
-"with the WMF staff, contractors, service providers, and volunteer "
-"coordinators who need to process the information in connection with their "
-"work for the Wikipedia Library, and who are subject to confidentiality "
-"obligations. We will also use your data for internal Wikipedia Library "
-"purposes such as distributing user surveys and account notifications, and in "
-"a depersonalized or aggregated fashion for statistical analysis and "
-"administration. Finally, we will share your information with the publishers "
-"whom you specifically select in order to provide you with access to "
-"resources. Otherwise, your information will not be shared with third "
-"parties, with the exception of the circumstances described below."
-msgstr ""
-"Работа Библиотеки Википедии осуществляется штатными и нештатными "
-"сотрудниками фонда Викимедиа, а также проверенными добровольцами-"
-"координаторами. Данные, связанные с вашей учётной записью, будут доступны "
-"штатным и внештатным сотрудникам фонда Викимедиа, поставщикам услуг и "
-"добровольцам-координаторам, которым может потребоваться обработать эту "
-"информацию при работе в Библиотеке Википедии, и которые связаны соглашением "
-"о неразглашении. Мы также будем использовать ваши данные для внутренних "
-"целей Библиотеки Википедии, таких как рассылка пользовательских опросов и "
-"уведомлений, а также, в деперсонализованном и агрегированном виде, для "
-"статистического анализа и администрирования. Наконец, мы будем предоставлять "
-"вашу информацию издателям, которых вы выберете, чтобы они могли предоставить "
-"вам доступ к ресурсам. В остальных случаях ваша информация не будет доступна "
-"третьим лицам, за исключением случаев, описанных ниже."
+msgid "The Wikipedia Library is run by WMF Staff, Contractors, and approved volunteer Coordinators. The data associated with your account will be shared with the WMF staff, contractors, service providers, and volunteer coordinators who need to process the information in connection with their work for the Wikipedia Library, and who are subject to confidentiality obligations. We will also use your data for internal Wikipedia Library purposes such as distributing user surveys and account notifications, and in a depersonalized or aggregated fashion for statistical analysis and administration. Finally, we will share your information with the publishers whom you specifically select in order to provide you with access to resources. Otherwise, your information will not be shared with third parties, with the exception of the circumstances described below."
+msgstr "Работа Библиотеки Википедии осуществляется штатными и нештатными сотрудниками фонда Викимедиа, а также проверенными добровольцами-координаторами. Данные, связанные с вашей учётной записью, будут доступны штатным и внештатным сотрудникам фонда Викимедиа, поставщикам услуг и добровольцам-координаторам, которым может потребоваться обработать эту информацию при работе в Библиотеке Википедии, и которые связаны соглашением о неразглашении. Мы также будем использовать ваши данные для внутренних целей Библиотеки Википедии, таких как рассылка пользовательских опросов и уведомлений, а также, в деперсонализованном и агрегированном виде, для статистического анализа и администрирования. Наконец, мы будем предоставлять вашу информацию издателям, которых вы выберете, чтобы они могли предоставить вам доступ к ресурсам. В остальных случаях ваша информация не будет доступна третьим лицам, за исключением случаев, описанных ниже."
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). WMF should not be translated.
 #: TWLight/users/templates/users/terms.html:338
-msgid ""
-"We may disclose any collected information when required by law, when we have "
-"your permission, when needed to protect our rights, privacy, safety, users, "
-"or the general public, and when necessary to enforce these terms, WMF’s "
-"general <a class=\"twl-links\" href=\"https://foundation.wikimedia.org/wiki/"
-"Terms_of_Use\">Terms of Use</a>, or any other WMF policy."
-msgstr ""
-"Мы можем раскрыть любую собранную информацию, если того требует закон, если "
-"у нас есть ваше разрешение, если это нужно для защиты наших прав, "
-"приватности, безопасности, пользователей или широкой публики, и когда это "
-"необходимо для осуществления данных условий использования, общих <a class="
-"\"twl-links\" href=\"https://foundation.wikimedia.org/wiki/Terms_of_Use"
-"\">условий использования Фонда Викимедиа</a>, или любой другой политики "
-"Фонда."
+msgid "We may disclose any collected information when required by law, when we have your permission, when needed to protect our rights, privacy, safety, users, or the general public, and when necessary to enforce these terms, WMF’s general <a class=\"twl-links\" href=\"https://foundation.wikimedia.org/wiki/Terms_of_Use\">Terms of Use</a>, or any other WMF policy."
+msgstr "Мы можем раскрыть любую собранную информацию, если того требует закон, если у нас есть ваше разрешение, если это нужно для защиты наших прав, приватности, безопасности, пользователей или широкой публики, и когда это необходимо для осуществления данных условий использования, общих <a class=\"twl-links\" href=\"https://foundation.wikimedia.org/wiki/Terms_of_Use\">условий использования Фонда Викимедиа</a>, или любой другой политики Фонда."
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:349
-msgid ""
-"We take the security of your personal data seriously, and take reasonable "
-"precautions to ensure your data is protected. These precautions include "
-"access controls to limit who has access to your data and security "
-"technologies to protect data stored on the server. However, we cannot "
-"guarantee the safety of your data as it is transmitted and stored."
-msgstr ""
-"Мы серьёзно относимся к безопасности ваших персональных данных, и принимаем "
-"разумные меры предосторожности, чтобы убедиться в защищённости ваших данных. "
-"Эти меры предосторожности включают управление доступом, чтобы ограничить "
-"число людей, имеющих доступ к вашим данным, и технологии информационной "
-"безопасности для защиты данных, хранимых на сервере. Однако мы не можем "
-"гарантировать безопасность данных при её передаче и хранении."
+msgid "We take the security of your personal data seriously, and take reasonable precautions to ensure your data is protected. These precautions include access controls to limit who has access to your data and security technologies to protect data stored on the server. However, we cannot guarantee the safety of your data as it is transmitted and stored."
+msgstr "Мы серьёзно относимся к безопасности ваших персональных данных, и принимаем разумные меры предосторожности, чтобы убедиться в защищённости ваших данных. Эти меры предосторожности включают управление доступом, чтобы ограничить число людей, имеющих доступ к вашим данным, и технологии информационной безопасности для защиты данных, хранимых на сервере. Однако мы не можем гарантировать безопасность данных при её передаче и хранении."
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:360
-msgid ""
-"Please note that these terms do not control the use and handling of your "
-"data by the publishers and service providers whose resources you access or "
-"apply to access. Please read their individual privacy policies for that "
-"information."
-msgstr ""
-"Пожалуйста, имейте в виду, что эти условия использования не ограничивают "
-"использование и обработку ваших данных издателями и поставщиками услуг, к "
-"ресурсом которых вы обращаетесь или подаёте заявку на доступ. Для получения "
-"этой информации ознакомьтесь с их собственными политиками конфиденциальности."
+msgid "Please note that these terms do not control the use and handling of your data by the publishers and service providers whose resources you access or apply to access. Please read their individual privacy policies for that information."
+msgstr "Пожалуйста, имейте в виду, что эти условия использования не ограничивают использование и обработку ваших данных издателями и поставщиками услуг, к ресурсом которых вы обращаетесь или подаёте заявку на доступ. Для получения этой информации ознакомьтесь с их собственными политиками конфиденциальности."
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:368
@@ -3906,54 +2875,18 @@ msgstr "Важное замечание"
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Wikimedia Foundation should not be translated. Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:373
-msgid ""
-"The Wikimedia Foundation is a nonprofit organization based in San Francisco, "
-"California. The Wikipedia Library program provides access to resources held "
-"by publishers in multiple countries. If you apply for a Wikipedia Library "
-"account (whether you are inside or outside of the United States), you "
-"understand that your personal data will be collected, transferred, stored, "
-"processed, disclosed and otherwise used in the U.S. as described in this "
-"privacy policy. You also understand that your information may be transferred "
-"by us from the U.S. to other countries, which may have different or less "
-"stringent data protection laws than your country, in connection with "
-"providing services to you, including evaluating your application and "
-"securing access to your chosen publishers (locations for each publisher are "
-"outlined on their respective partner information pages)."
-msgstr ""
-"Фонд Викимедиа — некоммерческая организация, располагающаяся в Сан-"
-"Франциско, штат Калифорния. Программа Библиотеки Википедии предоставляет "
-"доступ к ресурсам, хранящимся у издателей во многих странах. Создавая "
-"учётную запись Библиотеки Википедии (вне зависимости от того, находитесь ли "
-"вы внутри или вне Соединённых Штатов), вы понимаете, что ваши персональные "
-"данные будут собираться, пересылаться, храниться, обрабатываться, "
-"раскрываться и использоваться другими способами на территории США, как "
-"описано в политике конфиденциальности. Вы также понимаете, что ваша "
-"информация может быть переслана нами из США в другие страны, на территории "
-"которых могут быть другие или менее строгие законы о защите данных по "
-"сравнению с вашей страной, с целью предоставления вам услуг, включающих "
-"рассмотрение ваших заявок и обеспечение доступа к выбранным издателям "
-"(местонахождение каждого издателя указано на соответствующих страницах "
-"информации о партнёрах)."
+msgid "The Wikimedia Foundation is a nonprofit organization based in San Francisco, California. The Wikipedia Library program provides access to resources held by publishers in multiple countries. If you apply for a Wikipedia Library account (whether you are inside or outside of the United States), you understand that your personal data will be collected, transferred, stored, processed, disclosed and otherwise used in the U.S. as described in this privacy policy. You also understand that your information may be transferred by us from the U.S. to other countries, which may have different or less stringent data protection laws than your country, in connection with providing services to you, including evaluating your application and securing access to your chosen publishers (locations for each publisher are outlined on their respective partner information pages)."
+msgstr "Фонд Викимедиа — некоммерческая организация, располагающаяся в Сан-Франциско, штат Калифорния. Программа Библиотеки Википедии предоставляет доступ к ресурсам, хранящимся у издателей во многих странах. Создавая учётную запись Библиотеки Википедии (вне зависимости от того, находитесь ли вы внутри или вне Соединённых Штатов), вы понимаете, что ваши персональные данные будут собираться, пересылаться, храниться, обрабатываться, раскрываться и использоваться другими способами на территории США, как описано в политике конфиденциальности. Вы также понимаете, что ваша информация может быть переслана нами из США в другие страны, на территории которых могут быть другие или менее строгие законы о защите данных по сравнению с вашей страной, с целью предоставления вам услуг, включающих рассмотрение ваших заявок и обеспечение доступа к выбранным издателям (местонахождение каждого издателя указано на соответствующих страницах информации о партнёрах)."
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:392
-msgid ""
-"Please note that in the event of any differences in meaning or "
-"interpretation between the original English version of these terms and a "
-"translation, the original English version takes precedence."
-msgstr ""
-"Обратите внимание, что в случае любых различиях в смысле или возможной "
-"интерпретации между исходной английской версией этого соглашения и перевода, "
-"исходная английская версия имеет приоритет."
+msgid "Please note that in the event of any differences in meaning or interpretation between the original English version of these terms and a translation, the original English version takes precedence."
+msgstr "Обратите внимание, что в случае любых различиях в смысле или возможной интерпретации между исходной английской версией этого соглашения и перевода, исходная английская версия имеет приоритет."
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Wikimedia Foundation should not be translated.
 #: TWLight/users/templates/users/terms.html:403
-msgid ""
-"See also the <a class=\"twl-links\" href=\"https://wikimediafoundation.org/"
-"wiki/Privacy_policy\">Wikimedia Foundation Privacy Policy</a>."
-msgstr ""
-"См. также <a class=\"twl-links\" href=\"https://wikimediafoundation.org/wiki/"
-"Privacy_policy\">Политику конфиденциальности Фонда Викимедиа</a>."
+msgid "See also the <a class=\"twl-links\" href=\"https://wikimediafoundation.org/wiki/Privacy_policy\">Wikimedia Foundation Privacy Policy</a>."
+msgstr "См. также <a class=\"twl-links\" href=\"https://wikimediafoundation.org/wiki/Privacy_policy\">Политику конфиденциальности Фонда Викимедиа</a>."
 
 #. Translators: This is the second to last line of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:412
@@ -3972,17 +2905,8 @@ msgstr "Фонд Викимедиа"
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:426
-msgid ""
-"By checking this box and clicking “Submit”, you agree that you have read the "
-"above terms and that you will adhere to the terms of use in your application "
-"to and use of the The Wikipedia Library, and the publishers’ services to "
-"which you gain access through The Wikipedia Library program."
-msgstr ""
-"Поставив здесь галочку и нажав «Отправить», вы соглашаетесь с тем, что вы "
-"прочитали изложенные выше условия, и что вы будете придерживаться условий "
-"использования в ваших заявках и при использовании Библиотеки Википедии, а "
-"также услуг издателя, к которым вы будете получать доступ через программу "
-"Библиотеки Википедии."
+msgid "By checking this box and clicking “Submit”, you agree that you have read the above terms and that you will adhere to the terms of use in your application to and use of the The Wikipedia Library, and the publishers’ services to which you gain access through The Wikipedia Library program."
+msgstr "Поставив здесь галочку и нажав «Отправить», вы соглашаетесь с тем, что вы прочитали изложенные выше условия, и что вы будете придерживаться условий использования в ваших заявках и при использовании Библиотеки Википедии, а также услуг издателя, к которым вы будете получать доступ через программу Библиотеки Википедии."
 
 #: TWLight/users/templates/users/user_collection_tile.html:32
 msgid "Remove this collection from favorites"
@@ -4034,41 +2958,19 @@ msgstr "Удалить все данные"
 
 #. Translators: This message is displayed on the page where users can request the deletion of their data.
 #: TWLight/users/templates/users/user_confirm_delete.html:17
-msgid ""
-"<b>Warning:</b> Performing this action will delete your Wikipedia Library "
-"Card user account and all associated applications. This process is not "
-"reversible. You may lose any partner accounts you were granted, and will not "
-"be able to renew those accounts or apply for new ones."
-msgstr ""
-"<b>Внимание:</b> осуществление этих действий удалит вашу учётную запись "
-"Библиотеки Википедии и все связанные с ней заявки. Этот процесс не может "
-"быть отменён. Вы можете потерять полученные партнёрские учётные записи и не "
-"будете иметь возможность продлевать их или подавать заявки на новые."
+msgid "<b>Warning:</b> Performing this action will delete your Wikipedia Library Card user account and all associated applications. This process is not reversible. You may lose any partner accounts you were granted, and will not be able to renew those accounts or apply for new ones."
+msgstr "<b>Внимание:</b> осуществление этих действий удалит вашу учётную запись Библиотеки Википедии и все связанные с ней заявки. Этот процесс не может быть отменён. Вы можете потерять полученные партнёрские учётные записи и не будете иметь возможность продлевать их или подавать заявки на новые."
 
 #. Translators: this should show up for people who log in with a username/password and not OAuth, so we don't know what their Wikipedia identity is.
-#.
 #: TWLight/users/templates/users/user_detail.html:12
 #, python-format
-msgid ""
-"Hi, %(username)s! You don't have a Wikipedia editor profile attached to your "
-"account here, so you are probably a site administrator."
-msgstr ""
-"Привет, %(username)s! К вашей учётной записи не привязан профиль редактора "
-"Википедии — вероятно, вы администратор сайта."
+msgid "Hi, %(username)s! You don't have a Wikipedia editor profile attached to your account here, so you are probably a site administrator."
+msgstr "Привет, %(username)s! К вашей учётной записи не привязан профиль редактора Википедии — вероятно, вы администратор сайта."
 
 #. Translators: In the unlikely scenario that someone is able to register an account without using OAuth (thus leaving us without some of the information required for applications), users will see this message, encouraging them to re-register.
 #: TWLight/users/templates/users/user_detail.html:20
-msgid ""
-"If you aren't a site administrator, something weird has happened. You won't "
-"be able to apply for access without a Wikipedia editor profile. You should "
-"log out and create a new account by logging in via OAuth, or contact a site "
-"administrator for help."
-msgstr ""
-"Если вы не являетесь администратором сайта, случилось что-то странное. У вас "
-"не будет возможности подавать заявки без профиля редактора Википедии. Вам "
-"следует выйти с сайта, а затем создать новую учётную запись посредством "
-"авторизации через OAuth. Вы также можете связаться с администрацией сайта "
-"для получения помощи."
+msgid "If you aren't a site administrator, something weird has happened. You won't be able to apply for access without a Wikipedia editor profile. You should log out and create a new account by logging in via OAuth, or contact a site administrator for help."
+msgstr "Если вы не являетесь администратором сайта, случилось что-то странное. У вас не будет возможности подавать заявки без профиля редактора Википедии. Вам следует выйти с сайта, а затем создать новую учётную запись посредством авторизации через OAuth. Вы также можете связаться с администрацией сайта для получения помощи."
 
 #. Translators: Labels a sections where coordinators can select their email preferences.
 #: TWLight/users/templates/users/user_email_preferences.html:15
@@ -4078,23 +2980,13 @@ msgstr "Только для координаторов"
 #. Translators: This message is shown on user's own profile page, encouraging them to make sure their information is up to date, so that account coordinators can use the information to judge applications.
 #: TWLight/users/views.py:176
 #, python-brace-format
-msgid ""
-"Please <a class='twl-links' href='{url}'>update your contributions</a> to "
-"Wikipedia to help coordinators evaluate your applications."
-msgstr ""
-"Пожалуйста, <a class=\"twl-links\" href='{url}'>опишите свой вклад</a> в "
-"Википедию, чтобы помочь координаторам оценить ваши заявки."
+msgid "Please <a class='twl-links' href='{url}'>update your contributions</a> to Wikipedia to help coordinators evaluate your applications."
+msgstr "Пожалуйста, <a class=\"twl-links\" href='{url}'>опишите свой вклад</a> в Википедию, чтобы помочь координаторам оценить ваши заявки."
 
 #. Translators: Coordinators are shown this message when they unselect all three types of reminder email options under preferences.
 #: TWLight/users/views.py:288
-msgid ""
-"You have chosen not to receive reminder emails. As a coordinator, you should "
-"receive at least one type of reminder emails, so consider changing your "
-"preferences."
-msgstr ""
-"Вы выбрали не получать электронные письма с напоминаниями. Координаторы "
-"должны получать хотя бы один тип электронных писем с напоминаниями, поэтому "
-"просим поменять настройки."
+msgid "You have chosen not to receive reminder emails. As a coordinator, you should receive at least one type of reminder emails, so consider changing your preferences."
+msgstr "Вы выбрали не получать электронные письма с напоминаниями. Координаторы должны получать хотя бы один тип электронных писем с напоминаниями, поэтому просим поменять настройки."
 
 #. Translators: Coordinators are shown this message when they make changes to their reminder email options under preferences.
 #: TWLight/users/views.py:296
@@ -4117,9 +3009,7 @@ msgstr "Ваша информация обновлена."
 #. Translators: If a user tries to save the 'email change form' without entering one and checking the 'use my Wikipedia email address' checkbox, this message is presented.
 #: TWLight/users/views.py:448
 msgid "Both the values cannot be blank. Either enter a email or check the box."
-msgstr ""
-"Оба значения не могут быть пустыми. Либо введите электронный адрес, либо "
-"поставьте галочку."
+msgstr "Оба значения не могут быть пустыми. Либо введите электронный адрес, либо поставьте галочку."
 
 #. Translators: Shown to users when they successfully modify their email. Don't translate {email}.
 #: TWLight/users/views.py:476
@@ -4129,13 +3019,8 @@ msgstr "Ваш электронный адрес был изменён на {ema
 
 #. Translators: If the user has not filled out their email, they can browse the website but cannot apply for access to resources.
 #: TWLight/users/views.py:487
-msgid ""
-"Your email is blank. You can still explore the site, but you won't be able "
-"to apply for access to partner resources without an email."
-msgstr ""
-"Ваш электронный адрес пустой. Вы по-прежнему можете просматривать сайт, но "
-"вы не сможете подавать заявки на доступ к партнёрским ресурсам без "
-"электронной почти."
+msgid "Your email is blank. You can still explore the site, but you won't be able to apply for access to partner resources without an email."
+msgstr "Ваш электронный адрес пустой. Вы по-прежнему можете просматривать сайт, но вы не сможете подавать заявки на доступ к партнёрским ресурсам без электронной почти."
 
 #. Translators: This message is shown once the access to a partner has successfully been returned.
 #: TWLight/users/views.py:801
@@ -4167,31 +3052,3 @@ msgstr "Без активных блокировок"
 msgid "10+ edits in the last 30 days"
 msgstr "10+ правок за последние 30 дней"
 
-#: tests/shunit/data/bad_i18n_comment_1.py:3
-#: tests/shunit/data/bad_i18n_newline_1.py:5
-msgid "1"
-msgstr ""
-
-#. Translators: Lorem ipsum dolor sit amet, consectetur adipiscing elit. Mauris vitae ipsum ut purus faucibus pretium. Proin tempus neque et aliquet consectetur. Ut egestas sapien in consectetur sagittis. Mauris neque lacus, dapibus non viverra vitae, interdum ut aenean ipsum.
-#. Translators: Lorem ipsum dolor sit amet, consectetur adipiscing elit. Mauris vitae ipsum ut purus faucibus pretium. Proin tempus neque et aliquet consectetur. Ut egestas sapien in consectetur sagittis. Mauris neque lacus, dapibus non.
-#: tests/shunit/data/bad_i18n_comment_2.py:4
-#: tests/shunit/data/bad_i18n_newline_2.py:5 tests/shunit/data/good_i18n_1.py:2
-#: tests/shunit/data/good_i18n_2.py:2
-msgid "2"
-msgstr ""
-
-#: tests/shunit/data/bad_i18n_newline_3.py:5
-msgid "3"
-msgstr ""
-
-#: tests/shunit/data/bad_i18n_newline_4.py:5
-msgid "4"
-msgstr ""
-
-#: tests/shunit/data/bad_i18n_newline_5.py:5
-msgid "5"
-msgstr ""
-
-#: tests/shunit/data/bad_i18n_newline_6.py:5
-msgid "6"
-msgstr ""

--- a/locale/sr_Ec/LC_MESSAGES/django.po
+++ b/locale/sr_Ec/LC_MESSAGES/django.po
@@ -7,17 +7,17 @@
 # Author: Zoranzoki21
 msgid ""
 msgstr ""
+""
 "Project-Id-Version: Wikipedia Library Card Platform - Website\n"
-"Report-Msgid-Bugs-To: wikipedialibrary@wikimedia.org\n"
+"Report-Msgid-Bugs-To: translatewiki.net\n"
 "POT-Creation-Date: 2024-07-11 20:54+0000\n"
-"PO-Revision-Date: 2024-07-11 12:30:19+0000\n"
+"PO-Revision-Date: 2024-07-15 12:29:19+0000\n"
 "Language: sr_ec\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "X-POT-Import-Date: 2024-06-25 18:44:08+0000\n"
 "X-Generator: MediaWiki 1.43.0-alpha; Translate 2024-07-16\n"
-"Plural-Forms: nplurals=3; plural=(n%10 == 1 && n%100 != 11) ? 0 : ( (n%10 >= "
-"2 && n%10 <= 4 && (n%100 < 10 || n%100 >= 20)) ? 1 : 2 );\n"
+"Plural-Forms: nplurals=3; plural=(n%10 == 1 && n%100 != 11) ? 0 : ( (n%10 >= 2 && n%10 <= 4 && (n%100 < 10 || n%100 >= 20)) ? 1 : 2 );\n"
 "X-Translation-Project: translatewiki.net <https://translatewiki.net>\n"
 
 #. Translators: Labels the button users click to apply for a partner's resources.
@@ -43,9 +43,7 @@ msgstr "О вама"
 #. Translators: This note appears in a section of a form where we ask users to enter info (like country of residence) when applying for resource access.
 #: TWLight/applications/forms.py:179
 #, python-brace-format
-msgid ""
-"<p><small><i>Your personal data will be processed according to our <a "
-"class='twl-links' href='{terms_url}'> privacy policy</a>.</i></small></p>"
+msgid "<p><small><i>Your personal data will be processed according to our <a class='twl-links' href='{terms_url}'> privacy policy</a>.</i></small></p>"
 msgstr ""
 
 #. Translators: This is the title of the application form page, where users enter information required for the application. It lets the user know which partner application they are entering data for. {partner}
@@ -87,9 +85,7 @@ msgstr ""
 #. Translators: This labels a choice field where users will have to select the number of months they wish to have their access for as part of the application renewal confirmation.
 #. Translators: When filling out an application, users may be required to enter the length of the account (expiry) they wish to have for proxy partners.
 #: TWLight/applications/forms.py:339 TWLight/applications/helpers.py:100
-msgid ""
-"The number of months you wish to have this access for before renewal is "
-"required"
+msgid "The number of months you wish to have this access for before renewal is required"
 msgstr ""
 
 #. Translators: When filling out an application, users may need to specify their name
@@ -178,9 +174,7 @@ msgstr "Имејл"
 
 #. Translators: This comment is added to pending applications when our terms of use change.
 #: TWLight/applications/management/commands/notify_applicants_tou_changes.py:54
-msgid ""
-"Our terms of use have changed. Your applications will not be processed until "
-"you log in and agree to our updated terms."
+msgid "Our terms of use have changed. Your applications will not be processed until you log in and agree to our updated terms."
 msgstr ""
 
 #. Translators: This is the status of an application that has not yet been reviewed.
@@ -247,23 +241,17 @@ msgstr ""
 
 #. Translators: This text goes into account approval emails in the case that we need to send the user's details to a publisher for manual account setup.
 #: TWLight/applications/models.py:331
-msgid ""
-"You can expect to receive access details within a week or two once it has "
-"been processed."
+msgid "You can expect to receive access details within a week or two once it has been processed."
 msgstr ""
 
 #. Translators: This comment is added to open applications when a partner joins the Library Bundle, which does not require applications.
 #: TWLight/applications/signals.py:247
-msgid ""
-"This partner joined the Library Bundle, which does not require applications. "
-"This application will be marked as invalid."
+msgid "This partner joined the Library Bundle, which does not require applications. This application will be marked as invalid."
 msgstr ""
 
 #. Translators: This is shown to users if the application is to a partner for which we have run out of available accounts. The application is therefore on a 'waitlist', and will be reviewed when more accounts are available.
 #: TWLight/applications/templates/applications/application_evaluation.html:29
-msgid ""
-"This application is on the waitlist because this partner does not have any "
-"access grants available at this time."
+msgid "This application is on the waitlist because this partner does not have any access grants available at this time."
 msgstr ""
 
 #. Translators: This message is shown on pages where coordinators can see personal information about applicants.
@@ -271,9 +259,7 @@ msgstr ""
 #: TWLight/applications/templates/applications/application_list_include.html:6
 #: TWLight/applications/templates/applications/send_partner.html:45
 #: TWLight/resources/templates/resources/partner_users.html:18
-msgid ""
-"Coordinators: This page may contain personal information such as real names "
-"and email addresses. Please remember that this information is confidential."
+msgid "Coordinators: This page may contain personal information such as real names and email addresses. Please remember that this information is confidential."
 msgstr ""
 
 #. Translators: This is the title of the application page shown to users who are a coordinator, and are able to accept or reject the application.
@@ -283,9 +269,7 @@ msgstr ""
 
 #. Translators: This text is shown to coordinators on application pages if the applicant has restricted processing of their data.
 #: TWLight/applications/templates/applications/application_evaluation.html:42
-msgid ""
-"This user has requested a restriction on the processing of their data, so "
-"you cannot change the status of their application."
+msgid "This user has requested a restriction on the processing of their data, so you cannot change the status of their application."
 msgstr ""
 
 #. Translators: This is the title of the application page shown to users who are not a coordinator.
@@ -359,9 +343,7 @@ msgstr "Непознато"
 
 #. Translators: This is the text displayed to coordinators when an applicant has no country of residence in their profile.
 #: TWLight/applications/templates/applications/application_evaluation.html:123
-msgid ""
-"Please request the applicant add their country of residence to their profile "
-"before proceeding further."
+msgid "Please request the applicant add their country of residence to their profile before proceeding further."
 msgstr ""
 
 #. Translators: This labels the section of an application showing the total number of accounts available for a partner or their collection.
@@ -372,9 +354,7 @@ msgstr "Доступни налози"
 #. Translators: This labels the section of an application showing whether the user had agreed to the terms of use or not.
 #: TWLight/applications/templates/applications/application_evaluation.html:145
 #, python-format
-msgid ""
-"Has agreed to the site's <a class=\"twl-links\" href=\"%(terms_url)s\">terms "
-"of use</a>?"
+msgid "Has agreed to the site's <a class=\"twl-links\" href=\"%(terms_url)s\">terms of use</a>?"
 msgstr ""
 
 #. Translators: Displayed to coordinators when they've agreed to the terms of use.
@@ -410,9 +390,7 @@ msgstr "Не"
 
 #. Translators: This is the text displayed to coordinators when an applicant has not agreed to the terms of use.
 #: TWLight/applications/templates/applications/application_evaluation.html:159
-msgid ""
-"Please request the applicant agree to the site's terms of use before "
-"approving this application."
+msgid "Please request the applicant agree to the site's terms of use before approving this application."
 msgstr ""
 
 #. Translators: This labels the section of an application containing the user's motivation for wanting access to this resource.
@@ -433,8 +411,7 @@ msgstr ""
 #. Translators: This message is shown next to the 'Renewal of existing access grant?' label if the application is a renewal. Don't translate HTML tags or parent_url.
 #: TWLight/applications/templates/applications/application_evaluation.html:195
 #, python-format
-msgid ""
-"Yes (<a class=\"twl-links\" href=\"%(parent_url)s\">previous application</a>)"
+msgid "Yes (<a class=\"twl-links\" href=\"%(parent_url)s\">previous application</a>)"
 msgstr ""
 
 #. Translators: This labels the section of the application showing the length of access remaining on the user's previous authorization.
@@ -469,9 +446,7 @@ msgstr "Додај коментар"
 
 #. Translators: On an application page, this text tells users that the comments posted on the application are visible to coordinators and the submitting user only.
 #: TWLight/applications/templates/applications/application_evaluation.html:297
-msgid ""
-"Comments are visible to all coordinators and to the editor who submitted "
-"this application."
+msgid "Comments are visible to all coordinators and to the editor who submitted this application."
 msgstr ""
 
 #. Translators: This is the title of the section of an application page which lists information about the user who submitted the application.
@@ -683,12 +658,7 @@ msgstr "Постави статус"
 
 #: TWLight/applications/templates/applications/apply.html:20
 #, python-format
-msgid ""
-"If your application is successful we may share your email address with "
-"%(partner)s. This is required to set up your access to their resources. By "
-"submitting this form you agree to allow your email address to be shared with "
-"%(partner)s if your application is successful, for the purposes of account "
-"setup."
+msgid "If your application is successful we may share your email address with %(partner)s. This is required to set up your access to their resources. By submitting this form you agree to allow your email address to be shared with %(partner)s if your application is successful, for the purposes of account setup."
 msgstr ""
 
 #. Translators: This message is displayed on the page where users can confirm their renewal. Please do not translate partner.
@@ -717,9 +687,7 @@ msgstr "Којим ресурсима желите да приступите?"
 
 #. Translators: This text explains that Library Bundle partners are not shown in this list.
 #: TWLight/applications/templates/applications/request_for_application.html:26
-msgid ""
-"Library Bundle partners are not shown as eligibility is determined "
-"automatically."
+msgid "Library Bundle partners are not shown as eligibility is determined automatically."
 msgstr ""
 
 #. Translators: On the page where users can apply for multiple partners, this message shows next to the partner name, taking them to the full application page when clicked.
@@ -734,10 +702,7 @@ msgstr ""
 
 #. Translators: the HTML is so that the word 'waitlisted' will look the same as it does in the page above; please translate 'waitlisted' the same way you did elsewhere in this file.
 #: TWLight/applications/templates/applications/request_for_application.html:74
-msgid ""
-"You can apply to <span class=\"badge badge-warning\">Waitlisted</span> "
-"partners, but they don't have access grants available right now. We will "
-"process those applications when access becomes available."
+msgid "You can apply to <span class=\"badge badge-warning\">Waitlisted</span> partners, but they don't have access grants available right now. We will process those applications when access becomes available."
 msgstr ""
 
 #. Translators: On the page where coordinators can see approved applications which have not had their details sent to the partner, this message shows when there are applications ready to be processed.
@@ -759,9 +724,7 @@ msgstr ""
 #. Translators: This message is shown when applications exceed the number of accounts available.
 #: TWLight/applications/templates/applications/send_partner.html:54
 #, python-format
-msgid ""
-"Application(s) for %(object)s, if sent, will exceed the total available "
-"accounts for the partner. Please proceed at your own discretion."
+msgid "Application(s) for %(object)s, if sent, will exceed the total available accounts for the partner. Please proceed at your own discretion."
 msgstr ""
 
 #. Translators: When viewing the list of applications ready to be sent for a particular partner, this is instructions for the coordinator to click the 'mark as sent' button after they have sent the information.
@@ -779,9 +742,7 @@ msgstr[2] ""
 
 #. Translators: When viewing the list of applications ready to be sent for a particular partner, this message shows if there is no information about who the applications should be sent to. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/applications/templates/applications/send_partner.html:89
-msgid ""
-"Whoops, we don't have any listed contacts. Please notify Wikipedia Library "
-"administrators."
+msgid "Whoops, we don't have any listed contacts. Please notify Wikipedia Library administrators."
 msgstr ""
 
 #. Translators: When viewing the list of applications ready to be sent for a particular partner, this is the title of the section containing the information about those applications.
@@ -797,9 +758,7 @@ msgstr "Означи као послато"
 
 #. Translators: This text guides coordinators in using the code sending interface for approved applications.
 #: TWLight/applications/templates/applications/send_partner.html:152
-msgid ""
-"Use the dropdown menus to denote which editor will receive each code. Access "
-"codes will be sent to users automatically."
+msgid "Use the dropdown menus to denote which editor will receive each code. Access codes will be sent to users automatically."
 msgstr ""
 
 #. Translators: This labels a drop-down selection where staff can assign an access code to a user.
@@ -815,18 +774,13 @@ msgstr ""
 #. Translators: When a user applies for a set of resources, they receive this message if none are currently available. They are instead placed on a 'waitlist' for later approval.
 #. Translators: When a user renews their resource, they receive this message if none are currently available. They are instead placed on a 'waitlist' for later approval.
 #: TWLight/applications/views.py:140 TWLight/applications/views.py:1282
-msgid ""
-"This partner does not have any access grants available at this time. You may "
-"still apply for access; your application will be reviewed when access grants "
-"become available."
+msgid "This partner does not have any access grants available at this time. You may still apply for access; your application will be reviewed when access grants become available."
 msgstr ""
 
 #. Translators: This message is shown to users once they've successfully submitted their application for review.
 #: TWLight/applications/views.py:163
 #, python-brace-format
-msgid ""
-"Your application has been submitted for review. Head over to <a "
-"href='{applications_url}'>My Applications</a> to view the status."
+msgid "Your application has been submitted for review. Head over to <a href='{applications_url}'>My Applications</a> to view the status."
 msgstr ""
 
 #. Translators: This text is displayed to users when the user has chosen to restrict data and is trying to apply for multiple partners
@@ -875,16 +829,12 @@ msgstr ""
 
 #. Translators: After a coordinator has changed the status of an application to APPROVED, if the corresponding partner/collection is waitlisted this message appears.
 #: TWLight/applications/views.py:756
-msgid ""
-"Cannot approve application as partner with proxy authorization method is "
-"waitlisted."
+msgid "Cannot approve application as partner with proxy authorization method is waitlisted."
 msgstr ""
 
 #. Translators: After a coordinator has changed the status of an application to APPROVED, if the corresponding partner/collection has no accounts for distribution, this message appears.
 #: TWLight/applications/views.py:780
-msgid ""
-"Cannot approve application as partner with proxy authorization method is "
-"waitlisted and (or) has zero accounts available for distribution."
+msgid "Cannot approve application as partner with proxy authorization method is waitlisted and (or) has zero accounts available for distribution."
 msgstr ""
 
 #. Translators: This message appears on an "access denied" screen that stops users who attempt to authorize an editor to access a resource during a time period for which they are already authorized.
@@ -895,11 +845,7 @@ msgstr ""
 #. Translators: This message is shown to users when they access an application page of a now Bundle partner (new applications aren't allowed for Bundle partners and the status of old applications cannot be modified)
 #: TWLight/applications/views.py:857
 #, python-brace-format
-msgid ""
-"This application cannot be modified since this partner is now part of our <a "
-"href='{bundle}'>bundle access</a>. If you are eligible, you can access this "
-"resource from <a href='{library}'>your library</a>. <a "
-"href='{contact}'>Contact us</a> if you have any questions."
+msgid "This application cannot be modified since this partner is now part of our <a href='{bundle}'>bundle access</a>. If you are eligible, you can access this resource from <a href='{library}'>your library</a>. <a href='{contact}'>Contact us</a> if you have any questions."
 msgstr ""
 
 #. Translators: this lets a reviewer set the status of a single application.
@@ -909,9 +855,7 @@ msgstr ""
 
 #. Translators: This warning is message is shown to applicants when the number of pending applications is greater than the number of accounts available.
 #: TWLight/applications/views.py:891
-msgid ""
-"There are more pending applications than available accounts. Your "
-"application might get waitlisted."
+msgid "There are more pending applications than available accounts. Your application might get waitlisted."
 msgstr ""
 
 #. Translators: this message is shown to coordinators who attempt to change an application's Status from INVALID to any other Status.
@@ -931,11 +875,7 @@ msgstr ""
 
 #. Translators: After a coordinator has changed the status of a number of applications to APPROVED, if the corresponding partner(s) is/are waitlisted or has no accounts for distribution, this message appears.
 #: TWLight/applications/views.py:1051
-msgid ""
-"Cannot approve application(s) {} as partner(s) with proxy authorization "
-"method is/are waitlisted and (or) has/have not enough accounts available. If "
-"not enough accounts are available, prioritise the applications and then "
-"approve applications equal to the accounts available."
+msgid "Cannot approve application(s) {} as partner(s) with proxy authorization method is/are waitlisted and (or) has/have not enough accounts available. If not enough accounts are available, prioritise the applications and then approve applications equal to the accounts available."
 msgstr ""
 
 #. Translators: This message is shown to coordinators who attempt to assign the same access code to multiple users.
@@ -950,9 +890,7 @@ msgstr "Све изабране апликације су означене ка�
 
 #. Translators: When a user tries to renew their resource, they receive this message if the partner is not available.
 #: TWLight/applications/views.py:1272
-msgid ""
-"Cannot renew application at this time as partner is not available. Please "
-"check back later, or contact us for more information."
+msgid "Cannot renew application at this time as partner is not available. Please check back later, or contact us for more information."
 msgstr ""
 
 #. Translators: This message is displayed when an attempt by a user to renew an application has been denied for some reason.
@@ -963,16 +901,12 @@ msgstr ""
 
 #. Translators: If a user requests the renewal of their account, but it wasn't renewed, this message is shown to them.
 #: TWLight/applications/views.py:1385
-msgid ""
-"This object cannot be renewed. (This probably means that you have already "
-"requested that it be renewed.)"
+msgid "This object cannot be renewed. (This probably means that you have already requested that it be renewed.)"
 msgstr ""
 
 #. Translators: If a user requests the renewal of their account, this message is shown to them.
 #: TWLight/applications/views.py:1395
-msgid ""
-"Your renewal request has been received. A coordinator will review your "
-"request."
+msgid "Your renewal request has been received. A coordinator will review your request."
 msgstr ""
 
 #. Translators: This labels a textfield where users can enter their email ID.
@@ -982,9 +916,7 @@ msgstr "Ваша е-пошта:"
 
 #. Translators: This is the help text for the email field in the contact us form letting users know the field is updated by value pulled from their respective user profiles.
 #: TWLight/emails/forms.py:21
-msgid ""
-"This field is automatically updated with the email from your <a class='twl-"
-"links' href='{}'>user profile</a>."
+msgid "This field is automatically updated with the email from your <a class='twl-links' href='{}'>user profile</a>."
 msgstr ""
 
 #. Translators: This labels a textfield where users can enter their email message.
@@ -1008,19 +940,13 @@ msgstr "Пошаљи"
 #. Translators: This email is sent to users with their access code. Don't translate Jinja variables in curly braces like user or partner. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/access_code_email-body-html.html:5
 #, python-format
-msgid ""
-"<p>Your approved application to %(partner)s has now been finalised. Your "
-"access code or login details can be found below:</p> <p><b>%(access_code)s</"
-"b></p> <p>%(user_instructions)s</p>"
+msgid "<p>Your approved application to %(partner)s has now been finalised. Your access code or login details can be found below:</p> <p><b>%(access_code)s</b></p> <p>%(user_instructions)s</p>"
 msgstr ""
 
 #. Translators: This email is sent to users with their access code. Don't translate Jinja variables in curly braces like user or partner. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/access_code_email-body-text.html:3
 #, python-format
-msgid ""
-"Your approved application to %(partner)s has now been finalised. Your access "
-"code or login details can be found below: %(access_code)s "
-"%(user_instructions)s"
+msgid "Your approved application to %(partner)s has now been finalised. Your access code or login details can be found below: %(access_code)s %(user_instructions)s"
 msgstr ""
 
 #. Translators: This is the subject line of an email sent to users with their access code.
@@ -1031,23 +957,13 @@ msgstr ""
 #. Translators: This email is sent to users when their application is approved. Don't translate Jinja variables in curly braces like user or partner; don't translate html tags either. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/approval_notification-body-html.html:5
 #, python-format
-msgid ""
-"<p>Dear %(user)s,</p> <p>Thank you for applying for access to %(partner)s "
-"resources through The Wikipedia Library. We are happy to inform you that "
-"your application has been approved.</p> <p>%(user_instructions)s</p> <p>You "
-"can view the collections you're authorized to access at My Library: "
-"%(link)s</p> <p>Cheers!</p> <p>The Wikipedia Library</p>"
+msgid "<p>Dear %(user)s,</p> <p>Thank you for applying for access to %(partner)s resources through The Wikipedia Library. We are happy to inform you that your application has been approved.</p> <p>%(user_instructions)s</p> <p>You can view the collections you're authorized to access at My Library: %(link)s</p> <p>Cheers!</p> <p>The Wikipedia Library</p>"
 msgstr ""
 
 #. Translators: This email is sent to users when their application is approved. Don't translate Jinja variables in curly braces like user or partner. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/approval_notification-body-text.html:3
 #, python-format
-msgid ""
-"Dear %(user)s, Thank you for applying for access to %(partner)s resources "
-"through The Wikipedia Library. We are happy to inform you that your "
-"application has been approved. %(user_instructions)s You can view the "
-"collections you're authorized to access at My Library: %(link)s Cheers! The "
-"Wikipedia Library"
+msgid "Dear %(user)s, Thank you for applying for access to %(partner)s resources through The Wikipedia Library. We are happy to inform you that your application has been approved. %(user_instructions)s You can view the collections you're authorized to access at My Library: %(link)s Cheers! The Wikipedia Library"
 msgstr ""
 
 #. Translators: This is the subject of an email which is sent to users when their application has been approved. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
@@ -1058,19 +974,13 @@ msgstr ""
 #. Translators: This email is sent to coordinators when a comment is left on an application they are processing. Don't translate Jinja variables in curly braces like user or partner. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/comment_notification_coordinator-body-html.html:5
 #, python-format
-msgid ""
-"<p style=\"color: #500050\">%(submit_date)s - %(commenter)s</p> "
-"<blockquote><p>%(comment)s</p></blockquote> <p>Please reply to these at: <a "
-"href=\"%(app_url)s\">%(app_url)s</a></p> <p>Best,</p> <p>The Wikipedia "
-"Library</p>"
+msgid "<p style=\"color: #500050\">%(submit_date)s - %(commenter)s</p> <blockquote><p>%(comment)s</p></blockquote> <p>Please reply to these at: <a href=\"%(app_url)s\">%(app_url)s</a></p> <p>Best,</p> <p>The Wikipedia Library</p>"
 msgstr ""
 
 #. Translators: This email is sent to coordinators when a comment is left on an application they are processing. Don't translate Jinja variables in curly braces like user or partner. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/comment_notification_coordinator-body-text.html:3
 #, python-format
-msgid ""
-"%(submit_date)s - %(commenter)s %(comment)s Please reply to this at: "
-"%(app_url)s Best, The Wikipedia Library"
+msgid "%(submit_date)s - %(commenter)s %(comment)s Please reply to this at: %(app_url)s Best, The Wikipedia Library"
 msgstr ""
 
 #. Translators: This is the subject line of an email sent to coordinators when a comment is left on an application they processed.
@@ -1081,19 +991,13 @@ msgstr ""
 #. Translators: This email is sent to users when they receive a comment on their application. Don't translate Jinja variables in curly braces like user or partner; don't translate html tags either. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/comment_notification_editors-body-html.html:5
 #, python-format
-msgid ""
-"<p style=\"color: #500050\">%(submit_date)s - %(commenter)s</p> "
-"<blockquote><p>%(comment)s</p></blockquote> <p>Please reply to these at <a "
-"href=\"%(app_url)s\">%(app_url)s</a> so we can evaluate your application.</"
-"p> <p>Best,</p> <p>The Wikipedia Library</p>"
+msgid "<p style=\"color: #500050\">%(submit_date)s - %(commenter)s</p> <blockquote><p>%(comment)s</p></blockquote> <p>Please reply to these at <a href=\"%(app_url)s\">%(app_url)s</a> so we can evaluate your application.</p> <p>Best,</p> <p>The Wikipedia Library</p>"
 msgstr ""
 
 #. Translators: This email is sent to users when they receive a comment on their application. Don't translate Jinja variables in curly braces like user or partner. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/comment_notification_editors-body-text.html:3
 #, python-format
-msgid ""
-"%(submit_date)s - %(commenter)s %(comment)s Please reply to these at: "
-"%(app_url)s so we can evaluate your application. Best, The Wikipedia Library"
+msgid "%(submit_date)s - %(commenter)s %(comment)s Please reply to these at: %(app_url)s so we can evaluate your application. Best, The Wikipedia Library"
 msgstr ""
 
 #. Translators: This is the subject line of an email sent to users who have a comment added to one of their applications. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
@@ -1104,18 +1008,13 @@ msgstr ""
 #. Translators: This email is sent to users when an application they commented on receives another comment. Don't translate Jinja variables in curly braces like app_url; don't translate html tags either. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/comment_notification_others-body-html.html:5
 #, python-format
-msgid ""
-"<p style=\"color: #500050\">%(submit_date)s - %(commenter)s</p> "
-"<blockquote><p>%(comment)s</p></blockquote> See it at <a href=\"%(app_url)s"
-"\">%(app_url)s</a>. Thanks for helping review Wikipedia Library applications!"
+msgid "<p style=\"color: #500050\">%(submit_date)s - %(commenter)s</p> <blockquote><p>%(comment)s</p></blockquote> See it at <a href=\"%(app_url)s\">%(app_url)s</a>. Thanks for helping review Wikipedia Library applications!"
 msgstr ""
 
 #. Translators: This email is sent to users when an application they commented on receives another comment. Don't translate Jinja variables in curly braces like app_url. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/comment_notification_others-body-text.html:3
 #, python-format
-msgid ""
-"%(submit_date)s - %(commenter)s %(comment)s See it at: %(app_url)s Thanks "
-"for helping review Wikipedia Library applications!"
+msgid "%(submit_date)s - %(commenter)s %(comment)s See it at: %(app_url)s Thanks for helping review Wikipedia Library applications!"
 msgstr ""
 
 #. Translators: This is the subject line of an email sent to users who have a comment added to an application they also commented on. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
@@ -1126,10 +1025,7 @@ msgstr ""
 #. Translators: This text is part of a scheduled reminder email sent to coordinators who have applications requiring action. Don't translate Jinja variables in curly braces like total_apps, or user.
 #: TWLight/emails/templates/emails/coordinator_reminder_notification-body-html.html:5
 #, python-format
-msgid ""
-"<p>Dear %(user)s,</p> <p>Our records indicate that you are the designated "
-"coordinator for partners that have a total of %(total_apps)s applications.</"
-"p>"
+msgid "<p>Dear %(user)s,</p> <p>Our records indicate that you are the designated coordinator for partners that have a total of %(total_apps)s applications.</p>"
 msgstr ""
 
 #. Translators: Breakdown as in 'cost breakdown'; analysis.
@@ -1171,31 +1067,19 @@ msgstr[2] ""
 #. Translators: This text is part of a scheduled reminder email sent to coordinators who have applications requiring action. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library). Don't translate Jinja variables in curly braces like link; don't translate email addresses or html tags either.
 #: TWLight/emails/templates/emails/coordinator_reminder_notification-body-html.html:39
 #, python-format
-msgid ""
-"<p>This is a gentle reminder that you may review applications at <a href="
-"\"%(link)s\">%(link)s</a>.</p> <p>You can customise your reminders under "
-"'preferences' in your user profile.</p> <p>If you received this message in "
-"error, drop us a line at wikipedialibrary@wikimedia.org.</p> <p>Thanks for "
-"helping review Wikipedia Library applications!</p>"
+msgid "<p>This is a gentle reminder that you may review applications at <a href=\"%(link)s\">%(link)s</a>.</p> <p>You can customise your reminders under 'preferences' in your user profile.</p> <p>If you received this message in error, drop us a line at wikipedialibrary@wikimedia.org.</p> <p>Thanks for helping review Wikipedia Library applications!</p>"
 msgstr ""
 
 #. Translators: This text is part of a scheduled reminder email sent to coordinators who have applications requiring action. Don't translate Jinja variables in curly braces like total_apps, or user.
 #: TWLight/emails/templates/emails/coordinator_reminder_notification-body-text.html:3
 #, python-format
-msgid ""
-"Dear %(user)s, Our records indicate that you are the designated coordinator "
-"for partners that have a total of %(total_apps)s applications."
+msgid "Dear %(user)s, Our records indicate that you are the designated coordinator for partners that have a total of %(total_apps)s applications."
 msgstr ""
 
 #. Translators: This text is part of a scheduled reminder email sent to coordinators who have applications requiring action. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library). Don't translate Jinja variables in curly braces like link; don't translate the email address either.
 #: TWLight/emails/templates/emails/coordinator_reminder_notification-body-text.html:38
 #, python-format
-msgid ""
-"This is a gentle reminder that you may review applications at: %(link)s. You "
-"can customise your reminders under 'preferences' in your user profile. If "
-"you received this message in error, drop us a line at: "
-"wikipedialibrary@wikimedia.org Thanks for helping review Wikipedia Library "
-"applications!"
+msgid "This is a gentle reminder that you may review applications at: %(link)s. You can customise your reminders under 'preferences' in your user profile. If you received this message in error, drop us a line at: wikipedialibrary@wikimedia.org Thanks for helping review Wikipedia Library applications!"
 msgstr ""
 
 #. Translators: This is the subject line of a scheduled reminder email sent to coordinators who have applications to review. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library). Do not translate items in curly braces.
@@ -1206,22 +1090,13 @@ msgstr ""
 #. Translators: This email is sent to users when their application is rejected. Don't translate Jinja variables in curly braces like user or partner; don't translate html tags either. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/rejection_notification-body-html.html:5
 #, python-format
-msgid ""
-"<p>Dear %(user)s,</p> <p>Thank you for applying for access to %(partner)s "
-"resources through The Wikipedia Library. Unfortunately at this time your "
-"application has not been approved. You can view your application and review "
-"comments at <a href=\"%(app_url)s\">%(app_url)s</a>.</p> <p>Best,</p> <p>The "
-"Wikipedia Library</p>"
+msgid "<p>Dear %(user)s,</p> <p>Thank you for applying for access to %(partner)s resources through The Wikipedia Library. Unfortunately at this time your application has not been approved. You can view your application and review comments at <a href=\"%(app_url)s\">%(app_url)s</a>.</p> <p>Best,</p> <p>The Wikipedia Library</p>"
 msgstr ""
 
 #. Translators: This email is sent to users when their application is rejected. Don't translate Jinja variables in curly braces like user or partner. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/rejection_notification-body-text.html:3
 #, python-format
-msgid ""
-"Dear %(user)s, Thank you for applying for access to %(partner)s resources "
-"through The Wikipedia Library. Unfortunately at this time your application "
-"has not been approved. You can view your application and review comments at: "
-"%(app_url)s Best, The Wikipedia Library"
+msgid "Dear %(user)s, Thank you for applying for access to %(partner)s resources through The Wikipedia Library. Unfortunately at this time your application has not been approved. You can view your application and review comments at: %(app_url)s Best, The Wikipedia Library"
 msgstr ""
 
 #. Translators: This is the subject of an email which is sent to users when their application has been rejected. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
@@ -1232,25 +1107,13 @@ msgstr ""
 #. Translators: This email is sent to users when they have an account that is soon to expire. Don't translate Jinja variables in curly braces like partner_name or partner_link; don't translate html tags either. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/user_renewal_notice-body-html.html:5
 #, python-format
-msgid ""
-"<p>Dear %(user)s,</p> <p>According to our records, your access to "
-"%(partner_name)s will soon expire and you may lose access. If you want to "
-"continue making use of your free account, you can request renewal of your "
-"account by clicking the 'Renew' or 'Extend' button at %(partner_link)s.</p> "
-"<p>Best,</p> <p>The Wikipedia Library</p> <p>You can disable these emails in "
-"your user page preferences: https://wikipedialibrary.wmflabs.org/users/</p>"
+msgid "<p>Dear %(user)s,</p> <p>According to our records, your access to %(partner_name)s will soon expire and you may lose access. If you want to continue making use of your free account, you can request renewal of your account by clicking the 'Renew' or 'Extend' button at %(partner_link)s.</p> <p>Best,</p> <p>The Wikipedia Library</p> <p>You can disable these emails in your user page preferences: https://wikipedialibrary.wmflabs.org/users/</p>"
 msgstr ""
 
 #. Translators: This email is sent to users when they have an account that is soon to expire. Don't translate Jinja variables in curly braces like partner_name or partner_link; don't translate html tags either. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/user_renewal_notice-body-text.html:3
 #, python-format
-msgid ""
-"Dear %(user)s, According to our records, your access to %(partner_name)s "
-"will soon expire and you may lose access. If you want to continue making use "
-"of your free account, you can request renewal of your account by clicking "
-"the Renew button at %(partner_link)s. Best, The Wikipedia Library You can "
-"disable these emails in your user page preferences: https://wikipedialibrary."
-"wmflabs.org/users/"
+msgid "Dear %(user)s, According to our records, your access to %(partner_name)s will soon expire and you may lose access. If you want to continue making use of your free account, you can request renewal of your account by clicking the Renew button at %(partner_link)s. Best, The Wikipedia Library You can disable these emails in your user page preferences: https://wikipedialibrary.wmflabs.org/users/"
 msgstr ""
 
 #. Translators: This is the subject of an email sent to users when they have an account that is soon to expire. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
@@ -1261,24 +1124,13 @@ msgstr ""
 #. Translators: This email is sent to users when their application is waitlisted because there are no more accounts available. Don't translate Jinja variables in curly braces like user or partner; don't translate html tags either. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/waitlist_notification-body-html.html:5
 #, python-format
-msgid ""
-"<p>Dear %(user)s,</p> <p>Thank you for applying for access to %(partner)s "
-"resources through The Wikipedia Library. There are no accounts currently "
-"available so your application has been waitlisted. Your application will be "
-"evaluated if/when more accounts become available. You can see all available "
-"resources at <a href=\"%(link)s\">%(link)s</a>.</p> <p>Best,</p> <p>The "
-"Wikipedia Library</p>"
+msgid "<p>Dear %(user)s,</p> <p>Thank you for applying for access to %(partner)s resources through The Wikipedia Library. There are no accounts currently available so your application has been waitlisted. Your application will be evaluated if/when more accounts become available. You can see all available resources at <a href=\"%(link)s\">%(link)s</a>.</p> <p>Best,</p> <p>The Wikipedia Library</p>"
 msgstr ""
 
 #. Translators: This email is sent to users when their application is waitlisted because there are no more accounts available. Don't translate Jinja variables in curly braces like user or partner. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/waitlist_notification-body-text.html:3
 #, python-format
-msgid ""
-"Dear %(user)s, Thank you for applying for access to %(partner)s resources "
-"through The Wikipedia Library. There are no accounts currently available so "
-"your application has been waitlisted. Your application will be evaluated if/"
-"when more accounts become available. You can see all available resources at: "
-"%(link)s Best, The Wikipedia Library"
+msgid "Dear %(user)s, Thank you for applying for access to %(partner)s resources through The Wikipedia Library. There are no accounts currently available so your application has been waitlisted. Your application will be evaluated if/when more accounts become available. You can see all available resources at: %(link)s Best, The Wikipedia Library"
 msgstr ""
 
 #. Translators: This is the subject of an email sent to users when their application is waitlisted because there are no more accounts available. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
@@ -1443,17 +1295,14 @@ msgstr "Недоступно"
 #: TWLight/resources/templates/resources/filter_section.html:14
 #: TWLight/templates/about.html:12
 #: TWLight/users/templates/users/filter_section.html:13
-msgid ""
-"The Wikipedia Library allows active editors to access a wide range of "
-"collections of paywalled reliable sources for free!"
+msgid "The Wikipedia Library allows active editors to access a wide range of collections of paywalled reliable sources for free!"
 msgstr ""
 
 #. Translators: On the Browse Partners page (https://wikipedialibrary.wmflabs.org/partners/), this introduces users to The Wikipedia Library.
 #. Translators: On the MyLibrary page (https://wikipedialibrary.wmflabs.org/users/my_library), this introduces users to The Wikipedia Library.
 #: TWLight/resources/templates/resources/filter_section.html:17
 #: TWLight/users/templates/users/filter_section.html:15
-msgid ""
-"Start with the search bar at the top or browse publisher websites directly."
+msgid "Start with the search bar at the top or browse publisher websites directly."
 msgstr ""
 
 #. Translators: On the Browse Partners page (https://wikipedialibrary.wmflabs.org/partners/), this appears below introductory text and links to the 'About' page (https://wikipedialibrary.wmflabs.org/about/)
@@ -1527,52 +1376,38 @@ msgstr ""
 #. Translators: If we have no available accounts for a partner, the coordinator can change the application system to a waiting list.
 #: TWLight/resources/templates/resources/partner_detail.html:36
 #: TWLight/resources/templates/resources/partner_detail_apply.html:17
-msgid ""
-"There are no access grants available for this partner at this time. You can "
-"still apply for access; applications will be processed when access is "
-"available."
+msgid "There are no access grants available for this partner at this time. You can still apply for access; applications will be processed when access is available."
 msgstr ""
 
 #. Translators: This text links to the minimum user requirements and terms of use on the partner page.
 #: TWLight/resources/templates/resources/partner_detail.html:48
 #: TWLight/resources/templates/resources/partner_detail_apply.html:29
 #, python-format
-msgid ""
-"Before applying, please review the <strong><a class=\"twl-links\" href="
-"\"%(about)s#req\">minimum requirements</a></strong> for access and our "
-"<strong><a class=\"twl-links\" href=\"%(terms)s\">terms of use</a></strong>."
+msgid "Before applying, please review the <strong><a class=\"twl-links\" href=\"%(about)s#req\">minimum requirements</a></strong> for access and our <strong><a class=\"twl-links\" href=\"%(terms)s\">terms of use</a></strong>."
 msgstr ""
 
 #. Translators: This text refers to the page containing the content a user is authorized to access.
 #: TWLight/resources/templates/resources/partner_detail.html:69
 #, python-format
-msgid ""
-"View the status of your access in <strong><a class=\"twl-links\" href="
-"\"%(library_url)s\">My Library</a></strong> page."
+msgid "View the status of your access in <strong><a class=\"twl-links\" href=\"%(library_url)s\">My Library</a></strong> page."
 msgstr ""
 
 #. Translators: This message is shown when a user has open applications, linking to their respective applications page.
 #: TWLight/resources/templates/resources/partner_detail.html:78
 #, python-format
-msgid ""
-"View the status of your application(s) on your <strong><a class=\"twl-links"
-"\" href=\"%(applications_url)s\">My Applications</a></strong> page."
+msgid "View the status of your application(s) on your <strong><a class=\"twl-links\" href=\"%(applications_url)s\">My Applications</a></strong> page."
 msgstr ""
 
 #. Translators: This message is shown when a user has authorizations, linking to their respective collections page.
 #: TWLight/resources/templates/resources/partner_detail_apply.html:50
 #, python-format
-msgid ""
-"View the status of your access on your <strong><a href=\"%(library_url)s\" "
-"class=\"twl-links\">My Library</a></strong> page."
+msgid "View the status of your access on your <strong><a href=\"%(library_url)s\" class=\"twl-links\">My Library</a></strong> page."
 msgstr ""
 
 #. Translators: This message is shown when a user has open applications, linking to their respective applications page.
 #: TWLight/resources/templates/resources/partner_detail_apply.html:60
 #, python-format
-msgid ""
-"View the status of your application(s) on your <strong><a href="
-"\"%(applications_url)s\">My Applications</a></strong> page."
+msgid "View the status of your application(s) on your <strong><a href=\"%(applications_url)s\">My Applications</a></strong> page."
 msgstr ""
 
 #. Translators: One the partner detail page, this text labels the button which coordinators can click to remove a partner from waitlisted status.
@@ -1602,10 +1437,7 @@ msgstr ""
 
 #. Translators: If no account coordinator is assigned to a partner, the Wikipedia Library team will coordinate signups. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/resources/templates/resources/partner_detail_apply.html:112
-msgid ""
-"The Wikipedia Library team will process this application. Want to help? <a "
-"class=\"twl-links\" href=\"https://en.wikipedia.org/wiki/Wikipedia:"
-"The_Wikipedia_Library/Coordinators/Signup\">Sign up as a coordinator.</a>"
+msgid "The Wikipedia Library team will process this application. Want to help? <a class=\"twl-links\" href=\"https://en.wikipedia.org/wiki/Wikipedia:The_Wikipedia_Library/Coordinators/Signup\">Sign up as a coordinator.</a>"
 msgstr ""
 
 #. Translators: This text labels a button coordinators can click to view a list of users who have applied for access for a particular partner
@@ -1635,18 +1467,13 @@ msgstr ""
 
 #. Translators: Text shown to authenticated, bundle eligible users when they visit a Bundle partner page.
 #: TWLight/resources/templates/resources/partner_detail_apply.html:138
-msgid ""
-"You are eligible to access Library Bundle partners. Click the button above "
-"to access the collection."
+msgid "You are eligible to access Library Bundle partners. Click the button above to access the collection."
 msgstr ""
 
 #. Translators: Text shown to authenticated, bundle ineligible users when they visit a Bundle partner page.
 #: TWLight/resources/templates/resources/partner_detail_apply.html:152
 #, python-format
-msgid ""
-"You are not eligible to access Library Bundle partners. Visit the <a class="
-"\"twl-links\" href=\"%(homepage)s\">homepage</a> to check the eligibility "
-"criteria."
+msgid "You are not eligible to access Library Bundle partners. Visit the <a class=\"twl-links\" href=\"%(homepage)s\">homepage</a> to check the eligibility criteria."
 msgstr ""
 
 #. Translators: Buttton prompting users to log in.
@@ -1658,10 +1485,7 @@ msgstr "Пријави ме"
 #. Translators: Text shown to unauthenticated users when they visit a Bundle partner page.
 #: TWLight/resources/templates/resources/partner_detail_apply.html:168
 #, python-format
-msgid ""
-"This resource is part of our <a class=\"twl-links\" href=\"%(about)s"
-"\">Library Bundle</a>, which you can access if you meet our minimum "
-"eligibility criteria. Log in to find out if you are eligible."
+msgid "This resource is part of our <a class=\"twl-links\" href=\"%(about)s\">Library Bundle</a>, which you can access if you meet our minimum eligibility criteria. Log in to find out if you are eligible."
 msgstr ""
 
 #. Translators: This is the label for a number which shows the total active accounts for one partner. (e.g. https://wikipedialibrary.wmflabs.org/partners/8/).
@@ -1712,26 +1536,19 @@ msgstr ""
 #. Translators: If a partner has specified the excerpt limit both in words and percentage, this message will display the percentage of words and the number of words on the partner page.
 #: TWLight/resources/templates/resources/partner_detail_timeline.html:99
 #, python-format
-msgid ""
-"%(object)s allows a maximum of %(excerpt_limit)s words or "
-"%(excerpt_limit_percentage)s%% of an article be excerpted into a Wikipedia "
-"article."
+msgid "%(object)s allows a maximum of %(excerpt_limit)s words or %(excerpt_limit_percentage)s%% of an article be excerpted into a Wikipedia article."
 msgstr ""
 
 #. Translators: If a partner has specified the excerpt limit in words, this message will display the number of words on the partner page.
 #: TWLight/resources/templates/resources/partner_detail_timeline.html:106
 #, python-format
-msgid ""
-"%(object)s allows a maximum of %(excerpt_limit)s words be excerpted into a "
-"Wikipedia article."
+msgid "%(object)s allows a maximum of %(excerpt_limit)s words be excerpted into a Wikipedia article."
 msgstr ""
 
 #. Translators: If a partner has specified the excerpt limit in percentage, this message will display the percentage of words on the partner page.
 #: TWLight/resources/templates/resources/partner_detail_timeline.html:113
 #, python-format
-msgid ""
-"%(object)s allows a maximum of %(excerpt_limit_percentage)s%% of an article "
-"be excerpted into a Wikipedia article."
+msgid "%(object)s allows a maximum of %(excerpt_limit_percentage)s%% of an article be excerpted into a Wikipedia article."
 msgstr ""
 
 #. Translators: If a partner has other requirements for access, this text shows as the title for that information field. (e.g. https://wikipedialibrary.wmflabs.org/partners/10/).
@@ -1742,9 +1559,7 @@ msgstr ""
 #. Translators: If a user must agree to a Terms of Use document, they see this message, and must enter the name of the resource. Don't translate publisher or url.
 #: TWLight/resources/templates/resources/partner_detail_timeline.html:140
 #, python-format
-msgid ""
-"%(publisher)s requires that you agree with its <a href=\"%(url)s\">terms of "
-"use</a>."
+msgid "%(publisher)s requires that you agree with its <a href=\"%(url)s\">terms of use</a>."
 msgstr ""
 
 #. Translators: If a user must provide their real name to apply to a partner, they see this message, and must enter the name of the resource. Don't translate publisher.
@@ -1768,17 +1583,13 @@ msgstr ""
 #. Translators: If a user must select a specific resource to apply for, they see this message, and must enter the name of the resource. Don't translate publisher.
 #: TWLight/resources/templates/resources/partner_detail_timeline.html:177
 #, python-format
-msgid ""
-"%(publisher)s requires that you specify a particular title that you want to "
-"access."
+msgid "%(publisher)s requires that you specify a particular title that you want to access."
 msgstr ""
 
 #. Translators: If a user must register on the partner website before applying, they see this message. Don't translate partner.
 #: TWLight/resources/templates/resources/partner_detail_timeline.html:187
 #, python-format
-msgid ""
-"%(publisher)s requires that you sign up for an account before applying for "
-"access."
+msgid "%(publisher)s requires that you sign up for an account before applying for access."
 msgstr ""
 
 #. Translators: If a partner has their location listed, this message is a label for that location
@@ -1906,9 +1717,7 @@ msgstr "Желите ли заиста да избришете <b>%(object)s</b>
 
 #. Translators: If multiple authorizations where returned for a collection, this message is shown to a user
 #: TWLight/resources/views.py:268
-msgid ""
-"Multiple authorizations were returned – something's wrong. Please contact us "
-"and don't forget to mention this message."
+msgid "Multiple authorizations were returned – something's wrong. Please contact us and don't forget to mention this message."
 msgstr ""
 
 #. Translators: This message is shown when user tries to access a NOT_AVAILABLE Partner
@@ -1949,14 +1758,7 @@ msgstr ""
 #. Translators: Shown on the website's 400 page, when a user sends a bad request. Don't translate path or Phabricator.
 #: TWLight/templates/400.html:20
 #, python-format
-msgid ""
-"If you think we should know what to do with that, please email us about this "
-"error at <a class=\"twl-links\" href=\"mailto:wikipedialibrary@wikimedia.org?"
-"Subject=Wikipedia%%20Library%%20%(path)s%%20Permission%%20denied"
-"\">wikipedialibrary@wikimedia.org</a> or report it to us on <a class=\"twl-"
-"links\" href=\"https://phabricator.wikimedia.org/maniphest/task/edit/form/1/?"
-"projectPHIDs=Library-Card-Platform&title=Wikipedia%%20Library%%20%(path)s"
-"%%20Bad%%20Request\">Phabricator</a>"
+msgid "If you think we should know what to do with that, please email us about this error at <a class=\"twl-links\" href=\"mailto:wikipedialibrary@wikimedia.org?Subject=Wikipedia%%20Library%%20%(path)s%%20Permission%%20denied\">wikipedialibrary@wikimedia.org</a> or report it to us on <a class=\"twl-links\" href=\"https://phabricator.wikimedia.org/maniphest/task/edit/form/1/?projectPHIDs=Library-Card-Platform&title=Wikipedia%%20Library%%20%(path)s%%20Bad%%20Request\">Phabricator</a>"
 msgstr ""
 
 #. Translators: Alt text for an image shown on the 400 error page.
@@ -1978,15 +1780,7 @@ msgstr "Нажалост, није вам дозвољено да урадите
 #. Translators: Shown on the website's 403 page, when a user attempts to navigate to a page they don't have permission to view. Don't translate path or Phabricator.
 #: TWLight/templates/403.html:20
 #, python-format
-msgid ""
-"If you think your account should be able to do that, please email us about "
-"this error at <a class=\"twl-links\" href=\"mailto:"
-"wikipedialibrary@wikimedia.org?Subject=Wikipedia%%20Library%%20%(path)s"
-"%%20Permission%%20denied\">wikipedialibrary@wikimedia.org</a> or report it "
-"to us on <a class=\"twl-links\" href=\"https://phabricator.wikimedia.org/"
-"maniphest/task/edit/form/1/?projectPHIDs=Library-Card-"
-"Platform&title=Wikipedia%%20Library%%20%(path)s%%20Permission%%20denied"
-"\">Phabricator</a>"
+msgid "If you think your account should be able to do that, please email us about this error at <a class=\"twl-links\" href=\"mailto:wikipedialibrary@wikimedia.org?Subject=Wikipedia%%20Library%%20%(path)s%%20Permission%%20denied\">wikipedialibrary@wikimedia.org</a> or report it to us on <a class=\"twl-links\" href=\"https://phabricator.wikimedia.org/maniphest/task/edit/form/1/?projectPHIDs=Library-Card-Platform&title=Wikipedia%%20Library%%20%(path)s%%20Permission%%20denied\">Phabricator</a>"
 msgstr ""
 
 #. Translators: Shown on the website's 404 page, when a user attempts to navigate to a page that doesn't exist.
@@ -2002,14 +1796,7 @@ msgstr "Нажалост, не можемо да пронађемо то."
 #. Translators: Shown on the website's 404 page, when a user attempts to navigate to a page that doesn't exist. Don't translate path or Phabricator.
 #: TWLight/templates/404.html:19
 #, python-format
-msgid ""
-"If you are certain that something should be here, please email us about this "
-"error at <a class=\"twl-links\" href=\"mailto:wikipedialibrary@wikimedia.org?"
-"Subject=Wikipedia%%20Library%%20%(path)s%%20Not%%20found\"> "
-"wikipedialibrary@wikimedia.org</a> or report it to us on <a class=\"twl-links"
-"\" href=\"https://phabricator.wikimedia.org/maniphest/task/edit/form/1/?"
-"projectPHIDs=Library-Card-Platform&title=Wikipedia%%20Library%%20%(path)s"
-"%%20Not%%20found\">Phabricator</a>"
+msgid "If you are certain that something should be here, please email us about this error at <a class=\"twl-links\" href=\"mailto:wikipedialibrary@wikimedia.org?Subject=Wikipedia%%20Library%%20%(path)s%%20Not%%20found\"> wikipedialibrary@wikimedia.org</a> or report it to us on <a class=\"twl-links\" href=\"https://phabricator.wikimedia.org/maniphest/task/edit/form/1/?projectPHIDs=Library-Card-Platform&title=Wikipedia%%20Library%%20%(path)s%%20Not%%20found\">Phabricator</a>"
 msgstr ""
 
 #. Translators: Alt text for an image shown on the 404 error page.
@@ -2024,32 +1811,18 @@ msgstr ""
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:20
-msgid ""
-"This platform is our central tool for facilitating access to our available "
-"collections. Here you can see which partnerships are available, search their "
-"contents, and apply for and access the ones you’re interested in."
+msgid "This platform is our central tool for facilitating access to our available collections. Here you can see which partnerships are available, search their contents, and apply for and access the ones you’re interested in."
 msgstr ""
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/). Wikimedia Foundation should not be translated.
 #: TWLight/templates/about.html:29
-msgid ""
-"All users receive immediate access to some collections, which can be browsed "
-"by clicking the 'Access collection' buttons or using the search bar at the "
-"top of the page. Other collections require an application before access is "
-"granted, and may be accessed directly or via an individual login or access "
-"code. Volunteer coordinators, who have signed non-disclosure agreements with "
-"the Wikimedia Foundation, review these applications and work with publishers "
-"to get you your free access."
+msgid "All users receive immediate access to some collections, which can be browsed by clicking the 'Access collection' buttons or using the search bar at the top of the page. Other collections require an application before access is granted, and may be accessed directly or via an individual login or access code. Volunteer coordinators, who have signed non-disclosure agreements with the Wikimedia Foundation, review these applications and work with publishers to get you your free access."
 msgstr ""
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/). Don't translate terms_url.
 #: TWLight/templates/about.html:43
 #, python-format
-msgid ""
-"For more information about how your information is stored and reviewed "
-"please see our <a class=\"twl-links\" href=\"%(terms_url)s\"> terms of use "
-"and privacy policy</a>. Accounts you apply for are also subject to the Terms "
-"of Use provided by each partner’s platform; please review them."
+msgid "For more information about how your information is stored and reviewed please see our <a class=\"twl-links\" href=\"%(terms_url)s\"> terms of use and privacy policy</a>. Accounts you apply for are also subject to the Terms of Use provided by each partner’s platform; please review them."
 msgstr ""
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
@@ -2059,12 +1832,7 @@ msgstr "Ко може да приступи?"
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/). Wikimedia Foundation should not be translated.
 #: TWLight/templates/about.html:55
-msgid ""
-"Any active editor in good standing can receive access. For publishers with "
-"limited numbers of accounts, applications are reviewed based on the editor’s "
-"needs and contributions. If you think you could use access to one of our "
-"partner resources and are an active editor in any project supported by the "
-"Wikimedia Foundation, please apply."
+msgid "Any active editor in good standing can receive access. For publishers with limited numbers of accounts, applications are reviewed based on the editor’s needs and contributions. If you think you could use access to one of our partner resources and are an active editor in any project supported by the Wikimedia Foundation, please apply."
 msgstr ""
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
@@ -2094,23 +1862,12 @@ msgstr "Тренутно вам није забрањено уређивање �
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/)
 #: TWLight/templates/about.html:89
-msgid ""
-"If you are applying for an available collection, please first check that you "
-"don't already have access through another library or institution. If you do, "
-"please consider using that access rather than taking up a seat for this "
-"resource in The Wikipedia Library."
+msgid "If you are applying for an available collection, please first check that you don't already have access through another library or institution. If you do, please consider using that access rather than taking up a seat for this resource in The Wikipedia Library."
 msgstr ""
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/)
 #: TWLight/templates/about.html:99
-msgid ""
-"If your account is blocked on one or more Wikimedia projects, you may still "
-"be granted access to The Wikipedia Library. You will need to contact the "
-"Wikipedia Library team, who will review your blocks. If you have been "
-"blocked for content issues, most notably copyright violations, or have "
-"multiple long-term blocks, we may decline your request. Additionally, if "
-"your block status changes after being approved, you will need to request "
-"another review."
+msgid "If your account is blocked on one or more Wikimedia projects, you may still be granted access to The Wikipedia Library. You will need to contact the Wikipedia Library team, who will review your blocks. If you have been blocked for content issues, most notably copyright violations, or have multiple long-term blocks, we may decline your request. Additionally, if your block status changes after being approved, you will need to request another review."
 msgstr ""
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
@@ -2145,9 +1902,7 @@ msgstr ""
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:136
-msgid ""
-"Share their account logins or passwords with others, or sell their access to "
-"other parties"
+msgid "Share their account logins or passwords with others, or sell their access to other parties"
 msgstr ""
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
@@ -2157,23 +1912,17 @@ msgstr ""
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:144
-msgid ""
-"Systematically make printed or electronic copies of multiple extracts of "
-"restricted content available for any purpose"
+msgid "Systematically make printed or electronic copies of multiple extracts of restricted content available for any purpose"
 msgstr ""
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/). Stub is a technical term for a short Wikipedia article, use the appropriate Wikipedia term in your language.
 #: TWLight/templates/about.html:148
-msgid ""
-"Datamine metadata without permission, in order, for instance, to use "
-"metadata for auto-created stub articles"
+msgid "Datamine metadata without permission, in order, for instance, to use metadata for auto-created stub articles"
 msgstr ""
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:154
-msgid ""
-"Respecting these agreements allows us to continue growing the partnerships "
-"available to the community."
+msgid "Respecting these agreements allows us to continue growing the partnerships available to the community."
 msgstr ""
 
 #. Translators: This is the heading for a section on the About page (https://wikipedialibrary.wmflabs.org/about/).
@@ -2183,41 +1932,22 @@ msgstr ""
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:164
-msgid ""
-"EZProxy is a proxy server used to authenticate users for many Wikipedia "
-"Library partners. Users sign into EZProxy via the Library Card platform to "
-"verify that they are authorized users, and then the server accesses "
-"requested resources using its own IP address."
+msgid "EZProxy is a proxy server used to authenticate users for many Wikipedia Library partners. Users sign into EZProxy via the Library Card platform to verify that they are authorized users, and then the server accesses requested resources using its own IP address."
 msgstr ""
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:173
-msgid ""
-"You may notice that when accessing resources via EZProxy that URLs are "
-"dynamically rewritten. This is why we recommend logging in via the Library "
-"Card platform rather than going directly to the unproxied partner website. "
-"When in doubt, check the URL for ‘idm.oclc’. If it’s there, then you’re "
-"connected via EZProxy."
+msgid "You may notice that when accessing resources via EZProxy that URLs are dynamically rewritten. This is why we recommend logging in via the Library Card platform rather than going directly to the unproxied partner website. When in doubt, check the URL for ‘idm.oclc’. If it’s there, then you’re connected via EZProxy."
 msgstr ""
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:182
-msgid ""
-"Typically once you’ve logged in your session will remain active in your "
-"browser for up to two hours after you’ve finished searching. Note that use "
-"of EZProxy requires you to enable cookies. If you are having problems you "
-"should also try clearing your cache and restarting your browser."
+msgid "Typically once you’ve logged in your session will remain active in your browser for up to two hours after you’ve finished searching. Note that use of EZProxy requires you to enable cookies. If you are having problems you should also try clearing your cache and restarting your browser."
 msgstr ""
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/)
 #: TWLight/templates/about.html:193
-msgid ""
-"The Library Bundle is a collection of resources for which no application is "
-"required. If you meet the criteria laid out above, you will be authorized "
-"for access automatically upon logging in to the platform. Only some of our "
-"content is currently included in the Library Bundle, however we hope to "
-"expand the collection as more publishers become comfortable with "
-"participating. All Bundle content is accessed via EZProxy."
+msgid "The Library Bundle is a collection of resources for which no application is required. If you meet the criteria laid out above, you will be authorized for access automatically upon logging in to the platform. Only some of our content is currently included in the Library Bundle, however we hope to expand the collection as more publishers become comfortable with participating. All Bundle content is accessed via EZProxy."
 msgstr ""
 
 #. Translators: This is the heading for a section on the About page (https://wikipedialibrary.wmflabs.org/about/).
@@ -2227,12 +1957,7 @@ msgstr ""
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:206
-msgid ""
-"Citation practices vary by project and even by article. Generally, we "
-"support editors citing where they found information, in a form that allows "
-"others to check it for themselves. That often means providing both original "
-"source details as well as a link to the partner database in which the source "
-"was found."
+msgid "Citation practices vary by project and even by article. Generally, we support editors citing where they found information, in a form that allows others to check it for themselves. That often means providing both original source details as well as a link to the partner database in which the source was found."
 msgstr ""
 
 #. Translators: This is the heading for a section on the About page (https://wikipedialibrary.wmflabs.org/about/).
@@ -2244,9 +1969,7 @@ msgstr "Контактирајте нас"
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:218
 #, python-format
-msgid ""
-"If you have questions, need help, or want to volunteer to help, please see "
-"our <a class=\"twl-links\" href=\"%(contact_url)s\">contact page</a>."
+msgid "If you have questions, need help, or want to volunteer to help, please see our <a class=\"twl-links\" href=\"%(contact_url)s\">contact page</a>."
 msgstr ""
 
 #. Translators: This is the title of the panel box detailing the contact information for the Wikipedia Library team.
@@ -2286,9 +2009,7 @@ msgstr "Страница на Twitter-у Википедијине библиот
 #. Translators: This is the text that appears at the bottom of the contact us form directing users to the suggestions form.
 #: TWLight/templates/contact.html:48
 #, python-format
-msgid ""
-"(If you would like to suggest a partner, <a class=\"twl-links\" href="
-"\"%(suggest)s\"><strong>go here</strong></a>.)"
+msgid "(If you would like to suggest a partner, <a class=\"twl-links\" href=\"%(suggest)s\"><strong>go here</strong></a>.)"
 msgstr ""
 
 #. Translators: On a special 'link to search' page, this message is shown if JavaScript is disabled.
@@ -2345,9 +2066,7 @@ msgstr "Википедијина библиотека"
 #. Translators: Information about The Wikipedia Library.
 #: TWLight/templates/login_partial.html:53 TWLight/templates/new_base.html:21
 #, python-format
-msgid ""
-"More than 100 of the world's top subscription-only databases, with content "
-"in %(no_of_languages)s languages, free for Wikipedians of all backgrounds"
+msgid "More than 100 of the world's top subscription-only databases, with content in %(no_of_languages)s languages, free for Wikipedians of all backgrounds"
 msgstr ""
 
 #. Translators: Information about The Wikipedia Library.
@@ -2356,9 +2075,7 @@ msgid "Meet these criteria for automatic access"
 msgstr ""
 
 #: TWLight/templates/login_partial.html:69
-msgid ""
-"These criteria grant you access to certain collections but not all. Some "
-"collections are accessible on a per application basis only."
+msgid "These criteria grant you access to certain collections but not all. Some collections are accessible on a per application basis only."
 msgstr ""
 
 #: TWLight/templates/login_partial.html:89
@@ -2368,29 +2085,19 @@ msgstr ""
 #. Translators: Shown if the current user doesn't have a registered email on their account. Don't translate contact_us_url or email_url.
 #: TWLight/templates/message_partial.html:15
 #, python-format
-msgid ""
-"You don't have an email on file. We can't finalize your access to partner "
-"resources, and you won't be able to <a class=\"twl-links\" href="
-"\"%(contact_us_url)s\">contact us</a> without an email. Please <a class="
-"\"twl-links\" href=\"%(email_url)s\">update your email</a>."
+msgid "You don't have an email on file. We can't finalize your access to partner resources, and you won't be able to <a class=\"twl-links\" href=\"%(contact_us_url)s\">contact us</a> without an email. Please <a class=\"twl-links\" href=\"%(email_url)s\">update your email</a>."
 msgstr ""
 
 #. Translators: Shown if the current user has requested the processing of their data should be restricted.
 #: TWLight/templates/message_partial.html:26
 #, python-format
-msgid ""
-"You have requested a restriction on the processing of your data. Most site "
-"functionality will not be available to you until you <a class=\"twl-links\" "
-"href=\"%(restrict_url)s\">lift this restriction</a>."
+msgid "You have requested a restriction on the processing of your data. Most site functionality will not be available to you until you <a class=\"twl-links\" href=\"%(restrict_url)s\">lift this restriction</a>."
 msgstr ""
 
 #. Translators: Shown if the current user has not agreed to the terms of use.
 #: TWLight/templates/message_partial.html:37
 #, python-format
-msgid ""
-"You have not agreed to the <a class=\"twl-links\" href=\"%(terms_url)s"
-"\">terms of use</a> of this site. Your applications will not be processed "
-"and you won't be able to apply or access resources you are approved for."
+msgid "You have not agreed to the <a class=\"twl-links\" href=\"%(terms_url)s\">terms of use</a> of this site. Your applications will not be processed and you won't be able to apply or access resources you are approved for."
 msgstr ""
 
 #. Translators: This link is at the bottom of every page and links to the 'About' page (https://wikipedialibrary.wmflabs.org/about/)
@@ -2437,12 +2144,8 @@ msgstr "Ресетуј лозинку"
 
 #. Translators: If a user goes to reset their password, this message asks them to enter their email to do so.
 #: TWLight/templates/registration/password_reset_form.html:13
-msgid ""
-"Forgot your password? Enter your email address below, and we'll email "
-"instructions for setting a new one."
-msgstr ""
-"Заборавили сте лозинку? Унесите имејл-адресу ниже, па ћемо вам послати "
-"упутства како да поставите нову."
+msgid "Forgot your password? Enter your email address below, and we'll email instructions for setting a new one."
+msgstr "Заборавили сте лозинку? Унесите имејл-адресу ниже, па ћемо вам послати упутства како да поставите нову."
 
 #. Translators: This is the label for a button that users click to update their public information.
 #: TWLight/users/forms.py:36
@@ -2486,16 +2189,12 @@ msgstr "Прихватам услове коришћења"
 
 #. Translators: This text explains how to disagree to the site's terms of use and the restrictions that will come into effect when users disagree to the terms of use.
 #: TWLight/users/forms.py:185
-msgid ""
-"By unchecking this box and clicking “Update” you may explore the site, but "
-"you will not be able to apply for access to materials or evaluate "
-"applications unless you agree with the terms of use."
+msgid "By unchecking this box and clicking “Update” you may explore the site, but you will not be able to apply for access to materials or evaluate applications unless you agree with the terms of use."
 msgstr ""
 
 #. Translators: Users click this button to set their website email address to the one linked to their Wikipedia account.
 #: TWLight/users/forms.py:211
-msgid ""
-"Use my Wikipedia email address (will be updated the next time you login)."
+msgid "Use my Wikipedia email address (will be updated the next time you login)."
 msgstr ""
 
 #. Translators: This labels a button which users click to change their email.
@@ -2506,17 +2205,8 @@ msgstr "Ажурирај имејл"
 #. Translators: Shown if the current user tried to 'favorite' a partner they can't access. Do not translate '{partner}'
 #: TWLight/users/models.py:201
 #, python-brace-format
-msgid ""
-"Cannot add partner {partner} to your favorites because you don't have access "
-"to it"
+msgid "Cannot add partner {partner} to your favorites because you don't have access to it"
 msgstr ""
-
-#. Translators: Do not translate.
-#: TWLight/users/models.py:869
-#, fuzzy, python-brace-format
-#| msgid "Username"
-msgid "{wp_username}"
-msgstr "Корисничко име"
 
 #. Translators: This error message is shown when there's a problem with the authenticated login process.
 #: TWLight/users/oauth.py:243
@@ -2536,9 +2226,7 @@ msgstr ""
 
 #. Translators: this message is displayed to users that don't have accounts and clicked on a proxied link.
 #: TWLight/users/oauth.py:388
-msgid ""
-"To view this link you need to be an eligible library user. Please login to "
-"continue."
+msgid "To view this link you need to be an eligible library user. Please login to continue."
 msgstr ""
 
 #. Translators: This warning message is shown to users when the response received from Wikimedia OAuth servers is not a valid one.
@@ -2574,17 +2262,12 @@ msgstr "Корисничке информације"
 
 #. Translators: If the user tries to log in, but their account does not meet certain requirements, they cannot login.
 #: TWLight/users/oauth.py:528
-msgid ""
-"Your Wikipedia account does not meet the eligibility criteria in the terms "
-"of use, so your Wikipedia Library Card Platform account cannot be activated."
+msgid "Your Wikipedia account does not meet the eligibility criteria in the terms of use, so your Wikipedia Library Card Platform account cannot be activated."
 msgstr ""
 
 #. Translators: If the user tries to log in, but their account does not meet certain requirements, they cannot login.
 #: TWLight/users/oauth.py:536
-msgid ""
-"Your Wikipedia account no longer meets the eligibility criteria in the terms "
-"of use, so you cannot be logged in. If you think you should be able to log "
-"in, please email wikipedialibrary@wikimedia.org."
+msgid "Your Wikipedia account no longer meets the eligibility criteria in the terms of use, so you cannot be logged in. If you think you should be able to log in, please email wikipedialibrary@wikimedia.org."
 msgstr ""
 
 #. Translators: this message is displayed to users with brand new accounts.
@@ -2595,10 +2278,7 @@ msgstr "Добро дошли! Прихватите услове коришће�
 #. Translators: This message is displayed on the confirmation page where users can return their access to partner collections.
 #: TWLight/users/templates/users/authorization_confirm_return.html:13
 #, python-format
-msgid ""
-"You will no longer be able to access <b>%(partner)s's</b> resources via the "
-"Library Card platform, but can request access again by clicking 'renew', if "
-"you change your mind. Are you sure you want to return your access?"
+msgid "You will no longer be able to access <b>%(partner)s's</b> resources via the Library Card platform, but can request access again by clicking 'renew', if you change your mind. Are you sure you want to return your access?"
 msgstr ""
 
 #. Translators: On the MyLibrary page (https://wikipedialibrary.wmflabs.org/users/my_library), this tab shows all favorite collections a user has.
@@ -2668,10 +2348,7 @@ msgstr "Подаци о уреднику"
 
 #. Translators: This is shown on editor profiles, in their profile page or on applications.
 #: TWLight/users/templates/users/editor_detail.html:59
-msgid ""
-"Information with an * was retrieved from Wikipedia directly. Other "
-"information was entered directly by users or site admins, in their preferred "
-"language."
+msgid "Information with an * was retrieved from Wikipedia directly. Other information was entered directly by users or site admins, in their preferred language."
 msgstr ""
 
 #. Translators: This distinguishes users who have been flagged as account coordinators. Don't translate username.
@@ -2682,10 +2359,7 @@ msgstr ""
 
 #. Translators: This is shown on editor profiles, under the heading for Wikipedia editor data.
 #: TWLight/users/templates/users/editor_detail_data.html:5
-msgid ""
-"This information is updated automatically from your Wikimedia account each "
-"time you log in, except for the Contributions field, where you can describe "
-"your Wikimedia editing history."
+msgid "This information is updated automatically from your Wikimedia account each time you log in, except for the Contributions field, where you can describe your Wikimedia editing history."
 msgstr ""
 
 #. Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this labels the user's username.
@@ -2715,17 +2389,13 @@ msgstr ""
 
 #. Translators: when viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this question has a yes or no answer.
 #: TWLight/users/templates/users/editor_detail_data.html:57
-msgid ""
-"at their last login, did this user meet the criteria set forth in the terms "
-"of use?"
+msgid "at their last login, did this user meet the criteria set forth in the terms of use?"
 msgstr ""
 
 #. Translators: When viewing a user's profile in an application, this message shows if the software doesn't think that the user is eligible for access. Don't translate username.
 #: TWLight/users/templates/users/editor_detail_data.html:72
 #, python-format
-msgid ""
-"%(username)s may still be eligible for access grants at the coordinators' "
-"discretion."
+msgid "%(username)s may still be eligible for access grants at the coordinators' discretion."
 msgstr ""
 
 #. Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this is the heading for a Yes/No ToU question.
@@ -2760,10 +2430,7 @@ msgstr ""
 #. Translators: This message is shown on a user's profile if their Wikimedia account is blocked on one or more projects. They may still be granted access to the Library Bundle, but need to contact Wikipedia Library staff to verify.
 #: TWLight/users/templates/users/editor_detail_data.html:137
 #, python-format
-msgid ""
-"It looks like you have an active block on your account. If you meet the "
-"other criteria you may still be permitted access to the library - please <a "
-"class=\"twl-links\" href=\"%(contact_url)s\">contact us</a>."
+msgid "It looks like you have an active block on your account. If you meet the other criteria you may still be permitted access to the library - please <a class=\"twl-links\" href=\"%(contact_url)s\">contact us</a>."
 msgstr ""
 
 #. Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this is the heading for a Yes/No program eligibility question.
@@ -2773,10 +2440,7 @@ msgstr ""
 
 #. Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this question has a Yes or No answer.
 #: TWLight/users/templates/users/editor_detail_data.html:156
-msgid ""
-"At their last login, did this user meet the criteria set forth in the "
-"Library Bundle? Note that satisfying terms of use is a prerequisite to "
-"bundle eligibility."
+msgid "At their last login, did this user meet the criteria set forth in the Library Bundle? Note that satisfying terms of use is a prerequisite to bundle eligibility."
 msgstr ""
 
 #. Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this is the heading for a Yes/No program eligibility question.
@@ -2821,18 +2485,13 @@ msgstr ""
 
 #. Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this text is in the 'Personal data' section. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/users/templates/users/editor_detail_data.html:262
-msgid ""
-"The following information is visible only to you, site administrators, "
-"publishing partners (where required), and volunteer Wikipedia Library "
-"coordinators (who have signed a Non-Disclosure Agreement)."
+msgid "The following information is visible only to you, site administrators, publishing partners (where required), and volunteer Wikipedia Library coordinators (who have signed a Non-Disclosure Agreement)."
 msgstr ""
 
 #. Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this labels a button which users can click to update or remove their personal information. Don't translate update_url.
 #: TWLight/users/templates/users/editor_detail_data.html:272
 #, python-format
-msgid ""
-"You may <a class=\"twl-links\" href=\"%(update_url)s\">update or delete</a> "
-"your data at any time."
+msgid "You may <a class=\"twl-links\" href=\"%(update_url)s\">update or delete</a> your data at any time."
 msgstr ""
 
 #. Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this labels the user's email. Don't remove the *.
@@ -2852,24 +2511,18 @@ msgstr ""
 
 #. Translators: This message tells users that they are not eligible to access The Wikipedia Library content.
 #: TWLight/users/templates/users/eligibility_modal.html:7
-msgid ""
-"Sorry, your Wikipedia account doesn’t currently qualify to access The "
-"Wikipedia Library."
+msgid "Sorry, your Wikipedia account doesn’t currently qualify to access The Wikipedia Library."
 msgstr ""
 
 #. Translators: This message tells users that they have not agreed to the terms of use, therefore are ineligible to access the content in The Wikipedia Library.
 #: TWLight/users/templates/users/eligibility_modal.html:30
 #, python-format
-msgid ""
-"Agreed with <a href=\"%(terms)s\" class=\"text-danger\"> terms of use </a>"
+msgid "Agreed with <a href=\"%(terms)s\" class=\"text-danger\"> terms of use </a>"
 msgstr ""
 
 #: TWLight/users/templates/users/eligibility_modal.html:40
 #, python-format
-msgid ""
-"It looks like you have an active block on your account. If you meet the "
-"other criteria you may still be permitted access to the library - please <a "
-"href=\"%(contact_url)s\">contact us</a>."
+msgid "It looks like you have an active block on your account. If you meet the other criteria you may still be permitted access to the library - please <a href=\"%(contact_url)s\">contact us</a>."
 msgstr ""
 
 #. Translators: Instructions to refresh a user's data.
@@ -2909,10 +2562,7 @@ msgstr "Изаберите језик"
 
 #. Translators: This text on the user page helps users naviage to the TranslateWiki Wikipedia Library Card platform translation page.
 #: TWLight/users/templates/users/language_form.html:31
-msgid ""
-"You can help translate the tool at <a class=\"twl-links\" href=\"https://"
-"translatewiki.net/wiki/Translating:Wikipedia_Library_Card_Platform"
-"\">translatewiki.net</a>."
+msgid "You can help translate the tool at <a class=\"twl-links\" href=\"https://translatewiki.net/wiki/Translating:Wikipedia_Library_Card_Platform\">translatewiki.net</a>."
 msgstr ""
 
 #. Translators: When the user starts a new application and submits the application, the user can view the application and withdraw if need be. This changes the label for the Withdraw button.
@@ -2932,9 +2582,7 @@ msgstr ""
 
 #. Translators: On the page listing applications, this text explains a user they cannot renew their application since they've already requested a renewal or there aren't any renewals available.
 #: TWLight/users/templates/users/my_applications.html:79
-msgid ""
-"Renewals are either not required, not available right now, or you have "
-"already requested a renewal."
+msgid "Renewals are either not required, not available right now, or you have already requested a renewal."
 msgstr ""
 
 #. Translators: This text is the heading of a section in a user's profile where they can change their preferences.
@@ -2998,19 +2646,12 @@ msgstr ""
 
 #. Translators: This message is displayed on the page where users can request we stop processing their data.
 #: TWLight/users/templates/users/restrict_data.html:15
-msgid ""
-"Checking this box and clicking “Restrict” will pause all processing of the "
-"data you have entered into this website. You will not be able to apply for "
-"access to resources, your applications will not be further processed, and "
-"none of your data will be altered, until you return to this page and uncheck "
-"the box. This is not the same as deleting your data."
+msgid "Checking this box and clicking “Restrict” will pause all processing of the data you have entered into this website. You will not be able to apply for access to resources, your applications will not be further processed, and none of your data will be altered, until you return to this page and uncheck the box. This is not the same as deleting your data."
 msgstr ""
 
 #. Translators: This warning message is shown to coordinators who view the data restriction page.
 #: TWLight/users/templates/users/restrict_data.html:26
-msgid ""
-"You are a coordinator on this site. If you restrict the processing of your "
-"data, your coordinator flag will be removed."
+msgid "You are a coordinator on this site. If you restrict the processing of your data, your coordinator flag will be removed."
 msgstr ""
 
 #. Translators: use the date *when you are translating*, in a language-appropriate format.
@@ -3030,24 +2671,12 @@ msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:51
-msgid ""
-"<a class=\"twl-links\" href=\"https://meta.wikimedia.org/wiki/"
-"The_Wikipedia_Library\"> The Wikipedia Library </a> has partnered with "
-"publishers around the world to allow users to access otherwise paywalled "
-"resources. This website allows Wikipedia editors to search and access these "
-"resources."
+msgid "<a class=\"twl-links\" href=\"https://meta.wikimedia.org/wiki/The_Wikipedia_Library\"> The Wikipedia Library </a> has partnered with publishers around the world to allow users to access otherwise paywalled resources. This website allows Wikipedia editors to search and access these resources."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Wikimedia Foundation should not be translated. WMF should not be translated. Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:63
-msgid ""
-"This program is administered by the Wikimedia Foundation (WMF). These terms "
-"of use and privacy notice pertain to your application for access to "
-"resources through the Wikipedia Library, your use of this website, and your "
-"access to and use of those resources. They also describe our handling of the "
-"information you provide to us in order to create and administer your "
-"Wikipedia Library account. If we make material changes to the terms, we will "
-"notify users."
+msgid "This program is administered by the Wikimedia Foundation (WMF). These terms of use and privacy notice pertain to your application for access to resources through the Wikipedia Library, your use of this website, and your access to and use of those resources. They also describe our handling of the information you provide to us in order to create and administer your Wikipedia Library account. If we make material changes to the terms, we will notify users."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
@@ -3057,37 +2686,17 @@ msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:78
-msgid ""
-"Access to resources via The Wikipedia Library is reserved for community "
-"members who have demonstrated their commitment to the Wikimedia projects, "
-"and who will use their access to these resources to improve project content. "
-"To that end, in order to be eligible for The Wikipedia Library, we require "
-"that you be registered for a user account on the projects, with at least 500 "
-"edits, six (6) months of activity, and 10+ edits in the last month. We ask "
-"that you do not request access to any publishers with a limited number of "
-"available accounts whose resources you can already access for free through "
-"your local library or university, or another institution or organization, in "
-"order to provide that opportunity to others."
+msgid "Access to resources via The Wikipedia Library is reserved for community members who have demonstrated their commitment to the Wikimedia projects, and who will use their access to these resources to improve project content. To that end, in order to be eligible for The Wikipedia Library, we require that you be registered for a user account on the projects, with at least 500 edits, six (6) months of activity, and 10+ edits in the last month. We ask that you do not request access to any publishers with a limited number of available accounts whose resources you can already access for free through your local library or university, or another institution or organization, in order to provide that opportunity to others."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:94
-msgid ""
-"Additionally, if you are currently blocked or banned from a Wikimedia "
-"project, applications to resources may be rejected or restricted. If you "
-"obtain a Wikipedia Library account, but a block or ban is subsequently "
-"instituted against you on one of the projects, you may lose access to your "
-"Wikipedia Library account."
+msgid "Additionally, if you are currently blocked or banned from a Wikimedia project, applications to resources may be rejected or restricted. If you obtain a Wikipedia Library account, but a block or ban is subsequently instituted against you on one of the projects, you may lose access to your Wikipedia Library account."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:104
-msgid ""
-"Your eligibility to access The Wikipedia Library is assessed at each login. "
-"While more than half of the library's content is provided via this automated "
-"eligibility check, access to other publisher's content may be time limited, "
-"typically lapsing after one year, after which you will usually need to apply "
-"for renewal."
+msgid "Your eligibility to access The Wikipedia Library is assessed at each login. While more than half of the library's content is provided via this automated eligibility check, access to other publisher's content may be time limited, typically lapsing after one year, after which you will usually need to apply for renewal."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
@@ -3097,47 +2706,27 @@ msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:118
-msgid ""
-"In order to apply for access to a partner resource, you must provide us with "
-"certain information, which we will use to evaluate your application. If your "
-"application is approved, we may transfer the information you have given us "
-"to the publishers whose resources you wish to access. They will either "
-"contact you with the account information directly or we will send access "
-"information to you ourselves."
+msgid "In order to apply for access to a partner resource, you must provide us with certain information, which we will use to evaluate your application. If your application is approved, we may transfer the information you have given us to the publishers whose resources you wish to access. They will either contact you with the account information directly or we will send access information to you ourselves."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:130
-msgid ""
-"In addition to the basic information you provide to us, our system will "
-"retrieve some information directly from the Wikimedia projects: your "
-"username, email address, edit count, registration date, user ID number, "
-"groups to which you belong, and any special user rights."
+msgid "In addition to the basic information you provide to us, our system will retrieve some information directly from the Wikimedia projects: your username, email address, edit count, registration date, user ID number, groups to which you belong, and any special user rights."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:140
-msgid ""
-"Each time you log in to the Wikipedia Library Card Platform, this "
-"information will be automatically updated."
+msgid "Each time you log in to the Wikipedia Library Card Platform, this information will be automatically updated."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:148
-msgid ""
-"We will ask you to provide us with some information about your history of "
-"contributions to the Wikimedia projects. Information on contribution history "
-"is optional, but will greatly assist us in evaluating your application."
+msgid "We will ask you to provide us with some information about your history of contributions to the Wikimedia projects. Information on contribution history is optional, but will greatly assist us in evaluating your application."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). WMF should not be translated. Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:157
-msgid ""
-"The information you provide when creating your account will be visible to "
-"you while on the site but not to others unless they are approved Wikipedia "
-"Library Coordinators, WMF Staff, or WMF Contractors who need access to this "
-"data in order to carry out their work with the Wikipedia Library, all of "
-"whom are subject to non-disclosure obligations."
+msgid "The information you provide when creating your account will be visible to you while on the site but not to others unless they are approved Wikipedia Library Coordinators, WMF Staff, or WMF Contractors who need access to this data in order to carry out their work with the Wikipedia Library, all of whom are subject to non-disclosure obligations."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
@@ -3147,46 +2736,32 @@ msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:171
-msgid ""
-"In order to access an individual publisher’s resources, you must agree to "
-"that publisher’s terms of use and privacy policy. You agree that you will "
-"not violate such terms and policies in connection with your use of the "
-"Wikipedia Library. Additionally, the following activities are prohibited "
-"while accessing publisher resources through the Wikipedia Library."
+msgid "In order to access an individual publisher’s resources, you must agree to that publisher’s terms of use and privacy policy. You agree that you will not violate such terms and policies in connection with your use of the Wikipedia Library. Additionally, the following activities are prohibited while accessing publisher resources through the Wikipedia Library."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:184
-msgid ""
-"Sharing your Wikipedia account, usernames, passwords, or any access codes "
-"for publisher resources with others;"
+msgid "Sharing your Wikipedia account, usernames, passwords, or any access codes for publisher resources with others;"
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:191
-msgid ""
-"Automatically scraping or downloading restricted content from publishers;"
+msgid "Automatically scraping or downloading restricted content from publishers;"
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:197
-msgid ""
-"Systematically making printed or electronic copies of multiple extracts of "
-"restricted content available for any purpose;"
+msgid "Systematically making printed or electronic copies of multiple extracts of restricted content available for any purpose;"
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:204
-msgid ""
-"Data mining metadata without permission—for example, in order to use "
-"metadata for auto-created stub articles;"
+msgid "Data mining metadata without permission—for example, in order to use metadata for auto-created stub articles;"
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:211
-msgid ""
-"Using the access you receive through the Wikipedia Library for profit by "
-"selling access to your account or resources which you have through it."
+msgid "Using the access you receive through the Wikipedia Library for profit by selling access to your account or resources which you have through it."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
@@ -3196,18 +2771,12 @@ msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:224
-msgid ""
-"Certain resources may only be accessed using an external search service, "
-"such as the EBSCO Discovery Service, or a proxy service, such as OCLC "
-"EZProxy. If you use such external search and/or proxy services, please "
-"review the applicable terms of use and privacy policies."
+msgid "Certain resources may only be accessed using an external search service, such as the EBSCO Discovery Service, or a proxy service, such as OCLC EZProxy. If you use such external search and/or proxy services, please review the applicable terms of use and privacy policies."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:234
-msgid ""
-"In addition, if you use OCLC EZProxy, please note that you may not use it "
-"for commercial purposes."
+msgid "In addition, if you use OCLC EZProxy, please note that you may not use it for commercial purposes."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
@@ -3217,120 +2786,49 @@ msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Wikimedia Foundation should not be translated. Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:245
-msgid ""
-"The Wikimedia Foundation and our service providers use your information for "
-"the legitimate purpose of providing Wikipedia Library services in support of "
-"our charitable mission. When you apply for a Wikipedia Library account, or "
-"use your Wikipedia Library account, we may routinely collect the following "
-"information: your username, email address, edit count, registration date, "
-"user ID number, groups to which you belong, and any special user rights; "
-"your name, country of residence, and/or affiliation, if required by a "
-"partner to which you are applying; your narrative description of your "
-"contributions and reasons for applying for access to partner resources; and "
-"the date you agree to these terms of use."
+msgid "The Wikimedia Foundation and our service providers use your information for the legitimate purpose of providing Wikipedia Library services in support of our charitable mission. When you apply for a Wikipedia Library account, or use your Wikipedia Library account, we may routinely collect the following information: your username, email address, edit count, registration date, user ID number, groups to which you belong, and any special user rights; your name, country of residence, and/or affiliation, if required by a partner to which you are applying; your narrative description of your contributions and reasons for applying for access to partner resources; and the date you agree to these terms of use."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:262
 #, python-format
-msgid ""
-"Each publisher who is a member of the Wikipedia Library program requires "
-"different specific information in the application. Some publishers may "
-"request only an email address, while others request more detailed data, such "
-"as your name, location, or institutional affiliation. When you complete your "
-"application, you will only be asked to supply information required by the "
-"publishers you have chosen, and each publisher will only receive the "
-"information they require for providing you with access. Please see our <a "
-"class=\"twl-links\" href=\"%(all_partners_url)s\">partner information</a> "
-"pages to learn what information is required by each publisher to gain access "
-"to their resources."
+msgid "Each publisher who is a member of the Wikipedia Library program requires different specific information in the application. Some publishers may request only an email address, while others request more detailed data, such as your name, location, or institutional affiliation. When you complete your application, you will only be asked to supply information required by the publishers you have chosen, and each publisher will only receive the information they require for providing you with access. Please see our <a class=\"twl-links\" href=\"%(all_partners_url)s\">partner information</a> pages to learn what information is required by each publisher to gain access to their resources."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Wikimedia Foundation should not be translated. Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:277
-msgid ""
-"Some Wikipedia Library pages are visible without logging in, but you will "
-"need to log in to apply or access proprietary partner resources. We use the "
-"data provided by you via OAuth and Wikimedia API calls to assess your "
-"application for access and to process approved requests."
+msgid "Some Wikipedia Library pages are visible without logging in, but you will need to log in to apply or access proprietary partner resources. We use the data provided by you via OAuth and Wikimedia API calls to assess your application for access and to process approved requests."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:288
 #, python-format
-msgid ""
-"In order to administer the Wikipedia Library program, we will retain the "
-"application data we collect from you for three years after your most recent "
-"login, unless you delete your account, as described below. You can log in "
-"and go to <a class=\"twl-links\" href=\"%(profile_url)s\">your profile page</"
-"a> in order to see the information associated with your account, and can "
-"download it in JSON format. You may access, update, restrict, or delete this "
-"information at any time, except for the information that is automatically "
-"retrieved from the projects. If you have any questions or concerns about the "
-"handling of your data, please contact <a class=\"twl-links\" href=\"mailto:"
-"wikipedialibrary@wikimedia.org?Subject=Wikipedia%%20Library%%20Card"
-"%%20account%%20deactivation\"> wikipedialibrary@wikimedia.org </a>."
+msgid "In order to administer the Wikipedia Library program, we will retain the application data we collect from you for three years after your most recent login, unless you delete your account, as described below. You can log in and go to <a class=\"twl-links\" href=\"%(profile_url)s\">your profile page</a> in order to see the information associated with your account, and can download it in JSON format. You may access, update, restrict, or delete this information at any time, except for the information that is automatically retrieved from the projects. If you have any questions or concerns about the handling of your data, please contact <a class=\"twl-links\" href=\"mailto:wikipedialibrary@wikimedia.org?Subject=Wikipedia%%20Library%%20Card%%20account%%20deactivation\"> wikipedialibrary@wikimedia.org </a>."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:305
-msgid ""
-"If you decide to disable your Wikipedia Library account, you can use the "
-"delete button on your profile to delete certain personal information "
-"associated with your account. We will delete your real name, institutional "
-"affiliation, and country of residence. Please note that the system will "
-"retain a record of your username, the publishers to which you applied or had "
-"access, and the dates of that access. Note that deletion is not reversible. "
-"Deletion of your Wikipedia Library account may also correspond with the "
-"removal of any resource access to which you were eligible or approved. If "
-"you request the deletion of account information and later wish to apply for "
-"a new account, you will need to provide the necessary information again."
+msgid "If you decide to disable your Wikipedia Library account, you can use the delete button on your profile to delete certain personal information associated with your account. We will delete your real name, institutional affiliation, and country of residence. Please note that the system will retain a record of your username, the publishers to which you applied or had access, and the dates of that access. Note that deletion is not reversible. Deletion of your Wikipedia Library account may also correspond with the removal of any resource access to which you were eligible or approved. If you request the deletion of account information and later wish to apply for a new account, you will need to provide the necessary information again."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). WMF should not be translated. Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:321
-msgid ""
-"The Wikipedia Library is run by WMF Staff, Contractors, and approved "
-"volunteer Coordinators. The data associated with your account will be shared "
-"with the WMF staff, contractors, service providers, and volunteer "
-"coordinators who need to process the information in connection with their "
-"work for the Wikipedia Library, and who are subject to confidentiality "
-"obligations. We will also use your data for internal Wikipedia Library "
-"purposes such as distributing user surveys and account notifications, and in "
-"a depersonalized or aggregated fashion for statistical analysis and "
-"administration. Finally, we will share your information with the publishers "
-"whom you specifically select in order to provide you with access to "
-"resources. Otherwise, your information will not be shared with third "
-"parties, with the exception of the circumstances described below."
+msgid "The Wikipedia Library is run by WMF Staff, Contractors, and approved volunteer Coordinators. The data associated with your account will be shared with the WMF staff, contractors, service providers, and volunteer coordinators who need to process the information in connection with their work for the Wikipedia Library, and who are subject to confidentiality obligations. We will also use your data for internal Wikipedia Library purposes such as distributing user surveys and account notifications, and in a depersonalized or aggregated fashion for statistical analysis and administration. Finally, we will share your information with the publishers whom you specifically select in order to provide you with access to resources. Otherwise, your information will not be shared with third parties, with the exception of the circumstances described below."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). WMF should not be translated.
 #: TWLight/users/templates/users/terms.html:338
-msgid ""
-"We may disclose any collected information when required by law, when we have "
-"your permission, when needed to protect our rights, privacy, safety, users, "
-"or the general public, and when necessary to enforce these terms, WMF’s "
-"general <a class=\"twl-links\" href=\"https://foundation.wikimedia.org/wiki/"
-"Terms_of_Use\">Terms of Use</a>, or any other WMF policy."
+msgid "We may disclose any collected information when required by law, when we have your permission, when needed to protect our rights, privacy, safety, users, or the general public, and when necessary to enforce these terms, WMF’s general <a class=\"twl-links\" href=\"https://foundation.wikimedia.org/wiki/Terms_of_Use\">Terms of Use</a>, or any other WMF policy."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:349
-msgid ""
-"We take the security of your personal data seriously, and take reasonable "
-"precautions to ensure your data is protected. These precautions include "
-"access controls to limit who has access to your data and security "
-"technologies to protect data stored on the server. However, we cannot "
-"guarantee the safety of your data as it is transmitted and stored."
+msgid "We take the security of your personal data seriously, and take reasonable precautions to ensure your data is protected. These precautions include access controls to limit who has access to your data and security technologies to protect data stored on the server. However, we cannot guarantee the safety of your data as it is transmitted and stored."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:360
-msgid ""
-"Please note that these terms do not control the use and handling of your "
-"data by the publishers and service providers whose resources you access or "
-"apply to access. Please read their individual privacy policies for that "
-"information."
+msgid "Please note that these terms do not control the use and handling of your data by the publishers and service providers whose resources you access or apply to access. Please read their individual privacy policies for that information."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
@@ -3340,34 +2838,17 @@ msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Wikimedia Foundation should not be translated. Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:373
-msgid ""
-"The Wikimedia Foundation is a nonprofit organization based in San Francisco, "
-"California. The Wikipedia Library program provides access to resources held "
-"by publishers in multiple countries. If you apply for a Wikipedia Library "
-"account (whether you are inside or outside of the United States), you "
-"understand that your personal data will be collected, transferred, stored, "
-"processed, disclosed and otherwise used in the U.S. as described in this "
-"privacy policy. You also understand that your information may be transferred "
-"by us from the U.S. to other countries, which may have different or less "
-"stringent data protection laws than your country, in connection with "
-"providing services to you, including evaluating your application and "
-"securing access to your chosen publishers (locations for each publisher are "
-"outlined on their respective partner information pages)."
+msgid "The Wikimedia Foundation is a nonprofit organization based in San Francisco, California. The Wikipedia Library program provides access to resources held by publishers in multiple countries. If you apply for a Wikipedia Library account (whether you are inside or outside of the United States), you understand that your personal data will be collected, transferred, stored, processed, disclosed and otherwise used in the U.S. as described in this privacy policy. You also understand that your information may be transferred by us from the U.S. to other countries, which may have different or less stringent data protection laws than your country, in connection with providing services to you, including evaluating your application and securing access to your chosen publishers (locations for each publisher are outlined on their respective partner information pages)."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:392
-msgid ""
-"Please note that in the event of any differences in meaning or "
-"interpretation between the original English version of these terms and a "
-"translation, the original English version takes precedence."
+msgid "Please note that in the event of any differences in meaning or interpretation between the original English version of these terms and a translation, the original English version takes precedence."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Wikimedia Foundation should not be translated.
 #: TWLight/users/templates/users/terms.html:403
-msgid ""
-"See also the <a class=\"twl-links\" href=\"https://wikimediafoundation.org/"
-"wiki/Privacy_policy\">Wikimedia Foundation Privacy Policy</a>."
+msgid "See also the <a class=\"twl-links\" href=\"https://wikimediafoundation.org/wiki/Privacy_policy\">Wikimedia Foundation Privacy Policy</a>."
 msgstr ""
 
 #. Translators: This is the second to last line of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
@@ -3387,11 +2868,7 @@ msgstr "Задужбина Викимедија"
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:426
-msgid ""
-"By checking this box and clicking “Submit”, you agree that you have read the "
-"above terms and that you will adhere to the terms of use in your application "
-"to and use of the The Wikipedia Library, and the publishers’ services to "
-"which you gain access through The Wikipedia Library program."
+msgid "By checking this box and clicking “Submit”, you agree that you have read the above terms and that you will adhere to the terms of use in your application to and use of the The Wikipedia Library, and the publishers’ services to which you gain access through The Wikipedia Library program."
 msgstr ""
 
 #: TWLight/users/templates/users/user_collection_tile.html:32
@@ -3444,29 +2921,18 @@ msgstr "Избриши све податке"
 
 #. Translators: This message is displayed on the page where users can request the deletion of their data.
 #: TWLight/users/templates/users/user_confirm_delete.html:17
-msgid ""
-"<b>Warning:</b> Performing this action will delete your Wikipedia Library "
-"Card user account and all associated applications. This process is not "
-"reversible. You may lose any partner accounts you were granted, and will not "
-"be able to renew those accounts or apply for new ones."
+msgid "<b>Warning:</b> Performing this action will delete your Wikipedia Library Card user account and all associated applications. This process is not reversible. You may lose any partner accounts you were granted, and will not be able to renew those accounts or apply for new ones."
 msgstr ""
 
 #. Translators: this should show up for people who log in with a username/password and not OAuth, so we don't know what their Wikipedia identity is.
-#.
 #: TWLight/users/templates/users/user_detail.html:12
 #, python-format
-msgid ""
-"Hi, %(username)s! You don't have a Wikipedia editor profile attached to your "
-"account here, so you are probably a site administrator."
+msgid "Hi, %(username)s! You don't have a Wikipedia editor profile attached to your account here, so you are probably a site administrator."
 msgstr ""
 
 #. Translators: In the unlikely scenario that someone is able to register an account without using OAuth (thus leaving us without some of the information required for applications), users will see this message, encouraging them to re-register.
 #: TWLight/users/templates/users/user_detail.html:20
-msgid ""
-"If you aren't a site administrator, something weird has happened. You won't "
-"be able to apply for access without a Wikipedia editor profile. You should "
-"log out and create a new account by logging in via OAuth, or contact a site "
-"administrator for help."
+msgid "If you aren't a site administrator, something weird has happened. You won't be able to apply for access without a Wikipedia editor profile. You should log out and create a new account by logging in via OAuth, or contact a site administrator for help."
 msgstr ""
 
 #. Translators: Labels a sections where coordinators can select their email preferences.
@@ -3477,17 +2943,12 @@ msgstr ""
 #. Translators: This message is shown on user's own profile page, encouraging them to make sure their information is up to date, so that account coordinators can use the information to judge applications.
 #: TWLight/users/views.py:176
 #, python-brace-format
-msgid ""
-"Please <a class='twl-links' href='{url}'>update your contributions</a> to "
-"Wikipedia to help coordinators evaluate your applications."
+msgid "Please <a class='twl-links' href='{url}'>update your contributions</a> to Wikipedia to help coordinators evaluate your applications."
 msgstr ""
 
 #. Translators: Coordinators are shown this message when they unselect all three types of reminder email options under preferences.
 #: TWLight/users/views.py:288
-msgid ""
-"You have chosen not to receive reminder emails. As a coordinator, you should "
-"receive at least one type of reminder emails, so consider changing your "
-"preferences."
+msgid "You have chosen not to receive reminder emails. As a coordinator, you should receive at least one type of reminder emails, so consider changing your preferences."
 msgstr ""
 
 #. Translators: Coordinators are shown this message when they make changes to their reminder email options under preferences.
@@ -3521,9 +2982,7 @@ msgstr "Ваш имејл је промењен на имејл {email}."
 
 #. Translators: If the user has not filled out their email, they can browse the website but cannot apply for access to resources.
 #: TWLight/users/views.py:487
-msgid ""
-"Your email is blank. You can still explore the site, but you won't be able "
-"to apply for access to partner resources without an email."
+msgid "Your email is blank. You can still explore the site, but you won't be able to apply for access to partner resources without an email."
 msgstr ""
 
 #. Translators: This message is shown once the access to a partner has successfully been returned.
@@ -3556,31 +3015,3 @@ msgstr ""
 msgid "10+ edits in the last 30 days"
 msgstr ""
 
-#: tests/shunit/data/bad_i18n_comment_1.py:3
-#: tests/shunit/data/bad_i18n_newline_1.py:5
-msgid "1"
-msgstr ""
-
-#. Translators: Lorem ipsum dolor sit amet, consectetur adipiscing elit. Mauris vitae ipsum ut purus faucibus pretium. Proin tempus neque et aliquet consectetur. Ut egestas sapien in consectetur sagittis. Mauris neque lacus, dapibus non viverra vitae, interdum ut aenean ipsum.
-#. Translators: Lorem ipsum dolor sit amet, consectetur adipiscing elit. Mauris vitae ipsum ut purus faucibus pretium. Proin tempus neque et aliquet consectetur. Ut egestas sapien in consectetur sagittis. Mauris neque lacus, dapibus non.
-#: tests/shunit/data/bad_i18n_comment_2.py:4
-#: tests/shunit/data/bad_i18n_newline_2.py:5 tests/shunit/data/good_i18n_1.py:2
-#: tests/shunit/data/good_i18n_2.py:2
-msgid "2"
-msgstr ""
-
-#: tests/shunit/data/bad_i18n_newline_3.py:5
-msgid "3"
-msgstr ""
-
-#: tests/shunit/data/bad_i18n_newline_4.py:5
-msgid "4"
-msgstr ""
-
-#: tests/shunit/data/bad_i18n_newline_5.py:5
-msgid "5"
-msgstr ""
-
-#: tests/shunit/data/bad_i18n_newline_6.py:5
-msgid "6"
-msgstr ""

--- a/locale/sv/LC_MESSAGES/django.po
+++ b/locale/sv/LC_MESSAGES/django.po
@@ -10,10 +10,11 @@
 # Author: WikiPhoenix
 msgid ""
 msgstr ""
+""
 "Project-Id-Version: Wikipedia Library Card Platform - Website\n"
-"Report-Msgid-Bugs-To: wikipedialibrary@wikimedia.org\n"
+"Report-Msgid-Bugs-To: translatewiki.net\n"
 "POT-Creation-Date: 2024-07-11 20:54+0000\n"
-"PO-Revision-Date: 2024-07-11 12:30:19+0000\n"
+"PO-Revision-Date: 2024-07-15 12:29:19+0000\n"
 "Language: sv\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
@@ -45,12 +46,8 @@ msgstr "Om dig"
 #. Translators: This note appears in a section of a form where we ask users to enter info (like country of residence) when applying for resource access.
 #: TWLight/applications/forms.py:179
 #, python-brace-format
-msgid ""
-"<p><small><i>Your personal data will be processed according to our <a "
-"class='twl-links' href='{terms_url}'> privacy policy</a>.</i></small></p>"
-msgstr ""
-"<p><small><i>Din personliga data kommer att bearbetas enligt vår <a "
-"class='twl-links' href='{terms_url}'>integritetspolicy</a>.</i></small></p>"
+msgid "<p><small><i>Your personal data will be processed according to our <a class='twl-links' href='{terms_url}'> privacy policy</a>.</i></small></p>"
+msgstr "<p><small><i>Din personliga data kommer att bearbetas enligt vår <a class='twl-links' href='{terms_url}'>integritetspolicy</a>.</i></small></p>"
 
 #. Translators: This is the title of the application form page, where users enter information required for the application. It lets the user know which partner application they are entering data for. {partner}
 #: TWLight/applications/forms.py:189
@@ -92,9 +89,7 @@ msgstr "E-postadressen för ditt konto på partnerns webbplats"
 #. Translators: This labels a choice field where users will have to select the number of months they wish to have their access for as part of the application renewal confirmation.
 #. Translators: When filling out an application, users may be required to enter the length of the account (expiry) they wish to have for proxy partners.
 #: TWLight/applications/forms.py:339 TWLight/applications/helpers.py:100
-msgid ""
-"The number of months you wish to have this access for before renewal is "
-"required"
+msgid "The number of months you wish to have this access for before renewal is required"
 msgstr "Antalet månader du önskar ha tillgång innan det krävs att du förnyar"
 
 #. Translators: When filling out an application, users may need to specify their name
@@ -183,12 +178,8 @@ msgstr "E-post"
 
 #. Translators: This comment is added to pending applications when our terms of use change.
 #: TWLight/applications/management/commands/notify_applicants_tou_changes.py:54
-msgid ""
-"Our terms of use have changed. Your applications will not be processed until "
-"you log in and agree to our updated terms."
-msgstr ""
-"Våra användningsvillkor har ändrats. Dina ansökningar kommer inte bearbetas "
-"fören du loggar in och godkänner våra uppdaterade villkor."
+msgid "Our terms of use have changed. Your applications will not be processed until you log in and agree to our updated terms."
+msgstr "Våra användningsvillkor har ändrats. Dina ansökningar kommer inte bearbetas fören du loggar in och godkänner våra uppdaterade villkor."
 
 #. Translators: This is the status of an application that has not yet been reviewed.
 #: TWLight/applications/models.py:54
@@ -255,42 +246,26 @@ msgstr "Åtkomst-URL: {access_url}"
 
 #. Translators: This text goes into account approval emails in the case that we need to send the user's details to a publisher for manual account setup.
 #: TWLight/applications/models.py:331
-msgid ""
-"You can expect to receive access details within a week or two once it has "
-"been processed."
-msgstr ""
-"Du kan räkna med att få åtkomstdetaljer inom en vecka eller två när det väl "
-"har bearbetats."
+msgid "You can expect to receive access details within a week or two once it has been processed."
+msgstr "Du kan räkna med att få åtkomstdetaljer inom en vecka eller två när det väl har bearbetats."
 
 #. Translators: This comment is added to open applications when a partner joins the Library Bundle, which does not require applications.
 #: TWLight/applications/signals.py:247
-msgid ""
-"This partner joined the Library Bundle, which does not require applications. "
-"This application will be marked as invalid."
-msgstr ""
-"Denna partner gick med i bibliotekspaketet, vilket inte kräver godkännande. "
-"Denna begäran kommer att markeras som ogiltig."
+msgid "This partner joined the Library Bundle, which does not require applications. This application will be marked as invalid."
+msgstr "Denna partner gick med i bibliotekspaketet, vilket inte kräver godkännande. Denna begäran kommer att markeras som ogiltig."
 
 #. Translators: This is shown to users if the application is to a partner for which we have run out of available accounts. The application is therefore on a 'waitlist', and will be reviewed when more accounts are available.
 #: TWLight/applications/templates/applications/application_evaluation.html:29
-msgid ""
-"This application is on the waitlist because this partner does not have any "
-"access grants available at this time."
-msgstr ""
-"Denna ansökan finns på väntelistan eftersom den här partnern inte har några "
-"lediga konton för närvarande."
+msgid "This application is on the waitlist because this partner does not have any access grants available at this time."
+msgstr "Denna ansökan finns på väntelistan eftersom den här partnern inte har några lediga konton för närvarande."
 
 #. Translators: This message is shown on pages where coordinators can see personal information about applicants.
 #: TWLight/applications/templates/applications/application_evaluation.html:36
 #: TWLight/applications/templates/applications/application_list_include.html:6
 #: TWLight/applications/templates/applications/send_partner.html:45
 #: TWLight/resources/templates/resources/partner_users.html:18
-msgid ""
-"Coordinators: This page may contain personal information such as real names "
-"and email addresses. Please remember that this information is confidential."
-msgstr ""
-"Samordnare: Den här sidan kan innehålla personlig information som riktiga "
-"namn och e-postadresser. Kom ihåg att denna information är konfidentiell."
+msgid "Coordinators: This page may contain personal information such as real names and email addresses. Please remember that this information is confidential."
+msgstr "Samordnare: Den här sidan kan innehålla personlig information som riktiga namn och e-postadresser. Kom ihåg att denna information är konfidentiell."
 
 #. Translators: This is the title of the application page shown to users who are a coordinator, and are able to accept or reject the application.
 #: TWLight/applications/templates/applications/application_evaluation.html:39
@@ -299,12 +274,8 @@ msgstr "Utvärdera ansökning"
 
 #. Translators: This text is shown to coordinators on application pages if the applicant has restricted processing of their data.
 #: TWLight/applications/templates/applications/application_evaluation.html:42
-msgid ""
-"This user has requested a restriction on the processing of their data, so "
-"you cannot change the status of their application."
-msgstr ""
-"Den här användaren har begärt en begränsning av behandlingen av sina "
-"uppgifter, så du kan inte ändra statusen på hens ansökan."
+msgid "This user has requested a restriction on the processing of their data, so you cannot change the status of their application."
+msgstr "Den här användaren har begärt en begränsning av behandlingen av sina uppgifter, så du kan inte ändra statusen på hens ansökan."
 
 #. Translators: This is the title of the application page shown to users who are not a coordinator.
 #: TWLight/applications/templates/applications/application_evaluation.html:48
@@ -378,9 +349,7 @@ msgstr "Okänd"
 
 #. Translators: This is the text displayed to coordinators when an applicant has no country of residence in their profile.
 #: TWLight/applications/templates/applications/application_evaluation.html:123
-msgid ""
-"Please request the applicant add their country of residence to their profile "
-"before proceeding further."
+msgid "Please request the applicant add their country of residence to their profile before proceeding further."
 msgstr "Be sökanden lägga till sitt hemland i sin profil innan den går vidare."
 
 #. Translators: This labels the section of an application showing the total number of accounts available for a partner or their collection.
@@ -392,12 +361,8 @@ msgstr "Inte tillgänglig"
 #. Translators: This labels the section of an application showing whether the user had agreed to the terms of use or not.
 #: TWLight/applications/templates/applications/application_evaluation.html:145
 #, python-format
-msgid ""
-"Has agreed to the site's <a class=\"twl-links\" href=\"%(terms_url)s\">terms "
-"of use</a>?"
-msgstr ""
-"Har samtyckt till webbplatsens <a class=\"twl-links\" href=\"%(terms_url)s"
-"\">användarvillkor</a>?"
+msgid "Has agreed to the site's <a class=\"twl-links\" href=\"%(terms_url)s\">terms of use</a>?"
+msgstr "Har samtyckt till webbplatsens <a class=\"twl-links\" href=\"%(terms_url)s\">användarvillkor</a>?"
 
 #. Translators: Displayed to coordinators when they've agreed to the terms of use.
 #. Translators: Displayed if the user has agreed to the terms of use.
@@ -432,12 +397,8 @@ msgstr "Nej"
 
 #. Translators: This is the text displayed to coordinators when an applicant has not agreed to the terms of use.
 #: TWLight/applications/templates/applications/application_evaluation.html:159
-msgid ""
-"Please request the applicant agree to the site's terms of use before "
-"approving this application."
-msgstr ""
-"Vänligen begär att sökanden godkänner webbplatsens användarvillkor innan du "
-"godkänner denna ansökan."
+msgid "Please request the applicant agree to the site's terms of use before approving this application."
+msgstr "Vänligen begär att sökanden godkänner webbplatsens användarvillkor innan du godkänner denna ansökan."
 
 #. Translators: This labels the section of an application containing the user's motivation for wanting access to this resource.
 #: TWLight/applications/templates/applications/application_evaluation.html:176
@@ -457,10 +418,8 @@ msgstr "Förnyelse av befintligt konto?"
 #. Translators: This message is shown next to the 'Renewal of existing access grant?' label if the application is a renewal. Don't translate HTML tags or parent_url.
 #: TWLight/applications/templates/applications/application_evaluation.html:195
 #, python-format
-msgid ""
-"Yes (<a class=\"twl-links\" href=\"%(parent_url)s\">previous application</a>)"
-msgstr ""
-"Ja (<a class=\"twl-links\" href=\"%(parent_url)s\">föregående ansökan</a>)"
+msgid "Yes (<a class=\"twl-links\" href=\"%(parent_url)s\">previous application</a>)"
+msgstr "Ja (<a class=\"twl-links\" href=\"%(parent_url)s\">föregående ansökan</a>)"
 
 #. Translators: This labels the section of the application showing the length of access remaining on the user's previous authorization.
 #: TWLight/applications/templates/applications/application_evaluation.html:208
@@ -494,12 +453,8 @@ msgstr "Lägg till kommentar"
 
 #. Translators: On an application page, this text tells users that the comments posted on the application are visible to coordinators and the submitting user only.
 #: TWLight/applications/templates/applications/application_evaluation.html:297
-msgid ""
-"Comments are visible to all coordinators and to the editor who submitted "
-"this application."
-msgstr ""
-"Kommentarer är synliga för alla koordinatörer och redigeraren som skickade "
-"in denna ansökan."
+msgid "Comments are visible to all coordinators and to the editor who submitted this application."
+msgstr "Kommentarer är synliga för alla koordinatörer och redigeraren som skickade in denna ansökan."
 
 #. Translators: This is the title of the section of an application page which lists information about the user who submitted the application.
 #. Translators: On the page where coordinators can view data on applications to a partner they coordinate, this is a table column heading for the username.
@@ -713,17 +668,8 @@ msgstr "Ändra status"
 
 #: TWLight/applications/templates/applications/apply.html:20
 #, python-format
-msgid ""
-"If your application is successful we may share your email address with "
-"%(partner)s. This is required to set up your access to their resources. By "
-"submitting this form you agree to allow your email address to be shared with "
-"%(partner)s if your application is successful, for the purposes of account "
-"setup."
-msgstr ""
-"Om din ansökan godkänns kan vi komma att dela din e-postadress med "
-"%(partner)s. Detta krävs för att ge dig åtkomst till deras resurser. Genom "
-"att skicka in det här formuläret godkänner du att din e-postadress delas med "
-"%(partner)s om din ansökan godkänns, i syfte att skapa konto."
+msgid "If your application is successful we may share your email address with %(partner)s. This is required to set up your access to their resources. By submitting this form you agree to allow your email address to be shared with %(partner)s if your application is successful, for the purposes of account setup."
+msgstr "Om din ansökan godkänns kan vi komma att dela din e-postadress med %(partner)s. Detta krävs för att ge dig åtkomst till deras resurser. Genom att skicka in det här formuläret godkänner du att din e-postadress delas med %(partner)s om din ansökan godkänns, i syfte att skapa konto."
 
 #. Translators: This message is displayed on the page where users can confirm their renewal. Please do not translate partner.
 #: TWLight/applications/templates/applications/confirm_renewal.html:23
@@ -751,9 +697,7 @@ msgstr "Vilken resurs vill du komma åt?"
 
 #. Translators: This text explains that Library Bundle partners are not shown in this list.
 #: TWLight/applications/templates/applications/request_for_application.html:26
-msgid ""
-"Library Bundle partners are not shown as eligibility is determined "
-"automatically."
+msgid "Library Bundle partners are not shown as eligibility is determined automatically."
 msgstr ""
 
 #. Translators: On the page where users can apply for multiple partners, this message shows next to the partner name, taking them to the full application page when clicked.
@@ -768,10 +712,7 @@ msgstr "Ingen partnerdata har ännu lagts till."
 
 #. Translators: the HTML is so that the word 'waitlisted' will look the same as it does in the page above; please translate 'waitlisted' the same way you did elsewhere in this file.
 #: TWLight/applications/templates/applications/request_for_application.html:74
-msgid ""
-"You can apply to <span class=\"badge badge-warning\">Waitlisted</span> "
-"partners, but they don't have access grants available right now. We will "
-"process those applications when access becomes available."
+msgid "You can apply to <span class=\"badge badge-warning\">Waitlisted</span> partners, but they don't have access grants available right now. We will process those applications when access becomes available."
 msgstr ""
 
 #. Translators: On the page where coordinators can see approved applications which have not had their details sent to the partner, this message shows when there are applications ready to be processed.
@@ -793,12 +734,8 @@ msgstr "Ansökningsdata för %(object)s"
 #. Translators: This message is shown when applications exceed the number of accounts available.
 #: TWLight/applications/templates/applications/send_partner.html:54
 #, python-format
-msgid ""
-"Application(s) for %(object)s, if sent, will exceed the total available "
-"accounts for the partner. Please proceed at your own discretion."
-msgstr ""
-"Ansökning(ar) för %(object)s, om de skickas, kommer de överstrida antalet "
-"tillgängliga konton för partnern. Fortsätt på eget bevåg."
+msgid "Application(s) for %(object)s, if sent, will exceed the total available accounts for the partner. Please proceed at your own discretion."
+msgstr "Ansökning(ar) för %(object)s, om de skickas, kommer de överstrida antalet tillgängliga konton för partnern. Fortsätt på eget bevåg."
 
 #. Translators: When viewing the list of applications ready to be sent for a particular partner, this is instructions for the coordinator to click the 'mark as sent' button after they have sent the information.
 #: TWLight/applications/templates/applications/send_partner.html:65
@@ -814,9 +751,7 @@ msgstr[1] "Kontakter"
 
 #. Translators: When viewing the list of applications ready to be sent for a particular partner, this message shows if there is no information about who the applications should be sent to. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/applications/templates/applications/send_partner.html:89
-msgid ""
-"Whoops, we don't have any listed contacts. Please notify Wikipedia Library "
-"administrators."
+msgid "Whoops, we don't have any listed contacts. Please notify Wikipedia Library administrators."
 msgstr ""
 
 #. Translators: When viewing the list of applications ready to be sent for a particular partner, this is the title of the section containing the information about those applications.
@@ -832,9 +767,7 @@ msgstr "Markera som skickad"
 
 #. Translators: This text guides coordinators in using the code sending interface for approved applications.
 #: TWLight/applications/templates/applications/send_partner.html:152
-msgid ""
-"Use the dropdown menus to denote which editor will receive each code. Access "
-"codes will be sent to users automatically."
+msgid "Use the dropdown menus to denote which editor will receive each code. Access codes will be sent to users automatically."
 msgstr ""
 
 #. Translators: This labels a drop-down selection where staff can assign an access code to a user.
@@ -850,21 +783,14 @@ msgstr "Det finns inga godkända, oskickade ansökningar."
 #. Translators: When a user applies for a set of resources, they receive this message if none are currently available. They are instead placed on a 'waitlist' for later approval.
 #. Translators: When a user renews their resource, they receive this message if none are currently available. They are instead placed on a 'waitlist' for later approval.
 #: TWLight/applications/views.py:140 TWLight/applications/views.py:1282
-msgid ""
-"This partner does not have any access grants available at this time. You may "
-"still apply for access; your application will be reviewed when access grants "
-"become available."
+msgid "This partner does not have any access grants available at this time. You may still apply for access; your application will be reviewed when access grants become available."
 msgstr ""
 
 #. Translators: This message is shown to users once they've successfully submitted their application for review.
 #: TWLight/applications/views.py:163
 #, python-brace-format
-msgid ""
-"Your application has been submitted for review. Head over to <a "
-"href='{applications_url}'>My Applications</a> to view the status."
-msgstr ""
-"Din ansökan har skickats in för granskning. Gå till <a "
-"href='{applications_url}'>Mina ansökningar</a> för att se statusen."
+msgid "Your application has been submitted for review. Head over to <a href='{applications_url}'>My Applications</a> to view the status."
+msgstr "Din ansökan har skickats in för granskning. Gå till <a href='{applications_url}'>Mina ansökningar</a> för att se statusen."
 
 #. Translators: This text is displayed to users when the user has chosen to restrict data and is trying to apply for multiple partners
 #: TWLight/applications/views.py:276
@@ -912,16 +838,12 @@ msgstr "Skickade ansökningar"
 
 #. Translators: After a coordinator has changed the status of an application to APPROVED, if the corresponding partner/collection is waitlisted this message appears.
 #: TWLight/applications/views.py:756
-msgid ""
-"Cannot approve application as partner with proxy authorization method is "
-"waitlisted."
+msgid "Cannot approve application as partner with proxy authorization method is waitlisted."
 msgstr ""
 
 #. Translators: After a coordinator has changed the status of an application to APPROVED, if the corresponding partner/collection has no accounts for distribution, this message appears.
 #: TWLight/applications/views.py:780
-msgid ""
-"Cannot approve application as partner with proxy authorization method is "
-"waitlisted and (or) has zero accounts available for distribution."
+msgid "Cannot approve application as partner with proxy authorization method is waitlisted and (or) has zero accounts available for distribution."
 msgstr ""
 
 #. Translators: This message appears on an "access denied" screen that stops users who attempt to authorize an editor to access a resource during a time period for which they are already authorized.
@@ -932,11 +854,7 @@ msgstr ""
 #. Translators: This message is shown to users when they access an application page of a now Bundle partner (new applications aren't allowed for Bundle partners and the status of old applications cannot be modified)
 #: TWLight/applications/views.py:857
 #, python-brace-format
-msgid ""
-"This application cannot be modified since this partner is now part of our <a "
-"href='{bundle}'>bundle access</a>. If you are eligible, you can access this "
-"resource from <a href='{library}'>your library</a>. <a "
-"href='{contact}'>Contact us</a> if you have any questions."
+msgid "This application cannot be modified since this partner is now part of our <a href='{bundle}'>bundle access</a>. If you are eligible, you can access this resource from <a href='{library}'>your library</a>. <a href='{contact}'>Contact us</a> if you have any questions."
 msgstr ""
 
 #. Translators: this lets a reviewer set the status of a single application.
@@ -946,9 +864,7 @@ msgstr "Ändra ansökningsstatus"
 
 #. Translators: This warning is message is shown to applicants when the number of pending applications is greater than the number of accounts available.
 #: TWLight/applications/views.py:891
-msgid ""
-"There are more pending applications than available accounts. Your "
-"application might get waitlisted."
+msgid "There are more pending applications than available accounts. Your application might get waitlisted."
 msgstr ""
 
 #. Translators: this message is shown to coordinators who attempt to change an application's Status from INVALID to any other Status.
@@ -968,11 +884,7 @@ msgstr ""
 
 #. Translators: After a coordinator has changed the status of a number of applications to APPROVED, if the corresponding partner(s) is/are waitlisted or has no accounts for distribution, this message appears.
 #: TWLight/applications/views.py:1051
-msgid ""
-"Cannot approve application(s) {} as partner(s) with proxy authorization "
-"method is/are waitlisted and (or) has/have not enough accounts available. If "
-"not enough accounts are available, prioritise the applications and then "
-"approve applications equal to the accounts available."
+msgid "Cannot approve application(s) {} as partner(s) with proxy authorization method is/are waitlisted and (or) has/have not enough accounts available. If not enough accounts are available, prioritise the applications and then approve applications equal to the accounts available."
 msgstr ""
 
 #. Translators: This message is shown to coordinators who attempt to assign the same access code to multiple users.
@@ -987,9 +899,7 @@ msgstr "Alla markerade ansökningar har markerats som skickade."
 
 #. Translators: When a user tries to renew their resource, they receive this message if the partner is not available.
 #: TWLight/applications/views.py:1272
-msgid ""
-"Cannot renew application at this time as partner is not available. Please "
-"check back later, or contact us for more information."
+msgid "Cannot renew application at this time as partner is not available. Please check back later, or contact us for more information."
 msgstr ""
 
 #. Translators: This message is displayed when an attempt by a user to renew an application has been denied for some reason.
@@ -1000,16 +910,12 @@ msgstr "Försök att förnya ickegodkänd applikation #{pk} nekades"
 
 #. Translators: If a user requests the renewal of their account, but it wasn't renewed, this message is shown to them.
 #: TWLight/applications/views.py:1385
-msgid ""
-"This object cannot be renewed. (This probably means that you have already "
-"requested that it be renewed.)"
+msgid "This object cannot be renewed. (This probably means that you have already requested that it be renewed.)"
 msgstr ""
 
 #. Translators: If a user requests the renewal of their account, this message is shown to them.
 #: TWLight/applications/views.py:1395
-msgid ""
-"Your renewal request has been received. A coordinator will review your "
-"request."
+msgid "Your renewal request has been received. A coordinator will review your request."
 msgstr ""
 
 #. Translators: This labels a textfield where users can enter their email ID.
@@ -1019,12 +925,8 @@ msgstr "Din e-post"
 
 #. Translators: This is the help text for the email field in the contact us form letting users know the field is updated by value pulled from their respective user profiles.
 #: TWLight/emails/forms.py:21
-msgid ""
-"This field is automatically updated with the email from your <a class='twl-"
-"links' href='{}'>user profile</a>."
-msgstr ""
-"Det här fältet uppdateras automatiskt med e-postadressen från din <a "
-"class='twl-links' href='{}'>användarprofil</a>."
+msgid "This field is automatically updated with the email from your <a class='twl-links' href='{}'>user profile</a>."
+msgstr "Det här fältet uppdateras automatiskt med e-postadressen från din <a class='twl-links' href='{}'>användarprofil</a>."
 
 #. Translators: This labels a textfield where users can enter their email message.
 #: TWLight/emails/forms.py:26
@@ -1047,19 +949,13 @@ msgstr "Skicka"
 #. Translators: This email is sent to users with their access code. Don't translate Jinja variables in curly braces like user or partner. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/access_code_email-body-html.html:5
 #, python-format
-msgid ""
-"<p>Your approved application to %(partner)s has now been finalised. Your "
-"access code or login details can be found below:</p> <p><b>%(access_code)s</"
-"b></p> <p>%(user_instructions)s</p>"
+msgid "<p>Your approved application to %(partner)s has now been finalised. Your access code or login details can be found below:</p> <p><b>%(access_code)s</b></p> <p>%(user_instructions)s</p>"
 msgstr ""
 
 #. Translators: This email is sent to users with their access code. Don't translate Jinja variables in curly braces like user or partner. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/access_code_email-body-text.html:3
 #, python-format
-msgid ""
-"Your approved application to %(partner)s has now been finalised. Your access "
-"code or login details can be found below: %(access_code)s "
-"%(user_instructions)s"
+msgid "Your approved application to %(partner)s has now been finalised. Your access code or login details can be found below: %(access_code)s %(user_instructions)s"
 msgstr ""
 
 #. Translators: This is the subject line of an email sent to users with their access code.
@@ -1070,37 +966,14 @@ msgstr "Din åtkomstkod i Wikipediabiblioteket"
 #. Translators: This email is sent to users when their application is approved. Don't translate Jinja variables in curly braces like user or partner; don't translate html tags either. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/approval_notification-body-html.html:5
 #, python-format
-msgid ""
-"<p>Dear %(user)s,</p> <p>Thank you for applying for access to %(partner)s "
-"resources through The Wikipedia Library. We are happy to inform you that "
-"your application has been approved.</p> <p>%(user_instructions)s</p> <p>You "
-"can view the collections you're authorized to access at My Library: "
-"%(link)s</p> <p>Cheers!</p> <p>The Wikipedia Library</p>"
-msgstr ""
-"<p>Kära %(user)s,</p> <p>Tack för din ansökan om åtkomst till %(partner)s "
-"resurser via Wikipediabiblioteket. Vi är glada att meddela att din ansökan "
-"har godkänts.</p> <p>%(user_instructions)s</p> <p>Du kan titta på "
-"samlingarna du har tillgång till på Mitt Bibliotek: %(link)s</p> <p>Med "
-"vänliga hälsningar</p> <p>Wikipediabiblioteket</p>"
+msgid "<p>Dear %(user)s,</p> <p>Thank you for applying for access to %(partner)s resources through The Wikipedia Library. We are happy to inform you that your application has been approved.</p> <p>%(user_instructions)s</p> <p>You can view the collections you're authorized to access at My Library: %(link)s</p> <p>Cheers!</p> <p>The Wikipedia Library</p>"
+msgstr "<p>Kära %(user)s,</p> <p>Tack för din ansökan om åtkomst till %(partner)s resurser via Wikipediabiblioteket. Vi är glada att meddela att din ansökan har godkänts.</p> <p>%(user_instructions)s</p> <p>Du kan titta på samlingarna du har tillgång till på Mitt Bibliotek: %(link)s</p> <p>Med vänliga hälsningar</p> <p>Wikipediabiblioteket</p>"
 
 #. Translators: This email is sent to users when their application is approved. Don't translate Jinja variables in curly braces like user or partner. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/approval_notification-body-text.html:3
 #, python-format
-msgid ""
-"Dear %(user)s, Thank you for applying for access to %(partner)s resources "
-"through The Wikipedia Library. We are happy to inform you that your "
-"application has been approved. %(user_instructions)s You can view the "
-"collections you're authorized to access at My Library: %(link)s Cheers! The "
-"Wikipedia Library"
-msgstr ""
-"Kära %(user)s,\n"
-"\n"
-"Tack för din ansökan om åtkomst till %(partner)ss resurser via "
-"Wikipediabiblioteket. Vi är glada att meddela att din ansökan har godkänts. "
-"%(user_instructions)s Du kan se samlingarna du har tillgång till på Mitt "
-"bibliotek: %(link)s\n"
-"\n"
-"Med vänliga hälsningar Wikipediabiblioteket"
+msgid "Dear %(user)s, Thank you for applying for access to %(partner)s resources through The Wikipedia Library. We are happy to inform you that your application has been approved. %(user_instructions)s You can view the collections you're authorized to access at My Library: %(link)s Cheers! The Wikipedia Library"
+msgstr "Kära %(user)s,\n\nTack för din ansökan om åtkomst till %(partner)ss resurser via Wikipediabiblioteket. Vi är glada att meddela att din ansökan har godkänts. %(user_instructions)s Du kan se samlingarna du har tillgång till på Mitt bibliotek: %(link)s\n\nMed vänliga hälsningar Wikipediabiblioteket"
 
 #. Translators: This is the subject of an email which is sent to users when their application has been approved. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/approval_notification-subject.html:4
@@ -1110,19 +983,13 @@ msgstr "Din ansökning på Wikipediabiblioteket har godkänts"
 #. Translators: This email is sent to coordinators when a comment is left on an application they are processing. Don't translate Jinja variables in curly braces like user or partner. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/comment_notification_coordinator-body-html.html:5
 #, python-format
-msgid ""
-"<p style=\"color: #500050\">%(submit_date)s - %(commenter)s</p> "
-"<blockquote><p>%(comment)s</p></blockquote> <p>Please reply to these at: <a "
-"href=\"%(app_url)s\">%(app_url)s</a></p> <p>Best,</p> <p>The Wikipedia "
-"Library</p>"
+msgid "<p style=\"color: #500050\">%(submit_date)s - %(commenter)s</p> <blockquote><p>%(comment)s</p></blockquote> <p>Please reply to these at: <a href=\"%(app_url)s\">%(app_url)s</a></p> <p>Best,</p> <p>The Wikipedia Library</p>"
 msgstr ""
 
 #. Translators: This email is sent to coordinators when a comment is left on an application they are processing. Don't translate Jinja variables in curly braces like user or partner. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/comment_notification_coordinator-body-text.html:3
 #, python-format
-msgid ""
-"%(submit_date)s - %(commenter)s %(comment)s Please reply to this at: "
-"%(app_url)s Best, The Wikipedia Library"
+msgid "%(submit_date)s - %(commenter)s %(comment)s Please reply to this at: %(app_url)s Best, The Wikipedia Library"
 msgstr ""
 
 #. Translators: This is the subject line of an email sent to coordinators when a comment is left on an application they processed.
@@ -1133,23 +1000,13 @@ msgstr "Ny kommentar på en ansökning i Wikipediabiblioteket som du bearbetade"
 #. Translators: This email is sent to users when they receive a comment on their application. Don't translate Jinja variables in curly braces like user or partner; don't translate html tags either. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/comment_notification_editors-body-html.html:5
 #, python-format
-msgid ""
-"<p style=\"color: #500050\">%(submit_date)s - %(commenter)s</p> "
-"<blockquote><p>%(comment)s</p></blockquote> <p>Please reply to these at <a "
-"href=\"%(app_url)s\">%(app_url)s</a> so we can evaluate your application.</"
-"p> <p>Best,</p> <p>The Wikipedia Library</p>"
-msgstr ""
-"<p style=\"color: #500050\">%(submit_date)s - %(commenter)s</p> "
-"<blockquote><p>%(comment)s</p></blockquote> <p>Vänligen besvara dessa på <a "
-"href=\"%(app_url)s\">%(app_url)s</a>så vi kan bedöma din ansökan.</p> <p>Med "
-"vänliga hälsningar</p> <p>Wikipediabiblioteket</p>"
+msgid "<p style=\"color: #500050\">%(submit_date)s - %(commenter)s</p> <blockquote><p>%(comment)s</p></blockquote> <p>Please reply to these at <a href=\"%(app_url)s\">%(app_url)s</a> so we can evaluate your application.</p> <p>Best,</p> <p>The Wikipedia Library</p>"
+msgstr "<p style=\"color: #500050\">%(submit_date)s - %(commenter)s</p> <blockquote><p>%(comment)s</p></blockquote> <p>Vänligen besvara dessa på <a href=\"%(app_url)s\">%(app_url)s</a>så vi kan bedöma din ansökan.</p> <p>Med vänliga hälsningar</p> <p>Wikipediabiblioteket</p>"
 
 #. Translators: This email is sent to users when they receive a comment on their application. Don't translate Jinja variables in curly braces like user or partner. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/comment_notification_editors-body-text.html:3
 #, python-format
-msgid ""
-"%(submit_date)s - %(commenter)s %(comment)s Please reply to these at: "
-"%(app_url)s so we can evaluate your application. Best, The Wikipedia Library"
+msgid "%(submit_date)s - %(commenter)s %(comment)s Please reply to these at: %(app_url)s so we can evaluate your application. Best, The Wikipedia Library"
 msgstr ""
 
 #. Translators: This is the subject line of an email sent to users who have a comment added to one of their applications. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
@@ -1160,36 +1017,25 @@ msgstr "Ny kommentar på din ansökning i Wikipediabiblioteket"
 #. Translators: This email is sent to users when an application they commented on receives another comment. Don't translate Jinja variables in curly braces like app_url; don't translate html tags either. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/comment_notification_others-body-html.html:5
 #, python-format
-msgid ""
-"<p style=\"color: #500050\">%(submit_date)s - %(commenter)s</p> "
-"<blockquote><p>%(comment)s</p></blockquote> See it at <a href=\"%(app_url)s"
-"\">%(app_url)s</a>. Thanks for helping review Wikipedia Library applications!"
+msgid "<p style=\"color: #500050\">%(submit_date)s - %(commenter)s</p> <blockquote><p>%(comment)s</p></blockquote> See it at <a href=\"%(app_url)s\">%(app_url)s</a>. Thanks for helping review Wikipedia Library applications!"
 msgstr ""
 
 #. Translators: This email is sent to users when an application they commented on receives another comment. Don't translate Jinja variables in curly braces like app_url. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/comment_notification_others-body-text.html:3
 #, python-format
-msgid ""
-"%(submit_date)s - %(commenter)s %(comment)s See it at: %(app_url)s Thanks "
-"for helping review Wikipedia Library applications!"
+msgid "%(submit_date)s - %(commenter)s %(comment)s See it at: %(app_url)s Thanks for helping review Wikipedia Library applications!"
 msgstr ""
 
 #. Translators: This is the subject line of an email sent to users who have a comment added to an application they also commented on. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/comment_notification_others-subject.html:4
 msgid "New comment on a Wikipedia Library application you commented on"
-msgstr ""
-"Ny kommentar på en ansökning i Wikipediabiblioteket som du kommenterade på"
+msgstr "Ny kommentar på en ansökning i Wikipediabiblioteket som du kommenterade på"
 
 #. Translators: This text is part of a scheduled reminder email sent to coordinators who have applications requiring action. Don't translate Jinja variables in curly braces like total_apps, or user.
 #: TWLight/emails/templates/emails/coordinator_reminder_notification-body-html.html:5
 #, python-format
-msgid ""
-"<p>Dear %(user)s,</p> <p>Our records indicate that you are the designated "
-"coordinator for partners that have a total of %(total_apps)s applications.</"
-"p>"
-msgstr ""
-"<p>Kära %(user)s,</p> <p>Vår data indikerar att du är den tillägnade "
-"samordnaren för partners som har sammanlagt %(total_apps)s ansökningar.</p>"
+msgid "<p>Dear %(user)s,</p> <p>Our records indicate that you are the designated coordinator for partners that have a total of %(total_apps)s applications.</p>"
+msgstr "<p>Kära %(user)s,</p> <p>Vår data indikerar att du är den tillägnade samordnaren för partners som har sammanlagt %(total_apps)s ansökningar.</p>"
 
 #. Translators: Breakdown as in 'cost breakdown'; analysis.
 #: TWLight/emails/templates/emails/coordinator_reminder_notification-body-html.html:11
@@ -1227,31 +1073,19 @@ msgstr[1] "%(counter)s godkända ansökningar."
 #. Translators: This text is part of a scheduled reminder email sent to coordinators who have applications requiring action. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library). Don't translate Jinja variables in curly braces like link; don't translate email addresses or html tags either.
 #: TWLight/emails/templates/emails/coordinator_reminder_notification-body-html.html:39
 #, python-format
-msgid ""
-"<p>This is a gentle reminder that you may review applications at <a href="
-"\"%(link)s\">%(link)s</a>.</p> <p>You can customise your reminders under "
-"'preferences' in your user profile.</p> <p>If you received this message in "
-"error, drop us a line at wikipedialibrary@wikimedia.org.</p> <p>Thanks for "
-"helping review Wikipedia Library applications!</p>"
+msgid "<p>This is a gentle reminder that you may review applications at <a href=\"%(link)s\">%(link)s</a>.</p> <p>You can customise your reminders under 'preferences' in your user profile.</p> <p>If you received this message in error, drop us a line at wikipedialibrary@wikimedia.org.</p> <p>Thanks for helping review Wikipedia Library applications!</p>"
 msgstr ""
 
 #. Translators: This text is part of a scheduled reminder email sent to coordinators who have applications requiring action. Don't translate Jinja variables in curly braces like total_apps, or user.
 #: TWLight/emails/templates/emails/coordinator_reminder_notification-body-text.html:3
 #, python-format
-msgid ""
-"Dear %(user)s, Our records indicate that you are the designated coordinator "
-"for partners that have a total of %(total_apps)s applications."
+msgid "Dear %(user)s, Our records indicate that you are the designated coordinator for partners that have a total of %(total_apps)s applications."
 msgstr ""
 
 #. Translators: This text is part of a scheduled reminder email sent to coordinators who have applications requiring action. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library). Don't translate Jinja variables in curly braces like link; don't translate the email address either.
 #: TWLight/emails/templates/emails/coordinator_reminder_notification-body-text.html:38
 #, python-format
-msgid ""
-"This is a gentle reminder that you may review applications at: %(link)s. You "
-"can customise your reminders under 'preferences' in your user profile. If "
-"you received this message in error, drop us a line at: "
-"wikipedialibrary@wikimedia.org Thanks for helping review Wikipedia Library "
-"applications!"
+msgid "This is a gentle reminder that you may review applications at: %(link)s. You can customise your reminders under 'preferences' in your user profile. If you received this message in error, drop us a line at: wikipedialibrary@wikimedia.org Thanks for helping review Wikipedia Library applications!"
 msgstr ""
 
 #. Translators: This is the subject line of a scheduled reminder email sent to coordinators who have applications to review. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library). Do not translate items in curly braces.
@@ -1262,30 +1096,14 @@ msgstr "Ansökningar i Wikipediabiblioteket behöver granskas"
 #. Translators: This email is sent to users when their application is rejected. Don't translate Jinja variables in curly braces like user or partner; don't translate html tags either. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/rejection_notification-body-html.html:5
 #, python-format
-msgid ""
-"<p>Dear %(user)s,</p> <p>Thank you for applying for access to %(partner)s "
-"resources through The Wikipedia Library. Unfortunately at this time your "
-"application has not been approved. You can view your application and review "
-"comments at <a href=\"%(app_url)s\">%(app_url)s</a>.</p> <p>Best,</p> <p>The "
-"Wikipedia Library</p>"
+msgid "<p>Dear %(user)s,</p> <p>Thank you for applying for access to %(partner)s resources through The Wikipedia Library. Unfortunately at this time your application has not been approved. You can view your application and review comments at <a href=\"%(app_url)s\">%(app_url)s</a>.</p> <p>Best,</p> <p>The Wikipedia Library</p>"
 msgstr ""
 
 #. Translators: This email is sent to users when their application is rejected. Don't translate Jinja variables in curly braces like user or partner. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/rejection_notification-body-text.html:3
 #, python-format
-msgid ""
-"Dear %(user)s, Thank you for applying for access to %(partner)s resources "
-"through The Wikipedia Library. Unfortunately at this time your application "
-"has not been approved. You can view your application and review comments at: "
-"%(app_url)s Best, The Wikipedia Library"
-msgstr ""
-"Kära %(user)s,\n"
-"\n"
-"Tack för din ansökan om åtkomst till %(partner)ss resurser via "
-"Wikipediabiblioteket. Tyvärr har din ansökan inte godkänts. Du kan se din "
-"ansökan och granska kommentarer på: %(app_url)s\n"
-"\n"
-"Med vänliga hälsningar Wikipediabiblioteket"
+msgid "Dear %(user)s, Thank you for applying for access to %(partner)s resources through The Wikipedia Library. Unfortunately at this time your application has not been approved. You can view your application and review comments at: %(app_url)s Best, The Wikipedia Library"
+msgstr "Kära %(user)s,\n\nTack för din ansökan om åtkomst till %(partner)ss resurser via Wikipediabiblioteket. Tyvärr har din ansökan inte godkänts. Du kan se din ansökan och granska kommentarer på: %(app_url)s\n\nMed vänliga hälsningar Wikipediabiblioteket"
 
 #. Translators: This is the subject of an email which is sent to users when their application has been rejected. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/rejection_notification-subject.html:4
@@ -1295,25 +1113,13 @@ msgstr "Din ansökning till Wikipediabiblioteket"
 #. Translators: This email is sent to users when they have an account that is soon to expire. Don't translate Jinja variables in curly braces like partner_name or partner_link; don't translate html tags either. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/user_renewal_notice-body-html.html:5
 #, python-format
-msgid ""
-"<p>Dear %(user)s,</p> <p>According to our records, your access to "
-"%(partner_name)s will soon expire and you may lose access. If you want to "
-"continue making use of your free account, you can request renewal of your "
-"account by clicking the 'Renew' or 'Extend' button at %(partner_link)s.</p> "
-"<p>Best,</p> <p>The Wikipedia Library</p> <p>You can disable these emails in "
-"your user page preferences: https://wikipedialibrary.wmflabs.org/users/</p>"
+msgid "<p>Dear %(user)s,</p> <p>According to our records, your access to %(partner_name)s will soon expire and you may lose access. If you want to continue making use of your free account, you can request renewal of your account by clicking the 'Renew' or 'Extend' button at %(partner_link)s.</p> <p>Best,</p> <p>The Wikipedia Library</p> <p>You can disable these emails in your user page preferences: https://wikipedialibrary.wmflabs.org/users/</p>"
 msgstr ""
 
 #. Translators: This email is sent to users when they have an account that is soon to expire. Don't translate Jinja variables in curly braces like partner_name or partner_link; don't translate html tags either. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/user_renewal_notice-body-text.html:3
 #, python-format
-msgid ""
-"Dear %(user)s, According to our records, your access to %(partner_name)s "
-"will soon expire and you may lose access. If you want to continue making use "
-"of your free account, you can request renewal of your account by clicking "
-"the Renew button at %(partner_link)s. Best, The Wikipedia Library You can "
-"disable these emails in your user page preferences: https://wikipedialibrary."
-"wmflabs.org/users/"
+msgid "Dear %(user)s, According to our records, your access to %(partner_name)s will soon expire and you may lose access. If you want to continue making use of your free account, you can request renewal of your account by clicking the Renew button at %(partner_link)s. Best, The Wikipedia Library You can disable these emails in your user page preferences: https://wikipedialibrary.wmflabs.org/users/"
 msgstr ""
 
 #. Translators: This is the subject of an email sent to users when they have an account that is soon to expire. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
@@ -1324,33 +1130,14 @@ msgstr "Din åtkomst till Wikipediabiblioteket kan snart gå ut"
 #. Translators: This email is sent to users when their application is waitlisted because there are no more accounts available. Don't translate Jinja variables in curly braces like user or partner; don't translate html tags either. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/waitlist_notification-body-html.html:5
 #, python-format
-msgid ""
-"<p>Dear %(user)s,</p> <p>Thank you for applying for access to %(partner)s "
-"resources through The Wikipedia Library. There are no accounts currently "
-"available so your application has been waitlisted. Your application will be "
-"evaluated if/when more accounts become available. You can see all available "
-"resources at <a href=\"%(link)s\">%(link)s</a>.</p> <p>Best,</p> <p>The "
-"Wikipedia Library</p>"
+msgid "<p>Dear %(user)s,</p> <p>Thank you for applying for access to %(partner)s resources through The Wikipedia Library. There are no accounts currently available so your application has been waitlisted. Your application will be evaluated if/when more accounts become available. You can see all available resources at <a href=\"%(link)s\">%(link)s</a>.</p> <p>Best,</p> <p>The Wikipedia Library</p>"
 msgstr ""
 
 #. Translators: This email is sent to users when their application is waitlisted because there are no more accounts available. Don't translate Jinja variables in curly braces like user or partner. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/waitlist_notification-body-text.html:3
 #, python-format
-msgid ""
-"Dear %(user)s, Thank you for applying for access to %(partner)s resources "
-"through The Wikipedia Library. There are no accounts currently available so "
-"your application has been waitlisted. Your application will be evaluated if/"
-"when more accounts become available. You can see all available resources at: "
-"%(link)s Best, The Wikipedia Library"
-msgstr ""
-"Kära %(user)s,\n"
-"\n"
-"Tack för din ansökan om åtkomst till %(partner)ss resurser via "
-"Wikipediabiblioteket. Det finns inga konton tillgängliga för tillfället så "
-"din ansökan ligger i väntelistan. Din ansökan kommer utvärderas när/om fler "
-"konton blir tillgängliga. Du kan se alla tillgängliga resurser på: %(link)s\n"
-"\n"
-"Med vänliga hälsningar, Wikipediabiblioteket"
+msgid "Dear %(user)s, Thank you for applying for access to %(partner)s resources through The Wikipedia Library. There are no accounts currently available so your application has been waitlisted. Your application will be evaluated if/when more accounts become available. You can see all available resources at: %(link)s Best, The Wikipedia Library"
+msgstr "Kära %(user)s,\n\nTack för din ansökan om åtkomst till %(partner)ss resurser via Wikipediabiblioteket. Det finns inga konton tillgängliga för tillfället så din ansökan ligger i väntelistan. Din ansökan kommer utvärderas när/om fler konton blir tillgängliga. Du kan se alla tillgängliga resurser på: %(link)s\n\nMed vänliga hälsningar, Wikipediabiblioteket"
 
 #. Translators: This is the subject of an email sent to users when their application is waitlisted because there are no more accounts available. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/waitlist_notification-subject.html:4
@@ -1514,19 +1301,15 @@ msgstr "Inte tillgänglig"
 #: TWLight/resources/templates/resources/filter_section.html:14
 #: TWLight/templates/about.html:12
 #: TWLight/users/templates/users/filter_section.html:13
-msgid ""
-"The Wikipedia Library allows active editors to access a wide range of "
-"collections of paywalled reliable sources for free!"
+msgid "The Wikipedia Library allows active editors to access a wide range of collections of paywalled reliable sources for free!"
 msgstr ""
 
 #. Translators: On the Browse Partners page (https://wikipedialibrary.wmflabs.org/partners/), this introduces users to The Wikipedia Library.
 #. Translators: On the MyLibrary page (https://wikipedialibrary.wmflabs.org/users/my_library), this introduces users to The Wikipedia Library.
 #: TWLight/resources/templates/resources/filter_section.html:17
 #: TWLight/users/templates/users/filter_section.html:15
-msgid ""
-"Start with the search bar at the top or browse publisher websites directly."
-msgstr ""
-"Börja med sökfältet högst upp eller bläddra direkt på utgivares webbplatser."
+msgid "Start with the search bar at the top or browse publisher websites directly."
+msgstr "Börja med sökfältet högst upp eller bläddra direkt på utgivares webbplatser."
 
 #. Translators: On the Browse Partners page (https://wikipedialibrary.wmflabs.org/partners/), this appears below introductory text and links to the 'About' page (https://wikipedialibrary.wmflabs.org/about/)
 #. Translators: On the MyLibrary page (https://wikipedialibrary.wmflabs.org/users/my_library), this appears below introductory text and links to the 'About' page (https://wikipedialibrary.wmflabs.org/about/)
@@ -1600,52 +1383,38 @@ msgstr "Tillbaka till partner"
 #. Translators: If we have no available accounts for a partner, the coordinator can change the application system to a waiting list.
 #: TWLight/resources/templates/resources/partner_detail.html:36
 #: TWLight/resources/templates/resources/partner_detail_apply.html:17
-msgid ""
-"There are no access grants available for this partner at this time. You can "
-"still apply for access; applications will be processed when access is "
-"available."
+msgid "There are no access grants available for this partner at this time. You can still apply for access; applications will be processed when access is available."
 msgstr ""
 
 #. Translators: This text links to the minimum user requirements and terms of use on the partner page.
 #: TWLight/resources/templates/resources/partner_detail.html:48
 #: TWLight/resources/templates/resources/partner_detail_apply.html:29
 #, python-format
-msgid ""
-"Before applying, please review the <strong><a class=\"twl-links\" href="
-"\"%(about)s#req\">minimum requirements</a></strong> for access and our "
-"<strong><a class=\"twl-links\" href=\"%(terms)s\">terms of use</a></strong>."
+msgid "Before applying, please review the <strong><a class=\"twl-links\" href=\"%(about)s#req\">minimum requirements</a></strong> for access and our <strong><a class=\"twl-links\" href=\"%(terms)s\">terms of use</a></strong>."
 msgstr ""
 
 #. Translators: This text refers to the page containing the content a user is authorized to access.
 #: TWLight/resources/templates/resources/partner_detail.html:69
 #, python-format
-msgid ""
-"View the status of your access in <strong><a class=\"twl-links\" href="
-"\"%(library_url)s\">My Library</a></strong> page."
+msgid "View the status of your access in <strong><a class=\"twl-links\" href=\"%(library_url)s\">My Library</a></strong> page."
 msgstr ""
 
 #. Translators: This message is shown when a user has open applications, linking to their respective applications page.
 #: TWLight/resources/templates/resources/partner_detail.html:78
 #, python-format
-msgid ""
-"View the status of your application(s) on your <strong><a class=\"twl-links"
-"\" href=\"%(applications_url)s\">My Applications</a></strong> page."
+msgid "View the status of your application(s) on your <strong><a class=\"twl-links\" href=\"%(applications_url)s\">My Applications</a></strong> page."
 msgstr ""
 
 #. Translators: This message is shown when a user has authorizations, linking to their respective collections page.
 #: TWLight/resources/templates/resources/partner_detail_apply.html:50
 #, python-format
-msgid ""
-"View the status of your access on your <strong><a href=\"%(library_url)s\" "
-"class=\"twl-links\">My Library</a></strong> page."
+msgid "View the status of your access on your <strong><a href=\"%(library_url)s\" class=\"twl-links\">My Library</a></strong> page."
 msgstr ""
 
 #. Translators: This message is shown when a user has open applications, linking to their respective applications page.
 #: TWLight/resources/templates/resources/partner_detail_apply.html:60
 #, python-format
-msgid ""
-"View the status of your application(s) on your <strong><a href="
-"\"%(applications_url)s\">My Applications</a></strong> page."
+msgid "View the status of your application(s) on your <strong><a href=\"%(applications_url)s\">My Applications</a></strong> page."
 msgstr ""
 
 #. Translators: One the partner detail page, this text labels the button which coordinators can click to remove a partner from waitlisted status.
@@ -1661,8 +1430,7 @@ msgstr "Lägg till i väntelista"
 #: TWLight/resources/templates/resources/partner_detail_apply.html:86
 #, python-format
 msgid "<strong>%(coordinator)s</strong> processes applications to %(partner)s."
-msgstr ""
-"<strong>%(coordinator)s</strong> bearbetar ansökningar till %(partner)s."
+msgstr "<strong>%(coordinator)s</strong> bearbetar ansökningar till %(partner)s."
 
 #. Translators: When a coordinator is assigned to a partner, their details are shown on the page. This text labels a link to their Talk page on Wikipedia, and should be translated to the text used for Talk pages in the language you are translating to.
 #: TWLight/resources/templates/resources/partner_detail_apply.html:95
@@ -1676,10 +1444,7 @@ msgstr ""
 
 #. Translators: If no account coordinator is assigned to a partner, the Wikipedia Library team will coordinate signups. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/resources/templates/resources/partner_detail_apply.html:112
-msgid ""
-"The Wikipedia Library team will process this application. Want to help? <a "
-"class=\"twl-links\" href=\"https://en.wikipedia.org/wiki/Wikipedia:"
-"The_Wikipedia_Library/Coordinators/Signup\">Sign up as a coordinator.</a>"
+msgid "The Wikipedia Library team will process this application. Want to help? <a class=\"twl-links\" href=\"https://en.wikipedia.org/wiki/Wikipedia:The_Wikipedia_Library/Coordinators/Signup\">Sign up as a coordinator.</a>"
 msgstr ""
 
 #. Translators: This text labels a button coordinators can click to view a list of users who have applied for access for a particular partner
@@ -1709,18 +1474,13 @@ msgstr ""
 
 #. Translators: Text shown to authenticated, bundle eligible users when they visit a Bundle partner page.
 #: TWLight/resources/templates/resources/partner_detail_apply.html:138
-msgid ""
-"You are eligible to access Library Bundle partners. Click the button above "
-"to access the collection."
+msgid "You are eligible to access Library Bundle partners. Click the button above to access the collection."
 msgstr ""
 
 #. Translators: Text shown to authenticated, bundle ineligible users when they visit a Bundle partner page.
 #: TWLight/resources/templates/resources/partner_detail_apply.html:152
 #, python-format
-msgid ""
-"You are not eligible to access Library Bundle partners. Visit the <a class="
-"\"twl-links\" href=\"%(homepage)s\">homepage</a> to check the eligibility "
-"criteria."
+msgid "You are not eligible to access Library Bundle partners. Visit the <a class=\"twl-links\" href=\"%(homepage)s\">homepage</a> to check the eligibility criteria."
 msgstr ""
 
 #. Translators: Buttton prompting users to log in.
@@ -1732,10 +1492,7 @@ msgstr "Logga in"
 #. Translators: Text shown to unauthenticated users when they visit a Bundle partner page.
 #: TWLight/resources/templates/resources/partner_detail_apply.html:168
 #, python-format
-msgid ""
-"This resource is part of our <a class=\"twl-links\" href=\"%(about)s"
-"\">Library Bundle</a>, which you can access if you meet our minimum "
-"eligibility criteria. Log in to find out if you are eligible."
+msgid "This resource is part of our <a class=\"twl-links\" href=\"%(about)s\">Library Bundle</a>, which you can access if you meet our minimum eligibility criteria. Log in to find out if you are eligible."
 msgstr ""
 
 #. Translators: This is the label for a number which shows the total active accounts for one partner. (e.g. https://wikipedialibrary.wmflabs.org/partners/8/).
@@ -1786,26 +1543,19 @@ msgstr ""
 #. Translators: If a partner has specified the excerpt limit both in words and percentage, this message will display the percentage of words and the number of words on the partner page.
 #: TWLight/resources/templates/resources/partner_detail_timeline.html:99
 #, python-format
-msgid ""
-"%(object)s allows a maximum of %(excerpt_limit)s words or "
-"%(excerpt_limit_percentage)s%% of an article be excerpted into a Wikipedia "
-"article."
+msgid "%(object)s allows a maximum of %(excerpt_limit)s words or %(excerpt_limit_percentage)s%% of an article be excerpted into a Wikipedia article."
 msgstr ""
 
 #. Translators: If a partner has specified the excerpt limit in words, this message will display the number of words on the partner page.
 #: TWLight/resources/templates/resources/partner_detail_timeline.html:106
 #, python-format
-msgid ""
-"%(object)s allows a maximum of %(excerpt_limit)s words be excerpted into a "
-"Wikipedia article."
+msgid "%(object)s allows a maximum of %(excerpt_limit)s words be excerpted into a Wikipedia article."
 msgstr ""
 
 #. Translators: If a partner has specified the excerpt limit in percentage, this message will display the percentage of words on the partner page.
 #: TWLight/resources/templates/resources/partner_detail_timeline.html:113
 #, python-format
-msgid ""
-"%(object)s allows a maximum of %(excerpt_limit_percentage)s%% of an article "
-"be excerpted into a Wikipedia article."
+msgid "%(object)s allows a maximum of %(excerpt_limit_percentage)s%% of an article be excerpted into a Wikipedia article."
 msgstr ""
 
 #. Translators: If a partner has other requirements for access, this text shows as the title for that information field. (e.g. https://wikipedialibrary.wmflabs.org/partners/10/).
@@ -1816,9 +1566,7 @@ msgstr ""
 #. Translators: If a user must agree to a Terms of Use document, they see this message, and must enter the name of the resource. Don't translate publisher or url.
 #: TWLight/resources/templates/resources/partner_detail_timeline.html:140
 #, python-format
-msgid ""
-"%(publisher)s requires that you agree with its <a href=\"%(url)s\">terms of "
-"use</a>."
+msgid "%(publisher)s requires that you agree with its <a href=\"%(url)s\">terms of use</a>."
 msgstr ""
 
 #. Translators: If a user must provide their real name to apply to a partner, they see this message, and must enter the name of the resource. Don't translate publisher.
@@ -1842,17 +1590,13 @@ msgstr ""
 #. Translators: If a user must select a specific resource to apply for, they see this message, and must enter the name of the resource. Don't translate publisher.
 #: TWLight/resources/templates/resources/partner_detail_timeline.html:177
 #, python-format
-msgid ""
-"%(publisher)s requires that you specify a particular title that you want to "
-"access."
+msgid "%(publisher)s requires that you specify a particular title that you want to access."
 msgstr ""
 
 #. Translators: If a user must register on the partner website before applying, they see this message. Don't translate partner.
 #: TWLight/resources/templates/resources/partner_detail_timeline.html:187
 #, python-format
-msgid ""
-"%(publisher)s requires that you sign up for an account before applying for "
-"access."
+msgid "%(publisher)s requires that you sign up for an account before applying for access."
 msgstr ""
 
 #. Translators: If a partner has their location listed, this message is a label for that location
@@ -1980,9 +1724,7 @@ msgstr "Är du säker på att du vill radera <b>%(object)s</b>?"
 
 #. Translators: If multiple authorizations where returned for a collection, this message is shown to a user
 #: TWLight/resources/views.py:268
-msgid ""
-"Multiple authorizations were returned – something's wrong. Please contact us "
-"and don't forget to mention this message."
+msgid "Multiple authorizations were returned – something's wrong. Please contact us and don't forget to mention this message."
 msgstr ""
 
 #. Translators: This message is shown when user tries to access a NOT_AVAILABLE Partner
@@ -2023,14 +1765,7 @@ msgstr "Tyvärr, vi vet inte vad vi ska göra med detta."
 #. Translators: Shown on the website's 400 page, when a user sends a bad request. Don't translate path or Phabricator.
 #: TWLight/templates/400.html:20
 #, python-format
-msgid ""
-"If you think we should know what to do with that, please email us about this "
-"error at <a class=\"twl-links\" href=\"mailto:wikipedialibrary@wikimedia.org?"
-"Subject=Wikipedia%%20Library%%20%(path)s%%20Permission%%20denied"
-"\">wikipedialibrary@wikimedia.org</a> or report it to us on <a class=\"twl-"
-"links\" href=\"https://phabricator.wikimedia.org/maniphest/task/edit/form/1/?"
-"projectPHIDs=Library-Card-Platform&title=Wikipedia%%20Library%%20%(path)s"
-"%%20Bad%%20Request\">Phabricator</a>"
+msgid "If you think we should know what to do with that, please email us about this error at <a class=\"twl-links\" href=\"mailto:wikipedialibrary@wikimedia.org?Subject=Wikipedia%%20Library%%20%(path)s%%20Permission%%20denied\">wikipedialibrary@wikimedia.org</a> or report it to us on <a class=\"twl-links\" href=\"https://phabricator.wikimedia.org/maniphest/task/edit/form/1/?projectPHIDs=Library-Card-Platform&title=Wikipedia%%20Library%%20%(path)s%%20Bad%%20Request\">Phabricator</a>"
 msgstr ""
 
 #. Translators: Alt text for an image shown on the 400 error page.
@@ -2052,15 +1787,7 @@ msgstr "Tyvärr, du får inte göra detta."
 #. Translators: Shown on the website's 403 page, when a user attempts to navigate to a page they don't have permission to view. Don't translate path or Phabricator.
 #: TWLight/templates/403.html:20
 #, python-format
-msgid ""
-"If you think your account should be able to do that, please email us about "
-"this error at <a class=\"twl-links\" href=\"mailto:"
-"wikipedialibrary@wikimedia.org?Subject=Wikipedia%%20Library%%20%(path)s"
-"%%20Permission%%20denied\">wikipedialibrary@wikimedia.org</a> or report it "
-"to us on <a class=\"twl-links\" href=\"https://phabricator.wikimedia.org/"
-"maniphest/task/edit/form/1/?projectPHIDs=Library-Card-"
-"Platform&title=Wikipedia%%20Library%%20%(path)s%%20Permission%%20denied"
-"\">Phabricator</a>"
+msgid "If you think your account should be able to do that, please email us about this error at <a class=\"twl-links\" href=\"mailto:wikipedialibrary@wikimedia.org?Subject=Wikipedia%%20Library%%20%(path)s%%20Permission%%20denied\">wikipedialibrary@wikimedia.org</a> or report it to us on <a class=\"twl-links\" href=\"https://phabricator.wikimedia.org/maniphest/task/edit/form/1/?projectPHIDs=Library-Card-Platform&title=Wikipedia%%20Library%%20%(path)s%%20Permission%%20denied\">Phabricator</a>"
 msgstr ""
 
 #. Translators: Shown on the website's 404 page, when a user attempts to navigate to a page that doesn't exist.
@@ -2076,14 +1803,7 @@ msgstr "Tyvärr, vi kan inte hitta detta."
 #. Translators: Shown on the website's 404 page, when a user attempts to navigate to a page that doesn't exist. Don't translate path or Phabricator.
 #: TWLight/templates/404.html:19
 #, python-format
-msgid ""
-"If you are certain that something should be here, please email us about this "
-"error at <a class=\"twl-links\" href=\"mailto:wikipedialibrary@wikimedia.org?"
-"Subject=Wikipedia%%20Library%%20%(path)s%%20Not%%20found\"> "
-"wikipedialibrary@wikimedia.org</a> or report it to us on <a class=\"twl-links"
-"\" href=\"https://phabricator.wikimedia.org/maniphest/task/edit/form/1/?"
-"projectPHIDs=Library-Card-Platform&title=Wikipedia%%20Library%%20%(path)s"
-"%%20Not%%20found\">Phabricator</a>"
+msgid "If you are certain that something should be here, please email us about this error at <a class=\"twl-links\" href=\"mailto:wikipedialibrary@wikimedia.org?Subject=Wikipedia%%20Library%%20%(path)s%%20Not%%20found\"> wikipedialibrary@wikimedia.org</a> or report it to us on <a class=\"twl-links\" href=\"https://phabricator.wikimedia.org/maniphest/task/edit/form/1/?projectPHIDs=Library-Card-Platform&title=Wikipedia%%20Library%%20%(path)s%%20Not%%20found\">Phabricator</a>"
 msgstr ""
 
 #. Translators: Alt text for an image shown on the 404 error page.
@@ -2098,32 +1818,18 @@ msgstr "Om Wikipedia-biblioteket"
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:20
-msgid ""
-"This platform is our central tool for facilitating access to our available "
-"collections. Here you can see which partnerships are available, search their "
-"contents, and apply for and access the ones you’re interested in."
+msgid "This platform is our central tool for facilitating access to our available collections. Here you can see which partnerships are available, search their contents, and apply for and access the ones you’re interested in."
 msgstr ""
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/). Wikimedia Foundation should not be translated.
 #: TWLight/templates/about.html:29
-msgid ""
-"All users receive immediate access to some collections, which can be browsed "
-"by clicking the 'Access collection' buttons or using the search bar at the "
-"top of the page. Other collections require an application before access is "
-"granted, and may be accessed directly or via an individual login or access "
-"code. Volunteer coordinators, who have signed non-disclosure agreements with "
-"the Wikimedia Foundation, review these applications and work with publishers "
-"to get you your free access."
+msgid "All users receive immediate access to some collections, which can be browsed by clicking the 'Access collection' buttons or using the search bar at the top of the page. Other collections require an application before access is granted, and may be accessed directly or via an individual login or access code. Volunteer coordinators, who have signed non-disclosure agreements with the Wikimedia Foundation, review these applications and work with publishers to get you your free access."
 msgstr ""
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/). Don't translate terms_url.
 #: TWLight/templates/about.html:43
 #, python-format
-msgid ""
-"For more information about how your information is stored and reviewed "
-"please see our <a class=\"twl-links\" href=\"%(terms_url)s\"> terms of use "
-"and privacy policy</a>. Accounts you apply for are also subject to the Terms "
-"of Use provided by each partner’s platform; please review them."
+msgid "For more information about how your information is stored and reviewed please see our <a class=\"twl-links\" href=\"%(terms_url)s\"> terms of use and privacy policy</a>. Accounts you apply for are also subject to the Terms of Use provided by each partner’s platform; please review them."
 msgstr ""
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
@@ -2133,18 +1839,8 @@ msgstr "Vem kan få åtkomst?"
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/). Wikimedia Foundation should not be translated.
 #: TWLight/templates/about.html:55
-msgid ""
-"Any active editor in good standing can receive access. For publishers with "
-"limited numbers of accounts, applications are reviewed based on the editor’s "
-"needs and contributions. If you think you could use access to one of our "
-"partner resources and are an active editor in any project supported by the "
-"Wikimedia Foundation, please apply."
-msgstr ""
-"Alla aktiva användare med god ställning kan få åtkomst. För förlag med "
-"begränsat antal konton granskas ansökningar utifrån användarens behov och "
-"bidrag. Om du tror att du skulle kunna dra nytta av tillgång till en av våra "
-"partnerresurser och är en aktiv användare på något projekt som stöds av "
-"Wikimedia Foundation, vänligen ansök."
+msgid "Any active editor in good standing can receive access. For publishers with limited numbers of accounts, applications are reviewed based on the editor’s needs and contributions. If you think you could use access to one of our partner resources and are an active editor in any project supported by the Wikimedia Foundation, please apply."
+msgstr "Alla aktiva användare med god ställning kan få åtkomst. För förlag med begränsat antal konton granskas ansökningar utifrån användarens behov och bidrag. Om du tror att du skulle kunna dra nytta av tillgång till en av våra partnerresurser och är en aktiv användare på något projekt som stöds av Wikimedia Foundation, vänligen ansök."
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:65
@@ -2164,43 +1860,22 @@ msgstr "Du har gjort minst 500 redigeringar på Wikimedias projekt"
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:79
 msgid "You have made at least 10 edits to Wikimedia projects in the last month"
-msgstr ""
-"Du har gjort minst 10 redigeringar på Wikimedia-projekt under den senaste "
-"månaden."
+msgstr "Du har gjort minst 10 redigeringar på Wikimedia-projekt under den senaste månaden."
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:83
 msgid "You are not currently blocked from editing a Wikimedia project"
-msgstr ""
-"Du är för närvarande inte blockerad från att redigera ett Wikimedia-projekt."
+msgstr "Du är för närvarande inte blockerad från att redigera ett Wikimedia-projekt."
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/)
 #: TWLight/templates/about.html:89
-msgid ""
-"If you are applying for an available collection, please first check that you "
-"don't already have access through another library or institution. If you do, "
-"please consider using that access rather than taking up a seat for this "
-"resource in The Wikipedia Library."
+msgid "If you are applying for an available collection, please first check that you don't already have access through another library or institution. If you do, please consider using that access rather than taking up a seat for this resource in The Wikipedia Library."
 msgstr ""
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/)
 #: TWLight/templates/about.html:99
-msgid ""
-"If your account is blocked on one or more Wikimedia projects, you may still "
-"be granted access to The Wikipedia Library. You will need to contact the "
-"Wikipedia Library team, who will review your blocks. If you have been "
-"blocked for content issues, most notably copyright violations, or have "
-"multiple long-term blocks, we may decline your request. Additionally, if "
-"your block status changes after being approved, you will need to request "
-"another review."
-msgstr ""
-"Om ditt konto är blockerat på ett eller flera Wikimedia-projekt kan du "
-"fortfarande beviljas åtkomst till The Wikipedia Library. Du måste kontakta "
-"Wikipedia Library-teamet, som kommer att granska dina blockeringar. Om du "
-"har blockerats på grund av innehållsproblem, särskilt upphovsrättsbrott, "
-"eller har flera långvariga blockeringar, kan vi avslå din begäran. Dessutom, "
-"om din blockeringsstatus ändras efter att du har godkänts, måste du begära "
-"en till granskning."
+msgid "If your account is blocked on one or more Wikimedia projects, you may still be granted access to The Wikipedia Library. You will need to contact the Wikipedia Library team, who will review your blocks. If you have been blocked for content issues, most notably copyright violations, or have multiple long-term blocks, we may decline your request. Additionally, if your block status changes after being approved, you will need to request another review."
+msgstr "Om ditt konto är blockerat på ett eller flera Wikimedia-projekt kan du fortfarande beviljas åtkomst till The Wikipedia Library. Du måste kontakta Wikipedia Library-teamet, som kommer att granska dina blockeringar. Om du har blockerats på grund av innehållsproblem, särskilt upphovsrättsbrott, eller har flera långvariga blockeringar, kan vi avslå din begäran. Dessutom, om din blockeringsstatus ändras efter att du har godkänts, måste du begära en till granskning."
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:110
@@ -2234,12 +1909,8 @@ msgstr "Godkända redigerare <i>bör inte</i>:"
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:136
-msgid ""
-"Share their account logins or passwords with others, or sell their access to "
-"other parties"
-msgstr ""
-"Dela sina inloggningsuppgifter eller lösenord med andra, eller sälja sin "
-"åtkomst till andra parter"
+msgid "Share their account logins or passwords with others, or sell their access to other parties"
+msgstr "Dela sina inloggningsuppgifter eller lösenord med andra, eller sälja sin åtkomst till andra parter"
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:140
@@ -2248,23 +1919,17 @@ msgstr ""
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:144
-msgid ""
-"Systematically make printed or electronic copies of multiple extracts of "
-"restricted content available for any purpose"
+msgid "Systematically make printed or electronic copies of multiple extracts of restricted content available for any purpose"
 msgstr ""
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/). Stub is a technical term for a short Wikipedia article, use the appropriate Wikipedia term in your language.
 #: TWLight/templates/about.html:148
-msgid ""
-"Datamine metadata without permission, in order, for instance, to use "
-"metadata for auto-created stub articles"
+msgid "Datamine metadata without permission, in order, for instance, to use metadata for auto-created stub articles"
 msgstr ""
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:154
-msgid ""
-"Respecting these agreements allows us to continue growing the partnerships "
-"available to the community."
+msgid "Respecting these agreements allows us to continue growing the partnerships available to the community."
 msgstr ""
 
 #. Translators: This is the heading for a section on the About page (https://wikipedialibrary.wmflabs.org/about/).
@@ -2274,45 +1939,22 @@ msgstr "EZProxy"
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:164
-msgid ""
-"EZProxy is a proxy server used to authenticate users for many Wikipedia "
-"Library partners. Users sign into EZProxy via the Library Card platform to "
-"verify that they are authorized users, and then the server accesses "
-"requested resources using its own IP address."
+msgid "EZProxy is a proxy server used to authenticate users for many Wikipedia Library partners. Users sign into EZProxy via the Library Card platform to verify that they are authorized users, and then the server accesses requested resources using its own IP address."
 msgstr ""
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:173
-msgid ""
-"You may notice that when accessing resources via EZProxy that URLs are "
-"dynamically rewritten. This is why we recommend logging in via the Library "
-"Card platform rather than going directly to the unproxied partner website. "
-"When in doubt, check the URL for ‘idm.oclc’. If it’s there, then you’re "
-"connected via EZProxy."
+msgid "You may notice that when accessing resources via EZProxy that URLs are dynamically rewritten. This is why we recommend logging in via the Library Card platform rather than going directly to the unproxied partner website. When in doubt, check the URL for ‘idm.oclc’. If it’s there, then you’re connected via EZProxy."
 msgstr ""
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:182
-msgid ""
-"Typically once you’ve logged in your session will remain active in your "
-"browser for up to two hours after you’ve finished searching. Note that use "
-"of EZProxy requires you to enable cookies. If you are having problems you "
-"should also try clearing your cache and restarting your browser."
-msgstr ""
-"Vanligtvis när du loggar kommer din session vara aktiv i din webbläsare upp "
-"till två timmar när du har sökt färdigt. Observera att du måste aktivera "
-"webbläsarkakor för att använda EZProxy. Om du får problem bör du också prova "
-"att rensa din cache och starta om din webbläsare."
+msgid "Typically once you’ve logged in your session will remain active in your browser for up to two hours after you’ve finished searching. Note that use of EZProxy requires you to enable cookies. If you are having problems you should also try clearing your cache and restarting your browser."
+msgstr "Vanligtvis när du loggar kommer din session vara aktiv i din webbläsare upp till två timmar när du har sökt färdigt. Observera att du måste aktivera webbläsarkakor för att använda EZProxy. Om du får problem bör du också prova att rensa din cache och starta om din webbläsare."
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/)
 #: TWLight/templates/about.html:193
-msgid ""
-"The Library Bundle is a collection of resources for which no application is "
-"required. If you meet the criteria laid out above, you will be authorized "
-"for access automatically upon logging in to the platform. Only some of our "
-"content is currently included in the Library Bundle, however we hope to "
-"expand the collection as more publishers become comfortable with "
-"participating. All Bundle content is accessed via EZProxy."
+msgid "The Library Bundle is a collection of resources for which no application is required. If you meet the criteria laid out above, you will be authorized for access automatically upon logging in to the platform. Only some of our content is currently included in the Library Bundle, however we hope to expand the collection as more publishers become comfortable with participating. All Bundle content is accessed via EZProxy."
 msgstr ""
 
 #. Translators: This is the heading for a section on the About page (https://wikipedialibrary.wmflabs.org/about/).
@@ -2322,12 +1964,7 @@ msgstr ""
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:206
-msgid ""
-"Citation practices vary by project and even by article. Generally, we "
-"support editors citing where they found information, in a form that allows "
-"others to check it for themselves. That often means providing both original "
-"source details as well as a link to the partner database in which the source "
-"was found."
+msgid "Citation practices vary by project and even by article. Generally, we support editors citing where they found information, in a form that allows others to check it for themselves. That often means providing both original source details as well as a link to the partner database in which the source was found."
 msgstr ""
 
 #. Translators: This is the heading for a section on the About page (https://wikipedialibrary.wmflabs.org/about/).
@@ -2339,12 +1976,8 @@ msgstr "Kontakta oss"
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:218
 #, python-format
-msgid ""
-"If you have questions, need help, or want to volunteer to help, please see "
-"our <a class=\"twl-links\" href=\"%(contact_url)s\">contact page</a>."
-msgstr ""
-"Om du har några frågor, behöver hjälp eller vill hjälpa till, se vår <a "
-"class=\"twl-links\" href=\"%(contact_url)s\">kontaktsida</a>."
+msgid "If you have questions, need help, or want to volunteer to help, please see our <a class=\"twl-links\" href=\"%(contact_url)s\">contact page</a>."
+msgstr "Om du har några frågor, behöver hjälp eller vill hjälpa till, se vår <a class=\"twl-links\" href=\"%(contact_url)s\">kontaktsida</a>."
 
 #. Translators: This is the title of the panel box detailing the contact information for the Wikipedia Library team.
 #: TWLight/templates/contact.html:14
@@ -2383,9 +2016,7 @@ msgstr "Wikipediabibliotekets Twitter-sida"
 #. Translators: This is the text that appears at the bottom of the contact us form directing users to the suggestions form.
 #: TWLight/templates/contact.html:48
 #, python-format
-msgid ""
-"(If you would like to suggest a partner, <a class=\"twl-links\" href="
-"\"%(suggest)s\"><strong>go here</strong></a>.)"
+msgid "(If you would like to suggest a partner, <a class=\"twl-links\" href=\"%(suggest)s\"><strong>go here</strong></a>.)"
 msgstr ""
 
 #. Translators: On a special 'link to search' page, this message is shown if JavaScript is disabled.
@@ -2443,9 +2074,7 @@ msgstr "Wikipediabiblioteket"
 #. Translators: Information about The Wikipedia Library.
 #: TWLight/templates/login_partial.html:53 TWLight/templates/new_base.html:21
 #, python-format
-msgid ""
-"More than 100 of the world's top subscription-only databases, with content "
-"in %(no_of_languages)s languages, free for Wikipedians of all backgrounds"
+msgid "More than 100 of the world's top subscription-only databases, with content in %(no_of_languages)s languages, free for Wikipedians of all backgrounds"
 msgstr ""
 
 #. Translators: Information about The Wikipedia Library.
@@ -2454,12 +2083,8 @@ msgid "Meet these criteria for automatic access"
 msgstr "Uppfyll dessa kriterier för automatiskt åtkomst"
 
 #: TWLight/templates/login_partial.html:69
-msgid ""
-"These criteria grant you access to certain collections but not all. Some "
-"collections are accessible on a per application basis only."
-msgstr ""
-"Dessa kriterier ger dig åtkomst till vissa samlingar, men inte alla. Vissa "
-"samlingar kräver en individuell ansökan."
+msgid "These criteria grant you access to certain collections but not all. Some collections are accessible on a per application basis only."
+msgstr "Dessa kriterier ger dig åtkomst till vissa samlingar, men inte alla. Vissa samlingar kräver en individuell ansökan."
 
 #: TWLight/templates/login_partial.html:89
 msgid "Login via Wikipedia"
@@ -2468,29 +2093,19 @@ msgstr "Logga in via Wikipedia"
 #. Translators: Shown if the current user doesn't have a registered email on their account. Don't translate contact_us_url or email_url.
 #: TWLight/templates/message_partial.html:15
 #, python-format
-msgid ""
-"You don't have an email on file. We can't finalize your access to partner "
-"resources, and you won't be able to <a class=\"twl-links\" href="
-"\"%(contact_us_url)s\">contact us</a> without an email. Please <a class="
-"\"twl-links\" href=\"%(email_url)s\">update your email</a>."
+msgid "You don't have an email on file. We can't finalize your access to partner resources, and you won't be able to <a class=\"twl-links\" href=\"%(contact_us_url)s\">contact us</a> without an email. Please <a class=\"twl-links\" href=\"%(email_url)s\">update your email</a>."
 msgstr ""
 
 #. Translators: Shown if the current user has requested the processing of their data should be restricted.
 #: TWLight/templates/message_partial.html:26
 #, python-format
-msgid ""
-"You have requested a restriction on the processing of your data. Most site "
-"functionality will not be available to you until you <a class=\"twl-links\" "
-"href=\"%(restrict_url)s\">lift this restriction</a>."
+msgid "You have requested a restriction on the processing of your data. Most site functionality will not be available to you until you <a class=\"twl-links\" href=\"%(restrict_url)s\">lift this restriction</a>."
 msgstr ""
 
 #. Translators: Shown if the current user has not agreed to the terms of use.
 #: TWLight/templates/message_partial.html:37
 #, python-format
-msgid ""
-"You have not agreed to the <a class=\"twl-links\" href=\"%(terms_url)s"
-"\">terms of use</a> of this site. Your applications will not be processed "
-"and you won't be able to apply or access resources you are approved for."
+msgid "You have not agreed to the <a class=\"twl-links\" href=\"%(terms_url)s\">terms of use</a> of this site. Your applications will not be processed and you won't be able to apply or access resources you are approved for."
 msgstr ""
 
 #. Translators: This link is at the bottom of every page and links to the 'About' page (https://wikipedialibrary.wmflabs.org/about/)
@@ -2537,12 +2152,8 @@ msgstr "Återställ lösenord"
 
 #. Translators: If a user goes to reset their password, this message asks them to enter their email to do so.
 #: TWLight/templates/registration/password_reset_form.html:13
-msgid ""
-"Forgot your password? Enter your email address below, and we'll email "
-"instructions for setting a new one."
-msgstr ""
-"Glömt ditt lösenord? Ange din e-postadress nedan så kommer vi e-posta "
-"instruktioner för att ange ett nytt."
+msgid "Forgot your password? Enter your email address below, and we'll email instructions for setting a new one."
+msgstr "Glömt ditt lösenord? Ange din e-postadress nedan så kommer vi e-posta instruktioner för att ange ett nytt."
 
 #. Translators: This is the label for a button that users click to update their public information.
 #: TWLight/users/forms.py:36
@@ -2586,19 +2197,13 @@ msgstr "Jag samtycker med användningsvillkoren"
 
 #. Translators: This text explains how to disagree to the site's terms of use and the restrictions that will come into effect when users disagree to the terms of use.
 #: TWLight/users/forms.py:185
-msgid ""
-"By unchecking this box and clicking “Update” you may explore the site, but "
-"you will not be able to apply for access to materials or evaluate "
-"applications unless you agree with the terms of use."
+msgid "By unchecking this box and clicking “Update” you may explore the site, but you will not be able to apply for access to materials or evaluate applications unless you agree with the terms of use."
 msgstr ""
 
 #. Translators: Users click this button to set their website email address to the one linked to their Wikipedia account.
 #: TWLight/users/forms.py:211
-msgid ""
-"Use my Wikipedia email address (will be updated the next time you login)."
-msgstr ""
-"Använd min e-postadress för Wikipedia (kommer att uppdateras nästa gång du "
-"loggar in)."
+msgid "Use my Wikipedia email address (will be updated the next time you login)."
+msgstr "Använd min e-postadress för Wikipedia (kommer att uppdateras nästa gång du loggar in)."
 
 #. Translators: This labels a button which users click to change their email.
 #: TWLight/users/forms.py:232
@@ -2608,17 +2213,8 @@ msgstr "Uppdatera e-post"
 #. Translators: Shown if the current user tried to 'favorite' a partner they can't access. Do not translate '{partner}'
 #: TWLight/users/models.py:201
 #, python-brace-format
-msgid ""
-"Cannot add partner {partner} to your favorites because you don't have access "
-"to it"
+msgid "Cannot add partner {partner} to your favorites because you don't have access to it"
 msgstr ""
-
-#. Translators: Do not translate.
-#: TWLight/users/models.py:869
-#, fuzzy, python-brace-format
-#| msgid "Username"
-msgid "{wp_username}"
-msgstr "Användarnamn"
 
 #. Translators: This error message is shown when there's a problem with the authenticated login process.
 #: TWLight/users/oauth.py:243
@@ -2638,9 +2234,7 @@ msgstr ""
 
 #. Translators: this message is displayed to users that don't have accounts and clicked on a proxied link.
 #: TWLight/users/oauth.py:388
-msgid ""
-"To view this link you need to be an eligible library user. Please login to "
-"continue."
+msgid "To view this link you need to be an eligible library user. Please login to continue."
 msgstr ""
 
 #. Translators: This warning message is shown to users when the response received from Wikimedia OAuth servers is not a valid one.
@@ -2676,17 +2270,12 @@ msgstr "Användarinformation"
 
 #. Translators: If the user tries to log in, but their account does not meet certain requirements, they cannot login.
 #: TWLight/users/oauth.py:528
-msgid ""
-"Your Wikipedia account does not meet the eligibility criteria in the terms "
-"of use, so your Wikipedia Library Card Platform account cannot be activated."
+msgid "Your Wikipedia account does not meet the eligibility criteria in the terms of use, so your Wikipedia Library Card Platform account cannot be activated."
 msgstr ""
 
 #. Translators: If the user tries to log in, but their account does not meet certain requirements, they cannot login.
 #: TWLight/users/oauth.py:536
-msgid ""
-"Your Wikipedia account no longer meets the eligibility criteria in the terms "
-"of use, so you cannot be logged in. If you think you should be able to log "
-"in, please email wikipedialibrary@wikimedia.org."
+msgid "Your Wikipedia account no longer meets the eligibility criteria in the terms of use, so you cannot be logged in. If you think you should be able to log in, please email wikipedialibrary@wikimedia.org."
 msgstr ""
 
 #. Translators: this message is displayed to users with brand new accounts.
@@ -2697,10 +2286,7 @@ msgstr ""
 #. Translators: This message is displayed on the confirmation page where users can return their access to partner collections.
 #: TWLight/users/templates/users/authorization_confirm_return.html:13
 #, python-format
-msgid ""
-"You will no longer be able to access <b>%(partner)s's</b> resources via the "
-"Library Card platform, but can request access again by clicking 'renew', if "
-"you change your mind. Are you sure you want to return your access?"
+msgid "You will no longer be able to access <b>%(partner)s's</b> resources via the Library Card platform, but can request access again by clicking 'renew', if you change your mind. Are you sure you want to return your access?"
 msgstr ""
 
 #. Translators: On the MyLibrary page (https://wikipedialibrary.wmflabs.org/users/my_library), this tab shows all favorite collections a user has.
@@ -2770,14 +2356,8 @@ msgstr "Redigerardata"
 
 #. Translators: This is shown on editor profiles, in their profile page or on applications.
 #: TWLight/users/templates/users/editor_detail.html:59
-msgid ""
-"Information with an * was retrieved from Wikipedia directly. Other "
-"information was entered directly by users or site admins, in their preferred "
-"language."
-msgstr ""
-"Information med en * hämtades direkt från Wikipedia. Annan information "
-"skrevs in direkt av användare eller webbplatsadministratörer, på deras "
-"föredragna språk."
+msgid "Information with an * was retrieved from Wikipedia directly. Other information was entered directly by users or site admins, in their preferred language."
+msgstr "Information med en * hämtades direkt från Wikipedia. Annan information skrevs in direkt av användare eller webbplatsadministratörer, på deras föredragna språk."
 
 #. Translators: This distinguishes users who have been flagged as account coordinators. Don't translate username.
 #: TWLight/users/templates/users/editor_detail.html:71
@@ -2787,14 +2367,8 @@ msgstr "%(username)s har samordnarprivilegier på denna webbplats."
 
 #. Translators: This is shown on editor profiles, under the heading for Wikipedia editor data.
 #: TWLight/users/templates/users/editor_detail_data.html:5
-msgid ""
-"This information is updated automatically from your Wikimedia account each "
-"time you log in, except for the Contributions field, where you can describe "
-"your Wikimedia editing history."
-msgstr ""
-"Denna information uppdateras automatiskt från ditt Wikimediakonto varje gång "
-"du loggar loggar in, förutom Bidrag-fältet, där du kan beskriva din historik "
-"av att redigera på Wikimedias projekt."
+msgid "This information is updated automatically from your Wikimedia account each time you log in, except for the Contributions field, where you can describe your Wikimedia editing history."
+msgstr "Denna information uppdateras automatiskt från ditt Wikimediakonto varje gång du loggar loggar in, förutom Bidrag-fältet, där du kan beskriva din historik av att redigera på Wikimedias projekt."
 
 #. Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this labels the user's username.
 #: TWLight/users/templates/users/editor_detail_data.html:17
@@ -2823,17 +2397,13 @@ msgstr "Uppfyller användningsvillkoren?"
 
 #. Translators: when viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this question has a yes or no answer.
 #: TWLight/users/templates/users/editor_detail_data.html:57
-msgid ""
-"at their last login, did this user meet the criteria set forth in the terms "
-"of use?"
+msgid "at their last login, did this user meet the criteria set forth in the terms of use?"
 msgstr ""
 
 #. Translators: When viewing a user's profile in an application, this message shows if the software doesn't think that the user is eligible for access. Don't translate username.
 #: TWLight/users/templates/users/editor_detail_data.html:72
 #, python-format
-msgid ""
-"%(username)s may still be eligible for access grants at the coordinators' "
-"discretion."
+msgid "%(username)s may still be eligible for access grants at the coordinators' discretion."
 msgstr ""
 
 #. Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this is the heading for a Yes/No ToU question.
@@ -2868,10 +2438,7 @@ msgstr "(undantag beviljat)"
 #. Translators: This message is shown on a user's profile if their Wikimedia account is blocked on one or more projects. They may still be granted access to the Library Bundle, but need to contact Wikipedia Library staff to verify.
 #: TWLight/users/templates/users/editor_detail_data.html:137
 #, python-format
-msgid ""
-"It looks like you have an active block on your account. If you meet the "
-"other criteria you may still be permitted access to the library - please <a "
-"class=\"twl-links\" href=\"%(contact_url)s\">contact us</a>."
+msgid "It looks like you have an active block on your account. If you meet the other criteria you may still be permitted access to the library - please <a class=\"twl-links\" href=\"%(contact_url)s\">contact us</a>."
 msgstr ""
 
 #. Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this is the heading for a Yes/No program eligibility question.
@@ -2881,10 +2448,7 @@ msgstr ""
 
 #. Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this question has a Yes or No answer.
 #: TWLight/users/templates/users/editor_detail_data.html:156
-msgid ""
-"At their last login, did this user meet the criteria set forth in the "
-"Library Bundle? Note that satisfying terms of use is a prerequisite to "
-"bundle eligibility."
+msgid "At their last login, did this user meet the criteria set forth in the Library Bundle? Note that satisfying terms of use is a prerequisite to bundle eligibility."
 msgstr ""
 
 #. Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this is the heading for a Yes/No program eligibility question.
@@ -2929,21 +2493,14 @@ msgstr "Personlig data"
 
 #. Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this text is in the 'Personal data' section. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/users/templates/users/editor_detail_data.html:262
-msgid ""
-"The following information is visible only to you, site administrators, "
-"publishing partners (where required), and volunteer Wikipedia Library "
-"coordinators (who have signed a Non-Disclosure Agreement)."
+msgid "The following information is visible only to you, site administrators, publishing partners (where required), and volunteer Wikipedia Library coordinators (who have signed a Non-Disclosure Agreement)."
 msgstr ""
 
 #. Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this labels a button which users can click to update or remove their personal information. Don't translate update_url.
 #: TWLight/users/templates/users/editor_detail_data.html:272
 #, python-format
-msgid ""
-"You may <a class=\"twl-links\" href=\"%(update_url)s\">update or delete</a> "
-"your data at any time."
-msgstr ""
-"Du kan <a class=\"twl-links\" href=\"%(update_url)s\">uppdatera eller "
-"radera</a> din data när som helst."
+msgid "You may <a class=\"twl-links\" href=\"%(update_url)s\">update or delete</a> your data at any time."
+msgstr "Du kan <a class=\"twl-links\" href=\"%(update_url)s\">uppdatera eller radera</a> din data när som helst."
 
 #. Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this labels the user's email. Don't remove the *.
 #: TWLight/users/templates/users/editor_detail_data.html:283
@@ -2962,24 +2519,18 @@ msgstr ""
 
 #. Translators: This message tells users that they are not eligible to access The Wikipedia Library content.
 #: TWLight/users/templates/users/eligibility_modal.html:7
-msgid ""
-"Sorry, your Wikipedia account doesn’t currently qualify to access The "
-"Wikipedia Library."
+msgid "Sorry, your Wikipedia account doesn’t currently qualify to access The Wikipedia Library."
 msgstr ""
 
 #. Translators: This message tells users that they have not agreed to the terms of use, therefore are ineligible to access the content in The Wikipedia Library.
 #: TWLight/users/templates/users/eligibility_modal.html:30
 #, python-format
-msgid ""
-"Agreed with <a href=\"%(terms)s\" class=\"text-danger\"> terms of use </a>"
+msgid "Agreed with <a href=\"%(terms)s\" class=\"text-danger\"> terms of use </a>"
 msgstr ""
 
 #: TWLight/users/templates/users/eligibility_modal.html:40
 #, python-format
-msgid ""
-"It looks like you have an active block on your account. If you meet the "
-"other criteria you may still be permitted access to the library - please <a "
-"href=\"%(contact_url)s\">contact us</a>."
+msgid "It looks like you have an active block on your account. If you meet the other criteria you may still be permitted access to the library - please <a href=\"%(contact_url)s\">contact us</a>."
 msgstr ""
 
 #. Translators: Instructions to refresh a user's data.
@@ -3019,10 +2570,7 @@ msgstr "Ange språk"
 
 #. Translators: This text on the user page helps users naviage to the TranslateWiki Wikipedia Library Card platform translation page.
 #: TWLight/users/templates/users/language_form.html:31
-msgid ""
-"You can help translate the tool at <a class=\"twl-links\" href=\"https://"
-"translatewiki.net/wiki/Translating:Wikipedia_Library_Card_Platform"
-"\">translatewiki.net</a>."
+msgid "You can help translate the tool at <a class=\"twl-links\" href=\"https://translatewiki.net/wiki/Translating:Wikipedia_Library_Card_Platform\">translatewiki.net</a>."
 msgstr ""
 
 #. Translators: When the user starts a new application and submits the application, the user can view the application and withdraw if need be. This changes the label for the Withdraw button.
@@ -3042,9 +2590,7 @@ msgstr "Begär förnyelse"
 
 #. Translators: On the page listing applications, this text explains a user they cannot renew their application since they've already requested a renewal or there aren't any renewals available.
 #: TWLight/users/templates/users/my_applications.html:79
-msgid ""
-"Renewals are either not required, not available right now, or you have "
-"already requested a renewal."
+msgid "Renewals are either not required, not available right now, or you have already requested a renewal."
 msgstr ""
 
 #. Translators: This text is the heading of a section in a user's profile where they can change their preferences.
@@ -3108,19 +2654,12 @@ msgstr ""
 
 #. Translators: This message is displayed on the page where users can request we stop processing their data.
 #: TWLight/users/templates/users/restrict_data.html:15
-msgid ""
-"Checking this box and clicking “Restrict” will pause all processing of the "
-"data you have entered into this website. You will not be able to apply for "
-"access to resources, your applications will not be further processed, and "
-"none of your data will be altered, until you return to this page and uncheck "
-"the box. This is not the same as deleting your data."
+msgid "Checking this box and clicking “Restrict” will pause all processing of the data you have entered into this website. You will not be able to apply for access to resources, your applications will not be further processed, and none of your data will be altered, until you return to this page and uncheck the box. This is not the same as deleting your data."
 msgstr ""
 
 #. Translators: This warning message is shown to coordinators who view the data restriction page.
 #: TWLight/users/templates/users/restrict_data.html:26
-msgid ""
-"You are a coordinator on this site. If you restrict the processing of your "
-"data, your coordinator flag will be removed."
+msgid "You are a coordinator on this site. If you restrict the processing of your data, your coordinator flag will be removed."
 msgstr ""
 
 #. Translators: use the date *when you are translating*, in a language-appropriate format.
@@ -3140,24 +2679,12 @@ msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:51
-msgid ""
-"<a class=\"twl-links\" href=\"https://meta.wikimedia.org/wiki/"
-"The_Wikipedia_Library\"> The Wikipedia Library </a> has partnered with "
-"publishers around the world to allow users to access otherwise paywalled "
-"resources. This website allows Wikipedia editors to search and access these "
-"resources."
+msgid "<a class=\"twl-links\" href=\"https://meta.wikimedia.org/wiki/The_Wikipedia_Library\"> The Wikipedia Library </a> has partnered with publishers around the world to allow users to access otherwise paywalled resources. This website allows Wikipedia editors to search and access these resources."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Wikimedia Foundation should not be translated. WMF should not be translated. Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:63
-msgid ""
-"This program is administered by the Wikimedia Foundation (WMF). These terms "
-"of use and privacy notice pertain to your application for access to "
-"resources through the Wikipedia Library, your use of this website, and your "
-"access to and use of those resources. They also describe our handling of the "
-"information you provide to us in order to create and administer your "
-"Wikipedia Library account. If we make material changes to the terms, we will "
-"notify users."
+msgid "This program is administered by the Wikimedia Foundation (WMF). These terms of use and privacy notice pertain to your application for access to resources through the Wikipedia Library, your use of this website, and your access to and use of those resources. They also describe our handling of the information you provide to us in order to create and administer your Wikipedia Library account. If we make material changes to the terms, we will notify users."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
@@ -3167,37 +2694,17 @@ msgstr "Krav för ett kortkonto på Wikipediabiblioteket"
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:78
-msgid ""
-"Access to resources via The Wikipedia Library is reserved for community "
-"members who have demonstrated their commitment to the Wikimedia projects, "
-"and who will use their access to these resources to improve project content. "
-"To that end, in order to be eligible for The Wikipedia Library, we require "
-"that you be registered for a user account on the projects, with at least 500 "
-"edits, six (6) months of activity, and 10+ edits in the last month. We ask "
-"that you do not request access to any publishers with a limited number of "
-"available accounts whose resources you can already access for free through "
-"your local library or university, or another institution or organization, in "
-"order to provide that opportunity to others."
+msgid "Access to resources via The Wikipedia Library is reserved for community members who have demonstrated their commitment to the Wikimedia projects, and who will use their access to these resources to improve project content. To that end, in order to be eligible for The Wikipedia Library, we require that you be registered for a user account on the projects, with at least 500 edits, six (6) months of activity, and 10+ edits in the last month. We ask that you do not request access to any publishers with a limited number of available accounts whose resources you can already access for free through your local library or university, or another institution or organization, in order to provide that opportunity to others."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:94
-msgid ""
-"Additionally, if you are currently blocked or banned from a Wikimedia "
-"project, applications to resources may be rejected or restricted. If you "
-"obtain a Wikipedia Library account, but a block or ban is subsequently "
-"instituted against you on one of the projects, you may lose access to your "
-"Wikipedia Library account."
+msgid "Additionally, if you are currently blocked or banned from a Wikimedia project, applications to resources may be rejected or restricted. If you obtain a Wikipedia Library account, but a block or ban is subsequently instituted against you on one of the projects, you may lose access to your Wikipedia Library account."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:104
-msgid ""
-"Your eligibility to access The Wikipedia Library is assessed at each login. "
-"While more than half of the library's content is provided via this automated "
-"eligibility check, access to other publisher's content may be time limited, "
-"typically lapsing after one year, after which you will usually need to apply "
-"for renewal."
+msgid "Your eligibility to access The Wikipedia Library is assessed at each login. While more than half of the library's content is provided via this automated eligibility check, access to other publisher's content may be time limited, typically lapsing after one year, after which you will usually need to apply for renewal."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
@@ -3208,47 +2715,27 @@ msgstr "Ansök om ditt kortkonto på Wikipediabiblioteket"
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:118
-msgid ""
-"In order to apply for access to a partner resource, you must provide us with "
-"certain information, which we will use to evaluate your application. If your "
-"application is approved, we may transfer the information you have given us "
-"to the publishers whose resources you wish to access. They will either "
-"contact you with the account information directly or we will send access "
-"information to you ourselves."
+msgid "In order to apply for access to a partner resource, you must provide us with certain information, which we will use to evaluate your application. If your application is approved, we may transfer the information you have given us to the publishers whose resources you wish to access. They will either contact you with the account information directly or we will send access information to you ourselves."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:130
-msgid ""
-"In addition to the basic information you provide to us, our system will "
-"retrieve some information directly from the Wikimedia projects: your "
-"username, email address, edit count, registration date, user ID number, "
-"groups to which you belong, and any special user rights."
+msgid "In addition to the basic information you provide to us, our system will retrieve some information directly from the Wikimedia projects: your username, email address, edit count, registration date, user ID number, groups to which you belong, and any special user rights."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:140
-msgid ""
-"Each time you log in to the Wikipedia Library Card Platform, this "
-"information will be automatically updated."
+msgid "Each time you log in to the Wikipedia Library Card Platform, this information will be automatically updated."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:148
-msgid ""
-"We will ask you to provide us with some information about your history of "
-"contributions to the Wikimedia projects. Information on contribution history "
-"is optional, but will greatly assist us in evaluating your application."
+msgid "We will ask you to provide us with some information about your history of contributions to the Wikimedia projects. Information on contribution history is optional, but will greatly assist us in evaluating your application."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). WMF should not be translated. Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:157
-msgid ""
-"The information you provide when creating your account will be visible to "
-"you while on the site but not to others unless they are approved Wikipedia "
-"Library Coordinators, WMF Staff, or WMF Contractors who need access to this "
-"data in order to carry out their work with the Wikipedia Library, all of "
-"whom are subject to non-disclosure obligations."
+msgid "The information you provide when creating your account will be visible to you while on the site but not to others unless they are approved Wikipedia Library Coordinators, WMF Staff, or WMF Contractors who need access to this data in order to carry out their work with the Wikipedia Library, all of whom are subject to non-disclosure obligations."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
@@ -3258,46 +2745,32 @@ msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:171
-msgid ""
-"In order to access an individual publisher’s resources, you must agree to "
-"that publisher’s terms of use and privacy policy. You agree that you will "
-"not violate such terms and policies in connection with your use of the "
-"Wikipedia Library. Additionally, the following activities are prohibited "
-"while accessing publisher resources through the Wikipedia Library."
+msgid "In order to access an individual publisher’s resources, you must agree to that publisher’s terms of use and privacy policy. You agree that you will not violate such terms and policies in connection with your use of the Wikipedia Library. Additionally, the following activities are prohibited while accessing publisher resources through the Wikipedia Library."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:184
-msgid ""
-"Sharing your Wikipedia account, usernames, passwords, or any access codes "
-"for publisher resources with others;"
+msgid "Sharing your Wikipedia account, usernames, passwords, or any access codes for publisher resources with others;"
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:191
-msgid ""
-"Automatically scraping or downloading restricted content from publishers;"
+msgid "Automatically scraping or downloading restricted content from publishers;"
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:197
-msgid ""
-"Systematically making printed or electronic copies of multiple extracts of "
-"restricted content available for any purpose;"
+msgid "Systematically making printed or electronic copies of multiple extracts of restricted content available for any purpose;"
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:204
-msgid ""
-"Data mining metadata without permission—for example, in order to use "
-"metadata for auto-created stub articles;"
+msgid "Data mining metadata without permission—for example, in order to use metadata for auto-created stub articles;"
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:211
-msgid ""
-"Using the access you receive through the Wikipedia Library for profit by "
-"selling access to your account or resources which you have through it."
+msgid "Using the access you receive through the Wikipedia Library for profit by selling access to your account or resources which you have through it."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
@@ -3307,18 +2780,12 @@ msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:224
-msgid ""
-"Certain resources may only be accessed using an external search service, "
-"such as the EBSCO Discovery Service, or a proxy service, such as OCLC "
-"EZProxy. If you use such external search and/or proxy services, please "
-"review the applicable terms of use and privacy policies."
+msgid "Certain resources may only be accessed using an external search service, such as the EBSCO Discovery Service, or a proxy service, such as OCLC EZProxy. If you use such external search and/or proxy services, please review the applicable terms of use and privacy policies."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:234
-msgid ""
-"In addition, if you use OCLC EZProxy, please note that you may not use it "
-"for commercial purposes."
+msgid "In addition, if you use OCLC EZProxy, please note that you may not use it for commercial purposes."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
@@ -3328,120 +2795,49 @@ msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Wikimedia Foundation should not be translated. Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:245
-msgid ""
-"The Wikimedia Foundation and our service providers use your information for "
-"the legitimate purpose of providing Wikipedia Library services in support of "
-"our charitable mission. When you apply for a Wikipedia Library account, or "
-"use your Wikipedia Library account, we may routinely collect the following "
-"information: your username, email address, edit count, registration date, "
-"user ID number, groups to which you belong, and any special user rights; "
-"your name, country of residence, and/or affiliation, if required by a "
-"partner to which you are applying; your narrative description of your "
-"contributions and reasons for applying for access to partner resources; and "
-"the date you agree to these terms of use."
+msgid "The Wikimedia Foundation and our service providers use your information for the legitimate purpose of providing Wikipedia Library services in support of our charitable mission. When you apply for a Wikipedia Library account, or use your Wikipedia Library account, we may routinely collect the following information: your username, email address, edit count, registration date, user ID number, groups to which you belong, and any special user rights; your name, country of residence, and/or affiliation, if required by a partner to which you are applying; your narrative description of your contributions and reasons for applying for access to partner resources; and the date you agree to these terms of use."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:262
 #, python-format
-msgid ""
-"Each publisher who is a member of the Wikipedia Library program requires "
-"different specific information in the application. Some publishers may "
-"request only an email address, while others request more detailed data, such "
-"as your name, location, or institutional affiliation. When you complete your "
-"application, you will only be asked to supply information required by the "
-"publishers you have chosen, and each publisher will only receive the "
-"information they require for providing you with access. Please see our <a "
-"class=\"twl-links\" href=\"%(all_partners_url)s\">partner information</a> "
-"pages to learn what information is required by each publisher to gain access "
-"to their resources."
+msgid "Each publisher who is a member of the Wikipedia Library program requires different specific information in the application. Some publishers may request only an email address, while others request more detailed data, such as your name, location, or institutional affiliation. When you complete your application, you will only be asked to supply information required by the publishers you have chosen, and each publisher will only receive the information they require for providing you with access. Please see our <a class=\"twl-links\" href=\"%(all_partners_url)s\">partner information</a> pages to learn what information is required by each publisher to gain access to their resources."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Wikimedia Foundation should not be translated. Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:277
-msgid ""
-"Some Wikipedia Library pages are visible without logging in, but you will "
-"need to log in to apply or access proprietary partner resources. We use the "
-"data provided by you via OAuth and Wikimedia API calls to assess your "
-"application for access and to process approved requests."
+msgid "Some Wikipedia Library pages are visible without logging in, but you will need to log in to apply or access proprietary partner resources. We use the data provided by you via OAuth and Wikimedia API calls to assess your application for access and to process approved requests."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:288
 #, python-format
-msgid ""
-"In order to administer the Wikipedia Library program, we will retain the "
-"application data we collect from you for three years after your most recent "
-"login, unless you delete your account, as described below. You can log in "
-"and go to <a class=\"twl-links\" href=\"%(profile_url)s\">your profile page</"
-"a> in order to see the information associated with your account, and can "
-"download it in JSON format. You may access, update, restrict, or delete this "
-"information at any time, except for the information that is automatically "
-"retrieved from the projects. If you have any questions or concerns about the "
-"handling of your data, please contact <a class=\"twl-links\" href=\"mailto:"
-"wikipedialibrary@wikimedia.org?Subject=Wikipedia%%20Library%%20Card"
-"%%20account%%20deactivation\"> wikipedialibrary@wikimedia.org </a>."
+msgid "In order to administer the Wikipedia Library program, we will retain the application data we collect from you for three years after your most recent login, unless you delete your account, as described below. You can log in and go to <a class=\"twl-links\" href=\"%(profile_url)s\">your profile page</a> in order to see the information associated with your account, and can download it in JSON format. You may access, update, restrict, or delete this information at any time, except for the information that is automatically retrieved from the projects. If you have any questions or concerns about the handling of your data, please contact <a class=\"twl-links\" href=\"mailto:wikipedialibrary@wikimedia.org?Subject=Wikipedia%%20Library%%20Card%%20account%%20deactivation\"> wikipedialibrary@wikimedia.org </a>."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:305
-msgid ""
-"If you decide to disable your Wikipedia Library account, you can use the "
-"delete button on your profile to delete certain personal information "
-"associated with your account. We will delete your real name, institutional "
-"affiliation, and country of residence. Please note that the system will "
-"retain a record of your username, the publishers to which you applied or had "
-"access, and the dates of that access. Note that deletion is not reversible. "
-"Deletion of your Wikipedia Library account may also correspond with the "
-"removal of any resource access to which you were eligible or approved. If "
-"you request the deletion of account information and later wish to apply for "
-"a new account, you will need to provide the necessary information again."
+msgid "If you decide to disable your Wikipedia Library account, you can use the delete button on your profile to delete certain personal information associated with your account. We will delete your real name, institutional affiliation, and country of residence. Please note that the system will retain a record of your username, the publishers to which you applied or had access, and the dates of that access. Note that deletion is not reversible. Deletion of your Wikipedia Library account may also correspond with the removal of any resource access to which you were eligible or approved. If you request the deletion of account information and later wish to apply for a new account, you will need to provide the necessary information again."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). WMF should not be translated. Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:321
-msgid ""
-"The Wikipedia Library is run by WMF Staff, Contractors, and approved "
-"volunteer Coordinators. The data associated with your account will be shared "
-"with the WMF staff, contractors, service providers, and volunteer "
-"coordinators who need to process the information in connection with their "
-"work for the Wikipedia Library, and who are subject to confidentiality "
-"obligations. We will also use your data for internal Wikipedia Library "
-"purposes such as distributing user surveys and account notifications, and in "
-"a depersonalized or aggregated fashion for statistical analysis and "
-"administration. Finally, we will share your information with the publishers "
-"whom you specifically select in order to provide you with access to "
-"resources. Otherwise, your information will not be shared with third "
-"parties, with the exception of the circumstances described below."
+msgid "The Wikipedia Library is run by WMF Staff, Contractors, and approved volunteer Coordinators. The data associated with your account will be shared with the WMF staff, contractors, service providers, and volunteer coordinators who need to process the information in connection with their work for the Wikipedia Library, and who are subject to confidentiality obligations. We will also use your data for internal Wikipedia Library purposes such as distributing user surveys and account notifications, and in a depersonalized or aggregated fashion for statistical analysis and administration. Finally, we will share your information with the publishers whom you specifically select in order to provide you with access to resources. Otherwise, your information will not be shared with third parties, with the exception of the circumstances described below."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). WMF should not be translated.
 #: TWLight/users/templates/users/terms.html:338
-msgid ""
-"We may disclose any collected information when required by law, when we have "
-"your permission, when needed to protect our rights, privacy, safety, users, "
-"or the general public, and when necessary to enforce these terms, WMF’s "
-"general <a class=\"twl-links\" href=\"https://foundation.wikimedia.org/wiki/"
-"Terms_of_Use\">Terms of Use</a>, or any other WMF policy."
+msgid "We may disclose any collected information when required by law, when we have your permission, when needed to protect our rights, privacy, safety, users, or the general public, and when necessary to enforce these terms, WMF’s general <a class=\"twl-links\" href=\"https://foundation.wikimedia.org/wiki/Terms_of_Use\">Terms of Use</a>, or any other WMF policy."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:349
-msgid ""
-"We take the security of your personal data seriously, and take reasonable "
-"precautions to ensure your data is protected. These precautions include "
-"access controls to limit who has access to your data and security "
-"technologies to protect data stored on the server. However, we cannot "
-"guarantee the safety of your data as it is transmitted and stored."
+msgid "We take the security of your personal data seriously, and take reasonable precautions to ensure your data is protected. These precautions include access controls to limit who has access to your data and security technologies to protect data stored on the server. However, we cannot guarantee the safety of your data as it is transmitted and stored."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:360
-msgid ""
-"Please note that these terms do not control the use and handling of your "
-"data by the publishers and service providers whose resources you access or "
-"apply to access. Please read their individual privacy policies for that "
-"information."
+msgid "Please note that these terms do not control the use and handling of your data by the publishers and service providers whose resources you access or apply to access. Please read their individual privacy policies for that information."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
@@ -3451,34 +2847,17 @@ msgstr "Viktig anmärkning"
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Wikimedia Foundation should not be translated. Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:373
-msgid ""
-"The Wikimedia Foundation is a nonprofit organization based in San Francisco, "
-"California. The Wikipedia Library program provides access to resources held "
-"by publishers in multiple countries. If you apply for a Wikipedia Library "
-"account (whether you are inside or outside of the United States), you "
-"understand that your personal data will be collected, transferred, stored, "
-"processed, disclosed and otherwise used in the U.S. as described in this "
-"privacy policy. You also understand that your information may be transferred "
-"by us from the U.S. to other countries, which may have different or less "
-"stringent data protection laws than your country, in connection with "
-"providing services to you, including evaluating your application and "
-"securing access to your chosen publishers (locations for each publisher are "
-"outlined on their respective partner information pages)."
+msgid "The Wikimedia Foundation is a nonprofit organization based in San Francisco, California. The Wikipedia Library program provides access to resources held by publishers in multiple countries. If you apply for a Wikipedia Library account (whether you are inside or outside of the United States), you understand that your personal data will be collected, transferred, stored, processed, disclosed and otherwise used in the U.S. as described in this privacy policy. You also understand that your information may be transferred by us from the U.S. to other countries, which may have different or less stringent data protection laws than your country, in connection with providing services to you, including evaluating your application and securing access to your chosen publishers (locations for each publisher are outlined on their respective partner information pages)."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:392
-msgid ""
-"Please note that in the event of any differences in meaning or "
-"interpretation between the original English version of these terms and a "
-"translation, the original English version takes precedence."
+msgid "Please note that in the event of any differences in meaning or interpretation between the original English version of these terms and a translation, the original English version takes precedence."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Wikimedia Foundation should not be translated.
 #: TWLight/users/templates/users/terms.html:403
-msgid ""
-"See also the <a class=\"twl-links\" href=\"https://wikimediafoundation.org/"
-"wiki/Privacy_policy\">Wikimedia Foundation Privacy Policy</a>."
+msgid "See also the <a class=\"twl-links\" href=\"https://wikimediafoundation.org/wiki/Privacy_policy\">Wikimedia Foundation Privacy Policy</a>."
 msgstr ""
 
 #. Translators: This is the second to last line of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
@@ -3499,11 +2878,7 @@ msgstr "Antal Wikipedia-redigeringar"
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:426
-msgid ""
-"By checking this box and clicking “Submit”, you agree that you have read the "
-"above terms and that you will adhere to the terms of use in your application "
-"to and use of the The Wikipedia Library, and the publishers’ services to "
-"which you gain access through The Wikipedia Library program."
+msgid "By checking this box and clicking “Submit”, you agree that you have read the above terms and that you will adhere to the terms of use in your application to and use of the The Wikipedia Library, and the publishers’ services to which you gain access through The Wikipedia Library program."
 msgstr ""
 
 #: TWLight/users/templates/users/user_collection_tile.html:32
@@ -3556,29 +2931,18 @@ msgstr "Radera all data"
 
 #. Translators: This message is displayed on the page where users can request the deletion of their data.
 #: TWLight/users/templates/users/user_confirm_delete.html:17
-msgid ""
-"<b>Warning:</b> Performing this action will delete your Wikipedia Library "
-"Card user account and all associated applications. This process is not "
-"reversible. You may lose any partner accounts you were granted, and will not "
-"be able to renew those accounts or apply for new ones."
+msgid "<b>Warning:</b> Performing this action will delete your Wikipedia Library Card user account and all associated applications. This process is not reversible. You may lose any partner accounts you were granted, and will not be able to renew those accounts or apply for new ones."
 msgstr ""
 
 #. Translators: this should show up for people who log in with a username/password and not OAuth, so we don't know what their Wikipedia identity is.
-#.
 #: TWLight/users/templates/users/user_detail.html:12
 #, python-format
-msgid ""
-"Hi, %(username)s! You don't have a Wikipedia editor profile attached to your "
-"account here, so you are probably a site administrator."
+msgid "Hi, %(username)s! You don't have a Wikipedia editor profile attached to your account here, so you are probably a site administrator."
 msgstr ""
 
 #. Translators: In the unlikely scenario that someone is able to register an account without using OAuth (thus leaving us without some of the information required for applications), users will see this message, encouraging them to re-register.
 #: TWLight/users/templates/users/user_detail.html:20
-msgid ""
-"If you aren't a site administrator, something weird has happened. You won't "
-"be able to apply for access without a Wikipedia editor profile. You should "
-"log out and create a new account by logging in via OAuth, or contact a site "
-"administrator for help."
+msgid "If you aren't a site administrator, something weird has happened. You won't be able to apply for access without a Wikipedia editor profile. You should log out and create a new account by logging in via OAuth, or contact a site administrator for help."
 msgstr ""
 
 #. Translators: Labels a sections where coordinators can select their email preferences.
@@ -3589,21 +2953,14 @@ msgstr ""
 #. Translators: This message is shown on user's own profile page, encouraging them to make sure their information is up to date, so that account coordinators can use the information to judge applications.
 #: TWLight/users/views.py:176
 #, python-brace-format
-msgid ""
-"Please <a class='twl-links' href='{url}'>update your contributions</a> to "
-"Wikipedia to help coordinators evaluate your applications."
+msgid "Please <a class='twl-links' href='{url}'>update your contributions</a> to Wikipedia to help coordinators evaluate your applications."
 msgstr ""
 
 #. Translators: Coordinators are shown this message when they unselect all three types of reminder email options under preferences.
 #: TWLight/users/views.py:288
 #, fuzzy
-msgid ""
-"You have chosen not to receive reminder emails. As a coordinator, you should "
-"receive at least one type of reminder emails, so consider changing your "
-"preferences."
-msgstr ""
-"Du har valt att inte få påminnelser via e-post. Som samordnare borde du ta "
-"emot minst en sorts påminnelser så, överväg att ändra dina inställningar."
+msgid "You have chosen not to receive reminder emails. As a coordinator, you should receive at least one type of reminder emails, so consider changing your preferences."
+msgstr "Du har valt att inte få påminnelser via e-post. Som samordnare borde du ta emot minst en sorts påminnelser så, överväg att ändra dina inställningar."
 
 #. Translators: Coordinators are shown this message when they make changes to their reminder email options under preferences.
 #: TWLight/users/views.py:296
@@ -3636,9 +2993,7 @@ msgstr "Din e-postadress har ändrats till {email}."
 
 #. Translators: If the user has not filled out their email, they can browse the website but cannot apply for access to resources.
 #: TWLight/users/views.py:487
-msgid ""
-"Your email is blank. You can still explore the site, but you won't be able "
-"to apply for access to partner resources without an email."
+msgid "Your email is blank. You can still explore the site, but you won't be able to apply for access to partner resources without an email."
 msgstr ""
 
 #. Translators: This message is shown once the access to a partner has successfully been returned.
@@ -3673,31 +3028,3 @@ msgstr "Inga aktiva blockeringar"
 msgid "10+ edits in the last 30 days"
 msgstr "10+ redigeringar den senaste månaden"
 
-#: tests/shunit/data/bad_i18n_comment_1.py:3
-#: tests/shunit/data/bad_i18n_newline_1.py:5
-msgid "1"
-msgstr ""
-
-#. Translators: Lorem ipsum dolor sit amet, consectetur adipiscing elit. Mauris vitae ipsum ut purus faucibus pretium. Proin tempus neque et aliquet consectetur. Ut egestas sapien in consectetur sagittis. Mauris neque lacus, dapibus non viverra vitae, interdum ut aenean ipsum.
-#. Translators: Lorem ipsum dolor sit amet, consectetur adipiscing elit. Mauris vitae ipsum ut purus faucibus pretium. Proin tempus neque et aliquet consectetur. Ut egestas sapien in consectetur sagittis. Mauris neque lacus, dapibus non.
-#: tests/shunit/data/bad_i18n_comment_2.py:4
-#: tests/shunit/data/bad_i18n_newline_2.py:5 tests/shunit/data/good_i18n_1.py:2
-#: tests/shunit/data/good_i18n_2.py:2
-msgid "2"
-msgstr ""
-
-#: tests/shunit/data/bad_i18n_newline_3.py:5
-msgid "3"
-msgstr ""
-
-#: tests/shunit/data/bad_i18n_newline_4.py:5
-msgid "4"
-msgstr ""
-
-#: tests/shunit/data/bad_i18n_newline_5.py:5
-msgid "5"
-msgstr ""
-
-#: tests/shunit/data/bad_i18n_newline_6.py:5
-msgid "6"
-msgstr ""

--- a/locale/ta/LC_MESSAGES/django.po
+++ b/locale/ta/LC_MESSAGES/django.po
@@ -12,10 +12,11 @@
 # Author: UY Scuti
 msgid ""
 msgstr ""
+""
 "Project-Id-Version: Wikipedia Library Card Platform - Website\n"
-"Report-Msgid-Bugs-To: wikipedialibrary@wikimedia.org\n"
+"Report-Msgid-Bugs-To: translatewiki.net\n"
 "POT-Creation-Date: 2024-07-11 20:54+0000\n"
-"PO-Revision-Date: 2024-07-11 12:30:19+0000\n"
+"PO-Revision-Date: 2024-07-15 12:29:19+0000\n"
 "Language: ta\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
@@ -47,13 +48,8 @@ msgstr "உன்னை பற்றி"
 #. Translators: This note appears in a section of a form where we ask users to enter info (like country of residence) when applying for resource access.
 #: TWLight/applications/forms.py:179
 #, python-brace-format
-msgid ""
-"<p><small><i>Your personal data will be processed according to our <a "
-"class='twl-links' href='{terms_url}'> privacy policy</a>.</i></small></p>"
-msgstr ""
-"<p><small><i>உங்கள் தனிப்பட்ட தரவு எங்கள் \n"
-"<a class='twl-links' href='{terms_url}'>தனியுரிமை கொள்கையின்படி</a> "
-"பயன்படுத்தப்படும்.</i></small></p>"
+msgid "<p><small><i>Your personal data will be processed according to our <a class='twl-links' href='{terms_url}'> privacy policy</a>.</i></small></p>"
+msgstr "<p><small><i>உங்கள் தனிப்பட்ட தரவு எங்கள் \n<a class='twl-links' href='{terms_url}'>தனியுரிமை கொள்கையின்படி</a> பயன்படுத்தப்படும்.</i></small></p>"
 
 #. Translators: This is the title of the application form page, where users enter information required for the application. It lets the user know which partner application they are entering data for. {partner}
 #: TWLight/applications/forms.py:189
@@ -94,11 +90,8 @@ msgstr "பங்குதாரரின் வலைத்தளத்தி�
 #. Translators: This labels a choice field where users will have to select the number of months they wish to have their access for as part of the application renewal confirmation.
 #. Translators: When filling out an application, users may be required to enter the length of the account (expiry) they wish to have for proxy partners.
 #: TWLight/applications/forms.py:339 TWLight/applications/helpers.py:100
-msgid ""
-"The number of months you wish to have this access for before renewal is "
-"required"
-msgstr ""
-"புதுப்பிக்கப்படுவதற்கு முன்பு இந்த ஆதாரத்தை நீங்கள் பெற விரும்பும் மாதங்களின் எண்ணிக்கை"
+msgid "The number of months you wish to have this access for before renewal is required"
+msgstr "புதுப்பிக்கப்படுவதற்கு முன்பு இந்த ஆதாரத்தை நீங்கள் பெற விரும்பும் மாதங்களின் எண்ணிக்கை"
 
 #. Translators: When filling out an application, users may need to specify their name
 #: TWLight/applications/helpers.py:81
@@ -186,12 +179,8 @@ msgstr "மின்னஞ்சல்"
 
 #. Translators: This comment is added to pending applications when our terms of use change.
 #: TWLight/applications/management/commands/notify_applicants_tou_changes.py:54
-msgid ""
-"Our terms of use have changed. Your applications will not be processed until "
-"you log in and agree to our updated terms."
-msgstr ""
-"எங்கள் பயன்பாட்டு விதிமுறைகள் மாறிவிட்டன. நீங்கள் உள்நுழைந்து எங்கள் புதுப்பிக்கப்பட்ட "
-"விதிமுறைகளை ஒப்புக் கொள்ளும் வரை உங்கள் விண்ணப்பங்கள் மதிப்பாய்வு செய்யப்படமாட்டாது."
+msgid "Our terms of use have changed. Your applications will not be processed until you log in and agree to our updated terms."
+msgstr "எங்கள் பயன்பாட்டு விதிமுறைகள் மாறிவிட்டன. நீங்கள் உள்நுழைந்து எங்கள் புதுப்பிக்கப்பட்ட விதிமுறைகளை ஒப்புக் கொள்ளும் வரை உங்கள் விண்ணப்பங்கள் மதிப்பாய்வு செய்யப்படமாட்டாது."
 
 #. Translators: This is the status of an application that has not yet been reviewed.
 #: TWLight/applications/models.py:54
@@ -260,42 +249,26 @@ msgstr "அணுகல் URL: {access_url}"
 
 #. Translators: This text goes into account approval emails in the case that we need to send the user's details to a publisher for manual account setup.
 #: TWLight/applications/models.py:331
-msgid ""
-"You can expect to receive access details within a week or two once it has "
-"been processed."
-msgstr ""
-"மதிப்பாய்வு செய்யப்பட்ட ஒன்று அல்லது இரண்டு வாரங்களுக்குள் அணுகல் விவரங்களை நீங்கள் பெறுவீர்கள் "
-"என்று எதிர்பார்க்கலாம்."
+msgid "You can expect to receive access details within a week or two once it has been processed."
+msgstr "மதிப்பாய்வு செய்யப்பட்ட ஒன்று அல்லது இரண்டு வாரங்களுக்குள் அணுகல் விவரங்களை நீங்கள் பெறுவீர்கள் என்று எதிர்பார்க்கலாம்."
 
 #. Translators: This comment is added to open applications when a partner joins the Library Bundle, which does not require applications.
 #: TWLight/applications/signals.py:247
-msgid ""
-"This partner joined the Library Bundle, which does not require applications. "
-"This application will be marked as invalid."
-msgstr ""
-"இந்த கூட்டாளர் லைப்ரரி பண்டிலில் சேர்ந்துள்ளார், இதற்கு விண்ணப்பங்கள் தேவையில்லை. இந்த "
-"விண்ணப்பம் செல்லாது என குறிக்கப்படும்."
+msgid "This partner joined the Library Bundle, which does not require applications. This application will be marked as invalid."
+msgstr "இந்த கூட்டாளர் லைப்ரரி பண்டிலில் சேர்ந்துள்ளார், இதற்கு விண்ணப்பங்கள் தேவையில்லை. இந்த விண்ணப்பம் செல்லாது என குறிக்கப்படும்."
 
 #. Translators: This is shown to users if the application is to a partner for which we have run out of available accounts. The application is therefore on a 'waitlist', and will be reviewed when more accounts are available.
 #: TWLight/applications/templates/applications/application_evaluation.html:29
-msgid ""
-"This application is on the waitlist because this partner does not have any "
-"access grants available at this time."
-msgstr ""
-"இந்த பங்குதாரரிடம் தற்போது கணக்குகள் இல்லாத காரணத்தினால் இந்த விண்ணப்பம் காத்திருப்புப் "
-"பட்டியலில் உள்ளது"
+msgid "This application is on the waitlist because this partner does not have any access grants available at this time."
+msgstr "இந்த பங்குதாரரிடம் தற்போது கணக்குகள் இல்லாத காரணத்தினால் இந்த விண்ணப்பம் காத்திருப்புப் பட்டியலில் உள்ளது"
 
 #. Translators: This message is shown on pages where coordinators can see personal information about applicants.
 #: TWLight/applications/templates/applications/application_evaluation.html:36
 #: TWLight/applications/templates/applications/application_list_include.html:6
 #: TWLight/applications/templates/applications/send_partner.html:45
 #: TWLight/resources/templates/resources/partner_users.html:18
-msgid ""
-"Coordinators: This page may contain personal information such as real names "
-"and email addresses. Please remember that this information is confidential."
-msgstr ""
-"ஒருங்கிணைப்பாளர்கள்: இந்தப் பக்கத்தில் உண்மையான பெயர்கள் மற்றும் மின்னஞ்சல் முகவரிகள் போன்ற "
-"தனிப்பட்ட தகவல்கள் இருக்கலாம். இந்த தகவல் ரகசியமானது என்பதை நினைவில் கொள்க."
+msgid "Coordinators: This page may contain personal information such as real names and email addresses. Please remember that this information is confidential."
+msgstr "ஒருங்கிணைப்பாளர்கள்: இந்தப் பக்கத்தில் உண்மையான பெயர்கள் மற்றும் மின்னஞ்சல் முகவரிகள் போன்ற தனிப்பட்ட தகவல்கள் இருக்கலாம். இந்த தகவல் ரகசியமானது என்பதை நினைவில் கொள்க."
 
 #. Translators: This is the title of the application page shown to users who are a coordinator, and are able to accept or reject the application.
 #: TWLight/applications/templates/applications/application_evaluation.html:39
@@ -304,12 +277,8 @@ msgstr "விண்ணப்பத்தை மதிப்பாய்வு �
 
 #. Translators: This text is shown to coordinators on application pages if the applicant has restricted processing of their data.
 #: TWLight/applications/templates/applications/application_evaluation.html:42
-msgid ""
-"This user has requested a restriction on the processing of their data, so "
-"you cannot change the status of their application."
-msgstr ""
-"இந்த பயனர் அவர்களது தகவல்களை பயன்படுத்துவதில் கட்டுப்பாடு விதித்துள்ளார், எனவே நீங்கள் "
-"அவர்களின் விண்ணப்பத்தின் நிலையை மாற்ற முடியாது"
+msgid "This user has requested a restriction on the processing of their data, so you cannot change the status of their application."
+msgstr "இந்த பயனர் அவர்களது தகவல்களை பயன்படுத்துவதில் கட்டுப்பாடு விதித்துள்ளார், எனவே நீங்கள் அவர்களின் விண்ணப்பத்தின் நிலையை மாற்ற முடியாது"
 
 #. Translators: This is the title of the application page shown to users who are not a coordinator.
 #: TWLight/applications/templates/applications/application_evaluation.html:48
@@ -384,12 +353,8 @@ msgstr "அறியப்படாதது"
 
 #. Translators: This is the text displayed to coordinators when an applicant has no country of residence in their profile.
 #: TWLight/applications/templates/applications/application_evaluation.html:123
-msgid ""
-"Please request the applicant add their country of residence to their profile "
-"before proceeding further."
-msgstr ""
-"மேலும் தொடருமுன் விண்ணப்பதாரர் அவர்கள் வசிக்கும் நாட்டை தங்கள் சுயவிவரத்தில் சேர்க்குமாறு "
-"கோருங்கள்."
+msgid "Please request the applicant add their country of residence to their profile before proceeding further."
+msgstr "மேலும் தொடருமுன் விண்ணப்பதாரர் அவர்கள் வசிக்கும் நாட்டை தங்கள் சுயவிவரத்தில் சேர்க்குமாறு கோருங்கள்."
 
 #. Translators: This labels the section of an application showing the total number of accounts available for a partner or their collection.
 #: TWLight/applications/templates/applications/application_evaluation.html:134
@@ -400,12 +365,8 @@ msgstr "கிடைக்கப் பெறுவதில்லை"
 #. Translators: This labels the section of an application showing whether the user had agreed to the terms of use or not.
 #: TWLight/applications/templates/applications/application_evaluation.html:145
 #, python-format
-msgid ""
-"Has agreed to the site's <a class=\"twl-links\" href=\"%(terms_url)s\">terms "
-"of use</a>?"
-msgstr ""
-"தளத்தின் <a class=\"twl-links\" href=\"%(terms_url)s\">பயன்பாட்டு "
-"விதிமுறைகளுக்கு</a> ஒப்புக் கொண்டார்களா?"
+msgid "Has agreed to the site's <a class=\"twl-links\" href=\"%(terms_url)s\">terms of use</a>?"
+msgstr "தளத்தின் <a class=\"twl-links\" href=\"%(terms_url)s\">பயன்பாட்டு விதிமுறைகளுக்கு</a> ஒப்புக் கொண்டார்களா?"
 
 #. Translators: Displayed to coordinators when they've agreed to the terms of use.
 #. Translators: Displayed if the user has agreed to the terms of use.
@@ -440,12 +401,8 @@ msgstr "இல்லை"
 
 #. Translators: This is the text displayed to coordinators when an applicant has not agreed to the terms of use.
 #: TWLight/applications/templates/applications/application_evaluation.html:159
-msgid ""
-"Please request the applicant agree to the site's terms of use before "
-"approving this application."
-msgstr ""
-"இந்த விண்ணப்பத்திற்கு ஒப்புதல் அளிக்கும் முன் விண்ணப்பதாரர், தளத்தின் பயன்பாட்டு "
-"விதிமுறைகளுக்கு ஒப்புக் கொள்ளுமாறு கோருங்கள்."
+msgid "Please request the applicant agree to the site's terms of use before approving this application."
+msgstr "இந்த விண்ணப்பத்திற்கு ஒப்புதல் அளிக்கும் முன் விண்ணப்பதாரர், தளத்தின் பயன்பாட்டு விதிமுறைகளுக்கு ஒப்புக் கொள்ளுமாறு கோருங்கள்."
 
 #. Translators: This labels the section of an application containing the user's motivation for wanting access to this resource.
 #: TWLight/applications/templates/applications/application_evaluation.html:176
@@ -465,8 +422,7 @@ msgstr "ஏற்கனவே இருக்கும் தொகுப்ப�
 #. Translators: This message is shown next to the 'Renewal of existing access grant?' label if the application is a renewal. Don't translate HTML tags or parent_url.
 #: TWLight/applications/templates/applications/application_evaluation.html:195
 #, python-format
-msgid ""
-"Yes (<a class=\"twl-links\" href=\"%(parent_url)s\">previous application</a>)"
+msgid "Yes (<a class=\"twl-links\" href=\"%(parent_url)s\">previous application</a>)"
 msgstr "ஆம் (<a class=\"twl-links\" href=\"%(parent_url)s\">முந்தைய விண்ணப்பம்</a>)"
 
 #. Translators: This labels the section of the application showing the length of access remaining on the user's previous authorization.
@@ -503,12 +459,8 @@ msgstr "கருத்துகளைச் சேர்க்க"
 
 #. Translators: On an application page, this text tells users that the comments posted on the application are visible to coordinators and the submitting user only.
 #: TWLight/applications/templates/applications/application_evaluation.html:297
-msgid ""
-"Comments are visible to all coordinators and to the editor who submitted "
-"this application."
-msgstr ""
-"எல்லா ஒருங்கிணைப்பாளர்களுக்கும், இந்த விண்ணப்பத்தை சமர்ப்பித்த \n"
-"பயனருக்கும் கருத்துகள் புலப்படும்."
+msgid "Comments are visible to all coordinators and to the editor who submitted this application."
+msgstr "எல்லா ஒருங்கிணைப்பாளர்களுக்கும், இந்த விண்ணப்பத்தை சமர்ப்பித்த \nபயனருக்கும் கருத்துகள் புலப்படும்."
 
 #. Translators: This is the title of the section of an application page which lists information about the user who submitted the application.
 #. Translators: On the page where coordinators can view data on applications to a partner they coordinate, this is a table column heading for the username.
@@ -723,20 +675,14 @@ msgstr "நிலையை அமைக்கவும்"
 
 #: TWLight/applications/templates/applications/apply.html:20
 #, python-format
-msgid ""
-"If your application is successful we may share your email address with "
-"%(partner)s. This is required to set up your access to their resources. By "
-"submitting this form you agree to allow your email address to be shared with "
-"%(partner)s if your application is successful, for the purposes of account "
-"setup."
+msgid "If your application is successful we may share your email address with %(partner)s. This is required to set up your access to their resources. By submitting this form you agree to allow your email address to be shared with %(partner)s if your application is successful, for the purposes of account setup."
 msgstr ""
 
 #. Translators: This message is displayed on the page where users can confirm their renewal. Please do not translate partner.
 #: TWLight/applications/templates/applications/confirm_renewal.html:23
 #, python-format
 msgid "Click 'confirm' to renew your application for %(partner)s"
-msgstr ""
-"%(partner)s இற்கான உமது விண்ணப்பத்தை இற்றையாக்க 'உறுதிப்படுத்து' என்பதைச் சொடுக்குக"
+msgstr "%(partner)s இற்கான உமது விண்ணப்பத்தை இற்றையாக்க 'உறுதிப்படுத்து' என்பதைச் சொடுக்குக"
 
 #. Translators: Labels the submit button requesting confirmation of application renewal.
 #. Translators: This is the button coordinators click to confirm deletion of a suggestion.
@@ -758,9 +704,7 @@ msgstr ""
 
 #. Translators: This text explains that Library Bundle partners are not shown in this list.
 #: TWLight/applications/templates/applications/request_for_application.html:26
-msgid ""
-"Library Bundle partners are not shown as eligibility is determined "
-"automatically."
+msgid "Library Bundle partners are not shown as eligibility is determined automatically."
 msgstr ""
 
 #. Translators: On the page where users can apply for multiple partners, this message shows next to the partner name, taking them to the full application page when clicked.
@@ -775,10 +719,7 @@ msgstr ""
 
 #. Translators: the HTML is so that the word 'waitlisted' will look the same as it does in the page above; please translate 'waitlisted' the same way you did elsewhere in this file.
 #: TWLight/applications/templates/applications/request_for_application.html:74
-msgid ""
-"You can apply to <span class=\"badge badge-warning\">Waitlisted</span> "
-"partners, but they don't have access grants available right now. We will "
-"process those applications when access becomes available."
+msgid "You can apply to <span class=\"badge badge-warning\">Waitlisted</span> partners, but they don't have access grants available right now. We will process those applications when access becomes available."
 msgstr ""
 
 #. Translators: On the page where coordinators can see approved applications which have not had their details sent to the partner, this message shows when there are applications ready to be processed.
@@ -800,9 +741,7 @@ msgstr ""
 #. Translators: This message is shown when applications exceed the number of accounts available.
 #: TWLight/applications/templates/applications/send_partner.html:54
 #, python-format
-msgid ""
-"Application(s) for %(object)s, if sent, will exceed the total available "
-"accounts for the partner. Please proceed at your own discretion."
+msgid "Application(s) for %(object)s, if sent, will exceed the total available accounts for the partner. Please proceed at your own discretion."
 msgstr ""
 
 #. Translators: When viewing the list of applications ready to be sent for a particular partner, this is instructions for the coordinator to click the 'mark as sent' button after they have sent the information.
@@ -819,9 +758,7 @@ msgstr[1] ""
 
 #. Translators: When viewing the list of applications ready to be sent for a particular partner, this message shows if there is no information about who the applications should be sent to. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/applications/templates/applications/send_partner.html:89
-msgid ""
-"Whoops, we don't have any listed contacts. Please notify Wikipedia Library "
-"administrators."
+msgid "Whoops, we don't have any listed contacts. Please notify Wikipedia Library administrators."
 msgstr ""
 
 #. Translators: When viewing the list of applications ready to be sent for a particular partner, this is the title of the section containing the information about those applications.
@@ -837,9 +774,7 @@ msgstr "அனுப்பியதாகக் குறி"
 
 #. Translators: This text guides coordinators in using the code sending interface for approved applications.
 #: TWLight/applications/templates/applications/send_partner.html:152
-msgid ""
-"Use the dropdown menus to denote which editor will receive each code. Access "
-"codes will be sent to users automatically."
+msgid "Use the dropdown menus to denote which editor will receive each code. Access codes will be sent to users automatically."
 msgstr ""
 
 #. Translators: This labels a drop-down selection where staff can assign an access code to a user.
@@ -855,18 +790,13 @@ msgstr ""
 #. Translators: When a user applies for a set of resources, they receive this message if none are currently available. They are instead placed on a 'waitlist' for later approval.
 #. Translators: When a user renews their resource, they receive this message if none are currently available. They are instead placed on a 'waitlist' for later approval.
 #: TWLight/applications/views.py:140 TWLight/applications/views.py:1282
-msgid ""
-"This partner does not have any access grants available at this time. You may "
-"still apply for access; your application will be reviewed when access grants "
-"become available."
+msgid "This partner does not have any access grants available at this time. You may still apply for access; your application will be reviewed when access grants become available."
 msgstr ""
 
 #. Translators: This message is shown to users once they've successfully submitted their application for review.
 #: TWLight/applications/views.py:163
 #, python-brace-format
-msgid ""
-"Your application has been submitted for review. Head over to <a "
-"href='{applications_url}'>My Applications</a> to view the status."
+msgid "Your application has been submitted for review. Head over to <a href='{applications_url}'>My Applications</a> to view the status."
 msgstr ""
 
 #. Translators: This text is displayed to users when the user has chosen to restrict data and is trying to apply for multiple partners
@@ -915,16 +845,12 @@ msgstr "அனுப்பிய விண்ணப்பங்கள்"
 
 #. Translators: After a coordinator has changed the status of an application to APPROVED, if the corresponding partner/collection is waitlisted this message appears.
 #: TWLight/applications/views.py:756
-msgid ""
-"Cannot approve application as partner with proxy authorization method is "
-"waitlisted."
+msgid "Cannot approve application as partner with proxy authorization method is waitlisted."
 msgstr ""
 
 #. Translators: After a coordinator has changed the status of an application to APPROVED, if the corresponding partner/collection has no accounts for distribution, this message appears.
 #: TWLight/applications/views.py:780
-msgid ""
-"Cannot approve application as partner with proxy authorization method is "
-"waitlisted and (or) has zero accounts available for distribution."
+msgid "Cannot approve application as partner with proxy authorization method is waitlisted and (or) has zero accounts available for distribution."
 msgstr ""
 
 #. Translators: This message appears on an "access denied" screen that stops users who attempt to authorize an editor to access a resource during a time period for which they are already authorized.
@@ -935,11 +861,7 @@ msgstr ""
 #. Translators: This message is shown to users when they access an application page of a now Bundle partner (new applications aren't allowed for Bundle partners and the status of old applications cannot be modified)
 #: TWLight/applications/views.py:857
 #, python-brace-format
-msgid ""
-"This application cannot be modified since this partner is now part of our <a "
-"href='{bundle}'>bundle access</a>. If you are eligible, you can access this "
-"resource from <a href='{library}'>your library</a>. <a "
-"href='{contact}'>Contact us</a> if you have any questions."
+msgid "This application cannot be modified since this partner is now part of our <a href='{bundle}'>bundle access</a>. If you are eligible, you can access this resource from <a href='{library}'>your library</a>. <a href='{contact}'>Contact us</a> if you have any questions."
 msgstr ""
 
 #. Translators: this lets a reviewer set the status of a single application.
@@ -949,9 +871,7 @@ msgstr ""
 
 #. Translators: This warning is message is shown to applicants when the number of pending applications is greater than the number of accounts available.
 #: TWLight/applications/views.py:891
-msgid ""
-"There are more pending applications than available accounts. Your "
-"application might get waitlisted."
+msgid "There are more pending applications than available accounts. Your application might get waitlisted."
 msgstr ""
 
 #. Translators: this message is shown to coordinators who attempt to change an application's Status from INVALID to any other Status.
@@ -971,11 +891,7 @@ msgstr ""
 
 #. Translators: After a coordinator has changed the status of a number of applications to APPROVED, if the corresponding partner(s) is/are waitlisted or has no accounts for distribution, this message appears.
 #: TWLight/applications/views.py:1051
-msgid ""
-"Cannot approve application(s) {} as partner(s) with proxy authorization "
-"method is/are waitlisted and (or) has/have not enough accounts available. If "
-"not enough accounts are available, prioritise the applications and then "
-"approve applications equal to the accounts available."
+msgid "Cannot approve application(s) {} as partner(s) with proxy authorization method is/are waitlisted and (or) has/have not enough accounts available. If not enough accounts are available, prioritise the applications and then approve applications equal to the accounts available."
 msgstr ""
 
 #. Translators: This message is shown to coordinators who attempt to assign the same access code to multiple users.
@@ -990,9 +906,7 @@ msgstr ""
 
 #. Translators: When a user tries to renew their resource, they receive this message if the partner is not available.
 #: TWLight/applications/views.py:1272
-msgid ""
-"Cannot renew application at this time as partner is not available. Please "
-"check back later, or contact us for more information."
+msgid "Cannot renew application at this time as partner is not available. Please check back later, or contact us for more information."
 msgstr ""
 
 #. Translators: This message is displayed when an attempt by a user to renew an application has been denied for some reason.
@@ -1003,16 +917,12 @@ msgstr ""
 
 #. Translators: If a user requests the renewal of their account, but it wasn't renewed, this message is shown to them.
 #: TWLight/applications/views.py:1385
-msgid ""
-"This object cannot be renewed. (This probably means that you have already "
-"requested that it be renewed.)"
+msgid "This object cannot be renewed. (This probably means that you have already requested that it be renewed.)"
 msgstr ""
 
 #. Translators: If a user requests the renewal of their account, this message is shown to them.
 #: TWLight/applications/views.py:1395
-msgid ""
-"Your renewal request has been received. A coordinator will review your "
-"request."
+msgid "Your renewal request has been received. A coordinator will review your request."
 msgstr ""
 
 #. Translators: This labels a textfield where users can enter their email ID.
@@ -1023,9 +933,7 @@ msgstr "கணக்கு மின்னஞ்சல்"
 
 #. Translators: This is the help text for the email field in the contact us form letting users know the field is updated by value pulled from their respective user profiles.
 #: TWLight/emails/forms.py:21
-msgid ""
-"This field is automatically updated with the email from your <a class='twl-"
-"links' href='{}'>user profile</a>."
+msgid "This field is automatically updated with the email from your <a class='twl-links' href='{}'>user profile</a>."
 msgstr ""
 
 #. Translators: This labels a textfield where users can enter their email message.
@@ -1049,19 +957,13 @@ msgstr ""
 #. Translators: This email is sent to users with their access code. Don't translate Jinja variables in curly braces like user or partner. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/access_code_email-body-html.html:5
 #, python-format
-msgid ""
-"<p>Your approved application to %(partner)s has now been finalised. Your "
-"access code or login details can be found below:</p> <p><b>%(access_code)s</"
-"b></p> <p>%(user_instructions)s</p>"
+msgid "<p>Your approved application to %(partner)s has now been finalised. Your access code or login details can be found below:</p> <p><b>%(access_code)s</b></p> <p>%(user_instructions)s</p>"
 msgstr ""
 
 #. Translators: This email is sent to users with their access code. Don't translate Jinja variables in curly braces like user or partner. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/access_code_email-body-text.html:3
 #, python-format
-msgid ""
-"Your approved application to %(partner)s has now been finalised. Your access "
-"code or login details can be found below: %(access_code)s "
-"%(user_instructions)s"
+msgid "Your approved application to %(partner)s has now been finalised. Your access code or login details can be found below: %(access_code)s %(user_instructions)s"
 msgstr ""
 
 #. Translators: This is the subject line of an email sent to users with their access code.
@@ -1072,23 +974,13 @@ msgstr "உங்கள் விக்கிப்பீடியாவின�
 #. Translators: This email is sent to users when their application is approved. Don't translate Jinja variables in curly braces like user or partner; don't translate html tags either. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/approval_notification-body-html.html:5
 #, python-format
-msgid ""
-"<p>Dear %(user)s,</p> <p>Thank you for applying for access to %(partner)s "
-"resources through The Wikipedia Library. We are happy to inform you that "
-"your application has been approved.</p> <p>%(user_instructions)s</p> <p>You "
-"can view the collections you're authorized to access at My Library: "
-"%(link)s</p> <p>Cheers!</p> <p>The Wikipedia Library</p>"
+msgid "<p>Dear %(user)s,</p> <p>Thank you for applying for access to %(partner)s resources through The Wikipedia Library. We are happy to inform you that your application has been approved.</p> <p>%(user_instructions)s</p> <p>You can view the collections you're authorized to access at My Library: %(link)s</p> <p>Cheers!</p> <p>The Wikipedia Library</p>"
 msgstr ""
 
 #. Translators: This email is sent to users when their application is approved. Don't translate Jinja variables in curly braces like user or partner. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/approval_notification-body-text.html:3
 #, python-format
-msgid ""
-"Dear %(user)s, Thank you for applying for access to %(partner)s resources "
-"through The Wikipedia Library. We are happy to inform you that your "
-"application has been approved. %(user_instructions)s You can view the "
-"collections you're authorized to access at My Library: %(link)s Cheers! The "
-"Wikipedia Library"
+msgid "Dear %(user)s, Thank you for applying for access to %(partner)s resources through The Wikipedia Library. We are happy to inform you that your application has been approved. %(user_instructions)s You can view the collections you're authorized to access at My Library: %(link)s Cheers! The Wikipedia Library"
 msgstr ""
 
 #. Translators: This is the subject of an email which is sent to users when their application has been approved. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
@@ -1099,19 +991,13 @@ msgstr ""
 #. Translators: This email is sent to coordinators when a comment is left on an application they are processing. Don't translate Jinja variables in curly braces like user or partner. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/comment_notification_coordinator-body-html.html:5
 #, python-format
-msgid ""
-"<p style=\"color: #500050\">%(submit_date)s - %(commenter)s</p> "
-"<blockquote><p>%(comment)s</p></blockquote> <p>Please reply to these at: <a "
-"href=\"%(app_url)s\">%(app_url)s</a></p> <p>Best,</p> <p>The Wikipedia "
-"Library</p>"
+msgid "<p style=\"color: #500050\">%(submit_date)s - %(commenter)s</p> <blockquote><p>%(comment)s</p></blockquote> <p>Please reply to these at: <a href=\"%(app_url)s\">%(app_url)s</a></p> <p>Best,</p> <p>The Wikipedia Library</p>"
 msgstr ""
 
 #. Translators: This email is sent to coordinators when a comment is left on an application they are processing. Don't translate Jinja variables in curly braces like user or partner. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/comment_notification_coordinator-body-text.html:3
 #, python-format
-msgid ""
-"%(submit_date)s - %(commenter)s %(comment)s Please reply to this at: "
-"%(app_url)s Best, The Wikipedia Library"
+msgid "%(submit_date)s - %(commenter)s %(comment)s Please reply to this at: %(app_url)s Best, The Wikipedia Library"
 msgstr ""
 
 #. Translators: This is the subject line of an email sent to coordinators when a comment is left on an application they processed.
@@ -1122,19 +1008,13 @@ msgstr ""
 #. Translators: This email is sent to users when they receive a comment on their application. Don't translate Jinja variables in curly braces like user or partner; don't translate html tags either. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/comment_notification_editors-body-html.html:5
 #, python-format
-msgid ""
-"<p style=\"color: #500050\">%(submit_date)s - %(commenter)s</p> "
-"<blockquote><p>%(comment)s</p></blockquote> <p>Please reply to these at <a "
-"href=\"%(app_url)s\">%(app_url)s</a> so we can evaluate your application.</"
-"p> <p>Best,</p> <p>The Wikipedia Library</p>"
+msgid "<p style=\"color: #500050\">%(submit_date)s - %(commenter)s</p> <blockquote><p>%(comment)s</p></blockquote> <p>Please reply to these at <a href=\"%(app_url)s\">%(app_url)s</a> so we can evaluate your application.</p> <p>Best,</p> <p>The Wikipedia Library</p>"
 msgstr ""
 
 #. Translators: This email is sent to users when they receive a comment on their application. Don't translate Jinja variables in curly braces like user or partner. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/comment_notification_editors-body-text.html:3
 #, python-format
-msgid ""
-"%(submit_date)s - %(commenter)s %(comment)s Please reply to these at: "
-"%(app_url)s so we can evaluate your application. Best, The Wikipedia Library"
+msgid "%(submit_date)s - %(commenter)s %(comment)s Please reply to these at: %(app_url)s so we can evaluate your application. Best, The Wikipedia Library"
 msgstr ""
 
 #. Translators: This is the subject line of an email sent to users who have a comment added to one of their applications. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
@@ -1145,18 +1025,13 @@ msgstr ""
 #. Translators: This email is sent to users when an application they commented on receives another comment. Don't translate Jinja variables in curly braces like app_url; don't translate html tags either. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/comment_notification_others-body-html.html:5
 #, python-format
-msgid ""
-"<p style=\"color: #500050\">%(submit_date)s - %(commenter)s</p> "
-"<blockquote><p>%(comment)s</p></blockquote> See it at <a href=\"%(app_url)s"
-"\">%(app_url)s</a>. Thanks for helping review Wikipedia Library applications!"
+msgid "<p style=\"color: #500050\">%(submit_date)s - %(commenter)s</p> <blockquote><p>%(comment)s</p></blockquote> See it at <a href=\"%(app_url)s\">%(app_url)s</a>. Thanks for helping review Wikipedia Library applications!"
 msgstr ""
 
 #. Translators: This email is sent to users when an application they commented on receives another comment. Don't translate Jinja variables in curly braces like app_url. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/comment_notification_others-body-text.html:3
 #, python-format
-msgid ""
-"%(submit_date)s - %(commenter)s %(comment)s See it at: %(app_url)s Thanks "
-"for helping review Wikipedia Library applications!"
+msgid "%(submit_date)s - %(commenter)s %(comment)s See it at: %(app_url)s Thanks for helping review Wikipedia Library applications!"
 msgstr ""
 
 #. Translators: This is the subject line of an email sent to users who have a comment added to an application they also commented on. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
@@ -1167,10 +1042,7 @@ msgstr ""
 #. Translators: This text is part of a scheduled reminder email sent to coordinators who have applications requiring action. Don't translate Jinja variables in curly braces like total_apps, or user.
 #: TWLight/emails/templates/emails/coordinator_reminder_notification-body-html.html:5
 #, python-format
-msgid ""
-"<p>Dear %(user)s,</p> <p>Our records indicate that you are the designated "
-"coordinator for partners that have a total of %(total_apps)s applications.</"
-"p>"
+msgid "<p>Dear %(user)s,</p> <p>Our records indicate that you are the designated coordinator for partners that have a total of %(total_apps)s applications.</p>"
 msgstr ""
 
 #. Translators: Breakdown as in 'cost breakdown'; analysis.
@@ -1209,31 +1081,19 @@ msgstr[1] "தரவிறக்கப்பட்ட விண்ணப்ப�
 #. Translators: This text is part of a scheduled reminder email sent to coordinators who have applications requiring action. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library). Don't translate Jinja variables in curly braces like link; don't translate email addresses or html tags either.
 #: TWLight/emails/templates/emails/coordinator_reminder_notification-body-html.html:39
 #, python-format
-msgid ""
-"<p>This is a gentle reminder that you may review applications at <a href="
-"\"%(link)s\">%(link)s</a>.</p> <p>You can customise your reminders under "
-"'preferences' in your user profile.</p> <p>If you received this message in "
-"error, drop us a line at wikipedialibrary@wikimedia.org.</p> <p>Thanks for "
-"helping review Wikipedia Library applications!</p>"
+msgid "<p>This is a gentle reminder that you may review applications at <a href=\"%(link)s\">%(link)s</a>.</p> <p>You can customise your reminders under 'preferences' in your user profile.</p> <p>If you received this message in error, drop us a line at wikipedialibrary@wikimedia.org.</p> <p>Thanks for helping review Wikipedia Library applications!</p>"
 msgstr ""
 
 #. Translators: This text is part of a scheduled reminder email sent to coordinators who have applications requiring action. Don't translate Jinja variables in curly braces like total_apps, or user.
 #: TWLight/emails/templates/emails/coordinator_reminder_notification-body-text.html:3
 #, python-format
-msgid ""
-"Dear %(user)s, Our records indicate that you are the designated coordinator "
-"for partners that have a total of %(total_apps)s applications."
+msgid "Dear %(user)s, Our records indicate that you are the designated coordinator for partners that have a total of %(total_apps)s applications."
 msgstr ""
 
 #. Translators: This text is part of a scheduled reminder email sent to coordinators who have applications requiring action. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library). Don't translate Jinja variables in curly braces like link; don't translate the email address either.
 #: TWLight/emails/templates/emails/coordinator_reminder_notification-body-text.html:38
 #, python-format
-msgid ""
-"This is a gentle reminder that you may review applications at: %(link)s. You "
-"can customise your reminders under 'preferences' in your user profile. If "
-"you received this message in error, drop us a line at: "
-"wikipedialibrary@wikimedia.org Thanks for helping review Wikipedia Library "
-"applications!"
+msgid "This is a gentle reminder that you may review applications at: %(link)s. You can customise your reminders under 'preferences' in your user profile. If you received this message in error, drop us a line at: wikipedialibrary@wikimedia.org Thanks for helping review Wikipedia Library applications!"
 msgstr ""
 
 #. Translators: This is the subject line of a scheduled reminder email sent to coordinators who have applications to review. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library). Do not translate items in curly braces.
@@ -1244,22 +1104,13 @@ msgstr ""
 #. Translators: This email is sent to users when their application is rejected. Don't translate Jinja variables in curly braces like user or partner; don't translate html tags either. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/rejection_notification-body-html.html:5
 #, python-format
-msgid ""
-"<p>Dear %(user)s,</p> <p>Thank you for applying for access to %(partner)s "
-"resources through The Wikipedia Library. Unfortunately at this time your "
-"application has not been approved. You can view your application and review "
-"comments at <a href=\"%(app_url)s\">%(app_url)s</a>.</p> <p>Best,</p> <p>The "
-"Wikipedia Library</p>"
+msgid "<p>Dear %(user)s,</p> <p>Thank you for applying for access to %(partner)s resources through The Wikipedia Library. Unfortunately at this time your application has not been approved. You can view your application and review comments at <a href=\"%(app_url)s\">%(app_url)s</a>.</p> <p>Best,</p> <p>The Wikipedia Library</p>"
 msgstr ""
 
 #. Translators: This email is sent to users when their application is rejected. Don't translate Jinja variables in curly braces like user or partner. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/rejection_notification-body-text.html:3
 #, python-format
-msgid ""
-"Dear %(user)s, Thank you for applying for access to %(partner)s resources "
-"through The Wikipedia Library. Unfortunately at this time your application "
-"has not been approved. You can view your application and review comments at: "
-"%(app_url)s Best, The Wikipedia Library"
+msgid "Dear %(user)s, Thank you for applying for access to %(partner)s resources through The Wikipedia Library. Unfortunately at this time your application has not been approved. You can view your application and review comments at: %(app_url)s Best, The Wikipedia Library"
 msgstr ""
 
 #. Translators: This is the subject of an email which is sent to users when their application has been rejected. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
@@ -1271,25 +1122,13 @@ msgstr "உங்கள் விக்கிப்பீடியாவின�
 #. Translators: This email is sent to users when they have an account that is soon to expire. Don't translate Jinja variables in curly braces like partner_name or partner_link; don't translate html tags either. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/user_renewal_notice-body-html.html:5
 #, python-format
-msgid ""
-"<p>Dear %(user)s,</p> <p>According to our records, your access to "
-"%(partner_name)s will soon expire and you may lose access. If you want to "
-"continue making use of your free account, you can request renewal of your "
-"account by clicking the 'Renew' or 'Extend' button at %(partner_link)s.</p> "
-"<p>Best,</p> <p>The Wikipedia Library</p> <p>You can disable these emails in "
-"your user page preferences: https://wikipedialibrary.wmflabs.org/users/</p>"
+msgid "<p>Dear %(user)s,</p> <p>According to our records, your access to %(partner_name)s will soon expire and you may lose access. If you want to continue making use of your free account, you can request renewal of your account by clicking the 'Renew' or 'Extend' button at %(partner_link)s.</p> <p>Best,</p> <p>The Wikipedia Library</p> <p>You can disable these emails in your user page preferences: https://wikipedialibrary.wmflabs.org/users/</p>"
 msgstr ""
 
 #. Translators: This email is sent to users when they have an account that is soon to expire. Don't translate Jinja variables in curly braces like partner_name or partner_link; don't translate html tags either. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/user_renewal_notice-body-text.html:3
 #, python-format
-msgid ""
-"Dear %(user)s, According to our records, your access to %(partner_name)s "
-"will soon expire and you may lose access. If you want to continue making use "
-"of your free account, you can request renewal of your account by clicking "
-"the Renew button at %(partner_link)s. Best, The Wikipedia Library You can "
-"disable these emails in your user page preferences: https://wikipedialibrary."
-"wmflabs.org/users/"
+msgid "Dear %(user)s, According to our records, your access to %(partner_name)s will soon expire and you may lose access. If you want to continue making use of your free account, you can request renewal of your account by clicking the Renew button at %(partner_link)s. Best, The Wikipedia Library You can disable these emails in your user page preferences: https://wikipedialibrary.wmflabs.org/users/"
 msgstr ""
 
 #. Translators: This is the subject of an email sent to users when they have an account that is soon to expire. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
@@ -1301,24 +1140,13 @@ msgstr "விக்கிப்பீடியா நூலகத்தைப�
 #. Translators: This email is sent to users when their application is waitlisted because there are no more accounts available. Don't translate Jinja variables in curly braces like user or partner; don't translate html tags either. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/waitlist_notification-body-html.html:5
 #, python-format
-msgid ""
-"<p>Dear %(user)s,</p> <p>Thank you for applying for access to %(partner)s "
-"resources through The Wikipedia Library. There are no accounts currently "
-"available so your application has been waitlisted. Your application will be "
-"evaluated if/when more accounts become available. You can see all available "
-"resources at <a href=\"%(link)s\">%(link)s</a>.</p> <p>Best,</p> <p>The "
-"Wikipedia Library</p>"
+msgid "<p>Dear %(user)s,</p> <p>Thank you for applying for access to %(partner)s resources through The Wikipedia Library. There are no accounts currently available so your application has been waitlisted. Your application will be evaluated if/when more accounts become available. You can see all available resources at <a href=\"%(link)s\">%(link)s</a>.</p> <p>Best,</p> <p>The Wikipedia Library</p>"
 msgstr ""
 
 #. Translators: This email is sent to users when their application is waitlisted because there are no more accounts available. Don't translate Jinja variables in curly braces like user or partner. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/waitlist_notification-body-text.html:3
 #, python-format
-msgid ""
-"Dear %(user)s, Thank you for applying for access to %(partner)s resources "
-"through The Wikipedia Library. There are no accounts currently available so "
-"your application has been waitlisted. Your application will be evaluated if/"
-"when more accounts become available. You can see all available resources at: "
-"%(link)s Best, The Wikipedia Library"
+msgid "Dear %(user)s, Thank you for applying for access to %(partner)s resources through The Wikipedia Library. There are no accounts currently available so your application has been waitlisted. Your application will be evaluated if/when more accounts become available. You can see all available resources at: %(link)s Best, The Wikipedia Library"
 msgstr ""
 
 #. Translators: This is the subject of an email sent to users when their application is waitlisted because there are no more accounts available. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
@@ -1485,17 +1313,14 @@ msgstr "கிடைக்கப் பெறுவதில்லை"
 #: TWLight/resources/templates/resources/filter_section.html:14
 #: TWLight/templates/about.html:12
 #: TWLight/users/templates/users/filter_section.html:13
-msgid ""
-"The Wikipedia Library allows active editors to access a wide range of "
-"collections of paywalled reliable sources for free!"
+msgid "The Wikipedia Library allows active editors to access a wide range of collections of paywalled reliable sources for free!"
 msgstr ""
 
 #. Translators: On the Browse Partners page (https://wikipedialibrary.wmflabs.org/partners/), this introduces users to The Wikipedia Library.
 #. Translators: On the MyLibrary page (https://wikipedialibrary.wmflabs.org/users/my_library), this introduces users to The Wikipedia Library.
 #: TWLight/resources/templates/resources/filter_section.html:17
 #: TWLight/users/templates/users/filter_section.html:15
-msgid ""
-"Start with the search bar at the top or browse publisher websites directly."
+msgid "Start with the search bar at the top or browse publisher websites directly."
 msgstr ""
 
 #. Translators: On the Browse Partners page (https://wikipedialibrary.wmflabs.org/partners/), this appears below introductory text and links to the 'About' page (https://wikipedialibrary.wmflabs.org/about/)
@@ -1575,52 +1400,38 @@ msgstr "பங்குதாரருக்கு அனுப்பு"
 #. Translators: If we have no available accounts for a partner, the coordinator can change the application system to a waiting list.
 #: TWLight/resources/templates/resources/partner_detail.html:36
 #: TWLight/resources/templates/resources/partner_detail_apply.html:17
-msgid ""
-"There are no access grants available for this partner at this time. You can "
-"still apply for access; applications will be processed when access is "
-"available."
+msgid "There are no access grants available for this partner at this time. You can still apply for access; applications will be processed when access is available."
 msgstr ""
 
 #. Translators: This text links to the minimum user requirements and terms of use on the partner page.
 #: TWLight/resources/templates/resources/partner_detail.html:48
 #: TWLight/resources/templates/resources/partner_detail_apply.html:29
 #, python-format
-msgid ""
-"Before applying, please review the <strong><a class=\"twl-links\" href="
-"\"%(about)s#req\">minimum requirements</a></strong> for access and our "
-"<strong><a class=\"twl-links\" href=\"%(terms)s\">terms of use</a></strong>."
+msgid "Before applying, please review the <strong><a class=\"twl-links\" href=\"%(about)s#req\">minimum requirements</a></strong> for access and our <strong><a class=\"twl-links\" href=\"%(terms)s\">terms of use</a></strong>."
 msgstr ""
 
 #. Translators: This text refers to the page containing the content a user is authorized to access.
 #: TWLight/resources/templates/resources/partner_detail.html:69
 #, python-format
-msgid ""
-"View the status of your access in <strong><a class=\"twl-links\" href="
-"\"%(library_url)s\">My Library</a></strong> page."
+msgid "View the status of your access in <strong><a class=\"twl-links\" href=\"%(library_url)s\">My Library</a></strong> page."
 msgstr ""
 
 #. Translators: This message is shown when a user has open applications, linking to their respective applications page.
 #: TWLight/resources/templates/resources/partner_detail.html:78
 #, python-format
-msgid ""
-"View the status of your application(s) on your <strong><a class=\"twl-links"
-"\" href=\"%(applications_url)s\">My Applications</a></strong> page."
+msgid "View the status of your application(s) on your <strong><a class=\"twl-links\" href=\"%(applications_url)s\">My Applications</a></strong> page."
 msgstr ""
 
 #. Translators: This message is shown when a user has authorizations, linking to their respective collections page.
 #: TWLight/resources/templates/resources/partner_detail_apply.html:50
 #, python-format
-msgid ""
-"View the status of your access on your <strong><a href=\"%(library_url)s\" "
-"class=\"twl-links\">My Library</a></strong> page."
+msgid "View the status of your access on your <strong><a href=\"%(library_url)s\" class=\"twl-links\">My Library</a></strong> page."
 msgstr ""
 
 #. Translators: This message is shown when a user has open applications, linking to their respective applications page.
 #: TWLight/resources/templates/resources/partner_detail_apply.html:60
 #, python-format
-msgid ""
-"View the status of your application(s) on your <strong><a href="
-"\"%(applications_url)s\">My Applications</a></strong> page."
+msgid "View the status of your application(s) on your <strong><a href=\"%(applications_url)s\">My Applications</a></strong> page."
 msgstr ""
 
 #. Translators: One the partner detail page, this text labels the button which coordinators can click to remove a partner from waitlisted status.
@@ -1650,10 +1461,7 @@ msgstr ""
 
 #. Translators: If no account coordinator is assigned to a partner, the Wikipedia Library team will coordinate signups. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/resources/templates/resources/partner_detail_apply.html:112
-msgid ""
-"The Wikipedia Library team will process this application. Want to help? <a "
-"class=\"twl-links\" href=\"https://en.wikipedia.org/wiki/Wikipedia:"
-"The_Wikipedia_Library/Coordinators/Signup\">Sign up as a coordinator.</a>"
+msgid "The Wikipedia Library team will process this application. Want to help? <a class=\"twl-links\" href=\"https://en.wikipedia.org/wiki/Wikipedia:The_Wikipedia_Library/Coordinators/Signup\">Sign up as a coordinator.</a>"
 msgstr ""
 
 #. Translators: This text labels a button coordinators can click to view a list of users who have applied for access for a particular partner
@@ -1684,18 +1492,13 @@ msgstr ""
 
 #. Translators: Text shown to authenticated, bundle eligible users when they visit a Bundle partner page.
 #: TWLight/resources/templates/resources/partner_detail_apply.html:138
-msgid ""
-"You are eligible to access Library Bundle partners. Click the button above "
-"to access the collection."
+msgid "You are eligible to access Library Bundle partners. Click the button above to access the collection."
 msgstr ""
 
 #. Translators: Text shown to authenticated, bundle ineligible users when they visit a Bundle partner page.
 #: TWLight/resources/templates/resources/partner_detail_apply.html:152
 #, python-format
-msgid ""
-"You are not eligible to access Library Bundle partners. Visit the <a class="
-"\"twl-links\" href=\"%(homepage)s\">homepage</a> to check the eligibility "
-"criteria."
+msgid "You are not eligible to access Library Bundle partners. Visit the <a class=\"twl-links\" href=\"%(homepage)s\">homepage</a> to check the eligibility criteria."
 msgstr ""
 
 #. Translators: Buttton prompting users to log in.
@@ -1707,10 +1510,7 @@ msgstr ""
 #. Translators: Text shown to unauthenticated users when they visit a Bundle partner page.
 #: TWLight/resources/templates/resources/partner_detail_apply.html:168
 #, python-format
-msgid ""
-"This resource is part of our <a class=\"twl-links\" href=\"%(about)s"
-"\">Library Bundle</a>, which you can access if you meet our minimum "
-"eligibility criteria. Log in to find out if you are eligible."
+msgid "This resource is part of our <a class=\"twl-links\" href=\"%(about)s\">Library Bundle</a>, which you can access if you meet our minimum eligibility criteria. Log in to find out if you are eligible."
 msgstr ""
 
 #. Translators: This is the label for a number which shows the total active accounts for one partner. (e.g. https://wikipedialibrary.wmflabs.org/partners/8/).
@@ -1761,26 +1561,19 @@ msgstr ""
 #. Translators: If a partner has specified the excerpt limit both in words and percentage, this message will display the percentage of words and the number of words on the partner page.
 #: TWLight/resources/templates/resources/partner_detail_timeline.html:99
 #, python-format
-msgid ""
-"%(object)s allows a maximum of %(excerpt_limit)s words or "
-"%(excerpt_limit_percentage)s%% of an article be excerpted into a Wikipedia "
-"article."
+msgid "%(object)s allows a maximum of %(excerpt_limit)s words or %(excerpt_limit_percentage)s%% of an article be excerpted into a Wikipedia article."
 msgstr ""
 
 #. Translators: If a partner has specified the excerpt limit in words, this message will display the number of words on the partner page.
 #: TWLight/resources/templates/resources/partner_detail_timeline.html:106
 #, python-format
-msgid ""
-"%(object)s allows a maximum of %(excerpt_limit)s words be excerpted into a "
-"Wikipedia article."
+msgid "%(object)s allows a maximum of %(excerpt_limit)s words be excerpted into a Wikipedia article."
 msgstr ""
 
 #. Translators: If a partner has specified the excerpt limit in percentage, this message will display the percentage of words on the partner page.
 #: TWLight/resources/templates/resources/partner_detail_timeline.html:113
 #, python-format
-msgid ""
-"%(object)s allows a maximum of %(excerpt_limit_percentage)s%% of an article "
-"be excerpted into a Wikipedia article."
+msgid "%(object)s allows a maximum of %(excerpt_limit_percentage)s%% of an article be excerpted into a Wikipedia article."
 msgstr ""
 
 #. Translators: If a partner has other requirements for access, this text shows as the title for that information field. (e.g. https://wikipedialibrary.wmflabs.org/partners/10/).
@@ -1791,9 +1584,7 @@ msgstr ""
 #. Translators: If a user must agree to a Terms of Use document, they see this message, and must enter the name of the resource. Don't translate publisher or url.
 #: TWLight/resources/templates/resources/partner_detail_timeline.html:140
 #, python-format
-msgid ""
-"%(publisher)s requires that you agree with its <a href=\"%(url)s\">terms of "
-"use</a>."
+msgid "%(publisher)s requires that you agree with its <a href=\"%(url)s\">terms of use</a>."
 msgstr ""
 
 #. Translators: If a user must provide their real name to apply to a partner, they see this message, and must enter the name of the resource. Don't translate publisher.
@@ -1817,17 +1608,13 @@ msgstr ""
 #. Translators: If a user must select a specific resource to apply for, they see this message, and must enter the name of the resource. Don't translate publisher.
 #: TWLight/resources/templates/resources/partner_detail_timeline.html:177
 #, python-format
-msgid ""
-"%(publisher)s requires that you specify a particular title that you want to "
-"access."
+msgid "%(publisher)s requires that you specify a particular title that you want to access."
 msgstr ""
 
 #. Translators: If a user must register on the partner website before applying, they see this message. Don't translate partner.
 #: TWLight/resources/templates/resources/partner_detail_timeline.html:187
 #, python-format
-msgid ""
-"%(publisher)s requires that you sign up for an account before applying for "
-"access."
+msgid "%(publisher)s requires that you sign up for an account before applying for access."
 msgstr ""
 
 #. Translators: If a partner has their location listed, this message is a label for that location
@@ -1956,9 +1743,7 @@ msgstr ""
 
 #. Translators: If multiple authorizations where returned for a collection, this message is shown to a user
 #: TWLight/resources/views.py:268
-msgid ""
-"Multiple authorizations were returned – something's wrong. Please contact us "
-"and don't forget to mention this message."
+msgid "Multiple authorizations were returned – something's wrong. Please contact us and don't forget to mention this message."
 msgstr ""
 
 #. Translators: This message is shown when user tries to access a NOT_AVAILABLE Partner
@@ -1999,14 +1784,7 @@ msgstr ""
 #. Translators: Shown on the website's 400 page, when a user sends a bad request. Don't translate path or Phabricator.
 #: TWLight/templates/400.html:20
 #, python-format
-msgid ""
-"If you think we should know what to do with that, please email us about this "
-"error at <a class=\"twl-links\" href=\"mailto:wikipedialibrary@wikimedia.org?"
-"Subject=Wikipedia%%20Library%%20%(path)s%%20Permission%%20denied"
-"\">wikipedialibrary@wikimedia.org</a> or report it to us on <a class=\"twl-"
-"links\" href=\"https://phabricator.wikimedia.org/maniphest/task/edit/form/1/?"
-"projectPHIDs=Library-Card-Platform&title=Wikipedia%%20Library%%20%(path)s"
-"%%20Bad%%20Request\">Phabricator</a>"
+msgid "If you think we should know what to do with that, please email us about this error at <a class=\"twl-links\" href=\"mailto:wikipedialibrary@wikimedia.org?Subject=Wikipedia%%20Library%%20%(path)s%%20Permission%%20denied\">wikipedialibrary@wikimedia.org</a> or report it to us on <a class=\"twl-links\" href=\"https://phabricator.wikimedia.org/maniphest/task/edit/form/1/?projectPHIDs=Library-Card-Platform&title=Wikipedia%%20Library%%20%(path)s%%20Bad%%20Request\">Phabricator</a>"
 msgstr ""
 
 #. Translators: Alt text for an image shown on the 400 error page.
@@ -2028,15 +1806,7 @@ msgstr ""
 #. Translators: Shown on the website's 403 page, when a user attempts to navigate to a page they don't have permission to view. Don't translate path or Phabricator.
 #: TWLight/templates/403.html:20
 #, python-format
-msgid ""
-"If you think your account should be able to do that, please email us about "
-"this error at <a class=\"twl-links\" href=\"mailto:"
-"wikipedialibrary@wikimedia.org?Subject=Wikipedia%%20Library%%20%(path)s"
-"%%20Permission%%20denied\">wikipedialibrary@wikimedia.org</a> or report it "
-"to us on <a class=\"twl-links\" href=\"https://phabricator.wikimedia.org/"
-"maniphest/task/edit/form/1/?projectPHIDs=Library-Card-"
-"Platform&title=Wikipedia%%20Library%%20%(path)s%%20Permission%%20denied"
-"\">Phabricator</a>"
+msgid "If you think your account should be able to do that, please email us about this error at <a class=\"twl-links\" href=\"mailto:wikipedialibrary@wikimedia.org?Subject=Wikipedia%%20Library%%20%(path)s%%20Permission%%20denied\">wikipedialibrary@wikimedia.org</a> or report it to us on <a class=\"twl-links\" href=\"https://phabricator.wikimedia.org/maniphest/task/edit/form/1/?projectPHIDs=Library-Card-Platform&title=Wikipedia%%20Library%%20%(path)s%%20Permission%%20denied\">Phabricator</a>"
 msgstr ""
 
 #. Translators: Shown on the website's 404 page, when a user attempts to navigate to a page that doesn't exist.
@@ -2052,14 +1822,7 @@ msgstr ""
 #. Translators: Shown on the website's 404 page, when a user attempts to navigate to a page that doesn't exist. Don't translate path or Phabricator.
 #: TWLight/templates/404.html:19
 #, python-format
-msgid ""
-"If you are certain that something should be here, please email us about this "
-"error at <a class=\"twl-links\" href=\"mailto:wikipedialibrary@wikimedia.org?"
-"Subject=Wikipedia%%20Library%%20%(path)s%%20Not%%20found\"> "
-"wikipedialibrary@wikimedia.org</a> or report it to us on <a class=\"twl-links"
-"\" href=\"https://phabricator.wikimedia.org/maniphest/task/edit/form/1/?"
-"projectPHIDs=Library-Card-Platform&title=Wikipedia%%20Library%%20%(path)s"
-"%%20Not%%20found\">Phabricator</a>"
+msgid "If you are certain that something should be here, please email us about this error at <a class=\"twl-links\" href=\"mailto:wikipedialibrary@wikimedia.org?Subject=Wikipedia%%20Library%%20%(path)s%%20Not%%20found\"> wikipedialibrary@wikimedia.org</a> or report it to us on <a class=\"twl-links\" href=\"https://phabricator.wikimedia.org/maniphest/task/edit/form/1/?projectPHIDs=Library-Card-Platform&title=Wikipedia%%20Library%%20%(path)s%%20Not%%20found\">Phabricator</a>"
 msgstr ""
 
 #. Translators: Alt text for an image shown on the 404 error page.
@@ -2074,32 +1837,18 @@ msgstr "விக்கிப்பீடியா நூலகத்தைப�
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:20
-msgid ""
-"This platform is our central tool for facilitating access to our available "
-"collections. Here you can see which partnerships are available, search their "
-"contents, and apply for and access the ones you’re interested in."
+msgid "This platform is our central tool for facilitating access to our available collections. Here you can see which partnerships are available, search their contents, and apply for and access the ones you’re interested in."
 msgstr ""
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/). Wikimedia Foundation should not be translated.
 #: TWLight/templates/about.html:29
-msgid ""
-"All users receive immediate access to some collections, which can be browsed "
-"by clicking the 'Access collection' buttons or using the search bar at the "
-"top of the page. Other collections require an application before access is "
-"granted, and may be accessed directly or via an individual login or access "
-"code. Volunteer coordinators, who have signed non-disclosure agreements with "
-"the Wikimedia Foundation, review these applications and work with publishers "
-"to get you your free access."
+msgid "All users receive immediate access to some collections, which can be browsed by clicking the 'Access collection' buttons or using the search bar at the top of the page. Other collections require an application before access is granted, and may be accessed directly or via an individual login or access code. Volunteer coordinators, who have signed non-disclosure agreements with the Wikimedia Foundation, review these applications and work with publishers to get you your free access."
 msgstr ""
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/). Don't translate terms_url.
 #: TWLight/templates/about.html:43
 #, python-format
-msgid ""
-"For more information about how your information is stored and reviewed "
-"please see our <a class=\"twl-links\" href=\"%(terms_url)s\"> terms of use "
-"and privacy policy</a>. Accounts you apply for are also subject to the Terms "
-"of Use provided by each partner’s platform; please review them."
+msgid "For more information about how your information is stored and reviewed please see our <a class=\"twl-links\" href=\"%(terms_url)s\"> terms of use and privacy policy</a>. Accounts you apply for are also subject to the Terms of Use provided by each partner’s platform; please review them."
 msgstr ""
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
@@ -2109,12 +1858,7 @@ msgstr ""
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/). Wikimedia Foundation should not be translated.
 #: TWLight/templates/about.html:55
-msgid ""
-"Any active editor in good standing can receive access. For publishers with "
-"limited numbers of accounts, applications are reviewed based on the editor’s "
-"needs and contributions. If you think you could use access to one of our "
-"partner resources and are an active editor in any project supported by the "
-"Wikimedia Foundation, please apply."
+msgid "Any active editor in good standing can receive access. For publishers with limited numbers of accounts, applications are reviewed based on the editor’s needs and contributions. If you think you could use access to one of our partner resources and are an active editor in any project supported by the Wikimedia Foundation, please apply."
 msgstr ""
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
@@ -2145,23 +1889,12 @@ msgstr ""
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/)
 #: TWLight/templates/about.html:89
-msgid ""
-"If you are applying for an available collection, please first check that you "
-"don't already have access through another library or institution. If you do, "
-"please consider using that access rather than taking up a seat for this "
-"resource in The Wikipedia Library."
+msgid "If you are applying for an available collection, please first check that you don't already have access through another library or institution. If you do, please consider using that access rather than taking up a seat for this resource in The Wikipedia Library."
 msgstr ""
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/)
 #: TWLight/templates/about.html:99
-msgid ""
-"If your account is blocked on one or more Wikimedia projects, you may still "
-"be granted access to The Wikipedia Library. You will need to contact the "
-"Wikipedia Library team, who will review your blocks. If you have been "
-"blocked for content issues, most notably copyright violations, or have "
-"multiple long-term blocks, we may decline your request. Additionally, if "
-"your block status changes after being approved, you will need to request "
-"another review."
+msgid "If your account is blocked on one or more Wikimedia projects, you may still be granted access to The Wikipedia Library. You will need to contact the Wikipedia Library team, who will review your blocks. If you have been blocked for content issues, most notably copyright violations, or have multiple long-term blocks, we may decline your request. Additionally, if your block status changes after being approved, you will need to request another review."
 msgstr ""
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
@@ -2196,9 +1929,7 @@ msgstr ""
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:136
-msgid ""
-"Share their account logins or passwords with others, or sell their access to "
-"other parties"
+msgid "Share their account logins or passwords with others, or sell their access to other parties"
 msgstr ""
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
@@ -2208,23 +1939,17 @@ msgstr ""
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:144
-msgid ""
-"Systematically make printed or electronic copies of multiple extracts of "
-"restricted content available for any purpose"
+msgid "Systematically make printed or electronic copies of multiple extracts of restricted content available for any purpose"
 msgstr ""
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/). Stub is a technical term for a short Wikipedia article, use the appropriate Wikipedia term in your language.
 #: TWLight/templates/about.html:148
-msgid ""
-"Datamine metadata without permission, in order, for instance, to use "
-"metadata for auto-created stub articles"
+msgid "Datamine metadata without permission, in order, for instance, to use metadata for auto-created stub articles"
 msgstr ""
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:154
-msgid ""
-"Respecting these agreements allows us to continue growing the partnerships "
-"available to the community."
+msgid "Respecting these agreements allows us to continue growing the partnerships available to the community."
 msgstr ""
 
 #. Translators: This is the heading for a section on the About page (https://wikipedialibrary.wmflabs.org/about/).
@@ -2234,41 +1959,22 @@ msgstr ""
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:164
-msgid ""
-"EZProxy is a proxy server used to authenticate users for many Wikipedia "
-"Library partners. Users sign into EZProxy via the Library Card platform to "
-"verify that they are authorized users, and then the server accesses "
-"requested resources using its own IP address."
+msgid "EZProxy is a proxy server used to authenticate users for many Wikipedia Library partners. Users sign into EZProxy via the Library Card platform to verify that they are authorized users, and then the server accesses requested resources using its own IP address."
 msgstr ""
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:173
-msgid ""
-"You may notice that when accessing resources via EZProxy that URLs are "
-"dynamically rewritten. This is why we recommend logging in via the Library "
-"Card platform rather than going directly to the unproxied partner website. "
-"When in doubt, check the URL for ‘idm.oclc’. If it’s there, then you’re "
-"connected via EZProxy."
+msgid "You may notice that when accessing resources via EZProxy that URLs are dynamically rewritten. This is why we recommend logging in via the Library Card platform rather than going directly to the unproxied partner website. When in doubt, check the URL for ‘idm.oclc’. If it’s there, then you’re connected via EZProxy."
 msgstr ""
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:182
-msgid ""
-"Typically once you’ve logged in your session will remain active in your "
-"browser for up to two hours after you’ve finished searching. Note that use "
-"of EZProxy requires you to enable cookies. If you are having problems you "
-"should also try clearing your cache and restarting your browser."
+msgid "Typically once you’ve logged in your session will remain active in your browser for up to two hours after you’ve finished searching. Note that use of EZProxy requires you to enable cookies. If you are having problems you should also try clearing your cache and restarting your browser."
 msgstr ""
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/)
 #: TWLight/templates/about.html:193
-msgid ""
-"The Library Bundle is a collection of resources for which no application is "
-"required. If you meet the criteria laid out above, you will be authorized "
-"for access automatically upon logging in to the platform. Only some of our "
-"content is currently included in the Library Bundle, however we hope to "
-"expand the collection as more publishers become comfortable with "
-"participating. All Bundle content is accessed via EZProxy."
+msgid "The Library Bundle is a collection of resources for which no application is required. If you meet the criteria laid out above, you will be authorized for access automatically upon logging in to the platform. Only some of our content is currently included in the Library Bundle, however we hope to expand the collection as more publishers become comfortable with participating. All Bundle content is accessed via EZProxy."
 msgstr ""
 
 #. Translators: This is the heading for a section on the About page (https://wikipedialibrary.wmflabs.org/about/).
@@ -2278,12 +1984,7 @@ msgstr ""
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:206
-msgid ""
-"Citation practices vary by project and even by article. Generally, we "
-"support editors citing where they found information, in a form that allows "
-"others to check it for themselves. That often means providing both original "
-"source details as well as a link to the partner database in which the source "
-"was found."
+msgid "Citation practices vary by project and even by article. Generally, we support editors citing where they found information, in a form that allows others to check it for themselves. That often means providing both original source details as well as a link to the partner database in which the source was found."
 msgstr ""
 
 #. Translators: This is the heading for a section on the About page (https://wikipedialibrary.wmflabs.org/about/).
@@ -2295,9 +1996,7 @@ msgstr ""
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:218
 #, python-format
-msgid ""
-"If you have questions, need help, or want to volunteer to help, please see "
-"our <a class=\"twl-links\" href=\"%(contact_url)s\">contact page</a>."
+msgid "If you have questions, need help, or want to volunteer to help, please see our <a class=\"twl-links\" href=\"%(contact_url)s\">contact page</a>."
 msgstr ""
 
 #. Translators: This is the title of the panel box detailing the contact information for the Wikipedia Library team.
@@ -2339,9 +2038,7 @@ msgstr ""
 #. Translators: This is the text that appears at the bottom of the contact us form directing users to the suggestions form.
 #: TWLight/templates/contact.html:48
 #, python-format
-msgid ""
-"(If you would like to suggest a partner, <a class=\"twl-links\" href="
-"\"%(suggest)s\"><strong>go here</strong></a>.)"
+msgid "(If you would like to suggest a partner, <a class=\"twl-links\" href=\"%(suggest)s\"><strong>go here</strong></a>.)"
 msgstr ""
 
 #. Translators: On a special 'link to search' page, this message is shown if JavaScript is disabled.
@@ -2403,9 +2100,7 @@ msgstr "விக்கிப்பீடியா நூலகத்தைப�
 #. Translators: Information about The Wikipedia Library.
 #: TWLight/templates/login_partial.html:53 TWLight/templates/new_base.html:21
 #, python-format
-msgid ""
-"More than 100 of the world's top subscription-only databases, with content "
-"in %(no_of_languages)s languages, free for Wikipedians of all backgrounds"
+msgid "More than 100 of the world's top subscription-only databases, with content in %(no_of_languages)s languages, free for Wikipedians of all backgrounds"
 msgstr ""
 
 #. Translators: Information about The Wikipedia Library.
@@ -2414,9 +2109,7 @@ msgid "Meet these criteria for automatic access"
 msgstr ""
 
 #: TWLight/templates/login_partial.html:69
-msgid ""
-"These criteria grant you access to certain collections but not all. Some "
-"collections are accessible on a per application basis only."
+msgid "These criteria grant you access to certain collections but not all. Some collections are accessible on a per application basis only."
 msgstr ""
 
 #: TWLight/templates/login_partial.html:89
@@ -2426,29 +2119,19 @@ msgstr ""
 #. Translators: Shown if the current user doesn't have a registered email on their account. Don't translate contact_us_url or email_url.
 #: TWLight/templates/message_partial.html:15
 #, python-format
-msgid ""
-"You don't have an email on file. We can't finalize your access to partner "
-"resources, and you won't be able to <a class=\"twl-links\" href="
-"\"%(contact_us_url)s\">contact us</a> without an email. Please <a class="
-"\"twl-links\" href=\"%(email_url)s\">update your email</a>."
+msgid "You don't have an email on file. We can't finalize your access to partner resources, and you won't be able to <a class=\"twl-links\" href=\"%(contact_us_url)s\">contact us</a> without an email. Please <a class=\"twl-links\" href=\"%(email_url)s\">update your email</a>."
 msgstr ""
 
 #. Translators: Shown if the current user has requested the processing of their data should be restricted.
 #: TWLight/templates/message_partial.html:26
 #, python-format
-msgid ""
-"You have requested a restriction on the processing of your data. Most site "
-"functionality will not be available to you until you <a class=\"twl-links\" "
-"href=\"%(restrict_url)s\">lift this restriction</a>."
+msgid "You have requested a restriction on the processing of your data. Most site functionality will not be available to you until you <a class=\"twl-links\" href=\"%(restrict_url)s\">lift this restriction</a>."
 msgstr ""
 
 #. Translators: Shown if the current user has not agreed to the terms of use.
 #: TWLight/templates/message_partial.html:37
 #, python-format
-msgid ""
-"You have not agreed to the <a class=\"twl-links\" href=\"%(terms_url)s"
-"\">terms of use</a> of this site. Your applications will not be processed "
-"and you won't be able to apply or access resources you are approved for."
+msgid "You have not agreed to the <a class=\"twl-links\" href=\"%(terms_url)s\">terms of use</a> of this site. Your applications will not be processed and you won't be able to apply or access resources you are approved for."
 msgstr ""
 
 #. Translators: This link is at the bottom of every page and links to the 'About' page (https://wikipedialibrary.wmflabs.org/about/)
@@ -2496,9 +2179,7 @@ msgstr ""
 
 #. Translators: If a user goes to reset their password, this message asks them to enter their email to do so.
 #: TWLight/templates/registration/password_reset_form.html:13
-msgid ""
-"Forgot your password? Enter your email address below, and we'll email "
-"instructions for setting a new one."
+msgid "Forgot your password? Enter your email address below, and we'll email instructions for setting a new one."
 msgstr ""
 
 #. Translators: This is the label for a button that users click to update their public information.
@@ -2546,16 +2227,12 @@ msgstr ""
 
 #. Translators: This text explains how to disagree to the site's terms of use and the restrictions that will come into effect when users disagree to the terms of use.
 #: TWLight/users/forms.py:185
-msgid ""
-"By unchecking this box and clicking “Update” you may explore the site, but "
-"you will not be able to apply for access to materials or evaluate "
-"applications unless you agree with the terms of use."
+msgid "By unchecking this box and clicking “Update” you may explore the site, but you will not be able to apply for access to materials or evaluate applications unless you agree with the terms of use."
 msgstr ""
 
 #. Translators: Users click this button to set their website email address to the one linked to their Wikipedia account.
 #: TWLight/users/forms.py:211
-msgid ""
-"Use my Wikipedia email address (will be updated the next time you login)."
+msgid "Use my Wikipedia email address (will be updated the next time you login)."
 msgstr ""
 
 #. Translators: This labels a button which users click to change their email.
@@ -2566,17 +2243,8 @@ msgstr ""
 #. Translators: Shown if the current user tried to 'favorite' a partner they can't access. Do not translate '{partner}'
 #: TWLight/users/models.py:201
 #, python-brace-format
-msgid ""
-"Cannot add partner {partner} to your favorites because you don't have access "
-"to it"
+msgid "Cannot add partner {partner} to your favorites because you don't have access to it"
 msgstr ""
-
-#. Translators: Do not translate.
-#: TWLight/users/models.py:869
-#, fuzzy, python-brace-format
-#| msgid "Username"
-msgid "{wp_username}"
-msgstr "பயனர்பெயர்"
 
 #. Translators: This error message is shown when there's a problem with the authenticated login process.
 #: TWLight/users/oauth.py:243
@@ -2596,9 +2264,7 @@ msgstr ""
 
 #. Translators: this message is displayed to users that don't have accounts and clicked on a proxied link.
 #: TWLight/users/oauth.py:388
-msgid ""
-"To view this link you need to be an eligible library user. Please login to "
-"continue."
+msgid "To view this link you need to be an eligible library user. Please login to continue."
 msgstr ""
 
 #. Translators: This warning message is shown to users when the response received from Wikimedia OAuth servers is not a valid one.
@@ -2634,17 +2300,12 @@ msgstr "புதுப்பித்தல் உறுதிப்பாட�
 
 #. Translators: If the user tries to log in, but their account does not meet certain requirements, they cannot login.
 #: TWLight/users/oauth.py:528
-msgid ""
-"Your Wikipedia account does not meet the eligibility criteria in the terms "
-"of use, so your Wikipedia Library Card Platform account cannot be activated."
+msgid "Your Wikipedia account does not meet the eligibility criteria in the terms of use, so your Wikipedia Library Card Platform account cannot be activated."
 msgstr ""
 
 #. Translators: If the user tries to log in, but their account does not meet certain requirements, they cannot login.
 #: TWLight/users/oauth.py:536
-msgid ""
-"Your Wikipedia account no longer meets the eligibility criteria in the terms "
-"of use, so you cannot be logged in. If you think you should be able to log "
-"in, please email wikipedialibrary@wikimedia.org."
+msgid "Your Wikipedia account no longer meets the eligibility criteria in the terms of use, so you cannot be logged in. If you think you should be able to log in, please email wikipedialibrary@wikimedia.org."
 msgstr ""
 
 #. Translators: this message is displayed to users with brand new accounts.
@@ -2655,10 +2316,7 @@ msgstr ""
 #. Translators: This message is displayed on the confirmation page where users can return their access to partner collections.
 #: TWLight/users/templates/users/authorization_confirm_return.html:13
 #, python-format
-msgid ""
-"You will no longer be able to access <b>%(partner)s's</b> resources via the "
-"Library Card platform, but can request access again by clicking 'renew', if "
-"you change your mind. Are you sure you want to return your access?"
+msgid "You will no longer be able to access <b>%(partner)s's</b> resources via the Library Card platform, but can request access again by clicking 'renew', if you change your mind. Are you sure you want to return your access?"
 msgstr ""
 
 #. Translators: On the MyLibrary page (https://wikipedialibrary.wmflabs.org/users/my_library), this tab shows all favorite collections a user has.
@@ -2732,10 +2390,7 @@ msgstr ""
 
 #. Translators: This is shown on editor profiles, in their profile page or on applications.
 #: TWLight/users/templates/users/editor_detail.html:59
-msgid ""
-"Information with an * was retrieved from Wikipedia directly. Other "
-"information was entered directly by users or site admins, in their preferred "
-"language."
+msgid "Information with an * was retrieved from Wikipedia directly. Other information was entered directly by users or site admins, in their preferred language."
 msgstr ""
 
 #. Translators: This distinguishes users who have been flagged as account coordinators. Don't translate username.
@@ -2746,10 +2401,7 @@ msgstr ""
 
 #. Translators: This is shown on editor profiles, under the heading for Wikipedia editor data.
 #: TWLight/users/templates/users/editor_detail_data.html:5
-msgid ""
-"This information is updated automatically from your Wikimedia account each "
-"time you log in, except for the Contributions field, where you can describe "
-"your Wikimedia editing history."
+msgid "This information is updated automatically from your Wikimedia account each time you log in, except for the Contributions field, where you can describe your Wikimedia editing history."
 msgstr ""
 
 #. Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this labels the user's username.
@@ -2779,17 +2431,13 @@ msgstr ""
 
 #. Translators: when viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this question has a yes or no answer.
 #: TWLight/users/templates/users/editor_detail_data.html:57
-msgid ""
-"at their last login, did this user meet the criteria set forth in the terms "
-"of use?"
+msgid "at their last login, did this user meet the criteria set forth in the terms of use?"
 msgstr ""
 
 #. Translators: When viewing a user's profile in an application, this message shows if the software doesn't think that the user is eligible for access. Don't translate username.
 #: TWLight/users/templates/users/editor_detail_data.html:72
 #, python-format
-msgid ""
-"%(username)s may still be eligible for access grants at the coordinators' "
-"discretion."
+msgid "%(username)s may still be eligible for access grants at the coordinators' discretion."
 msgstr ""
 
 #. Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this is the heading for a Yes/No ToU question.
@@ -2824,10 +2472,7 @@ msgstr ""
 #. Translators: This message is shown on a user's profile if their Wikimedia account is blocked on one or more projects. They may still be granted access to the Library Bundle, but need to contact Wikipedia Library staff to verify.
 #: TWLight/users/templates/users/editor_detail_data.html:137
 #, python-format
-msgid ""
-"It looks like you have an active block on your account. If you meet the "
-"other criteria you may still be permitted access to the library - please <a "
-"class=\"twl-links\" href=\"%(contact_url)s\">contact us</a>."
+msgid "It looks like you have an active block on your account. If you meet the other criteria you may still be permitted access to the library - please <a class=\"twl-links\" href=\"%(contact_url)s\">contact us</a>."
 msgstr ""
 
 #. Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this is the heading for a Yes/No program eligibility question.
@@ -2837,10 +2482,7 @@ msgstr ""
 
 #. Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this question has a Yes or No answer.
 #: TWLight/users/templates/users/editor_detail_data.html:156
-msgid ""
-"At their last login, did this user meet the criteria set forth in the "
-"Library Bundle? Note that satisfying terms of use is a prerequisite to "
-"bundle eligibility."
+msgid "At their last login, did this user meet the criteria set forth in the Library Bundle? Note that satisfying terms of use is a prerequisite to bundle eligibility."
 msgstr ""
 
 #. Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this is the heading for a Yes/No program eligibility question.
@@ -2885,18 +2527,13 @@ msgstr ""
 
 #. Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this text is in the 'Personal data' section. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/users/templates/users/editor_detail_data.html:262
-msgid ""
-"The following information is visible only to you, site administrators, "
-"publishing partners (where required), and volunteer Wikipedia Library "
-"coordinators (who have signed a Non-Disclosure Agreement)."
+msgid "The following information is visible only to you, site administrators, publishing partners (where required), and volunteer Wikipedia Library coordinators (who have signed a Non-Disclosure Agreement)."
 msgstr ""
 
 #. Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this labels a button which users can click to update or remove their personal information. Don't translate update_url.
 #: TWLight/users/templates/users/editor_detail_data.html:272
 #, python-format
-msgid ""
-"You may <a class=\"twl-links\" href=\"%(update_url)s\">update or delete</a> "
-"your data at any time."
+msgid "You may <a class=\"twl-links\" href=\"%(update_url)s\">update or delete</a> your data at any time."
 msgstr ""
 
 #. Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this labels the user's email. Don't remove the *.
@@ -2916,26 +2553,18 @@ msgstr ""
 
 #. Translators: This message tells users that they are not eligible to access The Wikipedia Library content.
 #: TWLight/users/templates/users/eligibility_modal.html:7
-msgid ""
-"Sorry, your Wikipedia account doesn’t currently qualify to access The "
-"Wikipedia Library."
+msgid "Sorry, your Wikipedia account doesn’t currently qualify to access The Wikipedia Library."
 msgstr ""
 
 #. Translators: This message tells users that they have not agreed to the terms of use, therefore are ineligible to access the content in The Wikipedia Library.
 #: TWLight/users/templates/users/eligibility_modal.html:30
 #, python-format
-msgid ""
-"Agreed with <a href=\"%(terms)s\" class=\"text-danger\"> terms of use </a>"
-msgstr ""
-"தளத்தின் <a href=\"%(terms)s\" class=\"text-danger\">பயன்பாட்டு விதிமுறைகளுக்கு</"
-"a> ஒப்புக் கொண்டார்களா?"
+msgid "Agreed with <a href=\"%(terms)s\" class=\"text-danger\"> terms of use </a>"
+msgstr "தளத்தின் <a href=\"%(terms)s\" class=\"text-danger\">பயன்பாட்டு விதிமுறைகளுக்கு</a> ஒப்புக் கொண்டார்களா?"
 
 #: TWLight/users/templates/users/eligibility_modal.html:40
 #, python-format
-msgid ""
-"It looks like you have an active block on your account. If you meet the "
-"other criteria you may still be permitted access to the library - please <a "
-"href=\"%(contact_url)s\">contact us</a>."
+msgid "It looks like you have an active block on your account. If you meet the other criteria you may still be permitted access to the library - please <a href=\"%(contact_url)s\">contact us</a>."
 msgstr ""
 
 #. Translators: Instructions to refresh a user's data.
@@ -2975,10 +2604,7 @@ msgstr ""
 
 #. Translators: This text on the user page helps users naviage to the TranslateWiki Wikipedia Library Card platform translation page.
 #: TWLight/users/templates/users/language_form.html:31
-msgid ""
-"You can help translate the tool at <a class=\"twl-links\" href=\"https://"
-"translatewiki.net/wiki/Translating:Wikipedia_Library_Card_Platform"
-"\">translatewiki.net</a>."
+msgid "You can help translate the tool at <a class=\"twl-links\" href=\"https://translatewiki.net/wiki/Translating:Wikipedia_Library_Card_Platform\">translatewiki.net</a>."
 msgstr ""
 
 #. Translators: When the user starts a new application and submits the application, the user can view the application and withdraw if need be. This changes the label for the Withdraw button.
@@ -2998,9 +2624,7 @@ msgstr "புதுப்பித்தலை வேண்டுக"
 
 #. Translators: On the page listing applications, this text explains a user they cannot renew their application since they've already requested a renewal or there aren't any renewals available.
 #: TWLight/users/templates/users/my_applications.html:79
-msgid ""
-"Renewals are either not required, not available right now, or you have "
-"already requested a renewal."
+msgid "Renewals are either not required, not available right now, or you have already requested a renewal."
 msgstr ""
 
 #. Translators: This text is the heading of a section in a user's profile where they can change their preferences.
@@ -3068,19 +2692,12 @@ msgstr ""
 
 #. Translators: This message is displayed on the page where users can request we stop processing their data.
 #: TWLight/users/templates/users/restrict_data.html:15
-msgid ""
-"Checking this box and clicking “Restrict” will pause all processing of the "
-"data you have entered into this website. You will not be able to apply for "
-"access to resources, your applications will not be further processed, and "
-"none of your data will be altered, until you return to this page and uncheck "
-"the box. This is not the same as deleting your data."
+msgid "Checking this box and clicking “Restrict” will pause all processing of the data you have entered into this website. You will not be able to apply for access to resources, your applications will not be further processed, and none of your data will be altered, until you return to this page and uncheck the box. This is not the same as deleting your data."
 msgstr ""
 
 #. Translators: This warning message is shown to coordinators who view the data restriction page.
 #: TWLight/users/templates/users/restrict_data.html:26
-msgid ""
-"You are a coordinator on this site. If you restrict the processing of your "
-"data, your coordinator flag will be removed."
+msgid "You are a coordinator on this site. If you restrict the processing of your data, your coordinator flag will be removed."
 msgstr ""
 
 #. Translators: use the date *when you are translating*, in a language-appropriate format.
@@ -3101,24 +2718,12 @@ msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:51
-msgid ""
-"<a class=\"twl-links\" href=\"https://meta.wikimedia.org/wiki/"
-"The_Wikipedia_Library\"> The Wikipedia Library </a> has partnered with "
-"publishers around the world to allow users to access otherwise paywalled "
-"resources. This website allows Wikipedia editors to search and access these "
-"resources."
+msgid "<a class=\"twl-links\" href=\"https://meta.wikimedia.org/wiki/The_Wikipedia_Library\"> The Wikipedia Library </a> has partnered with publishers around the world to allow users to access otherwise paywalled resources. This website allows Wikipedia editors to search and access these resources."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Wikimedia Foundation should not be translated. WMF should not be translated. Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:63
-msgid ""
-"This program is administered by the Wikimedia Foundation (WMF). These terms "
-"of use and privacy notice pertain to your application for access to "
-"resources through the Wikipedia Library, your use of this website, and your "
-"access to and use of those resources. They also describe our handling of the "
-"information you provide to us in order to create and administer your "
-"Wikipedia Library account. If we make material changes to the terms, we will "
-"notify users."
+msgid "This program is administered by the Wikimedia Foundation (WMF). These terms of use and privacy notice pertain to your application for access to resources through the Wikipedia Library, your use of this website, and your access to and use of those resources. They also describe our handling of the information you provide to us in order to create and administer your Wikipedia Library account. If we make material changes to the terms, we will notify users."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
@@ -3128,37 +2733,17 @@ msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:78
-msgid ""
-"Access to resources via The Wikipedia Library is reserved for community "
-"members who have demonstrated their commitment to the Wikimedia projects, "
-"and who will use their access to these resources to improve project content. "
-"To that end, in order to be eligible for The Wikipedia Library, we require "
-"that you be registered for a user account on the projects, with at least 500 "
-"edits, six (6) months of activity, and 10+ edits in the last month. We ask "
-"that you do not request access to any publishers with a limited number of "
-"available accounts whose resources you can already access for free through "
-"your local library or university, or another institution or organization, in "
-"order to provide that opportunity to others."
+msgid "Access to resources via The Wikipedia Library is reserved for community members who have demonstrated their commitment to the Wikimedia projects, and who will use their access to these resources to improve project content. To that end, in order to be eligible for The Wikipedia Library, we require that you be registered for a user account on the projects, with at least 500 edits, six (6) months of activity, and 10+ edits in the last month. We ask that you do not request access to any publishers with a limited number of available accounts whose resources you can already access for free through your local library or university, or another institution or organization, in order to provide that opportunity to others."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:94
-msgid ""
-"Additionally, if you are currently blocked or banned from a Wikimedia "
-"project, applications to resources may be rejected or restricted. If you "
-"obtain a Wikipedia Library account, but a block or ban is subsequently "
-"instituted against you on one of the projects, you may lose access to your "
-"Wikipedia Library account."
+msgid "Additionally, if you are currently blocked or banned from a Wikimedia project, applications to resources may be rejected or restricted. If you obtain a Wikipedia Library account, but a block or ban is subsequently instituted against you on one of the projects, you may lose access to your Wikipedia Library account."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:104
-msgid ""
-"Your eligibility to access The Wikipedia Library is assessed at each login. "
-"While more than half of the library's content is provided via this automated "
-"eligibility check, access to other publisher's content may be time limited, "
-"typically lapsing after one year, after which you will usually need to apply "
-"for renewal."
+msgid "Your eligibility to access The Wikipedia Library is assessed at each login. While more than half of the library's content is provided via this automated eligibility check, access to other publisher's content may be time limited, typically lapsing after one year, after which you will usually need to apply for renewal."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
@@ -3169,47 +2754,27 @@ msgstr "உங்கள் விக்கிப்பீடியாவின�
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:118
-msgid ""
-"In order to apply for access to a partner resource, you must provide us with "
-"certain information, which we will use to evaluate your application. If your "
-"application is approved, we may transfer the information you have given us "
-"to the publishers whose resources you wish to access. They will either "
-"contact you with the account information directly or we will send access "
-"information to you ourselves."
+msgid "In order to apply for access to a partner resource, you must provide us with certain information, which we will use to evaluate your application. If your application is approved, we may transfer the information you have given us to the publishers whose resources you wish to access. They will either contact you with the account information directly or we will send access information to you ourselves."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:130
-msgid ""
-"In addition to the basic information you provide to us, our system will "
-"retrieve some information directly from the Wikimedia projects: your "
-"username, email address, edit count, registration date, user ID number, "
-"groups to which you belong, and any special user rights."
+msgid "In addition to the basic information you provide to us, our system will retrieve some information directly from the Wikimedia projects: your username, email address, edit count, registration date, user ID number, groups to which you belong, and any special user rights."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:140
-msgid ""
-"Each time you log in to the Wikipedia Library Card Platform, this "
-"information will be automatically updated."
+msgid "Each time you log in to the Wikipedia Library Card Platform, this information will be automatically updated."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:148
-msgid ""
-"We will ask you to provide us with some information about your history of "
-"contributions to the Wikimedia projects. Information on contribution history "
-"is optional, but will greatly assist us in evaluating your application."
+msgid "We will ask you to provide us with some information about your history of contributions to the Wikimedia projects. Information on contribution history is optional, but will greatly assist us in evaluating your application."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). WMF should not be translated. Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:157
-msgid ""
-"The information you provide when creating your account will be visible to "
-"you while on the site but not to others unless they are approved Wikipedia "
-"Library Coordinators, WMF Staff, or WMF Contractors who need access to this "
-"data in order to carry out their work with the Wikipedia Library, all of "
-"whom are subject to non-disclosure obligations."
+msgid "The information you provide when creating your account will be visible to you while on the site but not to others unless they are approved Wikipedia Library Coordinators, WMF Staff, or WMF Contractors who need access to this data in order to carry out their work with the Wikipedia Library, all of whom are subject to non-disclosure obligations."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
@@ -3219,46 +2784,32 @@ msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:171
-msgid ""
-"In order to access an individual publisher’s resources, you must agree to "
-"that publisher’s terms of use and privacy policy. You agree that you will "
-"not violate such terms and policies in connection with your use of the "
-"Wikipedia Library. Additionally, the following activities are prohibited "
-"while accessing publisher resources through the Wikipedia Library."
+msgid "In order to access an individual publisher’s resources, you must agree to that publisher’s terms of use and privacy policy. You agree that you will not violate such terms and policies in connection with your use of the Wikipedia Library. Additionally, the following activities are prohibited while accessing publisher resources through the Wikipedia Library."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:184
-msgid ""
-"Sharing your Wikipedia account, usernames, passwords, or any access codes "
-"for publisher resources with others;"
+msgid "Sharing your Wikipedia account, usernames, passwords, or any access codes for publisher resources with others;"
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:191
-msgid ""
-"Automatically scraping or downloading restricted content from publishers;"
+msgid "Automatically scraping or downloading restricted content from publishers;"
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:197
-msgid ""
-"Systematically making printed or electronic copies of multiple extracts of "
-"restricted content available for any purpose;"
+msgid "Systematically making printed or electronic copies of multiple extracts of restricted content available for any purpose;"
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:204
-msgid ""
-"Data mining metadata without permission—for example, in order to use "
-"metadata for auto-created stub articles;"
+msgid "Data mining metadata without permission—for example, in order to use metadata for auto-created stub articles;"
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:211
-msgid ""
-"Using the access you receive through the Wikipedia Library for profit by "
-"selling access to your account or resources which you have through it."
+msgid "Using the access you receive through the Wikipedia Library for profit by selling access to your account or resources which you have through it."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
@@ -3268,18 +2819,12 @@ msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:224
-msgid ""
-"Certain resources may only be accessed using an external search service, "
-"such as the EBSCO Discovery Service, or a proxy service, such as OCLC "
-"EZProxy. If you use such external search and/or proxy services, please "
-"review the applicable terms of use and privacy policies."
+msgid "Certain resources may only be accessed using an external search service, such as the EBSCO Discovery Service, or a proxy service, such as OCLC EZProxy. If you use such external search and/or proxy services, please review the applicable terms of use and privacy policies."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:234
-msgid ""
-"In addition, if you use OCLC EZProxy, please note that you may not use it "
-"for commercial purposes."
+msgid "In addition, if you use OCLC EZProxy, please note that you may not use it for commercial purposes."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
@@ -3289,120 +2834,49 @@ msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Wikimedia Foundation should not be translated. Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:245
-msgid ""
-"The Wikimedia Foundation and our service providers use your information for "
-"the legitimate purpose of providing Wikipedia Library services in support of "
-"our charitable mission. When you apply for a Wikipedia Library account, or "
-"use your Wikipedia Library account, we may routinely collect the following "
-"information: your username, email address, edit count, registration date, "
-"user ID number, groups to which you belong, and any special user rights; "
-"your name, country of residence, and/or affiliation, if required by a "
-"partner to which you are applying; your narrative description of your "
-"contributions and reasons for applying for access to partner resources; and "
-"the date you agree to these terms of use."
+msgid "The Wikimedia Foundation and our service providers use your information for the legitimate purpose of providing Wikipedia Library services in support of our charitable mission. When you apply for a Wikipedia Library account, or use your Wikipedia Library account, we may routinely collect the following information: your username, email address, edit count, registration date, user ID number, groups to which you belong, and any special user rights; your name, country of residence, and/or affiliation, if required by a partner to which you are applying; your narrative description of your contributions and reasons for applying for access to partner resources; and the date you agree to these terms of use."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:262
 #, python-format
-msgid ""
-"Each publisher who is a member of the Wikipedia Library program requires "
-"different specific information in the application. Some publishers may "
-"request only an email address, while others request more detailed data, such "
-"as your name, location, or institutional affiliation. When you complete your "
-"application, you will only be asked to supply information required by the "
-"publishers you have chosen, and each publisher will only receive the "
-"information they require for providing you with access. Please see our <a "
-"class=\"twl-links\" href=\"%(all_partners_url)s\">partner information</a> "
-"pages to learn what information is required by each publisher to gain access "
-"to their resources."
+msgid "Each publisher who is a member of the Wikipedia Library program requires different specific information in the application. Some publishers may request only an email address, while others request more detailed data, such as your name, location, or institutional affiliation. When you complete your application, you will only be asked to supply information required by the publishers you have chosen, and each publisher will only receive the information they require for providing you with access. Please see our <a class=\"twl-links\" href=\"%(all_partners_url)s\">partner information</a> pages to learn what information is required by each publisher to gain access to their resources."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Wikimedia Foundation should not be translated. Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:277
-msgid ""
-"Some Wikipedia Library pages are visible without logging in, but you will "
-"need to log in to apply or access proprietary partner resources. We use the "
-"data provided by you via OAuth and Wikimedia API calls to assess your "
-"application for access and to process approved requests."
+msgid "Some Wikipedia Library pages are visible without logging in, but you will need to log in to apply or access proprietary partner resources. We use the data provided by you via OAuth and Wikimedia API calls to assess your application for access and to process approved requests."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:288
 #, python-format
-msgid ""
-"In order to administer the Wikipedia Library program, we will retain the "
-"application data we collect from you for three years after your most recent "
-"login, unless you delete your account, as described below. You can log in "
-"and go to <a class=\"twl-links\" href=\"%(profile_url)s\">your profile page</"
-"a> in order to see the information associated with your account, and can "
-"download it in JSON format. You may access, update, restrict, or delete this "
-"information at any time, except for the information that is automatically "
-"retrieved from the projects. If you have any questions or concerns about the "
-"handling of your data, please contact <a class=\"twl-links\" href=\"mailto:"
-"wikipedialibrary@wikimedia.org?Subject=Wikipedia%%20Library%%20Card"
-"%%20account%%20deactivation\"> wikipedialibrary@wikimedia.org </a>."
+msgid "In order to administer the Wikipedia Library program, we will retain the application data we collect from you for three years after your most recent login, unless you delete your account, as described below. You can log in and go to <a class=\"twl-links\" href=\"%(profile_url)s\">your profile page</a> in order to see the information associated with your account, and can download it in JSON format. You may access, update, restrict, or delete this information at any time, except for the information that is automatically retrieved from the projects. If you have any questions or concerns about the handling of your data, please contact <a class=\"twl-links\" href=\"mailto:wikipedialibrary@wikimedia.org?Subject=Wikipedia%%20Library%%20Card%%20account%%20deactivation\"> wikipedialibrary@wikimedia.org </a>."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:305
-msgid ""
-"If you decide to disable your Wikipedia Library account, you can use the "
-"delete button on your profile to delete certain personal information "
-"associated with your account. We will delete your real name, institutional "
-"affiliation, and country of residence. Please note that the system will "
-"retain a record of your username, the publishers to which you applied or had "
-"access, and the dates of that access. Note that deletion is not reversible. "
-"Deletion of your Wikipedia Library account may also correspond with the "
-"removal of any resource access to which you were eligible or approved. If "
-"you request the deletion of account information and later wish to apply for "
-"a new account, you will need to provide the necessary information again."
+msgid "If you decide to disable your Wikipedia Library account, you can use the delete button on your profile to delete certain personal information associated with your account. We will delete your real name, institutional affiliation, and country of residence. Please note that the system will retain a record of your username, the publishers to which you applied or had access, and the dates of that access. Note that deletion is not reversible. Deletion of your Wikipedia Library account may also correspond with the removal of any resource access to which you were eligible or approved. If you request the deletion of account information and later wish to apply for a new account, you will need to provide the necessary information again."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). WMF should not be translated. Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:321
-msgid ""
-"The Wikipedia Library is run by WMF Staff, Contractors, and approved "
-"volunteer Coordinators. The data associated with your account will be shared "
-"with the WMF staff, contractors, service providers, and volunteer "
-"coordinators who need to process the information in connection with their "
-"work for the Wikipedia Library, and who are subject to confidentiality "
-"obligations. We will also use your data for internal Wikipedia Library "
-"purposes such as distributing user surveys and account notifications, and in "
-"a depersonalized or aggregated fashion for statistical analysis and "
-"administration. Finally, we will share your information with the publishers "
-"whom you specifically select in order to provide you with access to "
-"resources. Otherwise, your information will not be shared with third "
-"parties, with the exception of the circumstances described below."
+msgid "The Wikipedia Library is run by WMF Staff, Contractors, and approved volunteer Coordinators. The data associated with your account will be shared with the WMF staff, contractors, service providers, and volunteer coordinators who need to process the information in connection with their work for the Wikipedia Library, and who are subject to confidentiality obligations. We will also use your data for internal Wikipedia Library purposes such as distributing user surveys and account notifications, and in a depersonalized or aggregated fashion for statistical analysis and administration. Finally, we will share your information with the publishers whom you specifically select in order to provide you with access to resources. Otherwise, your information will not be shared with third parties, with the exception of the circumstances described below."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). WMF should not be translated.
 #: TWLight/users/templates/users/terms.html:338
-msgid ""
-"We may disclose any collected information when required by law, when we have "
-"your permission, when needed to protect our rights, privacy, safety, users, "
-"or the general public, and when necessary to enforce these terms, WMF’s "
-"general <a class=\"twl-links\" href=\"https://foundation.wikimedia.org/wiki/"
-"Terms_of_Use\">Terms of Use</a>, or any other WMF policy."
+msgid "We may disclose any collected information when required by law, when we have your permission, when needed to protect our rights, privacy, safety, users, or the general public, and when necessary to enforce these terms, WMF’s general <a class=\"twl-links\" href=\"https://foundation.wikimedia.org/wiki/Terms_of_Use\">Terms of Use</a>, or any other WMF policy."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:349
-msgid ""
-"We take the security of your personal data seriously, and take reasonable "
-"precautions to ensure your data is protected. These precautions include "
-"access controls to limit who has access to your data and security "
-"technologies to protect data stored on the server. However, we cannot "
-"guarantee the safety of your data as it is transmitted and stored."
+msgid "We take the security of your personal data seriously, and take reasonable precautions to ensure your data is protected. These precautions include access controls to limit who has access to your data and security technologies to protect data stored on the server. However, we cannot guarantee the safety of your data as it is transmitted and stored."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:360
-msgid ""
-"Please note that these terms do not control the use and handling of your "
-"data by the publishers and service providers whose resources you access or "
-"apply to access. Please read their individual privacy policies for that "
-"information."
+msgid "Please note that these terms do not control the use and handling of your data by the publishers and service providers whose resources you access or apply to access. Please read their individual privacy policies for that information."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
@@ -3412,34 +2886,17 @@ msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Wikimedia Foundation should not be translated. Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:373
-msgid ""
-"The Wikimedia Foundation is a nonprofit organization based in San Francisco, "
-"California. The Wikipedia Library program provides access to resources held "
-"by publishers in multiple countries. If you apply for a Wikipedia Library "
-"account (whether you are inside or outside of the United States), you "
-"understand that your personal data will be collected, transferred, stored, "
-"processed, disclosed and otherwise used in the U.S. as described in this "
-"privacy policy. You also understand that your information may be transferred "
-"by us from the U.S. to other countries, which may have different or less "
-"stringent data protection laws than your country, in connection with "
-"providing services to you, including evaluating your application and "
-"securing access to your chosen publishers (locations for each publisher are "
-"outlined on their respective partner information pages)."
+msgid "The Wikimedia Foundation is a nonprofit organization based in San Francisco, California. The Wikipedia Library program provides access to resources held by publishers in multiple countries. If you apply for a Wikipedia Library account (whether you are inside or outside of the United States), you understand that your personal data will be collected, transferred, stored, processed, disclosed and otherwise used in the U.S. as described in this privacy policy. You also understand that your information may be transferred by us from the U.S. to other countries, which may have different or less stringent data protection laws than your country, in connection with providing services to you, including evaluating your application and securing access to your chosen publishers (locations for each publisher are outlined on their respective partner information pages)."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:392
-msgid ""
-"Please note that in the event of any differences in meaning or "
-"interpretation between the original English version of these terms and a "
-"translation, the original English version takes precedence."
+msgid "Please note that in the event of any differences in meaning or interpretation between the original English version of these terms and a translation, the original English version takes precedence."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Wikimedia Foundation should not be translated.
 #: TWLight/users/templates/users/terms.html:403
-msgid ""
-"See also the <a class=\"twl-links\" href=\"https://wikimediafoundation.org/"
-"wiki/Privacy_policy\">Wikimedia Foundation Privacy Policy</a>."
+msgid "See also the <a class=\"twl-links\" href=\"https://wikimediafoundation.org/wiki/Privacy_policy\">Wikimedia Foundation Privacy Policy</a>."
 msgstr ""
 
 #. Translators: This is the second to last line of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
@@ -3459,11 +2916,7 @@ msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:426
-msgid ""
-"By checking this box and clicking “Submit”, you agree that you have read the "
-"above terms and that you will adhere to the terms of use in your application "
-"to and use of the The Wikipedia Library, and the publishers’ services to "
-"which you gain access through The Wikipedia Library program."
+msgid "By checking this box and clicking “Submit”, you agree that you have read the above terms and that you will adhere to the terms of use in your application to and use of the The Wikipedia Library, and the publishers’ services to which you gain access through The Wikipedia Library program."
 msgstr ""
 
 #: TWLight/users/templates/users/user_collection_tile.html:32
@@ -3518,29 +2971,18 @@ msgstr ""
 
 #. Translators: This message is displayed on the page where users can request the deletion of their data.
 #: TWLight/users/templates/users/user_confirm_delete.html:17
-msgid ""
-"<b>Warning:</b> Performing this action will delete your Wikipedia Library "
-"Card user account and all associated applications. This process is not "
-"reversible. You may lose any partner accounts you were granted, and will not "
-"be able to renew those accounts or apply for new ones."
+msgid "<b>Warning:</b> Performing this action will delete your Wikipedia Library Card user account and all associated applications. This process is not reversible. You may lose any partner accounts you were granted, and will not be able to renew those accounts or apply for new ones."
 msgstr ""
 
 #. Translators: this should show up for people who log in with a username/password and not OAuth, so we don't know what their Wikipedia identity is.
-#.
 #: TWLight/users/templates/users/user_detail.html:12
 #, python-format
-msgid ""
-"Hi, %(username)s! You don't have a Wikipedia editor profile attached to your "
-"account here, so you are probably a site administrator."
+msgid "Hi, %(username)s! You don't have a Wikipedia editor profile attached to your account here, so you are probably a site administrator."
 msgstr ""
 
 #. Translators: In the unlikely scenario that someone is able to register an account without using OAuth (thus leaving us without some of the information required for applications), users will see this message, encouraging them to re-register.
 #: TWLight/users/templates/users/user_detail.html:20
-msgid ""
-"If you aren't a site administrator, something weird has happened. You won't "
-"be able to apply for access without a Wikipedia editor profile. You should "
-"log out and create a new account by logging in via OAuth, or contact a site "
-"administrator for help."
+msgid "If you aren't a site administrator, something weird has happened. You won't be able to apply for access without a Wikipedia editor profile. You should log out and create a new account by logging in via OAuth, or contact a site administrator for help."
 msgstr ""
 
 #. Translators: Labels a sections where coordinators can select their email preferences.
@@ -3551,17 +2993,12 @@ msgstr ""
 #. Translators: This message is shown on user's own profile page, encouraging them to make sure their information is up to date, so that account coordinators can use the information to judge applications.
 #: TWLight/users/views.py:176
 #, python-brace-format
-msgid ""
-"Please <a class='twl-links' href='{url}'>update your contributions</a> to "
-"Wikipedia to help coordinators evaluate your applications."
+msgid "Please <a class='twl-links' href='{url}'>update your contributions</a> to Wikipedia to help coordinators evaluate your applications."
 msgstr ""
 
 #. Translators: Coordinators are shown this message when they unselect all three types of reminder email options under preferences.
 #: TWLight/users/views.py:288
-msgid ""
-"You have chosen not to receive reminder emails. As a coordinator, you should "
-"receive at least one type of reminder emails, so consider changing your "
-"preferences."
+msgid "You have chosen not to receive reminder emails. As a coordinator, you should receive at least one type of reminder emails, so consider changing your preferences."
 msgstr ""
 
 #. Translators: Coordinators are shown this message when they make changes to their reminder email options under preferences.
@@ -3596,9 +3033,7 @@ msgstr ""
 
 #. Translators: If the user has not filled out their email, they can browse the website but cannot apply for access to resources.
 #: TWLight/users/views.py:487
-msgid ""
-"Your email is blank. You can still explore the site, but you won't be able "
-"to apply for access to partner resources without an email."
+msgid "Your email is blank. You can still explore the site, but you won't be able to apply for access to partner resources without an email."
 msgstr ""
 
 #. Translators: This message is shown once the access to a partner has successfully been returned.
@@ -3632,31 +3067,3 @@ msgstr ""
 msgid "10+ edits in the last 30 days"
 msgstr ""
 
-#: tests/shunit/data/bad_i18n_comment_1.py:3
-#: tests/shunit/data/bad_i18n_newline_1.py:5
-msgid "1"
-msgstr ""
-
-#. Translators: Lorem ipsum dolor sit amet, consectetur adipiscing elit. Mauris vitae ipsum ut purus faucibus pretium. Proin tempus neque et aliquet consectetur. Ut egestas sapien in consectetur sagittis. Mauris neque lacus, dapibus non viverra vitae, interdum ut aenean ipsum.
-#. Translators: Lorem ipsum dolor sit amet, consectetur adipiscing elit. Mauris vitae ipsum ut purus faucibus pretium. Proin tempus neque et aliquet consectetur. Ut egestas sapien in consectetur sagittis. Mauris neque lacus, dapibus non.
-#: tests/shunit/data/bad_i18n_comment_2.py:4
-#: tests/shunit/data/bad_i18n_newline_2.py:5 tests/shunit/data/good_i18n_1.py:2
-#: tests/shunit/data/good_i18n_2.py:2
-msgid "2"
-msgstr ""
-
-#: tests/shunit/data/bad_i18n_newline_3.py:5
-msgid "3"
-msgstr ""
-
-#: tests/shunit/data/bad_i18n_newline_4.py:5
-msgid "4"
-msgstr ""
-
-#: tests/shunit/data/bad_i18n_newline_5.py:5
-msgid "5"
-msgstr ""
-
-#: tests/shunit/data/bad_i18n_newline_6.py:5
-msgid "6"
-msgstr ""

--- a/locale/tr/LC_MESSAGES/django.po
+++ b/locale/tr/LC_MESSAGES/django.po
@@ -20,10 +20,11 @@
 # Author: Ömer faruk çakmak
 msgid ""
 msgstr ""
+""
 "Project-Id-Version: Wikipedia Library Card Platform - Website\n"
-"Report-Msgid-Bugs-To: wikipedialibrary@wikimedia.org\n"
+"Report-Msgid-Bugs-To: translatewiki.net\n"
 "POT-Creation-Date: 2024-07-11 20:54+0000\n"
-"PO-Revision-Date: 2024-07-11 12:30:19+0000\n"
+"PO-Revision-Date: 2024-07-15 12:29:20+0000\n"
 "Language: tr\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
@@ -55,13 +56,8 @@ msgstr "Hakkınızda"
 #. Translators: This note appears in a section of a form where we ask users to enter info (like country of residence) when applying for resource access.
 #: TWLight/applications/forms.py:179
 #, python-brace-format
-msgid ""
-"<p><small><i>Your personal data will be processed according to our <a "
-"class='twl-links' href='{terms_url}'> privacy policy</a>.</i></small></p>"
-msgstr ""
-"<p><small><i>Kişisel verileriniz <a class='twl-links' "
-"href='{terms_url}'>gizlilik politikamıza</a> göre işlenecektir.</i></small></"
-"p>"
+msgid "<p><small><i>Your personal data will be processed according to our <a class='twl-links' href='{terms_url}'> privacy policy</a>.</i></small></p>"
+msgstr "<p><small><i>Kişisel verileriniz <a class='twl-links' href='{terms_url}'>gizlilik politikamıza</a> göre işlenecektir.</i></small></p>"
 
 #. Translators: This is the title of the application form page, where users enter information required for the application. It lets the user know which partner application they are entering data for. {partner}
 #: TWLight/applications/forms.py:189
@@ -102,11 +98,8 @@ msgstr "İş ortağının web sayfasındaki hesabınız için e-posta"
 #. Translators: This labels a choice field where users will have to select the number of months they wish to have their access for as part of the application renewal confirmation.
 #. Translators: When filling out an application, users may be required to enter the length of the account (expiry) they wish to have for proxy partners.
 #: TWLight/applications/forms.py:339 TWLight/applications/helpers.py:100
-msgid ""
-"The number of months you wish to have this access for before renewal is "
-"required"
-msgstr ""
-"Yenilemeden önce bu erişime sahip olmak istediğiniz ay sayısı gereklidir"
+msgid "The number of months you wish to have this access for before renewal is required"
+msgstr "Yenilemeden önce bu erişime sahip olmak istediğiniz ay sayısı gereklidir"
 
 #. Translators: When filling out an application, users may need to specify their name
 #: TWLight/applications/helpers.py:81
@@ -194,12 +187,8 @@ msgstr "E-posta"
 
 #. Translators: This comment is added to pending applications when our terms of use change.
 #: TWLight/applications/management/commands/notify_applicants_tou_changes.py:54
-msgid ""
-"Our terms of use have changed. Your applications will not be processed until "
-"you log in and agree to our updated terms."
-msgstr ""
-"Kullanım şartlarımız değişti. Siz oturum açıp güncellenmiş şartlarımızı "
-"kabul edene kadar başvurularınız işleme alınmayacaktır."
+msgid "Our terms of use have changed. Your applications will not be processed until you log in and agree to our updated terms."
+msgstr "Kullanım şartlarımız değişti. Siz oturum açıp güncellenmiş şartlarımızı kabul edene kadar başvurularınız işleme alınmayacaktır."
 
 #. Translators: This is the status of an application that has not yet been reviewed.
 #: TWLight/applications/models.py:54
@@ -265,42 +254,26 @@ msgstr "Erişim bağlantısı: {access_url}"
 
 #. Translators: This text goes into account approval emails in the case that we need to send the user's details to a publisher for manual account setup.
 #: TWLight/applications/models.py:331
-msgid ""
-"You can expect to receive access details within a week or two once it has "
-"been processed."
-msgstr ""
-"İşleme alındıktan sonra bir veya iki hafta içinde erişim ayrıntılarına sahip "
-"olmak için bekleyebilirsiniz."
+msgid "You can expect to receive access details within a week or two once it has been processed."
+msgstr "İşleme alındıktan sonra bir veya iki hafta içinde erişim ayrıntılarına sahip olmak için bekleyebilirsiniz."
 
 #. Translators: This comment is added to open applications when a partner joins the Library Bundle, which does not require applications.
 #: TWLight/applications/signals.py:247
-msgid ""
-"This partner joined the Library Bundle, which does not require applications. "
-"This application will be marked as invalid."
-msgstr ""
-"Bu iş ortağı, başvuru gerektirmeyen Kütüphane Paketi'ne katıldı. Bu uygulama "
-"geçersiz olarak işaretlenecek."
+msgid "This partner joined the Library Bundle, which does not require applications. This application will be marked as invalid."
+msgstr "Bu iş ortağı, başvuru gerektirmeyen Kütüphane Paketi'ne katıldı. Bu uygulama geçersiz olarak işaretlenecek."
 
 #. Translators: This is shown to users if the application is to a partner for which we have run out of available accounts. The application is therefore on a 'waitlist', and will be reviewed when more accounts are available.
 #: TWLight/applications/templates/applications/application_evaluation.html:29
-msgid ""
-"This application is on the waitlist because this partner does not have any "
-"access grants available at this time."
-msgstr ""
-"Bu iş ortağının şu anda erişim desteği olmadığı için bu başvuru bekleme "
-"listesinde."
+msgid "This application is on the waitlist because this partner does not have any access grants available at this time."
+msgstr "Bu iş ortağının şu anda erişim desteği olmadığı için bu başvuru bekleme listesinde."
 
 #. Translators: This message is shown on pages where coordinators can see personal information about applicants.
 #: TWLight/applications/templates/applications/application_evaluation.html:36
 #: TWLight/applications/templates/applications/application_list_include.html:6
 #: TWLight/applications/templates/applications/send_partner.html:45
 #: TWLight/resources/templates/resources/partner_users.html:18
-msgid ""
-"Coordinators: This page may contain personal information such as real names "
-"and email addresses. Please remember that this information is confidential."
-msgstr ""
-"Koordinatörler: Bu sayfa gerçek adlar ve e-posta adresleri gibi kişisel "
-"bilgiler içerebilir. Lütfen bu bilgilerin gizli olduğunu unutmayın."
+msgid "Coordinators: This page may contain personal information such as real names and email addresses. Please remember that this information is confidential."
+msgstr "Koordinatörler: Bu sayfa gerçek adlar ve e-posta adresleri gibi kişisel bilgiler içerebilir. Lütfen bu bilgilerin gizli olduğunu unutmayın."
 
 #. Translators: This is the title of the application page shown to users who are a coordinator, and are able to accept or reject the application.
 #: TWLight/applications/templates/applications/application_evaluation.html:39
@@ -309,12 +282,8 @@ msgstr "Başvuruyu değerlendir"
 
 #. Translators: This text is shown to coordinators on application pages if the applicant has restricted processing of their data.
 #: TWLight/applications/templates/applications/application_evaluation.html:42
-msgid ""
-"This user has requested a restriction on the processing of their data, so "
-"you cannot change the status of their application."
-msgstr ""
-"Bu kullanıcı, verilerin işlenmesiyle ilgili bir sınırlama isteğinde bulundu. "
-"Bu nedenle, başvurularının durumunu değiştiremezsiniz."
+msgid "This user has requested a restriction on the processing of their data, so you cannot change the status of their application."
+msgstr "Bu kullanıcı, verilerin işlenmesiyle ilgili bir sınırlama isteğinde bulundu. Bu nedenle, başvurularının durumunu değiştiremezsiniz."
 
 #. Translators: This is the title of the application page shown to users who are not a coordinator.
 #: TWLight/applications/templates/applications/application_evaluation.html:48
@@ -387,12 +356,8 @@ msgstr "Bilinmiyor"
 
 #. Translators: This is the text displayed to coordinators when an applicant has no country of residence in their profile.
 #: TWLight/applications/templates/applications/application_evaluation.html:123
-msgid ""
-"Please request the applicant add their country of residence to their profile "
-"before proceeding further."
-msgstr ""
-"Lütfen devam etmeden önce, başvuru sahibinin ikamet ettiği ülkeyi profiline "
-"eklemesini isteyin."
+msgid "Please request the applicant add their country of residence to their profile before proceeding further."
+msgstr "Lütfen devam etmeden önce, başvuru sahibinin ikamet ettiği ülkeyi profiline eklemesini isteyin."
 
 #. Translators: This labels the section of an application showing the total number of accounts available for a partner or their collection.
 #: TWLight/applications/templates/applications/application_evaluation.html:134
@@ -402,12 +367,8 @@ msgstr "Mevcut hesaplar"
 #. Translators: This labels the section of an application showing whether the user had agreed to the terms of use or not.
 #: TWLight/applications/templates/applications/application_evaluation.html:145
 #, python-format
-msgid ""
-"Has agreed to the site's <a class=\"twl-links\" href=\"%(terms_url)s\">terms "
-"of use</a>?"
-msgstr ""
-"Sitenin <a class=\"twl-links\" href=\"%(terms_url)s\">kullanım şartlarını</"
-"a> kabul etti mi?"
+msgid "Has agreed to the site's <a class=\"twl-links\" href=\"%(terms_url)s\">terms of use</a>?"
+msgstr "Sitenin <a class=\"twl-links\" href=\"%(terms_url)s\">kullanım şartlarını</a> kabul etti mi?"
 
 #. Translators: Displayed to coordinators when they've agreed to the terms of use.
 #. Translators: Displayed if the user has agreed to the terms of use.
@@ -442,12 +403,8 @@ msgstr "Hayır"
 
 #. Translators: This is the text displayed to coordinators when an applicant has not agreed to the terms of use.
 #: TWLight/applications/templates/applications/application_evaluation.html:159
-msgid ""
-"Please request the applicant agree to the site's terms of use before "
-"approving this application."
-msgstr ""
-"Lütfen başvuru sahibini bu başvuruyu onaylamadan önce sitenin kullanım "
-"koşullarını kabul etmesini isteyin."
+msgid "Please request the applicant agree to the site's terms of use before approving this application."
+msgstr "Lütfen başvuru sahibini bu başvuruyu onaylamadan önce sitenin kullanım koşullarını kabul etmesini isteyin."
 
 #. Translators: This labels the section of an application containing the user's motivation for wanting access to this resource.
 #: TWLight/applications/templates/applications/application_evaluation.html:176
@@ -467,10 +424,8 @@ msgstr "Mevcut erişim hibesinin yenilenmesi mi gerekiyor?"
 #. Translators: This message is shown next to the 'Renewal of existing access grant?' label if the application is a renewal. Don't translate HTML tags or parent_url.
 #: TWLight/applications/templates/applications/application_evaluation.html:195
 #, python-format
-msgid ""
-"Yes (<a class=\"twl-links\" href=\"%(parent_url)s\">previous application</a>)"
-msgstr ""
-"Evet (<a class=\"twl-links\" href=\"%(parent_url)s\">önceki başvuru</a>)"
+msgid "Yes (<a class=\"twl-links\" href=\"%(parent_url)s\">previous application</a>)"
+msgstr "Evet (<a class=\"twl-links\" href=\"%(parent_url)s\">önceki başvuru</a>)"
 
 #. Translators: This labels the section of the application showing the length of access remaining on the user's previous authorization.
 #: TWLight/applications/templates/applications/application_evaluation.html:208
@@ -504,11 +459,8 @@ msgstr "Yorum ekle"
 
 #. Translators: On an application page, this text tells users that the comments posted on the application are visible to coordinators and the submitting user only.
 #: TWLight/applications/templates/applications/application_evaluation.html:297
-msgid ""
-"Comments are visible to all coordinators and to the editor who submitted "
-"this application."
-msgstr ""
-"Yorumlar, tüm koordinatörlere ve bu uygulamayı gönderen editöre görünür."
+msgid "Comments are visible to all coordinators and to the editor who submitted this application."
+msgstr "Yorumlar, tüm koordinatörlere ve bu uygulamayı gönderen editöre görünür."
 
 #. Translators: This is the title of the section of an application page which lists information about the user who submitted the application.
 #. Translators: On the page where coordinators can view data on applications to a partner they coordinate, this is a table column heading for the username.
@@ -641,8 +593,7 @@ msgstr "İçeri aktarılan başvuru"
 #: TWLight/users/templates/users/my_applications.html:47
 #, python-format
 msgid "Last reviewed by %(reviewer)s on %(review_date)s"
-msgstr ""
-"Son değerlendirme %(review_date)s tarihinde %(reviewer)s tarafından yapıldı"
+msgstr "Son değerlendirme %(review_date)s tarihinde %(reviewer)s tarafından yapıldı"
 
 #. Translators: On the page listing applications, this shows next to an application which was previously reviewed. Don't translate review_date.
 #. Translators: If an application was previously reviewed, this text displays the date of the review.
@@ -720,18 +671,8 @@ msgstr "Durumu ayarla"
 
 #: TWLight/applications/templates/applications/apply.html:20
 #, python-format
-msgid ""
-"If your application is successful we may share your email address with "
-"%(partner)s. This is required to set up your access to their resources. By "
-"submitting this form you agree to allow your email address to be shared with "
-"%(partner)s if your application is successful, for the purposes of account "
-"setup."
-msgstr ""
-"Başvurunuz başarılı sonuçlanırsa e-posta adresinizi  %(partner)s ile "
-"paylaşabiliriz. Bu, kaynaklarına erişiminizi ayarlamak için gerekli bir "
-"adımdır. Bu formu göndererek başvurunuz başarılı olursa hesap kurulumu "
-"amacıyla e-posta adresinizin  %(partner)s ile paylaşılmasına izin vermiş "
-"olursunuz."
+msgid "If your application is successful we may share your email address with %(partner)s. This is required to set up your access to their resources. By submitting this form you agree to allow your email address to be shared with %(partner)s if your application is successful, for the purposes of account setup."
+msgstr "Başvurunuz başarılı sonuçlanırsa e-posta adresinizi  %(partner)s ile paylaşabiliriz. Bu, kaynaklarına erişiminizi ayarlamak için gerekli bir adımdır. Bu formu göndererek başvurunuz başarılı olursa hesap kurulumu amacıyla e-posta adresinizin  %(partner)s ile paylaşılmasına izin vermiş olursunuz."
 
 #. Translators: This message is displayed on the page where users can confirm their renewal. Please do not translate partner.
 #: TWLight/applications/templates/applications/confirm_renewal.html:23
@@ -759,12 +700,8 @@ msgstr "Hangi kaynaklara erişmek istiyorsunuz?"
 
 #. Translators: This text explains that Library Bundle partners are not shown in this list.
 #: TWLight/applications/templates/applications/request_for_application.html:26
-msgid ""
-"Library Bundle partners are not shown as eligibility is determined "
-"automatically."
-msgstr ""
-"Uygunluk otomatik olarak belirlendiği için Kitaplık Paketi ortakları "
-"gösterilmez."
+msgid "Library Bundle partners are not shown as eligibility is determined automatically."
+msgstr "Uygunluk otomatik olarak belirlendiği için Kitaplık Paketi ortakları gösterilmez."
 
 #. Translators: On the page where users can apply for multiple partners, this message shows next to the partner name, taking them to the full application page when clicked.
 #: TWLight/applications/templates/applications/request_for_application.html:48
@@ -778,14 +715,8 @@ msgstr "İş ortağı verisi henüz eklenmemiş."
 
 #. Translators: the HTML is so that the word 'waitlisted' will look the same as it does in the page above; please translate 'waitlisted' the same way you did elsewhere in this file.
 #: TWLight/applications/templates/applications/request_for_application.html:74
-msgid ""
-"You can apply to <span class=\"badge badge-warning\">Waitlisted</span> "
-"partners, but they don't have access grants available right now. We will "
-"process those applications when access becomes available."
-msgstr ""
-"<span class=\"badge badge-warning\">Bekleme listesindeki</span> iş "
-"ortaklarına başvurabilirsiniz fakat şu an erişime sahip değiller. Erişimi "
-"mümkün olduğunda bu başvuruları işleyeceğiz."
+msgid "You can apply to <span class=\"badge badge-warning\">Waitlisted</span> partners, but they don't have access grants available right now. We will process those applications when access becomes available."
+msgstr "<span class=\"badge badge-warning\">Bekleme listesindeki</span> iş ortaklarına başvurabilirsiniz fakat şu an erişime sahip değiller. Erişimi mümkün olduğunda bu başvuruları işleyeceğiz."
 
 #. Translators: On the page where coordinators can see approved applications which have not had their details sent to the partner, this message shows when there are applications ready to be processed.
 #: TWLight/applications/templates/applications/send.html:10
@@ -806,19 +737,13 @@ msgstr "%(object)s için başvuru verisi"
 #. Translators: This message is shown when applications exceed the number of accounts available.
 #: TWLight/applications/templates/applications/send_partner.html:54
 #, python-format
-msgid ""
-"Application(s) for %(object)s, if sent, will exceed the total available "
-"accounts for the partner. Please proceed at your own discretion."
-msgstr ""
-"%(object)s için başvuru gönderilirse iş ortağı için toplam kullanılabilir "
-"hesaplar aşılacaktır. Lütfen vereceğiniz karara göre ilerleyin."
+msgid "Application(s) for %(object)s, if sent, will exceed the total available accounts for the partner. Please proceed at your own discretion."
+msgstr "%(object)s için başvuru gönderilirse iş ortağı için toplam kullanılabilir hesaplar aşılacaktır. Lütfen vereceğiniz karara göre ilerleyin."
 
 #. Translators: When viewing the list of applications ready to be sent for a particular partner, this is instructions for the coordinator to click the 'mark as sent' button after they have sent the information.
 #: TWLight/applications/templates/applications/send_partner.html:65
 msgid "When you've processed the data below, click the 'mark as sent' button."
-msgstr ""
-"Aşağıdaki verileri işlediğinizde 'Gönderildi olarak işaretle' butonuna "
-"tıklayın."
+msgstr "Aşağıdaki verileri işlediğinizde 'Gönderildi olarak işaretle' butonuna tıklayın."
 
 #. Translators: When viewing the list of applications ready to be sent for a particular partner, this is the title of the section containing contact information for the people applications should be sent to.
 #: TWLight/applications/templates/applications/send_partner.html:71
@@ -828,12 +753,8 @@ msgstr[0] "İletişim"
 
 #. Translators: When viewing the list of applications ready to be sent for a particular partner, this message shows if there is no information about who the applications should be sent to. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/applications/templates/applications/send_partner.html:89
-msgid ""
-"Whoops, we don't have any listed contacts. Please notify Wikipedia Library "
-"administrators."
-msgstr ""
-"Ops, listede kayıtlı kişi yok! Lütfen Vikipedi Kütüphanesi yöneticilerini "
-"bilgilendirin."
+msgid "Whoops, we don't have any listed contacts. Please notify Wikipedia Library administrators."
+msgstr "Ops, listede kayıtlı kişi yok! Lütfen Vikipedi Kütüphanesi yöneticilerini bilgilendirin."
 
 #. Translators: When viewing the list of applications ready to be sent for a particular partner, this is the title of the section containing the information about those applications.
 #: TWLight/applications/templates/applications/send_partner.html:94
@@ -848,12 +769,8 @@ msgstr "Gönderildi olarak işaretle"
 
 #. Translators: This text guides coordinators in using the code sending interface for approved applications.
 #: TWLight/applications/templates/applications/send_partner.html:152
-msgid ""
-"Use the dropdown menus to denote which editor will receive each code. Access "
-"codes will be sent to users automatically."
-msgstr ""
-"Her kodu hangi düzenleyicinin alacağını belirtmek için açılır menüleri "
-"kullanın. Erişim kodları kullanıcılara otomatik olarak gönderilecektir."
+msgid "Use the dropdown menus to denote which editor will receive each code. Access codes will be sent to users automatically."
+msgstr "Her kodu hangi düzenleyicinin alacağını belirtmek için açılır menüleri kullanın. Erişim kodları kullanıcılara otomatik olarak gönderilecektir."
 
 #. Translators: This labels a drop-down selection where staff can assign an access code to a user.
 #: TWLight/applications/templates/applications/send_partner.html:173
@@ -868,24 +785,14 @@ msgstr "Onaylanmış, gönderilmemiş başvurular mevcut değil."
 #. Translators: When a user applies for a set of resources, they receive this message if none are currently available. They are instead placed on a 'waitlist' for later approval.
 #. Translators: When a user renews their resource, they receive this message if none are currently available. They are instead placed on a 'waitlist' for later approval.
 #: TWLight/applications/views.py:140 TWLight/applications/views.py:1282
-msgid ""
-"This partner does not have any access grants available at this time. You may "
-"still apply for access; your application will be reviewed when access grants "
-"become available."
-msgstr ""
-"Bu iş ortağının şu anda kullanılabilir erişim desteği yok. Erişim için hâlâ "
-"başvurabilirsiniz; erişim desteği mevcut olduğunda başvurunuz gözden "
-"geçirilecektir."
+msgid "This partner does not have any access grants available at this time. You may still apply for access; your application will be reviewed when access grants become available."
+msgstr "Bu iş ortağının şu anda kullanılabilir erişim desteği yok. Erişim için hâlâ başvurabilirsiniz; erişim desteği mevcut olduğunda başvurunuz gözden geçirilecektir."
 
 #. Translators: This message is shown to users once they've successfully submitted their application for review.
 #: TWLight/applications/views.py:163
 #, python-brace-format
-msgid ""
-"Your application has been submitted for review. Head over to <a "
-"href='{applications_url}'>My Applications</a> to view the status."
-msgstr ""
-"Başvurunuz incelenmek üzere gönderildi. Durumu görüntülemek için <a "
-"href='{applications_url}'>Başvurularım</a>'a gidin."
+msgid "Your application has been submitted for review. Head over to <a href='{applications_url}'>My Applications</a> to view the status."
+msgstr "Başvurunuz incelenmek üzere gönderildi. Durumu görüntülemek için <a href='{applications_url}'>Başvurularım</a>'a gidin."
 
 #. Translators: This text is displayed to users when the user has chosen to restrict data and is trying to apply for multiple partners
 #: TWLight/applications/views.py:276
@@ -933,21 +840,13 @@ msgstr "Gönderilmiş başvurular"
 
 #. Translators: After a coordinator has changed the status of an application to APPROVED, if the corresponding partner/collection is waitlisted this message appears.
 #: TWLight/applications/views.py:756
-msgid ""
-"Cannot approve application as partner with proxy authorization method is "
-"waitlisted."
-msgstr ""
-"Proxy yetkilendirme yöntemiyle iş ortağı bekleme listesine alındığından "
-"başvuru onaylanamıyor."
+msgid "Cannot approve application as partner with proxy authorization method is waitlisted."
+msgstr "Proxy yetkilendirme yöntemiyle iş ortağı bekleme listesine alındığından başvuru onaylanamıyor."
 
 #. Translators: After a coordinator has changed the status of an application to APPROVED, if the corresponding partner/collection has no accounts for distribution, this message appears.
 #: TWLight/applications/views.py:780
-msgid ""
-"Cannot approve application as partner with proxy authorization method is "
-"waitlisted and (or) has zero accounts available for distribution."
-msgstr ""
-"Başvuruyu proxy yetkilendirme yöntemiyle ortak olarak onaylayamıyor bekleme "
-"listesi ve (veya) dağıtım için uygun sıfır hesabı var."
+msgid "Cannot approve application as partner with proxy authorization method is waitlisted and (or) has zero accounts available for distribution."
+msgstr "Başvuruyu proxy yetkilendirme yöntemiyle ortak olarak onaylayamıyor bekleme listesi ve (veya) dağıtım için uygun sıfır hesabı var."
 
 #. Translators: This message appears on an "access denied" screen that stops users who attempt to authorize an editor to access a resource during a time period for which they are already authorized.
 #: TWLight/applications/views.py:803
@@ -957,16 +856,8 @@ msgstr "Yinelenen bir yetkilendirme oluşturmayı denediniz."
 #. Translators: This message is shown to users when they access an application page of a now Bundle partner (new applications aren't allowed for Bundle partners and the status of old applications cannot be modified)
 #: TWLight/applications/views.py:857
 #, python-brace-format
-msgid ""
-"This application cannot be modified since this partner is now part of our <a "
-"href='{bundle}'>bundle access</a>. If you are eligible, you can access this "
-"resource from <a href='{library}'>your library</a>. <a "
-"href='{contact}'>Contact us</a> if you have any questions."
-msgstr ""
-"Bu iş ortağı artık <a href='{bundle}'>paket erişimimizin</a> bir parçası "
-"olduğundan bu başvuru değiştirilemez. Uygunsanız bu kaynağa <a "
-"href='{library}'>kütüphanenizden</a> erişebilirsiniz. Herhangi bir sorunuz "
-"varsa <a href='{contact}'>bize ulaşın</a>."
+msgid "This application cannot be modified since this partner is now part of our <a href='{bundle}'>bundle access</a>. If you are eligible, you can access this resource from <a href='{library}'>your library</a>. <a href='{contact}'>Contact us</a> if you have any questions."
+msgstr "Bu iş ortağı artık <a href='{bundle}'>paket erişimimizin</a> bir parçası olduğundan bu başvuru değiştirilemez. Uygunsanız bu kaynağa <a href='{library}'>kütüphanenizden</a> erişebilirsiniz. Herhangi bir sorunuz varsa <a href='{contact}'>bize ulaşın</a>."
 
 #. Translators: this lets a reviewer set the status of a single application.
 #: TWLight/applications/views.py:873
@@ -975,12 +866,8 @@ msgstr "Başvuru durumunu ayarla"
 
 #. Translators: This warning is message is shown to applicants when the number of pending applications is greater than the number of accounts available.
 #: TWLight/applications/views.py:891
-msgid ""
-"There are more pending applications than available accounts. Your "
-"application might get waitlisted."
-msgstr ""
-"Mevcut hesaplardan daha fazla bekleyen başvuru var. Başvurunuz, bekleme "
-"listesine alınabilir."
+msgid "There are more pending applications than available accounts. Your application might get waitlisted."
+msgstr "Mevcut hesaplardan daha fazla bekleyen başvuru var. Başvurunuz, bekleme listesine alınabilir."
 
 #. Translators: this message is shown to coordinators who attempt to change an application's Status from INVALID to any other Status.
 #: TWLight/applications/views.py:904
@@ -999,16 +886,8 @@ msgstr "Toplu iş/uygulama {} başarılı."
 
 #. Translators: After a coordinator has changed the status of a number of applications to APPROVED, if the corresponding partner(s) is/are waitlisted or has no accounts for distribution, this message appears.
 #: TWLight/applications/views.py:1051
-msgid ""
-"Cannot approve application(s) {} as partner(s) with proxy authorization "
-"method is/are waitlisted and (or) has/have not enough accounts available. If "
-"not enough accounts are available, prioritise the applications and then "
-"approve applications equal to the accounts available."
-msgstr ""
-"{} Başvurularını peroksit yetkilendirme yöntemiyle ortak(lar) olarak kabul "
-"edemiyor/beklemede ve (veya) yeterli hesabı yok. Yeterli hesap yoksa, "
-"başvuruları önceliklendirin ve ardından mevcut hesaplara eşit başvuruları "
-"onaylayın."
+msgid "Cannot approve application(s) {} as partner(s) with proxy authorization method is/are waitlisted and (or) has/have not enough accounts available. If not enough accounts are available, prioritise the applications and then approve applications equal to the accounts available."
+msgstr "{} Başvurularını peroksit yetkilendirme yöntemiyle ortak(lar) olarak kabul edemiyor/beklemede ve (veya) yeterli hesabı yok. Yeterli hesap yoksa, başvuruları önceliklendirin ve ardından mevcut hesaplara eşit başvuruları onaylayın."
 
 #. Translators: This message is shown to coordinators who attempt to assign the same access code to multiple users.
 #: TWLight/applications/views.py:1191
@@ -1022,12 +901,8 @@ msgstr "Seçilen tüm başvurular, gönderildi olarak işaretlendi."
 
 #. Translators: When a user tries to renew their resource, they receive this message if the partner is not available.
 #: TWLight/applications/views.py:1272
-msgid ""
-"Cannot renew application at this time as partner is not available. Please "
-"check back later, or contact us for more information."
-msgstr ""
-"İş ortağı olmadığı için uygulama şu anda yenilenemiyor. Lütfen daha sonra "
-"tekrar kontrol edin veya daha fazla bilgi için bizimle iletişime geçin."
+msgid "Cannot renew application at this time as partner is not available. Please check back later, or contact us for more information."
+msgstr "İş ortağı olmadığı için uygulama şu anda yenilenemiyor. Lütfen daha sonra tekrar kontrol edin veya daha fazla bilgi için bizimle iletişime geçin."
 
 #. Translators: This message is displayed when an attempt by a user to renew an application has been denied for some reason.
 #: TWLight/applications/views.py:1308
@@ -1037,18 +912,12 @@ msgstr "Onaylanmayan bir başvurusu yenilemeye çalışıldı #{pk} reddedildi"
 
 #. Translators: If a user requests the renewal of their account, but it wasn't renewed, this message is shown to them.
 #: TWLight/applications/views.py:1385
-msgid ""
-"This object cannot be renewed. (This probably means that you have already "
-"requested that it be renewed.)"
-msgstr ""
-"Bu nesne yenilenemez. (Bu, muhtemelen bunun zaten yenilenmesini istediniz "
-"demektir.)"
+msgid "This object cannot be renewed. (This probably means that you have already requested that it be renewed.)"
+msgstr "Bu nesne yenilenemez. (Bu, muhtemelen bunun zaten yenilenmesini istediniz demektir.)"
 
 #. Translators: If a user requests the renewal of their account, this message is shown to them.
 #: TWLight/applications/views.py:1395
-msgid ""
-"Your renewal request has been received. A coordinator will review your "
-"request."
+msgid "Your renewal request has been received. A coordinator will review your request."
 msgstr "Yenileme talebiniz alındı. Bir koordinatör isteğinizi inceleyecektir."
 
 #. Translators: This labels a textfield where users can enter their email ID.
@@ -1058,12 +927,8 @@ msgstr "E-postanız"
 
 #. Translators: This is the help text for the email field in the contact us form letting users know the field is updated by value pulled from their respective user profiles.
 #: TWLight/emails/forms.py:21
-msgid ""
-"This field is automatically updated with the email from your <a class='twl-"
-"links' href='{}'>user profile</a>."
-msgstr ""
-"Bu alan, <a class='twl-links' href='{}'>kullanıcı profilinizden</a> gelen e-"
-"posta ile otomatik olarak güncellenir."
+msgid "This field is automatically updated with the email from your <a class='twl-links' href='{}'>user profile</a>."
+msgstr "Bu alan, <a class='twl-links' href='{}'>kullanıcı profilinizden</a> gelen e-posta ile otomatik olarak güncellenir."
 
 #. Translators: This labels a textfield where users can enter their email message.
 #: TWLight/emails/forms.py:26
@@ -1086,26 +951,14 @@ msgstr "Gönder"
 #. Translators: This email is sent to users with their access code. Don't translate Jinja variables in curly braces like user or partner. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/access_code_email-body-html.html:5
 #, python-format
-msgid ""
-"<p>Your approved application to %(partner)s has now been finalised. Your "
-"access code or login details can be found below:</p> <p><b>%(access_code)s</"
-"b></p> <p>%(user_instructions)s</p>"
-msgstr ""
-"<p>%(partner)s onaylanmış başvurunuz şimdi sonlandırıldı. Erişim kodunuzu "
-"veya giriş bilgilerinizi aşağıda bulabilirsiniz:</p> <p><b>%(access_code)s</"
-"b></p> <p>%(user_instructions)s</p>"
+msgid "<p>Your approved application to %(partner)s has now been finalised. Your access code or login details can be found below:</p> <p><b>%(access_code)s</b></p> <p>%(user_instructions)s</p>"
+msgstr "<p>%(partner)s onaylanmış başvurunuz şimdi sonlandırıldı. Erişim kodunuzu veya giriş bilgilerinizi aşağıda bulabilirsiniz:</p> <p><b>%(access_code)s</b></p> <p>%(user_instructions)s</p>"
 
 #. Translators: This email is sent to users with their access code. Don't translate Jinja variables in curly braces like user or partner. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/access_code_email-body-text.html:3
 #, python-format
-msgid ""
-"Your approved application to %(partner)s has now been finalised. Your access "
-"code or login details can be found below: %(access_code)s "
-"%(user_instructions)s"
-msgstr ""
-"%(partner)s onaylanmış başvurunuz şimdi sonlandırıldı. Erişim kodunuzu veya "
-"giriş bilgilerinizi aşağıda bulabilirsiniz: %(access_code)s "
-"%(user_instructions)s"
+msgid "Your approved application to %(partner)s has now been finalised. Your access code or login details can be found below: %(access_code)s %(user_instructions)s"
+msgstr "%(partner)s onaylanmış başvurunuz şimdi sonlandırıldı. Erişim kodunuzu veya giriş bilgilerinizi aşağıda bulabilirsiniz: %(access_code)s %(user_instructions)s"
 
 #. Translators: This is the subject line of an email sent to users with their access code.
 #: TWLight/emails/templates/emails/access_code_email-subject.html:3
@@ -1115,34 +968,14 @@ msgstr "Vikipedi Kütüphanesi erişim kodunuz"
 #. Translators: This email is sent to users when their application is approved. Don't translate Jinja variables in curly braces like user or partner; don't translate html tags either. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/approval_notification-body-html.html:5
 #, python-format
-msgid ""
-"<p>Dear %(user)s,</p> <p>Thank you for applying for access to %(partner)s "
-"resources through The Wikipedia Library. We are happy to inform you that "
-"your application has been approved.</p> <p>%(user_instructions)s</p> <p>You "
-"can view the collections you're authorized to access at My Library: "
-"%(link)s</p> <p>Cheers!</p> <p>The Wikipedia Library</p>"
-msgstr ""
-"<p>Sevgili %(user)s,</p> <p>%(partner)s kaynaklarına Vikipedi Kütüphanesi "
-"aracılığıyla erişim başvurusu yaptığınız için teşekkür ederiz. Başvurunuzun "
-"onaylandığını bildirmekten memnuniyet duyarız.</p> <p>%(user_instructions)s</"
-"p> <p>Erişim izniniz olan koleksiyonları Kütüphanem'de "
-"görüntüleyebilirsiniz: %(link)s</p> <p>Bravo!</p> <p>Vikipedi Kütüphanesi</p>"
+msgid "<p>Dear %(user)s,</p> <p>Thank you for applying for access to %(partner)s resources through The Wikipedia Library. We are happy to inform you that your application has been approved.</p> <p>%(user_instructions)s</p> <p>You can view the collections you're authorized to access at My Library: %(link)s</p> <p>Cheers!</p> <p>The Wikipedia Library</p>"
+msgstr "<p>Sevgili %(user)s,</p> <p>%(partner)s kaynaklarına Vikipedi Kütüphanesi aracılığıyla erişim başvurusu yaptığınız için teşekkür ederiz. Başvurunuzun onaylandığını bildirmekten memnuniyet duyarız.</p> <p>%(user_instructions)s</p> <p>Erişim izniniz olan koleksiyonları Kütüphanem'de görüntüleyebilirsiniz: %(link)s</p> <p>Bravo!</p> <p>Vikipedi Kütüphanesi</p>"
 
 #. Translators: This email is sent to users when their application is approved. Don't translate Jinja variables in curly braces like user or partner. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/approval_notification-body-text.html:3
 #, python-format
-msgid ""
-"Dear %(user)s, Thank you for applying for access to %(partner)s resources "
-"through The Wikipedia Library. We are happy to inform you that your "
-"application has been approved. %(user_instructions)s You can view the "
-"collections you're authorized to access at My Library: %(link)s Cheers! The "
-"Wikipedia Library"
-msgstr ""
-"Sevgili %(user)s, Vikipedi Kütüphanesi aracılığıyla %(partner)s kaynaklarına "
-"erişim başvurusu yaptığınız için teşekkür ederiz. Başvurunuzun onaylandığını "
-"size bildirmekten memnuniyet duyarız. %(user_instructions)s erişim izniniz "
-"olan koleksiyonları Kütüphanem'de görüntüleyebilirsiniz: %(link)s Bravo! "
-"Vikipedi Kütüphanesi"
+msgid "Dear %(user)s, Thank you for applying for access to %(partner)s resources through The Wikipedia Library. We are happy to inform you that your application has been approved. %(user_instructions)s You can view the collections you're authorized to access at My Library: %(link)s Cheers! The Wikipedia Library"
+msgstr "Sevgili %(user)s, Vikipedi Kütüphanesi aracılığıyla %(partner)s kaynaklarına erişim başvurusu yaptığınız için teşekkür ederiz. Başvurunuzun onaylandığını size bildirmekten memnuniyet duyarız. %(user_instructions)s erişim izniniz olan koleksiyonları Kütüphanem'de görüntüleyebilirsiniz: %(link)s Bravo! Vikipedi Kütüphanesi"
 
 #. Translators: This is the subject of an email which is sent to users when their application has been approved. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/approval_notification-subject.html:4
@@ -1152,58 +985,31 @@ msgstr "Vikipedi Kütüphanesi başvurunuz onaylandı"
 #. Translators: This email is sent to coordinators when a comment is left on an application they are processing. Don't translate Jinja variables in curly braces like user or partner. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/comment_notification_coordinator-body-html.html:5
 #, python-format
-msgid ""
-"<p style=\"color: #500050\">%(submit_date)s - %(commenter)s</p> "
-"<blockquote><p>%(comment)s</p></blockquote> <p>Please reply to these at: <a "
-"href=\"%(app_url)s\">%(app_url)s</a></p> <p>Best,</p> <p>The Wikipedia "
-"Library</p>"
-msgstr ""
-"<p style=\"color: #500050\">%(submit_date)s - %(commenter)s</p> "
-"<blockquote><p>%(comment)s</p></blockquote> <p>Lütfen, şu adresten "
-"yanıtlayın: <a href=\"%(app_url)s\">%(app_url)s</a></p> <p>Saygılarımızla,</"
-"p> <p>Vikipedi Kütüphanesi</p>"
+msgid "<p style=\"color: #500050\">%(submit_date)s - %(commenter)s</p> <blockquote><p>%(comment)s</p></blockquote> <p>Please reply to these at: <a href=\"%(app_url)s\">%(app_url)s</a></p> <p>Best,</p> <p>The Wikipedia Library</p>"
+msgstr "<p style=\"color: #500050\">%(submit_date)s - %(commenter)s</p> <blockquote><p>%(comment)s</p></blockquote> <p>Lütfen, şu adresten yanıtlayın: <a href=\"%(app_url)s\">%(app_url)s</a></p> <p>Saygılarımızla,</p> <p>Vikipedi Kütüphanesi</p>"
 
 #. Translators: This email is sent to coordinators when a comment is left on an application they are processing. Don't translate Jinja variables in curly braces like user or partner. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/comment_notification_coordinator-body-text.html:3
 #, python-format
-msgid ""
-"%(submit_date)s - %(commenter)s %(comment)s Please reply to this at: "
-"%(app_url)s Best, The Wikipedia Library"
-msgstr ""
-"%(submit_date)s - %(commenter)s %(comment)s Lütfen, şu adresten yanıtlayın: "
-"%(app_url)s Saygılarımızla, Vikipedi Kütüphanesi"
+msgid "%(submit_date)s - %(commenter)s %(comment)s Please reply to this at: %(app_url)s Best, The Wikipedia Library"
+msgstr "%(submit_date)s - %(commenter)s %(comment)s Lütfen, şu adresten yanıtlayın: %(app_url)s Saygılarımızla, Vikipedi Kütüphanesi"
 
 #. Translators: This is the subject line of an email sent to coordinators when a comment is left on an application they processed.
 #: TWLight/emails/templates/emails/comment_notification_coordinator-subject.html:3
 msgid "New comment on a Wikipedia Library application you processed"
-msgstr ""
-"Sürecine dahil olduğunuz bir Vikipedi Kütüphanesi başvurusuna yeni bir yorum "
-"yapıldı"
+msgstr "Sürecine dahil olduğunuz bir Vikipedi Kütüphanesi başvurusuna yeni bir yorum yapıldı"
 
 #. Translators: This email is sent to users when they receive a comment on their application. Don't translate Jinja variables in curly braces like user or partner; don't translate html tags either. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/comment_notification_editors-body-html.html:5
 #, python-format
-msgid ""
-"<p style=\"color: #500050\">%(submit_date)s - %(commenter)s</p> "
-"<blockquote><p>%(comment)s</p></blockquote> <p>Please reply to these at <a "
-"href=\"%(app_url)s\">%(app_url)s</a> so we can evaluate your application.</"
-"p> <p>Best,</p> <p>The Wikipedia Library</p>"
-msgstr ""
-"<p style=\"color: #500050\">%(submit_date)s - %(commenter)s</p> "
-"<blockquote><p>%(comment)s</p></blockquote> <p>Lütfen bunlara <a href="
-"\"%(app_url)s\">%(app_url)s</a> adresinden cevap verin, böylece başvurunuzu "
-"değerlendirebiliriz.</p> <p>Saygılarımızla,</p> <p>Vikipedi Kütüphanesi</p>"
+msgid "<p style=\"color: #500050\">%(submit_date)s - %(commenter)s</p> <blockquote><p>%(comment)s</p></blockquote> <p>Please reply to these at <a href=\"%(app_url)s\">%(app_url)s</a> so we can evaluate your application.</p> <p>Best,</p> <p>The Wikipedia Library</p>"
+msgstr "<p style=\"color: #500050\">%(submit_date)s - %(commenter)s</p> <blockquote><p>%(comment)s</p></blockquote> <p>Lütfen bunlara <a href=\"%(app_url)s\">%(app_url)s</a> adresinden cevap verin, böylece başvurunuzu değerlendirebiliriz.</p> <p>Saygılarımızla,</p> <p>Vikipedi Kütüphanesi</p>"
 
 #. Translators: This email is sent to users when they receive a comment on their application. Don't translate Jinja variables in curly braces like user or partner. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/comment_notification_editors-body-text.html:3
 #, python-format
-msgid ""
-"%(submit_date)s - %(commenter)s %(comment)s Please reply to these at: "
-"%(app_url)s so we can evaluate your application. Best, The Wikipedia Library"
-msgstr ""
-"%(submit_date)s - %(commenter)s %(comment)s Lütfen bunları şu adreste "
-"yanıtlayın: %(app_url)s böylece başvurunuzu değerlendirebiliriz. "
-"Saygılarımızla, Vikipedi Kütüphanesi"
+msgid "%(submit_date)s - %(commenter)s %(comment)s Please reply to these at: %(app_url)s so we can evaluate your application. Best, The Wikipedia Library"
+msgstr "%(submit_date)s - %(commenter)s %(comment)s Lütfen bunları şu adreste yanıtlayın: %(app_url)s böylece başvurunuzu değerlendirebiliriz. Saygılarımızla, Vikipedi Kütüphanesi"
 
 #. Translators: This is the subject line of an email sent to users who have a comment added to one of their applications. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/comment_notification_editors-subject.html:3
@@ -1213,43 +1019,25 @@ msgstr "Vikipedi Kütüphanesi başvurunuza yeni bir yorum yapıldı"
 #. Translators: This email is sent to users when an application they commented on receives another comment. Don't translate Jinja variables in curly braces like app_url; don't translate html tags either. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/comment_notification_others-body-html.html:5
 #, python-format
-msgid ""
-"<p style=\"color: #500050\">%(submit_date)s - %(commenter)s</p> "
-"<blockquote><p>%(comment)s</p></blockquote> See it at <a href=\"%(app_url)s"
-"\">%(app_url)s</a>. Thanks for helping review Wikipedia Library applications!"
-msgstr ""
-"<p style=\"color: #500050\">%(submit_date)s - %(commenter)s</p> "
-"<blockquote><p>%(comment)s</p></blockquote> Görmek için <a href=\"%(app_url)s"
-"\">%(app_url)s</a> adresine gidin. Vikipedi Kütüphanesi başvurularını gözden "
-"geçirdiğiniz için teşekkürler!"
+msgid "<p style=\"color: #500050\">%(submit_date)s - %(commenter)s</p> <blockquote><p>%(comment)s</p></blockquote> See it at <a href=\"%(app_url)s\">%(app_url)s</a>. Thanks for helping review Wikipedia Library applications!"
+msgstr "<p style=\"color: #500050\">%(submit_date)s - %(commenter)s</p> <blockquote><p>%(comment)s</p></blockquote> Görmek için <a href=\"%(app_url)s\">%(app_url)s</a> adresine gidin. Vikipedi Kütüphanesi başvurularını gözden geçirdiğiniz için teşekkürler!"
 
 #. Translators: This email is sent to users when an application they commented on receives another comment. Don't translate Jinja variables in curly braces like app_url. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/comment_notification_others-body-text.html:3
 #, python-format
-msgid ""
-"%(submit_date)s - %(commenter)s %(comment)s See it at: %(app_url)s Thanks "
-"for helping review Wikipedia Library applications!"
-msgstr ""
-"%(submit_date)s - %(commenter)s %(comment)s Görmek için şu adrese gidiniz: "
-"%(app_url)s Vikipedi Kütüphanesi başvurularını gözden geçirdiğiniz için "
-"teşekkürler!"
+msgid "%(submit_date)s - %(commenter)s %(comment)s See it at: %(app_url)s Thanks for helping review Wikipedia Library applications!"
+msgstr "%(submit_date)s - %(commenter)s %(comment)s Görmek için şu adrese gidiniz: %(app_url)s Vikipedi Kütüphanesi başvurularını gözden geçirdiğiniz için teşekkürler!"
 
 #. Translators: This is the subject line of an email sent to users who have a comment added to an application they also commented on. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/comment_notification_others-subject.html:4
 msgid "New comment on a Wikipedia Library application you commented on"
-msgstr ""
-"Yorum yaptığınız bir Vikipedi Kütüphanesi başvurusuna yeni bir yorum yapıldı"
+msgstr "Yorum yaptığınız bir Vikipedi Kütüphanesi başvurusuna yeni bir yorum yapıldı"
 
 #. Translators: This text is part of a scheduled reminder email sent to coordinators who have applications requiring action. Don't translate Jinja variables in curly braces like total_apps, or user.
 #: TWLight/emails/templates/emails/coordinator_reminder_notification-body-html.html:5
 #, python-format
-msgid ""
-"<p>Dear %(user)s,</p> <p>Our records indicate that you are the designated "
-"coordinator for partners that have a total of %(total_apps)s applications.</"
-"p>"
-msgstr ""
-"<p>Sayın %(user)s,</p><p> Kayıtlarımız, toplam %(total_apps)s başvuruya "
-"sahip iş ortakları için atanmış koordinatör olduğunuzu gösteriyor.</p>"
+msgid "<p>Dear %(user)s,</p> <p>Our records indicate that you are the designated coordinator for partners that have a total of %(total_apps)s applications.</p>"
+msgstr "<p>Sayın %(user)s,</p><p> Kayıtlarımız, toplam %(total_apps)s başvuruya sahip iş ortakları için atanmış koordinatör olduğunuzu gösteriyor.</p>"
 
 #. Translators: Breakdown as in 'cost breakdown'; analysis.
 #: TWLight/emails/templates/emails/coordinator_reminder_notification-body-html.html:11
@@ -1284,44 +1072,20 @@ msgstr[0] "%(counter)s onaylanan başvuru."
 #. Translators: This text is part of a scheduled reminder email sent to coordinators who have applications requiring action. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library). Don't translate Jinja variables in curly braces like link; don't translate email addresses or html tags either.
 #: TWLight/emails/templates/emails/coordinator_reminder_notification-body-html.html:39
 #, python-format
-msgid ""
-"<p>This is a gentle reminder that you may review applications at <a href="
-"\"%(link)s\">%(link)s</a>.</p> <p>You can customise your reminders under "
-"'preferences' in your user profile.</p> <p>If you received this message in "
-"error, drop us a line at wikipedialibrary@wikimedia.org.</p> <p>Thanks for "
-"helping review Wikipedia Library applications!</p>"
-msgstr ""
-"<p>Bu, <a href=\"%(link)s\">%(link)s</a> adresindeki başvuruları "
-"inceleyebileceğinizle ilgili kibar bir hatırlatmadır.</p> <p>Bu mesajı "
-"yanlışlıkla aldıysanız, wikipedialibrary@wikimedia.org adresinden bize yazın."
-"</p> <p>Vikipedi Kütüphanesi başvurularını gözden geçirdiğiniz için "
-"teşekkürler!</p>"
+msgid "<p>This is a gentle reminder that you may review applications at <a href=\"%(link)s\">%(link)s</a>.</p> <p>You can customise your reminders under 'preferences' in your user profile.</p> <p>If you received this message in error, drop us a line at wikipedialibrary@wikimedia.org.</p> <p>Thanks for helping review Wikipedia Library applications!</p>"
+msgstr "<p>Bu, <a href=\"%(link)s\">%(link)s</a> adresindeki başvuruları inceleyebileceğinizle ilgili kibar bir hatırlatmadır.</p> <p>Bu mesajı yanlışlıkla aldıysanız, wikipedialibrary@wikimedia.org adresinden bize yazın.</p> <p>Vikipedi Kütüphanesi başvurularını gözden geçirdiğiniz için teşekkürler!</p>"
 
 #. Translators: This text is part of a scheduled reminder email sent to coordinators who have applications requiring action. Don't translate Jinja variables in curly braces like total_apps, or user.
 #: TWLight/emails/templates/emails/coordinator_reminder_notification-body-text.html:3
 #, python-format
-msgid ""
-"Dear %(user)s, Our records indicate that you are the designated coordinator "
-"for partners that have a total of %(total_apps)s applications."
-msgstr ""
-"Sevgili %(user)s, kayıtlarımız, toplam %(total_apps)s başvuruya sahip iş "
-"ortakları için belirlenmiş koordinatör olduğunuzu gösteriyor."
+msgid "Dear %(user)s, Our records indicate that you are the designated coordinator for partners that have a total of %(total_apps)s applications."
+msgstr "Sevgili %(user)s, kayıtlarımız, toplam %(total_apps)s başvuruya sahip iş ortakları için belirlenmiş koordinatör olduğunuzu gösteriyor."
 
 #. Translators: This text is part of a scheduled reminder email sent to coordinators who have applications requiring action. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library). Don't translate Jinja variables in curly braces like link; don't translate the email address either.
 #: TWLight/emails/templates/emails/coordinator_reminder_notification-body-text.html:38
 #, python-format
-msgid ""
-"This is a gentle reminder that you may review applications at: %(link)s. You "
-"can customise your reminders under 'preferences' in your user profile. If "
-"you received this message in error, drop us a line at: "
-"wikipedialibrary@wikimedia.org Thanks for helping review Wikipedia Library "
-"applications!"
-msgstr ""
-"Bu, başvuruları inceleyebileceğiniz nazik bir hatırlatmadır: %(link)s. "
-"Hatırlatıcılarınızı kullanıcı profilinizdeki 'tercihler' altında "
-"özelleştirebilirsiniz. Bu mesajı yanlışlıkla aldıysanız bize bir mesaj "
-"bırakın: wikipedialibrary@wikimedia.org Vikipedi Kütüphane uygulamalarını "
-"incelemeye yardımcı olduğunuz için teşekkür ederiz!"
+msgid "This is a gentle reminder that you may review applications at: %(link)s. You can customise your reminders under 'preferences' in your user profile. If you received this message in error, drop us a line at: wikipedialibrary@wikimedia.org Thanks for helping review Wikipedia Library applications!"
+msgstr "Bu, başvuruları inceleyebileceğiniz nazik bir hatırlatmadır: %(link)s. Hatırlatıcılarınızı kullanıcı profilinizdeki 'tercihler' altında özelleştirebilirsiniz. Bu mesajı yanlışlıkla aldıysanız bize bir mesaj bırakın: wikipedialibrary@wikimedia.org Vikipedi Kütüphane uygulamalarını incelemeye yardımcı olduğunuz için teşekkür ederiz!"
 
 #. Translators: This is the subject line of a scheduled reminder email sent to coordinators who have applications to review. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library). Do not translate items in curly braces.
 #: TWLight/emails/templates/emails/coordinator_reminder_notification-subject.html:4
@@ -1331,32 +1095,14 @@ msgstr "Vikipedi Kütüphanesi başvuruları değerlendirmenizi bekliyor"
 #. Translators: This email is sent to users when their application is rejected. Don't translate Jinja variables in curly braces like user or partner; don't translate html tags either. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/rejection_notification-body-html.html:5
 #, python-format
-msgid ""
-"<p>Dear %(user)s,</p> <p>Thank you for applying for access to %(partner)s "
-"resources through The Wikipedia Library. Unfortunately at this time your "
-"application has not been approved. You can view your application and review "
-"comments at <a href=\"%(app_url)s\">%(app_url)s</a>.</p> <p>Best,</p> <p>The "
-"Wikipedia Library</p>"
-msgstr ""
-"<p>Sevgili %(user)s,</p> <p>Vikipedi Kütüphanesi aracılığıyla %(partner)s "
-"erişim başvurusu yaptığınız için teşekkür ederiz. Maalesef başvurunuz şu an "
-"onaylanmadı. Başvurunuzu görüntüleyebilir ve yorumları <a href=\"%(app_url)s"
-"\">%(app_url)s</a> adresinden inceleyebilirsiniz.</p> <p>Sevgilerle,</p> "
-"<p>Vikipedi Kütüphanesi</p>"
+msgid "<p>Dear %(user)s,</p> <p>Thank you for applying for access to %(partner)s resources through The Wikipedia Library. Unfortunately at this time your application has not been approved. You can view your application and review comments at <a href=\"%(app_url)s\">%(app_url)s</a>.</p> <p>Best,</p> <p>The Wikipedia Library</p>"
+msgstr "<p>Sevgili %(user)s,</p> <p>Vikipedi Kütüphanesi aracılığıyla %(partner)s erişim başvurusu yaptığınız için teşekkür ederiz. Maalesef başvurunuz şu an onaylanmadı. Başvurunuzu görüntüleyebilir ve yorumları <a href=\"%(app_url)s\">%(app_url)s</a> adresinden inceleyebilirsiniz.</p> <p>Sevgilerle,</p> <p>Vikipedi Kütüphanesi</p>"
 
 #. Translators: This email is sent to users when their application is rejected. Don't translate Jinja variables in curly braces like user or partner. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/rejection_notification-body-text.html:3
 #, python-format
-msgid ""
-"Dear %(user)s, Thank you for applying for access to %(partner)s resources "
-"through The Wikipedia Library. Unfortunately at this time your application "
-"has not been approved. You can view your application and review comments at: "
-"%(app_url)s Best, The Wikipedia Library"
-msgstr ""
-"Sevgili %(user)s, Vikipedi Kütüphanesi aracılığıyla %(partner)s erişim "
-"başvurusu yaptığınız için teşekkür ederiz. Maalesef başvurunuz şu anda "
-"onaylanmadı. Başvurunuzu ve yorumları şu adreste görüntüleyebilirsiniz: "
-"%(app_url)s Sevgilerle, Vikipedi Kütüphanesi"
+msgid "Dear %(user)s, Thank you for applying for access to %(partner)s resources through The Wikipedia Library. Unfortunately at this time your application has not been approved. You can view your application and review comments at: %(app_url)s Best, The Wikipedia Library"
+msgstr "Sevgili %(user)s, Vikipedi Kütüphanesi aracılığıyla %(partner)s erişim başvurusu yaptığınız için teşekkür ederiz. Maalesef başvurunuz şu anda onaylanmadı. Başvurunuzu ve yorumları şu adreste görüntüleyebilirsiniz: %(app_url)s Sevgilerle, Vikipedi Kütüphanesi"
 
 #. Translators: This is the subject of an email which is sent to users when their application has been rejected. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/rejection_notification-subject.html:4
@@ -1366,39 +1112,14 @@ msgstr "Vikipedi Kütüphanesi başvurunuz"
 #. Translators: This email is sent to users when they have an account that is soon to expire. Don't translate Jinja variables in curly braces like partner_name or partner_link; don't translate html tags either. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/user_renewal_notice-body-html.html:5
 #, python-format
-msgid ""
-"<p>Dear %(user)s,</p> <p>According to our records, your access to "
-"%(partner_name)s will soon expire and you may lose access. If you want to "
-"continue making use of your free account, you can request renewal of your "
-"account by clicking the 'Renew' or 'Extend' button at %(partner_link)s.</p> "
-"<p>Best,</p> <p>The Wikipedia Library</p> <p>You can disable these emails in "
-"your user page preferences: https://wikipedialibrary.wmflabs.org/users/</p>"
-msgstr ""
-"<p>Sevgili %(user)s,</p> <p>Kayıtlarımıza göre, %(partner_name)s için "
-"erişiminiz yakında sona erecek ve erişiminizi kaybedebilirsiniz. Ücretsiz "
-"hesabınızı kullanmaya devam etmek istiyorsanız %(partner_link)s adresindeki "
-"'Yenile' veya 'Uzat' düğmesini tıklatarak hesabınızın yenilenmesini "
-"isteyebilirsiniz.</p> <p>Sevgilerle,</p> <p>Vikipedi Kütüphanesi</p> <p>Bu e-"
-"postaları kullanıcı sayfanızın tercihlerinde devre dışı bırakabilirsiniz: "
-"https://wikipedialibrary.wmflabs.org/users/</p>"
+msgid "<p>Dear %(user)s,</p> <p>According to our records, your access to %(partner_name)s will soon expire and you may lose access. If you want to continue making use of your free account, you can request renewal of your account by clicking the 'Renew' or 'Extend' button at %(partner_link)s.</p> <p>Best,</p> <p>The Wikipedia Library</p> <p>You can disable these emails in your user page preferences: https://wikipedialibrary.wmflabs.org/users/</p>"
+msgstr "<p>Sevgili %(user)s,</p> <p>Kayıtlarımıza göre, %(partner_name)s için erişiminiz yakında sona erecek ve erişiminizi kaybedebilirsiniz. Ücretsiz hesabınızı kullanmaya devam etmek istiyorsanız %(partner_link)s adresindeki 'Yenile' veya 'Uzat' düğmesini tıklatarak hesabınızın yenilenmesini isteyebilirsiniz.</p> <p>Sevgilerle,</p> <p>Vikipedi Kütüphanesi</p> <p>Bu e-postaları kullanıcı sayfanızın tercihlerinde devre dışı bırakabilirsiniz: https://wikipedialibrary.wmflabs.org/users/</p>"
 
 #. Translators: This email is sent to users when they have an account that is soon to expire. Don't translate Jinja variables in curly braces like partner_name or partner_link; don't translate html tags either. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/user_renewal_notice-body-text.html:3
 #, python-format
-msgid ""
-"Dear %(user)s, According to our records, your access to %(partner_name)s "
-"will soon expire and you may lose access. If you want to continue making use "
-"of your free account, you can request renewal of your account by clicking "
-"the Renew button at %(partner_link)s. Best, The Wikipedia Library You can "
-"disable these emails in your user page preferences: https://wikipedialibrary."
-"wmflabs.org/users/"
-msgstr ""
-"Sayın %(user)s, kayıtlarımıza göre, %(partner_name)s erişiminiz yakında sona "
-"erecek ve erişiminizi kaybedebilirsiniz. Ücretsiz hesabınızı kullanmaya "
-"devam etmek istiyorsanız %(partner_link)s konumundaki Yenile düğmesini "
-"tıklatarak hesabınızın yenilenmesini isteyebilirsiniz. Sevgilerle, Vikipedi "
-"Kütüphanesi Bu e-postaları kullanıcı sayfanızın tercihlerinde devre dışı "
-"bırakabilirsiniz: https://wikipedialibrary.wmflabs.org/users/"
+msgid "Dear %(user)s, According to our records, your access to %(partner_name)s will soon expire and you may lose access. If you want to continue making use of your free account, you can request renewal of your account by clicking the Renew button at %(partner_link)s. Best, The Wikipedia Library You can disable these emails in your user page preferences: https://wikipedialibrary.wmflabs.org/users/"
+msgstr "Sayın %(user)s, kayıtlarımıza göre, %(partner_name)s erişiminiz yakında sona erecek ve erişiminizi kaybedebilirsiniz. Ücretsiz hesabınızı kullanmaya devam etmek istiyorsanız %(partner_link)s konumundaki Yenile düğmesini tıklatarak hesabınızın yenilenmesini isteyebilirsiniz. Sevgilerle, Vikipedi Kütüphanesi Bu e-postaları kullanıcı sayfanızın tercihlerinde devre dışı bırakabilirsiniz: https://wikipedialibrary.wmflabs.org/users/"
 
 #. Translators: This is the subject of an email sent to users when they have an account that is soon to expire. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/user_renewal_notice-subject.html:4
@@ -1408,37 +1129,14 @@ msgstr "Vikipedi Kütüphanesi erişiminiz yakında sona erebilir"
 #. Translators: This email is sent to users when their application is waitlisted because there are no more accounts available. Don't translate Jinja variables in curly braces like user or partner; don't translate html tags either. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/waitlist_notification-body-html.html:5
 #, python-format
-msgid ""
-"<p>Dear %(user)s,</p> <p>Thank you for applying for access to %(partner)s "
-"resources through The Wikipedia Library. There are no accounts currently "
-"available so your application has been waitlisted. Your application will be "
-"evaluated if/when more accounts become available. You can see all available "
-"resources at <a href=\"%(link)s\">%(link)s</a>.</p> <p>Best,</p> <p>The "
-"Wikipedia Library</p>"
-msgstr ""
-"<p>Sevgili %(user)s,</p> <p>Vikipedi Kütüphanesi aracılığıyla %(partner)s iş "
-"ortağına erişim başvurusu yaptığınız için teşekkür ederiz. Şu anda "
-"kullanılabilir bir hesap mevcut olmadığı için başvurunuz beklemede. "
-"Kullanılabilir daha fazla hesap mevcut olduğunda başvurunuz "
-"değerlendirilecektir. Tüm kaynakları <a href=\"%(link)s\">%(link)s</a> "
-"adresinde görebilirsiniz.</p> <p>Sevgilerle,</p> <p>Vikipedi Kütüphanesi</p>"
+msgid "<p>Dear %(user)s,</p> <p>Thank you for applying for access to %(partner)s resources through The Wikipedia Library. There are no accounts currently available so your application has been waitlisted. Your application will be evaluated if/when more accounts become available. You can see all available resources at <a href=\"%(link)s\">%(link)s</a>.</p> <p>Best,</p> <p>The Wikipedia Library</p>"
+msgstr "<p>Sevgili %(user)s,</p> <p>Vikipedi Kütüphanesi aracılığıyla %(partner)s iş ortağına erişim başvurusu yaptığınız için teşekkür ederiz. Şu anda kullanılabilir bir hesap mevcut olmadığı için başvurunuz beklemede. Kullanılabilir daha fazla hesap mevcut olduğunda başvurunuz değerlendirilecektir. Tüm kaynakları <a href=\"%(link)s\">%(link)s</a> adresinde görebilirsiniz.</p> <p>Sevgilerle,</p> <p>Vikipedi Kütüphanesi</p>"
 
 #. Translators: This email is sent to users when their application is waitlisted because there are no more accounts available. Don't translate Jinja variables in curly braces like user or partner. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/waitlist_notification-body-text.html:3
 #, python-format
-msgid ""
-"Dear %(user)s, Thank you for applying for access to %(partner)s resources "
-"through The Wikipedia Library. There are no accounts currently available so "
-"your application has been waitlisted. Your application will be evaluated if/"
-"when more accounts become available. You can see all available resources at: "
-"%(link)s Best, The Wikipedia Library"
-msgstr ""
-"Sevgili %(user)s, Vikipedi Kütüphanesi aracılığıyla %(partner)s iş ortağına "
-"erişim başvurusu yaptığınız için teşekkür ederiz. Şu anda kullanılabilir bir "
-"hesap mevcut olmadığı için başvurunuz beklemede. Kullanılabilir daha fazla "
-"hesap mevcut olduğunda başvurunuz değerlendirilecektir. Tüm kaynakları şu "
-"adreste görebilirsiniz:\n"
-"%(link)s Sevgilerle, Vikipedi Kütüphanesi"
+msgid "Dear %(user)s, Thank you for applying for access to %(partner)s resources through The Wikipedia Library. There are no accounts currently available so your application has been waitlisted. Your application will be evaluated if/when more accounts become available. You can see all available resources at: %(link)s Best, The Wikipedia Library"
+msgstr "Sevgili %(user)s, Vikipedi Kütüphanesi aracılığıyla %(partner)s iş ortağına erişim başvurusu yaptığınız için teşekkür ederiz. Şu anda kullanılabilir bir hesap mevcut olmadığı için başvurunuz beklemede. Kullanılabilir daha fazla hesap mevcut olduğunda başvurunuz değerlendirilecektir. Tüm kaynakları şu adreste görebilirsiniz:\n%(link)s Sevgilerle, Vikipedi Kütüphanesi"
 
 #. Translators: This is the subject of an email sent to users when their application is waitlisted because there are no more accounts available. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/waitlist_notification-subject.html:4
@@ -1599,22 +1297,15 @@ msgstr "Mevcut Değil"
 #: TWLight/resources/templates/resources/filter_section.html:14
 #: TWLight/templates/about.html:12
 #: TWLight/users/templates/users/filter_section.html:13
-msgid ""
-"The Wikipedia Library allows active editors to access a wide range of "
-"collections of paywalled reliable sources for free!"
-msgstr ""
-"Vikipedi Kütüphanesi, aktif editörlerin ödeme isteyen güvenilir birçok "
-"kaynak koleksiyonuna ücretsiz olarak erişimini sağlar!"
+msgid "The Wikipedia Library allows active editors to access a wide range of collections of paywalled reliable sources for free!"
+msgstr "Vikipedi Kütüphanesi, aktif editörlerin ödeme isteyen güvenilir birçok kaynak koleksiyonuna ücretsiz olarak erişimini sağlar!"
 
 #. Translators: On the Browse Partners page (https://wikipedialibrary.wmflabs.org/partners/), this introduces users to The Wikipedia Library.
 #. Translators: On the MyLibrary page (https://wikipedialibrary.wmflabs.org/users/my_library), this introduces users to The Wikipedia Library.
 #: TWLight/resources/templates/resources/filter_section.html:17
 #: TWLight/users/templates/users/filter_section.html:15
-msgid ""
-"Start with the search bar at the top or browse publisher websites directly."
-msgstr ""
-"En üstteki arama çubuğuyla veya yayıncılara ait web sitelere göz atarak işe "
-"başlayabilirsiniz."
+msgid "Start with the search bar at the top or browse publisher websites directly."
+msgstr "En üstteki arama çubuğuyla veya yayıncılara ait web sitelere göz atarak işe başlayabilirsiniz."
 
 #. Translators: On the Browse Partners page (https://wikipedialibrary.wmflabs.org/partners/), this appears below introductory text and links to the 'About' page (https://wikipedialibrary.wmflabs.org/about/)
 #. Translators: On the MyLibrary page (https://wikipedialibrary.wmflabs.org/users/my_library), this appears below introductory text and links to the 'About' page (https://wikipedialibrary.wmflabs.org/about/)
@@ -1687,66 +1378,39 @@ msgstr "İş ortaklarına geri dön"
 #. Translators: If we have no available accounts for a partner, the coordinator can change the application system to a waiting list.
 #: TWLight/resources/templates/resources/partner_detail.html:36
 #: TWLight/resources/templates/resources/partner_detail_apply.html:17
-msgid ""
-"There are no access grants available for this partner at this time. You can "
-"still apply for access; applications will be processed when access is "
-"available."
-msgstr ""
-"Bu iş ortağı için şu anda kullanılabilir erişim mevcut değil. Yine de erişim "
-"için başvurabilirsiniz, erişim olduğunda başvurular işlenecektir."
+msgid "There are no access grants available for this partner at this time. You can still apply for access; applications will be processed when access is available."
+msgstr "Bu iş ortağı için şu anda kullanılabilir erişim mevcut değil. Yine de erişim için başvurabilirsiniz, erişim olduğunda başvurular işlenecektir."
 
 #. Translators: This text links to the minimum user requirements and terms of use on the partner page.
 #: TWLight/resources/templates/resources/partner_detail.html:48
 #: TWLight/resources/templates/resources/partner_detail_apply.html:29
 #, python-format
-msgid ""
-"Before applying, please review the <strong><a class=\"twl-links\" href="
-"\"%(about)s#req\">minimum requirements</a></strong> for access and our "
-"<strong><a class=\"twl-links\" href=\"%(terms)s\">terms of use</a></strong>."
-msgstr ""
-"Başvuru yapmadan önce lütfen erişim için <strong><a class=\"twl-links\" href="
-"\"%(about)s#req\">minimum şartları</a></strong> ve <strong><a class=\"twl-"
-"links\" href=\"%(terms)s\">kullanım şartlarımızı</a></strong> inceleyin."
+msgid "Before applying, please review the <strong><a class=\"twl-links\" href=\"%(about)s#req\">minimum requirements</a></strong> for access and our <strong><a class=\"twl-links\" href=\"%(terms)s\">terms of use</a></strong>."
+msgstr "Başvuru yapmadan önce lütfen erişim için <strong><a class=\"twl-links\" href=\"%(about)s#req\">minimum şartları</a></strong> ve <strong><a class=\"twl-links\" href=\"%(terms)s\">kullanım şartlarımızı</a></strong> inceleyin."
 
 #. Translators: This text refers to the page containing the content a user is authorized to access.
 #: TWLight/resources/templates/resources/partner_detail.html:69
 #, python-format
-msgid ""
-"View the status of your access in <strong><a class=\"twl-links\" href="
-"\"%(library_url)s\">My Library</a></strong> page."
-msgstr ""
-"Erişiminizin durumunu <strong><a class=\"twl-links\" href=\"%(library_url)s"
-"\">Kütüphanem</a></strong> sayfasında görüntüleyin."
+msgid "View the status of your access in <strong><a class=\"twl-links\" href=\"%(library_url)s\">My Library</a></strong> page."
+msgstr "Erişiminizin durumunu <strong><a class=\"twl-links\" href=\"%(library_url)s\">Kütüphanem</a></strong> sayfasında görüntüleyin."
 
 #. Translators: This message is shown when a user has open applications, linking to their respective applications page.
 #: TWLight/resources/templates/resources/partner_detail.html:78
 #, python-format
-msgid ""
-"View the status of your application(s) on your <strong><a class=\"twl-links"
-"\" href=\"%(applications_url)s\">My Applications</a></strong> page."
-msgstr ""
-"Başvurularınızın durumunu <strong> <a class=\"twl-links\" href="
-"\"%(applications_url)s\">Başvurularım</a> </strong> sayfanızda görüntüleyin."
+msgid "View the status of your application(s) on your <strong><a class=\"twl-links\" href=\"%(applications_url)s\">My Applications</a></strong> page."
+msgstr "Başvurularınızın durumunu <strong> <a class=\"twl-links\" href=\"%(applications_url)s\">Başvurularım</a> </strong> sayfanızda görüntüleyin."
 
 #. Translators: This message is shown when a user has authorizations, linking to their respective collections page.
 #: TWLight/resources/templates/resources/partner_detail_apply.html:50
 #, python-format
-msgid ""
-"View the status of your access on your <strong><a href=\"%(library_url)s\" "
-"class=\"twl-links\">My Library</a></strong> page."
-msgstr ""
-"Erişiminizin durumunu <strong><a href=\"%(library_url)s\" class=\"twl-links"
-"\">Kütüphanem</a></strong> sayfasında görüntüleyin."
+msgid "View the status of your access on your <strong><a href=\"%(library_url)s\" class=\"twl-links\">My Library</a></strong> page."
+msgstr "Erişiminizin durumunu <strong><a href=\"%(library_url)s\" class=\"twl-links\">Kütüphanem</a></strong> sayfasında görüntüleyin."
 
 #. Translators: This message is shown when a user has open applications, linking to their respective applications page.
 #: TWLight/resources/templates/resources/partner_detail_apply.html:60
 #, python-format
-msgid ""
-"View the status of your application(s) on your <strong><a href="
-"\"%(applications_url)s\">My Applications</a></strong> page."
-msgstr ""
-"Başvurularınızın durumunu <strong> <a href=\"%(applications_url)s"
-"\">Başvurularım</a> </strong> sayfanızda görüntüleyin."
+msgid "View the status of your application(s) on your <strong><a href=\"%(applications_url)s\">My Applications</a></strong> page."
+msgstr "Başvurularınızın durumunu <strong> <a href=\"%(applications_url)s\">Başvurularım</a> </strong> sayfanızda görüntüleyin."
 
 #. Translators: One the partner detail page, this text labels the button which coordinators can click to remove a partner from waitlisted status.
 #: TWLight/resources/templates/resources/partner_detail_apply.html:73
@@ -1761,9 +1425,7 @@ msgstr "Beklemede olarak ayarla"
 #: TWLight/resources/templates/resources/partner_detail_apply.html:86
 #, python-format
 msgid "<strong>%(coordinator)s</strong> processes applications to %(partner)s."
-msgstr ""
-"<strong>%(coordinator)s</strong>, başvuruları %(partner)s iş ortağına "
-"işlemektedir."
+msgstr "<strong>%(coordinator)s</strong>, başvuruları %(partner)s iş ortağına işlemektedir."
 
 #. Translators: When a coordinator is assigned to a partner, their details are shown on the page. This text labels a link to their Talk page on Wikipedia, and should be translated to the text used for Talk pages in the language you are translating to.
 #: TWLight/resources/templates/resources/partner_detail_apply.html:95
@@ -1777,15 +1439,8 @@ msgstr "Özel:E-postaGönder sayfası"
 
 #. Translators: If no account coordinator is assigned to a partner, the Wikipedia Library team will coordinate signups. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/resources/templates/resources/partner_detail_apply.html:112
-msgid ""
-"The Wikipedia Library team will process this application. Want to help? <a "
-"class=\"twl-links\" href=\"https://en.wikipedia.org/wiki/Wikipedia:"
-"The_Wikipedia_Library/Coordinators/Signup\">Sign up as a coordinator.</a>"
-msgstr ""
-"Vikipedi Kütüphanesi ekibi bu başvuruyu işleme alacaktır. Yardım etmek ister "
-"misiniz?<a class=\"twl-links\" href=\"https://en.wikipedia.org/wiki/"
-"Wikipedia:The_Wikipedia_Library/Coordinators/Signup\">Bir koordinatör olarak "
-"kaydolun.</a>"
+msgid "The Wikipedia Library team will process this application. Want to help? <a class=\"twl-links\" href=\"https://en.wikipedia.org/wiki/Wikipedia:The_Wikipedia_Library/Coordinators/Signup\">Sign up as a coordinator.</a>"
+msgstr "Vikipedi Kütüphanesi ekibi bu başvuruyu işleme alacaktır. Yardım etmek ister misiniz?<a class=\"twl-links\" href=\"https://en.wikipedia.org/wiki/Wikipedia:The_Wikipedia_Library/Coordinators/Signup\">Bir koordinatör olarak kaydolun.</a>"
 
 #. Translators: This text labels a button coordinators can click to view a list of users who have applied for access for a particular partner
 #: TWLight/resources/templates/resources/partner_detail_apply.html:121
@@ -1814,24 +1469,14 @@ msgstr "Kütüphane paketi erişimi"
 
 #. Translators: Text shown to authenticated, bundle eligible users when they visit a Bundle partner page.
 #: TWLight/resources/templates/resources/partner_detail_apply.html:138
-msgid ""
-"You are eligible to access Library Bundle partners. Click the button above "
-"to access the collection."
-msgstr ""
-"Kütüphane Paketi iş ortaklarına erişmek için uygun şartlara sahipsiniz. "
-"Koleksiyona erişmek için yukarıdaki düğmeye tıklayın."
+msgid "You are eligible to access Library Bundle partners. Click the button above to access the collection."
+msgstr "Kütüphane Paketi iş ortaklarına erişmek için uygun şartlara sahipsiniz. Koleksiyona erişmek için yukarıdaki düğmeye tıklayın."
 
 #. Translators: Text shown to authenticated, bundle ineligible users when they visit a Bundle partner page.
 #: TWLight/resources/templates/resources/partner_detail_apply.html:152
 #, python-format
-msgid ""
-"You are not eligible to access Library Bundle partners. Visit the <a class="
-"\"twl-links\" href=\"%(homepage)s\">homepage</a> to check the eligibility "
-"criteria."
-msgstr ""
-"Kütüphane Paketi iş ortaklarına erişmek için uygun şartlara sahip "
-"değilsiniz. Uygunluk ölçütlerini kontrol etmek için <a class=\"twl-links\" "
-"href=\"%(homepage)s\">anasayfayı</a> ziyaret edin."
+msgid "You are not eligible to access Library Bundle partners. Visit the <a class=\"twl-links\" href=\"%(homepage)s\">homepage</a> to check the eligibility criteria."
+msgstr "Kütüphane Paketi iş ortaklarına erişmek için uygun şartlara sahip değilsiniz. Uygunluk ölçütlerini kontrol etmek için <a class=\"twl-links\" href=\"%(homepage)s\">anasayfayı</a> ziyaret edin."
 
 #. Translators: Buttton prompting users to log in.
 #: TWLight/resources/templates/resources/partner_detail_apply.html:160
@@ -1842,14 +1487,8 @@ msgstr "Oturum aç"
 #. Translators: Text shown to unauthenticated users when they visit a Bundle partner page.
 #: TWLight/resources/templates/resources/partner_detail_apply.html:168
 #, python-format
-msgid ""
-"This resource is part of our <a class=\"twl-links\" href=\"%(about)s"
-"\">Library Bundle</a>, which you can access if you meet our minimum "
-"eligibility criteria. Log in to find out if you are eligible."
-msgstr ""
-"Bu kaynak, minimum uygunluk ölçütlerimizi karşılıyorsanız erişebileceğiniz "
-"<a class=\"twl-links\" href=\"%(about)s\">Kütüphane Paketimizin</a> bir "
-"parçasıdır. Uygun olup olmadığınızı öğrenmek için oturum açın."
+msgid "This resource is part of our <a class=\"twl-links\" href=\"%(about)s\">Library Bundle</a>, which you can access if you meet our minimum eligibility criteria. Log in to find out if you are eligible."
+msgstr "Bu kaynak, minimum uygunluk ölçütlerimizi karşılıyorsanız erişebileceğiniz <a class=\"twl-links\" href=\"%(about)s\">Kütüphane Paketimizin</a> bir parçasıdır. Uygun olup olmadığınızı öğrenmek için oturum açın."
 
 #. Translators: This is the label for a number which shows the total active accounts for one partner. (e.g. https://wikipedialibrary.wmflabs.org/partners/8/).
 #: TWLight/resources/templates/resources/partner_detail_stats.html:21
@@ -1899,34 +1538,20 @@ msgstr "Alıntı sınırı"
 #. Translators: If a partner has specified the excerpt limit both in words and percentage, this message will display the percentage of words and the number of words on the partner page.
 #: TWLight/resources/templates/resources/partner_detail_timeline.html:99
 #, python-format
-msgid ""
-"%(object)s allows a maximum of %(excerpt_limit)s words or "
-"%(excerpt_limit_percentage)s%% of an article be excerpted into a Wikipedia "
-"article."
-msgstr ""
-"%(object)s, bir Vikipedi maddesine en fazla %(excerpt_limit)s kelime ya da "
-"bir makalenin %(excerpt_limit_percentage)s%% oranında alıntı yapılmasını "
-"izin vermektedir."
+msgid "%(object)s allows a maximum of %(excerpt_limit)s words or %(excerpt_limit_percentage)s%% of an article be excerpted into a Wikipedia article."
+msgstr "%(object)s, bir Vikipedi maddesine en fazla %(excerpt_limit)s kelime ya da bir makalenin %(excerpt_limit_percentage)s%% oranında alıntı yapılmasını izin vermektedir."
 
 #. Translators: If a partner has specified the excerpt limit in words, this message will display the number of words on the partner page.
 #: TWLight/resources/templates/resources/partner_detail_timeline.html:106
 #, python-format
-msgid ""
-"%(object)s allows a maximum of %(excerpt_limit)s words be excerpted into a "
-"Wikipedia article."
-msgstr ""
-"%(object)s, bir Vikipedi maddesine en fazla %(excerpt_limit)s kelime olacak "
-"şekilde alıntı yapılmasına izin vermektedir."
+msgid "%(object)s allows a maximum of %(excerpt_limit)s words be excerpted into a Wikipedia article."
+msgstr "%(object)s, bir Vikipedi maddesine en fazla %(excerpt_limit)s kelime olacak şekilde alıntı yapılmasına izin vermektedir."
 
 #. Translators: If a partner has specified the excerpt limit in percentage, this message will display the percentage of words on the partner page.
 #: TWLight/resources/templates/resources/partner_detail_timeline.html:113
 #, python-format
-msgid ""
-"%(object)s allows a maximum of %(excerpt_limit_percentage)s%% of an article "
-"be excerpted into a Wikipedia article."
-msgstr ""
-"%(object)s, bir Vikipedi maddesine makalenin en fazla "
-"%(excerpt_limit_percentage)s%% oranında alıntı yapılmasına izin vermektedir."
+msgid "%(object)s allows a maximum of %(excerpt_limit_percentage)s%% of an article be excerpted into a Wikipedia article."
+msgstr "%(object)s, bir Vikipedi maddesine makalenin en fazla %(excerpt_limit_percentage)s%% oranında alıntı yapılmasına izin vermektedir."
 
 #. Translators: If a partner has other requirements for access, this text shows as the title for that information field. (e.g. https://wikipedialibrary.wmflabs.org/partners/10/).
 #: TWLight/resources/templates/resources/partner_detail_timeline.html:132
@@ -1936,12 +1561,8 @@ msgstr "Başvuru sahipleri için özel şartlar"
 #. Translators: If a user must agree to a Terms of Use document, they see this message, and must enter the name of the resource. Don't translate publisher or url.
 #: TWLight/resources/templates/resources/partner_detail_timeline.html:140
 #, python-format
-msgid ""
-"%(publisher)s requires that you agree with its <a href=\"%(url)s\">terms of "
-"use</a>."
-msgstr ""
-"%(publisher)s, <a href=\"%(url)s\">kullanım şartlarını</a> kabul etmenizi "
-"istiyor."
+msgid "%(publisher)s requires that you agree with its <a href=\"%(url)s\">terms of use</a>."
+msgstr "%(publisher)s, <a href=\"%(url)s\">kullanım şartlarını</a> kabul etmenizi istiyor."
 
 #. Translators: If a user must provide their real name to apply to a partner, they see this message, and must enter the name of the resource. Don't translate publisher.
 #: TWLight/resources/templates/resources/partner_detail_timeline.html:150
@@ -1964,20 +1585,14 @@ msgstr "%(publisher)s, kurumsal firmanızı belirtmenizi istiyor."
 #. Translators: If a user must select a specific resource to apply for, they see this message, and must enter the name of the resource. Don't translate publisher.
 #: TWLight/resources/templates/resources/partner_detail_timeline.html:177
 #, python-format
-msgid ""
-"%(publisher)s requires that you specify a particular title that you want to "
-"access."
-msgstr ""
-"%(publisher)s, erişmek istediğiniz belirli bir başlığı belirtmenizi istiyor."
+msgid "%(publisher)s requires that you specify a particular title that you want to access."
+msgstr "%(publisher)s, erişmek istediğiniz belirli bir başlığı belirtmenizi istiyor."
 
 #. Translators: If a user must register on the partner website before applying, they see this message. Don't translate partner.
 #: TWLight/resources/templates/resources/partner_detail_timeline.html:187
 #, python-format
-msgid ""
-"%(publisher)s requires that you sign up for an account before applying for "
-"access."
-msgstr ""
-"%(publisher)s, erişim için başvurmadan önce bir hesap oluşturmanızı istiyor."
+msgid "%(publisher)s requires that you sign up for an account before applying for access."
+msgstr "%(publisher)s, erişim için başvurmadan önce bir hesap oluşturmanızı istiyor."
 
 #. Translators: If a partner has their location listed, this message is a label for that location
 #: TWLight/resources/templates/resources/partner_detail_timeline.html:206
@@ -2103,12 +1718,8 @@ msgstr "Şunları silmek istediğinizden emin misiniz: <b>%(object)s</b>?"
 
 #. Translators: If multiple authorizations where returned for a collection, this message is shown to a user
 #: TWLight/resources/views.py:268
-msgid ""
-"Multiple authorizations were returned – something's wrong. Please contact us "
-"and don't forget to mention this message."
-msgstr ""
-"Birden fazla yetkilendirme iade edildi, bir sorun var. Lütfen bizimle "
-"iletişime geçin ve bu mesajdan bahsetmeyi unutmayın."
+msgid "Multiple authorizations were returned – something's wrong. Please contact us and don't forget to mention this message."
+msgstr "Birden fazla yetkilendirme iade edildi, bir sorun var. Lütfen bizimle iletişime geçin ve bu mesajdan bahsetmeyi unutmayın."
 
 #. Translators: This message is shown when user tries to access a NOT_AVAILABLE Partner
 #: TWLight/resources/views.py:316
@@ -2148,23 +1759,8 @@ msgstr "Üzgünüz: Bununla ne yapacağımızı bilmiyoruz."
 #. Translators: Shown on the website's 400 page, when a user sends a bad request. Don't translate path or Phabricator.
 #: TWLight/templates/400.html:20
 #, python-format
-msgid ""
-"If you think we should know what to do with that, please email us about this "
-"error at <a class=\"twl-links\" href=\"mailto:wikipedialibrary@wikimedia.org?"
-"Subject=Wikipedia%%20Library%%20%(path)s%%20Permission%%20denied"
-"\">wikipedialibrary@wikimedia.org</a> or report it to us on <a class=\"twl-"
-"links\" href=\"https://phabricator.wikimedia.org/maniphest/task/edit/form/1/?"
-"projectPHIDs=Library-Card-Platform&title=Wikipedia%%20Library%%20%(path)s"
-"%%20Bad%%20Request\">Phabricator</a>"
-msgstr ""
-"Bunu nasıl çözeceğimizi bildiğinizi düşünüyorsanız lütfen bu hatayı bize <a "
-"class=\"twl-links\" href=\"mailto:wikipedialibrary@wikimedia.org?"
-"Subject=Wikipedia%%20Library%%20%(path)s%%20Permission%%20denied"
-"\">wikipedialibrary@wikimedia.org</a> adresinden e-posta şeklinde gönderin "
-"ya da <a class=\"twl-links\" href=\"https://phabricator.wikimedia.org/"
-"maniphest/task/edit/form/1/?projectPHIDs=Library-Card-"
-"Platform&title=Wikipedia%%20Library%%20%(path)s%%20Bad%%20Request"
-"\">Phabricator</a> üzerinden bizi bilgilendirin."
+msgid "If you think we should know what to do with that, please email us about this error at <a class=\"twl-links\" href=\"mailto:wikipedialibrary@wikimedia.org?Subject=Wikipedia%%20Library%%20%(path)s%%20Permission%%20denied\">wikipedialibrary@wikimedia.org</a> or report it to us on <a class=\"twl-links\" href=\"https://phabricator.wikimedia.org/maniphest/task/edit/form/1/?projectPHIDs=Library-Card-Platform&title=Wikipedia%%20Library%%20%(path)s%%20Bad%%20Request\">Phabricator</a>"
+msgstr "Bunu nasıl çözeceğimizi bildiğinizi düşünüyorsanız lütfen bu hatayı bize <a class=\"twl-links\" href=\"mailto:wikipedialibrary@wikimedia.org?Subject=Wikipedia%%20Library%%20%(path)s%%20Permission%%20denied\">wikipedialibrary@wikimedia.org</a> adresinden e-posta şeklinde gönderin ya da <a class=\"twl-links\" href=\"https://phabricator.wikimedia.org/maniphest/task/edit/form/1/?projectPHIDs=Library-Card-Platform&title=Wikipedia%%20Library%%20%(path)s%%20Bad%%20Request\">Phabricator</a> üzerinden bizi bilgilendirin."
 
 #. Translators: Alt text for an image shown on the 400 error page.
 #. Translators: Alt text for an image shown on the 403 error page.
@@ -2185,24 +1781,8 @@ msgstr "Üzgünüz, bunu yapmaya yetkiniz yok."
 #. Translators: Shown on the website's 403 page, when a user attempts to navigate to a page they don't have permission to view. Don't translate path or Phabricator.
 #: TWLight/templates/403.html:20
 #, python-format
-msgid ""
-"If you think your account should be able to do that, please email us about "
-"this error at <a class=\"twl-links\" href=\"mailto:"
-"wikipedialibrary@wikimedia.org?Subject=Wikipedia%%20Library%%20%(path)s"
-"%%20Permission%%20denied\">wikipedialibrary@wikimedia.org</a> or report it "
-"to us on <a class=\"twl-links\" href=\"https://phabricator.wikimedia.org/"
-"maniphest/task/edit/form/1/?projectPHIDs=Library-Card-"
-"Platform&title=Wikipedia%%20Library%%20%(path)s%%20Permission%%20denied"
-"\">Phabricator</a>"
-msgstr ""
-"Bunu nasıl çözeceğimizi bildiğinizi düşünüyorsanız lütfen bu hatayı bize <a "
-"class=\"twl-links\" href=\"mailto:wikipedialibrary@wikimedia.org?"
-"Subject=Wikipedia%%20Library%%20%(path)s%%20Permission%%20denied"
-"\">wikipedialibrary@wikimedia.org</a> adresinden e-posta şeklinde gönderin "
-"ya da <a class=\"twl-links\" href=\"https://phabricator.wikimedia.org/"
-"maniphest/task/edit/form/1/?projectPHIDs=Library-Card-"
-"Platform&title=Wikipedia%%20Library%%20%(path)s%%20Bad%%20Request"
-"\">Phabricator</a> üzerinden bizi bilgilendirin."
+msgid "If you think your account should be able to do that, please email us about this error at <a class=\"twl-links\" href=\"mailto:wikipedialibrary@wikimedia.org?Subject=Wikipedia%%20Library%%20%(path)s%%20Permission%%20denied\">wikipedialibrary@wikimedia.org</a> or report it to us on <a class=\"twl-links\" href=\"https://phabricator.wikimedia.org/maniphest/task/edit/form/1/?projectPHIDs=Library-Card-Platform&title=Wikipedia%%20Library%%20%(path)s%%20Permission%%20denied\">Phabricator</a>"
+msgstr "Bunu nasıl çözeceğimizi bildiğinizi düşünüyorsanız lütfen bu hatayı bize <a class=\"twl-links\" href=\"mailto:wikipedialibrary@wikimedia.org?Subject=Wikipedia%%20Library%%20%(path)s%%20Permission%%20denied\">wikipedialibrary@wikimedia.org</a> adresinden e-posta şeklinde gönderin ya da <a class=\"twl-links\" href=\"https://phabricator.wikimedia.org/maniphest/task/edit/form/1/?projectPHIDs=Library-Card-Platform&title=Wikipedia%%20Library%%20%(path)s%%20Bad%%20Request\">Phabricator</a> üzerinden bizi bilgilendirin."
 
 #. Translators: Shown on the website's 404 page, when a user attempts to navigate to a page that doesn't exist.
 #: TWLight/templates/404.html:11
@@ -2217,23 +1797,8 @@ msgstr "Üzgünüz: Bunu bulamıyoruz."
 #. Translators: Shown on the website's 404 page, when a user attempts to navigate to a page that doesn't exist. Don't translate path or Phabricator.
 #: TWLight/templates/404.html:19
 #, python-format
-msgid ""
-"If you are certain that something should be here, please email us about this "
-"error at <a class=\"twl-links\" href=\"mailto:wikipedialibrary@wikimedia.org?"
-"Subject=Wikipedia%%20Library%%20%(path)s%%20Not%%20found\"> "
-"wikipedialibrary@wikimedia.org</a> or report it to us on <a class=\"twl-links"
-"\" href=\"https://phabricator.wikimedia.org/maniphest/task/edit/form/1/?"
-"projectPHIDs=Library-Card-Platform&title=Wikipedia%%20Library%%20%(path)s"
-"%%20Not%%20found\">Phabricator</a>"
-msgstr ""
-"Bir şeyin burada olması gerektiğinden eminseniz lütfen bu hatayı bize <a "
-"class=\"twl-links\" href=\"mailto:wikipedialibrary@wikimedia.org?"
-"Subject=Wikipedia%%20Library%%20%(path)s%%20Not%%20found\"> "
-"wikipedialibrary@wikimedia.org</a> adresinden e-posta şeklinde gönderin veya "
-"<a class=\"twl-links\" href=\"https://phabricator.wikimedia.org/maniphest/"
-"task/edit/form/1/?projectPHIDs=Library-Card-Platform&title=Wikipedia"
-"%%20Library%%20%(path)s%%20Not%%20found\">Phabricator</a> üzerinden bizi "
-"bilgilendirin."
+msgid "If you are certain that something should be here, please email us about this error at <a class=\"twl-links\" href=\"mailto:wikipedialibrary@wikimedia.org?Subject=Wikipedia%%20Library%%20%(path)s%%20Not%%20found\"> wikipedialibrary@wikimedia.org</a> or report it to us on <a class=\"twl-links\" href=\"https://phabricator.wikimedia.org/maniphest/task/edit/form/1/?projectPHIDs=Library-Card-Platform&title=Wikipedia%%20Library%%20%(path)s%%20Not%%20found\">Phabricator</a>"
+msgstr "Bir şeyin burada olması gerektiğinden eminseniz lütfen bu hatayı bize <a class=\"twl-links\" href=\"mailto:wikipedialibrary@wikimedia.org?Subject=Wikipedia%%20Library%%20%(path)s%%20Not%%20found\"> wikipedialibrary@wikimedia.org</a> adresinden e-posta şeklinde gönderin veya <a class=\"twl-links\" href=\"https://phabricator.wikimedia.org/maniphest/task/edit/form/1/?projectPHIDs=Library-Card-Platform&title=Wikipedia%%20Library%%20%(path)s%%20Not%%20found\">Phabricator</a> üzerinden bizi bilgilendirin."
 
 #. Translators: Alt text for an image shown on the 404 error page.
 #: TWLight/templates/404.html:32
@@ -2247,49 +1812,19 @@ msgstr "Vikipedi Kütüphanesi Hakkında"
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:20
-msgid ""
-"This platform is our central tool for facilitating access to our available "
-"collections. Here you can see which partnerships are available, search their "
-"contents, and apply for and access the ones you’re interested in."
-msgstr ""
-"Bu platform, mevcut koleksiyonlarımıza erişimi kolaylaştıran merkezi "
-"aracımızdır. Burada hangi ortaklıkların mevcut olduğunu görebilir, "
-"içeriklerini arayabilir ve ilgilendiklerinize başvurabilir ve bunlara "
-"erişebilirsiniz."
+msgid "This platform is our central tool for facilitating access to our available collections. Here you can see which partnerships are available, search their contents, and apply for and access the ones you’re interested in."
+msgstr "Bu platform, mevcut koleksiyonlarımıza erişimi kolaylaştıran merkezi aracımızdır. Burada hangi ortaklıkların mevcut olduğunu görebilir, içeriklerini arayabilir ve ilgilendiklerinize başvurabilir ve bunlara erişebilirsiniz."
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/). Wikimedia Foundation should not be translated.
 #: TWLight/templates/about.html:29
-msgid ""
-"All users receive immediate access to some collections, which can be browsed "
-"by clicking the 'Access collection' buttons or using the search bar at the "
-"top of the page. Other collections require an application before access is "
-"granted, and may be accessed directly or via an individual login or access "
-"code. Volunteer coordinators, who have signed non-disclosure agreements with "
-"the Wikimedia Foundation, review these applications and work with publishers "
-"to get you your free access."
-msgstr ""
-"Tüm kullanıcılar, 'Koleksiyona erişim' butonuna tıklayarak veya sayfanın üst "
-"kısmındaki arama çubuğunu kullanarak göz atılabilen bazı koleksiyonlara "
-"anında erişim elde eder. Diğer koleksiyonlar, erişim verilmeden önce bir "
-"başvuru gerektirir ve doğrudan veya bireysel oturum açma veya erişim kodu "
-"aracılığıyla erişilebilir. Wikimedia Vakfı ile gizlilik anlaşmaları "
-"imzalamış olan gönüllü koordinatörler, bu uygulamaları gözden geçirir ve "
-"size ücretsiz erişiminizi sağlamak için yayıncılarla birlikte çalışır."
+msgid "All users receive immediate access to some collections, which can be browsed by clicking the 'Access collection' buttons or using the search bar at the top of the page. Other collections require an application before access is granted, and may be accessed directly or via an individual login or access code. Volunteer coordinators, who have signed non-disclosure agreements with the Wikimedia Foundation, review these applications and work with publishers to get you your free access."
+msgstr "Tüm kullanıcılar, 'Koleksiyona erişim' butonuna tıklayarak veya sayfanın üst kısmındaki arama çubuğunu kullanarak göz atılabilen bazı koleksiyonlara anında erişim elde eder. Diğer koleksiyonlar, erişim verilmeden önce bir başvuru gerektirir ve doğrudan veya bireysel oturum açma veya erişim kodu aracılığıyla erişilebilir. Wikimedia Vakfı ile gizlilik anlaşmaları imzalamış olan gönüllü koordinatörler, bu uygulamaları gözden geçirir ve size ücretsiz erişiminizi sağlamak için yayıncılarla birlikte çalışır."
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/). Don't translate terms_url.
 #: TWLight/templates/about.html:43
 #, python-format
-msgid ""
-"For more information about how your information is stored and reviewed "
-"please see our <a class=\"twl-links\" href=\"%(terms_url)s\"> terms of use "
-"and privacy policy</a>. Accounts you apply for are also subject to the Terms "
-"of Use provided by each partner’s platform; please review them."
-msgstr ""
-"Bilgilerinizin nasıl saklandığı ve incelendiği hakkında daha fazla bilgi "
-"için lütfen <a class=\"twl-links\" href=\"%(terms_url)s\">kullanım şartları "
-"ve gizlilik politikamıza</a> bakın. Başvurduğunuz hesaplar ayrıca her bir "
-"ortak platformunun sağladığı kullanım koşullarına tabidir; lütfen onları "
-"gözden geçirin."
+msgid "For more information about how your information is stored and reviewed please see our <a class=\"twl-links\" href=\"%(terms_url)s\"> terms of use and privacy policy</a>. Accounts you apply for are also subject to the Terms of Use provided by each partner’s platform; please review them."
+msgstr "Bilgilerinizin nasıl saklandığı ve incelendiği hakkında daha fazla bilgi için lütfen <a class=\"twl-links\" href=\"%(terms_url)s\">kullanım şartları ve gizlilik politikamıza</a> bakın. Başvurduğunuz hesaplar ayrıca her bir ortak platformunun sağladığı kullanım koşullarına tabidir; lütfen onları gözden geçirin."
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:51
@@ -2298,25 +1833,13 @@ msgstr "Kimler erişim alabilir?"
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/). Wikimedia Foundation should not be translated.
 #: TWLight/templates/about.html:55
-msgid ""
-"Any active editor in good standing can receive access. For publishers with "
-"limited numbers of accounts, applications are reviewed based on the editor’s "
-"needs and contributions. If you think you could use access to one of our "
-"partner resources and are an active editor in any project supported by the "
-"Wikimedia Foundation, please apply."
-msgstr ""
-"İyi durumda olan herhangi bir aktif düzenleyici erişim alabilir. Sınırlı "
-"sayıda hesabı olan yayıncılar için uygulamalar, editörün ihtiyaçları ve "
-"katkıları esas alınarak gözden geçirilir. Ortak kaynaklarımızdan birine "
-"erişiminizi kullanabileceğinizi düşünüyorsanız ve Wikimedia Foundation "
-"tarafından desteklenen herhangi bir projede aktif bir editörseniz, lütfen "
-"başvurunuz."
+msgid "Any active editor in good standing can receive access. For publishers with limited numbers of accounts, applications are reviewed based on the editor’s needs and contributions. If you think you could use access to one of our partner resources and are an active editor in any project supported by the Wikimedia Foundation, please apply."
+msgstr "İyi durumda olan herhangi bir aktif düzenleyici erişim alabilir. Sınırlı sayıda hesabı olan yayıncılar için uygulamalar, editörün ihtiyaçları ve katkıları esas alınarak gözden geçirilir. Ortak kaynaklarımızdan birine erişiminizi kullanabileceğinizi düşünüyorsanız ve Wikimedia Foundation tarafından desteklenen herhangi bir projede aktif bir editörseniz, lütfen başvurunuz."
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:65
 msgid "Any editor can use the library if they meet a few basic requirements:"
-msgstr ""
-"Herhangi bir editör, birkaç temel koşulu karşılıyorsa kitaplığı kullanabilir:"
+msgstr "Herhangi bir editör, birkaç temel koşulu karşılıyorsa kitaplığı kullanabilir:"
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:71
@@ -2331,48 +1854,22 @@ msgstr "Wikimedia projelerinde minimum 500 düzenleme yapmış olmalısınız"
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:79
 msgid "You have made at least 10 edits to Wikimedia projects in the last month"
-msgstr ""
-"Son bir ay içinde Wikimedia projelerinde en az 10 değişiklik yapmış "
-"olmalısınız"
+msgstr "Son bir ay içinde Wikimedia projelerinde en az 10 değişiklik yapmış olmalısınız"
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:83
 msgid "You are not currently blocked from editing a Wikimedia project"
-msgstr ""
-"Şu anda bir Wikimedia projesinde düzenleme yapmanız için engellenmemiş "
-"olmalısınız"
+msgstr "Şu anda bir Wikimedia projesinde düzenleme yapmanız için engellenmemiş olmalısınız"
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/)
 #: TWLight/templates/about.html:89
-msgid ""
-"If you are applying for an available collection, please first check that you "
-"don't already have access through another library or institution. If you do, "
-"please consider using that access rather than taking up a seat for this "
-"resource in The Wikipedia Library."
-msgstr ""
-"Mevcut bir koleksiyon için başvuruyorsanız lütfen önce başka bir kütüphane "
-"veya kurum aracılığıyla erişiminiz olup olmadığını kontrol edin. Bunu "
-"yaparsanız Vikipedi Kütüphanesi'ndeki bu kaynak için yeniden başvuru yerine "
-"lütfen bu erişimi kullanmayı düşünün."
+msgid "If you are applying for an available collection, please first check that you don't already have access through another library or institution. If you do, please consider using that access rather than taking up a seat for this resource in The Wikipedia Library."
+msgstr "Mevcut bir koleksiyon için başvuruyorsanız lütfen önce başka bir kütüphane veya kurum aracılığıyla erişiminiz olup olmadığını kontrol edin. Bunu yaparsanız Vikipedi Kütüphanesi'ndeki bu kaynak için yeniden başvuru yerine lütfen bu erişimi kullanmayı düşünün."
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/)
 #: TWLight/templates/about.html:99
-msgid ""
-"If your account is blocked on one or more Wikimedia projects, you may still "
-"be granted access to The Wikipedia Library. You will need to contact the "
-"Wikipedia Library team, who will review your blocks. If you have been "
-"blocked for content issues, most notably copyright violations, or have "
-"multiple long-term blocks, we may decline your request. Additionally, if "
-"your block status changes after being approved, you will need to request "
-"another review."
-msgstr ""
-"Hesabınız bir veya daha fazla Wikimedia projesinde engellenmiş olsa da yine "
-"de Vikipedi Kütüphanesi'ne erişiminiz olabilir. Engelinizi gözden geçirecek "
-"olan Vikipedi Kütüphanesi ekibiyle iletişime geçmeniz gerekecek. İçerik "
-"sorunları özellikle telif hakkı ihlalleri nedeniyle engellendiyseniz veya "
-"birden fazla uzun vadeli engellemeniz varsa isteğinizi reddedebiliriz. "
-"Ayrıca onaylandıktan sonra engelleme durumunuz değişirse başka bir inceleme "
-"talep etmeniz gerekecektir."
+msgid "If your account is blocked on one or more Wikimedia projects, you may still be granted access to The Wikipedia Library. You will need to contact the Wikipedia Library team, who will review your blocks. If you have been blocked for content issues, most notably copyright violations, or have multiple long-term blocks, we may decline your request. Additionally, if your block status changes after being approved, you will need to request another review."
+msgstr "Hesabınız bir veya daha fazla Wikimedia projesinde engellenmiş olsa da yine de Vikipedi Kütüphanesi'ne erişiminiz olabilir. Engelinizi gözden geçirecek olan Vikipedi Kütüphanesi ekibiyle iletişime geçmeniz gerekecek. İçerik sorunları özellikle telif hakkı ihlalleri nedeniyle engellendiyseniz veya birden fazla uzun vadeli engellemeniz varsa isteğinizi reddedebiliriz. Ayrıca onaylandıktan sonra engelleme durumunuz değişirse başka bir inceleme talep etmeniz gerekecektir."
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:110
@@ -2406,12 +1903,8 @@ msgstr "Onaylanan editörler şunları <i>yapmamalıdır</i>:"
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:136
-msgid ""
-"Share their account logins or passwords with others, or sell their access to "
-"other parties"
-msgstr ""
-"Hesap girişlerini veya parolalarını başkalarıyla paylaşma veya diğer "
-"taraflara erişim sağlama"
+msgid "Share their account logins or passwords with others, or sell their access to other parties"
+msgstr "Hesap girişlerini veya parolalarını başkalarıyla paylaşma veya diğer taraflara erişim sağlama"
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:140
@@ -2420,30 +1913,18 @@ msgstr "İş ortağı içeriğini toplu indirme"
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:144
-msgid ""
-"Systematically make printed or electronic copies of multiple extracts of "
-"restricted content available for any purpose"
-msgstr ""
-"Herhangi bir amaç için mevcut kısıtlanmış içeriğin çoklu özetlerinin basılı "
-"veya elektronik kopyalarını sistematik olarak oluşturma"
+msgid "Systematically make printed or electronic copies of multiple extracts of restricted content available for any purpose"
+msgstr "Herhangi bir amaç için mevcut kısıtlanmış içeriğin çoklu özetlerinin basılı veya elektronik kopyalarını sistematik olarak oluşturma"
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/). Stub is a technical term for a short Wikipedia article, use the appropriate Wikipedia term in your language.
 #: TWLight/templates/about.html:148
-msgid ""
-"Datamine metadata without permission, in order, for instance, to use "
-"metadata for auto-created stub articles"
-msgstr ""
-"Örneğin, otomatik oluşturulmuş taslak makaleleri için meta verileri "
-"kullanmak için izinsiz üst verileri alma"
+msgid "Datamine metadata without permission, in order, for instance, to use metadata for auto-created stub articles"
+msgstr "Örneğin, otomatik oluşturulmuş taslak makaleleri için meta verileri kullanmak için izinsiz üst verileri alma"
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:154
-msgid ""
-"Respecting these agreements allows us to continue growing the partnerships "
-"available to the community."
-msgstr ""
-"Bu anlaşmalara saygı duymak, toplum için mevcut ortaklıkları büyütmeye devam "
-"etmemizi sağlar."
+msgid "Respecting these agreements allows us to continue growing the partnerships available to the community."
+msgstr "Bu anlaşmalara saygı duymak, toplum için mevcut ortaklıkları büyütmeye devam etmemizi sağlar."
 
 #. Translators: This is the heading for a section on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:160
@@ -2452,62 +1933,23 @@ msgstr "EZProxy"
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:164
-msgid ""
-"EZProxy is a proxy server used to authenticate users for many Wikipedia "
-"Library partners. Users sign into EZProxy via the Library Card platform to "
-"verify that they are authorized users, and then the server accesses "
-"requested resources using its own IP address."
-msgstr ""
-"EZProxy, birçok Vikipedi Kütüphanesi iş ortağı için kullanıcıları doğrulamak "
-"için kullanılan bir proxy sunucusudur. Kullanıcılar, yetkilendirilmiş "
-"kullanıcılar olduklarını doğrulamak için Kütüphane Kartı platformu üzerinden "
-"EZProxy'de oturum açar ve ardından sunucu, kendi IP adresini kullanarak "
-"istenen kaynaklara erişir."
+msgid "EZProxy is a proxy server used to authenticate users for many Wikipedia Library partners. Users sign into EZProxy via the Library Card platform to verify that they are authorized users, and then the server accesses requested resources using its own IP address."
+msgstr "EZProxy, birçok Vikipedi Kütüphanesi iş ortağı için kullanıcıları doğrulamak için kullanılan bir proxy sunucusudur. Kullanıcılar, yetkilendirilmiş kullanıcılar olduklarını doğrulamak için Kütüphane Kartı platformu üzerinden EZProxy'de oturum açar ve ardından sunucu, kendi IP adresini kullanarak istenen kaynaklara erişir."
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:173
-msgid ""
-"You may notice that when accessing resources via EZProxy that URLs are "
-"dynamically rewritten. This is why we recommend logging in via the Library "
-"Card platform rather than going directly to the unproxied partner website. "
-"When in doubt, check the URL for ‘idm.oclc’. If it’s there, then you’re "
-"connected via EZProxy."
-msgstr ""
-"Kaynaklara EZProxy aracılığıyla erişirken URL'lerin dinamik olarak yeniden "
-"yazıldığını fark edebilirsiniz. Bu nedenle, doğrudan proxy'siz ortak web "
-"sitesine gitmek yerine Kütüphane Kartı platformu üzerinden oturum açmanızı "
-"öneririz. Şüphe duyduğunuzda 'idm.oclc' URL'sini kontrol edin. Eğer oradaysa "
-"EZProxy aracılığıyla bağlanıyorsunuz demektir."
+msgid "You may notice that when accessing resources via EZProxy that URLs are dynamically rewritten. This is why we recommend logging in via the Library Card platform rather than going directly to the unproxied partner website. When in doubt, check the URL for ‘idm.oclc’. If it’s there, then you’re connected via EZProxy."
+msgstr "Kaynaklara EZProxy aracılığıyla erişirken URL'lerin dinamik olarak yeniden yazıldığını fark edebilirsiniz. Bu nedenle, doğrudan proxy'siz ortak web sitesine gitmek yerine Kütüphane Kartı platformu üzerinden oturum açmanızı öneririz. Şüphe duyduğunuzda 'idm.oclc' URL'sini kontrol edin. Eğer oradaysa EZProxy aracılığıyla bağlanıyorsunuz demektir."
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:182
-msgid ""
-"Typically once you’ve logged in your session will remain active in your "
-"browser for up to two hours after you’ve finished searching. Note that use "
-"of EZProxy requires you to enable cookies. If you are having problems you "
-"should also try clearing your cache and restarting your browser."
-msgstr ""
-"Genelde oturum açtıktan sonra oturumunuz, aramayı bitirdikten sonra "
-"tarayıcınızda iki saat kadar aktif kalır. EZProxy kullanımının çerezleri "
-"etkinleştirmenizi gerektirdiğini unutmayın. Sorun yaşıyorsanız önbelleğinizi "
-"temizlemeyi ve tarayıcınızı yeniden başlatmayı da denemelisiniz."
+msgid "Typically once you’ve logged in your session will remain active in your browser for up to two hours after you’ve finished searching. Note that use of EZProxy requires you to enable cookies. If you are having problems you should also try clearing your cache and restarting your browser."
+msgstr "Genelde oturum açtıktan sonra oturumunuz, aramayı bitirdikten sonra tarayıcınızda iki saat kadar aktif kalır. EZProxy kullanımının çerezleri etkinleştirmenizi gerektirdiğini unutmayın. Sorun yaşıyorsanız önbelleğinizi temizlemeyi ve tarayıcınızı yeniden başlatmayı da denemelisiniz."
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/)
 #: TWLight/templates/about.html:193
-msgid ""
-"The Library Bundle is a collection of resources for which no application is "
-"required. If you meet the criteria laid out above, you will be authorized "
-"for access automatically upon logging in to the platform. Only some of our "
-"content is currently included in the Library Bundle, however we hope to "
-"expand the collection as more publishers become comfortable with "
-"participating. All Bundle content is accessed via EZProxy."
-msgstr ""
-"Kütüphane Paketi, başvuru gerektirmeyen bir kaynak koleksiyonudur. Yukarıda "
-"belirtilen kriterleri karşılıyorsanız platforma giriş yaptığınızda otomatik "
-"olarak erişim için yetkilendirileceksiniz. İçeriğimizin yalnızca bir kısmı "
-"şu anda Kütüphane Paketi'ne dahil edilmiştir ancak daha fazla yayıncı "
-"katılım konusunda rahat oldukça koleksiyonu genişletmeyi umuyoruz. Tüm paket "
-"içeriğine EZProxy aracılığıyla erişilir."
+msgid "The Library Bundle is a collection of resources for which no application is required. If you meet the criteria laid out above, you will be authorized for access automatically upon logging in to the platform. Only some of our content is currently included in the Library Bundle, however we hope to expand the collection as more publishers become comfortable with participating. All Bundle content is accessed via EZProxy."
+msgstr "Kütüphane Paketi, başvuru gerektirmeyen bir kaynak koleksiyonudur. Yukarıda belirtilen kriterleri karşılıyorsanız platforma giriş yaptığınızda otomatik olarak erişim için yetkilendirileceksiniz. İçeriğimizin yalnızca bir kısmı şu anda Kütüphane Paketi'ne dahil edilmiştir ancak daha fazla yayıncı katılım konusunda rahat oldukça koleksiyonu genişletmeyi umuyoruz. Tüm paket içeriğine EZProxy aracılığıyla erişilir."
 
 #. Translators: This is the heading for a section on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:202
@@ -2516,18 +1958,8 @@ msgstr "Atıf uygulamaları"
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:206
-msgid ""
-"Citation practices vary by project and even by article. Generally, we "
-"support editors citing where they found information, in a form that allows "
-"others to check it for themselves. That often means providing both original "
-"source details as well as a link to the partner database in which the source "
-"was found."
-msgstr ""
-"Atıf uygulamaları projeye ve hatta maddeye göre değişir. Genel olarak, "
-"bilgileri nerede bulduklarını belirten editörleri, başkalarının kendileri "
-"için kontrol etmesini sağlayacak bir biçimde destekliyoruz. Bu genellikle "
-"hem orijinal kaynak ayrıntılarını hem de kaynağın bulunduğu iş ortağı "
-"veritabanına bir bağlantı sağlamak anlamına gelir."
+msgid "Citation practices vary by project and even by article. Generally, we support editors citing where they found information, in a form that allows others to check it for themselves. That often means providing both original source details as well as a link to the partner database in which the source was found."
+msgstr "Atıf uygulamaları projeye ve hatta maddeye göre değişir. Genel olarak, bilgileri nerede bulduklarını belirten editörleri, başkalarının kendileri için kontrol etmesini sağlayacak bir biçimde destekliyoruz. Bu genellikle hem orijinal kaynak ayrıntılarını hem de kaynağın bulunduğu iş ortağı veritabanına bir bağlantı sağlamak anlamına gelir."
 
 #. Translators: This is the heading for a section on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #. Translators: This link is at the bottom of every page and can be clicked by users to contact the wikipedia library team.
@@ -2538,13 +1970,8 @@ msgstr "İletişim"
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:218
 #, python-format
-msgid ""
-"If you have questions, need help, or want to volunteer to help, please see "
-"our <a class=\"twl-links\" href=\"%(contact_url)s\">contact page</a>."
-msgstr ""
-"Sorularınız varsa, yardıma ihtiyacınız varsa veya yardım için gönüllü olmak "
-"istiyorsanız, lütfen <a class=\"twl-links\" href=\"%(contact_url)s"
-"\">iletişim sayfamıza</a> bakın."
+msgid "If you have questions, need help, or want to volunteer to help, please see our <a class=\"twl-links\" href=\"%(contact_url)s\">contact page</a>."
+msgstr "Sorularınız varsa, yardıma ihtiyacınız varsa veya yardım için gönüllü olmak istiyorsanız, lütfen <a class=\"twl-links\" href=\"%(contact_url)s\">iletişim sayfamıza</a> bakın."
 
 #. Translators: This is the title of the panel box detailing the contact information for the Wikipedia Library team.
 #: TWLight/templates/contact.html:14
@@ -2583,18 +2010,13 @@ msgstr "Vikipedi Kütüphanesi Twitter sayfası"
 #. Translators: This is the text that appears at the bottom of the contact us form directing users to the suggestions form.
 #: TWLight/templates/contact.html:48
 #, python-format
-msgid ""
-"(If you would like to suggest a partner, <a class=\"twl-links\" href="
-"\"%(suggest)s\"><strong>go here</strong></a>.)"
-msgstr ""
-"(Bir iş ortağı önermek istiyorsanız <a class=\"twl-links\" href=\"%(suggest)s"
-"\"><strong>buraya tıklayın</strong></a>.)"
+msgid "(If you would like to suggest a partner, <a class=\"twl-links\" href=\"%(suggest)s\"><strong>go here</strong></a>.)"
+msgstr "(Bir iş ortağı önermek istiyorsanız <a class=\"twl-links\" href=\"%(suggest)s\"><strong>buraya tıklayın</strong></a>.)"
 
 #. Translators: On a special 'link to search' page, this message is shown if JavaScript is disabled.
 #: TWLight/templates/eds_search_endpoint.html:7
 msgid "JavaScript is disabled; use the button below to continue."
-msgstr ""
-"JavaScript devre dışı bırakıldı, devam etmek için aşağıdaki butonu kullanın."
+msgstr "JavaScript devre dışı bırakıldı, devam etmek için aşağıdaki butonu kullanın."
 
 #. Translators: Alt text for the Wikipedia Library shown in the top left of all pages.
 #: TWLight/templates/header_partial_b4.html:14
@@ -2646,13 +2068,8 @@ msgstr "Vikipedi Kütüphanesi"
 #. Translators: Information about The Wikipedia Library.
 #: TWLight/templates/login_partial.html:53 TWLight/templates/new_base.html:21
 #, python-format
-msgid ""
-"More than 100 of the world's top subscription-only databases, with content "
-"in %(no_of_languages)s languages, free for Wikipedians of all backgrounds"
-msgstr ""
-"%(no_of_languages)s dilde içeriğe sahip olan ve abonelik gerektiren dünyanın "
-"en iyi 100'den fazla veritabanı, herhangi bir geçmişi olan Vikipedistler "
-"için ücretsiz!"
+msgid "More than 100 of the world's top subscription-only databases, with content in %(no_of_languages)s languages, free for Wikipedians of all backgrounds"
+msgstr "%(no_of_languages)s dilde içeriğe sahip olan ve abonelik gerektiren dünyanın en iyi 100'den fazla veritabanı, herhangi bir geçmişi olan Vikipedistler için ücretsiz!"
 
 #. Translators: Information about The Wikipedia Library.
 #: TWLight/templates/login_partial.html:64
@@ -2660,13 +2077,8 @@ msgid "Meet these criteria for automatic access"
 msgstr "Otomatik erişim için şu kriterleri karşılamalısınız:"
 
 #: TWLight/templates/login_partial.html:69
-msgid ""
-"These criteria grant you access to certain collections but not all. Some "
-"collections are accessible on a per application basis only."
-msgstr ""
-"Bu ölçütler, belirli koleksiyonlara erişmenizi sağlar fakat koleksiyonun "
-"tamamına erişim sağlamayabilir. Bazı koleksiyonlara yalnızca uygulama "
-"bazında erişilebilir."
+msgid "These criteria grant you access to certain collections but not all. Some collections are accessible on a per application basis only."
+msgstr "Bu ölçütler, belirli koleksiyonlara erişmenizi sağlar fakat koleksiyonun tamamına erişim sağlamayabilir. Bazı koleksiyonlara yalnızca uygulama bazında erişilebilir."
 
 #: TWLight/templates/login_partial.html:89
 msgid "Login via Wikipedia"
@@ -2675,40 +2087,20 @@ msgstr "Vikipedi ile oturum açın"
 #. Translators: Shown if the current user doesn't have a registered email on their account. Don't translate contact_us_url or email_url.
 #: TWLight/templates/message_partial.html:15
 #, python-format
-msgid ""
-"You don't have an email on file. We can't finalize your access to partner "
-"resources, and you won't be able to <a class=\"twl-links\" href="
-"\"%(contact_us_url)s\">contact us</a> without an email. Please <a class="
-"\"twl-links\" href=\"%(email_url)s\">update your email</a>."
-msgstr ""
-"Dosyada bir e-postan yok. İş ortağı kaynaklarına erişiminizi "
-"sonlandıramıyoruz ve bir e-posta olmadan <a class=\"twl-links\" href="
-"\"%(contact_us_url)s\">bize ulaşın</a>. Lütfen <a class=\"twl-links\" href="
-"\"%(email_url)s\">e-postanızı güncelleyin</a>."
+msgid "You don't have an email on file. We can't finalize your access to partner resources, and you won't be able to <a class=\"twl-links\" href=\"%(contact_us_url)s\">contact us</a> without an email. Please <a class=\"twl-links\" href=\"%(email_url)s\">update your email</a>."
+msgstr "Dosyada bir e-postan yok. İş ortağı kaynaklarına erişiminizi sonlandıramıyoruz ve bir e-posta olmadan <a class=\"twl-links\" href=\"%(contact_us_url)s\">bize ulaşın</a>. Lütfen <a class=\"twl-links\" href=\"%(email_url)s\">e-postanızı güncelleyin</a>."
 
 #. Translators: Shown if the current user has requested the processing of their data should be restricted.
 #: TWLight/templates/message_partial.html:26
 #, python-format
-msgid ""
-"You have requested a restriction on the processing of your data. Most site "
-"functionality will not be available to you until you <a class=\"twl-links\" "
-"href=\"%(restrict_url)s\">lift this restriction</a>."
-msgstr ""
-"Verilerinizin işlenmesi için bir kısıtlama isteğinde bulundunuz. <a class="
-"\"twl-links\" href=\"%(restrict_url)s\">Bu kısıtlamayı kaldırana kadar</a> "
-"site işlevlerinin çoğu kullanılamayacaktır."
+msgid "You have requested a restriction on the processing of your data. Most site functionality will not be available to you until you <a class=\"twl-links\" href=\"%(restrict_url)s\">lift this restriction</a>."
+msgstr "Verilerinizin işlenmesi için bir kısıtlama isteğinde bulundunuz. <a class=\"twl-links\" href=\"%(restrict_url)s\">Bu kısıtlamayı kaldırana kadar</a> site işlevlerinin çoğu kullanılamayacaktır."
 
 #. Translators: Shown if the current user has not agreed to the terms of use.
 #: TWLight/templates/message_partial.html:37
 #, python-format
-msgid ""
-"You have not agreed to the <a class=\"twl-links\" href=\"%(terms_url)s"
-"\">terms of use</a> of this site. Your applications will not be processed "
-"and you won't be able to apply or access resources you are approved for."
-msgstr ""
-"Bu sitenin <a class=\"twl-links\" href=\"%(terms_url)s\">kullanım "
-"şartlarını</a> kabul etmediniz. Başvurularınız işleme alınmayacak ve "
-"onaylandığınız kaynaklara başvuramayacak veya bunlara erişemeyeceksiniz."
+msgid "You have not agreed to the <a class=\"twl-links\" href=\"%(terms_url)s\">terms of use</a> of this site. Your applications will not be processed and you won't be able to apply or access resources you are approved for."
+msgstr "Bu sitenin <a class=\"twl-links\" href=\"%(terms_url)s\">kullanım şartlarını</a> kabul etmediniz. Başvurularınız işleme alınmayacak ve onaylandığınız kaynaklara başvuramayacak veya bunlara erişemeyeceksiniz."
 
 #. Translators: This link is at the bottom of every page and links to the 'About' page (https://wikipedialibrary.wmflabs.org/about/)
 #: TWLight/templates/new_base.html:107
@@ -2754,12 +2146,8 @@ msgstr "Parolayı sıfırla"
 
 #. Translators: If a user goes to reset their password, this message asks them to enter their email to do so.
 #: TWLight/templates/registration/password_reset_form.html:13
-msgid ""
-"Forgot your password? Enter your email address below, and we'll email "
-"instructions for setting a new one."
-msgstr ""
-"Parolanızı mı unuttunuz? E-posta adresinizi aşağıya girin ve yeni bir parola "
-"belirleme talimatlarını e-postayla göndereceğiz."
+msgid "Forgot your password? Enter your email address below, and we'll email instructions for setting a new one."
+msgstr "Parolanızı mı unuttunuz? E-posta adresinizi aşağıya girin ve yeni bir parola belirleme talimatlarını e-postayla göndereceğiz."
 
 #. Translators: This is the label for a button that users click to update their public information.
 #: TWLight/users/forms.py:36
@@ -2803,22 +2191,13 @@ msgstr "Kullanım şartlarını kabul ediyorum"
 
 #. Translators: This text explains how to disagree to the site's terms of use and the restrictions that will come into effect when users disagree to the terms of use.
 #: TWLight/users/forms.py:185
-msgid ""
-"By unchecking this box and clicking “Update” you may explore the site, but "
-"you will not be able to apply for access to materials or evaluate "
-"applications unless you agree with the terms of use."
-msgstr ""
-"Bu kutunun işaretini kaldırarak ve \"Güncelle\"ye tıklayarak siteyi "
-"keşfedebilirsiniz ancak kullanım şartlarını kabul etmedikçe içeriklere "
-"erişim için başvuruda bulunamaz veya başvuruları değerlendiremezsiniz."
+msgid "By unchecking this box and clicking “Update” you may explore the site, but you will not be able to apply for access to materials or evaluate applications unless you agree with the terms of use."
+msgstr "Bu kutunun işaretini kaldırarak ve \"Güncelle\"ye tıklayarak siteyi keşfedebilirsiniz ancak kullanım şartlarını kabul etmedikçe içeriklere erişim için başvuruda bulunamaz veya başvuruları değerlendiremezsiniz."
 
 #. Translators: Users click this button to set their website email address to the one linked to their Wikipedia account.
 #: TWLight/users/forms.py:211
-msgid ""
-"Use my Wikipedia email address (will be updated the next time you login)."
-msgstr ""
-"Vikipedi e-posta adresimi kullan (bir sonraki oturum açışınızda "
-"güncellenecektir)."
+msgid "Use my Wikipedia email address (will be updated the next time you login)."
+msgstr "Vikipedi e-posta adresimi kullan (bir sonraki oturum açışınızda güncellenecektir)."
 
 #. Translators: This labels a button which users click to change their email.
 #: TWLight/users/forms.py:232
@@ -2828,19 +2207,8 @@ msgstr "E-postayı güncelle"
 #. Translators: Shown if the current user tried to 'favorite' a partner they can't access. Do not translate '{partner}'
 #: TWLight/users/models.py:201
 #, python-brace-format
-msgid ""
-"Cannot add partner {partner} to your favorites because you don't have access "
-"to it"
-msgstr ""
-"Erişiminiz olmadığı için {partner} iş ortağını favorilerinize "
-"ekleyemiyorsunuz"
-
-#. Translators: Do not translate.
-#: TWLight/users/models.py:869
-#, fuzzy, python-brace-format
-#| msgid "Username"
-msgid "{wp_username}"
-msgstr "Kullanıcı adı"
+msgid "Cannot add partner {partner} to your favorites because you don't have access to it"
+msgstr "Erişiminiz olmadığı için {partner} iş ortağını favorilerinize ekleyemiyorsunuz"
 
 #. Translators: This error message is shown when there's a problem with the authenticated login process.
 #: TWLight/users/oauth.py:243
@@ -2856,18 +2224,12 @@ msgstr "{domain}, izin verilen bir sunucu değil."
 #. Translators: This warning message is shown to users when OAuth handshaker can't be initiated.
 #: TWLight/users/oauth.py:364
 msgid "Handshaker not initiated, please try logging in again."
-msgstr ""
-"OAuth-Handshaker aracılığıyla kimlik doğrulama başlatılmadı, lütfen tekrar "
-"oturum açın."
+msgstr "OAuth-Handshaker aracılığıyla kimlik doğrulama başlatılmadı, lütfen tekrar oturum açın."
 
 #. Translators: this message is displayed to users that don't have accounts and clicked on a proxied link.
 #: TWLight/users/oauth.py:388
-msgid ""
-"To view this link you need to be an eligible library user. Please login to "
-"continue."
-msgstr ""
-"Bu bağlantıyı görüntülemek için uygun bir kütüphane kullanıcısı olmanız "
-"gerekir. Devam etmek için lütfen giriş yapınız."
+msgid "To view this link you need to be an eligible library user. Please login to continue."
+msgstr "Bu bağlantıyı görüntülemek için uygun bir kütüphane kullanıcısı olmanız gerekir. Devam etmek için lütfen giriş yapınız."
 
 #. Translators: This warning message is shown to users when the response received from Wikimedia OAuth servers is not a valid one.
 #: TWLight/users/oauth.py:430
@@ -2902,25 +2264,13 @@ msgstr "Daha fazla bilgi için: {issue}"
 
 #. Translators: If the user tries to log in, but their account does not meet certain requirements, they cannot login.
 #: TWLight/users/oauth.py:528
-msgid ""
-"Your Wikipedia account does not meet the eligibility criteria in the terms "
-"of use, so your Wikipedia Library Card Platform account cannot be activated."
-msgstr ""
-"Vikipedi hesabınız kullanım koşullarındaki uygunluk kriterlerini "
-"karşılamıyor, bu nedenle Vikipedi Kütüphanesi Kart Platformu hesabınız "
-"etkinleştirilemiyor."
+msgid "Your Wikipedia account does not meet the eligibility criteria in the terms of use, so your Wikipedia Library Card Platform account cannot be activated."
+msgstr "Vikipedi hesabınız kullanım koşullarındaki uygunluk kriterlerini karşılamıyor, bu nedenle Vikipedi Kütüphanesi Kart Platformu hesabınız etkinleştirilemiyor."
 
 #. Translators: If the user tries to log in, but their account does not meet certain requirements, they cannot login.
 #: TWLight/users/oauth.py:536
-msgid ""
-"Your Wikipedia account no longer meets the eligibility criteria in the terms "
-"of use, so you cannot be logged in. If you think you should be able to log "
-"in, please email wikipedialibrary@wikimedia.org."
-msgstr ""
-"Vikipedi hesabınız kullanım koşullarındaki uygunluk kriterlerini artık "
-"karşılamıyor, bu yüzden giriş yapamıyorsunuz. Giriş yapabilmeniz gerektiğini "
-"düşünüyorsanız lütfen wikipedialibrary@wikimedia.org adresine e-posta "
-"gönderin."
+msgid "Your Wikipedia account no longer meets the eligibility criteria in the terms of use, so you cannot be logged in. If you think you should be able to log in, please email wikipedialibrary@wikimedia.org."
+msgstr "Vikipedi hesabınız kullanım koşullarındaki uygunluk kriterlerini artık karşılamıyor, bu yüzden giriş yapamıyorsunuz. Giriş yapabilmeniz gerektiğini düşünüyorsanız lütfen wikipedialibrary@wikimedia.org adresine e-posta gönderin."
 
 #. Translators: this message is displayed to users with brand new accounts.
 #: TWLight/users/oauth.py:549
@@ -2930,15 +2280,8 @@ msgstr "Hoş geldiniz! Lütfen kullanım şartlarını kabul edin."
 #. Translators: This message is displayed on the confirmation page where users can return their access to partner collections.
 #: TWLight/users/templates/users/authorization_confirm_return.html:13
 #, python-format
-msgid ""
-"You will no longer be able to access <b>%(partner)s's</b> resources via the "
-"Library Card platform, but can request access again by clicking 'renew', if "
-"you change your mind. Are you sure you want to return your access?"
-msgstr ""
-"Artık <b>%(partner)s</b> iş ortağının kaynaklarına Kütüphane Kartı platformu "
-"üzerinden erişemeyeceksiniz ancak fikrinizi değiştirirseniz 'yenile'ye "
-"tıklayarak tekrar erişim talep edebilirsiniz. Erişiminizi iade etmek "
-"istediğinizden emin misiniz?"
+msgid "You will no longer be able to access <b>%(partner)s's</b> resources via the Library Card platform, but can request access again by clicking 'renew', if you change your mind. Are you sure you want to return your access?"
+msgstr "Artık <b>%(partner)s</b> iş ortağının kaynaklarına Kütüphane Kartı platformu üzerinden erişemeyeceksiniz ancak fikrinizi değiştirirseniz 'yenile'ye tıklayarak tekrar erişim talep edebilirsiniz. Erişiminizi iade etmek istediğinizden emin misiniz?"
 
 #. Translators: On the MyLibrary page (https://wikipedialibrary.wmflabs.org/users/my_library), this tab shows all favorite collections a user has.
 #: TWLight/users/templates/users/collections_section.html:9
@@ -3007,14 +2350,8 @@ msgstr "Düzenleyici verileri"
 
 #. Translators: This is shown on editor profiles, in their profile page or on applications.
 #: TWLight/users/templates/users/editor_detail.html:59
-msgid ""
-"Information with an * was retrieved from Wikipedia directly. Other "
-"information was entered directly by users or site admins, in their preferred "
-"language."
-msgstr ""
-"* ile gösterilen bilgiler doğrudan Vikipedi'den alınmıştır. Diğer bilgiler "
-"doğrudan kullanıcılar veya site yöneticileri tarafından tercih ettikleri "
-"dilde girildi."
+msgid "Information with an * was retrieved from Wikipedia directly. Other information was entered directly by users or site admins, in their preferred language."
+msgstr "* ile gösterilen bilgiler doğrudan Vikipedi'den alınmıştır. Diğer bilgiler doğrudan kullanıcılar veya site yöneticileri tarafından tercih ettikleri dilde girildi."
 
 #. Translators: This distinguishes users who have been flagged as account coordinators. Don't translate username.
 #: TWLight/users/templates/users/editor_detail.html:71
@@ -3024,14 +2361,8 @@ msgstr "%(username)s, bu sitede koordinatör ayrıcalıklarına sahiptir."
 
 #. Translators: This is shown on editor profiles, under the heading for Wikipedia editor data.
 #: TWLight/users/templates/users/editor_detail_data.html:5
-msgid ""
-"This information is updated automatically from your Wikimedia account each "
-"time you log in, except for the Contributions field, where you can describe "
-"your Wikimedia editing history."
-msgstr ""
-"Bu bilgiler, Wikimedia düzenleme geçmişinizi tanımlayabileceğiniz Katkılar "
-"alanı dışında, her oturum açtığınızda Wikimedia hesabınızdan otomatik olarak "
-"güncellenir."
+msgid "This information is updated automatically from your Wikimedia account each time you log in, except for the Contributions field, where you can describe your Wikimedia editing history."
+msgstr "Bu bilgiler, Wikimedia düzenleme geçmişinizi tanımlayabileceğiniz Katkılar alanı dışında, her oturum açtığınızda Wikimedia hesabınızdan otomatik olarak güncellenir."
 
 #. Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this labels the user's username.
 #: TWLight/users/templates/users/editor_detail_data.html:17
@@ -3060,22 +2391,14 @@ msgstr "Kullanım şartlarını karşılıyor mu?"
 
 #. Translators: when viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this question has a yes or no answer.
 #: TWLight/users/templates/users/editor_detail_data.html:57
-msgid ""
-"at their last login, did this user meet the criteria set forth in the terms "
-"of use?"
-msgstr ""
-"Bu kullanıcı son girişinde kullanım şartlarında belirtilen kriterleri "
-"karşıladı mı?"
+msgid "at their last login, did this user meet the criteria set forth in the terms of use?"
+msgstr "Bu kullanıcı son girişinde kullanım şartlarında belirtilen kriterleri karşıladı mı?"
 
 #. Translators: When viewing a user's profile in an application, this message shows if the software doesn't think that the user is eligible for access. Don't translate username.
 #: TWLight/users/templates/users/editor_detail_data.html:72
 #, python-format
-msgid ""
-"%(username)s may still be eligible for access grants at the coordinators' "
-"discretion."
-msgstr ""
-"%(username)s, koordinatörlerin takdirine bağlı olarak hâlâ erişim hakkı "
-"almaya hak kazanabilir."
+msgid "%(username)s may still be eligible for access grants at the coordinators' discretion."
+msgstr "%(username)s, koordinatörlerin takdirine bağlı olarak hâlâ erişim hakkı almaya hak kazanabilir."
 
 #. Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this is the heading for a Yes/No ToU question.
 #: TWLight/users/templates/users/editor_detail_data.html:83
@@ -3109,14 +2432,8 @@ msgstr ""
 #. Translators: This message is shown on a user's profile if their Wikimedia account is blocked on one or more projects. They may still be granted access to the Library Bundle, but need to contact Wikipedia Library staff to verify.
 #: TWLight/users/templates/users/editor_detail_data.html:137
 #, python-format
-msgid ""
-"It looks like you have an active block on your account. If you meet the "
-"other criteria you may still be permitted access to the library - please <a "
-"class=\"twl-links\" href=\"%(contact_url)s\">contact us</a>."
-msgstr ""
-"Hesabınızda aktif bir engelleme var gibi görünüyor. Diğer ölçütleri "
-"karşılıyorsanız Kütüphane Paketi'ne erişmenize izin verilebilir. Lütfen <a "
-"class=\"twl-links\" href=\"%(contact_url)s\">bize ulaşın</a>."
+msgid "It looks like you have an active block on your account. If you meet the other criteria you may still be permitted access to the library - please <a class=\"twl-links\" href=\"%(contact_url)s\">contact us</a>."
+msgstr "Hesabınızda aktif bir engelleme var gibi görünüyor. Diğer ölçütleri karşılıyorsanız Kütüphane Paketi'ne erişmenize izin verilebilir. Lütfen <a class=\"twl-links\" href=\"%(contact_url)s\">bize ulaşın</a>."
 
 #. Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this is the heading for a Yes/No program eligibility question.
 #: TWLight/users/templates/users/editor_detail_data.html:153
@@ -3125,14 +2442,8 @@ msgstr "Paket için uygun mu?"
 
 #. Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this question has a Yes or No answer.
 #: TWLight/users/templates/users/editor_detail_data.html:156
-msgid ""
-"At their last login, did this user meet the criteria set forth in the "
-"Library Bundle? Note that satisfying terms of use is a prerequisite to "
-"bundle eligibility."
-msgstr ""
-"Bu kullanıcı son oturum açışında Kitaplık Paketi'nde belirtilen kriterleri "
-"karşıladı mı? Uygun kullanım koşullarının paket uygunluğu için bir ön koşul "
-"olduğunu unutmayın."
+msgid "At their last login, did this user meet the criteria set forth in the Library Bundle? Note that satisfying terms of use is a prerequisite to bundle eligibility."
+msgstr "Bu kullanıcı son oturum açışında Kitaplık Paketi'nde belirtilen kriterleri karşıladı mı? Uygun kullanım koşullarının paket uygunluğu için bir ön koşul olduğunu unutmayın."
 
 #. Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this is the heading for a Yes/No program eligibility question.
 #: TWLight/users/templates/users/editor_detail_data.html:177
@@ -3176,24 +2487,14 @@ msgstr "Kişisel veri"
 
 #. Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this text is in the 'Personal data' section. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/users/templates/users/editor_detail_data.html:262
-msgid ""
-"The following information is visible only to you, site administrators, "
-"publishing partners (where required), and volunteer Wikipedia Library "
-"coordinators (who have signed a Non-Disclosure Agreement)."
-msgstr ""
-"Aşağıdaki bilgileri yalnızca siz, site yöneticileri, yayın ortakları "
-"(gerektiğinde) ve gönüllü Vikipedi Kütüphanesi koordinatörleri (Gizlilik "
-"Sözleşmesi imzalamış olanlar) görebilir."
+msgid "The following information is visible only to you, site administrators, publishing partners (where required), and volunteer Wikipedia Library coordinators (who have signed a Non-Disclosure Agreement)."
+msgstr "Aşağıdaki bilgileri yalnızca siz, site yöneticileri, yayın ortakları (gerektiğinde) ve gönüllü Vikipedi Kütüphanesi koordinatörleri (Gizlilik Sözleşmesi imzalamış olanlar) görebilir."
 
 #. Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this labels a button which users can click to update or remove their personal information. Don't translate update_url.
 #: TWLight/users/templates/users/editor_detail_data.html:272
 #, python-format
-msgid ""
-"You may <a class=\"twl-links\" href=\"%(update_url)s\">update or delete</a> "
-"your data at any time."
-msgstr ""
-"Verilerinizi istediğiniz zaman <a class=\"twl-links\" href=\"%(update_url)s"
-"\">güncelleyebilir veya silebilirsiniz.</a>"
+msgid "You may <a class=\"twl-links\" href=\"%(update_url)s\">update or delete</a> your data at any time."
+msgstr "Verilerinizi istediğiniz zaman <a class=\"twl-links\" href=\"%(update_url)s\">güncelleyebilir veya silebilirsiniz.</a>"
 
 #. Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this labels the user's email. Don't remove the *.
 #: TWLight/users/templates/users/editor_detail_data.html:283
@@ -3212,32 +2513,19 @@ msgstr "Kurumsal üyelik"
 
 #. Translators: This message tells users that they are not eligible to access The Wikipedia Library content.
 #: TWLight/users/templates/users/eligibility_modal.html:7
-msgid ""
-"Sorry, your Wikipedia account doesn’t currently qualify to access The "
-"Wikipedia Library."
-msgstr ""
-"Üzgünüz, Vikipedi hesabınız şu anda Vikipedi Kütüphanesi erişimine uygun "
-"değil."
+msgid "Sorry, your Wikipedia account doesn’t currently qualify to access The Wikipedia Library."
+msgstr "Üzgünüz, Vikipedi hesabınız şu anda Vikipedi Kütüphanesi erişimine uygun değil."
 
 #. Translators: This message tells users that they have not agreed to the terms of use, therefore are ineligible to access the content in The Wikipedia Library.
 #: TWLight/users/templates/users/eligibility_modal.html:30
 #, python-format
-msgid ""
-"Agreed with <a href=\"%(terms)s\" class=\"text-danger\"> terms of use </a>"
-msgstr ""
-"<a href=\"%(terms)s\" class=\"text-danger\">Kullanım koşullarını</a> kabul "
-"ettiniz mi?"
+msgid "Agreed with <a href=\"%(terms)s\" class=\"text-danger\"> terms of use </a>"
+msgstr "<a href=\"%(terms)s\" class=\"text-danger\">Kullanım koşullarını</a> kabul ettiniz mi?"
 
 #: TWLight/users/templates/users/eligibility_modal.html:40
 #, python-format
-msgid ""
-"It looks like you have an active block on your account. If you meet the "
-"other criteria you may still be permitted access to the library - please <a "
-"href=\"%(contact_url)s\">contact us</a>."
-msgstr ""
-"Hesabınızda aktif bir engelleme var gibi görünüyor. Diğer ölçütleri "
-"karşılıyorsanız Kütüphane Paketi'ne erişmenize izin verilebilir. Lütfen <a "
-"href=\"%(contact_url)s\">bize ulaşın</a>."
+msgid "It looks like you have an active block on your account. If you meet the other criteria you may still be permitted access to the library - please <a href=\"%(contact_url)s\">contact us</a>."
+msgstr "Hesabınızda aktif bir engelleme var gibi görünüyor. Diğer ölçütleri karşılıyorsanız Kütüphane Paketi'ne erişmenize izin verilebilir. Lütfen <a href=\"%(contact_url)s\">bize ulaşın</a>."
 
 #. Translators: Instructions to refresh a user's data.
 #: TWLight/users/templates/users/eligibility_modal.html:50
@@ -3276,14 +2564,8 @@ msgstr "Dili ayarla"
 
 #. Translators: This text on the user page helps users naviage to the TranslateWiki Wikipedia Library Card platform translation page.
 #: TWLight/users/templates/users/language_form.html:31
-msgid ""
-"You can help translate the tool at <a class=\"twl-links\" href=\"https://"
-"translatewiki.net/wiki/Translating:Wikipedia_Library_Card_Platform"
-"\">translatewiki.net</a>."
-msgstr ""
-"Aracı, <a class=\"twl-links\" href=\"https://translatewiki.net/wiki/"
-"Translating:Wikipedia_Library_Card_Platform\">translatewiki.net</a> "
-"adresinden çevirmeye yardımcı olabilirsiniz."
+msgid "You can help translate the tool at <a class=\"twl-links\" href=\"https://translatewiki.net/wiki/Translating:Wikipedia_Library_Card_Platform\">translatewiki.net</a>."
+msgstr "Aracı, <a class=\"twl-links\" href=\"https://translatewiki.net/wiki/Translating:Wikipedia_Library_Card_Platform\">translatewiki.net</a> adresinden çevirmeye yardımcı olabilirsiniz."
 
 #. Translators: When the user starts a new application and submits the application, the user can view the application and withdraw if need be. This changes the label for the Withdraw button.
 #: TWLight/users/templates/users/my_applications.html:65
@@ -3302,12 +2584,8 @@ msgstr "Yenileme isteği"
 
 #. Translators: On the page listing applications, this text explains a user they cannot renew their application since they've already requested a renewal or there aren't any renewals available.
 #: TWLight/users/templates/users/my_applications.html:79
-msgid ""
-"Renewals are either not required, not available right now, or you have "
-"already requested a renewal."
-msgstr ""
-"Yenilemeler gerekli değildir, şu anda mevcut değildir veya zaten bir "
-"yenileme talep etmişsinizdir."
+msgid "Renewals are either not required, not available right now, or you have already requested a renewal."
+msgstr "Yenilemeler gerekli değildir, şu anda mevcut değildir veya zaten bir yenileme talep etmişsinizdir."
 
 #. Translators: This text is the heading of a section in a user's profile where they can change their preferences.
 #: TWLight/users/templates/users/preferences.html:6
@@ -3370,27 +2648,13 @@ msgstr "Veri işlemeyi kısıtlayın"
 
 #. Translators: This message is displayed on the page where users can request we stop processing their data.
 #: TWLight/users/templates/users/restrict_data.html:15
-msgid ""
-"Checking this box and clicking “Restrict” will pause all processing of the "
-"data you have entered into this website. You will not be able to apply for "
-"access to resources, your applications will not be further processed, and "
-"none of your data will be altered, until you return to this page and uncheck "
-"the box. This is not the same as deleting your data."
-msgstr ""
-"Bu kutuyu işaretleyip “Kısıtla” butonuna tıklamak, bu web sitesine "
-"girdiğiniz verilerin tüm işlemlerini duraklatacaktır. Kaynaklara erişim için "
-"başvuru yapamazsınız, başvurunuz daha fazla işlenmeyecek ve bu sayfaya "
-"dönene ve kutunun işaretini kaldırana kadar verilerinizden hiçbiri "
-"değiştirilmeyecektir. Bu, verilerinizi silmekle aynı şey değildir."
+msgid "Checking this box and clicking “Restrict” will pause all processing of the data you have entered into this website. You will not be able to apply for access to resources, your applications will not be further processed, and none of your data will be altered, until you return to this page and uncheck the box. This is not the same as deleting your data."
+msgstr "Bu kutuyu işaretleyip “Kısıtla” butonuna tıklamak, bu web sitesine girdiğiniz verilerin tüm işlemlerini duraklatacaktır. Kaynaklara erişim için başvuru yapamazsınız, başvurunuz daha fazla işlenmeyecek ve bu sayfaya dönene ve kutunun işaretini kaldırana kadar verilerinizden hiçbiri değiştirilmeyecektir. Bu, verilerinizi silmekle aynı şey değildir."
 
 #. Translators: This warning message is shown to coordinators who view the data restriction page.
 #: TWLight/users/templates/users/restrict_data.html:26
-msgid ""
-"You are a coordinator on this site. If you restrict the processing of your "
-"data, your coordinator flag will be removed."
-msgstr ""
-"Bu sitede bir koordinatörünüz. Verilerinizin işlenmesini kısıtlarsanız "
-"koordinatör etiketiniz kaldırılır."
+msgid "You are a coordinator on this site. If you restrict the processing of your data, your coordinator flag will be removed."
+msgstr "Bu sitede bir koordinatörünüz. Verilerinizin işlenmesini kısıtlarsanız koordinatör etiketiniz kaldırılır."
 
 #. Translators: use the date *when you are translating*, in a language-appropriate format.
 #: TWLight/users/templates/users/terms.html:33
@@ -3409,37 +2673,13 @@ msgstr "Vikipedi Kütüphane Kartı Kullanım Koşulları ve Gizlilik Bildirimi"
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:51
-msgid ""
-"<a class=\"twl-links\" href=\"https://meta.wikimedia.org/wiki/"
-"The_Wikipedia_Library\"> The Wikipedia Library </a> has partnered with "
-"publishers around the world to allow users to access otherwise paywalled "
-"resources. This website allows Wikipedia editors to search and access these "
-"resources."
-msgstr ""
-"<a class=\"twl-links\" href=\"https://meta.wikimedia.org/wiki/"
-"The_Wikipedia_Library\">Vikipedi Kütüphanesi</a>, kullanıcıların ödemeli "
-"kaynaklara erişmeni sağlamak için dünya çapındaki yayıncılarla ortaklık "
-"kurmaktadır. Bu web sitesi, Vikipedi editörlerinin bu kaynakları aramasına "
-"ve bu kaynaklara erişmesine izin verir."
+msgid "<a class=\"twl-links\" href=\"https://meta.wikimedia.org/wiki/The_Wikipedia_Library\"> The Wikipedia Library </a> has partnered with publishers around the world to allow users to access otherwise paywalled resources. This website allows Wikipedia editors to search and access these resources."
+msgstr "<a class=\"twl-links\" href=\"https://meta.wikimedia.org/wiki/The_Wikipedia_Library\">Vikipedi Kütüphanesi</a>, kullanıcıların ödemeli kaynaklara erişmeni sağlamak için dünya çapındaki yayıncılarla ortaklık kurmaktadır. Bu web sitesi, Vikipedi editörlerinin bu kaynakları aramasına ve bu kaynaklara erişmesine izin verir."
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Wikimedia Foundation should not be translated. WMF should not be translated. Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:63
-msgid ""
-"This program is administered by the Wikimedia Foundation (WMF). These terms "
-"of use and privacy notice pertain to your application for access to "
-"resources through the Wikipedia Library, your use of this website, and your "
-"access to and use of those resources. They also describe our handling of the "
-"information you provide to us in order to create and administer your "
-"Wikipedia Library account. If we make material changes to the terms, we will "
-"notify users."
-msgstr ""
-"Bu program, Wikimedia Vakfı (WMF) tarafından yönetilmektedir. Bu kullanım "
-"koşulları ve gizlilik bildirimi; Vikipedi Kütüphanesi aracılığıyla "
-"kaynaklara erişim, bu web sitesini kullanımınız ve bu kaynaklara erişiminiz "
-"ve bu kaynaklara erişiminiz için geçerlidir. Ayrıca, Vikipedi Kütüphane "
-"hesabınızı oluşturmak ve yönetmek için bize sağladığınız bilgileri ele "
-"almamızı da açıklarlar. Şartlarda önemli değişiklikler yaparsak "
-"kullanıcıları bilgilendiririz."
+msgid "This program is administered by the Wikimedia Foundation (WMF). These terms of use and privacy notice pertain to your application for access to resources through the Wikipedia Library, your use of this website, and your access to and use of those resources. They also describe our handling of the information you provide to us in order to create and administer your Wikipedia Library account. If we make material changes to the terms, we will notify users."
+msgstr "Bu program, Wikimedia Vakfı (WMF) tarafından yönetilmektedir. Bu kullanım koşulları ve gizlilik bildirimi; Vikipedi Kütüphanesi aracılığıyla kaynaklara erişim, bu web sitesini kullanımınız ve bu kaynaklara erişiminiz ve bu kaynaklara erişiminiz için geçerlidir. Ayrıca, Vikipedi Kütüphane hesabınızı oluşturmak ve yönetmek için bize sağladığınız bilgileri ele almamızı da açıklarlar. Şartlarda önemli değişiklikler yaparsak kullanıcıları bilgilendiririz."
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:74
@@ -3448,58 +2688,18 @@ msgstr "Vikipedi Kütüphanesi Kart Hesabı Gereksinimleri"
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:78
-msgid ""
-"Access to resources via The Wikipedia Library is reserved for community "
-"members who have demonstrated their commitment to the Wikimedia projects, "
-"and who will use their access to these resources to improve project content. "
-"To that end, in order to be eligible for The Wikipedia Library, we require "
-"that you be registered for a user account on the projects, with at least 500 "
-"edits, six (6) months of activity, and 10+ edits in the last month. We ask "
-"that you do not request access to any publishers with a limited number of "
-"available accounts whose resources you can already access for free through "
-"your local library or university, or another institution or organization, in "
-"order to provide that opportunity to others."
-msgstr ""
-"Vikipedi Kütüphanesi aracılığıyla kaynaklara erişim, Wikimedia projelerine "
-"bağlılıklarını gösteren ve bu kaynaklara erişimlerini proje içeriğini "
-"geliştirmek için kullanacak olan topluluk üyelerine ayrılmıştır. Bu amaçla, "
-"Vikipedi Kütüphanesi'nden yararlanabilmek için projelerde en az 500 "
-"düzenleme, altı (6) aylık etkinlik ve geçen ay 10'dan fazla düzenlemeye "
-"sahip olmanız gerekmektedir. Yerel kütüphaneniz veya üniversiteniz veya "
-"başka bir kurum veya kuruluş aracılığıyla kaynaklarına halihâzırda ücretsiz "
-"olarak erişebileceğiniz sınırlı sayıda kullanılabilir hesabı olan hiçbir "
-"yayıncıya, başkalarına bu fırsatı sağlamak için erişim talebinde "
-"bulunmamanızı rica ederiz."
+msgid "Access to resources via The Wikipedia Library is reserved for community members who have demonstrated their commitment to the Wikimedia projects, and who will use their access to these resources to improve project content. To that end, in order to be eligible for The Wikipedia Library, we require that you be registered for a user account on the projects, with at least 500 edits, six (6) months of activity, and 10+ edits in the last month. We ask that you do not request access to any publishers with a limited number of available accounts whose resources you can already access for free through your local library or university, or another institution or organization, in order to provide that opportunity to others."
+msgstr "Vikipedi Kütüphanesi aracılığıyla kaynaklara erişim, Wikimedia projelerine bağlılıklarını gösteren ve bu kaynaklara erişimlerini proje içeriğini geliştirmek için kullanacak olan topluluk üyelerine ayrılmıştır. Bu amaçla, Vikipedi Kütüphanesi'nden yararlanabilmek için projelerde en az 500 düzenleme, altı (6) aylık etkinlik ve geçen ay 10'dan fazla düzenlemeye sahip olmanız gerekmektedir. Yerel kütüphaneniz veya üniversiteniz veya başka bir kurum veya kuruluş aracılığıyla kaynaklarına halihâzırda ücretsiz olarak erişebileceğiniz sınırlı sayıda kullanılabilir hesabı olan hiçbir yayıncıya, başkalarına bu fırsatı sağlamak için erişim talebinde bulunmamanızı rica ederiz."
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:94
-msgid ""
-"Additionally, if you are currently blocked or banned from a Wikimedia "
-"project, applications to resources may be rejected or restricted. If you "
-"obtain a Wikipedia Library account, but a block or ban is subsequently "
-"instituted against you on one of the projects, you may lose access to your "
-"Wikipedia Library account."
-msgstr ""
-"Ek olarak şu anda bir Wikimedia projesinden engellenmiş veya "
-"yasaklanmışsanız kaynaklara yapılan başvurular reddedilebilir veya "
-"kısıtlanabilir. Bir Vikipedi Kütüphanesi hesabı edinirseniz ve projelerden "
-"birinde akabinde aleyhinize bir engelleme veya yasaklama uygulanırsa "
-"Vikipedi Kütüphanesi hesabınıza erişiminizi kaybedebilirsiniz."
+msgid "Additionally, if you are currently blocked or banned from a Wikimedia project, applications to resources may be rejected or restricted. If you obtain a Wikipedia Library account, but a block or ban is subsequently instituted against you on one of the projects, you may lose access to your Wikipedia Library account."
+msgstr "Ek olarak şu anda bir Wikimedia projesinden engellenmiş veya yasaklanmışsanız kaynaklara yapılan başvurular reddedilebilir veya kısıtlanabilir. Bir Vikipedi Kütüphanesi hesabı edinirseniz ve projelerden birinde akabinde aleyhinize bir engelleme veya yasaklama uygulanırsa Vikipedi Kütüphanesi hesabınıza erişiminizi kaybedebilirsiniz."
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:104
-msgid ""
-"Your eligibility to access The Wikipedia Library is assessed at each login. "
-"While more than half of the library's content is provided via this automated "
-"eligibility check, access to other publisher's content may be time limited, "
-"typically lapsing after one year, after which you will usually need to apply "
-"for renewal."
-msgstr ""
-"Vikipedi Kütüphanesi'ne erişim hakkınız, her girişte yeniden "
-"değerlendirilir. Kütüphane içeriğinin yarısından fazlası bu otomatik "
-"uygunluk kontrolü yoluyla sağlanırken diğer yayıncıların içeriğine erişim "
-"zaman sınırlı olabilir ki bu erişim, genellikle bir yıl sonra sona erer ve "
-"sonrasında genellikle yenileme için yeniden başvurmanız gerekir."
+msgid "Your eligibility to access The Wikipedia Library is assessed at each login. While more than half of the library's content is provided via this automated eligibility check, access to other publisher's content may be time limited, typically lapsing after one year, after which you will usually need to apply for renewal."
+msgstr "Vikipedi Kütüphanesi'ne erişim hakkınız, her girişte yeniden değerlendirilir. Kütüphane içeriğinin yarısından fazlası bu otomatik uygunluk kontrolü yoluyla sağlanırken diğer yayıncıların içeriğine erişim zaman sınırlı olabilir ki bu erişim, genellikle bir yıl sonra sona erer ve sonrasında genellikle yenileme için yeniden başvurmanız gerekir."
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:114
@@ -3508,68 +2708,28 @@ msgstr "Vikipedi Kütüphane Kartı Hesabınız ile Başvuru"
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:118
-msgid ""
-"In order to apply for access to a partner resource, you must provide us with "
-"certain information, which we will use to evaluate your application. If your "
-"application is approved, we may transfer the information you have given us "
-"to the publishers whose resources you wish to access. They will either "
-"contact you with the account information directly or we will send access "
-"information to you ourselves."
-msgstr ""
-"Bir iş ortağı kaynağına erişim başvurusunda bulunmak için, başvurunuzu "
-"değerlendirmek için kullanacağımız bazı bilgileri bize sağlamalısınız. "
-"Başvurunuz onaylanırsa bize verdiğiniz bilgileri kaynaklarına erişmek "
-"istediğiniz yayıncılara aktarabiliriz. Ya sizinle doğrudan hesap "
-"bilgileriyle bağlantı kuracaklar ya da size erişim bilgisini kendimiz "
-"göndereceğiz."
+msgid "In order to apply for access to a partner resource, you must provide us with certain information, which we will use to evaluate your application. If your application is approved, we may transfer the information you have given us to the publishers whose resources you wish to access. They will either contact you with the account information directly or we will send access information to you ourselves."
+msgstr "Bir iş ortağı kaynağına erişim başvurusunda bulunmak için, başvurunuzu değerlendirmek için kullanacağımız bazı bilgileri bize sağlamalısınız. Başvurunuz onaylanırsa bize verdiğiniz bilgileri kaynaklarına erişmek istediğiniz yayıncılara aktarabiliriz. Ya sizinle doğrudan hesap bilgileriyle bağlantı kuracaklar ya da size erişim bilgisini kendimiz göndereceğiz."
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:130
-msgid ""
-"In addition to the basic information you provide to us, our system will "
-"retrieve some information directly from the Wikimedia projects: your "
-"username, email address, edit count, registration date, user ID number, "
-"groups to which you belong, and any special user rights."
-msgstr ""
-"Bize sağladığınız temel bilgilere ek olarak, sistemimiz doğrudan Wikimedia "
-"projelerinden bazı bilgiler alacaktır: kullanıcı adınız, e-posta adresiniz, "
-"düzenleme sayınız, kayıt tarihiniz, kullanıcı kimliği numaranız, ait "
-"olduğunuz gruplar ve özel kullanıcı hakları."
+msgid "In addition to the basic information you provide to us, our system will retrieve some information directly from the Wikimedia projects: your username, email address, edit count, registration date, user ID number, groups to which you belong, and any special user rights."
+msgstr "Bize sağladığınız temel bilgilere ek olarak, sistemimiz doğrudan Wikimedia projelerinden bazı bilgiler alacaktır: kullanıcı adınız, e-posta adresiniz, düzenleme sayınız, kayıt tarihiniz, kullanıcı kimliği numaranız, ait olduğunuz gruplar ve özel kullanıcı hakları."
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:140
-msgid ""
-"Each time you log in to the Wikipedia Library Card Platform, this "
-"information will be automatically updated."
-msgstr ""
-"Vikipedi Kütüphane Kartı Platformu'na her giriş yaptığınızda, bu bilgiler "
-"otomatik olarak güncellenecektir."
+msgid "Each time you log in to the Wikipedia Library Card Platform, this information will be automatically updated."
+msgstr "Vikipedi Kütüphane Kartı Platformu'na her giriş yaptığınızda, bu bilgiler otomatik olarak güncellenecektir."
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:148
-msgid ""
-"We will ask you to provide us with some information about your history of "
-"contributions to the Wikimedia projects. Information on contribution history "
-"is optional, but will greatly assist us in evaluating your application."
-msgstr ""
-"Sizden, Wikimedia projelerine yaptığınız katkıların geçmişi hakkında bize "
-"biraz bilgi vermenizi isteyeceğiz. Katkı geçmişi hakkında bilgi isteğe "
-"bağlıdır, ancak başvurunuzu değerlendirmede bize çok yardımcı olacaktır."
+msgid "We will ask you to provide us with some information about your history of contributions to the Wikimedia projects. Information on contribution history is optional, but will greatly assist us in evaluating your application."
+msgstr "Sizden, Wikimedia projelerine yaptığınız katkıların geçmişi hakkında bize biraz bilgi vermenizi isteyeceğiz. Katkı geçmişi hakkında bilgi isteğe bağlıdır, ancak başvurunuzu değerlendirmede bize çok yardımcı olacaktır."
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). WMF should not be translated. Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:157
-msgid ""
-"The information you provide when creating your account will be visible to "
-"you while on the site but not to others unless they are approved Wikipedia "
-"Library Coordinators, WMF Staff, or WMF Contractors who need access to this "
-"data in order to carry out their work with the Wikipedia Library, all of "
-"whom are subject to non-disclosure obligations."
-msgstr ""
-"Hesabınızı oluştururken sağladığınız bilgiler sitedeyken size görünür olacak "
-"ancak onaylı Vikipedi Kütüphanesi Koordinatörleri, WMF Personeli veya WMF "
-"Yüklenicileri ile çalışmalarını yürütmek için bu verilere erişmesi gereken "
-"WMF Yüklenicileri olmadıkça başkaları tarafından görülemeyecek. Tamamı ifşa "
-"etmeme yükümlülüğüne tabi olan Wikipedia Kütüphanesi."
+msgid "The information you provide when creating your account will be visible to you while on the site but not to others unless they are approved Wikipedia Library Coordinators, WMF Staff, or WMF Contractors who need access to this data in order to carry out their work with the Wikipedia Library, all of whom are subject to non-disclosure obligations."
+msgstr "Hesabınızı oluştururken sağladığınız bilgiler sitedeyken size görünür olacak ancak onaylı Vikipedi Kütüphanesi Koordinatörleri, WMF Personeli veya WMF Yüklenicileri ile çalışmalarını yürütmek için bu verilere erişmesi gereken WMF Yüklenicileri olmadıkça başkaları tarafından görülemeyecek. Tamamı ifşa etmeme yükümlülüğüne tabi olan Wikipedia Kütüphanesi."
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:167
@@ -3578,61 +2738,33 @@ msgstr "Yayıncı Kaynaklarını Kullanım Durumunuz"
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:171
-msgid ""
-"In order to access an individual publisher’s resources, you must agree to "
-"that publisher’s terms of use and privacy policy. You agree that you will "
-"not violate such terms and policies in connection with your use of the "
-"Wikipedia Library. Additionally, the following activities are prohibited "
-"while accessing publisher resources through the Wikipedia Library."
-msgstr ""
-"Tek bir yayıncının kaynaklarına erişmek için o yayıncının kullanım "
-"şartlarını ve gizlilik politikasını kabul etmelisiniz. Vikipedi "
-"Kütüphanesini kullanımınızla bağlantılı olarak bu hüküm ve politikaları "
-"ihlal etmeyeceğinizi kabul edersiniz. Ayrıca, Vikipedi Kütüphanesi üzerinden "
-"yayıncı kaynaklarına erişirken aşağıdaki faaliyetler yasaktır."
+msgid "In order to access an individual publisher’s resources, you must agree to that publisher’s terms of use and privacy policy. You agree that you will not violate such terms and policies in connection with your use of the Wikipedia Library. Additionally, the following activities are prohibited while accessing publisher resources through the Wikipedia Library."
+msgstr "Tek bir yayıncının kaynaklarına erişmek için o yayıncının kullanım şartlarını ve gizlilik politikasını kabul etmelisiniz. Vikipedi Kütüphanesini kullanımınızla bağlantılı olarak bu hüküm ve politikaları ihlal etmeyeceğinizi kabul edersiniz. Ayrıca, Vikipedi Kütüphanesi üzerinden yayıncı kaynaklarına erişirken aşağıdaki faaliyetler yasaktır."
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:184
-msgid ""
-"Sharing your Wikipedia account, usernames, passwords, or any access codes "
-"for publisher resources with others;"
-msgstr ""
-"Vikipedi hesabınızı, kullanıcı adlarınızı, şifrelerinizi veya yayıncı "
-"kaynakları için herhangi bir erişim kodunuzu başkalarıyla paylaşmak;"
+msgid "Sharing your Wikipedia account, usernames, passwords, or any access codes for publisher resources with others;"
+msgstr "Vikipedi hesabınızı, kullanıcı adlarınızı, şifrelerinizi veya yayıncı kaynakları için herhangi bir erişim kodunuzu başkalarıyla paylaşmak;"
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:191
-msgid ""
-"Automatically scraping or downloading restricted content from publishers;"
-msgstr ""
-"Kısıtlanmış içeriği yayıncılardan otomatik olarak kazımak veya indirmek;"
+msgid "Automatically scraping or downloading restricted content from publishers;"
+msgstr "Kısıtlanmış içeriği yayıncılardan otomatik olarak kazımak veya indirmek;"
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:197
-msgid ""
-"Systematically making printed or electronic copies of multiple extracts of "
-"restricted content available for any purpose;"
-msgstr ""
-"Herhangi bir amaç için kısıtlanmış içeriğin birden fazla bölümünün basılı "
-"veya elektronik kopyalarının sistematik olarak sunulması;"
+msgid "Systematically making printed or electronic copies of multiple extracts of restricted content available for any purpose;"
+msgstr "Herhangi bir amaç için kısıtlanmış içeriğin birden fazla bölümünün basılı veya elektronik kopyalarının sistematik olarak sunulması;"
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:204
-msgid ""
-"Data mining metadata without permission—for example, in order to use "
-"metadata for auto-created stub articles;"
-msgstr ""
-"İzinsiz veri madenciliği meta verileri. Örneğin, otomatik oluşturulan taslak "
-"maddeler için meta verileri kullanmak amacıyla;"
+msgid "Data mining metadata without permission—for example, in order to use metadata for auto-created stub articles;"
+msgstr "İzinsiz veri madenciliği meta verileri. Örneğin, otomatik oluşturulan taslak maddeler için meta verileri kullanmak amacıyla;"
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:211
-msgid ""
-"Using the access you receive through the Wikipedia Library for profit by "
-"selling access to your account or resources which you have through it."
-msgstr ""
-"Hesabınıza veya sahip olduğunuz kaynaklara erişim satarak, Vikipedi "
-"Kütüphanesi'nden aldığınız erişimi kar için kullanın."
+msgid "Using the access you receive through the Wikipedia Library for profit by selling access to your account or resources which you have through it."
+msgstr "Hesabınıza veya sahip olduğunuz kaynaklara erişim satarak, Vikipedi Kütüphanesi'nden aldığınız erişimi kar için kullanın."
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:220
@@ -3641,25 +2773,13 @@ msgstr "Harici Arama ve Proxy Hizmetleri"
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:224
-msgid ""
-"Certain resources may only be accessed using an external search service, "
-"such as the EBSCO Discovery Service, or a proxy service, such as OCLC "
-"EZProxy. If you use such external search and/or proxy services, please "
-"review the applicable terms of use and privacy policies."
-msgstr ""
-"Bazı kaynaklara yalnızca EBSCO Keşif Servisi gibi harici bir arama servisi "
-"veya OCLC EZProxy gibi bir proxy servisi kullanılarak erişilebilir. Bu tür "
-"harici arama ve/veya proxy servislerini kullanıyorsanız, lütfen geçerli "
-"kullanım koşullarını ve gizlilik politikalarını gözden geçirin."
+msgid "Certain resources may only be accessed using an external search service, such as the EBSCO Discovery Service, or a proxy service, such as OCLC EZProxy. If you use such external search and/or proxy services, please review the applicable terms of use and privacy policies."
+msgstr "Bazı kaynaklara yalnızca EBSCO Keşif Servisi gibi harici bir arama servisi veya OCLC EZProxy gibi bir proxy servisi kullanılarak erişilebilir. Bu tür harici arama ve/veya proxy servislerini kullanıyorsanız, lütfen geçerli kullanım koşullarını ve gizlilik politikalarını gözden geçirin."
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:234
-msgid ""
-"In addition, if you use OCLC EZProxy, please note that you may not use it "
-"for commercial purposes."
-msgstr ""
-"Ek olarak, OCLC EZProxy kullanıyorsanız, lütfen ticari amaçlarla "
-"kullanamayabileceğinizi unutmayın."
+msgid "In addition, if you use OCLC EZProxy, please note that you may not use it for commercial purposes."
+msgstr "Ek olarak, OCLC EZProxy kullanıyorsanız, lütfen ticari amaçlarla kullanamayabileceğinizi unutmayın."
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:241
@@ -3669,195 +2789,51 @@ msgstr "Veri Saklama ve İşleme"
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Wikimedia Foundation should not be translated. Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:245
 #, fuzzy
-msgid ""
-"The Wikimedia Foundation and our service providers use your information for "
-"the legitimate purpose of providing Wikipedia Library services in support of "
-"our charitable mission. When you apply for a Wikipedia Library account, or "
-"use your Wikipedia Library account, we may routinely collect the following "
-"information: your username, email address, edit count, registration date, "
-"user ID number, groups to which you belong, and any special user rights; "
-"your name, country of residence, and/or affiliation, if required by a "
-"partner to which you are applying; your narrative description of your "
-"contributions and reasons for applying for access to partner resources; and "
-"the date you agree to these terms of use."
-msgstr ""
-"Wikimedia Vakfı ve hizmet sağlayıcılarımız, bilgilerinizi, Vikipedi'deki "
-"hizmetlerimizi, yasal misyonumuzu desteklemek için meşru bir amaç için "
-"kullanırlar. Bir Vikipedi Kütüphanesi hesabına başvurduğunuzda veya Vikipedi "
-"Kütüphanesi hesabınızı kullanırken, rutin olarak aşağıdaki bilgileri "
-"toplayabiliriz: kullanıcı adınız, e-posta adresiniz, düzenleme sayısını, "
-"kayıt tarihini, kullanıcı kimliği numaranızı, ait olduğunuz grupları ve "
-"herhangi bir özel kullanıcıyı Haklar; başvuruda bulunacağınız bir ortak "
-"tarafından talep edilmesi halinde adınız, ikamet ettiğiniz ülke, mesleğiniz "
-"ve/veya bağlılığınız; ortak kaynaklara erişim için başvuruda bulunma "
-"konusundaki katkılarınız ve sebepleriniz hakkındaki açıklamalarınızı; ve bu "
-"kullanım şartlarını kabul ettiğiniz tarih."
+msgid "The Wikimedia Foundation and our service providers use your information for the legitimate purpose of providing Wikipedia Library services in support of our charitable mission. When you apply for a Wikipedia Library account, or use your Wikipedia Library account, we may routinely collect the following information: your username, email address, edit count, registration date, user ID number, groups to which you belong, and any special user rights; your name, country of residence, and/or affiliation, if required by a partner to which you are applying; your narrative description of your contributions and reasons for applying for access to partner resources; and the date you agree to these terms of use."
+msgstr "Wikimedia Vakfı ve hizmet sağlayıcılarımız, bilgilerinizi, Vikipedi'deki hizmetlerimizi, yasal misyonumuzu desteklemek için meşru bir amaç için kullanırlar. Bir Vikipedi Kütüphanesi hesabına başvurduğunuzda veya Vikipedi Kütüphanesi hesabınızı kullanırken, rutin olarak aşağıdaki bilgileri toplayabiliriz: kullanıcı adınız, e-posta adresiniz, düzenleme sayısını, kayıt tarihini, kullanıcı kimliği numaranızı, ait olduğunuz grupları ve herhangi bir özel kullanıcıyı Haklar; başvuruda bulunacağınız bir ortak tarafından talep edilmesi halinde adınız, ikamet ettiğiniz ülke, mesleğiniz ve/veya bağlılığınız; ortak kaynaklara erişim için başvuruda bulunma konusundaki katkılarınız ve sebepleriniz hakkındaki açıklamalarınızı; ve bu kullanım şartlarını kabul ettiğiniz tarih."
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:262
 #, fuzzy, python-format
-msgid ""
-"Each publisher who is a member of the Wikipedia Library program requires "
-"different specific information in the application. Some publishers may "
-"request only an email address, while others request more detailed data, such "
-"as your name, location, or institutional affiliation. When you complete your "
-"application, you will only be asked to supply information required by the "
-"publishers you have chosen, and each publisher will only receive the "
-"information they require for providing you with access. Please see our <a "
-"class=\"twl-links\" href=\"%(all_partners_url)s\">partner information</a> "
-"pages to learn what information is required by each publisher to gain access "
-"to their resources."
-msgstr ""
-"Vikipedi Kütüphanesi programına üye olan her yayıncı, başvuruda farklı özel "
-"bilgiler gerektirir. Bazı yayıncılar yalnızca bir e-posta adresi "
-"isteyebilir, bazıları ise adınız, yeriniz, mesleğiniz veya kurumsal "
-"bağlılığınız gibi daha ayrıntılı veriler ister. Başvurunuzu "
-"tamamladığınızda, yalnızca seçtiğiniz yayıncıların istediği bilgileri "
-"sağlamanız istenecek ve her yayıncı yalnızca size erişim sağlamak için "
-"ihtiyaç duydukları bilgileri alacaktır. Her yayıncının kaynaklarına erişmek "
-"için hangi bilgilerin gerekli olduğunu öğrenmek için lütfen <a class=\"twl-"
-"links\" href=\"%(all_partners_url)s\">ortak bilgileri</a> sayfalarımıza "
-"bakın."
+msgid "Each publisher who is a member of the Wikipedia Library program requires different specific information in the application. Some publishers may request only an email address, while others request more detailed data, such as your name, location, or institutional affiliation. When you complete your application, you will only be asked to supply information required by the publishers you have chosen, and each publisher will only receive the information they require for providing you with access. Please see our <a class=\"twl-links\" href=\"%(all_partners_url)s\">partner information</a> pages to learn what information is required by each publisher to gain access to their resources."
+msgstr "Vikipedi Kütüphanesi programına üye olan her yayıncı, başvuruda farklı özel bilgiler gerektirir. Bazı yayıncılar yalnızca bir e-posta adresi isteyebilir, bazıları ise adınız, yeriniz, mesleğiniz veya kurumsal bağlılığınız gibi daha ayrıntılı veriler ister. Başvurunuzu tamamladığınızda, yalnızca seçtiğiniz yayıncıların istediği bilgileri sağlamanız istenecek ve her yayıncı yalnızca size erişim sağlamak için ihtiyaç duydukları bilgileri alacaktır. Her yayıncının kaynaklarına erişmek için hangi bilgilerin gerekli olduğunu öğrenmek için lütfen <a class=\"twl-links\" href=\"%(all_partners_url)s\">ortak bilgileri</a> sayfalarımıza bakın."
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Wikimedia Foundation should not be translated. Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:277
-msgid ""
-"Some Wikipedia Library pages are visible without logging in, but you will "
-"need to log in to apply or access proprietary partner resources. We use the "
-"data provided by you via OAuth and Wikimedia API calls to assess your "
-"application for access and to process approved requests."
-msgstr ""
-"Giriş yapmadan bazı Vikipedi Kütüphanesi sayfalarına giriş yapmadan da göz "
-"atabilirsiniz ancak tescilli ortak kaynaklarına başvurmak veya erişmek için "
-"giriş yapmanız gerekir. Sizin tarafınızdan sağlanan verileri, erişim "
-"başvurunuzu değerlendirmek ve onaylanan talepleri işleme koymak için OAuth "
-"ve Wikimedia API çağrıları aracılığıyla kullanırız."
+msgid "Some Wikipedia Library pages are visible without logging in, but you will need to log in to apply or access proprietary partner resources. We use the data provided by you via OAuth and Wikimedia API calls to assess your application for access and to process approved requests."
+msgstr "Giriş yapmadan bazı Vikipedi Kütüphanesi sayfalarına giriş yapmadan da göz atabilirsiniz ancak tescilli ortak kaynaklarına başvurmak veya erişmek için giriş yapmanız gerekir. Sizin tarafınızdan sağlanan verileri, erişim başvurunuzu değerlendirmek ve onaylanan talepleri işleme koymak için OAuth ve Wikimedia API çağrıları aracılığıyla kullanırız."
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:288
 #, python-format
-msgid ""
-"In order to administer the Wikipedia Library program, we will retain the "
-"application data we collect from you for three years after your most recent "
-"login, unless you delete your account, as described below. You can log in "
-"and go to <a class=\"twl-links\" href=\"%(profile_url)s\">your profile page</"
-"a> in order to see the information associated with your account, and can "
-"download it in JSON format. You may access, update, restrict, or delete this "
-"information at any time, except for the information that is automatically "
-"retrieved from the projects. If you have any questions or concerns about the "
-"handling of your data, please contact <a class=\"twl-links\" href=\"mailto:"
-"wikipedialibrary@wikimedia.org?Subject=Wikipedia%%20Library%%20Card"
-"%%20account%%20deactivation\"> wikipedialibrary@wikimedia.org </a>."
-msgstr ""
-"Vikipedi Kütüphanesi programını yönetmek için, hesabınızı silmediğiniz "
-"sürece, en son girişinizden sonra üç yıl boyunca sizden topladığımız "
-"uygulama verilerini aşağıda açıklandığı gibi tutacağız. Hesabınızla ilgili "
-"bilgileri görmek için giriş yapabilir ve hesabınızla ilişkili bilgileri "
-"görmek için <a class=\"twl-links\" href=\"%(profile_url)s\">profil "
-"sayfanıza</a> gidebilir ve JSON formatında indirebilirsiniz. Projelerden "
-"otomatik olarak alınan bilgiler dışında, bu bilgilere istediğiniz zaman "
-"erişebilir, güncelleyebilir, kısıtlayabilir veya <a class=\"twl-links\" href="
-"\"mailto:wikipedialibrary@wikimedia.org?Subject=Wikipedia%%20Library%%20Card"
-"%%20account%%20deactivation\"> wikipedialibrary@wikimedia.org </a> ile "
-"iletişime geçin."
+msgid "In order to administer the Wikipedia Library program, we will retain the application data we collect from you for three years after your most recent login, unless you delete your account, as described below. You can log in and go to <a class=\"twl-links\" href=\"%(profile_url)s\">your profile page</a> in order to see the information associated with your account, and can download it in JSON format. You may access, update, restrict, or delete this information at any time, except for the information that is automatically retrieved from the projects. If you have any questions or concerns about the handling of your data, please contact <a class=\"twl-links\" href=\"mailto:wikipedialibrary@wikimedia.org?Subject=Wikipedia%%20Library%%20Card%%20account%%20deactivation\"> wikipedialibrary@wikimedia.org </a>."
+msgstr "Vikipedi Kütüphanesi programını yönetmek için, hesabınızı silmediğiniz sürece, en son girişinizden sonra üç yıl boyunca sizden topladığımız uygulama verilerini aşağıda açıklandığı gibi tutacağız. Hesabınızla ilgili bilgileri görmek için giriş yapabilir ve hesabınızla ilişkili bilgileri görmek için <a class=\"twl-links\" href=\"%(profile_url)s\">profil sayfanıza</a> gidebilir ve JSON formatında indirebilirsiniz. Projelerden otomatik olarak alınan bilgiler dışında, bu bilgilere istediğiniz zaman erişebilir, güncelleyebilir, kısıtlayabilir veya <a class=\"twl-links\" href=\"mailto:wikipedialibrary@wikimedia.org?Subject=Wikipedia%%20Library%%20Card%%20account%%20deactivation\"> wikipedialibrary@wikimedia.org </a> ile iletişime geçin."
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:305
 #, fuzzy
-msgid ""
-"If you decide to disable your Wikipedia Library account, you can use the "
-"delete button on your profile to delete certain personal information "
-"associated with your account. We will delete your real name, institutional "
-"affiliation, and country of residence. Please note that the system will "
-"retain a record of your username, the publishers to which you applied or had "
-"access, and the dates of that access. Note that deletion is not reversible. "
-"Deletion of your Wikipedia Library account may also correspond with the "
-"removal of any resource access to which you were eligible or approved. If "
-"you request the deletion of account information and later wish to apply for "
-"a new account, you will need to provide the necessary information again."
-msgstr ""
-"Vikipedi Kütüphanesi hesabınızı devre dışı bırakmaya karar verirseniz, "
-"hesabınızla ilişkili bazı kişisel bilgileri silmek için profilinizdeki sil "
-"düğmesini kullanabilirsiniz. Gerçek adınızı, mesleğinizi, kurumsal "
-"bağlantınızı ve ikamet ettiğiniz ülkeyi sileceğiz. Sistemin kullanıcı "
-"adınızın, başvurduğunuz veya erişiminiz olan yayıncıların ve bu erişim "
-"tarihlerinin bir kaydını tutacağını lütfen unutmayın. Silme işleminin geri "
-"alınamaz olduğunu unutmayın. Vikipedi Kütüphanesi hesabınızın silinmesi, "
-"uygun veya onaylanmış olduğunuz kaynak erişiminin kaldırılmasına da karşılık "
-"gelebilir. Hesap bilgilerinin silinmesini talep ederseniz ve daha sonra yeni "
-"bir hesaba başvurmak isterseniz, gerekli bilgileri tekrar sağlamanız gerekir."
+msgid "If you decide to disable your Wikipedia Library account, you can use the delete button on your profile to delete certain personal information associated with your account. We will delete your real name, institutional affiliation, and country of residence. Please note that the system will retain a record of your username, the publishers to which you applied or had access, and the dates of that access. Note that deletion is not reversible. Deletion of your Wikipedia Library account may also correspond with the removal of any resource access to which you were eligible or approved. If you request the deletion of account information and later wish to apply for a new account, you will need to provide the necessary information again."
+msgstr "Vikipedi Kütüphanesi hesabınızı devre dışı bırakmaya karar verirseniz, hesabınızla ilişkili bazı kişisel bilgileri silmek için profilinizdeki sil düğmesini kullanabilirsiniz. Gerçek adınızı, mesleğinizi, kurumsal bağlantınızı ve ikamet ettiğiniz ülkeyi sileceğiz. Sistemin kullanıcı adınızın, başvurduğunuz veya erişiminiz olan yayıncıların ve bu erişim tarihlerinin bir kaydını tutacağını lütfen unutmayın. Silme işleminin geri alınamaz olduğunu unutmayın. Vikipedi Kütüphanesi hesabınızın silinmesi, uygun veya onaylanmış olduğunuz kaynak erişiminin kaldırılmasına da karşılık gelebilir. Hesap bilgilerinin silinmesini talep ederseniz ve daha sonra yeni bir hesaba başvurmak isterseniz, gerekli bilgileri tekrar sağlamanız gerekir."
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). WMF should not be translated. Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:321
-msgid ""
-"The Wikipedia Library is run by WMF Staff, Contractors, and approved "
-"volunteer Coordinators. The data associated with your account will be shared "
-"with the WMF staff, contractors, service providers, and volunteer "
-"coordinators who need to process the information in connection with their "
-"work for the Wikipedia Library, and who are subject to confidentiality "
-"obligations. We will also use your data for internal Wikipedia Library "
-"purposes such as distributing user surveys and account notifications, and in "
-"a depersonalized or aggregated fashion for statistical analysis and "
-"administration. Finally, we will share your information with the publishers "
-"whom you specifically select in order to provide you with access to "
-"resources. Otherwise, your information will not be shared with third "
-"parties, with the exception of the circumstances described below."
-msgstr ""
-"Vikipedi Kütüphanesi WMF Ekibi, Yükleniciler ve onaylı gönüllü "
-"Koordinatörleri tarafından yönetilmektedir. Hesabınızla ilişkili veriler, "
-"Vikipedi Kütüphanesi ile ilgili çalışmaları ile ilgili bilgileri işlemesi "
-"gereken ve gizlilik yükümlülüklerine tabi olan WMF personeli, yükleniciler, "
-"servis sağlayıcılar ve gönüllü koordinatörlerle paylaşılacaktır. "
-"Verilerinizi ayrıca, kullanıcı anketlerini ve hesap bildirimlerini dağıtmak "
-"gibi iç Vikipedi Kütüphanesi amaçları için ve istatistiksel analiz ve "
-"yönetim için kişileşmemiş veya toplu bir şekilde kullanacağız. Son olarak, "
-"bilgilerinizi, kaynaklara erişim sağlamak için özel olarak seçtiğiniz "
-"yayıncılarla paylaşacağız. Aksi takdirde, bilgileriniz aşağıda açıklanan "
-"durumlar dışında üçüncü taraflarla paylaşılmayacaktır."
+msgid "The Wikipedia Library is run by WMF Staff, Contractors, and approved volunteer Coordinators. The data associated with your account will be shared with the WMF staff, contractors, service providers, and volunteer coordinators who need to process the information in connection with their work for the Wikipedia Library, and who are subject to confidentiality obligations. We will also use your data for internal Wikipedia Library purposes such as distributing user surveys and account notifications, and in a depersonalized or aggregated fashion for statistical analysis and administration. Finally, we will share your information with the publishers whom you specifically select in order to provide you with access to resources. Otherwise, your information will not be shared with third parties, with the exception of the circumstances described below."
+msgstr "Vikipedi Kütüphanesi WMF Ekibi, Yükleniciler ve onaylı gönüllü Koordinatörleri tarafından yönetilmektedir. Hesabınızla ilişkili veriler, Vikipedi Kütüphanesi ile ilgili çalışmaları ile ilgili bilgileri işlemesi gereken ve gizlilik yükümlülüklerine tabi olan WMF personeli, yükleniciler, servis sağlayıcılar ve gönüllü koordinatörlerle paylaşılacaktır. Verilerinizi ayrıca, kullanıcı anketlerini ve hesap bildirimlerini dağıtmak gibi iç Vikipedi Kütüphanesi amaçları için ve istatistiksel analiz ve yönetim için kişileşmemiş veya toplu bir şekilde kullanacağız. Son olarak, bilgilerinizi, kaynaklara erişim sağlamak için özel olarak seçtiğiniz yayıncılarla paylaşacağız. Aksi takdirde, bilgileriniz aşağıda açıklanan durumlar dışında üçüncü taraflarla paylaşılmayacaktır."
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). WMF should not be translated.
 #: TWLight/users/templates/users/terms.html:338
-msgid ""
-"We may disclose any collected information when required by law, when we have "
-"your permission, when needed to protect our rights, privacy, safety, users, "
-"or the general public, and when necessary to enforce these terms, WMF’s "
-"general <a class=\"twl-links\" href=\"https://foundation.wikimedia.org/wiki/"
-"Terms_of_Use\">Terms of Use</a>, or any other WMF policy."
-msgstr ""
-"Yasalar gereği, sizden izin aldığımızda haklarımızı, gizliliğimizi, "
-"güvenliğimizi, kullanıcılarımızı veya kamuoyunu korumak için gerektiğinde ve "
-"bu şartları uygulamak için <a class=\"twl-links\" href=\"https://foundation."
-"wikimedia.org/wiki/Terms_of_Use\">Kullanım Şartları</a> veya başka bir WMF "
-"politikası gerektiğinde WMF genelinin topladığı bilgileri ifşa edebiliriz."
+msgid "We may disclose any collected information when required by law, when we have your permission, when needed to protect our rights, privacy, safety, users, or the general public, and when necessary to enforce these terms, WMF’s general <a class=\"twl-links\" href=\"https://foundation.wikimedia.org/wiki/Terms_of_Use\">Terms of Use</a>, or any other WMF policy."
+msgstr "Yasalar gereği, sizden izin aldığımızda haklarımızı, gizliliğimizi, güvenliğimizi, kullanıcılarımızı veya kamuoyunu korumak için gerektiğinde ve bu şartları uygulamak için <a class=\"twl-links\" href=\"https://foundation.wikimedia.org/wiki/Terms_of_Use\">Kullanım Şartları</a> veya başka bir WMF politikası gerektiğinde WMF genelinin topladığı bilgileri ifşa edebiliriz."
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:349
-msgid ""
-"We take the security of your personal data seriously, and take reasonable "
-"precautions to ensure your data is protected. These precautions include "
-"access controls to limit who has access to your data and security "
-"technologies to protect data stored on the server. However, we cannot "
-"guarantee the safety of your data as it is transmitted and stored."
-msgstr ""
-"Kişisel verilerinizin güvenliğini ciddiye alıyor ve verilerinizin "
-"korunmasını sağlamak için makul önlemleri alıyoruz. Bu önlemler, sunucuda "
-"depolanan verileri korumak için verilerinize ve güvenlik teknolojilerinize "
-"kimin erişimi olduğunu sınırlamaya yönelik erişim denetimlerini içerir. "
-"Ancak, iletildiği ve depolandığı için verilerinizin güvenliğini garanti "
-"edemeyiz."
+msgid "We take the security of your personal data seriously, and take reasonable precautions to ensure your data is protected. These precautions include access controls to limit who has access to your data and security technologies to protect data stored on the server. However, we cannot guarantee the safety of your data as it is transmitted and stored."
+msgstr "Kişisel verilerinizin güvenliğini ciddiye alıyor ve verilerinizin korunmasını sağlamak için makul önlemleri alıyoruz. Bu önlemler, sunucuda depolanan verileri korumak için verilerinize ve güvenlik teknolojilerinize kimin erişimi olduğunu sınırlamaya yönelik erişim denetimlerini içerir. Ancak, iletildiği ve depolandığı için verilerinizin güvenliğini garanti edemeyiz."
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:360
-msgid ""
-"Please note that these terms do not control the use and handling of your "
-"data by the publishers and service providers whose resources you access or "
-"apply to access. Please read their individual privacy policies for that "
-"information."
-msgstr ""
-"Lütfen bu şartların, kaynaklarına eriştiğiniz veya erişmek için başvuruda "
-"bulunduğunuz yayıncılar ve servis sağlayıcılar tarafından verilerinizin "
-"kullanımını ve kullanılmasını kontrol etmediğini unutmayın. Lütfen bu bilgi "
-"için kişisel gizlilik politikalarını okuyun."
+msgid "Please note that these terms do not control the use and handling of your data by the publishers and service providers whose resources you access or apply to access. Please read their individual privacy policies for that information."
+msgstr "Lütfen bu şartların, kaynaklarına eriştiğiniz veya erişmek için başvuruda bulunduğunuz yayıncılar ve servis sağlayıcılar tarafından verilerinizin kullanımını ve kullanılmasını kontrol etmediğini unutmayın. Lütfen bu bilgi için kişisel gizlilik politikalarını okuyun."
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:368
@@ -3866,52 +2842,18 @@ msgstr "Önemli Not"
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Wikimedia Foundation should not be translated. Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:373
-msgid ""
-"The Wikimedia Foundation is a nonprofit organization based in San Francisco, "
-"California. The Wikipedia Library program provides access to resources held "
-"by publishers in multiple countries. If you apply for a Wikipedia Library "
-"account (whether you are inside or outside of the United States), you "
-"understand that your personal data will be collected, transferred, stored, "
-"processed, disclosed and otherwise used in the U.S. as described in this "
-"privacy policy. You also understand that your information may be transferred "
-"by us from the U.S. to other countries, which may have different or less "
-"stringent data protection laws than your country, in connection with "
-"providing services to you, including evaluating your application and "
-"securing access to your chosen publishers (locations for each publisher are "
-"outlined on their respective partner information pages)."
-msgstr ""
-"Wikimedia Vakfı, San Francisco, Kaliforniya merkezli kar amacı gütmeyen bir "
-"organizasyondur. Vikipedi Kütüphanesi programı, birçok ülkede yayıncılar "
-"tarafından tutulan kaynaklara erişim sağlar. Bir Vikipedi Kütüphanesi "
-"hesabına başvurursanız (ABD’nin içinde veya dışındaysanız), kişisel "
-"verilerinizin bu gizlilik politikasında tanımlandığı şekilde ABD’de "
-"toplanacağını, transfer edileceğini, saklanacağını, işleneceğini, "
-"açıklanacağını ve başka şekilde kullanılacağını anlıyorsunuz. Ayrıca, "
-"başvurunuzun değerlendirilmesi ve seçtiğinize erişimin sağlanması da dahil "
-"olmak üzere, bilgilerinizin ABD'den, ülkenizden farklı veya daha az katı "
-"veri koruma yasalarına sahip olabilecek diğer ülkelere aktarılabileceğini "
-"anlıyorsunuz. yayıncılar (yayıncıların yerleri, ilgili ortak bilgileri "
-"sayfalarında belirtilmiştir)."
+msgid "The Wikimedia Foundation is a nonprofit organization based in San Francisco, California. The Wikipedia Library program provides access to resources held by publishers in multiple countries. If you apply for a Wikipedia Library account (whether you are inside or outside of the United States), you understand that your personal data will be collected, transferred, stored, processed, disclosed and otherwise used in the U.S. as described in this privacy policy. You also understand that your information may be transferred by us from the U.S. to other countries, which may have different or less stringent data protection laws than your country, in connection with providing services to you, including evaluating your application and securing access to your chosen publishers (locations for each publisher are outlined on their respective partner information pages)."
+msgstr "Wikimedia Vakfı, San Francisco, Kaliforniya merkezli kar amacı gütmeyen bir organizasyondur. Vikipedi Kütüphanesi programı, birçok ülkede yayıncılar tarafından tutulan kaynaklara erişim sağlar. Bir Vikipedi Kütüphanesi hesabına başvurursanız (ABD’nin içinde veya dışındaysanız), kişisel verilerinizin bu gizlilik politikasında tanımlandığı şekilde ABD’de toplanacağını, transfer edileceğini, saklanacağını, işleneceğini, açıklanacağını ve başka şekilde kullanılacağını anlıyorsunuz. Ayrıca, başvurunuzun değerlendirilmesi ve seçtiğinize erişimin sağlanması da dahil olmak üzere, bilgilerinizin ABD'den, ülkenizden farklı veya daha az katı veri koruma yasalarına sahip olabilecek diğer ülkelere aktarılabileceğini anlıyorsunuz. yayıncılar (yayıncıların yerleri, ilgili ortak bilgileri sayfalarında belirtilmiştir)."
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:392
-msgid ""
-"Please note that in the event of any differences in meaning or "
-"interpretation between the original English version of these terms and a "
-"translation, the original English version takes precedence."
-msgstr ""
-"Lütfen bu terimlerin İngilizce orijinali ile çeviri arasında bir anlam veya "
-"yorumda herhangi bir fark olması durumunda, orijinal İngilizce versiyonunun "
-"öncelikli olduğunu unutmayın."
+msgid "Please note that in the event of any differences in meaning or interpretation between the original English version of these terms and a translation, the original English version takes precedence."
+msgstr "Lütfen bu terimlerin İngilizce orijinali ile çeviri arasında bir anlam veya yorumda herhangi bir fark olması durumunda, orijinal İngilizce versiyonunun öncelikli olduğunu unutmayın."
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Wikimedia Foundation should not be translated.
 #: TWLight/users/templates/users/terms.html:403
-msgid ""
-"See also the <a class=\"twl-links\" href=\"https://wikimediafoundation.org/"
-"wiki/Privacy_policy\">Wikimedia Foundation Privacy Policy</a>."
-msgstr ""
-"Ayrıca <a class=\"twl-links\" href=\"https://meta.wikimedia.org/wiki/"
-"Privacy_policy/tr\">Meta Viki Gizlilik Politikası</a> sayfasına bakın."
+msgid "See also the <a class=\"twl-links\" href=\"https://wikimediafoundation.org/wiki/Privacy_policy\">Wikimedia Foundation Privacy Policy</a>."
+msgstr "Ayrıca <a class=\"twl-links\" href=\"https://meta.wikimedia.org/wiki/Privacy_policy/tr\">Meta Viki Gizlilik Politikası</a> sayfasına bakın."
 
 #. Translators: This is the second to last line of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:412
@@ -3930,16 +2872,8 @@ msgstr "Wikimedia Vakfı"
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:426
-msgid ""
-"By checking this box and clicking “Submit”, you agree that you have read the "
-"above terms and that you will adhere to the terms of use in your application "
-"to and use of the The Wikipedia Library, and the publishers’ services to "
-"which you gain access through The Wikipedia Library program."
-msgstr ""
-"Bu kutuyu işaretleyerek ve “Kabul et” düğmesine tıklayarak, yukarıdaki "
-"şartları okuduğunuzu ve başvurunuzdaki Vikipedi Kütüphanesi ve yayımcıların "
-"hizmetlerini kullanmanız ve kullanımında uymanız gerektiğini kabul "
-"edersiniz. Vikipedi Kütüphanesi programından erişim kazanın."
+msgid "By checking this box and clicking “Submit”, you agree that you have read the above terms and that you will adhere to the terms of use in your application to and use of the The Wikipedia Library, and the publishers’ services to which you gain access through The Wikipedia Library program."
+msgstr "Bu kutuyu işaretleyerek ve “Kabul et” düğmesine tıklayarak, yukarıdaki şartları okuduğunuzu ve başvurunuzdaki Vikipedi Kütüphanesi ve yayımcıların hizmetlerini kullanmanız ve kullanımında uymanız gerektiğini kabul edersiniz. Vikipedi Kütüphanesi programından erişim kazanın."
 
 #: TWLight/users/templates/users/user_collection_tile.html:32
 msgid "Remove this collection from favorites"
@@ -3991,40 +2925,19 @@ msgstr "Tüm verileri silin"
 
 #. Translators: This message is displayed on the page where users can request the deletion of their data.
 #: TWLight/users/templates/users/user_confirm_delete.html:17
-msgid ""
-"<b>Warning:</b> Performing this action will delete your Wikipedia Library "
-"Card user account and all associated applications. This process is not "
-"reversible. You may lose any partner accounts you were granted, and will not "
-"be able to renew those accounts or apply for new ones."
-msgstr ""
-"<b>Uyarı:</b> Bu eylemi gerçekleştirmek, Vikipedi Kütüphanesi Kart kullanıcı "
-"hesabınızı ve tüm ilişkili başvuruları silecektir. Bu süreç, bir daha geri "
-"alınamaz. Size verilen tüm ortak hesaplarınızı kaybedebilir ve bu hesapları "
-"yenileyemez veya yenilerine başvuramazsınız."
+msgid "<b>Warning:</b> Performing this action will delete your Wikipedia Library Card user account and all associated applications. This process is not reversible. You may lose any partner accounts you were granted, and will not be able to renew those accounts or apply for new ones."
+msgstr "<b>Uyarı:</b> Bu eylemi gerçekleştirmek, Vikipedi Kütüphanesi Kart kullanıcı hesabınızı ve tüm ilişkili başvuruları silecektir. Bu süreç, bir daha geri alınamaz. Size verilen tüm ortak hesaplarınızı kaybedebilir ve bu hesapları yenileyemez veya yenilerine başvuramazsınız."
 
 #. Translators: this should show up for people who log in with a username/password and not OAuth, so we don't know what their Wikipedia identity is.
-#.
 #: TWLight/users/templates/users/user_detail.html:12
 #, python-format
-msgid ""
-"Hi, %(username)s! You don't have a Wikipedia editor profile attached to your "
-"account here, so you are probably a site administrator."
-msgstr ""
-"Selam %(username)s! Buradaki hesabınıza eklenmiş bir Vikipedi editör "
-"profiliniz mevcut değil, muhtemelen bir site yöneticisisiniz."
+msgid "Hi, %(username)s! You don't have a Wikipedia editor profile attached to your account here, so you are probably a site administrator."
+msgstr "Selam %(username)s! Buradaki hesabınıza eklenmiş bir Vikipedi editör profiliniz mevcut değil, muhtemelen bir site yöneticisisiniz."
 
 #. Translators: In the unlikely scenario that someone is able to register an account without using OAuth (thus leaving us without some of the information required for applications), users will see this message, encouraging them to re-register.
 #: TWLight/users/templates/users/user_detail.html:20
-msgid ""
-"If you aren't a site administrator, something weird has happened. You won't "
-"be able to apply for access without a Wikipedia editor profile. You should "
-"log out and create a new account by logging in via OAuth, or contact a site "
-"administrator for help."
-msgstr ""
-"Site yöneticisi değilseniz tuhaf bir şeyler meydana gelmiştir demek oluyor. "
-"Bir Vikipedi editör profili olmadan erişim için başvuru yapamazsınız. Oturum "
-"açıp OAuth aracılığıyla giriş yaparak yeni bir hesap oluşturmalı veya yardım "
-"için bir site yöneticisiyle iletişime geçmelisiniz."
+msgid "If you aren't a site administrator, something weird has happened. You won't be able to apply for access without a Wikipedia editor profile. You should log out and create a new account by logging in via OAuth, or contact a site administrator for help."
+msgstr "Site yöneticisi değilseniz tuhaf bir şeyler meydana gelmiştir demek oluyor. Bir Vikipedi editör profili olmadan erişim için başvuru yapamazsınız. Oturum açıp OAuth aracılığıyla giriş yaparak yeni bir hesap oluşturmalı veya yardım için bir site yöneticisiyle iletişime geçmelisiniz."
 
 #. Translators: Labels a sections where coordinators can select their email preferences.
 #: TWLight/users/templates/users/user_email_preferences.html:15
@@ -4034,24 +2947,13 @@ msgstr "Yalnızca koordinatörler"
 #. Translators: This message is shown on user's own profile page, encouraging them to make sure their information is up to date, so that account coordinators can use the information to judge applications.
 #: TWLight/users/views.py:176
 #, python-brace-format
-msgid ""
-"Please <a class='twl-links' href='{url}'>update your contributions</a> to "
-"Wikipedia to help coordinators evaluate your applications."
-msgstr ""
-"Koordinatörlerin başvurularınızı değerlendirmesine yardımcı olmak için "
-"lütfen <a class=\"twl-links\" href='{url}'>Vikipedi'deki katkılarınızı "
-"güncelleyin</a>."
+msgid "Please <a class='twl-links' href='{url}'>update your contributions</a> to Wikipedia to help coordinators evaluate your applications."
+msgstr "Koordinatörlerin başvurularınızı değerlendirmesine yardımcı olmak için lütfen <a class=\"twl-links\" href='{url}'>Vikipedi'deki katkılarınızı güncelleyin</a>."
 
 #. Translators: Coordinators are shown this message when they unselect all three types of reminder email options under preferences.
 #: TWLight/users/views.py:288
-msgid ""
-"You have chosen not to receive reminder emails. As a coordinator, you should "
-"receive at least one type of reminder emails, so consider changing your "
-"preferences."
-msgstr ""
-"Hatırlatma e-postaları almamayı seçtiniz. Bir koordinatör olarak en az bir "
-"tür hatırlatma e-postası almalısınız, bu nedenle tercihlerinizi değiştirmeyi "
-"düşünün."
+msgid "You have chosen not to receive reminder emails. As a coordinator, you should receive at least one type of reminder emails, so consider changing your preferences."
+msgstr "Hatırlatma e-postaları almamayı seçtiniz. Bir koordinatör olarak en az bir tür hatırlatma e-postası almalısınız, bu nedenle tercihlerinizi değiştirmeyi düşünün."
 
 #. Translators: Coordinators are shown this message when they make changes to their reminder email options under preferences.
 #: TWLight/users/views.py:296
@@ -4074,9 +2976,7 @@ msgstr "Bilgileriniz güncellendi."
 #. Translators: If a user tries to save the 'email change form' without entering one and checking the 'use my Wikipedia email address' checkbox, this message is presented.
 #: TWLight/users/views.py:448
 msgid "Both the values cannot be blank. Either enter a email or check the box."
-msgstr ""
-"Her iki değer de boş olamaz. Bir e-posta adresi girin veya kutuyu "
-"işaretleyin."
+msgstr "Her iki değer de boş olamaz. Bir e-posta adresi girin veya kutuyu işaretleyin."
 
 #. Translators: Shown to users when they successfully modify their email. Don't translate {email}.
 #: TWLight/users/views.py:476
@@ -4086,12 +2986,8 @@ msgstr "E-postanız {email} olarak değiştirildi."
 
 #. Translators: If the user has not filled out their email, they can browse the website but cannot apply for access to resources.
 #: TWLight/users/views.py:487
-msgid ""
-"Your email is blank. You can still explore the site, but you won't be able "
-"to apply for access to partner resources without an email."
-msgstr ""
-"E-postanız boş. Siteyi yine de keşfedebilirsiniz ancak e-postanız olmadan iş "
-"ortağı kaynaklarına erişim başvurusunda bulunamazsınız."
+msgid "Your email is blank. You can still explore the site, but you won't be able to apply for access to partner resources without an email."
+msgstr "E-postanız boş. Siteyi yine de keşfedebilirsiniz ancak e-postanız olmadan iş ortağı kaynaklarına erişim başvurusunda bulunamazsınız."
 
 #. Translators: This message is shown once the access to a partner has successfully been returned.
 #: TWLight/users/views.py:801
@@ -4123,31 +3019,3 @@ msgstr "Engellenmiş olmamak"
 msgid "10+ edits in the last 30 days"
 msgstr "Son 30 günde 10+ düzenleme yapmak"
 
-#: tests/shunit/data/bad_i18n_comment_1.py:3
-#: tests/shunit/data/bad_i18n_newline_1.py:5
-msgid "1"
-msgstr ""
-
-#. Translators: Lorem ipsum dolor sit amet, consectetur adipiscing elit. Mauris vitae ipsum ut purus faucibus pretium. Proin tempus neque et aliquet consectetur. Ut egestas sapien in consectetur sagittis. Mauris neque lacus, dapibus non viverra vitae, interdum ut aenean ipsum.
-#. Translators: Lorem ipsum dolor sit amet, consectetur adipiscing elit. Mauris vitae ipsum ut purus faucibus pretium. Proin tempus neque et aliquet consectetur. Ut egestas sapien in consectetur sagittis. Mauris neque lacus, dapibus non.
-#: tests/shunit/data/bad_i18n_comment_2.py:4
-#: tests/shunit/data/bad_i18n_newline_2.py:5 tests/shunit/data/good_i18n_1.py:2
-#: tests/shunit/data/good_i18n_2.py:2
-msgid "2"
-msgstr ""
-
-#: tests/shunit/data/bad_i18n_newline_3.py:5
-msgid "3"
-msgstr ""
-
-#: tests/shunit/data/bad_i18n_newline_4.py:5
-msgid "4"
-msgstr ""
-
-#: tests/shunit/data/bad_i18n_newline_5.py:5
-msgid "5"
-msgstr ""
-
-#: tests/shunit/data/bad_i18n_newline_6.py:5
-msgid "6"
-msgstr ""

--- a/locale/uk/LC_MESSAGES/django.po
+++ b/locale/uk/LC_MESSAGES/django.po
@@ -17,17 +17,17 @@
 # Author: Пан Хаунд
 msgid ""
 msgstr ""
+""
 "Project-Id-Version: Wikipedia Library Card Platform - Website\n"
-"Report-Msgid-Bugs-To: wikipedialibrary@wikimedia.org\n"
+"Report-Msgid-Bugs-To: translatewiki.net\n"
 "POT-Creation-Date: 2024-07-11 20:54+0000\n"
-"PO-Revision-Date: 2024-07-11 12:30:19+0000\n"
+"PO-Revision-Date: 2024-07-15 12:29:20+0000\n"
 "Language: uk\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "X-POT-Import-Date: 2024-06-25 18:44:08+0000\n"
 "X-Generator: MediaWiki 1.43.0-alpha; Translate 2024-07-16\n"
-"Plural-Forms: nplurals=3; plural=(n%10 == 1 && n%100 != 11) ? 0 : ( (n%10 >= "
-"2 && n%10 <= 4 && (n%100 < 10 || n%100 >= 20)) ? 1 : 2 );\n"
+"Plural-Forms: nplurals=3; plural=(n%10 == 1 && n%100 != 11) ? 0 : ( (n%10 >= 2 && n%10 <= 4 && (n%100 < 10 || n%100 >= 20)) ? 1 : 2 );\n"
 "X-Translation-Project: translatewiki.net <https://translatewiki.net>\n"
 
 #. Translators: Labels the button users click to apply for a partner's resources.
@@ -53,13 +53,8 @@ msgstr "Про вас"
 #. Translators: This note appears in a section of a form where we ask users to enter info (like country of residence) when applying for resource access.
 #: TWLight/applications/forms.py:179
 #, python-brace-format
-msgid ""
-"<p><small><i>Your personal data will be processed according to our <a "
-"class='twl-links' href='{terms_url}'> privacy policy</a>.</i></small></p>"
-msgstr ""
-"<p><small><i>Ваші персональні дані буде опрацьовано відповідно до нашої <a "
-"class='twl-links' href='{terms_url}'>політики приватності</a>.</i></small></"
-"p>"
+msgid "<p><small><i>Your personal data will be processed according to our <a class='twl-links' href='{terms_url}'> privacy policy</a>.</i></small></p>"
+msgstr "<p><small><i>Ваші персональні дані буде опрацьовано відповідно до нашої <a class='twl-links' href='{terms_url}'>політики приватності</a>.</i></small></p>"
 
 #. Translators: This is the title of the application form page, where users enter information required for the application. It lets the user know which partner application they are entering data for. {partner}
 #: TWLight/applications/forms.py:189
@@ -71,8 +66,7 @@ msgstr "Ваша заявка до {partner}"
 #: TWLight/applications/forms.py:220
 #, python-brace-format
 msgid "You must register at {url} before applying."
-msgstr ""
-"Ви повинні зареєструватися за посиланням {url} до того, як подавати заявку."
+msgstr "Ви повинні зареєструватися за посиланням {url} до того, як подавати заявку."
 
 #. Translators: Label of the field where coordinators can enter the username of a user
 #. Translators: This labels the column description that lists the name of the applicants.
@@ -101,12 +95,8 @@ msgstr "Електронна пошта вашого облікового зап
 #. Translators: This labels a choice field where users will have to select the number of months they wish to have their access for as part of the application renewal confirmation.
 #. Translators: When filling out an application, users may be required to enter the length of the account (expiry) they wish to have for proxy partners.
 #: TWLight/applications/forms.py:339 TWLight/applications/helpers.py:100
-msgid ""
-"The number of months you wish to have this access for before renewal is "
-"required"
-msgstr ""
-"Кількість місяців терміну, на який ви хочете отримати доступ, перш ніж буде "
-"потрібно поновлення доступу"
+msgid "The number of months you wish to have this access for before renewal is required"
+msgstr "Кількість місяців терміну, на який ви хочете отримати доступ, перш ніж буде потрібно поновлення доступу"
 
 #. Translators: When filling out an application, users may need to specify their name
 #: TWLight/applications/helpers.py:81
@@ -194,12 +184,8 @@ msgstr "Електронна пошта"
 
 #. Translators: This comment is added to pending applications when our terms of use change.
 #: TWLight/applications/management/commands/notify_applicants_tou_changes.py:54
-msgid ""
-"Our terms of use have changed. Your applications will not be processed until "
-"you log in and agree to our updated terms."
-msgstr ""
-"Наші умови використання змінилися. Ваші заявки не будуть оброблятися, поки "
-"ви не увійдете й не погодитеся з нашими оновленими умовами."
+msgid "Our terms of use have changed. Your applications will not be processed until you log in and agree to our updated terms."
+msgstr "Наші умови використання змінилися. Ваші заявки не будуть оброблятися, поки ви не увійдете й не погодитеся з нашими оновленими умовами."
 
 #. Translators: This is the status of an application that has not yet been reviewed.
 #: TWLight/applications/models.py:54
@@ -265,43 +251,26 @@ msgstr "Посилання з доступом: {access_url}"
 
 #. Translators: This text goes into account approval emails in the case that we need to send the user's details to a publisher for manual account setup.
 #: TWLight/applications/models.py:331
-msgid ""
-"You can expect to receive access details within a week or two once it has "
-"been processed."
-msgstr ""
-"Ви можете очікувати на отримання подробиць стосовно доступу протягом одного-"
-"двох тижнів після того, як вона буде оброблена."
+msgid "You can expect to receive access details within a week or two once it has been processed."
+msgstr "Ви можете очікувати на отримання подробиць стосовно доступу протягом одного-двох тижнів після того, як вона буде оброблена."
 
 #. Translators: This comment is added to open applications when a partner joins the Library Bundle, which does not require applications.
 #: TWLight/applications/signals.py:247
-msgid ""
-"This partner joined the Library Bundle, which does not require applications. "
-"This application will be marked as invalid."
-msgstr ""
-"Цей партнер приєднався до Library Bundle, де не вимагаються заявки. Цю "
-"заявку буде позначено недійсною."
+msgid "This partner joined the Library Bundle, which does not require applications. This application will be marked as invalid."
+msgstr "Цей партнер приєднався до Library Bundle, де не вимагаються заявки. Цю заявку буде позначено недійсною."
 
 #. Translators: This is shown to users if the application is to a partner for which we have run out of available accounts. The application is therefore on a 'waitlist', and will be reviewed when more accounts are available.
 #: TWLight/applications/templates/applications/application_evaluation.html:29
-msgid ""
-"This application is on the waitlist because this partner does not have any "
-"access grants available at this time."
-msgstr ""
-"Ця заявка перебуває в списку очікування, оскільки цей партнер наразі не може "
-"надати доступ."
+msgid "This application is on the waitlist because this partner does not have any access grants available at this time."
+msgstr "Ця заявка перебуває в списку очікування, оскільки цей партнер наразі не може надати доступ."
 
 #. Translators: This message is shown on pages where coordinators can see personal information about applicants.
 #: TWLight/applications/templates/applications/application_evaluation.html:36
 #: TWLight/applications/templates/applications/application_list_include.html:6
 #: TWLight/applications/templates/applications/send_partner.html:45
 #: TWLight/resources/templates/resources/partner_users.html:18
-msgid ""
-"Coordinators: This page may contain personal information such as real names "
-"and email addresses. Please remember that this information is confidential."
-msgstr ""
-"Координаторам: Ця сторінка може містити персональну інформацію, наприклад, "
-"справжні імена та адреси електронної пошти. Будь ласка, пам'ятайте, що ця "
-"інформація є конфіденційною."
+msgid "Coordinators: This page may contain personal information such as real names and email addresses. Please remember that this information is confidential."
+msgstr "Координаторам: Ця сторінка може містити персональну інформацію, наприклад, справжні імена та адреси електронної пошти. Будь ласка, пам'ятайте, що ця інформація є конфіденційною."
 
 #. Translators: This is the title of the application page shown to users who are a coordinator, and are able to accept or reject the application.
 #: TWLight/applications/templates/applications/application_evaluation.html:39
@@ -310,12 +279,8 @@ msgstr "Оцінити заявку"
 
 #. Translators: This text is shown to coordinators on application pages if the applicant has restricted processing of their data.
 #: TWLight/applications/templates/applications/application_evaluation.html:42
-msgid ""
-"This user has requested a restriction on the processing of their data, so "
-"you cannot change the status of their application."
-msgstr ""
-"Цей користувач надіслав запит на обмеження обробки їхніх даних, тож ви не "
-"можете змінити статус їхньої заявки."
+msgid "This user has requested a restriction on the processing of their data, so you cannot change the status of their application."
+msgstr "Цей користувач надіслав запит на обмеження обробки їхніх даних, тож ви не можете змінити статус їхньої заявки."
 
 #. Translators: This is the title of the application page shown to users who are not a coordinator.
 #: TWLight/applications/templates/applications/application_evaluation.html:48
@@ -388,12 +353,8 @@ msgstr "Невідомо"
 
 #. Translators: This is the text displayed to coordinators when an applicant has no country of residence in their profile.
 #: TWLight/applications/templates/applications/application_evaluation.html:123
-msgid ""
-"Please request the applicant add their country of residence to their profile "
-"before proceeding further."
-msgstr ""
-"Будь ласка, перш ніж продовжувати, попросіть заявника додати у своєму "
-"профілі країну проживання."
+msgid "Please request the applicant add their country of residence to their profile before proceeding further."
+msgstr "Будь ласка, перш ніж продовжувати, попросіть заявника додати у своєму профілі країну проживання."
 
 #. Translators: This labels the section of an application showing the total number of accounts available for a partner or their collection.
 #: TWLight/applications/templates/applications/application_evaluation.html:134
@@ -404,12 +365,8 @@ msgstr "Доступні облікові записи:"
 #. Translators: This labels the section of an application showing whether the user had agreed to the terms of use or not.
 #: TWLight/applications/templates/applications/application_evaluation.html:145
 #, python-format
-msgid ""
-"Has agreed to the site's <a class=\"twl-links\" href=\"%(terms_url)s\">terms "
-"of use</a>?"
-msgstr ""
-"Погодилися з <a class=\"twl-links\" href=\"%(terms_url)s\">умовами "
-"користування</a> сайту?"
+msgid "Has agreed to the site's <a class=\"twl-links\" href=\"%(terms_url)s\">terms of use</a>?"
+msgstr "Погодилися з <a class=\"twl-links\" href=\"%(terms_url)s\">умовами користування</a> сайту?"
 
 #. Translators: Displayed to coordinators when they've agreed to the terms of use.
 #. Translators: Displayed if the user has agreed to the terms of use.
@@ -444,12 +401,8 @@ msgstr "Ні"
 
 #. Translators: This is the text displayed to coordinators when an applicant has not agreed to the terms of use.
 #: TWLight/applications/templates/applications/application_evaluation.html:159
-msgid ""
-"Please request the applicant agree to the site's terms of use before "
-"approving this application."
-msgstr ""
-"Будь ласка, попросіть заявника погодитися з умовами користування, перш ніж "
-"схвалювати цю заявку."
+msgid "Please request the applicant agree to the site's terms of use before approving this application."
+msgstr "Будь ласка, попросіть заявника погодитися з умовами користування, перш ніж схвалювати цю заявку."
 
 #. Translators: This labels the section of an application containing the user's motivation for wanting access to this resource.
 #: TWLight/applications/templates/applications/application_evaluation.html:176
@@ -469,10 +422,8 @@ msgstr "Поновлення наявного доступу?"
 #. Translators: This message is shown next to the 'Renewal of existing access grant?' label if the application is a renewal. Don't translate HTML tags or parent_url.
 #: TWLight/applications/templates/applications/application_evaluation.html:195
 #, python-format
-msgid ""
-"Yes (<a class=\"twl-links\" href=\"%(parent_url)s\">previous application</a>)"
-msgstr ""
-"Так (<a class=\"twl-links\" href=\"%(parent_url)s\">попередня заявка</a>)"
+msgid "Yes (<a class=\"twl-links\" href=\"%(parent_url)s\">previous application</a>)"
+msgstr "Так (<a class=\"twl-links\" href=\"%(parent_url)s\">попередня заявка</a>)"
 
 #. Translators: This labels the section of the application showing the length of access remaining on the user's previous authorization.
 #: TWLight/applications/templates/applications/application_evaluation.html:208
@@ -506,9 +457,7 @@ msgstr "Додати коментар"
 
 #. Translators: On an application page, this text tells users that the comments posted on the application are visible to coordinators and the submitting user only.
 #: TWLight/applications/templates/applications/application_evaluation.html:297
-msgid ""
-"Comments are visible to all coordinators and to the editor who submitted "
-"this application."
+msgid "Comments are visible to all coordinators and to the editor who submitted this application."
 msgstr "Коментарі видимі усім координаторам та автору заявки"
 
 #. Translators: This is the title of the section of an application page which lists information about the user who submitted the application.
@@ -723,18 +672,8 @@ msgstr "Встановити статус"
 
 #: TWLight/applications/templates/applications/apply.html:20
 #, python-format
-msgid ""
-"If your application is successful we may share your email address with "
-"%(partner)s. This is required to set up your access to their resources. By "
-"submitting this form you agree to allow your email address to be shared with "
-"%(partner)s if your application is successful, for the purposes of account "
-"setup."
-msgstr ""
-"Якщо ваша заявка буде успішною, ми можемо поділитися вашою адресою "
-"електронної пошти з %(partner)s. Це потрібно, щоб налаштувати доступ до "
-"їхніх ресурсів. Надсилаючи цю форму, ви погоджуєтеся надати %(partner)s "
-"доступ до вашої адреси електронної пошти, якщо ваша заявка буде успішною, з "
-"метою налаштування облікового запису."
+msgid "If your application is successful we may share your email address with %(partner)s. This is required to set up your access to their resources. By submitting this form you agree to allow your email address to be shared with %(partner)s if your application is successful, for the purposes of account setup."
+msgstr "Якщо ваша заявка буде успішною, ми можемо поділитися вашою адресою електронної пошти з %(partner)s. Це потрібно, щоб налаштувати доступ до їхніх ресурсів. Надсилаючи цю форму, ви погоджуєтеся надати %(partner)s доступ до вашої адреси електронної пошти, якщо ваша заявка буде успішною, з метою налаштування облікового запису."
 
 #. Translators: This message is displayed on the page where users can confirm their renewal. Please do not translate partner.
 #: TWLight/applications/templates/applications/confirm_renewal.html:23
@@ -762,12 +701,8 @@ msgstr "До яких ресурсів ви хочете отримати дос
 
 #. Translators: This text explains that Library Bundle partners are not shown in this list.
 #: TWLight/applications/templates/applications/request_for_application.html:26
-msgid ""
-"Library Bundle partners are not shown as eligibility is determined "
-"automatically."
-msgstr ""
-"Партнери Library Bundle не показуються, оскільки відповідність критеріям "
-"участі визначається автоматично."
+msgid "Library Bundle partners are not shown as eligibility is determined automatically."
+msgstr "Партнери Library Bundle не показуються, оскільки відповідність критеріям участі визначається автоматично."
 
 #. Translators: On the page where users can apply for multiple partners, this message shows next to the partner name, taking them to the full application page when clicked.
 #: TWLight/applications/templates/applications/request_for_application.html:48
@@ -781,14 +716,8 @@ msgstr "Партнерських даних ще не додано."
 
 #. Translators: the HTML is so that the word 'waitlisted' will look the same as it does in the page above; please translate 'waitlisted' the same way you did elsewhere in this file.
 #: TWLight/applications/templates/applications/request_for_application.html:74
-msgid ""
-"You can apply to <span class=\"badge badge-warning\">Waitlisted</span> "
-"partners, but they don't have access grants available right now. We will "
-"process those applications when access becomes available."
-msgstr ""
-"Ви можете подати заявку до Партнерів <span class=\"badge badge-warning\">у "
-"списку очікування</span>, але вони наразі не надають доступу. Ми будемо "
-"обробляти такі заявки тоді, коли відкриється надавання доступу."
+msgid "You can apply to <span class=\"badge badge-warning\">Waitlisted</span> partners, but they don't have access grants available right now. We will process those applications when access becomes available."
+msgstr "Ви можете подати заявку до Партнерів <span class=\"badge badge-warning\">у списку очікування</span>, але вони наразі не надають доступу. Ми будемо обробляти такі заявки тоді, коли відкриється надавання доступу."
 
 #. Translators: On the page where coordinators can see approved applications which have not had their details sent to the partner, this message shows when there are applications ready to be processed.
 #: TWLight/applications/templates/applications/send.html:10
@@ -809,18 +738,13 @@ msgstr "Дані заявок до %(object)s"
 #. Translators: This message is shown when applications exceed the number of accounts available.
 #: TWLight/applications/templates/applications/send_partner.html:54
 #, python-format
-msgid ""
-"Application(s) for %(object)s, if sent, will exceed the total available "
-"accounts for the partner. Please proceed at your own discretion."
-msgstr ""
-"Заявка(и) на %(object)s, у разі надсилання, перевищить сумарну кількість "
-"доступних облікових записів партнера. Будь ласка, дійте на власний розсуд."
+msgid "Application(s) for %(object)s, if sent, will exceed the total available accounts for the partner. Please proceed at your own discretion."
+msgstr "Заявка(и) на %(object)s, у разі надсилання, перевищить сумарну кількість доступних облікових записів партнера. Будь ласка, дійте на власний розсуд."
 
 #. Translators: When viewing the list of applications ready to be sent for a particular partner, this is instructions for the coordinator to click the 'mark as sent' button after they have sent the information.
 #: TWLight/applications/templates/applications/send_partner.html:65
 msgid "When you've processed the data below, click the 'mark as sent' button."
-msgstr ""
-"Коли ви опрацювали дані внизу, натисніть кнопку «позначити як надіслане»."
+msgstr "Коли ви опрацювали дані внизу, натисніть кнопку «позначити як надіслане»."
 
 #. Translators: When viewing the list of applications ready to be sent for a particular partner, this is the title of the section containing contact information for the people applications should be sent to.
 #: TWLight/applications/templates/applications/send_partner.html:71
@@ -832,12 +756,8 @@ msgstr[2] ""
 
 #. Translators: When viewing the list of applications ready to be sent for a particular partner, this message shows if there is no information about who the applications should be sent to. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/applications/templates/applications/send_partner.html:89
-msgid ""
-"Whoops, we don't have any listed contacts. Please notify Wikipedia Library "
-"administrators."
-msgstr ""
-"Ой, у нас немає жодних контактів у списку. Будь ласка, повідомте "
-"адміністраторів Бібліотеки Вікіпедії."
+msgid "Whoops, we don't have any listed contacts. Please notify Wikipedia Library administrators."
+msgstr "Ой, у нас немає жодних контактів у списку. Будь ласка, повідомте адміністраторів Бібліотеки Вікіпедії."
 
 #. Translators: When viewing the list of applications ready to be sent for a particular partner, this is the title of the section containing the information about those applications.
 #: TWLight/applications/templates/applications/send_partner.html:94
@@ -852,12 +772,8 @@ msgstr "Позначити як надіслане"
 
 #. Translators: This text guides coordinators in using the code sending interface for approved applications.
 #: TWLight/applications/templates/applications/send_partner.html:152
-msgid ""
-"Use the dropdown menus to denote which editor will receive each code. Access "
-"codes will be sent to users automatically."
-msgstr ""
-"Скористайтеся випадним меню, щоб позначити, який редактор отримає кожен код. "
-"Коди доступу будуть надіслані користувачам автоматично."
+msgid "Use the dropdown menus to denote which editor will receive each code. Access codes will be sent to users automatically."
+msgstr "Скористайтеся випадним меню, щоб позначити, який редактор отримає кожен код. Коди доступу будуть надіслані користувачам автоматично."
 
 #. Translators: This labels a drop-down selection where staff can assign an access code to a user.
 #: TWLight/applications/templates/applications/send_partner.html:173
@@ -872,24 +788,14 @@ msgstr "Немає несхвалених, ненадісланих заявок
 #. Translators: When a user applies for a set of resources, they receive this message if none are currently available. They are instead placed on a 'waitlist' for later approval.
 #. Translators: When a user renews their resource, they receive this message if none are currently available. They are instead placed on a 'waitlist' for later approval.
 #: TWLight/applications/views.py:140 TWLight/applications/views.py:1282
-msgid ""
-"This partner does not have any access grants available at this time. You may "
-"still apply for access; your application will be reviewed when access grants "
-"become available."
-msgstr ""
-"Цей партнер наразі не надає жодних доступів. Ви все ще можете подати заявку "
-"на доступ; вашу заявку буде розглянути, коли надавання доступу буде "
-"поновлено."
+msgid "This partner does not have any access grants available at this time. You may still apply for access; your application will be reviewed when access grants become available."
+msgstr "Цей партнер наразі не надає жодних доступів. Ви все ще можете подати заявку на доступ; вашу заявку буде розглянути, коли надавання доступу буде поновлено."
 
 #. Translators: This message is shown to users once they've successfully submitted their application for review.
 #: TWLight/applications/views.py:163
 #, python-brace-format
-msgid ""
-"Your application has been submitted for review. Head over to <a "
-"href='{applications_url}'>My Applications</a> to view the status."
-msgstr ""
-"Ваша заявка надіслана на розгляд. Перейдіть на сторінку <a "
-"href='{applications_url}'>Мої заявки</a>, щоб переглянути її статус."
+msgid "Your application has been submitted for review. Head over to <a href='{applications_url}'>My Applications</a> to view the status."
+msgstr "Ваша заявка надіслана на розгляд. Перейдіть на сторінку <a href='{applications_url}'>Мої заявки</a>, щоб переглянути її статус."
 
 #. Translators: This text is displayed to users when the user has chosen to restrict data and is trying to apply for multiple partners
 #: TWLight/applications/views.py:276
@@ -937,22 +843,13 @@ msgstr "Надіслані заявки"
 
 #. Translators: After a coordinator has changed the status of an application to APPROVED, if the corresponding partner/collection is waitlisted this message appears.
 #: TWLight/applications/views.py:756
-msgid ""
-"Cannot approve application as partner with proxy authorization method is "
-"waitlisted."
-msgstr ""
-"Не вдається схвалити заявку оскільки партнер із проксі-авторизацією "
-"знаходиться у списку очікування."
+msgid "Cannot approve application as partner with proxy authorization method is waitlisted."
+msgstr "Не вдається схвалити заявку оскільки партнер із проксі-авторизацією знаходиться у списку очікування."
 
 #. Translators: After a coordinator has changed the status of an application to APPROVED, if the corresponding partner/collection has no accounts for distribution, this message appears.
 #: TWLight/applications/views.py:780
-msgid ""
-"Cannot approve application as partner with proxy authorization method is "
-"waitlisted and (or) has zero accounts available for distribution."
-msgstr ""
-"Не вдається схвалити заявку оскільки партнер із проксі-авторизацією "
-"знаходиться у списку очікування, або зараз не має облікових записів для "
-"розповсюдження."
+msgid "Cannot approve application as partner with proxy authorization method is waitlisted and (or) has zero accounts available for distribution."
+msgstr "Не вдається схвалити заявку оскільки партнер із проксі-авторизацією знаходиться у списку очікування, або зараз не має облікових записів для розповсюдження."
 
 #. Translators: This message appears on an "access denied" screen that stops users who attempt to authorize an editor to access a resource during a time period for which they are already authorized.
 #: TWLight/applications/views.py:803
@@ -962,17 +859,8 @@ msgstr "Ви зробили спробу створити дублікат ав�
 #. Translators: This message is shown to users when they access an application page of a now Bundle partner (new applications aren't allowed for Bundle partners and the status of old applications cannot be modified)
 #: TWLight/applications/views.py:857
 #, python-brace-format
-msgid ""
-"This application cannot be modified since this partner is now part of our <a "
-"href='{bundle}'>bundle access</a>. If you are eligible, you can access this "
-"resource from <a href='{library}'>your library</a>. <a "
-"href='{contact}'>Contact us</a> if you have any questions."
-msgstr ""
-"Цю заявку не можна змінити, оскільки цей партнер тепер є частиною нашого <a "
-"href='{bundle}'>пакетного доступу</a>. Якщо ви відповідаєте критеріям, то "
-"можете отримати доступ до цього ресурсу зі <a href='{library}'>своєї "
-"бібліотеки</a>. <a href='{contact}'>Зв'яжіться з нами</a>, якщо у вас є "
-"якісь запитання."
+msgid "This application cannot be modified since this partner is now part of our <a href='{bundle}'>bundle access</a>. If you are eligible, you can access this resource from <a href='{library}'>your library</a>. <a href='{contact}'>Contact us</a> if you have any questions."
+msgstr "Цю заявку не можна змінити, оскільки цей партнер тепер є частиною нашого <a href='{bundle}'>пакетного доступу</a>. Якщо ви відповідаєте критеріям, то можете отримати доступ до цього ресурсу зі <a href='{library}'>своєї бібліотеки</a>. <a href='{contact}'>Зв'яжіться з нами</a>, якщо у вас є якісь запитання."
 
 #. Translators: this lets a reviewer set the status of a single application.
 #: TWLight/applications/views.py:873
@@ -981,12 +869,8 @@ msgstr "Встановити статус заявки"
 
 #. Translators: This warning is message is shown to applicants when the number of pending applications is greater than the number of accounts available.
 #: TWLight/applications/views.py:891
-msgid ""
-"There are more pending applications than available accounts. Your "
-"application might get waitlisted."
-msgstr ""
-"Поданих заявок більше, ніж доступних облікових записів. Ваша заявка може "
-"опинитися у списку чекання."
+msgid "There are more pending applications than available accounts. Your application might get waitlisted."
+msgstr "Поданих заявок більше, ніж доступних облікових записів. Ваша заявка може опинитися у списку чекання."
 
 #. Translators: this message is shown to coordinators who attempt to change an application's Status from INVALID to any other Status.
 #: TWLight/applications/views.py:904
@@ -1005,17 +889,8 @@ msgstr "Пакетне оновлення заявик(ок) {} успішне."
 
 #. Translators: After a coordinator has changed the status of a number of applications to APPROVED, if the corresponding partner(s) is/are waitlisted or has no accounts for distribution, this message appears.
 #: TWLight/applications/views.py:1051
-msgid ""
-"Cannot approve application(s) {} as partner(s) with proxy authorization "
-"method is/are waitlisted and (or) has/have not enough accounts available. If "
-"not enough accounts are available, prioritise the applications and then "
-"approve applications equal to the accounts available."
-msgstr ""
-"Не вдається схвалити заявки {} оскільки партнери із проксі-авторизацією "
-"знаходяться у списку очікування, або  недостатньо облікових записів. У "
-"випадку недостатності облікових записів, треба виставити пріоритети заявкам, "
-"а потім схвалити заявки у відповідності до кількості доступних облікових "
-"записів."
+msgid "Cannot approve application(s) {} as partner(s) with proxy authorization method is/are waitlisted and (or) has/have not enough accounts available. If not enough accounts are available, prioritise the applications and then approve applications equal to the accounts available."
+msgstr "Не вдається схвалити заявки {} оскільки партнери із проксі-авторизацією знаходяться у списку очікування, або  недостатньо облікових записів. У випадку недостатності облікових записів, треба виставити пріоритети заявкам, а потім схвалити заявки у відповідності до кількості доступних облікових записів."
 
 #. Translators: This message is shown to coordinators who attempt to assign the same access code to multiple users.
 #: TWLight/applications/views.py:1191
@@ -1029,12 +904,8 @@ msgstr "Усі вибрані заявки мають бути позначен�
 
 #. Translators: When a user tries to renew their resource, they receive this message if the partner is not available.
 #: TWLight/applications/views.py:1272
-msgid ""
-"Cannot renew application at this time as partner is not available. Please "
-"check back later, or contact us for more information."
-msgstr ""
-"Не вдалося поновити заявку цього разу, оскільки партнер недоступний. Будь "
-"ласка, зверніться пізніше або напишіть нам за детальнішою інформацією."
+msgid "Cannot renew application at this time as partner is not available. Please check back later, or contact us for more information."
+msgstr "Не вдалося поновити заявку цього разу, оскільки партнер недоступний. Будь ласка, зверніться пізніше або напишіть нам за детальнішою інформацією."
 
 #. Translators: This message is displayed when an attempt by a user to renew an application has been denied for some reason.
 #: TWLight/applications/views.py:1308
@@ -1044,18 +915,12 @@ msgstr "Спробу поновити відхилену заявку #{pk} бу
 
 #. Translators: If a user requests the renewal of their account, but it wasn't renewed, this message is shown to them.
 #: TWLight/applications/views.py:1385
-msgid ""
-"This object cannot be renewed. (This probably means that you have already "
-"requested that it be renewed.)"
-msgstr ""
-"Цей об'єкт не можна поновити. (Це, вірогідно, означає, що ви вже подали "
-"запит на поновлення)."
+msgid "This object cannot be renewed. (This probably means that you have already requested that it be renewed.)"
+msgstr "Цей об'єкт не можна поновити. (Це, вірогідно, означає, що ви вже подали запит на поновлення)."
 
 #. Translators: If a user requests the renewal of their account, this message is shown to them.
 #: TWLight/applications/views.py:1395
-msgid ""
-"Your renewal request has been received. A coordinator will review your "
-"request."
+msgid "Your renewal request has been received. A coordinator will review your request."
 msgstr "Ваш запит на поновлення отримано. Координатор розгляне ваш запит."
 
 #. Translators: This labels a textfield where users can enter their email ID.
@@ -1065,12 +930,8 @@ msgstr "Ваша електронна пошта"
 
 #. Translators: This is the help text for the email field in the contact us form letting users know the field is updated by value pulled from their respective user profiles.
 #: TWLight/emails/forms.py:21
-msgid ""
-"This field is automatically updated with the email from your <a class='twl-"
-"links' href='{}'>user profile</a>."
-msgstr ""
-"Це поле автоматично оновлюється електронною поштою з вашого <a class='twl-"
-"links' href='{}'>профілю користувача</a>."
+msgid "This field is automatically updated with the email from your <a class='twl-links' href='{}'>user profile</a>."
+msgstr "Це поле автоматично оновлюється електронною поштою з вашого <a class='twl-links' href='{}'>профілю користувача</a>."
 
 #. Translators: This labels a textfield where users can enter their email message.
 #: TWLight/emails/forms.py:26
@@ -1093,26 +954,14 @@ msgstr "Надіслати"
 #. Translators: This email is sent to users with their access code. Don't translate Jinja variables in curly braces like user or partner. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/access_code_email-body-html.html:5
 #, python-format
-msgid ""
-"<p>Your approved application to %(partner)s has now been finalised. Your "
-"access code or login details can be found below:</p> <p><b>%(access_code)s</"
-"b></p> <p>%(user_instructions)s</p>"
-msgstr ""
-"<p>Ваша схвалена заявка до %(partner)s фіналізована. Свій код доступу або "
-"деталі для входу ви можете знайти нижче:</p> <p><b>%(access_code)s</b></p> "
-"<p>%(user_instructions)s</p>"
+msgid "<p>Your approved application to %(partner)s has now been finalised. Your access code or login details can be found below:</p> <p><b>%(access_code)s</b></p> <p>%(user_instructions)s</p>"
+msgstr "<p>Ваша схвалена заявка до %(partner)s фіналізована. Свій код доступу або деталі для входу ви можете знайти нижче:</p> <p><b>%(access_code)s</b></p> <p>%(user_instructions)s</p>"
 
 #. Translators: This email is sent to users with their access code. Don't translate Jinja variables in curly braces like user or partner. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/access_code_email-body-text.html:3
 #, python-format
-msgid ""
-"Your approved application to %(partner)s has now been finalised. Your access "
-"code or login details can be found below: %(access_code)s "
-"%(user_instructions)s"
-msgstr ""
-"Ваша схвалена заявка до %(partner)s фіналізована. Свій код доступу або "
-"деталі для входу ви можете знайти нижче: %(access_code)s "
-"%(user_instructions)s"
+msgid "Your approved application to %(partner)s has now been finalised. Your access code or login details can be found below: %(access_code)s %(user_instructions)s"
+msgstr "Ваша схвалена заявка до %(partner)s фіналізована. Свій код доступу або деталі для входу ви можете знайти нижче: %(access_code)s %(user_instructions)s"
 
 #. Translators: This is the subject line of an email sent to users with their access code.
 #: TWLight/emails/templates/emails/access_code_email-subject.html:3
@@ -1122,34 +971,14 @@ msgstr "Ваш код доступу Бібліотеки Вікіпедії"
 #. Translators: This email is sent to users when their application is approved. Don't translate Jinja variables in curly braces like user or partner; don't translate html tags either. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/approval_notification-body-html.html:5
 #, python-format
-msgid ""
-"<p>Dear %(user)s,</p> <p>Thank you for applying for access to %(partner)s "
-"resources through The Wikipedia Library. We are happy to inform you that "
-"your application has been approved.</p> <p>%(user_instructions)s</p> <p>You "
-"can view the collections you're authorized to access at My Library: "
-"%(link)s</p> <p>Cheers!</p> <p>The Wikipedia Library</p>"
-msgstr ""
-"<p>Шановний/а %(user)s,</p> <p>Дякуємо вам за подачу заявки на доступ до "
-"ресурсів %(partner)s через Бібліотеку Вікіпедії. Ми раді повідомити вам, що "
-"вашу заявку було схвалено.</p> <p>%(user_instructions)s</p> <p>Ви можете "
-"переглянути колекції, до яких маєте доступ, на сторінці Моя бібліотека: "
-"%(link)s</p> <p>Щасти!</p> <p>Бібліотека Вікіпедії</p>"
+msgid "<p>Dear %(user)s,</p> <p>Thank you for applying for access to %(partner)s resources through The Wikipedia Library. We are happy to inform you that your application has been approved.</p> <p>%(user_instructions)s</p> <p>You can view the collections you're authorized to access at My Library: %(link)s</p> <p>Cheers!</p> <p>The Wikipedia Library</p>"
+msgstr "<p>Шановний/а %(user)s,</p> <p>Дякуємо вам за подачу заявки на доступ до ресурсів %(partner)s через Бібліотеку Вікіпедії. Ми раді повідомити вам, що вашу заявку було схвалено.</p> <p>%(user_instructions)s</p> <p>Ви можете переглянути колекції, до яких маєте доступ, на сторінці Моя бібліотека: %(link)s</p> <p>Щасти!</p> <p>Бібліотека Вікіпедії</p>"
 
 #. Translators: This email is sent to users when their application is approved. Don't translate Jinja variables in curly braces like user or partner. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/approval_notification-body-text.html:3
 #, python-format
-msgid ""
-"Dear %(user)s, Thank you for applying for access to %(partner)s resources "
-"through The Wikipedia Library. We are happy to inform you that your "
-"application has been approved. %(user_instructions)s You can view the "
-"collections you're authorized to access at My Library: %(link)s Cheers! The "
-"Wikipedia Library"
-msgstr ""
-"Шановний/а %(user)s, Дякуємо вам за подачу заявки на доступ до ресурсів "
-"%(partner)s через Бібліотеку Вікіпедії. Ми раді повідомити вам, що вашу "
-"заявку було схвалено. %(user_instructions)s Ви можете переглянути колекції, "
-"до яких маєте доступ, на сторінці Моя бібліотека: %(link)s Щасти! Бібліотека "
-"Вікіпедії"
+msgid "Dear %(user)s, Thank you for applying for access to %(partner)s resources through The Wikipedia Library. We are happy to inform you that your application has been approved. %(user_instructions)s You can view the collections you're authorized to access at My Library: %(link)s Cheers! The Wikipedia Library"
+msgstr "Шановний/а %(user)s, Дякуємо вам за подачу заявки на доступ до ресурсів %(partner)s через Бібліотеку Вікіпедії. Ми раді повідомити вам, що вашу заявку було схвалено. %(user_instructions)s Ви можете переглянути колекції, до яких маєте доступ, на сторінці Моя бібліотека: %(link)s Щасти! Бібліотека Вікіпедії"
 
 #. Translators: This is the subject of an email which is sent to users when their application has been approved. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/approval_notification-subject.html:4
@@ -1159,26 +988,14 @@ msgstr "Вашу заявку до Бібліотеки Вікіпедії бу�
 #. Translators: This email is sent to coordinators when a comment is left on an application they are processing. Don't translate Jinja variables in curly braces like user or partner. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/comment_notification_coordinator-body-html.html:5
 #, python-format
-msgid ""
-"<p style=\"color: #500050\">%(submit_date)s - %(commenter)s</p> "
-"<blockquote><p>%(comment)s</p></blockquote> <p>Please reply to these at: <a "
-"href=\"%(app_url)s\">%(app_url)s</a></p> <p>Best,</p> <p>The Wikipedia "
-"Library</p>"
-msgstr ""
-"<p style=\"color: #500050\">%(submit_date)s - %(commenter)s</p> "
-"<blockquote><p>%(comment)s</p></blockquote> <p>Будь ласка, відповідайте на "
-"це отут: <a href=\"%(app_url)s\">%(app_url)s</a></p> <p>З найкращими "
-"побажаннями,</p> <p>Бібліотека Вікіпедії</p>"
+msgid "<p style=\"color: #500050\">%(submit_date)s - %(commenter)s</p> <blockquote><p>%(comment)s</p></blockquote> <p>Please reply to these at: <a href=\"%(app_url)s\">%(app_url)s</a></p> <p>Best,</p> <p>The Wikipedia Library</p>"
+msgstr "<p style=\"color: #500050\">%(submit_date)s - %(commenter)s</p> <blockquote><p>%(comment)s</p></blockquote> <p>Будь ласка, відповідайте на це отут: <a href=\"%(app_url)s\">%(app_url)s</a></p> <p>З найкращими побажаннями,</p> <p>Бібліотека Вікіпедії</p>"
 
 #. Translators: This email is sent to coordinators when a comment is left on an application they are processing. Don't translate Jinja variables in curly braces like user or partner. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/comment_notification_coordinator-body-text.html:3
 #, python-format
-msgid ""
-"%(submit_date)s - %(commenter)s %(comment)s Please reply to this at: "
-"%(app_url)s Best, The Wikipedia Library"
-msgstr ""
-"%(submit_date)s - %(commenter)s %(comment)s Будь ласка, відповідайте на це "
-"отут: %(app_url)s З найкращими побажаннями, Бібліотека Вікіпедії"
+msgid "%(submit_date)s - %(commenter)s %(comment)s Please reply to this at: %(app_url)s Best, The Wikipedia Library"
+msgstr "%(submit_date)s - %(commenter)s %(comment)s Будь ласка, відповідайте на це отут: %(app_url)s З найкращими побажаннями, Бібліотека Вікіпедії"
 
 #. Translators: This is the subject line of an email sent to coordinators when a comment is left on an application they processed.
 #: TWLight/emails/templates/emails/comment_notification_coordinator-subject.html:3
@@ -1188,27 +1005,14 @@ msgstr "Новий коментар у заявці Бібліотеки Вік�
 #. Translators: This email is sent to users when they receive a comment on their application. Don't translate Jinja variables in curly braces like user or partner; don't translate html tags either. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/comment_notification_editors-body-html.html:5
 #, python-format
-msgid ""
-"<p style=\"color: #500050\">%(submit_date)s - %(commenter)s</p> "
-"<blockquote><p>%(comment)s</p></blockquote> <p>Please reply to these at <a "
-"href=\"%(app_url)s\">%(app_url)s</a> so we can evaluate your application.</"
-"p> <p>Best,</p> <p>The Wikipedia Library</p>"
-msgstr ""
-"<p style=\"color: #500050\">%(submit_date)s — %(commenter)s</p> "
-"<blockquote><p>%(comment)s</p></blockquote> <p>Будь ласка, дайте на них "
-"відповідь тут: <a href=\"%(app_url)s\">%(app_url)s</a>, щоб ми могли оцінити "
-"вашу заявку.</p> <p>З найкращими побажаннями,</p> <p>Бібліотека Вікіпедії</p>"
+msgid "<p style=\"color: #500050\">%(submit_date)s - %(commenter)s</p> <blockquote><p>%(comment)s</p></blockquote> <p>Please reply to these at <a href=\"%(app_url)s\">%(app_url)s</a> so we can evaluate your application.</p> <p>Best,</p> <p>The Wikipedia Library</p>"
+msgstr "<p style=\"color: #500050\">%(submit_date)s — %(commenter)s</p> <blockquote><p>%(comment)s</p></blockquote> <p>Будь ласка, дайте на них відповідь тут: <a href=\"%(app_url)s\">%(app_url)s</a>, щоб ми могли оцінити вашу заявку.</p> <p>З найкращими побажаннями,</p> <p>Бібліотека Вікіпедії</p>"
 
 #. Translators: This email is sent to users when they receive a comment on their application. Don't translate Jinja variables in curly braces like user or partner. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/comment_notification_editors-body-text.html:3
 #, python-format
-msgid ""
-"%(submit_date)s - %(commenter)s %(comment)s Please reply to these at: "
-"%(app_url)s so we can evaluate your application. Best, The Wikipedia Library"
-msgstr ""
-"%(submit_date)s — %(commenter)s %(comment)s Будь ласка, відповідайте на них "
-"отут: %(app_url)s, щоб ми могли оцінити вашу заявку. З найкращими "
-"побажаннями, Бібліотека Вікіпедії"
+msgid "%(submit_date)s - %(commenter)s %(comment)s Please reply to these at: %(app_url)s so we can evaluate your application. Best, The Wikipedia Library"
+msgstr "%(submit_date)s — %(commenter)s %(comment)s Будь ласка, відповідайте на них отут: %(app_url)s, щоб ми могли оцінити вашу заявку. З найкращими побажаннями, Бібліотека Вікіпедії"
 
 #. Translators: This is the subject line of an email sent to users who have a comment added to one of their applications. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/comment_notification_editors-subject.html:3
@@ -1218,25 +1022,14 @@ msgstr "Новий коментар до вашої заявки у Бібліо
 #. Translators: This email is sent to users when an application they commented on receives another comment. Don't translate Jinja variables in curly braces like app_url; don't translate html tags either. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/comment_notification_others-body-html.html:5
 #, python-format
-msgid ""
-"<p style=\"color: #500050\">%(submit_date)s - %(commenter)s</p> "
-"<blockquote><p>%(comment)s</p></blockquote> See it at <a href=\"%(app_url)s"
-"\">%(app_url)s</a>. Thanks for helping review Wikipedia Library applications!"
-msgstr ""
-"<p style=\"color: #500050\">%(submit_date)s — %(commenter)s</p> "
-"<blockquote><p>%(comment)s</p></blockquote> Перегляньте його на <a href="
-"\"%(app_url)s\">%(app_url)s</a>. Дякуємо, що допомагаєте розглядати заявки "
-"Бібліотеки Вікіпедії!"
+msgid "<p style=\"color: #500050\">%(submit_date)s - %(commenter)s</p> <blockquote><p>%(comment)s</p></blockquote> See it at <a href=\"%(app_url)s\">%(app_url)s</a>. Thanks for helping review Wikipedia Library applications!"
+msgstr "<p style=\"color: #500050\">%(submit_date)s — %(commenter)s</p> <blockquote><p>%(comment)s</p></blockquote> Перегляньте його на <a href=\"%(app_url)s\">%(app_url)s</a>. Дякуємо, що допомагаєте розглядати заявки Бібліотеки Вікіпедії!"
 
 #. Translators: This email is sent to users when an application they commented on receives another comment. Don't translate Jinja variables in curly braces like app_url. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/comment_notification_others-body-text.html:3
 #, python-format
-msgid ""
-"%(submit_date)s - %(commenter)s %(comment)s See it at: %(app_url)s Thanks "
-"for helping review Wikipedia Library applications!"
-msgstr ""
-"%(submit_date)s — %(commenter)s %(comment)s Перегляньте його на %(app_url)s. "
-"Дякуємо, що допомагаєте розглядати заявки Бібліотеки Вікіпедії!"
+msgid "%(submit_date)s - %(commenter)s %(comment)s See it at: %(app_url)s Thanks for helping review Wikipedia Library applications!"
+msgstr "%(submit_date)s — %(commenter)s %(comment)s Перегляньте його на %(app_url)s. Дякуємо, що допомагаєте розглядати заявки Бібліотеки Вікіпедії!"
 
 #. Translators: This is the subject line of an email sent to users who have a comment added to an application they also commented on. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/comment_notification_others-subject.html:4
@@ -1246,13 +1039,8 @@ msgstr "Новий коментар до заявки Бібліотеки Ві�
 #. Translators: This text is part of a scheduled reminder email sent to coordinators who have applications requiring action. Don't translate Jinja variables in curly braces like total_apps, or user.
 #: TWLight/emails/templates/emails/coordinator_reminder_notification-body-html.html:5
 #, python-format
-msgid ""
-"<p>Dear %(user)s,</p> <p>Our records indicate that you are the designated "
-"coordinator for partners that have a total of %(total_apps)s applications.</"
-"p>"
-msgstr ""
-"<p>Шановний/а %(user)s,</p> <p>Наші записи свідчать, що ви є призначеним "
-"координатором для партнерів, які мають сумарно %(total_apps)s заявок.</p>"
+msgid "<p>Dear %(user)s,</p> <p>Our records indicate that you are the designated coordinator for partners that have a total of %(total_apps)s applications.</p>"
+msgstr "<p>Шановний/а %(user)s,</p> <p>Наші записи свідчать, що ви є призначеним координатором для партнерів, які мають сумарно %(total_apps)s заявок.</p>"
 
 #. Translators: Breakdown as in 'cost breakdown'; analysis.
 #: TWLight/emails/templates/emails/coordinator_reminder_notification-body-html.html:11
@@ -1293,45 +1081,20 @@ msgstr[2] "%(counter)s схвалених заявок."
 #. Translators: This text is part of a scheduled reminder email sent to coordinators who have applications requiring action. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library). Don't translate Jinja variables in curly braces like link; don't translate email addresses or html tags either.
 #: TWLight/emails/templates/emails/coordinator_reminder_notification-body-html.html:39
 #, python-format
-msgid ""
-"<p>This is a gentle reminder that you may review applications at <a href="
-"\"%(link)s\">%(link)s</a>.</p> <p>You can customise your reminders under "
-"'preferences' in your user profile.</p> <p>If you received this message in "
-"error, drop us a line at wikipedialibrary@wikimedia.org.</p> <p>Thanks for "
-"helping review Wikipedia Library applications!</p>"
-msgstr ""
-"<p>Це легке нагадування, що ви можете розглядати ці заявки на <a href="
-"\"%(link)s\">%(link)s</a>.</p> <p>Ви можете налаштувати свої нагадування у "
-"налаштуваннях свого профілю користувача.</p> <p>Якщо ви отримали це "
-"повідомлення помилково, повідомте нас про це, написавши на "
-"wikipedialibrary@wikimedia.org.</p> <p>Дякуємо, що допомагаєте розглядати "
-"заявки Бібліотеки Вікіпедії!</p>"
+msgid "<p>This is a gentle reminder that you may review applications at <a href=\"%(link)s\">%(link)s</a>.</p> <p>You can customise your reminders under 'preferences' in your user profile.</p> <p>If you received this message in error, drop us a line at wikipedialibrary@wikimedia.org.</p> <p>Thanks for helping review Wikipedia Library applications!</p>"
+msgstr "<p>Це легке нагадування, що ви можете розглядати ці заявки на <a href=\"%(link)s\">%(link)s</a>.</p> <p>Ви можете налаштувати свої нагадування у налаштуваннях свого профілю користувача.</p> <p>Якщо ви отримали це повідомлення помилково, повідомте нас про це, написавши на wikipedialibrary@wikimedia.org.</p> <p>Дякуємо, що допомагаєте розглядати заявки Бібліотеки Вікіпедії!</p>"
 
 #. Translators: This text is part of a scheduled reminder email sent to coordinators who have applications requiring action. Don't translate Jinja variables in curly braces like total_apps, or user.
 #: TWLight/emails/templates/emails/coordinator_reminder_notification-body-text.html:3
 #, python-format
-msgid ""
-"Dear %(user)s, Our records indicate that you are the designated coordinator "
-"for partners that have a total of %(total_apps)s applications."
-msgstr ""
-"Шановний/а %(user)s! Наші записи свідчать, що ви є призначеним координатором "
-"для партнерів, які мають сумарно %(total_apps)s заявок."
+msgid "Dear %(user)s, Our records indicate that you are the designated coordinator for partners that have a total of %(total_apps)s applications."
+msgstr "Шановний/а %(user)s! Наші записи свідчать, що ви є призначеним координатором для партнерів, які мають сумарно %(total_apps)s заявок."
 
 #. Translators: This text is part of a scheduled reminder email sent to coordinators who have applications requiring action. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library). Don't translate Jinja variables in curly braces like link; don't translate the email address either.
 #: TWLight/emails/templates/emails/coordinator_reminder_notification-body-text.html:38
 #, python-format
-msgid ""
-"This is a gentle reminder that you may review applications at: %(link)s. You "
-"can customise your reminders under 'preferences' in your user profile. If "
-"you received this message in error, drop us a line at: "
-"wikipedialibrary@wikimedia.org Thanks for helping review Wikipedia Library "
-"applications!"
-msgstr ""
-"Це легке нагадування, що ви можете розглядати ці заявки на %(link)s. Ви "
-"можете налаштувати свої нагадування у налаштуваннях свого профілю "
-"користувача. Якщо ви отримали це повідомлення помилково, повідомте нас про "
-"це, написавши на wikipedialibrary@wikimedia.org. Дякуємо, що допомагаєте "
-"розглядати заявки Бібліотеки Вікіпедії!"
+msgid "This is a gentle reminder that you may review applications at: %(link)s. You can customise your reminders under 'preferences' in your user profile. If you received this message in error, drop us a line at: wikipedialibrary@wikimedia.org Thanks for helping review Wikipedia Library applications!"
+msgstr "Це легке нагадування, що ви можете розглядати ці заявки на %(link)s. Ви можете налаштувати свої нагадування у налаштуваннях свого профілю користувача. Якщо ви отримали це повідомлення помилково, повідомте нас про це, написавши на wikipedialibrary@wikimedia.org. Дякуємо, що допомагаєте розглядати заявки Бібліотеки Вікіпедії!"
 
 #. Translators: This is the subject line of a scheduled reminder email sent to coordinators who have applications to review. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library). Do not translate items in curly braces.
 #: TWLight/emails/templates/emails/coordinator_reminder_notification-subject.html:4
@@ -1341,32 +1104,14 @@ msgstr "Заявки Бібліотеки Вікіпедії чекають ва
 #. Translators: This email is sent to users when their application is rejected. Don't translate Jinja variables in curly braces like user or partner; don't translate html tags either. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/rejection_notification-body-html.html:5
 #, python-format
-msgid ""
-"<p>Dear %(user)s,</p> <p>Thank you for applying for access to %(partner)s "
-"resources through The Wikipedia Library. Unfortunately at this time your "
-"application has not been approved. You can view your application and review "
-"comments at <a href=\"%(app_url)s\">%(app_url)s</a>.</p> <p>Best,</p> <p>The "
-"Wikipedia Library</p>"
-msgstr ""
-"<p>Шановний/а %(user)s,</p> <p>Дякуємо за вашу заявку на доступ до ресурсів "
-"%(partner)s через Бібліотеку Вікіпедії. На жаль, наразі вашу заявку не "
-"схвалено. Ви можете переглянути свою заявку та коментарі до неї на <a href="
-"\"%(app_url)s\">%(app_url)s</a>.</p> <p>З найкращими побажаннями,</p> "
-"<p>Бібліотека Вікіпедії</p>"
+msgid "<p>Dear %(user)s,</p> <p>Thank you for applying for access to %(partner)s resources through The Wikipedia Library. Unfortunately at this time your application has not been approved. You can view your application and review comments at <a href=\"%(app_url)s\">%(app_url)s</a>.</p> <p>Best,</p> <p>The Wikipedia Library</p>"
+msgstr "<p>Шановний/а %(user)s,</p> <p>Дякуємо за вашу заявку на доступ до ресурсів %(partner)s через Бібліотеку Вікіпедії. На жаль, наразі вашу заявку не схвалено. Ви можете переглянути свою заявку та коментарі до неї на <a href=\"%(app_url)s\">%(app_url)s</a>.</p> <p>З найкращими побажаннями,</p> <p>Бібліотека Вікіпедії</p>"
 
 #. Translators: This email is sent to users when their application is rejected. Don't translate Jinja variables in curly braces like user or partner. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/rejection_notification-body-text.html:3
 #, python-format
-msgid ""
-"Dear %(user)s, Thank you for applying for access to %(partner)s resources "
-"through The Wikipedia Library. Unfortunately at this time your application "
-"has not been approved. You can view your application and review comments at: "
-"%(app_url)s Best, The Wikipedia Library"
-msgstr ""
-"Шановний/а %(user)s, Дякуємо за вашу заявку на доступ до ресурсів "
-"%(partner)s через Бібліотеку Вікіпедії. На жаль, наразі вашу заявку не "
-"схвалено. Ви можете переглянути свою заявку та коментарі до неї на "
-"%(app_url)s. З найкращими побажаннями, Бібліотека Вікіпедії"
+msgid "Dear %(user)s, Thank you for applying for access to %(partner)s resources through The Wikipedia Library. Unfortunately at this time your application has not been approved. You can view your application and review comments at: %(app_url)s Best, The Wikipedia Library"
+msgstr "Шановний/а %(user)s, Дякуємо за вашу заявку на доступ до ресурсів %(partner)s через Бібліотеку Вікіпедії. На жаль, наразі вашу заявку не схвалено. Ви можете переглянути свою заявку та коментарі до неї на %(app_url)s. З найкращими побажаннями, Бібліотека Вікіпедії"
 
 #. Translators: This is the subject of an email which is sent to users when their application has been rejected. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/rejection_notification-subject.html:4
@@ -1376,41 +1121,14 @@ msgstr "Ваша заявка до Бібліотеки Вікіпедії"
 #. Translators: This email is sent to users when they have an account that is soon to expire. Don't translate Jinja variables in curly braces like partner_name or partner_link; don't translate html tags either. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/user_renewal_notice-body-html.html:5
 #, python-format
-msgid ""
-"<p>Dear %(user)s,</p> <p>According to our records, your access to "
-"%(partner_name)s will soon expire and you may lose access. If you want to "
-"continue making use of your free account, you can request renewal of your "
-"account by clicking the 'Renew' or 'Extend' button at %(partner_link)s.</p> "
-"<p>Best,</p> <p>The Wikipedia Library</p> <p>You can disable these emails in "
-"your user page preferences: https://wikipedialibrary.wmflabs.org/users/</p>"
-msgstr ""
-"<p>Шановний/а %(user)s,</p> <p>Згідно з нашими записами, термін дії вашого "
-"доступу до %(partner_name)s скоро закінчиться і ви можете втратити доступ. "
-"Якщо ви хочете продовжити використовувати свій безкоштовний обліковий запис, "
-"ви можете подати запит на поновлення свого облікового запису, натиснувши "
-"кнопку «Поновлення» або «Розширити» на %(partner_link)s.</p> <p>З найкращими "
-"побажаннями,</p> <p>Бібліотека Вікіпедії</p> <p>Ви можете вимкнути ці "
-"повідомлення на своїй сторінці налаштувань користувача: https://"
-"wikipedialibrary.wmflabs.org/users/</p>"
+msgid "<p>Dear %(user)s,</p> <p>According to our records, your access to %(partner_name)s will soon expire and you may lose access. If you want to continue making use of your free account, you can request renewal of your account by clicking the 'Renew' or 'Extend' button at %(partner_link)s.</p> <p>Best,</p> <p>The Wikipedia Library</p> <p>You can disable these emails in your user page preferences: https://wikipedialibrary.wmflabs.org/users/</p>"
+msgstr "<p>Шановний/а %(user)s,</p> <p>Згідно з нашими записами, термін дії вашого доступу до %(partner_name)s скоро закінчиться і ви можете втратити доступ. Якщо ви хочете продовжити використовувати свій безкоштовний обліковий запис, ви можете подати запит на поновлення свого облікового запису, натиснувши кнопку «Поновлення» або «Розширити» на %(partner_link)s.</p> <p>З найкращими побажаннями,</p> <p>Бібліотека Вікіпедії</p> <p>Ви можете вимкнути ці повідомлення на своїй сторінці налаштувань користувача: https://wikipedialibrary.wmflabs.org/users/</p>"
 
 #. Translators: This email is sent to users when they have an account that is soon to expire. Don't translate Jinja variables in curly braces like partner_name or partner_link; don't translate html tags either. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/user_renewal_notice-body-text.html:3
 #, python-format
-msgid ""
-"Dear %(user)s, According to our records, your access to %(partner_name)s "
-"will soon expire and you may lose access. If you want to continue making use "
-"of your free account, you can request renewal of your account by clicking "
-"the Renew button at %(partner_link)s. Best, The Wikipedia Library You can "
-"disable these emails in your user page preferences: https://wikipedialibrary."
-"wmflabs.org/users/"
-msgstr ""
-"Шановний/а %(user)s, Згідно з нашими записами, термін дії вашого доступу до "
-"%(partner_name)s скоро закінчиться і ви можете втратити доступ. Якщо ви "
-"хочете продовжити використовувати свій безкоштовний обліковий запис, ви "
-"можете подати запит на поновлення свого облікового запису, натиснувши кнопку "
-"«Поновлення» на %(partner_link)s. З найкращими побажаннями, Бібліотека "
-"Вікіпедії Ви можете вимкнути ці повідомлення на своїй сторінці налаштувань "
-"користувача: https://wikipedialibrary.wmflabs.org/users/"
+msgid "Dear %(user)s, According to our records, your access to %(partner_name)s will soon expire and you may lose access. If you want to continue making use of your free account, you can request renewal of your account by clicking the Renew button at %(partner_link)s. Best, The Wikipedia Library You can disable these emails in your user page preferences: https://wikipedialibrary.wmflabs.org/users/"
+msgstr "Шановний/а %(user)s, Згідно з нашими записами, термін дії вашого доступу до %(partner_name)s скоро закінчиться і ви можете втратити доступ. Якщо ви хочете продовжити використовувати свій безкоштовний обліковий запис, ви можете подати запит на поновлення свого облікового запису, натиснувши кнопку «Поновлення» на %(partner_link)s. З найкращими побажаннями, Бібліотека Вікіпедії Ви можете вимкнути ці повідомлення на своїй сторінці налаштувань користувача: https://wikipedialibrary.wmflabs.org/users/"
 
 #. Translators: This is the subject of an email sent to users when they have an account that is soon to expire. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/user_renewal_notice-subject.html:4
@@ -1420,36 +1138,14 @@ msgstr "Ваш доступ Бібліотеки Вікіпедії може с�
 #. Translators: This email is sent to users when their application is waitlisted because there are no more accounts available. Don't translate Jinja variables in curly braces like user or partner; don't translate html tags either. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/waitlist_notification-body-html.html:5
 #, python-format
-msgid ""
-"<p>Dear %(user)s,</p> <p>Thank you for applying for access to %(partner)s "
-"resources through The Wikipedia Library. There are no accounts currently "
-"available so your application has been waitlisted. Your application will be "
-"evaluated if/when more accounts become available. You can see all available "
-"resources at <a href=\"%(link)s\">%(link)s</a>.</p> <p>Best,</p> <p>The "
-"Wikipedia Library</p>"
-msgstr ""
-"<p>Шановний/а %(user)s,</p> <p>Дякуємо, що подали заявку на доступ до "
-"ресурсів %(partner)s через Бібліотеку Вікіпедії. Наразі доступ не надається, "
-"тож ваша заявка потрапила у список очікування. Вашу заявку буде розглянуто, "
-"якщо/коли надавання доступу відновиться. Ви можете переглянути усі доступні "
-"ресурси на <a href=\"%(link)s\">%(link)s</a>.</p> <p>З найкращими "
-"побажаннями,</p> <p>Бібліотека Вікіпедії</p>"
+msgid "<p>Dear %(user)s,</p> <p>Thank you for applying for access to %(partner)s resources through The Wikipedia Library. There are no accounts currently available so your application has been waitlisted. Your application will be evaluated if/when more accounts become available. You can see all available resources at <a href=\"%(link)s\">%(link)s</a>.</p> <p>Best,</p> <p>The Wikipedia Library</p>"
+msgstr "<p>Шановний/а %(user)s,</p> <p>Дякуємо, що подали заявку на доступ до ресурсів %(partner)s через Бібліотеку Вікіпедії. Наразі доступ не надається, тож ваша заявка потрапила у список очікування. Вашу заявку буде розглянуто, якщо/коли надавання доступу відновиться. Ви можете переглянути усі доступні ресурси на <a href=\"%(link)s\">%(link)s</a>.</p> <p>З найкращими побажаннями,</p> <p>Бібліотека Вікіпедії</p>"
 
 #. Translators: This email is sent to users when their application is waitlisted because there are no more accounts available. Don't translate Jinja variables in curly braces like user or partner. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/waitlist_notification-body-text.html:3
 #, python-format
-msgid ""
-"Dear %(user)s, Thank you for applying for access to %(partner)s resources "
-"through The Wikipedia Library. There are no accounts currently available so "
-"your application has been waitlisted. Your application will be evaluated if/"
-"when more accounts become available. You can see all available resources at: "
-"%(link)s Best, The Wikipedia Library"
-msgstr ""
-"Шановний/а %(user)s, Дякуємо, що подали заявку на доступ до ресурсів "
-"%(partner)s через Бібліотеку Вікіпедії. Наразі доступ не надається, тож ваша "
-"заявка потрапила у список очікування. Вашу заявку буде розглянуто, якщо/коли "
-"надавання доступу відновиться. Ви можете переглянути усі доступні ресурси на "
-"%(link)s. З найкращими побажаннями, Бібліотека Вікіпедії"
+msgid "Dear %(user)s, Thank you for applying for access to %(partner)s resources through The Wikipedia Library. There are no accounts currently available so your application has been waitlisted. Your application will be evaluated if/when more accounts become available. You can see all available resources at: %(link)s Best, The Wikipedia Library"
+msgstr "Шановний/а %(user)s, Дякуємо, що подали заявку на доступ до ресурсів %(partner)s через Бібліотеку Вікіпедії. Наразі доступ не надається, тож ваша заявка потрапила у список очікування. Вашу заявку буде розглянуто, якщо/коли надавання доступу відновиться. Ви можете переглянути усі доступні ресурси на %(link)s. З найкращими побажаннями, Бібліотека Вікіпедії"
 
 #. Translators: This is the subject of an email sent to users when their application is waitlisted because there are no more accounts available. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/waitlist_notification-subject.html:4
@@ -1610,22 +1306,15 @@ msgstr "Недоступний"
 #: TWLight/resources/templates/resources/filter_section.html:14
 #: TWLight/templates/about.html:12
 #: TWLight/users/templates/users/filter_section.html:13
-msgid ""
-"The Wikipedia Library allows active editors to access a wide range of "
-"collections of paywalled reliable sources for free!"
-msgstr ""
-"Бібліотека Вікіпедії дозволяє активним редакторам безкоштовно отримувати "
-"доступ до широкого спектру колекцій надійних джерел з платним доступом!"
+msgid "The Wikipedia Library allows active editors to access a wide range of collections of paywalled reliable sources for free!"
+msgstr "Бібліотека Вікіпедії дозволяє активним редакторам безкоштовно отримувати доступ до широкого спектру колекцій надійних джерел з платним доступом!"
 
 #. Translators: On the Browse Partners page (https://wikipedialibrary.wmflabs.org/partners/), this introduces users to The Wikipedia Library.
 #. Translators: On the MyLibrary page (https://wikipedialibrary.wmflabs.org/users/my_library), this introduces users to The Wikipedia Library.
 #: TWLight/resources/templates/resources/filter_section.html:17
 #: TWLight/users/templates/users/filter_section.html:15
-msgid ""
-"Start with the search bar at the top or browse publisher websites directly."
-msgstr ""
-"Почніть з рядка пошуку вгорі або перегляньте веб-сайти видавців "
-"безпосередньо."
+msgid "Start with the search bar at the top or browse publisher websites directly."
+msgstr "Почніть з рядка пошуку вгорі або перегляньте веб-сайти видавців безпосередньо."
 
 #. Translators: On the Browse Partners page (https://wikipedialibrary.wmflabs.org/partners/), this appears below introductory text and links to the 'About' page (https://wikipedialibrary.wmflabs.org/about/)
 #. Translators: On the MyLibrary page (https://wikipedialibrary.wmflabs.org/users/my_library), this appears below introductory text and links to the 'About' page (https://wikipedialibrary.wmflabs.org/about/)
@@ -1698,67 +1387,39 @@ msgstr "Назад до партнерів"
 #. Translators: If we have no available accounts for a partner, the coordinator can change the application system to a waiting list.
 #: TWLight/resources/templates/resources/partner_detail.html:36
 #: TWLight/resources/templates/resources/partner_detail_apply.html:17
-msgid ""
-"There are no access grants available for this partner at this time. You can "
-"still apply for access; applications will be processed when access is "
-"available."
-msgstr ""
-"Цей партнер наразі не надає доступу. Ви й далі можете подавати заявку на "
-"доступ; заявки буде опрацьовано, коли надавання доступу відновиться."
+msgid "There are no access grants available for this partner at this time. You can still apply for access; applications will be processed when access is available."
+msgstr "Цей партнер наразі не надає доступу. Ви й далі можете подавати заявку на доступ; заявки буде опрацьовано, коли надавання доступу відновиться."
 
 #. Translators: This text links to the minimum user requirements and terms of use on the partner page.
 #: TWLight/resources/templates/resources/partner_detail.html:48
 #: TWLight/resources/templates/resources/partner_detail_apply.html:29
 #, python-format
-msgid ""
-"Before applying, please review the <strong><a class=\"twl-links\" href="
-"\"%(about)s#req\">minimum requirements</a></strong> for access and our "
-"<strong><a class=\"twl-links\" href=\"%(terms)s\">terms of use</a></strong>."
-msgstr ""
-"Перед подачею заявки, будь ласка, перегляньте <strong><a class=\"twl-links\" "
-"href=\"%(about)s#req\">мінімальні вимоги</a></strong> для доступу та наші "
-"<strong><a class=\"twl-links\" href=\"%(terms)s\">умови користування</a></"
-"strong>."
+msgid "Before applying, please review the <strong><a class=\"twl-links\" href=\"%(about)s#req\">minimum requirements</a></strong> for access and our <strong><a class=\"twl-links\" href=\"%(terms)s\">terms of use</a></strong>."
+msgstr "Перед подачею заявки, будь ласка, перегляньте <strong><a class=\"twl-links\" href=\"%(about)s#req\">мінімальні вимоги</a></strong> для доступу та наші <strong><a class=\"twl-links\" href=\"%(terms)s\">умови користування</a></strong>."
 
 #. Translators: This text refers to the page containing the content a user is authorized to access.
 #: TWLight/resources/templates/resources/partner_detail.html:69
 #, python-format
-msgid ""
-"View the status of your access in <strong><a class=\"twl-links\" href="
-"\"%(library_url)s\">My Library</a></strong> page."
-msgstr ""
-"Перегляньте статус свого доступу на сторінці <strong><a class=\"twl-links\" "
-"href=\"%(library_url)s\">Моя бібліотека</a></strong>."
+msgid "View the status of your access in <strong><a class=\"twl-links\" href=\"%(library_url)s\">My Library</a></strong> page."
+msgstr "Перегляньте статус свого доступу на сторінці <strong><a class=\"twl-links\" href=\"%(library_url)s\">Моя бібліотека</a></strong>."
 
 #. Translators: This message is shown when a user has open applications, linking to their respective applications page.
 #: TWLight/resources/templates/resources/partner_detail.html:78
 #, python-format
-msgid ""
-"View the status of your application(s) on your <strong><a class=\"twl-links"
-"\" href=\"%(applications_url)s\">My Applications</a></strong> page."
-msgstr ""
-"Перегляньте статус своїх заявок на сторінці <strong><a class=\"twl-links\" "
-"href=\"%(applications_url)s\">Мої заявки</a></strong>."
+msgid "View the status of your application(s) on your <strong><a class=\"twl-links\" href=\"%(applications_url)s\">My Applications</a></strong> page."
+msgstr "Перегляньте статус своїх заявок на сторінці <strong><a class=\"twl-links\" href=\"%(applications_url)s\">Мої заявки</a></strong>."
 
 #. Translators: This message is shown when a user has authorizations, linking to their respective collections page.
 #: TWLight/resources/templates/resources/partner_detail_apply.html:50
 #, python-format
-msgid ""
-"View the status of your access on your <strong><a href=\"%(library_url)s\" "
-"class=\"twl-links\">My Library</a></strong> page."
-msgstr ""
-"Перегляньте статус вашого доступу у <strong><a href=\"%(library_url)s"
-"\">Вашій бібліотеці</a></strong>."
+msgid "View the status of your access on your <strong><a href=\"%(library_url)s\" class=\"twl-links\">My Library</a></strong> page."
+msgstr "Перегляньте статус вашого доступу у <strong><a href=\"%(library_url)s\">Вашій бібліотеці</a></strong>."
 
 #. Translators: This message is shown when a user has open applications, linking to their respective applications page.
 #: TWLight/resources/templates/resources/partner_detail_apply.html:60
 #, python-format
-msgid ""
-"View the status of your application(s) on your <strong><a href="
-"\"%(applications_url)s\">My Applications</a></strong> page."
-msgstr ""
-"Перегляньте статус своїх заявок на сторінці <strong><a href="
-"\"%(applications_url)s\">Мої заявки</a></strong>."
+msgid "View the status of your application(s) on your <strong><a href=\"%(applications_url)s\">My Applications</a></strong> page."
+msgstr "Перегляньте статус своїх заявок на сторінці <strong><a href=\"%(applications_url)s\">Мої заявки</a></strong>."
 
 #. Translators: One the partner detail page, this text labels the button which coordinators can click to remove a partner from waitlisted status.
 #: TWLight/resources/templates/resources/partner_detail_apply.html:73
@@ -1787,14 +1448,8 @@ msgstr "Сторінка Спеціальна:Лист користувачев�
 
 #. Translators: If no account coordinator is assigned to a partner, the Wikipedia Library team will coordinate signups. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/resources/templates/resources/partner_detail_apply.html:112
-msgid ""
-"The Wikipedia Library team will process this application. Want to help? <a "
-"class=\"twl-links\" href=\"https://en.wikipedia.org/wiki/Wikipedia:"
-"The_Wikipedia_Library/Coordinators/Signup\">Sign up as a coordinator.</a>"
-msgstr ""
-"Команда Бібліотеки Вікіпедії опрацює цю заявку. Бажаєте допомогти? <a class="
-"\"twl-links\" href=\"https://en.wikipedia.org/wiki/Wikipedia:"
-"The_Wikipedia_Library/Coordinators/Signup\">Запишіться як координатор.</a>"
+msgid "The Wikipedia Library team will process this application. Want to help? <a class=\"twl-links\" href=\"https://en.wikipedia.org/wiki/Wikipedia:The_Wikipedia_Library/Coordinators/Signup\">Sign up as a coordinator.</a>"
+msgstr "Команда Бібліотеки Вікіпедії опрацює цю заявку. Бажаєте допомогти? <a class=\"twl-links\" href=\"https://en.wikipedia.org/wiki/Wikipedia:The_Wikipedia_Library/Coordinators/Signup\">Запишіться як координатор.</a>"
 
 #. Translators: This text labels a button coordinators can click to view a list of users who have applied for access for a particular partner
 #: TWLight/resources/templates/resources/partner_detail_apply.html:121
@@ -1823,24 +1478,14 @@ msgstr "Доступ до Library Bundle"
 
 #. Translators: Text shown to authenticated, bundle eligible users when they visit a Bundle partner page.
 #: TWLight/resources/templates/resources/partner_detail_apply.html:138
-msgid ""
-"You are eligible to access Library Bundle partners. Click the button above "
-"to access the collection."
-msgstr ""
-"Ви відповідаєте критеріям доступу до партнерів Library Bundle. Натисніть на "
-"кнопку угорі, щоб отримати доступ до колекції."
+msgid "You are eligible to access Library Bundle partners. Click the button above to access the collection."
+msgstr "Ви відповідаєте критеріям доступу до партнерів Library Bundle. Натисніть на кнопку угорі, щоб отримати доступ до колекції."
 
 #. Translators: Text shown to authenticated, bundle ineligible users when they visit a Bundle partner page.
 #: TWLight/resources/templates/resources/partner_detail_apply.html:152
 #, python-format
-msgid ""
-"You are not eligible to access Library Bundle partners. Visit the <a class="
-"\"twl-links\" href=\"%(homepage)s\">homepage</a> to check the eligibility "
-"criteria."
-msgstr ""
-"Ви не відповідаєте критеріям доступу до партнерів Library Bundle. Перейдіть "
-"на <a class=\"twl-links\" href=\"%(homepage)s\">домашню сторінку</a>, щоб "
-"ознайомитися з критеріями."
+msgid "You are not eligible to access Library Bundle partners. Visit the <a class=\"twl-links\" href=\"%(homepage)s\">homepage</a> to check the eligibility criteria."
+msgstr "Ви не відповідаєте критеріям доступу до партнерів Library Bundle. Перейдіть на <a class=\"twl-links\" href=\"%(homepage)s\">домашню сторінку</a>, щоб ознайомитися з критеріями."
 
 #. Translators: Buttton prompting users to log in.
 #: TWLight/resources/templates/resources/partner_detail_apply.html:160
@@ -1851,15 +1496,8 @@ msgstr "Увійти"
 #. Translators: Text shown to unauthenticated users when they visit a Bundle partner page.
 #: TWLight/resources/templates/resources/partner_detail_apply.html:168
 #, python-format
-msgid ""
-"This resource is part of our <a class=\"twl-links\" href=\"%(about)s"
-"\">Library Bundle</a>, which you can access if you meet our minimum "
-"eligibility criteria. Log in to find out if you are eligible."
-msgstr ""
-"Цей ресурс є частиною нашого <a class=\"twl-links\" href=\"%(about)s"
-"\">Library Bundle</a>, до якого ви можете отримати доступ, якщо відповідаєте "
-"нашим мінімальним критеріям доступу. Увійдіть, щоб дізнатися, чи ви "
-"відповідає критеріям."
+msgid "This resource is part of our <a class=\"twl-links\" href=\"%(about)s\">Library Bundle</a>, which you can access if you meet our minimum eligibility criteria. Log in to find out if you are eligible."
+msgstr "Цей ресурс є частиною нашого <a class=\"twl-links\" href=\"%(about)s\">Library Bundle</a>, до якого ви можете отримати доступ, якщо відповідаєте нашим мінімальним критеріям доступу. Увійдіть, щоб дізнатися, чи ви відповідає критеріям."
 
 #. Translators: This is the label for a number which shows the total active accounts for one partner. (e.g. https://wikipedialibrary.wmflabs.org/partners/8/).
 #: TWLight/resources/templates/resources/partner_detail_stats.html:21
@@ -1909,33 +1547,20 @@ msgstr "Обмеження уривка"
 #. Translators: If a partner has specified the excerpt limit both in words and percentage, this message will display the percentage of words and the number of words on the partner page.
 #: TWLight/resources/templates/resources/partner_detail_timeline.html:99
 #, python-format
-msgid ""
-"%(object)s allows a maximum of %(excerpt_limit)s words or "
-"%(excerpt_limit_percentage)s%% of an article be excerpted into a Wikipedia "
-"article."
-msgstr ""
-"%(object)s дозволяє додати у Вікіпедію щонайбільше %(excerpt_limit)s слів "
-"або %(excerpt_limit_percentage)s%% від статті."
+msgid "%(object)s allows a maximum of %(excerpt_limit)s words or %(excerpt_limit_percentage)s%% of an article be excerpted into a Wikipedia article."
+msgstr "%(object)s дозволяє додати у Вікіпедію щонайбільше %(excerpt_limit)s слів або %(excerpt_limit_percentage)s%% від статті."
 
 #. Translators: If a partner has specified the excerpt limit in words, this message will display the number of words on the partner page.
 #: TWLight/resources/templates/resources/partner_detail_timeline.html:106
 #, python-format
-msgid ""
-"%(object)s allows a maximum of %(excerpt_limit)s words be excerpted into a "
-"Wikipedia article."
-msgstr ""
-"%(object)s дозволяє додати у статтю Вікіпедії щонайбільше %(excerpt_limit)s "
-"слів."
+msgid "%(object)s allows a maximum of %(excerpt_limit)s words be excerpted into a Wikipedia article."
+msgstr "%(object)s дозволяє додати у статтю Вікіпедії щонайбільше %(excerpt_limit)s слів."
 
 #. Translators: If a partner has specified the excerpt limit in percentage, this message will display the percentage of words on the partner page.
 #: TWLight/resources/templates/resources/partner_detail_timeline.html:113
 #, python-format
-msgid ""
-"%(object)s allows a maximum of %(excerpt_limit_percentage)s%% of an article "
-"be excerpted into a Wikipedia article."
-msgstr ""
-"%(object)s дозволяє додати у статтю Вікіпедії щонайбільше "
-"%(excerpt_limit_percentage)s%% статті."
+msgid "%(object)s allows a maximum of %(excerpt_limit_percentage)s%% of an article be excerpted into a Wikipedia article."
+msgstr "%(object)s дозволяє додати у статтю Вікіпедії щонайбільше %(excerpt_limit_percentage)s%% статті."
 
 #. Translators: If a partner has other requirements for access, this text shows as the title for that information field. (e.g. https://wikipedialibrary.wmflabs.org/partners/10/).
 #: TWLight/resources/templates/resources/partner_detail_timeline.html:132
@@ -1945,12 +1570,8 @@ msgstr "Особливі вимоги до заявників"
 #. Translators: If a user must agree to a Terms of Use document, they see this message, and must enter the name of the resource. Don't translate publisher or url.
 #: TWLight/resources/templates/resources/partner_detail_timeline.html:140
 #, python-format
-msgid ""
-"%(publisher)s requires that you agree with its <a href=\"%(url)s\">terms of "
-"use</a>."
-msgstr ""
-"%(publisher)s вимагає, щоб ви погодилися з їхніми <a href=\"%(url)s"
-"\">умовами користування</a>."
+msgid "%(publisher)s requires that you agree with its <a href=\"%(url)s\">terms of use</a>."
+msgstr "%(publisher)s вимагає, щоб ви погодилися з їхніми <a href=\"%(url)s\">умовами користування</a>."
 
 #. Translators: If a user must provide their real name to apply to a partner, they see this message, and must enter the name of the resource. Don't translate publisher.
 #: TWLight/resources/templates/resources/partner_detail_timeline.html:150
@@ -1973,22 +1594,14 @@ msgstr "%(publisher)s вимагає, щоб ви вказали свою інс
 #. Translators: If a user must select a specific resource to apply for, they see this message, and must enter the name of the resource. Don't translate publisher.
 #: TWLight/resources/templates/resources/partner_detail_timeline.html:177
 #, python-format
-msgid ""
-"%(publisher)s requires that you specify a particular title that you want to "
-"access."
-msgstr ""
-"%(publisher)s вимагає, щоб ви вказали конкретну назву, до якої ви хочете "
-"отримати доступ."
+msgid "%(publisher)s requires that you specify a particular title that you want to access."
+msgstr "%(publisher)s вимагає, щоб ви вказали конкретну назву, до якої ви хочете отримати доступ."
 
 #. Translators: If a user must register on the partner website before applying, they see this message. Don't translate partner.
 #: TWLight/resources/templates/resources/partner_detail_timeline.html:187
 #, python-format
-msgid ""
-"%(publisher)s requires that you sign up for an account before applying for "
-"access."
-msgstr ""
-"%(publisher)s вимагає, щоб ви зареєструвалися до того, як подавати заявку на "
-"доступ."
+msgid "%(publisher)s requires that you sign up for an account before applying for access."
+msgstr "%(publisher)s вимагає, щоб ви зареєструвалися до того, як подавати заявку на доступ."
 
 #. Translators: If a partner has their location listed, this message is a label for that location
 #: TWLight/resources/templates/resources/partner_detail_timeline.html:206
@@ -2114,12 +1727,8 @@ msgstr "Ви впевнені, що бажаєте вилучити <b>%(object)
 
 #. Translators: If multiple authorizations where returned for a collection, this message is shown to a user
 #: TWLight/resources/views.py:268
-msgid ""
-"Multiple authorizations were returned – something's wrong. Please contact us "
-"and don't forget to mention this message."
-msgstr ""
-"Отримано багато авторизацій — щось не так. Будь ласка, зв'яжіться з нами, і "
-"не забудьте згадати це повідомлення."
+msgid "Multiple authorizations were returned – something's wrong. Please contact us and don't forget to mention this message."
+msgstr "Отримано багато авторизацій — щось не так. Будь ласка, зв'яжіться з нами, і не забудьте згадати це повідомлення."
 
 #. Translators: This message is shown when user tries to access a NOT_AVAILABLE Partner
 #: TWLight/resources/views.py:316
@@ -2159,23 +1768,8 @@ msgstr "Вибачте, ми не знаємо, що з цим робити."
 #. Translators: Shown on the website's 400 page, when a user sends a bad request. Don't translate path or Phabricator.
 #: TWLight/templates/400.html:20
 #, python-format
-msgid ""
-"If you think we should know what to do with that, please email us about this "
-"error at <a class=\"twl-links\" href=\"mailto:wikipedialibrary@wikimedia.org?"
-"Subject=Wikipedia%%20Library%%20%(path)s%%20Permission%%20denied"
-"\">wikipedialibrary@wikimedia.org</a> or report it to us on <a class=\"twl-"
-"links\" href=\"https://phabricator.wikimedia.org/maniphest/task/edit/form/1/?"
-"projectPHIDs=Library-Card-Platform&title=Wikipedia%%20Library%%20%(path)s"
-"%%20Bad%%20Request\">Phabricator</a>"
-msgstr ""
-"Якщо ви вважаєте, що ми маємо знати, що з цим зробити, будь ласка, напишіть "
-"нам листа про цю помилку на <a class=\"twl-links\" href=\"mailto:"
-"wikipedialibrary@wikimedia.org?Subject=Wikipedia%%20Library%%20%(path)s"
-"%%20Permission%%20denied\">wikipedialibrary@wikimedia.org</a> або залишіть "
-"звіт на <a class=\"twl-links\" href=\"https://phabricator.wikimedia.org/"
-"maniphest/task/edit/form/1/?projectPHIDs=Library-Card-"
-"Platform&title=Wikipedia%%20Library%%20%(path)s%%20Bad%%20Request"
-"\">Фабрикаторі</a>"
+msgid "If you think we should know what to do with that, please email us about this error at <a class=\"twl-links\" href=\"mailto:wikipedialibrary@wikimedia.org?Subject=Wikipedia%%20Library%%20%(path)s%%20Permission%%20denied\">wikipedialibrary@wikimedia.org</a> or report it to us on <a class=\"twl-links\" href=\"https://phabricator.wikimedia.org/maniphest/task/edit/form/1/?projectPHIDs=Library-Card-Platform&title=Wikipedia%%20Library%%20%(path)s%%20Bad%%20Request\">Phabricator</a>"
+msgstr "Якщо ви вважаєте, що ми маємо знати, що з цим зробити, будь ласка, напишіть нам листа про цю помилку на <a class=\"twl-links\" href=\"mailto:wikipedialibrary@wikimedia.org?Subject=Wikipedia%%20Library%%20%(path)s%%20Permission%%20denied\">wikipedialibrary@wikimedia.org</a> або залишіть звіт на <a class=\"twl-links\" href=\"https://phabricator.wikimedia.org/maniphest/task/edit/form/1/?projectPHIDs=Library-Card-Platform&title=Wikipedia%%20Library%%20%(path)s%%20Bad%%20Request\">Фабрикаторі</a>"
 
 #. Translators: Alt text for an image shown on the 400 error page.
 #. Translators: Alt text for an image shown on the 403 error page.
@@ -2196,24 +1790,8 @@ msgstr "Вибачте, ви не маєте прав цього роботи."
 #. Translators: Shown on the website's 403 page, when a user attempts to navigate to a page they don't have permission to view. Don't translate path or Phabricator.
 #: TWLight/templates/403.html:20
 #, python-format
-msgid ""
-"If you think your account should be able to do that, please email us about "
-"this error at <a class=\"twl-links\" href=\"mailto:"
-"wikipedialibrary@wikimedia.org?Subject=Wikipedia%%20Library%%20%(path)s"
-"%%20Permission%%20denied\">wikipedialibrary@wikimedia.org</a> or report it "
-"to us on <a class=\"twl-links\" href=\"https://phabricator.wikimedia.org/"
-"maniphest/task/edit/form/1/?projectPHIDs=Library-Card-"
-"Platform&title=Wikipedia%%20Library%%20%(path)s%%20Permission%%20denied"
-"\">Phabricator</a>"
-msgstr ""
-"Якщо ви вважаєте, що ваш обліковий запис має мати змогу це робити, будь "
-"ласка, напишіть нам про цю помилку на <a class=\"twl-links\" href=\"mailto:"
-"wikipedialibrary@wikimedia.org?Subject=Wikipedia%%20Library%%20%(path)s"
-"%%20Permission%%20denied\">wikipedialibrary@wikimedia.org</a> або залиште "
-"звіт на <a class=\"twl-links\" href=\"https://phabricator.wikimedia.org/"
-"maniphest/task/edit/form/1/?projectPHIDs=Library-Card-"
-"Platform&title=Wikipedia%%20Library%%20%(path)s%%20Permission%%20denied"
-"\">Фабрикаторі</a>"
+msgid "If you think your account should be able to do that, please email us about this error at <a class=\"twl-links\" href=\"mailto:wikipedialibrary@wikimedia.org?Subject=Wikipedia%%20Library%%20%(path)s%%20Permission%%20denied\">wikipedialibrary@wikimedia.org</a> or report it to us on <a class=\"twl-links\" href=\"https://phabricator.wikimedia.org/maniphest/task/edit/form/1/?projectPHIDs=Library-Card-Platform&title=Wikipedia%%20Library%%20%(path)s%%20Permission%%20denied\">Phabricator</a>"
+msgstr "Якщо ви вважаєте, що ваш обліковий запис має мати змогу це робити, будь ласка, напишіть нам про цю помилку на <a class=\"twl-links\" href=\"mailto:wikipedialibrary@wikimedia.org?Subject=Wikipedia%%20Library%%20%(path)s%%20Permission%%20denied\">wikipedialibrary@wikimedia.org</a> або залиште звіт на <a class=\"twl-links\" href=\"https://phabricator.wikimedia.org/maniphest/task/edit/form/1/?projectPHIDs=Library-Card-Platform&title=Wikipedia%%20Library%%20%(path)s%%20Permission%%20denied\">Фабрикаторі</a>"
 
 #. Translators: Shown on the website's 404 page, when a user attempts to navigate to a page that doesn't exist.
 #: TWLight/templates/404.html:11
@@ -2228,22 +1806,8 @@ msgstr "Вибачте, ми не можемо знайти це."
 #. Translators: Shown on the website's 404 page, when a user attempts to navigate to a page that doesn't exist. Don't translate path or Phabricator.
 #: TWLight/templates/404.html:19
 #, python-format
-msgid ""
-"If you are certain that something should be here, please email us about this "
-"error at <a class=\"twl-links\" href=\"mailto:wikipedialibrary@wikimedia.org?"
-"Subject=Wikipedia%%20Library%%20%(path)s%%20Not%%20found\"> "
-"wikipedialibrary@wikimedia.org</a> or report it to us on <a class=\"twl-links"
-"\" href=\"https://phabricator.wikimedia.org/maniphest/task/edit/form/1/?"
-"projectPHIDs=Library-Card-Platform&title=Wikipedia%%20Library%%20%(path)s"
-"%%20Not%%20found\">Phabricator</a>"
-msgstr ""
-"Якщо ви впевнені, що тут щось має бути, будь ласка, напишіть нам про цю "
-"помилку на <a class=\"twl-links\" href=\"mailto:wikipedialibrary@wikimedia."
-"org?Subject=Wikipedia%%20Library%%20%(path)s%%20Not%%20found\"> "
-"wikipedialibrary@wikimedia.org</a> або залиште звіт на <a class=\"twl-links"
-"\" href=\"https://phabricator.wikimedia.org/maniphest/task/edit/form/1/?"
-"projectPHIDs=Library-Card-Platform&title=Wikipedia%%20Library%%20%(path)s"
-"%%20Not%%20found\">Фабрикаторі</a>"
+msgid "If you are certain that something should be here, please email us about this error at <a class=\"twl-links\" href=\"mailto:wikipedialibrary@wikimedia.org?Subject=Wikipedia%%20Library%%20%(path)s%%20Not%%20found\"> wikipedialibrary@wikimedia.org</a> or report it to us on <a class=\"twl-links\" href=\"https://phabricator.wikimedia.org/maniphest/task/edit/form/1/?projectPHIDs=Library-Card-Platform&title=Wikipedia%%20Library%%20%(path)s%%20Not%%20found\">Phabricator</a>"
+msgstr "Якщо ви впевнені, що тут щось має бути, будь ласка, напишіть нам про цю помилку на <a class=\"twl-links\" href=\"mailto:wikipedialibrary@wikimedia.org?Subject=Wikipedia%%20Library%%20%(path)s%%20Not%%20found\"> wikipedialibrary@wikimedia.org</a> або залиште звіт на <a class=\"twl-links\" href=\"https://phabricator.wikimedia.org/maniphest/task/edit/form/1/?projectPHIDs=Library-Card-Platform&title=Wikipedia%%20Library%%20%(path)s%%20Not%%20found\">Фабрикаторі</a>"
 
 #. Translators: Alt text for an image shown on the 404 error page.
 #: TWLight/templates/404.html:32
@@ -2257,48 +1821,19 @@ msgstr "Про Бібліотеку Вікіпедії"
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:20
-msgid ""
-"This platform is our central tool for facilitating access to our available "
-"collections. Here you can see which partnerships are available, search their "
-"contents, and apply for and access the ones you’re interested in."
-msgstr ""
-"Ця платформа є нашим центральним інструментом для полегшення доступу до "
-"наших доступних колекцій. Тут ви можете побачити, які партнерства доступні, "
-"шукати їх вміст, подати заявку та отримати доступ до тих, які вас цікавлять."
+msgid "This platform is our central tool for facilitating access to our available collections. Here you can see which partnerships are available, search their contents, and apply for and access the ones you’re interested in."
+msgstr "Ця платформа є нашим центральним інструментом для полегшення доступу до наших доступних колекцій. Тут ви можете побачити, які партнерства доступні, шукати їх вміст, подати заявку та отримати доступ до тих, які вас цікавлять."
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/). Wikimedia Foundation should not be translated.
 #: TWLight/templates/about.html:29
-msgid ""
-"All users receive immediate access to some collections, which can be browsed "
-"by clicking the 'Access collection' buttons or using the search bar at the "
-"top of the page. Other collections require an application before access is "
-"granted, and may be accessed directly or via an individual login or access "
-"code. Volunteer coordinators, who have signed non-disclosure agreements with "
-"the Wikimedia Foundation, review these applications and work with publishers "
-"to get you your free access."
-msgstr ""
-"Усі користувачі отримують негайний доступ до деяких колекцій, які можна "
-"переглянути, натиснувши кнопку «Доступ до колекції» або скориставшись рядком "
-"пошуку у верхній частині сторінки. Для надання доступу до інших колекцій "
-"потрібен додаток, і доступ до них можна отримати безпосередньо або за "
-"допомогою індивідуального входу чи коду доступу. Координатори волонтерів, "
-"які підписали угоди про нерозголошення з Фондом Вікімедіа, переглядають ці "
-"програми та співпрацюють з видавцями, щоб отримати вам безкоштовний доступ."
+msgid "All users receive immediate access to some collections, which can be browsed by clicking the 'Access collection' buttons or using the search bar at the top of the page. Other collections require an application before access is granted, and may be accessed directly or via an individual login or access code. Volunteer coordinators, who have signed non-disclosure agreements with the Wikimedia Foundation, review these applications and work with publishers to get you your free access."
+msgstr "Усі користувачі отримують негайний доступ до деяких колекцій, які можна переглянути, натиснувши кнопку «Доступ до колекції» або скориставшись рядком пошуку у верхній частині сторінки. Для надання доступу до інших колекцій потрібен додаток, і доступ до них можна отримати безпосередньо або за допомогою індивідуального входу чи коду доступу. Координатори волонтерів, які підписали угоди про нерозголошення з Фондом Вікімедіа, переглядають ці програми та співпрацюють з видавцями, щоб отримати вам безкоштовний доступ."
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/). Don't translate terms_url.
 #: TWLight/templates/about.html:43
 #, python-format
-msgid ""
-"For more information about how your information is stored and reviewed "
-"please see our <a class=\"twl-links\" href=\"%(terms_url)s\"> terms of use "
-"and privacy policy</a>. Accounts you apply for are also subject to the Terms "
-"of Use provided by each partner’s platform; please review them."
-msgstr ""
-"Детальнішу інформацію про те, як зберігається і розглядається інформація з "
-"заявок, перегляньте, будь ласка, в <a class=\"twl-links\" href="
-"\"%(terms_url)s\">умовах використання та політиці приватності</a>. Облікові "
-"записи, на які ви подаєте заявку, є також предметом Умов використання "
-"відповідної партнерської платформи; будь ласка, перегляньте їх."
+msgid "For more information about how your information is stored and reviewed please see our <a class=\"twl-links\" href=\"%(terms_url)s\"> terms of use and privacy policy</a>. Accounts you apply for are also subject to the Terms of Use provided by each partner’s platform; please review them."
+msgstr "Детальнішу інформацію про те, як зберігається і розглядається інформація з заявок, перегляньте, будь ласка, в <a class=\"twl-links\" href=\"%(terms_url)s\">умовах використання та політиці приватності</a>. Облікові записи, на які ви подаєте заявку, є також предметом Умов використання відповідної партнерської платформи; будь ласка, перегляньте їх."
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:51
@@ -2307,25 +1842,13 @@ msgstr "Хто може отримати доступ?"
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/). Wikimedia Foundation should not be translated.
 #: TWLight/templates/about.html:55
-msgid ""
-"Any active editor in good standing can receive access. For publishers with "
-"limited numbers of accounts, applications are reviewed based on the editor’s "
-"needs and contributions. If you think you could use access to one of our "
-"partner resources and are an active editor in any project supported by the "
-"Wikimedia Foundation, please apply."
-msgstr ""
-"Будь-який активний редактор з хорошою репутацією може отримати доступ. Для "
-"видавців з лімітованим числом облікових записів заявки розглядаються залежно "
-"від потреб та внеску редактора. Якщо ви вважаєте, що вам допоможе доступ до "
-"одного з наших партнерських ресурсів, і ви є активним редактором у будь-"
-"якому проєкті, підтримуваному Фондом Вікімедіа, будь ласка, подавайтеся."
+msgid "Any active editor in good standing can receive access. For publishers with limited numbers of accounts, applications are reviewed based on the editor’s needs and contributions. If you think you could use access to one of our partner resources and are an active editor in any project supported by the Wikimedia Foundation, please apply."
+msgstr "Будь-який активний редактор з хорошою репутацією може отримати доступ. Для видавців з лімітованим числом облікових записів заявки розглядаються залежно від потреб та внеску редактора. Якщо ви вважаєте, що вам допоможе доступ до одного з наших партнерських ресурсів, і ви є активним редактором у будь-якому проєкті, підтримуваному Фондом Вікімедіа, будь ласка, подавайтеся."
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:65
 msgid "Any editor can use the library if they meet a few basic requirements:"
-msgstr ""
-"Будь-який редактор може користуватися бібліотекою, якщо вони відповідають "
-"кільком основним вимогам:"
+msgstr "Будь-який редактор може користуватися бібліотекою, якщо вони відповідають кільком основним вимогам:"
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:71
@@ -2340,8 +1863,7 @@ msgstr "Ви зробили щонайменше 500 редагувань у п�
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:79
 msgid "You have made at least 10 edits to Wikimedia projects in the last month"
-msgstr ""
-"Ви зробити щонайменше 10 редагувань у проєктах Вікімедіа за останній місяць"
+msgstr "Ви зробити щонайменше 10 редагувань у проєктах Вікімедіа за останній місяць"
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:83
@@ -2350,35 +1872,13 @@ msgstr "Ви зараз не заблоковані у проєкті Вікім
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/)
 #: TWLight/templates/about.html:89
-msgid ""
-"If you are applying for an available collection, please first check that you "
-"don't already have access through another library or institution. If you do, "
-"please consider using that access rather than taking up a seat for this "
-"resource in The Wikipedia Library."
-msgstr ""
-"Якщо ви подаєте заявку на доступну колекцію, спершу перевірте, чи у вас ще "
-"немає доступу через іншу бібліотеку чи установу. Якщо так, будь ласка, "
-"подумайте про використання цього доступу, а не займати місце для цього "
-"ресурсу в бібліотеці Вікіпедії."
+msgid "If you are applying for an available collection, please first check that you don't already have access through another library or institution. If you do, please consider using that access rather than taking up a seat for this resource in The Wikipedia Library."
+msgstr "Якщо ви подаєте заявку на доступну колекцію, спершу перевірте, чи у вас ще немає доступу через іншу бібліотеку чи установу. Якщо так, будь ласка, подумайте про використання цього доступу, а не займати місце для цього ресурсу в бібліотеці Вікіпедії."
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/)
 #: TWLight/templates/about.html:99
-msgid ""
-"If your account is blocked on one or more Wikimedia projects, you may still "
-"be granted access to The Wikipedia Library. You will need to contact the "
-"Wikipedia Library team, who will review your blocks. If you have been "
-"blocked for content issues, most notably copyright violations, or have "
-"multiple long-term blocks, we may decline your request. Additionally, if "
-"your block status changes after being approved, you will need to request "
-"another review."
-msgstr ""
-"Якщо ваш обліковий запис заблокований в одному чи більше проєктів Вікімедіа, "
-"ви все одно можете отримати доступ до Бібліотеки Вікіпедії. Вам треба буде "
-"зв'язатися з командою Бібліотеки Вікіпедії, яка перегляне ваше блокування. "
-"Якщо ви були заблоковані за проблеми з вмістом, перш за все, за порушення "
-"авторських прав, або маєте численні довготермінові блокування, ми можемо "
-"відхилити ваш запит. Окрім цього, якщо ваш статус блокування зміниться після "
-"схвалення, вам треба буде подати запит на інший перегляд."
+msgid "If your account is blocked on one or more Wikimedia projects, you may still be granted access to The Wikipedia Library. You will need to contact the Wikipedia Library team, who will review your blocks. If you have been blocked for content issues, most notably copyright violations, or have multiple long-term blocks, we may decline your request. Additionally, if your block status changes after being approved, you will need to request another review."
+msgstr "Якщо ваш обліковий запис заблокований в одному чи більше проєктів Вікімедіа, ви все одно можете отримати доступ до Бібліотеки Вікіпедії. Вам треба буде зв'язатися з командою Бібліотеки Вікіпедії, яка перегляне ваше блокування. Якщо ви були заблоковані за проблеми з вмістом, перш за все, за порушення авторських прав, або маєте численні довготермінові блокування, ми можемо відхилити ваш запит. Окрім цього, якщо ваш статус блокування зміниться після схвалення, вам треба буде подати запит на інший перегляд."
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:110
@@ -2412,12 +1912,8 @@ msgstr "Схвалені редактори <i>не мають</i>:"
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:136
-msgid ""
-"Share their account logins or passwords with others, or sell their access to "
-"other parties"
-msgstr ""
-"Ділитися своїми логінами-паролями з іншими чи продавати свій доступ іншим "
-"сторонам"
+msgid "Share their account logins or passwords with others, or sell their access to other parties"
+msgstr "Ділитися своїми логінами-паролями з іншими чи продавати свій доступ іншим сторонам"
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:140
@@ -2426,30 +1922,18 @@ msgstr "Масово завантажувати партнерський кон�
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:144
-msgid ""
-"Systematically make printed or electronic copies of multiple extracts of "
-"restricted content available for any purpose"
-msgstr ""
-"Систематично робити друковані чи електронні копії численних уривків "
-"доступного обмеженого контенту з будь-якою метою"
+msgid "Systematically make printed or electronic copies of multiple extracts of restricted content available for any purpose"
+msgstr "Систематично робити друковані чи електронні копії численних уривків доступного обмеженого контенту з будь-якою метою"
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/). Stub is a technical term for a short Wikipedia article, use the appropriate Wikipedia term in your language.
 #: TWLight/templates/about.html:148
-msgid ""
-"Datamine metadata without permission, in order, for instance, to use "
-"metadata for auto-created stub articles"
-msgstr ""
-"Використовувати метадані без дозволу, наприклад, щоб на їх основі "
-"автоматично створювати статті-заготовки"
+msgid "Datamine metadata without permission, in order, for instance, to use metadata for auto-created stub articles"
+msgstr "Використовувати метадані без дозволу, наприклад, щоб на їх основі автоматично створювати статті-заготовки"
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:154
-msgid ""
-"Respecting these agreements allows us to continue growing the partnerships "
-"available to the community."
-msgstr ""
-"Повага до цих угод дозволить нам продовжувати розширювати партнерства, "
-"доступні усій спільноті."
+msgid "Respecting these agreements allows us to continue growing the partnerships available to the community."
+msgstr "Повага до цих угод дозволить нам продовжувати розширювати партнерства, доступні усій спільноті."
 
 #. Translators: This is the heading for a section on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:160
@@ -2459,62 +1943,23 @@ msgstr "Проксі"
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:164
-msgid ""
-"EZProxy is a proxy server used to authenticate users for many Wikipedia "
-"Library partners. Users sign into EZProxy via the Library Card platform to "
-"verify that they are authorized users, and then the server accesses "
-"requested resources using its own IP address."
-msgstr ""
-"EZProxy — це проксі-сервер, що використовується для автентифікації "
-"користувачів у багатьох партнерів Бібліотеки Вікіпедії. Користувачі входять "
-"у систему EZProxy через Карткову платформу Бібліотеки Вікіпедії, щоб "
-"довести, що вони є авторизованими користувачами, а тоді сервер отримує "
-"запитувані ресурси, використовуючи власну IP-адресу."
+msgid "EZProxy is a proxy server used to authenticate users for many Wikipedia Library partners. Users sign into EZProxy via the Library Card platform to verify that they are authorized users, and then the server accesses requested resources using its own IP address."
+msgstr "EZProxy — це проксі-сервер, що використовується для автентифікації користувачів у багатьох партнерів Бібліотеки Вікіпедії. Користувачі входять у систему EZProxy через Карткову платформу Бібліотеки Вікіпедії, щоб довести, що вони є авторизованими користувачами, а тоді сервер отримує запитувані ресурси, використовуючи власну IP-адресу."
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:173
-msgid ""
-"You may notice that when accessing resources via EZProxy that URLs are "
-"dynamically rewritten. This is why we recommend logging in via the Library "
-"Card platform rather than going directly to the unproxied partner website. "
-"When in doubt, check the URL for ‘idm.oclc’. If it’s there, then you’re "
-"connected via EZProxy."
-msgstr ""
-"Ви можете помітити, що при доступі до ресурсів через EZProxy посилання "
-"динамічно переписуються. Ось чому ми рекомендуємо входити в систему через "
-"Карткову платформу Бібліотеки Вікіпедії, а не переходити напряму на сайт "
-"партнера без проксі. Якщо вагаєтеся, перевірте, чи є у посиланні частинка "
-"«idm.oclc». Якщо є, це означає, що ви з'єднані через EZProxy."
+msgid "You may notice that when accessing resources via EZProxy that URLs are dynamically rewritten. This is why we recommend logging in via the Library Card platform rather than going directly to the unproxied partner website. When in doubt, check the URL for ‘idm.oclc’. If it’s there, then you’re connected via EZProxy."
+msgstr "Ви можете помітити, що при доступі до ресурсів через EZProxy посилання динамічно переписуються. Ось чому ми рекомендуємо входити в систему через Карткову платформу Бібліотеки Вікіпедії, а не переходити напряму на сайт партнера без проксі. Якщо вагаєтеся, перевірте, чи є у посиланні частинка «idm.oclc». Якщо є, це означає, що ви з'єднані через EZProxy."
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:182
-msgid ""
-"Typically once you’ve logged in your session will remain active in your "
-"browser for up to two hours after you’ve finished searching. Note that use "
-"of EZProxy requires you to enable cookies. If you are having problems you "
-"should also try clearing your cache and restarting your browser."
-msgstr ""
-"Зазвичай, як тільки ви увійшли, ваш сеанс лишатиметься активним у вашому "
-"браузері до двох годин після закінчення пошуку. Зверніть увагу, що "
-"використання EZProxy вимагає уможливлення cookies. Якщо у вас виникають "
-"проблеми, вам варто очистити кеш і перезапустити браузер."
+msgid "Typically once you’ve logged in your session will remain active in your browser for up to two hours after you’ve finished searching. Note that use of EZProxy requires you to enable cookies. If you are having problems you should also try clearing your cache and restarting your browser."
+msgstr "Зазвичай, як тільки ви увійшли, ваш сеанс лишатиметься активним у вашому браузері до двох годин після закінчення пошуку. Зверніть увагу, що використання EZProxy вимагає уможливлення cookies. Якщо у вас виникають проблеми, вам варто очистити кеш і перезапустити браузер."
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/)
 #: TWLight/templates/about.html:193
-msgid ""
-"The Library Bundle is a collection of resources for which no application is "
-"required. If you meet the criteria laid out above, you will be authorized "
-"for access automatically upon logging in to the platform. Only some of our "
-"content is currently included in the Library Bundle, however we hope to "
-"expand the collection as more publishers become comfortable with "
-"participating. All Bundle content is accessed via EZProxy."
-msgstr ""
-"Library Bundle — це колекція ресурсів, для яких не потрібна заявка. Якщо ви "
-"відповідає вищеописаним критеріям, ви будете автоматично авторизовані для "
-"доступу до них після того, як увійдете в систему. Лише деякий наш вміст "
-"наразі доданий у Library Bundle, однак ми сподіваємося розширити колекцію, "
-"коли більше видавців почуватимуться достатньо комфортно, щоб взяти в цьому "
-"участь. Доступ до всього вмісту Bundle здійснюється через EZProxy."
+msgid "The Library Bundle is a collection of resources for which no application is required. If you meet the criteria laid out above, you will be authorized for access automatically upon logging in to the platform. Only some of our content is currently included in the Library Bundle, however we hope to expand the collection as more publishers become comfortable with participating. All Bundle content is accessed via EZProxy."
+msgstr "Library Bundle — це колекція ресурсів, для яких не потрібна заявка. Якщо ви відповідає вищеописаним критеріям, ви будете автоматично авторизовані для доступу до них після того, як увійдете в систему. Лише деякий наш вміст наразі доданий у Library Bundle, однак ми сподіваємося розширити колекцію, коли більше видавців почуватимуться достатньо комфортно, щоб взяти в цьому участь. Доступ до всього вмісту Bundle здійснюється через EZProxy."
 
 #. Translators: This is the heading for a section on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:202
@@ -2523,18 +1968,8 @@ msgstr "Практики посилань на джерела"
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:206
-msgid ""
-"Citation practices vary by project and even by article. Generally, we "
-"support editors citing where they found information, in a form that allows "
-"others to check it for themselves. That often means providing both original "
-"source details as well as a link to the partner database in which the source "
-"was found."
-msgstr ""
-"Практики використання джерел відрізняється в різних проєктах і навіть "
-"статтях. Загалом, ми радимо, щоб редактори посилалися на джерела, де вони "
-"знайшли інформацію, у такій формі, яка допоможе іншим перевірити її для "
-"себе. Часто це означає надання як інформації про оригінальне джерело, так і "
-"посилання на партнерську базу даних, де це джерело можна знайти."
+msgid "Citation practices vary by project and even by article. Generally, we support editors citing where they found information, in a form that allows others to check it for themselves. That often means providing both original source details as well as a link to the partner database in which the source was found."
+msgstr "Практики використання джерел відрізняється в різних проєктах і навіть статтях. Загалом, ми радимо, щоб редактори посилалися на джерела, де вони знайшли інформацію, у такій формі, яка допоможе іншим перевірити її для себе. Часто це означає надання як інформації про оригінальне джерело, так і посилання на партнерську базу даних, де це джерело можна знайти."
 
 #. Translators: This is the heading for a section on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #. Translators: This link is at the bottom of every page and can be clicked by users to contact the wikipedia library team.
@@ -2545,13 +1980,8 @@ msgstr "Зв'язатися з нами"
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:218
 #, python-format
-msgid ""
-"If you have questions, need help, or want to volunteer to help, please see "
-"our <a class=\"twl-links\" href=\"%(contact_url)s\">contact page</a>."
-msgstr ""
-"Якщо у вас є запитання, потрібна допомога або ви хочете зголоситися "
-"допомагати іншим, будь ласка, завітайте на нашу <a class=\"twl-links\" href="
-"\"%(contact_url)s\">контактну сторінку</a>."
+msgid "If you have questions, need help, or want to volunteer to help, please see our <a class=\"twl-links\" href=\"%(contact_url)s\">contact page</a>."
+msgstr "Якщо у вас є запитання, потрібна допомога або ви хочете зголоситися допомагати іншим, будь ласка, завітайте на нашу <a class=\"twl-links\" href=\"%(contact_url)s\">контактну сторінку</a>."
 
 #. Translators: This is the title of the panel box detailing the contact information for the Wikipedia Library team.
 #: TWLight/templates/contact.html:14
@@ -2590,12 +2020,8 @@ msgstr "Twitter-сторінка Бібліотеки Вікіпедії"
 #. Translators: This is the text that appears at the bottom of the contact us form directing users to the suggestions form.
 #: TWLight/templates/contact.html:48
 #, python-format
-msgid ""
-"(If you would like to suggest a partner, <a class=\"twl-links\" href="
-"\"%(suggest)s\"><strong>go here</strong></a>.)"
-msgstr ""
-"(Якщо ви хочете запропонувати партнера, <a class=\"twl-links\" href="
-"\"%(suggest)s\"><strong>перейдіть сюди</strong></a>.)"
+msgid "(If you would like to suggest a partner, <a class=\"twl-links\" href=\"%(suggest)s\"><strong>go here</strong></a>.)"
+msgstr "(Якщо ви хочете запропонувати партнера, <a class=\"twl-links\" href=\"%(suggest)s\"><strong>перейдіть сюди</strong></a>.)"
 
 #. Translators: On a special 'link to search' page, this message is shown if JavaScript is disabled.
 #: TWLight/templates/eds_search_endpoint.html:7
@@ -2652,12 +2078,8 @@ msgstr "Бібліотека Вікіпедії"
 #. Translators: Information about The Wikipedia Library.
 #: TWLight/templates/login_partial.html:53 TWLight/templates/new_base.html:21
 #, python-format
-msgid ""
-"More than 100 of the world's top subscription-only databases, with content "
-"in %(no_of_languages)s languages, free for Wikipedians of all backgrounds"
-msgstr ""
-"Понад 100 найпопулярніших у світі баз даних лише за передплатою з вмістом "
-"%(no_of_languages)s мовами, безкоштовних для всіх вікіпедистів"
+msgid "More than 100 of the world's top subscription-only databases, with content in %(no_of_languages)s languages, free for Wikipedians of all backgrounds"
+msgstr "Понад 100 найпопулярніших у світі баз даних лише за передплатою з вмістом %(no_of_languages)s мовами, безкоштовних для всіх вікіпедистів"
 
 #. Translators: Information about The Wikipedia Library.
 #: TWLight/templates/login_partial.html:64
@@ -2665,12 +2087,8 @@ msgid "Meet these criteria for automatic access"
 msgstr "Відповідайте цим критеріям для автоматичного доступу"
 
 #: TWLight/templates/login_partial.html:69
-msgid ""
-"These criteria grant you access to certain collections but not all. Some "
-"collections are accessible on a per application basis only."
-msgstr ""
-"Ці критерії надають вам доступ до певних колекцій, але не всіх. Деякі "
-"колекції доступні лише для кожної заявки."
+msgid "These criteria grant you access to certain collections but not all. Some collections are accessible on a per application basis only."
+msgstr "Ці критерії надають вам доступ до певних колекцій, але не всіх. Деякі колекції доступні лише для кожної заявки."
 
 #: TWLight/templates/login_partial.html:89
 msgid "Login via Wikipedia"
@@ -2679,42 +2097,20 @@ msgstr "Увійти через Вікіпедію"
 #. Translators: Shown if the current user doesn't have a registered email on their account. Don't translate contact_us_url or email_url.
 #: TWLight/templates/message_partial.html:15
 #, python-format
-msgid ""
-"You don't have an email on file. We can't finalize your access to partner "
-"resources, and you won't be able to <a class=\"twl-links\" href="
-"\"%(contact_us_url)s\">contact us</a> without an email. Please <a class="
-"\"twl-links\" href=\"%(email_url)s\">update your email</a>."
-msgstr ""
-"У вас не вказане електронна пошта. Ми не можемо фіналізувати ваш доступ до "
-"партнерських ресурсів, а вам не вдасться <a class=\"twl-links\" href="
-"\"%(contact_us_url)s\">зв'язатися з нами</a> без електронної пошти. Будь "
-"ласка, <a class=\"twl-links\" href=\"%(email_url)s\">додайте свою електронну "
-"скриньку</a>."
+msgid "You don't have an email on file. We can't finalize your access to partner resources, and you won't be able to <a class=\"twl-links\" href=\"%(contact_us_url)s\">contact us</a> without an email. Please <a class=\"twl-links\" href=\"%(email_url)s\">update your email</a>."
+msgstr "У вас не вказане електронна пошта. Ми не можемо фіналізувати ваш доступ до партнерських ресурсів, а вам не вдасться <a class=\"twl-links\" href=\"%(contact_us_url)s\">зв'язатися з нами</a> без електронної пошти. Будь ласка, <a class=\"twl-links\" href=\"%(email_url)s\">додайте свою електронну скриньку</a>."
 
 #. Translators: Shown if the current user has requested the processing of their data should be restricted.
 #: TWLight/templates/message_partial.html:26
 #, python-format
-msgid ""
-"You have requested a restriction on the processing of your data. Most site "
-"functionality will not be available to you until you <a class=\"twl-links\" "
-"href=\"%(restrict_url)s\">lift this restriction</a>."
-msgstr ""
-"Ви зробили запит на обмеження обробки ваших даних. Більшість функцій сайту "
-"не будуть вам доступні, поки ви не <a class=\"twl-links\" href="
-"\"%(restrict_url)s\">послабите це обмеження</a>."
+msgid "You have requested a restriction on the processing of your data. Most site functionality will not be available to you until you <a class=\"twl-links\" href=\"%(restrict_url)s\">lift this restriction</a>."
+msgstr "Ви зробили запит на обмеження обробки ваших даних. Більшість функцій сайту не будуть вам доступні, поки ви не <a class=\"twl-links\" href=\"%(restrict_url)s\">послабите це обмеження</a>."
 
 #. Translators: Shown if the current user has not agreed to the terms of use.
 #: TWLight/templates/message_partial.html:37
 #, python-format
-msgid ""
-"You have not agreed to the <a class=\"twl-links\" href=\"%(terms_url)s"
-"\">terms of use</a> of this site. Your applications will not be processed "
-"and you won't be able to apply or access resources you are approved for."
-msgstr ""
-"Ви не погодилися з <a class=\"twl-links\" href=\"%(terms_url)s\">умовами "
-"користування</a> цього сайту. Ваші заявки не будуть оброблятися і ви не "
-"зможете податися чи отримати доступ до ресурсів, на який ви отримали "
-"схвалення."
+msgid "You have not agreed to the <a class=\"twl-links\" href=\"%(terms_url)s\">terms of use</a> of this site. Your applications will not be processed and you won't be able to apply or access resources you are approved for."
+msgstr "Ви не погодилися з <a class=\"twl-links\" href=\"%(terms_url)s\">умовами користування</a> цього сайту. Ваші заявки не будуть оброблятися і ви не зможете податися чи отримати доступ до ресурсів, на який ви отримали схвалення."
 
 #. Translators: This link is at the bottom of every page and links to the 'About' page (https://wikipedialibrary.wmflabs.org/about/)
 #: TWLight/templates/new_base.html:107
@@ -2760,12 +2156,8 @@ msgstr "Скинути пароль"
 
 #. Translators: If a user goes to reset their password, this message asks them to enter their email to do so.
 #: TWLight/templates/registration/password_reset_form.html:13
-msgid ""
-"Forgot your password? Enter your email address below, and we'll email "
-"instructions for setting a new one."
-msgstr ""
-"Забули свій пароль? Уведіть нижче свою електронну адресу, і ми надішлемо вам "
-"лист з інструкціями, як отримати новий."
+msgid "Forgot your password? Enter your email address below, and we'll email instructions for setting a new one."
+msgstr "Забули свій пароль? Уведіть нижче свою електронну адресу, і ми надішлемо вам лист з інструкціями, як отримати новий."
 
 #. Translators: This is the label for a button that users click to update their public information.
 #: TWLight/users/forms.py:36
@@ -2809,22 +2201,13 @@ msgstr "Я погоджуюся з умовами використання"
 
 #. Translators: This text explains how to disagree to the site's terms of use and the restrictions that will come into effect when users disagree to the terms of use.
 #: TWLight/users/forms.py:185
-msgid ""
-"By unchecking this box and clicking “Update” you may explore the site, but "
-"you will not be able to apply for access to materials or evaluate "
-"applications unless you agree with the terms of use."
-msgstr ""
-"Знявши тут позначку і натиснувши «Оновити» ви можете переглядати вміст "
-"сайту, але ви не зможете подати заявку на доступ до матеріалів чи оцінювати "
-"заявки, поки не погодитеся з умовами використання."
+msgid "By unchecking this box and clicking “Update” you may explore the site, but you will not be able to apply for access to materials or evaluate applications unless you agree with the terms of use."
+msgstr "Знявши тут позначку і натиснувши «Оновити» ви можете переглядати вміст сайту, але ви не зможете подати заявку на доступ до матеріалів чи оцінювати заявки, поки не погодитеся з умовами використання."
 
 #. Translators: Users click this button to set their website email address to the one linked to their Wikipedia account.
 #: TWLight/users/forms.py:211
-msgid ""
-"Use my Wikipedia email address (will be updated the next time you login)."
-msgstr ""
-"Використовувати мою адресу електронної пошти з Вікіпедії (буде оновлено під "
-"час вашого наступного входу в систему)."
+msgid "Use my Wikipedia email address (will be updated the next time you login)."
+msgstr "Використовувати мою адресу електронної пошти з Вікіпедії (буде оновлено під час вашого наступного входу в систему)."
 
 #. Translators: This labels a button which users click to change their email.
 #: TWLight/users/forms.py:232
@@ -2834,19 +2217,8 @@ msgstr "Оновити електронну пошту"
 #. Translators: Shown if the current user tried to 'favorite' a partner they can't access. Do not translate '{partner}'
 #: TWLight/users/models.py:201
 #, python-brace-format
-msgid ""
-"Cannot add partner {partner} to your favorites because you don't have access "
-"to it"
-msgstr ""
-"Неможливо додати партнера {partner} до вибраного, оскільки ви не маєте до "
-"нього доступу"
-
-#. Translators: Do not translate.
-#: TWLight/users/models.py:869
-#, fuzzy, python-brace-format
-#| msgid "Username"
-msgid "{wp_username}"
-msgstr "Ім'я користувача"
+msgid "Cannot add partner {partner} to your favorites because you don't have access to it"
+msgstr "Неможливо додати партнера {partner} до вибраного, оскільки ви не маєте до нього доступу"
 
 #. Translators: This error message is shown when there's a problem with the authenticated login process.
 #: TWLight/users/oauth.py:243
@@ -2866,12 +2238,8 @@ msgstr "Рукостискання не ініційовано, спробуйт
 
 #. Translators: this message is displayed to users that don't have accounts and clicked on a proxied link.
 #: TWLight/users/oauth.py:388
-msgid ""
-"To view this link you need to be an eligible library user. Please login to "
-"continue."
-msgstr ""
-"Щоб переглянути це посилання, ви маєте бути відповідним користувачем "
-"бібліотеки. Будь ласка, увійдіть, щоб продовжити."
+msgid "To view this link you need to be an eligible library user. Please login to continue."
+msgstr "Щоб переглянути це посилання, ви маєте бути відповідним користувачем бібліотеки. Будь ласка, увійдіть, щоб продовжити."
 
 #. Translators: This warning message is shown to users when the response received from Wikimedia OAuth servers is not a valid one.
 #: TWLight/users/oauth.py:430
@@ -2897,8 +2265,7 @@ msgstr "Немає токена запиту."
 #. Translators: This message is shown when the OAuth login process fails.
 #: TWLight/users/oauth.py:498
 msgid "Access token generation failed, please try logging in again."
-msgstr ""
-"Не вдалося згенерувати токен доступу, будь ласка, спробуйте увійти ще раз."
+msgstr "Не вдалося згенерувати токен доступу, будь ласка, спробуйте увійти ще раз."
 
 #. Translators: This message is shown when more information is available on another page. Do not translate {issue}
 #: TWLight/users/oauth.py:507
@@ -2908,24 +2275,13 @@ msgstr "Див. {issue} для отримання додаткової інфо�
 
 #. Translators: If the user tries to log in, but their account does not meet certain requirements, they cannot login.
 #: TWLight/users/oauth.py:528
-msgid ""
-"Your Wikipedia account does not meet the eligibility criteria in the terms "
-"of use, so your Wikipedia Library Card Platform account cannot be activated."
-msgstr ""
-"Ваш обліковий запис Вікіпедії не відповідає критеріям в умовах використання, "
-"тому ваш обліковий запис Карткової платформи Бібліотеки Вікіпедії не може "
-"бути активовано."
+msgid "Your Wikipedia account does not meet the eligibility criteria in the terms of use, so your Wikipedia Library Card Platform account cannot be activated."
+msgstr "Ваш обліковий запис Вікіпедії не відповідає критеріям в умовах використання, тому ваш обліковий запис Карткової платформи Бібліотеки Вікіпедії не може бути активовано."
 
 #. Translators: If the user tries to log in, but their account does not meet certain requirements, they cannot login.
 #: TWLight/users/oauth.py:536
-msgid ""
-"Your Wikipedia account no longer meets the eligibility criteria in the terms "
-"of use, so you cannot be logged in. If you think you should be able to log "
-"in, please email wikipedialibrary@wikimedia.org."
-msgstr ""
-"Ваш обліковий запис Вікіпедії більше не відповідає критеріям в умовах "
-"використання, тому ви не можете увійти. Якщо ви вважаєте, що маєте мати "
-"змогу увійти, будь ласка, напишіть на wikipedialibrary@wikimedia.org."
+msgid "Your Wikipedia account no longer meets the eligibility criteria in the terms of use, so you cannot be logged in. If you think you should be able to log in, please email wikipedialibrary@wikimedia.org."
+msgstr "Ваш обліковий запис Вікіпедії більше не відповідає критеріям в умовах використання, тому ви не можете увійти. Якщо ви вважаєте, що маєте мати змогу увійти, будь ласка, напишіть на wikipedialibrary@wikimedia.org."
 
 #. Translators: this message is displayed to users with brand new accounts.
 #: TWLight/users/oauth.py:549
@@ -2935,15 +2291,8 @@ msgstr "Ласкаво просимо! Будь ласка, погодьтеся
 #. Translators: This message is displayed on the confirmation page where users can return their access to partner collections.
 #: TWLight/users/templates/users/authorization_confirm_return.html:13
 #, python-format
-msgid ""
-"You will no longer be able to access <b>%(partner)s's</b> resources via the "
-"Library Card platform, but can request access again by clicking 'renew', if "
-"you change your mind. Are you sure you want to return your access?"
-msgstr ""
-"Ви більше не зможете отримувати доступ до ресурсів партнера <b>%(partner)s</"
-"b> через Карткову платформу Бібліотеки, але можете знову запит на доступ, "
-"натиснувши «поновити», якщо зміните свою думку. Ви впевнені, що бажаєте "
-"здати свій доступ?"
+msgid "You will no longer be able to access <b>%(partner)s's</b> resources via the Library Card platform, but can request access again by clicking 'renew', if you change your mind. Are you sure you want to return your access?"
+msgstr "Ви більше не зможете отримувати доступ до ресурсів партнера <b>%(partner)s</b> через Карткову платформу Бібліотеки, але можете знову запит на доступ, натиснувши «поновити», якщо зміните свою думку. Ви впевнені, що бажаєте здати свій доступ?"
 
 #. Translators: On the MyLibrary page (https://wikipedialibrary.wmflabs.org/users/my_library), this tab shows all favorite collections a user has.
 #: TWLight/users/templates/users/collections_section.html:9
@@ -3012,13 +2361,8 @@ msgstr "Дані про редактора"
 
 #. Translators: This is shown on editor profiles, in their profile page or on applications.
 #: TWLight/users/templates/users/editor_detail.html:59
-msgid ""
-"Information with an * was retrieved from Wikipedia directly. Other "
-"information was entered directly by users or site admins, in their preferred "
-"language."
-msgstr ""
-"Зірочкою помічена інформація, що отримана прямо з Вікіпедії. Інша інформація "
-"вводиться самими користувачами або адмінами сайту їхньою мовою."
+msgid "Information with an * was retrieved from Wikipedia directly. Other information was entered directly by users or site admins, in their preferred language."
+msgstr "Зірочкою помічена інформація, що отримана прямо з Вікіпедії. Інша інформація вводиться самими користувачами або адмінами сайту їхньою мовою."
 
 #. Translators: This distinguishes users who have been flagged as account coordinators. Don't translate username.
 #: TWLight/users/templates/users/editor_detail.html:71
@@ -3028,14 +2372,8 @@ msgstr "%(username)s має права координатора на цьому 
 
 #. Translators: This is shown on editor profiles, under the heading for Wikipedia editor data.
 #: TWLight/users/templates/users/editor_detail_data.html:5
-msgid ""
-"This information is updated automatically from your Wikimedia account each "
-"time you log in, except for the Contributions field, where you can describe "
-"your Wikimedia editing history."
-msgstr ""
-"Ця інформація оновлюється автоматичного з вашого облікового запису Вікіпедії "
-"кожного разу, коли ви входите, окрім поля внеску, де ви можете самі описати "
-"свою історію редагування Вікімедіа."
+msgid "This information is updated automatically from your Wikimedia account each time you log in, except for the Contributions field, where you can describe your Wikimedia editing history."
+msgstr "Ця інформація оновлюється автоматичного з вашого облікового запису Вікіпедії кожного разу, коли ви входите, окрім поля внеску, де ви можете самі описати свою історію редагування Вікімедіа."
 
 #. Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this labels the user's username.
 #: TWLight/users/templates/users/editor_detail_data.html:17
@@ -3064,22 +2402,14 @@ msgstr "Задовольняє умови використання?"
 
 #. Translators: when viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this question has a yes or no answer.
 #: TWLight/users/templates/users/editor_detail_data.html:57
-msgid ""
-"at their last login, did this user meet the criteria set forth in the terms "
-"of use?"
-msgstr ""
-"на момент попереднього входу в систему, чи відповідав цей користувач "
-"критеріям, заданим в умовах використання?"
+msgid "at their last login, did this user meet the criteria set forth in the terms of use?"
+msgstr "на момент попереднього входу в систему, чи відповідав цей користувач критеріям, заданим в умовах використання?"
 
 #. Translators: When viewing a user's profile in an application, this message shows if the software doesn't think that the user is eligible for access. Don't translate username.
 #: TWLight/users/templates/users/editor_detail_data.html:72
 #, python-format
-msgid ""
-"%(username)s may still be eligible for access grants at the coordinators' "
-"discretion."
-msgstr ""
-"%(username)s все ще може відповідати критеріям отримання доступу на власну "
-"думку координаторів."
+msgid "%(username)s may still be eligible for access grants at the coordinators' discretion."
+msgstr "%(username)s все ще може відповідати критеріям отримання доступу на власну думку координаторів."
 
 #. Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this is the heading for a Yes/No ToU question.
 #: TWLight/users/templates/users/editor_detail_data.html:83
@@ -3113,15 +2443,8 @@ msgstr "(надано виняток)"
 #. Translators: This message is shown on a user's profile if their Wikimedia account is blocked on one or more projects. They may still be granted access to the Library Bundle, but need to contact Wikipedia Library staff to verify.
 #: TWLight/users/templates/users/editor_detail_data.html:137
 #, python-format
-msgid ""
-"It looks like you have an active block on your account. If you meet the "
-"other criteria you may still be permitted access to the library - please <a "
-"class=\"twl-links\" href=\"%(contact_url)s\">contact us</a>."
-msgstr ""
-"Схоже, у вас є активне блокування вашого облікового запису. Якщо ви "
-"відповідаєте іншим критеріям, вам все одно можуть дозволити доступ до "
-"бібліотеки — будь ласка, <a class=\"twl-links\" href=\"%(contact_url)s"
-"\">зв'яжіться з нами</a>."
+msgid "It looks like you have an active block on your account. If you meet the other criteria you may still be permitted access to the library - please <a class=\"twl-links\" href=\"%(contact_url)s\">contact us</a>."
+msgstr "Схоже, у вас є активне блокування вашого облікового запису. Якщо ви відповідаєте іншим критеріям, вам все одно можуть дозволити доступ до бібліотеки — будь ласка, <a class=\"twl-links\" href=\"%(contact_url)s\">зв'яжіться з нами</a>."
 
 #. Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this is the heading for a Yes/No program eligibility question.
 #: TWLight/users/templates/users/editor_detail_data.html:153
@@ -3130,14 +2453,8 @@ msgstr "Відповідає критеріям Bundle?"
 
 #. Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this question has a Yes or No answer.
 #: TWLight/users/templates/users/editor_detail_data.html:156
-msgid ""
-"At their last login, did this user meet the criteria set forth in the "
-"Library Bundle? Note that satisfying terms of use is a prerequisite to "
-"bundle eligibility."
-msgstr ""
-"На момент попереднього входу в систему, чи відповідав цей користувач "
-"критеріям, заданим в Library Bundle? Зверніть увагу, що відповідність умовам "
-"використання — попередня вимога для відповідності критеріям Bundle."
+msgid "At their last login, did this user meet the criteria set forth in the Library Bundle? Note that satisfying terms of use is a prerequisite to bundle eligibility."
+msgstr "На момент попереднього входу в систему, чи відповідав цей користувач критеріям, заданим в Library Bundle? Зверніть увагу, що відповідність умовам використання — попередня вимога для відповідності критеріям Bundle."
 
 #. Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this is the heading for a Yes/No program eligibility question.
 #: TWLight/users/templates/users/editor_detail_data.html:177
@@ -3181,24 +2498,14 @@ msgstr "Персональні дані"
 
 #. Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this text is in the 'Personal data' section. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/users/templates/users/editor_detail_data.html:262
-msgid ""
-"The following information is visible only to you, site administrators, "
-"publishing partners (where required), and volunteer Wikipedia Library "
-"coordinators (who have signed a Non-Disclosure Agreement)."
-msgstr ""
-"Подана інформація видима лише вам, адміністраторам сайту, партнерам (де "
-"необхідно) та координаторам-волонтерам Бібліотеки Вікімедіа (які підписали "
-"Угоду про нерозголошення)."
+msgid "The following information is visible only to you, site administrators, publishing partners (where required), and volunteer Wikipedia Library coordinators (who have signed a Non-Disclosure Agreement)."
+msgstr "Подана інформація видима лише вам, адміністраторам сайту, партнерам (де необхідно) та координаторам-волонтерам Бібліотеки Вікімедіа (які підписали Угоду про нерозголошення)."
 
 #. Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this labels a button which users can click to update or remove their personal information. Don't translate update_url.
 #: TWLight/users/templates/users/editor_detail_data.html:272
 #, python-format
-msgid ""
-"You may <a class=\"twl-links\" href=\"%(update_url)s\">update or delete</a> "
-"your data at any time."
-msgstr ""
-"Ви можете <a class=\"twl-links\" href=\"%(update_url)s\">оновити чи "
-"вилучити</a> свої дані у будь-який час."
+msgid "You may <a class=\"twl-links\" href=\"%(update_url)s\">update or delete</a> your data at any time."
+msgstr "Ви можете <a class=\"twl-links\" href=\"%(update_url)s\">оновити чи вилучити</a> свої дані у будь-який час."
 
 #. Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this labels the user's email. Don't remove the *.
 #: TWLight/users/templates/users/editor_detail_data.html:283
@@ -3217,32 +2524,19 @@ msgstr "Інституційна приналежність"
 
 #. Translators: This message tells users that they are not eligible to access The Wikipedia Library content.
 #: TWLight/users/templates/users/eligibility_modal.html:7
-msgid ""
-"Sorry, your Wikipedia account doesn’t currently qualify to access The "
-"Wikipedia Library."
-msgstr ""
-"На жаль, ваш обліковий запис Вікіпедії наразі не відповідає вимогам доступу "
-"до Бібліотеки Вікіпедії."
+msgid "Sorry, your Wikipedia account doesn’t currently qualify to access The Wikipedia Library."
+msgstr "На жаль, ваш обліковий запис Вікіпедії наразі не відповідає вимогам доступу до Бібліотеки Вікіпедії."
 
 #. Translators: This message tells users that they have not agreed to the terms of use, therefore are ineligible to access the content in The Wikipedia Library.
 #: TWLight/users/templates/users/eligibility_modal.html:30
 #, python-format
-msgid ""
-"Agreed with <a href=\"%(terms)s\" class=\"text-danger\"> terms of use </a>"
-msgstr ""
-"Погодилися з <a href=\"%(terms)s\" class=\"text-danger\">умовами "
-"користування</a> сайту?"
+msgid "Agreed with <a href=\"%(terms)s\" class=\"text-danger\"> terms of use </a>"
+msgstr "Погодилися з <a href=\"%(terms)s\" class=\"text-danger\">умовами користування</a> сайту?"
 
 #: TWLight/users/templates/users/eligibility_modal.html:40
 #, python-format
-msgid ""
-"It looks like you have an active block on your account. If you meet the "
-"other criteria you may still be permitted access to the library - please <a "
-"href=\"%(contact_url)s\">contact us</a>."
-msgstr ""
-"Схоже, у вас є активне блокування вашого облікового запису. Якщо ви "
-"відповідаєте іншим критеріям, вам все одно можуть дозволити доступ до "
-"бібліотеки — будь ласка, <a href=\"%(contact_url)s\">зв'яжіться з нами</a>."
+msgid "It looks like you have an active block on your account. If you meet the other criteria you may still be permitted access to the library - please <a href=\"%(contact_url)s\">contact us</a>."
+msgstr "Схоже, у вас є активне блокування вашого облікового запису. Якщо ви відповідаєте іншим критеріям, вам все одно можуть дозволити доступ до бібліотеки — будь ласка, <a href=\"%(contact_url)s\">зв'яжіться з нами</a>."
 
 #. Translators: Instructions to refresh a user's data.
 #: TWLight/users/templates/users/eligibility_modal.html:50
@@ -3281,14 +2575,8 @@ msgstr "Вибрати мову"
 
 #. Translators: This text on the user page helps users naviage to the TranslateWiki Wikipedia Library Card platform translation page.
 #: TWLight/users/templates/users/language_form.html:31
-msgid ""
-"You can help translate the tool at <a class=\"twl-links\" href=\"https://"
-"translatewiki.net/wiki/Translating:Wikipedia_Library_Card_Platform"
-"\">translatewiki.net</a>."
-msgstr ""
-"Ви можете допомогти перекласти цей інструмент на <a class=\"twl-links\" href="
-"\"https://translatewiki.net/wiki/Translating:Wikipedia_Library_Card_Platform"
-"\">translatewiki.net</a>."
+msgid "You can help translate the tool at <a class=\"twl-links\" href=\"https://translatewiki.net/wiki/Translating:Wikipedia_Library_Card_Platform\">translatewiki.net</a>."
+msgstr "Ви можете допомогти перекласти цей інструмент на <a class=\"twl-links\" href=\"https://translatewiki.net/wiki/Translating:Wikipedia_Library_Card_Platform\">translatewiki.net</a>."
 
 #. Translators: When the user starts a new application and submits the application, the user can view the application and withdraw if need be. This changes the label for the Withdraw button.
 #: TWLight/users/templates/users/my_applications.html:65
@@ -3307,12 +2595,8 @@ msgstr "Подати запит на поновлення"
 
 #. Translators: On the page listing applications, this text explains a user they cannot renew their application since they've already requested a renewal or there aren't any renewals available.
 #: TWLight/users/templates/users/my_applications.html:79
-msgid ""
-"Renewals are either not required, not available right now, or you have "
-"already requested a renewal."
-msgstr ""
-"Поновлення або не потрібно, або недоступне зараз, або ви вже подали запит на "
-"поновлення."
+msgid "Renewals are either not required, not available right now, or you have already requested a renewal."
+msgstr "Поновлення або не потрібно, або недоступне зараз, або ви вже подали запит на поновлення."
 
 #. Translators: This text is the heading of a section in a user's profile where they can change their preferences.
 #: TWLight/users/templates/users/preferences.html:6
@@ -3375,27 +2659,13 @@ msgstr "Обмежити обробку даних"
 
 #. Translators: This message is displayed on the page where users can request we stop processing their data.
 #: TWLight/users/templates/users/restrict_data.html:15
-msgid ""
-"Checking this box and clicking “Restrict” will pause all processing of the "
-"data you have entered into this website. You will not be able to apply for "
-"access to resources, your applications will not be further processed, and "
-"none of your data will be altered, until you return to this page and uncheck "
-"the box. This is not the same as deleting your data."
-msgstr ""
-"Галочка тут та натискання «Обмежити» призупинить всяку обробку даних, які ви "
-"ввели на цьому веб-сайті. Ви не зможете подаватися на доступ до ресурсів, "
-"ваші заявки не будуть далі розглядатися, і жодні ваші дані не будуть "
-"змінені, поки ви не повернетеся на цю сторінку і не знімете галочку. Це не "
-"те саме, що вилучити ваші дані."
+msgid "Checking this box and clicking “Restrict” will pause all processing of the data you have entered into this website. You will not be able to apply for access to resources, your applications will not be further processed, and none of your data will be altered, until you return to this page and uncheck the box. This is not the same as deleting your data."
+msgstr "Галочка тут та натискання «Обмежити» призупинить всяку обробку даних, які ви ввели на цьому веб-сайті. Ви не зможете подаватися на доступ до ресурсів, ваші заявки не будуть далі розглядатися, і жодні ваші дані не будуть змінені, поки ви не повернетеся на цю сторінку і не знімете галочку. Це не те саме, що вилучити ваші дані."
 
 #. Translators: This warning message is shown to coordinators who view the data restriction page.
 #: TWLight/users/templates/users/restrict_data.html:26
-msgid ""
-"You are a coordinator on this site. If you restrict the processing of your "
-"data, your coordinator flag will be removed."
-msgstr ""
-"Ви є координатором на цьому сайті. Якщо ви обмежите обробку своїх даних, то "
-"втратите права координатора."
+msgid "You are a coordinator on this site. If you restrict the processing of your data, your coordinator flag will be removed."
+msgstr "Ви є координатором на цьому сайті. Якщо ви обмежите обробку своїх даних, то втратите права координатора."
 
 #. Translators: use the date *when you are translating*, in a language-appropriate format.
 #: TWLight/users/templates/users/terms.html:33
@@ -3410,47 +2680,18 @@ msgstr "Політика приватності Фонду Вікімедіа"
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:41
 msgid "Wikipedia Library Card Terms of Use and Privacy Statement"
-msgstr ""
-"Умови використання та Заява про приватність Карткової платформи Бібліотеки "
-"Вікіпедії"
+msgstr "Умови використання та Заява про приватність Карткової платформи Бібліотеки Вікіпедії"
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:51
-msgid ""
-"<a class=\"twl-links\" href=\"https://meta.wikimedia.org/wiki/"
-"The_Wikipedia_Library\"> The Wikipedia Library </a> has partnered with "
-"publishers around the world to allow users to access otherwise paywalled "
-"resources. This website allows Wikipedia editors to search and access these "
-"resources."
-msgstr ""
-"<a class=\"twl-links\" href=\"https://meta.wikimedia.org/wiki/"
-"The_Wikipedia_Library\">Бібліотека Вікіпедії</a> має партнерські зв'язки з "
-"видавцями по всьому світу, що дозволяє користувачам отримувати доступ до "
-"ресурсів, що інакше є платними. Цей вебсайт дозволяє користувачам одночасно "
-"подавати заявку на доступ до матеріалів багатьох видавців і робить "
-"адміністрування й доступ до облікових записів Бібліотеки Вікімедіа простим "
-"та ефективним."
+msgid "<a class=\"twl-links\" href=\"https://meta.wikimedia.org/wiki/The_Wikipedia_Library\"> The Wikipedia Library </a> has partnered with publishers around the world to allow users to access otherwise paywalled resources. This website allows Wikipedia editors to search and access these resources."
+msgstr "<a class=\"twl-links\" href=\"https://meta.wikimedia.org/wiki/The_Wikipedia_Library\">Бібліотека Вікіпедії</a> має партнерські зв'язки з видавцями по всьому світу, що дозволяє користувачам отримувати доступ до ресурсів, що інакше є платними. Цей вебсайт дозволяє користувачам одночасно подавати заявку на доступ до матеріалів багатьох видавців і робить адміністрування й доступ до облікових записів Бібліотеки Вікімедіа простим та ефективним."
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Wikimedia Foundation should not be translated. WMF should not be translated. Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:63
 #, fuzzy
-msgid ""
-"This program is administered by the Wikimedia Foundation (WMF). These terms "
-"of use and privacy notice pertain to your application for access to "
-"resources through the Wikipedia Library, your use of this website, and your "
-"access to and use of those resources. They also describe our handling of the "
-"information you provide to us in order to create and administer your "
-"Wikipedia Library account. If we make material changes to the terms, we will "
-"notify users."
-msgstr ""
-"Ці умови стосуються вашої заявки на доступ до ресурсів Бібліотеки Вікіпедії "
-"і вашого використання цих ресурсів. Вони також описують нашу обробку "
-"інформації, яку ви нам надаєте, щоб ми створювали й адміністрували ваш "
-"обліковий запис Бібліотеки Вікімедіа. Система Бібліотеки Вікімедіа "
-"розвивається, і з часом ми можемо оновлювати ці умови внаслідок зміни "
-"технологій. Ми рекомендуємо вам переглядати ці умови час від часу. Якщо ми "
-"внесемо значні зміни до умов, то надішлемо користувачам Бібліотеки Вікіпедії "
-"листа-сповіщення про це."
+msgid "This program is administered by the Wikimedia Foundation (WMF). These terms of use and privacy notice pertain to your application for access to resources through the Wikipedia Library, your use of this website, and your access to and use of those resources. They also describe our handling of the information you provide to us in order to create and administer your Wikipedia Library account. If we make material changes to the terms, we will notify users."
+msgstr "Ці умови стосуються вашої заявки на доступ до ресурсів Бібліотеки Вікіпедії і вашого використання цих ресурсів. Вони також описують нашу обробку інформації, яку ви нам надаєте, щоб ми створювали й адміністрували ваш обліковий запис Бібліотеки Вікімедіа. Система Бібліотеки Вікімедіа розвивається, і з часом ми можемо оновлювати ці умови внаслідок зміни технологій. Ми рекомендуємо вам переглядати ці умови час від часу. Якщо ми внесемо значні зміни до умов, то надішлемо користувачам Бібліотеки Вікіпедії листа-сповіщення про це."
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:74
@@ -3459,130 +2700,49 @@ msgstr "Вимоги до облікового запису у Карткові�
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:78
-msgid ""
-"Access to resources via The Wikipedia Library is reserved for community "
-"members who have demonstrated their commitment to the Wikimedia projects, "
-"and who will use their access to these resources to improve project content. "
-"To that end, in order to be eligible for The Wikipedia Library, we require "
-"that you be registered for a user account on the projects, with at least 500 "
-"edits, six (6) months of activity, and 10+ edits in the last month. We ask "
-"that you do not request access to any publishers with a limited number of "
-"available accounts whose resources you can already access for free through "
-"your local library or university, or another institution or organization, in "
-"order to provide that opportunity to others."
-msgstr ""
-"Доступ до ресурсів через Бібліотеку Вікіпедії зарезервований для членів "
-"спільноти, які продемонстрували свою відданість проєктам Вікімедіа і які "
-"використовують свій доступ до ресурсів на покращення контенту проєктів. "
-"Таким чином, аби мати право на участь у програмі Бібліотеки Вікіпедії, ми "
-"вимагаємо, щоб ви були зареєстровані у проєктах. Ми віддаємо перевагу "
-"користувачам, які мають принаймні 500 редагувань і шість місяців активності, "
-"але це не строгі вимоги. Ми просимо, щоб ви не подавали запит на доступ до "
-"тих видавців, до чиїх ресурсів у вас і так є безкоштовний доступ через "
-"місцеву бібліотеку чи університет або іншу установу чи організацію, щоб ми "
-"могли надати цю можливість іншим."
+msgid "Access to resources via The Wikipedia Library is reserved for community members who have demonstrated their commitment to the Wikimedia projects, and who will use their access to these resources to improve project content. To that end, in order to be eligible for The Wikipedia Library, we require that you be registered for a user account on the projects, with at least 500 edits, six (6) months of activity, and 10+ edits in the last month. We ask that you do not request access to any publishers with a limited number of available accounts whose resources you can already access for free through your local library or university, or another institution or organization, in order to provide that opportunity to others."
+msgstr "Доступ до ресурсів через Бібліотеку Вікіпедії зарезервований для членів спільноти, які продемонстрували свою відданість проєктам Вікімедіа і які використовують свій доступ до ресурсів на покращення контенту проєктів. Таким чином, аби мати право на участь у програмі Бібліотеки Вікіпедії, ми вимагаємо, щоб ви були зареєстровані у проєктах. Ми віддаємо перевагу користувачам, які мають принаймні 500 редагувань і шість місяців активності, але це не строгі вимоги. Ми просимо, щоб ви не подавали запит на доступ до тих видавців, до чиїх ресурсів у вас і так є безкоштовний доступ через місцеву бібліотеку чи університет або іншу установу чи організацію, щоб ми могли надати цю можливість іншим."
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:94
-msgid ""
-"Additionally, if you are currently blocked or banned from a Wikimedia "
-"project, applications to resources may be rejected or restricted. If you "
-"obtain a Wikipedia Library account, but a block or ban is subsequently "
-"instituted against you on one of the projects, you may lose access to your "
-"Wikipedia Library account."
-msgstr ""
-"Окрім цього, якщо ви зараз заблоковані чи забанені у проекті Вікімедіа, "
-"заявки на доступ можуть бути відхилені або обмежені. Якщо ви вже маєте "
-"обліковий запис Бібліотеки Вікіпедії, але на вас згодом накладено "
-"довготривале блокування чи бан в одному з проектів, ви можете втратити "
-"доступ до свого облікового запису Бібліотеки Вікіпедії."
+msgid "Additionally, if you are currently blocked or banned from a Wikimedia project, applications to resources may be rejected or restricted. If you obtain a Wikipedia Library account, but a block or ban is subsequently instituted against you on one of the projects, you may lose access to your Wikipedia Library account."
+msgstr "Окрім цього, якщо ви зараз заблоковані чи забанені у проекті Вікімедіа, заявки на доступ можуть бути відхилені або обмежені. Якщо ви вже маєте обліковий запис Бібліотеки Вікіпедії, але на вас згодом накладено довготривале блокування чи бан в одному з проектів, ви можете втратити доступ до свого облікового запису Бібліотеки Вікіпедії."
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:104
-msgid ""
-"Your eligibility to access The Wikipedia Library is assessed at each login. "
-"While more than half of the library's content is provided via this automated "
-"eligibility check, access to other publisher's content may be time limited, "
-"typically lapsing after one year, after which you will usually need to apply "
-"for renewal."
-msgstr ""
-"Ваше право на доступ до Бібліотеки Вікіпедії оцінюється під час кожного "
-"входу. Хоча більше половини вмісту бібліотеки надається за допомогою цієї "
-"автоматизованої перевірки відповідності вимогам, доступ до вмісту інших "
-"видавців може бути обмеженим у часі, як правило, закінчується через рік, "
-"після чого зазвичай потрібно подавати заяву на поновлення."
+msgid "Your eligibility to access The Wikipedia Library is assessed at each login. While more than half of the library's content is provided via this automated eligibility check, access to other publisher's content may be time limited, typically lapsing after one year, after which you will usually need to apply for renewal."
+msgstr "Ваше право на доступ до Бібліотеки Вікіпедії оцінюється під час кожного входу. Хоча більше половини вмісту бібліотеки надається за допомогою цієї автоматизованої перевірки відповідності вимогам, доступ до вмісту інших видавців може бути обмеженим у часі, як правило, закінчується через рік, після чого зазвичай потрібно подавати заяву на поновлення."
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:114
 #, fuzzy
 msgid "Applying via Your Wikipedia Library Card Account"
-msgstr ""
-"Подання запиту на обліковий запис Карткової платформи Бібліотеки Вікіпедії"
+msgstr "Подання запиту на обліковий запис Карткової платформи Бібліотеки Вікіпедії"
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:118
-msgid ""
-"In order to apply for access to a partner resource, you must provide us with "
-"certain information, which we will use to evaluate your application. If your "
-"application is approved, we may transfer the information you have given us "
-"to the publishers whose resources you wish to access. They will either "
-"contact you with the account information directly or we will send access "
-"information to you ourselves."
-msgstr ""
-"Для того, щоб подати запит на доступ до партнерських ресурсів, ви мусите "
-"надати нам певну інформацію, яку ми використаємо для оцінки вашої заявки. "
-"Якщо вашу заявку буде схвалено, ми можемо передати інформацію, отриману від "
-"вас, видавцям, до ресурсів яких ви хочете отримати доступ. Вони зв'яжуться з "
-"вами й або вони нададуть вам інформацію про обліковий запис, або ми "
-"надішлемо вам інформацію про доступ самостійно."
+msgid "In order to apply for access to a partner resource, you must provide us with certain information, which we will use to evaluate your application. If your application is approved, we may transfer the information you have given us to the publishers whose resources you wish to access. They will either contact you with the account information directly or we will send access information to you ourselves."
+msgstr "Для того, щоб подати запит на доступ до партнерських ресурсів, ви мусите надати нам певну інформацію, яку ми використаємо для оцінки вашої заявки. Якщо вашу заявку буде схвалено, ми можемо передати інформацію, отриману від вас, видавцям, до ресурсів яких ви хочете отримати доступ. Вони зв'яжуться з вами й або вони нададуть вам інформацію про обліковий запис, або ми надішлемо вам інформацію про доступ самостійно."
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:130
-msgid ""
-"In addition to the basic information you provide to us, our system will "
-"retrieve some information directly from the Wikimedia projects: your "
-"username, email address, edit count, registration date, user ID number, "
-"groups to which you belong, and any special user rights."
-msgstr ""
-"Окрім базової інформації, яку ви нам надаєте, наша система отримує деяку "
-"інформацію прямо з проектів Вікімедіа: ваше ім'я користувача, електронну "
-"пошту, кількість редагувань, дату реєстрації, ідентифікатор користувача, "
-"групи, до яких ви належите, та спеціальні права користувача."
+msgid "In addition to the basic information you provide to us, our system will retrieve some information directly from the Wikimedia projects: your username, email address, edit count, registration date, user ID number, groups to which you belong, and any special user rights."
+msgstr "Окрім базової інформації, яку ви нам надаєте, наша система отримує деяку інформацію прямо з проектів Вікімедіа: ваше ім'я користувача, електронну пошту, кількість редагувань, дату реєстрації, ідентифікатор користувача, групи, до яких ви належите, та спеціальні права користувача."
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:140
-msgid ""
-"Each time you log in to the Wikipedia Library Card Platform, this "
-"information will be automatically updated."
-msgstr ""
-"Щоразу, коли ви входите у Карткову платформу Бібліотеки Вікіпедії, ця "
-"інформація автоматично оновлюється."
+msgid "Each time you log in to the Wikipedia Library Card Platform, this information will be automatically updated."
+msgstr "Щоразу, коли ви входите у Карткову платформу Бібліотеки Вікіпедії, ця інформація автоматично оновлюється."
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:148
-msgid ""
-"We will ask you to provide us with some information about your history of "
-"contributions to the Wikimedia projects. Information on contribution history "
-"is optional, but will greatly assist us in evaluating your application."
-msgstr ""
-"Ми просимо вас надати нам певну інформацію про історію вашого внеску до "
-"проектів Вікімедіа. Інформація про історію внеску є необов'язковою, але вона "
-"дуже допомагає нам під час оцінки вашої заявки."
+msgid "We will ask you to provide us with some information about your history of contributions to the Wikimedia projects. Information on contribution history is optional, but will greatly assist us in evaluating your application."
+msgstr "Ми просимо вас надати нам певну інформацію про історію вашого внеску до проектів Вікімедіа. Інформація про історію внеску є необов'язковою, але вона дуже допомагає нам під час оцінки вашої заявки."
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). WMF should not be translated. Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:157
-msgid ""
-"The information you provide when creating your account will be visible to "
-"you while on the site but not to others unless they are approved Wikipedia "
-"Library Coordinators, WMF Staff, or WMF Contractors who need access to this "
-"data in order to carry out their work with the Wikipedia Library, all of "
-"whom are subject to non-disclosure obligations."
-msgstr ""
-"Інформація, яку ви надаєте під час створення свого облікового запису, буде "
-"видима вам на сайті, але не іншим — окрім координаторів Бібліотеки "
-"Вікіпедії, працівників ФВМ чи підрядників ФВМ, яким потрібен доступ до цих "
-"даних, щоб виконувати свою роботу, пов'язану з Бібліотекою Вікіпедії; усі "
-"вони підписали угоду про нерозголошення."
+msgid "The information you provide when creating your account will be visible to you while on the site but not to others unless they are approved Wikipedia Library Coordinators, WMF Staff, or WMF Contractors who need access to this data in order to carry out their work with the Wikipedia Library, all of whom are subject to non-disclosure obligations."
+msgstr "Інформація, яку ви надаєте під час створення свого облікового запису, буде видима вам на сайті, але не іншим — окрім координаторів Бібліотеки Вікіпедії, працівників ФВМ чи підрядників ФВМ, яким потрібен доступ до цих даних, щоб виконувати свою роботу, пов'язану з Бібліотекою Вікіпедії; усі вони підписали угоду про нерозголошення."
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:167
@@ -3591,65 +2751,35 @@ msgstr "Ваше використання ресурсів видавця"
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:171
-msgid ""
-"In order to access an individual publisher’s resources, you must agree to "
-"that publisher’s terms of use and privacy policy. You agree that you will "
-"not violate such terms and policies in connection with your use of the "
-"Wikipedia Library. Additionally, the following activities are prohibited "
-"while accessing publisher resources through the Wikipedia Library."
-msgstr ""
-"Для отримання доступу до ресурсів окремого видавця, ви мусите погодитися "
-"дотримуватися умов використання та політики приватності цього видавця. Ви "
-"погоджуєтеся, що не порушуватимете такі умови та політики під час свого "
-"використання Бібліотеки Вікіпедії. Окрім цього, під час доступу до ресурсів "
-"видавця через Бібліотеку Вікіпедії заборонена наступна діяльність."
+msgid "In order to access an individual publisher’s resources, you must agree to that publisher’s terms of use and privacy policy. You agree that you will not violate such terms and policies in connection with your use of the Wikipedia Library. Additionally, the following activities are prohibited while accessing publisher resources through the Wikipedia Library."
+msgstr "Для отримання доступу до ресурсів окремого видавця, ви мусите погодитися дотримуватися умов використання та політики приватності цього видавця. Ви погоджуєтеся, що не порушуватимете такі умови та політики під час свого використання Бібліотеки Вікіпедії. Окрім цього, під час доступу до ресурсів видавця через Бібліотеку Вікіпедії заборонена наступна діяльність."
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:184
-msgid ""
-"Sharing your Wikipedia account, usernames, passwords, or any access codes "
-"for publisher resources with others;"
-msgstr ""
-"Передача своїх імен користувача, паролів чи будь-яких кодів доступу до "
-"ресурсів видавця іншим людям;"
+msgid "Sharing your Wikipedia account, usernames, passwords, or any access codes for publisher resources with others;"
+msgstr "Передача своїх імен користувача, паролів чи будь-яких кодів доступу до ресурсів видавця іншим людям;"
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:191
-msgid ""
-"Automatically scraping or downloading restricted content from publishers;"
-msgstr ""
-"Автоматичне зчитування чи завантаження обмеженого контенту із сайтів "
-"видавців;"
+msgid "Automatically scraping or downloading restricted content from publishers;"
+msgstr "Автоматичне зчитування чи завантаження обмеженого контенту із сайтів видавців;"
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:197
 #, fuzzy
-msgid ""
-"Systematically making printed or electronic copies of multiple extracts of "
-"restricted content available for any purpose;"
-msgstr ""
-"Систематично робити друковані чи електронні копії численних уривків "
-"доступного обмеженого контенту з будь-якою метою"
+msgid "Systematically making printed or electronic copies of multiple extracts of restricted content available for any purpose;"
+msgstr "Систематично робити друковані чи електронні копії численних уривків доступного обмеженого контенту з будь-якою метою"
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:204
 #, fuzzy
-msgid ""
-"Data mining metadata without permission—for example, in order to use "
-"metadata for auto-created stub articles;"
-msgstr ""
-"Використовувати метадані без дозволу, наприклад, щоб на їх основі "
-"автоматично створювати статті-заготовки"
+msgid "Data mining metadata without permission—for example, in order to use metadata for auto-created stub articles;"
+msgstr "Використовувати метадані без дозволу, наприклад, щоб на їх основі автоматично створювати статті-заготовки"
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:211
-msgid ""
-"Using the access you receive through the Wikipedia Library for profit by "
-"selling access to your account or resources which you have through it."
-msgstr ""
-"Використання доступу, який ви отримуєте через Бібліотеку Вікіпедії, з метою "
-"отримання прибутку від продажу доступу до вашого облікового запису чи "
-"ресурсів, які ви через нього маєте."
+msgid "Using the access you receive through the Wikipedia Library for profit by selling access to your account or resources which you have through it."
+msgstr "Використання доступу, який ви отримуєте через Бібліотеку Вікіпедії, з метою отримання прибутку від продажу доступу до вашого облікового запису чи ресурсів, які ви через нього маєте."
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:220
@@ -3658,26 +2788,13 @@ msgstr "Зовнішній пошук та сервіси проксі"
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:224
-msgid ""
-"Certain resources may only be accessed using an external search service, "
-"such as the EBSCO Discovery Service, or a proxy service, such as OCLC "
-"EZProxy. If you use such external search and/or proxy services, please "
-"review the applicable terms of use and privacy policies."
-msgstr ""
-"Певні ресурси можна відкрити лише з використанням зовнішнього пошукового "
-"сервісу, такого як EBSCO Discovery Service, або проксі, наприклад, OCLC "
-"EZProxy. Якщо ви використовуєте подібні зовнішні пошукові та/або проксі "
-"сервіси, будь ласка, перегляньте відповідні умови використання та політику "
-"приватності."
+msgid "Certain resources may only be accessed using an external search service, such as the EBSCO Discovery Service, or a proxy service, such as OCLC EZProxy. If you use such external search and/or proxy services, please review the applicable terms of use and privacy policies."
+msgstr "Певні ресурси можна відкрити лише з використанням зовнішнього пошукового сервісу, такого як EBSCO Discovery Service, або проксі, наприклад, OCLC EZProxy. Якщо ви використовуєте подібні зовнішні пошукові та/або проксі сервіси, будь ласка, перегляньте відповідні умови використання та політику приватності."
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:234
-msgid ""
-"In addition, if you use OCLC EZProxy, please note that you may not use it "
-"for commercial purposes."
-msgstr ""
-"Окрім цього, якщо ви використовуєте OCLC EZProxy, то зверніть увагу, що ви "
-"не можете користуватися цим у комерційних цілях."
+msgid "In addition, if you use OCLC EZProxy, please note that you may not use it for commercial purposes."
+msgstr "Окрім цього, якщо ви використовуєте OCLC EZProxy, то зверніть увагу, що ви не можете користуватися цим у комерційних цілях."
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:241
@@ -3687,199 +2804,51 @@ msgstr "Зберігання та обробка даних"
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Wikimedia Foundation should not be translated. Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:245
 #, fuzzy
-msgid ""
-"The Wikimedia Foundation and our service providers use your information for "
-"the legitimate purpose of providing Wikipedia Library services in support of "
-"our charitable mission. When you apply for a Wikipedia Library account, or "
-"use your Wikipedia Library account, we may routinely collect the following "
-"information: your username, email address, edit count, registration date, "
-"user ID number, groups to which you belong, and any special user rights; "
-"your name, country of residence, and/or affiliation, if required by a "
-"partner to which you are applying; your narrative description of your "
-"contributions and reasons for applying for access to partner resources; and "
-"the date you agree to these terms of use."
-msgstr ""
-"Фонд Вікімедіа та провайдери наших послуг використовують вашу інформацію із "
-"законною метою надавати послуги Бібліотеки Вікіпедії на підтримку нашої "
-"благодійної мети. Коли ви подаєте заявку на обліковий запис Бібліотеки "
-"Вікіпедії або використовуєте свій обліковий запис Бібліотеки Вікіпедії, ми "
-"можемо регулярно збирати таку інформацію: ваше ім'я користувача, адресу "
-"електронної пошти, кількість редагувань, дату реєстрації, ID-номер "
-"користувача, групи, до яких ви належите, та будь-які спеціальні права; ваше "
-"ім'я, країну проживання, рід занять та/або афіліацію, якщо цього вимагає "
-"партнер, до якого ви хочете отримати доступ; вашу розповідь про свій внесок "
-"та причини подачі заявки на доступ до партнерських ресурсів; а також дату, "
-"коли ви погодилися з цими умовами використання."
+msgid "The Wikimedia Foundation and our service providers use your information for the legitimate purpose of providing Wikipedia Library services in support of our charitable mission. When you apply for a Wikipedia Library account, or use your Wikipedia Library account, we may routinely collect the following information: your username, email address, edit count, registration date, user ID number, groups to which you belong, and any special user rights; your name, country of residence, and/or affiliation, if required by a partner to which you are applying; your narrative description of your contributions and reasons for applying for access to partner resources; and the date you agree to these terms of use."
+msgstr "Фонд Вікімедіа та провайдери наших послуг використовують вашу інформацію із законною метою надавати послуги Бібліотеки Вікіпедії на підтримку нашої благодійної мети. Коли ви подаєте заявку на обліковий запис Бібліотеки Вікіпедії або використовуєте свій обліковий запис Бібліотеки Вікіпедії, ми можемо регулярно збирати таку інформацію: ваше ім'я користувача, адресу електронної пошти, кількість редагувань, дату реєстрації, ID-номер користувача, групи, до яких ви належите, та будь-які спеціальні права; ваше ім'я, країну проживання, рід занять та/або афіліацію, якщо цього вимагає партнер, до якого ви хочете отримати доступ; вашу розповідь про свій внесок та причини подачі заявки на доступ до партнерських ресурсів; а також дату, коли ви погодилися з цими умовами використання."
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:262
 #, fuzzy, python-format
-msgid ""
-"Each publisher who is a member of the Wikipedia Library program requires "
-"different specific information in the application. Some publishers may "
-"request only an email address, while others request more detailed data, such "
-"as your name, location, or institutional affiliation. When you complete your "
-"application, you will only be asked to supply information required by the "
-"publishers you have chosen, and each publisher will only receive the "
-"information they require for providing you with access. Please see our <a "
-"class=\"twl-links\" href=\"%(all_partners_url)s\">partner information</a> "
-"pages to learn what information is required by each publisher to gain access "
-"to their resources."
-msgstr ""
-"Кожен видавець, який є членом програми Бібліотеки Вікіпедії, вимагає іншої "
-"інформації у заявці. Деякі видавці можуть запитувати лише адресу електронної "
-"пошти, тоді як інші запитують більш детальні дані, такі як ваше ім'я, "
-"розташування, рід занять чи інституційна приналежність. Коли ви заповнюєте "
-"свою заявку, вас просять надати лише ту інформацію, якої потребують обрані "
-"вами видавці, і кожен видавець отримає лише ту інформацію, якої він потребує "
-"для надання вам доступу. Будь ласка, перегляньте наші сторінки <a class="
-"\"twl-links\" href=\"%(all_partners_url)s\">інформації про партнерів</a>, "
-"щоб дізнатися більше про те, яку інформацію вимагає кожен видавець для "
-"отримання доступу до їхніх ресурсів."
+msgid "Each publisher who is a member of the Wikipedia Library program requires different specific information in the application. Some publishers may request only an email address, while others request more detailed data, such as your name, location, or institutional affiliation. When you complete your application, you will only be asked to supply information required by the publishers you have chosen, and each publisher will only receive the information they require for providing you with access. Please see our <a class=\"twl-links\" href=\"%(all_partners_url)s\">partner information</a> pages to learn what information is required by each publisher to gain access to their resources."
+msgstr "Кожен видавець, який є членом програми Бібліотеки Вікіпедії, вимагає іншої інформації у заявці. Деякі видавці можуть запитувати лише адресу електронної пошти, тоді як інші запитують більш детальні дані, такі як ваше ім'я, розташування, рід занять чи інституційна приналежність. Коли ви заповнюєте свою заявку, вас просять надати лише ту інформацію, якої потребують обрані вами видавці, і кожен видавець отримає лише ту інформацію, якої він потребує для надання вам доступу. Будь ласка, перегляньте наші сторінки <a class=\"twl-links\" href=\"%(all_partners_url)s\">інформації про партнерів</a>, щоб дізнатися більше про те, яку інформацію вимагає кожен видавець для отримання доступу до їхніх ресурсів."
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Wikimedia Foundation should not be translated. Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:277
-msgid ""
-"Some Wikipedia Library pages are visible without logging in, but you will "
-"need to log in to apply or access proprietary partner resources. We use the "
-"data provided by you via OAuth and Wikimedia API calls to assess your "
-"application for access and to process approved requests."
-msgstr ""
-"Ви можете переглядати сайт Бібліотеки Вікіпедії без входу в систему, але вам "
-"треба буде увійти в систему, щоб подати заявку або отримати доступ до "
-"пропрієтарних партнерських ресурсів. Ми використовуємо надані вами дані "
-"через OAuth та виклики Вікімедіа API для оцінки вашої заявки на доступ та "
-"обробки схвалених запитів."
+msgid "Some Wikipedia Library pages are visible without logging in, but you will need to log in to apply or access proprietary partner resources. We use the data provided by you via OAuth and Wikimedia API calls to assess your application for access and to process approved requests."
+msgstr "Ви можете переглядати сайт Бібліотеки Вікіпедії без входу в систему, але вам треба буде увійти в систему, щоб подати заявку або отримати доступ до пропрієтарних партнерських ресурсів. Ми використовуємо надані вами дані через OAuth та виклики Вікімедіа API для оцінки вашої заявки на доступ та обробки схвалених запитів."
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:288
 #, python-format
-msgid ""
-"In order to administer the Wikipedia Library program, we will retain the "
-"application data we collect from you for three years after your most recent "
-"login, unless you delete your account, as described below. You can log in "
-"and go to <a class=\"twl-links\" href=\"%(profile_url)s\">your profile page</"
-"a> in order to see the information associated with your account, and can "
-"download it in JSON format. You may access, update, restrict, or delete this "
-"information at any time, except for the information that is automatically "
-"retrieved from the projects. If you have any questions or concerns about the "
-"handling of your data, please contact <a class=\"twl-links\" href=\"mailto:"
-"wikipedialibrary@wikimedia.org?Subject=Wikipedia%%20Library%%20Card"
-"%%20account%%20deactivation\"> wikipedialibrary@wikimedia.org </a>."
-msgstr ""
-"З метою адміністрування програми Бібліотеки Вікіпедії, ми зберігаємо "
-"програмні дані, які збираємо від вас, упродовж трьох років після вашого "
-"останнього входу в систему, поки ви не вилучите свій обліковий запис, як "
-"описано нижче. Ви можете увійти і перейти до <a class=\"twl-links\" href="
-"\"%(profile_url)s\">своєї сторінки профілю</a>, щоб переглянути інформацію, "
-"пов'язану з вашим обліковим записом, і можете завантажити її у форматі JSON. "
-"Ви можете відкривати, оновлювати, обмежувати чи вилучати цю інформацію у "
-"будь-який час, окрім інформації, яка автоматично оновлюється з проєктів. "
-"Якщо у вас є будь-які запитання чи застереження щодо обробки ваших даних, "
-"будь ласка, напишіть на <a class=\"twl-links\" href=\"mailto:"
-"wikipedialibrary@wikimedia.org?Subject=Wikipedia%%20Library%%20Card"
-"%%20account%%20deactivation\">wikipedialibrary@wikimedia.org</a>."
+msgid "In order to administer the Wikipedia Library program, we will retain the application data we collect from you for three years after your most recent login, unless you delete your account, as described below. You can log in and go to <a class=\"twl-links\" href=\"%(profile_url)s\">your profile page</a> in order to see the information associated with your account, and can download it in JSON format. You may access, update, restrict, or delete this information at any time, except for the information that is automatically retrieved from the projects. If you have any questions or concerns about the handling of your data, please contact <a class=\"twl-links\" href=\"mailto:wikipedialibrary@wikimedia.org?Subject=Wikipedia%%20Library%%20Card%%20account%%20deactivation\"> wikipedialibrary@wikimedia.org </a>."
+msgstr "З метою адміністрування програми Бібліотеки Вікіпедії, ми зберігаємо програмні дані, які збираємо від вас, упродовж трьох років після вашого останнього входу в систему, поки ви не вилучите свій обліковий запис, як описано нижче. Ви можете увійти і перейти до <a class=\"twl-links\" href=\"%(profile_url)s\">своєї сторінки профілю</a>, щоб переглянути інформацію, пов'язану з вашим обліковим записом, і можете завантажити її у форматі JSON. Ви можете відкривати, оновлювати, обмежувати чи вилучати цю інформацію у будь-який час, окрім інформації, яка автоматично оновлюється з проєктів. Якщо у вас є будь-які запитання чи застереження щодо обробки ваших даних, будь ласка, напишіть на <a class=\"twl-links\" href=\"mailto:wikipedialibrary@wikimedia.org?Subject=Wikipedia%%20Library%%20Card%%20account%%20deactivation\">wikipedialibrary@wikimedia.org</a>."
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:305
 #, fuzzy
-msgid ""
-"If you decide to disable your Wikipedia Library account, you can use the "
-"delete button on your profile to delete certain personal information "
-"associated with your account. We will delete your real name, institutional "
-"affiliation, and country of residence. Please note that the system will "
-"retain a record of your username, the publishers to which you applied or had "
-"access, and the dates of that access. Note that deletion is not reversible. "
-"Deletion of your Wikipedia Library account may also correspond with the "
-"removal of any resource access to which you were eligible or approved. If "
-"you request the deletion of account information and later wish to apply for "
-"a new account, you will need to provide the necessary information again."
-msgstr ""
-"Якщо ви вирішите відімкнути свій обліковий запис Бібліотеки Вікіпедії, ви "
-"можете написати нам листа на <a href=\"mailto:wikipedialibrary@wikimedia.org?"
-"Subject=Wikipedia%%20Library%%20Card%%20account%%20deactivation"
-"\">wikipedialibrary@wikimedia.org</a> із запитом на вилучення певної "
-"персональної інформації, пов'язаної з вашим обліковим записом. Ми вилучимо "
-"ваше справжнє ім'я, рід занять, інституційну приналежність та країну "
-"проживання. Будь ласка, зверніть увагу, що система збереже запис про ваше "
-"ім'я користувача, до яких видавців ви подавали запит або отримали доступ і "
-"дати цього доступу. Якщо ви подасте запит на вилучення інформації облікового "
-"запису, а пізніше забажаєте отримати новий обліковий запис, вам необхідно "
-"буде надати потрібну інформацію знову."
+msgid "If you decide to disable your Wikipedia Library account, you can use the delete button on your profile to delete certain personal information associated with your account. We will delete your real name, institutional affiliation, and country of residence. Please note that the system will retain a record of your username, the publishers to which you applied or had access, and the dates of that access. Note that deletion is not reversible. Deletion of your Wikipedia Library account may also correspond with the removal of any resource access to which you were eligible or approved. If you request the deletion of account information and later wish to apply for a new account, you will need to provide the necessary information again."
+msgstr "Якщо ви вирішите відімкнути свій обліковий запис Бібліотеки Вікіпедії, ви можете написати нам листа на <a href=\"mailto:wikipedialibrary@wikimedia.org?Subject=Wikipedia%%20Library%%20Card%%20account%%20deactivation\">wikipedialibrary@wikimedia.org</a> із запитом на вилучення певної персональної інформації, пов'язаної з вашим обліковим записом. Ми вилучимо ваше справжнє ім'я, рід занять, інституційну приналежність та країну проживання. Будь ласка, зверніть увагу, що система збереже запис про ваше ім'я користувача, до яких видавців ви подавали запит або отримали доступ і дати цього доступу. Якщо ви подасте запит на вилучення інформації облікового запису, а пізніше забажаєте отримати новий обліковий запис, вам необхідно буде надати потрібну інформацію знову."
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). WMF should not be translated. Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:321
-msgid ""
-"The Wikipedia Library is run by WMF Staff, Contractors, and approved "
-"volunteer Coordinators. The data associated with your account will be shared "
-"with the WMF staff, contractors, service providers, and volunteer "
-"coordinators who need to process the information in connection with their "
-"work for the Wikipedia Library, and who are subject to confidentiality "
-"obligations. We will also use your data for internal Wikipedia Library "
-"purposes such as distributing user surveys and account notifications, and in "
-"a depersonalized or aggregated fashion for statistical analysis and "
-"administration. Finally, we will share your information with the publishers "
-"whom you specifically select in order to provide you with access to "
-"resources. Otherwise, your information will not be shared with third "
-"parties, with the exception of the circumstances described below."
-msgstr ""
-"Бібліотекою Вікіпедії опікуються працівники і підрядники Фонду Вікімедіа, а "
-"також схвалені координатори-волонтери, які можуть мати доступ до вашої "
-"інформації. Дані, пов'язані з вашим обліковим записом, будуть надані "
-"працівникам ФВМ, підрядникам, надавачам послуг та координаторам-волонтерам, "
-"яким необхідно обробити інформацію у рамках своєї роботи на Бібліотеку "
-"Вікіпедії і які зв'язані зобов'язаннями конфіденційності. Ми також "
-"використовуватимемо ваші дані у внутрішніх цілях Бібліотеки Вікіпедії, таких "
-"як розсилання опитувань користувачів та сповіщень облікових записів, а також "
-"у знеособленому чи агрегованому вигляді для статистичного аналізу й "
-"адміністрування. І наостанок, ми надаватимемо вашу інформацію видавцям, яких "
-"ви конкретно вибираєте, щоб вони могли надати вам доступ до ресурсів. В "
-"іншому випадку, ваша інформація не буде надана третім сторонам, за винятком "
-"обставин, описаних нижче."
+msgid "The Wikipedia Library is run by WMF Staff, Contractors, and approved volunteer Coordinators. The data associated with your account will be shared with the WMF staff, contractors, service providers, and volunteer coordinators who need to process the information in connection with their work for the Wikipedia Library, and who are subject to confidentiality obligations. We will also use your data for internal Wikipedia Library purposes such as distributing user surveys and account notifications, and in a depersonalized or aggregated fashion for statistical analysis and administration. Finally, we will share your information with the publishers whom you specifically select in order to provide you with access to resources. Otherwise, your information will not be shared with third parties, with the exception of the circumstances described below."
+msgstr "Бібліотекою Вікіпедії опікуються працівники і підрядники Фонду Вікімедіа, а також схвалені координатори-волонтери, які можуть мати доступ до вашої інформації. Дані, пов'язані з вашим обліковим записом, будуть надані працівникам ФВМ, підрядникам, надавачам послуг та координаторам-волонтерам, яким необхідно обробити інформацію у рамках своєї роботи на Бібліотеку Вікіпедії і які зв'язані зобов'язаннями конфіденційності. Ми також використовуватимемо ваші дані у внутрішніх цілях Бібліотеки Вікіпедії, таких як розсилання опитувань користувачів та сповіщень облікових записів, а також у знеособленому чи агрегованому вигляді для статистичного аналізу й адміністрування. І наостанок, ми надаватимемо вашу інформацію видавцям, яких ви конкретно вибираєте, щоб вони могли надати вам доступ до ресурсів. В іншому випадку, ваша інформація не буде надана третім сторонам, за винятком обставин, описаних нижче."
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). WMF should not be translated.
 #: TWLight/users/templates/users/terms.html:338
-msgid ""
-"We may disclose any collected information when required by law, when we have "
-"your permission, when needed to protect our rights, privacy, safety, users, "
-"or the general public, and when necessary to enforce these terms, WMF’s "
-"general <a class=\"twl-links\" href=\"https://foundation.wikimedia.org/wiki/"
-"Terms_of_Use\">Terms of Use</a>, or any other WMF policy."
-msgstr ""
-"Ми можемо розкрити будь-яку зібрану інформацію, коли це вимагається законом, "
-"коли ми маємо ваш дозвіл, коли нам потрібно захистити наші права, "
-"приватність, безпеку, користувачів або широку громадськість і коли необхідно "
-"здійснити ці умови, загальні <a class=\"twl-links\" href=\"https://"
-"foundation.wikimedia.org/wiki/Terms_of_Use/uk\">Умови використання</a> ФВМ "
-"або будь-яку іншу політику ФВМ."
+msgid "We may disclose any collected information when required by law, when we have your permission, when needed to protect our rights, privacy, safety, users, or the general public, and when necessary to enforce these terms, WMF’s general <a class=\"twl-links\" href=\"https://foundation.wikimedia.org/wiki/Terms_of_Use\">Terms of Use</a>, or any other WMF policy."
+msgstr "Ми можемо розкрити будь-яку зібрану інформацію, коли це вимагається законом, коли ми маємо ваш дозвіл, коли нам потрібно захистити наші права, приватність, безпеку, користувачів або широку громадськість і коли необхідно здійснити ці умови, загальні <a class=\"twl-links\" href=\"https://foundation.wikimedia.org/wiki/Terms_of_Use/uk\">Умови використання</a> ФВМ або будь-яку іншу політику ФВМ."
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:349
-msgid ""
-"We take the security of your personal data seriously, and take reasonable "
-"precautions to ensure your data is protected. These precautions include "
-"access controls to limit who has access to your data and security "
-"technologies to protect data stored on the server. However, we cannot "
-"guarantee the safety of your data as it is transmitted and stored."
-msgstr ""
-"Ми серйозно ставимося до безпеки ваших персональних даних і здійснюємо "
-"розумні запобіжні заходи захисту ваших даних. Ці заходи включають контроль "
-"доступу з обмеженням тих, хто може отримати доступ до ваших даних, та "
-"безпекові технології захисту даних, що зберігаються на сервері. Однак ми не "
-"можемо гарантувати безпеку ваших даних у процесі передачі чи зберігання."
+msgid "We take the security of your personal data seriously, and take reasonable precautions to ensure your data is protected. These precautions include access controls to limit who has access to your data and security technologies to protect data stored on the server. However, we cannot guarantee the safety of your data as it is transmitted and stored."
+msgstr "Ми серйозно ставимося до безпеки ваших персональних даних і здійснюємо розумні запобіжні заходи захисту ваших даних. Ці заходи включають контроль доступу з обмеженням тих, хто може отримати доступ до ваших даних, та безпекові технології захисту даних, що зберігаються на сервері. Однак ми не можемо гарантувати безпеку ваших даних у процесі передачі чи зберігання."
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:360
-msgid ""
-"Please note that these terms do not control the use and handling of your "
-"data by the publishers and service providers whose resources you access or "
-"apply to access. Please read their individual privacy policies for that "
-"information."
-msgstr ""
-"Будь ласка, візьміть до уваги, що ці умови не контролюють використання та "
-"обробку ваших даних видавцями та провайдерами послуг, доступ до ресурсів "
-"яких ви отримуєте або подаєте заявку на отримання. Будь ласка, почитайте "
-"їхні індивідуальні правила приватності, щоб отримати цю інформацію."
+msgid "Please note that these terms do not control the use and handling of your data by the publishers and service providers whose resources you access or apply to access. Please read their individual privacy policies for that information."
+msgstr "Будь ласка, візьміть до уваги, що ці умови не контролюють використання та обробку ваших даних видавцями та провайдерами послуг, доступ до ресурсів яких ви отримуєте або подаєте заявку на отримання. Будь ласка, почитайте їхні індивідуальні правила приватності, щоб отримати цю інформацію."
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:368
@@ -3888,52 +2857,18 @@ msgstr "Важлива примітка"
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Wikimedia Foundation should not be translated. Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:373
-msgid ""
-"The Wikimedia Foundation is a nonprofit organization based in San Francisco, "
-"California. The Wikipedia Library program provides access to resources held "
-"by publishers in multiple countries. If you apply for a Wikipedia Library "
-"account (whether you are inside or outside of the United States), you "
-"understand that your personal data will be collected, transferred, stored, "
-"processed, disclosed and otherwise used in the U.S. as described in this "
-"privacy policy. You also understand that your information may be transferred "
-"by us from the U.S. to other countries, which may have different or less "
-"stringent data protection laws than your country, in connection with "
-"providing services to you, including evaluating your application and "
-"securing access to your chosen publishers (locations for each publisher are "
-"outlined on their respective partner information pages)."
-msgstr ""
-"Фонд Вікімедіа є неприбутковою організацією, розташованою у Сан-Франциско "
-"(Каліфорнія). Програма Бібліотеки Вікіпедії надає доступ до ресурсів від "
-"видавців у багатьох країнах. Якщо ви подаєте запит на обліковий запис "
-"Бібліотеки Вікіпедії (не залежно від того, чи ви у Сполучених Штатах, чи "
-"поза ними), ви розумієте, що ваші персональні дані будуть збиратися, "
-"передаватися, зберігатися, оброблятися, розкриватися та інакше "
-"використовуватися у США, як це описано у цій політиці приватності. Ви також "
-"розумієте, що ваша інформація може бути передана нами зі США до інших країн, "
-"які можуть мати інші або менш строгі закони щодо захисту даних, ніж ті, що "
-"діють у вашій країні, у зв'язку з наданням вам послуг, включно з оцінкою "
-"вашої заявки та забезпечення доступ до обраних видавців (розташування "
-"кожного видавця вказана на відповідній інформаційній сторінці партнера)."
+msgid "The Wikimedia Foundation is a nonprofit organization based in San Francisco, California. The Wikipedia Library program provides access to resources held by publishers in multiple countries. If you apply for a Wikipedia Library account (whether you are inside or outside of the United States), you understand that your personal data will be collected, transferred, stored, processed, disclosed and otherwise used in the U.S. as described in this privacy policy. You also understand that your information may be transferred by us from the U.S. to other countries, which may have different or less stringent data protection laws than your country, in connection with providing services to you, including evaluating your application and securing access to your chosen publishers (locations for each publisher are outlined on their respective partner information pages)."
+msgstr "Фонд Вікімедіа є неприбутковою організацією, розташованою у Сан-Франциско (Каліфорнія). Програма Бібліотеки Вікіпедії надає доступ до ресурсів від видавців у багатьох країнах. Якщо ви подаєте запит на обліковий запис Бібліотеки Вікіпедії (не залежно від того, чи ви у Сполучених Штатах, чи поза ними), ви розумієте, що ваші персональні дані будуть збиратися, передаватися, зберігатися, оброблятися, розкриватися та інакше використовуватися у США, як це описано у цій політиці приватності. Ви також розумієте, що ваша інформація може бути передана нами зі США до інших країн, які можуть мати інші або менш строгі закони щодо захисту даних, ніж ті, що діють у вашій країні, у зв'язку з наданням вам послуг, включно з оцінкою вашої заявки та забезпечення доступ до обраних видавців (розташування кожного видавця вказана на відповідній інформаційній сторінці партнера)."
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:392
-msgid ""
-"Please note that in the event of any differences in meaning or "
-"interpretation between the original English version of these terms and a "
-"translation, the original English version takes precedence."
-msgstr ""
-"Будь ласка, зверніть увагу, що у випадку будь-який розбіжностей у значенні "
-"чи трактуванні між оригінальною англомовною версією цих умов та перекладом, "
-"перевага надається оригінальній англійській версії."
+msgid "Please note that in the event of any differences in meaning or interpretation between the original English version of these terms and a translation, the original English version takes precedence."
+msgstr "Будь ласка, зверніть увагу, що у випадку будь-який розбіжностей у значенні чи трактуванні між оригінальною англомовною версією цих умов та перекладом, перевага надається оригінальній англійській версії."
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Wikimedia Foundation should not be translated.
 #: TWLight/users/templates/users/terms.html:403
-msgid ""
-"See also the <a class=\"twl-links\" href=\"https://wikimediafoundation.org/"
-"wiki/Privacy_policy\">Wikimedia Foundation Privacy Policy</a>."
-msgstr ""
-"Див. також <a class=\"twl-links\" href=\"https://wikimediafoundation.org/"
-"wiki/Privacy_policy\">Політику конфіденційності Фонду Вікімедіа</a>."
+msgid "See also the <a class=\"twl-links\" href=\"https://wikimediafoundation.org/wiki/Privacy_policy\">Wikimedia Foundation Privacy Policy</a>."
+msgstr "Див. також <a class=\"twl-links\" href=\"https://wikimediafoundation.org/wiki/Privacy_policy\">Політику конфіденційності Фонду Вікімедіа</a>."
 
 #. Translators: This is the second to last line of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:412
@@ -3953,16 +2888,8 @@ msgstr "Політика приватності Фонду Вікімедіа"
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:426
-msgid ""
-"By checking this box and clicking “Submit”, you agree that you have read the "
-"above terms and that you will adhere to the terms of use in your application "
-"to and use of the The Wikipedia Library, and the publishers’ services to "
-"which you gain access through The Wikipedia Library program."
-msgstr ""
-"Ставлячи цю галочку і натискаючи «Надіслати», ви погоджуєтеся, що прочитали "
-"викладені вище умови і що будете дотримуватися умов використання у своїй "
-"заявці та використанні Бібліотеки Вікіпедії і послуг видавців, до яких ви "
-"отримуєте доступ завдяки програмі Бібліотеки Вікіпедії."
+msgid "By checking this box and clicking “Submit”, you agree that you have read the above terms and that you will adhere to the terms of use in your application to and use of the The Wikipedia Library, and the publishers’ services to which you gain access through The Wikipedia Library program."
+msgstr "Ставлячи цю галочку і натискаючи «Надіслати», ви погоджуєтеся, що прочитали викладені вище умови і що будете дотримуватися умов використання у своїй заявці та використанні Бібліотеки Вікіпедії і послуг видавців, до яких ви отримуєте доступ завдяки програмі Бібліотеки Вікіпедії."
 
 #: TWLight/users/templates/users/user_collection_tile.html:32
 msgid "Remove this collection from favorites"
@@ -4014,41 +2941,19 @@ msgstr "Вилучити усі дані"
 
 #. Translators: This message is displayed on the page where users can request the deletion of their data.
 #: TWLight/users/templates/users/user_confirm_delete.html:17
-msgid ""
-"<b>Warning:</b> Performing this action will delete your Wikipedia Library "
-"Card user account and all associated applications. This process is not "
-"reversible. You may lose any partner accounts you were granted, and will not "
-"be able to renew those accounts or apply for new ones."
-msgstr ""
-"<b>Попередження:</b> Виконання цієї дії вилучить ваш обліковий запис "
-"користувача у Картковій платформі Бібліотеки Вікіпедії та усі пов'язані "
-"заявки. Цей процес неможливо скасувати. Ви можете втратити будь-які "
-"партнерські облікові записи, які ви отримали, і не зможете поновити їх чи "
-"податися на нові."
+msgid "<b>Warning:</b> Performing this action will delete your Wikipedia Library Card user account and all associated applications. This process is not reversible. You may lose any partner accounts you were granted, and will not be able to renew those accounts or apply for new ones."
+msgstr "<b>Попередження:</b> Виконання цієї дії вилучить ваш обліковий запис користувача у Картковій платформі Бібліотеки Вікіпедії та усі пов'язані заявки. Цей процес неможливо скасувати. Ви можете втратити будь-які партнерські облікові записи, які ви отримали, і не зможете поновити їх чи податися на нові."
 
 #. Translators: this should show up for people who log in with a username/password and not OAuth, so we don't know what their Wikipedia identity is.
-#.
 #: TWLight/users/templates/users/user_detail.html:12
 #, python-format
-msgid ""
-"Hi, %(username)s! You don't have a Wikipedia editor profile attached to your "
-"account here, so you are probably a site administrator."
-msgstr ""
-"Привіт, %(username)s! У вас немає профілю редактора Вікіпедії, пов'язаного з "
-"обліковим записом тут, тож ви напевно адміністратор сайту.%(username)s"
+msgid "Hi, %(username)s! You don't have a Wikipedia editor profile attached to your account here, so you are probably a site administrator."
+msgstr "Привіт, %(username)s! У вас немає профілю редактора Вікіпедії, пов'язаного з обліковим записом тут, тож ви напевно адміністратор сайту.%(username)s"
 
 #. Translators: In the unlikely scenario that someone is able to register an account without using OAuth (thus leaving us without some of the information required for applications), users will see this message, encouraging them to re-register.
 #: TWLight/users/templates/users/user_detail.html:20
-msgid ""
-"If you aren't a site administrator, something weird has happened. You won't "
-"be able to apply for access without a Wikipedia editor profile. You should "
-"log out and create a new account by logging in via OAuth, or contact a site "
-"administrator for help."
-msgstr ""
-"Якщо ви не є адміністратором сайту, то сталося щось дивне. Ви не зможете "
-"подати заявку на доступ без профілю редактора Вікіпедії. Вам варто вийти і "
-"створити новий обліковий запис, увійшовши з допомогою OAuth, або попросити "
-"допомоги в адміністратора сайту."
+msgid "If you aren't a site administrator, something weird has happened. You won't be able to apply for access without a Wikipedia editor profile. You should log out and create a new account by logging in via OAuth, or contact a site administrator for help."
+msgstr "Якщо ви не є адміністратором сайту, то сталося щось дивне. Ви не зможете подати заявку на доступ без профілю редактора Вікіпедії. Вам варто вийти і створити новий обліковий запис, увійшовши з допомогою OAuth, або попросити допомоги в адміністратора сайту."
 
 #. Translators: Labels a sections where coordinators can select their email preferences.
 #: TWLight/users/templates/users/user_email_preferences.html:15
@@ -4058,23 +2963,13 @@ msgstr "Лише координатори"
 #. Translators: This message is shown on user's own profile page, encouraging them to make sure their information is up to date, so that account coordinators can use the information to judge applications.
 #: TWLight/users/views.py:176
 #, python-brace-format
-msgid ""
-"Please <a class='twl-links' href='{url}'>update your contributions</a> to "
-"Wikipedia to help coordinators evaluate your applications."
-msgstr ""
-"Будь ласка, <a class='twl-links' href='{url}'>оновіть свій внесок</a> у "
-"Вікіпедію, щоб полегшити координаторам оцінку ваших заявок."
+msgid "Please <a class='twl-links' href='{url}'>update your contributions</a> to Wikipedia to help coordinators evaluate your applications."
+msgstr "Будь ласка, <a class='twl-links' href='{url}'>оновіть свій внесок</a> у Вікіпедію, щоб полегшити координаторам оцінку ваших заявок."
 
 #. Translators: Coordinators are shown this message when they unselect all three types of reminder email options under preferences.
 #: TWLight/users/views.py:288
-msgid ""
-"You have chosen not to receive reminder emails. As a coordinator, you should "
-"receive at least one type of reminder emails, so consider changing your "
-"preferences."
-msgstr ""
-"Ви зробили вибір не отримувати листи-нагадування. Як координатор, ви маєте "
-"отримувати хоча б один тип листів-нагадувань, тому, будь ласка, змініть свої "
-"налаштування."
+msgid "You have chosen not to receive reminder emails. As a coordinator, you should receive at least one type of reminder emails, so consider changing your preferences."
+msgstr "Ви зробили вибір не отримувати листи-нагадування. Як координатор, ви маєте отримувати хоча б один тип листів-нагадувань, тому, будь ласка, змініть свої налаштування."
 
 #. Translators: Coordinators are shown this message when they make changes to their reminder email options under preferences.
 #: TWLight/users/views.py:296
@@ -4097,9 +2992,7 @@ msgstr "Вашу інформацію оновлено."
 #. Translators: If a user tries to save the 'email change form' without entering one and checking the 'use my Wikipedia email address' checkbox, this message is presented.
 #: TWLight/users/views.py:448
 msgid "Both the values cannot be blank. Either enter a email or check the box."
-msgstr ""
-"Обидва значення не можуть бути пустими. Або введіть електронну пошту, або "
-"поставте галочку."
+msgstr "Обидва значення не можуть бути пустими. Або введіть електронну пошту, або поставте галочку."
 
 #. Translators: Shown to users when they successfully modify their email. Don't translate {email}.
 #: TWLight/users/views.py:476
@@ -4109,13 +3002,8 @@ msgstr "Вашу електронну пошту було змінено на {e
 
 #. Translators: If the user has not filled out their email, they can browse the website but cannot apply for access to resources.
 #: TWLight/users/views.py:487
-msgid ""
-"Your email is blank. You can still explore the site, but you won't be able "
-"to apply for access to partner resources without an email."
-msgstr ""
-"Ваша електронна пошта порожня. Ви й далі можете переглядати вміст сайту, але "
-"ви не зможете подати заявку на доступ до партнерських ресурсів без вказання "
-"електронної пошти."
+msgid "Your email is blank. You can still explore the site, but you won't be able to apply for access to partner resources without an email."
+msgstr "Ваша електронна пошта порожня. Ви й далі можете переглядати вміст сайту, але ви не зможете подати заявку на доступ до партнерських ресурсів без вказання електронної пошти."
 
 #. Translators: This message is shown once the access to a partner has successfully been returned.
 #: TWLight/users/views.py:801
@@ -4148,31 +3036,3 @@ msgstr "Немає активних блокувань"
 msgid "10+ edits in the last 30 days"
 msgstr "10+ редагувань за минулі 30 днів"
 
-#: tests/shunit/data/bad_i18n_comment_1.py:3
-#: tests/shunit/data/bad_i18n_newline_1.py:5
-msgid "1"
-msgstr ""
-
-#. Translators: Lorem ipsum dolor sit amet, consectetur adipiscing elit. Mauris vitae ipsum ut purus faucibus pretium. Proin tempus neque et aliquet consectetur. Ut egestas sapien in consectetur sagittis. Mauris neque lacus, dapibus non viverra vitae, interdum ut aenean ipsum.
-#. Translators: Lorem ipsum dolor sit amet, consectetur adipiscing elit. Mauris vitae ipsum ut purus faucibus pretium. Proin tempus neque et aliquet consectetur. Ut egestas sapien in consectetur sagittis. Mauris neque lacus, dapibus non.
-#: tests/shunit/data/bad_i18n_comment_2.py:4
-#: tests/shunit/data/bad_i18n_newline_2.py:5 tests/shunit/data/good_i18n_1.py:2
-#: tests/shunit/data/good_i18n_2.py:2
-msgid "2"
-msgstr ""
-
-#: tests/shunit/data/bad_i18n_newline_3.py:5
-msgid "3"
-msgstr ""
-
-#: tests/shunit/data/bad_i18n_newline_4.py:5
-msgid "4"
-msgstr ""
-
-#: tests/shunit/data/bad_i18n_newline_5.py:5
-msgid "5"
-msgstr ""
-
-#: tests/shunit/data/bad_i18n_newline_6.py:5
-msgid "6"
-msgstr ""

--- a/locale/vi/LC_MESSAGES/django.po
+++ b/locale/vi/LC_MESSAGES/django.po
@@ -18,10 +18,11 @@
 # Author: Yosari101
 msgid ""
 msgstr ""
+""
 "Project-Id-Version: Wikipedia Library Card Platform - Website\n"
-"Report-Msgid-Bugs-To: wikipedialibrary@wikimedia.org\n"
+"Report-Msgid-Bugs-To: translatewiki.net\n"
 "POT-Creation-Date: 2024-07-11 20:54+0000\n"
-"PO-Revision-Date: 2024-07-11 12:30:20+0000\n"
+"PO-Revision-Date: 2024-07-15 12:29:20+0000\n"
 "Language: vi\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
@@ -53,13 +54,8 @@ msgstr "Tự giới thiệu"
 #. Translators: This note appears in a section of a form where we ask users to enter info (like country of residence) when applying for resource access.
 #: TWLight/applications/forms.py:179
 #, python-brace-format
-msgid ""
-"<p><small><i>Your personal data will be processed according to our <a "
-"class='twl-links' href='{terms_url}'> privacy policy</a>.</i></small></p>"
-msgstr ""
-"<p><small><i>Dữ liệu cá nhân của bạn sẽ được xử lý theo <a class='twl-links' "
-"href='{terms_url}'> quy định quyền riêng tư</a> của chúng tôi.</i></small></"
-"p>"
+msgid "<p><small><i>Your personal data will be processed according to our <a class='twl-links' href='{terms_url}'> privacy policy</a>.</i></small></p>"
+msgstr "<p><small><i>Dữ liệu cá nhân của bạn sẽ được xử lý theo <a class='twl-links' href='{terms_url}'> quy định quyền riêng tư</a> của chúng tôi.</i></small></p>"
 
 #. Translators: This is the title of the application form page, where users enter information required for the application. It lets the user know which partner application they are entering data for. {partner}
 #: TWLight/applications/forms.py:189
@@ -101,9 +97,7 @@ msgstr "Địa chỉ thư điện tử tài khoản của bạn tại trang web 
 #. Translators: This labels a choice field where users will have to select the number of months they wish to have their access for as part of the application renewal confirmation.
 #. Translators: When filling out an application, users may be required to enter the length of the account (expiry) they wish to have for proxy partners.
 #: TWLight/applications/forms.py:339 TWLight/applications/helpers.py:100
-msgid ""
-"The number of months you wish to have this access for before renewal is "
-"required"
+msgid "The number of months you wish to have this access for before renewal is required"
 msgstr "Số tháng bạn cần quyền truy cập trước khi bắt buộc phải gia hạn"
 
 #. Translators: When filling out an application, users may need to specify their name
@@ -192,13 +186,8 @@ msgstr "Địa chỉ thư điện tử"
 
 #. Translators: This comment is added to pending applications when our terms of use change.
 #: TWLight/applications/management/commands/notify_applicants_tou_changes.py:54
-msgid ""
-"Our terms of use have changed. Your applications will not be processed until "
-"you log in and agree to our updated terms."
-msgstr ""
-"Những điều khoản sử dụng của chúng tôi đã có sự thay đổi. Hồ sơ của bạn sẽ "
-"không được xử lý cho đến khi nào bạn đăng nhập và đồng ý với các điều khoản "
-"mới của chúng tôi."
+msgid "Our terms of use have changed. Your applications will not be processed until you log in and agree to our updated terms."
+msgstr "Những điều khoản sử dụng của chúng tôi đã có sự thay đổi. Hồ sơ của bạn sẽ không được xử lý cho đến khi nào bạn đăng nhập và đồng ý với các điều khoản mới của chúng tôi."
 
 #. Translators: This is the status of an application that has not yet been reviewed.
 #: TWLight/applications/models.py:54
@@ -264,42 +253,26 @@ msgstr "URL truy cập: {access_url}"
 
 #. Translators: This text goes into account approval emails in the case that we need to send the user's details to a publisher for manual account setup.
 #: TWLight/applications/models.py:331
-msgid ""
-"You can expect to receive access details within a week or two once it has "
-"been processed."
-msgstr ""
-"Bạn sẽ nhận được chi tiết về quyền truy cập của mình trong vòng một hoặc "
-"tuần sau khi đã được xử lý."
+msgid "You can expect to receive access details within a week or two once it has been processed."
+msgstr "Bạn sẽ nhận được chi tiết về quyền truy cập của mình trong vòng một hoặc tuần sau khi đã được xử lý."
 
 #. Translators: This comment is added to open applications when a partner joins the Library Bundle, which does not require applications.
 #: TWLight/applications/signals.py:247
-msgid ""
-"This partner joined the Library Bundle, which does not require applications. "
-"This application will be marked as invalid."
-msgstr ""
-"Đối tác này đã gia nhập Gói Thư viện, và không đòi hỏi nộp hồ sơ. Hồ sơ này "
-"đã được ghi chú là không hợp lệ."
+msgid "This partner joined the Library Bundle, which does not require applications. This application will be marked as invalid."
+msgstr "Đối tác này đã gia nhập Gói Thư viện, và không đòi hỏi nộp hồ sơ. Hồ sơ này đã được ghi chú là không hợp lệ."
 
 #. Translators: This is shown to users if the application is to a partner for which we have run out of available accounts. The application is therefore on a 'waitlist', and will be reviewed when more accounts are available.
 #: TWLight/applications/templates/applications/application_evaluation.html:29
-msgid ""
-"This application is on the waitlist because this partner does not have any "
-"access grants available at this time."
-msgstr ""
-"Hồ sơ này đang chờ xử lý vì đối tác này chưa có thêm quyền truy cập trống "
-"vào lúc này."
+msgid "This application is on the waitlist because this partner does not have any access grants available at this time."
+msgstr "Hồ sơ này đang chờ xử lý vì đối tác này chưa có thêm quyền truy cập trống vào lúc này."
 
 #. Translators: This message is shown on pages where coordinators can see personal information about applicants.
 #: TWLight/applications/templates/applications/application_evaluation.html:36
 #: TWLight/applications/templates/applications/application_list_include.html:6
 #: TWLight/applications/templates/applications/send_partner.html:45
 #: TWLight/resources/templates/resources/partner_users.html:18
-msgid ""
-"Coordinators: This page may contain personal information such as real names "
-"and email addresses. Please remember that this information is confidential."
-msgstr ""
-"Điều phối viên: Trang này có thể chứa thông tin cá nhân như tên thật và địa "
-"chỉ thư điện tử. Xin nhớ rằng thông tin này cần được bảo mật."
+msgid "Coordinators: This page may contain personal information such as real names and email addresses. Please remember that this information is confidential."
+msgstr "Điều phối viên: Trang này có thể chứa thông tin cá nhân như tên thật và địa chỉ thư điện tử. Xin nhớ rằng thông tin này cần được bảo mật."
 
 #. Translators: This is the title of the application page shown to users who are a coordinator, and are able to accept or reject the application.
 #: TWLight/applications/templates/applications/application_evaluation.html:39
@@ -308,12 +281,8 @@ msgstr "Đánh giá hồ sơ"
 
 #. Translators: This text is shown to coordinators on application pages if the applicant has restricted processing of their data.
 #: TWLight/applications/templates/applications/application_evaluation.html:42
-msgid ""
-"This user has requested a restriction on the processing of their data, so "
-"you cannot change the status of their application."
-msgstr ""
-"Thành viên này đòi hỏi một số hạn chế khi xử lý dữ liệu của họ, do đó bạn "
-"không thể thay đổi tình trạng của hồ sơ của họ."
+msgid "This user has requested a restriction on the processing of their data, so you cannot change the status of their application."
+msgstr "Thành viên này đòi hỏi một số hạn chế khi xử lý dữ liệu của họ, do đó bạn không thể thay đổi tình trạng của hồ sơ của họ."
 
 #. Translators: This is the title of the application page shown to users who are not a coordinator.
 #: TWLight/applications/templates/applications/application_evaluation.html:48
@@ -386,12 +355,8 @@ msgstr "Không rõ"
 
 #. Translators: This is the text displayed to coordinators when an applicant has no country of residence in their profile.
 #: TWLight/applications/templates/applications/application_evaluation.html:123
-msgid ""
-"Please request the applicant add their country of residence to their profile "
-"before proceeding further."
-msgstr ""
-"Vui lòng yêu cầu đương đơn thêm quốc gia đang sinh sống vào hồ sơ của họ "
-"trước khi sang bước tiếp theo."
+msgid "Please request the applicant add their country of residence to their profile before proceeding further."
+msgstr "Vui lòng yêu cầu đương đơn thêm quốc gia đang sinh sống vào hồ sơ của họ trước khi sang bước tiếp theo."
 
 #. Translators: This labels the section of an application showing the total number of accounts available for a partner or their collection.
 #: TWLight/applications/templates/applications/application_evaluation.html:134
@@ -402,12 +367,8 @@ msgstr "Số tài khoản còn dư:"
 #. Translators: This labels the section of an application showing whether the user had agreed to the terms of use or not.
 #: TWLight/applications/templates/applications/application_evaluation.html:145
 #, python-format
-msgid ""
-"Has agreed to the site's <a class=\"twl-links\" href=\"%(terms_url)s\">terms "
-"of use</a>?"
-msgstr ""
-"Có chấp nhận các <a class=\"twl-links\" href=\"%(terms_url)s\">điều khoản sử "
-"dụng</a> của trang Web?"
+msgid "Has agreed to the site's <a class=\"twl-links\" href=\"%(terms_url)s\">terms of use</a>?"
+msgstr "Có chấp nhận các <a class=\"twl-links\" href=\"%(terms_url)s\">điều khoản sử dụng</a> của trang Web?"
 
 #. Translators: Displayed to coordinators when they've agreed to the terms of use.
 #. Translators: Displayed if the user has agreed to the terms of use.
@@ -442,12 +403,8 @@ msgstr "Không"
 
 #. Translators: This is the text displayed to coordinators when an applicant has not agreed to the terms of use.
 #: TWLight/applications/templates/applications/application_evaluation.html:159
-msgid ""
-"Please request the applicant agree to the site's terms of use before "
-"approving this application."
-msgstr ""
-"Vui lòng yêu cầu đương đơn đồng ý với các điều khoản sử dụng của trang trước "
-"khi chấp thuận hồ sơ này."
+msgid "Please request the applicant agree to the site's terms of use before approving this application."
+msgstr "Vui lòng yêu cầu đương đơn đồng ý với các điều khoản sử dụng của trang trước khi chấp thuận hồ sơ này."
 
 #. Translators: This labels the section of an application containing the user's motivation for wanting access to this resource.
 #: TWLight/applications/templates/applications/application_evaluation.html:176
@@ -467,8 +424,7 @@ msgstr "Có phải xin gia hạn quyền truy cập?"
 #. Translators: This message is shown next to the 'Renewal of existing access grant?' label if the application is a renewal. Don't translate HTML tags or parent_url.
 #: TWLight/applications/templates/applications/application_evaluation.html:195
 #, python-format
-msgid ""
-"Yes (<a class=\"twl-links\" href=\"%(parent_url)s\">previous application</a>)"
+msgid "Yes (<a class=\"twl-links\" href=\"%(parent_url)s\">previous application</a>)"
 msgstr "Đúng (<a class=\"twl-links\" href=\"%(parent_url)s\">hồ sơ cũ</a>)"
 
 #. Translators: This labels the section of the application showing the length of access remaining on the user's previous authorization.
@@ -503,12 +459,8 @@ msgstr "Thêm bình luận"
 
 #. Translators: On an application page, this text tells users that the comments posted on the application are visible to coordinators and the submitting user only.
 #: TWLight/applications/templates/applications/application_evaluation.html:297
-msgid ""
-"Comments are visible to all coordinators and to the editor who submitted "
-"this application."
-msgstr ""
-"Bình luận được toàn bộ điều phối viên cũng như biên tập viên đã nộp hồ sơ "
-"nhìn thấy."
+msgid "Comments are visible to all coordinators and to the editor who submitted this application."
+msgstr "Bình luận được toàn bộ điều phối viên cũng như biên tập viên đã nộp hồ sơ nhìn thấy."
 
 #. Translators: This is the title of the section of an application page which lists information about the user who submitted the application.
 #. Translators: On the page where coordinators can view data on applications to a partner they coordinate, this is a table column heading for the username.
@@ -719,18 +671,8 @@ msgstr "Lưu trạng thái"
 
 #: TWLight/applications/templates/applications/apply.html:20
 #, python-format
-msgid ""
-"If your application is successful we may share your email address with "
-"%(partner)s. This is required to set up your access to their resources. By "
-"submitting this form you agree to allow your email address to be shared with "
-"%(partner)s if your application is successful, for the purposes of account "
-"setup."
-msgstr ""
-"Nếu đơn đăng ký của bạn thành công, chúng tôi có thể chia sẻ địa chỉ email "
-"của bạn với %(partner)s. Chúng tôi cần làm vậy để thiết lập quyền truy cập "
-"vào tài nguyên của họ cho bạn. Khi gửi biểu mẫu này, bạn cho phép chúng tôi "
-"chia sẻ địa chỉ email của mình với %(partner)s nhằm mục đích thiết lập tài "
-"khoản nếu đơn đăng ký của bạn thành công."
+msgid "If your application is successful we may share your email address with %(partner)s. This is required to set up your access to their resources. By submitting this form you agree to allow your email address to be shared with %(partner)s if your application is successful, for the purposes of account setup."
+msgstr "Nếu đơn đăng ký của bạn thành công, chúng tôi có thể chia sẻ địa chỉ email của bạn với %(partner)s. Chúng tôi cần làm vậy để thiết lập quyền truy cập vào tài nguyên của họ cho bạn. Khi gửi biểu mẫu này, bạn cho phép chúng tôi chia sẻ địa chỉ email của mình với %(partner)s nhằm mục đích thiết lập tài khoản nếu đơn đăng ký của bạn thành công."
 
 #. Translators: This message is displayed on the page where users can confirm their renewal. Please do not translate partner.
 #: TWLight/applications/templates/applications/confirm_renewal.html:23
@@ -758,12 +700,8 @@ msgstr "Bạn muốn truy cập vào tài nguyên nào?"
 
 #. Translators: This text explains that Library Bundle partners are not shown in this list.
 #: TWLight/applications/templates/applications/request_for_application.html:26
-msgid ""
-"Library Bundle partners are not shown as eligibility is determined "
-"automatically."
-msgstr ""
-"Các đối tác của Gói Thư viện sẽ không được hiển thị vì điều kiện sử dụng "
-"được xác nhận tự động."
+msgid "Library Bundle partners are not shown as eligibility is determined automatically."
+msgstr "Các đối tác của Gói Thư viện sẽ không được hiển thị vì điều kiện sử dụng được xác nhận tự động."
 
 #. Translators: On the page where users can apply for multiple partners, this message shows next to the partner name, taking them to the full application page when clicked.
 #: TWLight/applications/templates/applications/request_for_application.html:48
@@ -777,14 +715,8 @@ msgstr "Chưa thêm dữ liệu đối tác."
 
 #. Translators: the HTML is so that the word 'waitlisted' will look the same as it does in the page above; please translate 'waitlisted' the same way you did elsewhere in this file.
 #: TWLight/applications/templates/applications/request_for_application.html:74
-msgid ""
-"You can apply to <span class=\"badge badge-warning\">Waitlisted</span> "
-"partners, but they don't have access grants available right now. We will "
-"process those applications when access becomes available."
-msgstr ""
-"Bạn có thể nộp hồ sơ cho các đối tác <span class=\"badge badge-warning\">Chờ "
-"chỗ trống</span>, nhưng họ vẫn chưa có chỗ trống để cấp quyền truy cập. "
-"Chúng tôi sẽ xử lý các hồ sơ này khi có chỗ trống."
+msgid "You can apply to <span class=\"badge badge-warning\">Waitlisted</span> partners, but they don't have access grants available right now. We will process those applications when access becomes available."
+msgstr "Bạn có thể nộp hồ sơ cho các đối tác <span class=\"badge badge-warning\">Chờ chỗ trống</span>, nhưng họ vẫn chưa có chỗ trống để cấp quyền truy cập. Chúng tôi sẽ xử lý các hồ sơ này khi có chỗ trống."
 
 #. Translators: On the page where coordinators can see approved applications which have not had their details sent to the partner, this message shows when there are applications ready to be processed.
 #: TWLight/applications/templates/applications/send.html:10
@@ -805,9 +737,7 @@ msgstr "Dữ liệu hồ sơ cho %(object)s"
 #. Translators: This message is shown when applications exceed the number of accounts available.
 #: TWLight/applications/templates/applications/send_partner.html:54
 #, python-format
-msgid ""
-"Application(s) for %(object)s, if sent, will exceed the total available "
-"accounts for the partner. Please proceed at your own discretion."
+msgid "Application(s) for %(object)s, if sent, will exceed the total available accounts for the partner. Please proceed at your own discretion."
 msgstr ""
 
 #. Translators: When viewing the list of applications ready to be sent for a particular partner, this is instructions for the coordinator to click the 'mark as sent' button after they have sent the information.
@@ -823,9 +753,7 @@ msgstr[0] ""
 
 #. Translators: When viewing the list of applications ready to be sent for a particular partner, this message shows if there is no information about who the applications should be sent to. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/applications/templates/applications/send_partner.html:89
-msgid ""
-"Whoops, we don't have any listed contacts. Please notify Wikipedia Library "
-"administrators."
+msgid "Whoops, we don't have any listed contacts. Please notify Wikipedia Library administrators."
 msgstr ""
 
 #. Translators: When viewing the list of applications ready to be sent for a particular partner, this is the title of the section containing the information about those applications.
@@ -841,9 +769,7 @@ msgstr "Đánh dấu là đã gửi"
 
 #. Translators: This text guides coordinators in using the code sending interface for approved applications.
 #: TWLight/applications/templates/applications/send_partner.html:152
-msgid ""
-"Use the dropdown menus to denote which editor will receive each code. Access "
-"codes will be sent to users automatically."
+msgid "Use the dropdown menus to denote which editor will receive each code. Access codes will be sent to users automatically."
 msgstr ""
 
 #. Translators: This labels a drop-down selection where staff can assign an access code to a user.
@@ -859,18 +785,13 @@ msgstr ""
 #. Translators: When a user applies for a set of resources, they receive this message if none are currently available. They are instead placed on a 'waitlist' for later approval.
 #. Translators: When a user renews their resource, they receive this message if none are currently available. They are instead placed on a 'waitlist' for later approval.
 #: TWLight/applications/views.py:140 TWLight/applications/views.py:1282
-msgid ""
-"This partner does not have any access grants available at this time. You may "
-"still apply for access; your application will be reviewed when access grants "
-"become available."
+msgid "This partner does not have any access grants available at this time. You may still apply for access; your application will be reviewed when access grants become available."
 msgstr ""
 
 #. Translators: This message is shown to users once they've successfully submitted their application for review.
 #: TWLight/applications/views.py:163
 #, python-brace-format
-msgid ""
-"Your application has been submitted for review. Head over to <a "
-"href='{applications_url}'>My Applications</a> to view the status."
+msgid "Your application has been submitted for review. Head over to <a href='{applications_url}'>My Applications</a> to view the status."
 msgstr ""
 
 #. Translators: This text is displayed to users when the user has chosen to restrict data and is trying to apply for multiple partners
@@ -919,16 +840,12 @@ msgstr "Hồ sơ đã gửi"
 
 #. Translators: After a coordinator has changed the status of an application to APPROVED, if the corresponding partner/collection is waitlisted this message appears.
 #: TWLight/applications/views.py:756
-msgid ""
-"Cannot approve application as partner with proxy authorization method is "
-"waitlisted."
+msgid "Cannot approve application as partner with proxy authorization method is waitlisted."
 msgstr ""
 
 #. Translators: After a coordinator has changed the status of an application to APPROVED, if the corresponding partner/collection has no accounts for distribution, this message appears.
 #: TWLight/applications/views.py:780
-msgid ""
-"Cannot approve application as partner with proxy authorization method is "
-"waitlisted and (or) has zero accounts available for distribution."
+msgid "Cannot approve application as partner with proxy authorization method is waitlisted and (or) has zero accounts available for distribution."
 msgstr ""
 
 #. Translators: This message appears on an "access denied" screen that stops users who attempt to authorize an editor to access a resource during a time period for which they are already authorized.
@@ -939,11 +856,7 @@ msgstr ""
 #. Translators: This message is shown to users when they access an application page of a now Bundle partner (new applications aren't allowed for Bundle partners and the status of old applications cannot be modified)
 #: TWLight/applications/views.py:857
 #, python-brace-format
-msgid ""
-"This application cannot be modified since this partner is now part of our <a "
-"href='{bundle}'>bundle access</a>. If you are eligible, you can access this "
-"resource from <a href='{library}'>your library</a>. <a "
-"href='{contact}'>Contact us</a> if you have any questions."
+msgid "This application cannot be modified since this partner is now part of our <a href='{bundle}'>bundle access</a>. If you are eligible, you can access this resource from <a href='{library}'>your library</a>. <a href='{contact}'>Contact us</a> if you have any questions."
 msgstr ""
 
 #. Translators: this lets a reviewer set the status of a single application.
@@ -953,9 +866,7 @@ msgstr "Đặt tình trạng hồ sơ"
 
 #. Translators: This warning is message is shown to applicants when the number of pending applications is greater than the number of accounts available.
 #: TWLight/applications/views.py:891
-msgid ""
-"There are more pending applications than available accounts. Your "
-"application might get waitlisted."
+msgid "There are more pending applications than available accounts. Your application might get waitlisted."
 msgstr ""
 
 #. Translators: this message is shown to coordinators who attempt to change an application's Status from INVALID to any other Status.
@@ -975,11 +886,7 @@ msgstr "Cập nhật hàng loạt đơn đăng ký {} thành công."
 
 #. Translators: After a coordinator has changed the status of a number of applications to APPROVED, if the corresponding partner(s) is/are waitlisted or has no accounts for distribution, this message appears.
 #: TWLight/applications/views.py:1051
-msgid ""
-"Cannot approve application(s) {} as partner(s) with proxy authorization "
-"method is/are waitlisted and (or) has/have not enough accounts available. If "
-"not enough accounts are available, prioritise the applications and then "
-"approve applications equal to the accounts available."
+msgid "Cannot approve application(s) {} as partner(s) with proxy authorization method is/are waitlisted and (or) has/have not enough accounts available. If not enough accounts are available, prioritise the applications and then approve applications equal to the accounts available."
 msgstr ""
 
 #. Translators: This message is shown to coordinators who attempt to assign the same access code to multiple users.
@@ -994,9 +901,7 @@ msgstr ""
 
 #. Translators: When a user tries to renew their resource, they receive this message if the partner is not available.
 #: TWLight/applications/views.py:1272
-msgid ""
-"Cannot renew application at this time as partner is not available. Please "
-"check back later, or contact us for more information."
+msgid "Cannot renew application at this time as partner is not available. Please check back later, or contact us for more information."
 msgstr ""
 
 #. Translators: This message is displayed when an attempt by a user to renew an application has been denied for some reason.
@@ -1007,16 +912,12 @@ msgstr ""
 
 #. Translators: If a user requests the renewal of their account, but it wasn't renewed, this message is shown to them.
 #: TWLight/applications/views.py:1385
-msgid ""
-"This object cannot be renewed. (This probably means that you have already "
-"requested that it be renewed.)"
+msgid "This object cannot be renewed. (This probably means that you have already requested that it be renewed.)"
 msgstr ""
 
 #. Translators: If a user requests the renewal of their account, this message is shown to them.
 #: TWLight/applications/views.py:1395
-msgid ""
-"Your renewal request has been received. A coordinator will review your "
-"request."
+msgid "Your renewal request has been received. A coordinator will review your request."
 msgstr ""
 
 #. Translators: This labels a textfield where users can enter their email ID.
@@ -1026,9 +927,7 @@ msgstr "Địa chỉ thư điện tử của bạn"
 
 #. Translators: This is the help text for the email field in the contact us form letting users know the field is updated by value pulled from their respective user profiles.
 #: TWLight/emails/forms.py:21
-msgid ""
-"This field is automatically updated with the email from your <a class='twl-"
-"links' href='{}'>user profile</a>."
+msgid "This field is automatically updated with the email from your <a class='twl-links' href='{}'>user profile</a>."
 msgstr ""
 
 #. Translators: This labels a textfield where users can enter their email message.
@@ -1052,26 +951,14 @@ msgstr "Nộp"
 #. Translators: This email is sent to users with their access code. Don't translate Jinja variables in curly braces like user or partner. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/access_code_email-body-html.html:5
 #, python-format
-msgid ""
-"<p>Your approved application to %(partner)s has now been finalised. Your "
-"access code or login details can be found below:</p> <p><b>%(access_code)s</"
-"b></p> <p>%(user_instructions)s</p>"
-msgstr ""
-"<p>Đơn đăng ký %(partner)s được phê duyệt của bạn hiện đã được hoàn tất. Mã "
-"truy cập hoặc chi tiết đăng nhập của bạn có thể được tìm thấy dưới đây:</p> "
-"<p><b>%(access_code)s</b></p> <p>%(user_instructions)s</p>"
+msgid "<p>Your approved application to %(partner)s has now been finalised. Your access code or login details can be found below:</p> <p><b>%(access_code)s</b></p> <p>%(user_instructions)s</p>"
+msgstr "<p>Đơn đăng ký %(partner)s được phê duyệt của bạn hiện đã được hoàn tất. Mã truy cập hoặc chi tiết đăng nhập của bạn có thể được tìm thấy dưới đây:</p> <p><b>%(access_code)s</b></p> <p>%(user_instructions)s</p>"
 
 #. Translators: This email is sent to users with their access code. Don't translate Jinja variables in curly braces like user or partner. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/access_code_email-body-text.html:3
 #, python-format
-msgid ""
-"Your approved application to %(partner)s has now been finalised. Your access "
-"code or login details can be found below: %(access_code)s "
-"%(user_instructions)s"
-msgstr ""
-"Đơn đăng ký %(partner)s được phê duyệt của bạn hiện đã được hoàn tất. Bạn có "
-"thể tìm thấy mã truy cập hoặc chi tiết đăng nhập của mình bên dưới: "
-"%(access_code)s %(user_instructions)s"
+msgid "Your approved application to %(partner)s has now been finalised. Your access code or login details can be found below: %(access_code)s %(user_instructions)s"
+msgstr "Đơn đăng ký %(partner)s được phê duyệt của bạn hiện đã được hoàn tất. Bạn có thể tìm thấy mã truy cập hoặc chi tiết đăng nhập của mình bên dưới: %(access_code)s %(user_instructions)s"
 
 #. Translators: This is the subject line of an email sent to users with their access code.
 #: TWLight/emails/templates/emails/access_code_email-subject.html:3
@@ -1081,23 +968,13 @@ msgstr "Mã truy cập Thư viện Wikipedia của bạn"
 #. Translators: This email is sent to users when their application is approved. Don't translate Jinja variables in curly braces like user or partner; don't translate html tags either. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/approval_notification-body-html.html:5
 #, python-format
-msgid ""
-"<p>Dear %(user)s,</p> <p>Thank you for applying for access to %(partner)s "
-"resources through The Wikipedia Library. We are happy to inform you that "
-"your application has been approved.</p> <p>%(user_instructions)s</p> <p>You "
-"can view the collections you're authorized to access at My Library: "
-"%(link)s</p> <p>Cheers!</p> <p>The Wikipedia Library</p>"
+msgid "<p>Dear %(user)s,</p> <p>Thank you for applying for access to %(partner)s resources through The Wikipedia Library. We are happy to inform you that your application has been approved.</p> <p>%(user_instructions)s</p> <p>You can view the collections you're authorized to access at My Library: %(link)s</p> <p>Cheers!</p> <p>The Wikipedia Library</p>"
 msgstr ""
 
 #. Translators: This email is sent to users when their application is approved. Don't translate Jinja variables in curly braces like user or partner. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/approval_notification-body-text.html:3
 #, python-format
-msgid ""
-"Dear %(user)s, Thank you for applying for access to %(partner)s resources "
-"through The Wikipedia Library. We are happy to inform you that your "
-"application has been approved. %(user_instructions)s You can view the "
-"collections you're authorized to access at My Library: %(link)s Cheers! The "
-"Wikipedia Library"
+msgid "Dear %(user)s, Thank you for applying for access to %(partner)s resources through The Wikipedia Library. We are happy to inform you that your application has been approved. %(user_instructions)s You can view the collections you're authorized to access at My Library: %(link)s Cheers! The Wikipedia Library"
 msgstr ""
 
 #. Translators: This is the subject of an email which is sent to users when their application has been approved. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
@@ -1108,19 +985,13 @@ msgstr "Đơn xin Thư viện Wikipedia của bạn được chấp nhận"
 #. Translators: This email is sent to coordinators when a comment is left on an application they are processing. Don't translate Jinja variables in curly braces like user or partner. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/comment_notification_coordinator-body-html.html:5
 #, python-format
-msgid ""
-"<p style=\"color: #500050\">%(submit_date)s - %(commenter)s</p> "
-"<blockquote><p>%(comment)s</p></blockquote> <p>Please reply to these at: <a "
-"href=\"%(app_url)s\">%(app_url)s</a></p> <p>Best,</p> <p>The Wikipedia "
-"Library</p>"
+msgid "<p style=\"color: #500050\">%(submit_date)s - %(commenter)s</p> <blockquote><p>%(comment)s</p></blockquote> <p>Please reply to these at: <a href=\"%(app_url)s\">%(app_url)s</a></p> <p>Best,</p> <p>The Wikipedia Library</p>"
 msgstr ""
 
 #. Translators: This email is sent to coordinators when a comment is left on an application they are processing. Don't translate Jinja variables in curly braces like user or partner. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/comment_notification_coordinator-body-text.html:3
 #, python-format
-msgid ""
-"%(submit_date)s - %(commenter)s %(comment)s Please reply to this at: "
-"%(app_url)s Best, The Wikipedia Library"
+msgid "%(submit_date)s - %(commenter)s %(comment)s Please reply to this at: %(app_url)s Best, The Wikipedia Library"
 msgstr ""
 
 #. Translators: This is the subject line of an email sent to coordinators when a comment is left on an application they processed.
@@ -1131,19 +1002,13 @@ msgstr ""
 #. Translators: This email is sent to users when they receive a comment on their application. Don't translate Jinja variables in curly braces like user or partner; don't translate html tags either. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/comment_notification_editors-body-html.html:5
 #, python-format
-msgid ""
-"<p style=\"color: #500050\">%(submit_date)s - %(commenter)s</p> "
-"<blockquote><p>%(comment)s</p></blockquote> <p>Please reply to these at <a "
-"href=\"%(app_url)s\">%(app_url)s</a> so we can evaluate your application.</"
-"p> <p>Best,</p> <p>The Wikipedia Library</p>"
+msgid "<p style=\"color: #500050\">%(submit_date)s - %(commenter)s</p> <blockquote><p>%(comment)s</p></blockquote> <p>Please reply to these at <a href=\"%(app_url)s\">%(app_url)s</a> so we can evaluate your application.</p> <p>Best,</p> <p>The Wikipedia Library</p>"
 msgstr ""
 
 #. Translators: This email is sent to users when they receive a comment on their application. Don't translate Jinja variables in curly braces like user or partner. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/comment_notification_editors-body-text.html:3
 #, python-format
-msgid ""
-"%(submit_date)s - %(commenter)s %(comment)s Please reply to these at: "
-"%(app_url)s so we can evaluate your application. Best, The Wikipedia Library"
+msgid "%(submit_date)s - %(commenter)s %(comment)s Please reply to these at: %(app_url)s so we can evaluate your application. Best, The Wikipedia Library"
 msgstr ""
 
 #. Translators: This is the subject line of an email sent to users who have a comment added to one of their applications. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
@@ -1154,18 +1019,13 @@ msgstr "Bình luận mới trong đơn xin của bạn tại Thư viện Wikiped
 #. Translators: This email is sent to users when an application they commented on receives another comment. Don't translate Jinja variables in curly braces like app_url; don't translate html tags either. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/comment_notification_others-body-html.html:5
 #, python-format
-msgid ""
-"<p style=\"color: #500050\">%(submit_date)s - %(commenter)s</p> "
-"<blockquote><p>%(comment)s</p></blockquote> See it at <a href=\"%(app_url)s"
-"\">%(app_url)s</a>. Thanks for helping review Wikipedia Library applications!"
+msgid "<p style=\"color: #500050\">%(submit_date)s - %(commenter)s</p> <blockquote><p>%(comment)s</p></blockquote> See it at <a href=\"%(app_url)s\">%(app_url)s</a>. Thanks for helping review Wikipedia Library applications!"
 msgstr ""
 
 #. Translators: This email is sent to users when an application they commented on receives another comment. Don't translate Jinja variables in curly braces like app_url. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/comment_notification_others-body-text.html:3
 #, python-format
-msgid ""
-"%(submit_date)s - %(commenter)s %(comment)s See it at: %(app_url)s Thanks "
-"for helping review Wikipedia Library applications!"
+msgid "%(submit_date)s - %(commenter)s %(comment)s See it at: %(app_url)s Thanks for helping review Wikipedia Library applications!"
 msgstr ""
 
 #. Translators: This is the subject line of an email sent to users who have a comment added to an application they also commented on. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
@@ -1176,10 +1036,7 @@ msgstr "Bình luận mới trong đơn xin Thư viện Wikipedia mà bạn đã 
 #. Translators: This text is part of a scheduled reminder email sent to coordinators who have applications requiring action. Don't translate Jinja variables in curly braces like total_apps, or user.
 #: TWLight/emails/templates/emails/coordinator_reminder_notification-body-html.html:5
 #, python-format
-msgid ""
-"<p>Dear %(user)s,</p> <p>Our records indicate that you are the designated "
-"coordinator for partners that have a total of %(total_apps)s applications.</"
-"p>"
+msgid "<p>Dear %(user)s,</p> <p>Our records indicate that you are the designated coordinator for partners that have a total of %(total_apps)s applications.</p>"
 msgstr ""
 
 #. Translators: Breakdown as in 'cost breakdown'; analysis.
@@ -1215,31 +1072,19 @@ msgstr[0] "%(counter)s đơn xin được chấp nhận."
 #. Translators: This text is part of a scheduled reminder email sent to coordinators who have applications requiring action. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library). Don't translate Jinja variables in curly braces like link; don't translate email addresses or html tags either.
 #: TWLight/emails/templates/emails/coordinator_reminder_notification-body-html.html:39
 #, python-format
-msgid ""
-"<p>This is a gentle reminder that you may review applications at <a href="
-"\"%(link)s\">%(link)s</a>.</p> <p>You can customise your reminders under "
-"'preferences' in your user profile.</p> <p>If you received this message in "
-"error, drop us a line at wikipedialibrary@wikimedia.org.</p> <p>Thanks for "
-"helping review Wikipedia Library applications!</p>"
+msgid "<p>This is a gentle reminder that you may review applications at <a href=\"%(link)s\">%(link)s</a>.</p> <p>You can customise your reminders under 'preferences' in your user profile.</p> <p>If you received this message in error, drop us a line at wikipedialibrary@wikimedia.org.</p> <p>Thanks for helping review Wikipedia Library applications!</p>"
 msgstr ""
 
 #. Translators: This text is part of a scheduled reminder email sent to coordinators who have applications requiring action. Don't translate Jinja variables in curly braces like total_apps, or user.
 #: TWLight/emails/templates/emails/coordinator_reminder_notification-body-text.html:3
 #, python-format
-msgid ""
-"Dear %(user)s, Our records indicate that you are the designated coordinator "
-"for partners that have a total of %(total_apps)s applications."
+msgid "Dear %(user)s, Our records indicate that you are the designated coordinator for partners that have a total of %(total_apps)s applications."
 msgstr ""
 
 #. Translators: This text is part of a scheduled reminder email sent to coordinators who have applications requiring action. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library). Don't translate Jinja variables in curly braces like link; don't translate the email address either.
 #: TWLight/emails/templates/emails/coordinator_reminder_notification-body-text.html:38
 #, python-format
-msgid ""
-"This is a gentle reminder that you may review applications at: %(link)s. You "
-"can customise your reminders under 'preferences' in your user profile. If "
-"you received this message in error, drop us a line at: "
-"wikipedialibrary@wikimedia.org Thanks for helping review Wikipedia Library "
-"applications!"
+msgid "This is a gentle reminder that you may review applications at: %(link)s. You can customise your reminders under 'preferences' in your user profile. If you received this message in error, drop us a line at: wikipedialibrary@wikimedia.org Thanks for helping review Wikipedia Library applications!"
 msgstr ""
 
 #. Translators: This is the subject line of a scheduled reminder email sent to coordinators who have applications to review. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library). Do not translate items in curly braces.
@@ -1250,22 +1095,13 @@ msgstr ""
 #. Translators: This email is sent to users when their application is rejected. Don't translate Jinja variables in curly braces like user or partner; don't translate html tags either. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/rejection_notification-body-html.html:5
 #, python-format
-msgid ""
-"<p>Dear %(user)s,</p> <p>Thank you for applying for access to %(partner)s "
-"resources through The Wikipedia Library. Unfortunately at this time your "
-"application has not been approved. You can view your application and review "
-"comments at <a href=\"%(app_url)s\">%(app_url)s</a>.</p> <p>Best,</p> <p>The "
-"Wikipedia Library</p>"
+msgid "<p>Dear %(user)s,</p> <p>Thank you for applying for access to %(partner)s resources through The Wikipedia Library. Unfortunately at this time your application has not been approved. You can view your application and review comments at <a href=\"%(app_url)s\">%(app_url)s</a>.</p> <p>Best,</p> <p>The Wikipedia Library</p>"
 msgstr ""
 
 #. Translators: This email is sent to users when their application is rejected. Don't translate Jinja variables in curly braces like user or partner. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/rejection_notification-body-text.html:3
 #, python-format
-msgid ""
-"Dear %(user)s, Thank you for applying for access to %(partner)s resources "
-"through The Wikipedia Library. Unfortunately at this time your application "
-"has not been approved. You can view your application and review comments at: "
-"%(app_url)s Best, The Wikipedia Library"
+msgid "Dear %(user)s, Thank you for applying for access to %(partner)s resources through The Wikipedia Library. Unfortunately at this time your application has not been approved. You can view your application and review comments at: %(app_url)s Best, The Wikipedia Library"
 msgstr ""
 
 #. Translators: This is the subject of an email which is sent to users when their application has been rejected. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
@@ -1276,25 +1112,13 @@ msgstr "Đơn xin Thư viện Wikipedia của bạn"
 #. Translators: This email is sent to users when they have an account that is soon to expire. Don't translate Jinja variables in curly braces like partner_name or partner_link; don't translate html tags either. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/user_renewal_notice-body-html.html:5
 #, python-format
-msgid ""
-"<p>Dear %(user)s,</p> <p>According to our records, your access to "
-"%(partner_name)s will soon expire and you may lose access. If you want to "
-"continue making use of your free account, you can request renewal of your "
-"account by clicking the 'Renew' or 'Extend' button at %(partner_link)s.</p> "
-"<p>Best,</p> <p>The Wikipedia Library</p> <p>You can disable these emails in "
-"your user page preferences: https://wikipedialibrary.wmflabs.org/users/</p>"
+msgid "<p>Dear %(user)s,</p> <p>According to our records, your access to %(partner_name)s will soon expire and you may lose access. If you want to continue making use of your free account, you can request renewal of your account by clicking the 'Renew' or 'Extend' button at %(partner_link)s.</p> <p>Best,</p> <p>The Wikipedia Library</p> <p>You can disable these emails in your user page preferences: https://wikipedialibrary.wmflabs.org/users/</p>"
 msgstr ""
 
 #. Translators: This email is sent to users when they have an account that is soon to expire. Don't translate Jinja variables in curly braces like partner_name or partner_link; don't translate html tags either. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/user_renewal_notice-body-text.html:3
 #, python-format
-msgid ""
-"Dear %(user)s, According to our records, your access to %(partner_name)s "
-"will soon expire and you may lose access. If you want to continue making use "
-"of your free account, you can request renewal of your account by clicking "
-"the Renew button at %(partner_link)s. Best, The Wikipedia Library You can "
-"disable these emails in your user page preferences: https://wikipedialibrary."
-"wmflabs.org/users/"
+msgid "Dear %(user)s, According to our records, your access to %(partner_name)s will soon expire and you may lose access. If you want to continue making use of your free account, you can request renewal of your account by clicking the Renew button at %(partner_link)s. Best, The Wikipedia Library You can disable these emails in your user page preferences: https://wikipedialibrary.wmflabs.org/users/"
 msgstr ""
 
 #. Translators: This is the subject of an email sent to users when they have an account that is soon to expire. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
@@ -1305,31 +1129,19 @@ msgstr "Bạn có thể sắp sửa hết hạn quyền truy cập Thư viện W
 #. Translators: This email is sent to users when their application is waitlisted because there are no more accounts available. Don't translate Jinja variables in curly braces like user or partner; don't translate html tags either. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/waitlist_notification-body-html.html:5
 #, python-format
-msgid ""
-"<p>Dear %(user)s,</p> <p>Thank you for applying for access to %(partner)s "
-"resources through The Wikipedia Library. There are no accounts currently "
-"available so your application has been waitlisted. Your application will be "
-"evaluated if/when more accounts become available. You can see all available "
-"resources at <a href=\"%(link)s\">%(link)s</a>.</p> <p>Best,</p> <p>The "
-"Wikipedia Library</p>"
+msgid "<p>Dear %(user)s,</p> <p>Thank you for applying for access to %(partner)s resources through The Wikipedia Library. There are no accounts currently available so your application has been waitlisted. Your application will be evaluated if/when more accounts become available. You can see all available resources at <a href=\"%(link)s\">%(link)s</a>.</p> <p>Best,</p> <p>The Wikipedia Library</p>"
 msgstr ""
 
 #. Translators: This email is sent to users when their application is waitlisted because there are no more accounts available. Don't translate Jinja variables in curly braces like user or partner. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/waitlist_notification-body-text.html:3
 #, python-format
-msgid ""
-"Dear %(user)s, Thank you for applying for access to %(partner)s resources "
-"through The Wikipedia Library. There are no accounts currently available so "
-"your application has been waitlisted. Your application will be evaluated if/"
-"when more accounts become available. You can see all available resources at: "
-"%(link)s Best, The Wikipedia Library"
+msgid "Dear %(user)s, Thank you for applying for access to %(partner)s resources through The Wikipedia Library. There are no accounts currently available so your application has been waitlisted. Your application will be evaluated if/when more accounts become available. You can see all available resources at: %(link)s Best, The Wikipedia Library"
 msgstr ""
 
 #. Translators: This is the subject of an email sent to users when their application is waitlisted because there are no more accounts available. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/waitlist_notification-subject.html:4
 msgid "Your Wikipedia Library application has been waitlisted"
-msgstr ""
-"Yêu cầu truy cập Thư viện Wikipedia của bạn đã được đưa vào danh sách chờ"
+msgstr "Yêu cầu truy cập Thư viện Wikipedia của bạn đã được đưa vào danh sách chờ"
 
 #. Translators: Shown to users when they successfully submit a new message using the contact us form.
 #: TWLight/emails/views.py:51
@@ -1485,23 +1297,15 @@ msgstr "Không có sẵn"
 #: TWLight/resources/templates/resources/filter_section.html:14
 #: TWLight/templates/about.html:12
 #: TWLight/users/templates/users/filter_section.html:13
-msgid ""
-"The Wikipedia Library allows active editors to access a wide range of "
-"collections of paywalled reliable sources for free!"
-msgstr ""
-"Thư viện Wikipedia cho phép các biên tập viên đang hoạt động truy cập vào "
-"những bộ sưu tập đa dạng gồm các nguồn tài liệu có tính phí đáng tin cậy một "
-"cách miễn phí!"
+msgid "The Wikipedia Library allows active editors to access a wide range of collections of paywalled reliable sources for free!"
+msgstr "Thư viện Wikipedia cho phép các biên tập viên đang hoạt động truy cập vào những bộ sưu tập đa dạng gồm các nguồn tài liệu có tính phí đáng tin cậy một cách miễn phí!"
 
 #. Translators: On the Browse Partners page (https://wikipedialibrary.wmflabs.org/partners/), this introduces users to The Wikipedia Library.
 #. Translators: On the MyLibrary page (https://wikipedialibrary.wmflabs.org/users/my_library), this introduces users to The Wikipedia Library.
 #: TWLight/resources/templates/resources/filter_section.html:17
 #: TWLight/users/templates/users/filter_section.html:15
-msgid ""
-"Start with the search bar at the top or browse publisher websites directly."
-msgstr ""
-"Bắt đầu bằng thanh tìm kiếm ở đầu trang hoặc vào thẳng trang web của nhà "
-"xuất bản."
+msgid "Start with the search bar at the top or browse publisher websites directly."
+msgstr "Bắt đầu bằng thanh tìm kiếm ở đầu trang hoặc vào thẳng trang web của nhà xuất bản."
 
 #. Translators: On the Browse Partners page (https://wikipedialibrary.wmflabs.org/partners/), this appears below introductory text and links to the 'About' page (https://wikipedialibrary.wmflabs.org/about/)
 #. Translators: On the MyLibrary page (https://wikipedialibrary.wmflabs.org/users/my_library), this appears below introductory text and links to the 'About' page (https://wikipedialibrary.wmflabs.org/about/)
@@ -1575,52 +1379,38 @@ msgstr "Quay lại đối tác"
 #. Translators: If we have no available accounts for a partner, the coordinator can change the application system to a waiting list.
 #: TWLight/resources/templates/resources/partner_detail.html:36
 #: TWLight/resources/templates/resources/partner_detail_apply.html:17
-msgid ""
-"There are no access grants available for this partner at this time. You can "
-"still apply for access; applications will be processed when access is "
-"available."
+msgid "There are no access grants available for this partner at this time. You can still apply for access; applications will be processed when access is available."
 msgstr ""
 
 #. Translators: This text links to the minimum user requirements and terms of use on the partner page.
 #: TWLight/resources/templates/resources/partner_detail.html:48
 #: TWLight/resources/templates/resources/partner_detail_apply.html:29
 #, python-format
-msgid ""
-"Before applying, please review the <strong><a class=\"twl-links\" href="
-"\"%(about)s#req\">minimum requirements</a></strong> for access and our "
-"<strong><a class=\"twl-links\" href=\"%(terms)s\">terms of use</a></strong>."
+msgid "Before applying, please review the <strong><a class=\"twl-links\" href=\"%(about)s#req\">minimum requirements</a></strong> for access and our <strong><a class=\"twl-links\" href=\"%(terms)s\">terms of use</a></strong>."
 msgstr ""
 
 #. Translators: This text refers to the page containing the content a user is authorized to access.
 #: TWLight/resources/templates/resources/partner_detail.html:69
 #, python-format
-msgid ""
-"View the status of your access in <strong><a class=\"twl-links\" href="
-"\"%(library_url)s\">My Library</a></strong> page."
+msgid "View the status of your access in <strong><a class=\"twl-links\" href=\"%(library_url)s\">My Library</a></strong> page."
 msgstr ""
 
 #. Translators: This message is shown when a user has open applications, linking to their respective applications page.
 #: TWLight/resources/templates/resources/partner_detail.html:78
 #, python-format
-msgid ""
-"View the status of your application(s) on your <strong><a class=\"twl-links"
-"\" href=\"%(applications_url)s\">My Applications</a></strong> page."
+msgid "View the status of your application(s) on your <strong><a class=\"twl-links\" href=\"%(applications_url)s\">My Applications</a></strong> page."
 msgstr ""
 
 #. Translators: This message is shown when a user has authorizations, linking to their respective collections page.
 #: TWLight/resources/templates/resources/partner_detail_apply.html:50
 #, python-format
-msgid ""
-"View the status of your access on your <strong><a href=\"%(library_url)s\" "
-"class=\"twl-links\">My Library</a></strong> page."
+msgid "View the status of your access on your <strong><a href=\"%(library_url)s\" class=\"twl-links\">My Library</a></strong> page."
 msgstr ""
 
 #. Translators: This message is shown when a user has open applications, linking to their respective applications page.
 #: TWLight/resources/templates/resources/partner_detail_apply.html:60
 #, python-format
-msgid ""
-"View the status of your application(s) on your <strong><a href="
-"\"%(applications_url)s\">My Applications</a></strong> page."
+msgid "View the status of your application(s) on your <strong><a href=\"%(applications_url)s\">My Applications</a></strong> page."
 msgstr ""
 
 #. Translators: One the partner detail page, this text labels the button which coordinators can click to remove a partner from waitlisted status.
@@ -1650,10 +1440,7 @@ msgstr "Trang Đặc biệt:Gửi thư"
 
 #. Translators: If no account coordinator is assigned to a partner, the Wikipedia Library team will coordinate signups. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/resources/templates/resources/partner_detail_apply.html:112
-msgid ""
-"The Wikipedia Library team will process this application. Want to help? <a "
-"class=\"twl-links\" href=\"https://en.wikipedia.org/wiki/Wikipedia:"
-"The_Wikipedia_Library/Coordinators/Signup\">Sign up as a coordinator.</a>"
+msgid "The Wikipedia Library team will process this application. Want to help? <a class=\"twl-links\" href=\"https://en.wikipedia.org/wiki/Wikipedia:The_Wikipedia_Library/Coordinators/Signup\">Sign up as a coordinator.</a>"
 msgstr ""
 
 #. Translators: This text labels a button coordinators can click to view a list of users who have applied for access for a particular partner
@@ -1683,18 +1470,13 @@ msgstr "Truy cập Gói thư viện"
 
 #. Translators: Text shown to authenticated, bundle eligible users when they visit a Bundle partner page.
 #: TWLight/resources/templates/resources/partner_detail_apply.html:138
-msgid ""
-"You are eligible to access Library Bundle partners. Click the button above "
-"to access the collection."
+msgid "You are eligible to access Library Bundle partners. Click the button above to access the collection."
 msgstr ""
 
 #. Translators: Text shown to authenticated, bundle ineligible users when they visit a Bundle partner page.
 #: TWLight/resources/templates/resources/partner_detail_apply.html:152
 #, python-format
-msgid ""
-"You are not eligible to access Library Bundle partners. Visit the <a class="
-"\"twl-links\" href=\"%(homepage)s\">homepage</a> to check the eligibility "
-"criteria."
+msgid "You are not eligible to access Library Bundle partners. Visit the <a class=\"twl-links\" href=\"%(homepage)s\">homepage</a> to check the eligibility criteria."
 msgstr ""
 
 #. Translators: Buttton prompting users to log in.
@@ -1706,10 +1488,7 @@ msgstr "Đăng nhập"
 #. Translators: Text shown to unauthenticated users when they visit a Bundle partner page.
 #: TWLight/resources/templates/resources/partner_detail_apply.html:168
 #, python-format
-msgid ""
-"This resource is part of our <a class=\"twl-links\" href=\"%(about)s"
-"\">Library Bundle</a>, which you can access if you meet our minimum "
-"eligibility criteria. Log in to find out if you are eligible."
+msgid "This resource is part of our <a class=\"twl-links\" href=\"%(about)s\">Library Bundle</a>, which you can access if you meet our minimum eligibility criteria. Log in to find out if you are eligible."
 msgstr ""
 
 #. Translators: This is the label for a number which shows the total active accounts for one partner. (e.g. https://wikipedialibrary.wmflabs.org/partners/8/).
@@ -1760,34 +1539,20 @@ msgstr "Giới hạn trích dẫn"
 #. Translators: If a partner has specified the excerpt limit both in words and percentage, this message will display the percentage of words and the number of words on the partner page.
 #: TWLight/resources/templates/resources/partner_detail_timeline.html:99
 #, python-format
-msgid ""
-"%(object)s allows a maximum of %(excerpt_limit)s words or "
-"%(excerpt_limit_percentage)s%% of an article be excerpted into a Wikipedia "
-"article."
-msgstr ""
-"%(object)s cho phép trích dẫn tối đa %(excerpt_limit)s từ hoặc "
-"%(excerpt_limit_percentage)s%% của nội dung bài viết vào một bài viết "
-"Wikipedia."
+msgid "%(object)s allows a maximum of %(excerpt_limit)s words or %(excerpt_limit_percentage)s%% of an article be excerpted into a Wikipedia article."
+msgstr "%(object)s cho phép trích dẫn tối đa %(excerpt_limit)s từ hoặc %(excerpt_limit_percentage)s%% của nội dung bài viết vào một bài viết Wikipedia."
 
 #. Translators: If a partner has specified the excerpt limit in words, this message will display the number of words on the partner page.
 #: TWLight/resources/templates/resources/partner_detail_timeline.html:106
 #, python-format
-msgid ""
-"%(object)s allows a maximum of %(excerpt_limit)s words be excerpted into a "
-"Wikipedia article."
-msgstr ""
-"%(object)s cho phép trích dẫn tối đa %(excerpt_limit)s từ vào một bài viết "
-"Wikipedia."
+msgid "%(object)s allows a maximum of %(excerpt_limit)s words be excerpted into a Wikipedia article."
+msgstr "%(object)s cho phép trích dẫn tối đa %(excerpt_limit)s từ vào một bài viết Wikipedia."
 
 #. Translators: If a partner has specified the excerpt limit in percentage, this message will display the percentage of words on the partner page.
 #: TWLight/resources/templates/resources/partner_detail_timeline.html:113
 #, python-format
-msgid ""
-"%(object)s allows a maximum of %(excerpt_limit_percentage)s%% of an article "
-"be excerpted into a Wikipedia article."
-msgstr ""
-"%(object)s cho phép trích dẫn tối đa %(excerpt_limit_percentage)s%% của nội "
-"dung bài việt vào một bài viết Wikipedia."
+msgid "%(object)s allows a maximum of %(excerpt_limit_percentage)s%% of an article be excerpted into a Wikipedia article."
+msgstr "%(object)s cho phép trích dẫn tối đa %(excerpt_limit_percentage)s%% của nội dung bài việt vào một bài viết Wikipedia."
 
 #. Translators: If a partner has other requirements for access, this text shows as the title for that information field. (e.g. https://wikipedialibrary.wmflabs.org/partners/10/).
 #: TWLight/resources/templates/resources/partner_detail_timeline.html:132
@@ -1797,12 +1562,8 @@ msgstr "Yêu cầu đặc biệt cho người nộp đơn"
 #. Translators: If a user must agree to a Terms of Use document, they see this message, and must enter the name of the resource. Don't translate publisher or url.
 #: TWLight/resources/templates/resources/partner_detail_timeline.html:140
 #, python-format
-msgid ""
-"%(publisher)s requires that you agree with its <a href=\"%(url)s\">terms of "
-"use</a>."
-msgstr ""
-"%(publisher)s yêu cầu bạn chấp nhận các <a href=\"%(url)s\">điều khoản sử "
-"dụng</a> của họ."
+msgid "%(publisher)s requires that you agree with its <a href=\"%(url)s\">terms of use</a>."
+msgstr "%(publisher)s yêu cầu bạn chấp nhận các <a href=\"%(url)s\">điều khoản sử dụng</a> của họ."
 
 #. Translators: If a user must provide their real name to apply to a partner, they see this message, and must enter the name of the resource. Don't translate publisher.
 #: TWLight/resources/templates/resources/partner_detail_timeline.html:150
@@ -1825,17 +1586,13 @@ msgstr ""
 #. Translators: If a user must select a specific resource to apply for, they see this message, and must enter the name of the resource. Don't translate publisher.
 #: TWLight/resources/templates/resources/partner_detail_timeline.html:177
 #, python-format
-msgid ""
-"%(publisher)s requires that you specify a particular title that you want to "
-"access."
+msgid "%(publisher)s requires that you specify a particular title that you want to access."
 msgstr "%(publisher)s yêu cầu bạn định rõ tên tài nguyên cụ thể để truy cập."
 
 #. Translators: If a user must register on the partner website before applying, they see this message. Don't translate partner.
 #: TWLight/resources/templates/resources/partner_detail_timeline.html:187
 #, python-format
-msgid ""
-"%(publisher)s requires that you sign up for an account before applying for "
-"access."
+msgid "%(publisher)s requires that you sign up for an account before applying for access."
 msgstr "%(publisher)s yêu cầu bạn mở tài khoản trước khi nộp đơn xin truy cập."
 
 #. Translators: If a partner has their location listed, this message is a label for that location
@@ -1963,9 +1720,7 @@ msgstr "Bạn có chắc muốn xóa <b>%(object)s</b>?"
 
 #. Translators: If multiple authorizations where returned for a collection, this message is shown to a user
 #: TWLight/resources/views.py:268
-msgid ""
-"Multiple authorizations were returned – something's wrong. Please contact us "
-"and don't forget to mention this message."
+msgid "Multiple authorizations were returned – something's wrong. Please contact us and don't forget to mention this message."
 msgstr ""
 
 #. Translators: This message is shown when user tries to access a NOT_AVAILABLE Partner
@@ -2006,14 +1761,7 @@ msgstr "Xin lỗi, chúng tôi không biết làm thế nào với điều trên
 #. Translators: Shown on the website's 400 page, when a user sends a bad request. Don't translate path or Phabricator.
 #: TWLight/templates/400.html:20
 #, python-format
-msgid ""
-"If you think we should know what to do with that, please email us about this "
-"error at <a class=\"twl-links\" href=\"mailto:wikipedialibrary@wikimedia.org?"
-"Subject=Wikipedia%%20Library%%20%(path)s%%20Permission%%20denied"
-"\">wikipedialibrary@wikimedia.org</a> or report it to us on <a class=\"twl-"
-"links\" href=\"https://phabricator.wikimedia.org/maniphest/task/edit/form/1/?"
-"projectPHIDs=Library-Card-Platform&title=Wikipedia%%20Library%%20%(path)s"
-"%%20Bad%%20Request\">Phabricator</a>"
+msgid "If you think we should know what to do with that, please email us about this error at <a class=\"twl-links\" href=\"mailto:wikipedialibrary@wikimedia.org?Subject=Wikipedia%%20Library%%20%(path)s%%20Permission%%20denied\">wikipedialibrary@wikimedia.org</a> or report it to us on <a class=\"twl-links\" href=\"https://phabricator.wikimedia.org/maniphest/task/edit/form/1/?projectPHIDs=Library-Card-Platform&title=Wikipedia%%20Library%%20%(path)s%%20Bad%%20Request\">Phabricator</a>"
 msgstr ""
 
 #. Translators: Alt text for an image shown on the 400 error page.
@@ -2035,15 +1783,7 @@ msgstr "Xin lỗi, bạn không được phép làm điều đó."
 #. Translators: Shown on the website's 403 page, when a user attempts to navigate to a page they don't have permission to view. Don't translate path or Phabricator.
 #: TWLight/templates/403.html:20
 #, python-format
-msgid ""
-"If you think your account should be able to do that, please email us about "
-"this error at <a class=\"twl-links\" href=\"mailto:"
-"wikipedialibrary@wikimedia.org?Subject=Wikipedia%%20Library%%20%(path)s"
-"%%20Permission%%20denied\">wikipedialibrary@wikimedia.org</a> or report it "
-"to us on <a class=\"twl-links\" href=\"https://phabricator.wikimedia.org/"
-"maniphest/task/edit/form/1/?projectPHIDs=Library-Card-"
-"Platform&title=Wikipedia%%20Library%%20%(path)s%%20Permission%%20denied"
-"\">Phabricator</a>"
+msgid "If you think your account should be able to do that, please email us about this error at <a class=\"twl-links\" href=\"mailto:wikipedialibrary@wikimedia.org?Subject=Wikipedia%%20Library%%20%(path)s%%20Permission%%20denied\">wikipedialibrary@wikimedia.org</a> or report it to us on <a class=\"twl-links\" href=\"https://phabricator.wikimedia.org/maniphest/task/edit/form/1/?projectPHIDs=Library-Card-Platform&title=Wikipedia%%20Library%%20%(path)s%%20Permission%%20denied\">Phabricator</a>"
 msgstr ""
 
 #. Translators: Shown on the website's 404 page, when a user attempts to navigate to a page that doesn't exist.
@@ -2059,14 +1799,7 @@ msgstr "Xin lỗi chúng tôi không thể tìm thấy nó."
 #. Translators: Shown on the website's 404 page, when a user attempts to navigate to a page that doesn't exist. Don't translate path or Phabricator.
 #: TWLight/templates/404.html:19
 #, python-format
-msgid ""
-"If you are certain that something should be here, please email us about this "
-"error at <a class=\"twl-links\" href=\"mailto:wikipedialibrary@wikimedia.org?"
-"Subject=Wikipedia%%20Library%%20%(path)s%%20Not%%20found\"> "
-"wikipedialibrary@wikimedia.org</a> or report it to us on <a class=\"twl-links"
-"\" href=\"https://phabricator.wikimedia.org/maniphest/task/edit/form/1/?"
-"projectPHIDs=Library-Card-Platform&title=Wikipedia%%20Library%%20%(path)s"
-"%%20Not%%20found\">Phabricator</a>"
+msgid "If you are certain that something should be here, please email us about this error at <a class=\"twl-links\" href=\"mailto:wikipedialibrary@wikimedia.org?Subject=Wikipedia%%20Library%%20%(path)s%%20Not%%20found\"> wikipedialibrary@wikimedia.org</a> or report it to us on <a class=\"twl-links\" href=\"https://phabricator.wikimedia.org/maniphest/task/edit/form/1/?projectPHIDs=Library-Card-Platform&title=Wikipedia%%20Library%%20%(path)s%%20Not%%20found\">Phabricator</a>"
 msgstr ""
 
 #. Translators: Alt text for an image shown on the 404 error page.
@@ -2081,32 +1814,18 @@ msgstr "Giới thiệu về Thư viện Wikipedia"
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:20
-msgid ""
-"This platform is our central tool for facilitating access to our available "
-"collections. Here you can see which partnerships are available, search their "
-"contents, and apply for and access the ones you’re interested in."
+msgid "This platform is our central tool for facilitating access to our available collections. Here you can see which partnerships are available, search their contents, and apply for and access the ones you’re interested in."
 msgstr ""
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/). Wikimedia Foundation should not be translated.
 #: TWLight/templates/about.html:29
-msgid ""
-"All users receive immediate access to some collections, which can be browsed "
-"by clicking the 'Access collection' buttons or using the search bar at the "
-"top of the page. Other collections require an application before access is "
-"granted, and may be accessed directly or via an individual login or access "
-"code. Volunteer coordinators, who have signed non-disclosure agreements with "
-"the Wikimedia Foundation, review these applications and work with publishers "
-"to get you your free access."
+msgid "All users receive immediate access to some collections, which can be browsed by clicking the 'Access collection' buttons or using the search bar at the top of the page. Other collections require an application before access is granted, and may be accessed directly or via an individual login or access code. Volunteer coordinators, who have signed non-disclosure agreements with the Wikimedia Foundation, review these applications and work with publishers to get you your free access."
 msgstr ""
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/). Don't translate terms_url.
 #: TWLight/templates/about.html:43
 #, python-format
-msgid ""
-"For more information about how your information is stored and reviewed "
-"please see our <a class=\"twl-links\" href=\"%(terms_url)s\"> terms of use "
-"and privacy policy</a>. Accounts you apply for are also subject to the Terms "
-"of Use provided by each partner’s platform; please review them."
+msgid "For more information about how your information is stored and reviewed please see our <a class=\"twl-links\" href=\"%(terms_url)s\"> terms of use and privacy policy</a>. Accounts you apply for are also subject to the Terms of Use provided by each partner’s platform; please review them."
 msgstr ""
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
@@ -2116,12 +1835,7 @@ msgstr "Ai được phép truy cập?"
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/). Wikimedia Foundation should not be translated.
 #: TWLight/templates/about.html:55
-msgid ""
-"Any active editor in good standing can receive access. For publishers with "
-"limited numbers of accounts, applications are reviewed based on the editor’s "
-"needs and contributions. If you think you could use access to one of our "
-"partner resources and are an active editor in any project supported by the "
-"Wikimedia Foundation, please apply."
+msgid "Any active editor in good standing can receive access. For publishers with limited numbers of accounts, applications are reviewed based on the editor’s needs and contributions. If you think you could use access to one of our partner resources and are an active editor in any project supported by the Wikimedia Foundation, please apply."
 msgstr ""
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
@@ -2142,8 +1856,7 @@ msgstr "Bạn đã đóng góp ít nhất 500 sửa đổi cho các dự án c�
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:79
 msgid "You have made at least 10 edits to Wikimedia projects in the last month"
-msgstr ""
-"Bạn phải đóng góp ít nhất 10 sửa đổi vào dự án Wikimedia vào tháng vừa rồi"
+msgstr "Bạn phải đóng góp ít nhất 10 sửa đổi vào dự án Wikimedia vào tháng vừa rồi"
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:83
@@ -2152,23 +1865,12 @@ msgstr "Bạn hiện không bị cấm sửa đổi Wikipedia"
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/)
 #: TWLight/templates/about.html:89
-msgid ""
-"If you are applying for an available collection, please first check that you "
-"don't already have access through another library or institution. If you do, "
-"please consider using that access rather than taking up a seat for this "
-"resource in The Wikipedia Library."
+msgid "If you are applying for an available collection, please first check that you don't already have access through another library or institution. If you do, please consider using that access rather than taking up a seat for this resource in The Wikipedia Library."
 msgstr ""
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/)
 #: TWLight/templates/about.html:99
-msgid ""
-"If your account is blocked on one or more Wikimedia projects, you may still "
-"be granted access to The Wikipedia Library. You will need to contact the "
-"Wikipedia Library team, who will review your blocks. If you have been "
-"blocked for content issues, most notably copyright violations, or have "
-"multiple long-term blocks, we may decline your request. Additionally, if "
-"your block status changes after being approved, you will need to request "
-"another review."
+msgid "If your account is blocked on one or more Wikimedia projects, you may still be granted access to The Wikipedia Library. You will need to contact the Wikipedia Library team, who will review your blocks. If you have been blocked for content issues, most notably copyright violations, or have multiple long-term blocks, we may decline your request. Additionally, if your block status changes after being approved, you will need to request another review."
 msgstr ""
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
@@ -2179,9 +1881,7 @@ msgstr "Tôi có thể làm gì sau khi có quyền truy cập?"
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:114
 msgid "Approved editors <i>may</i> use their access to:"
-msgstr ""
-"Những người sửa đổi đã được chấp nhận <i>có thể</i> sử dụng quyền truy cập "
-"để:"
+msgstr "Những người sửa đổi đã được chấp nhận <i>có thể</i> sử dụng quyền truy cập để:"
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:118
@@ -2205,12 +1905,8 @@ msgstr "Những người sửa đổi được chấp nhận <i>đừng nên</i>
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:136
-msgid ""
-"Share their account logins or passwords with others, or sell their access to "
-"other parties"
-msgstr ""
-"Chia sẻ tên người dùng hoặc mật khẩu tài khoản với người khác hoặc bán quyền "
-"truy cập cho bên thứ ba"
+msgid "Share their account logins or passwords with others, or sell their access to other parties"
+msgstr "Chia sẻ tên người dùng hoặc mật khẩu tài khoản với người khác hoặc bán quyền truy cập cho bên thứ ba"
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:140
@@ -2219,23 +1915,17 @@ msgstr "Quét hàng loạt hoặc tải về hàng loạt nội dung của đố
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:144
-msgid ""
-"Systematically make printed or electronic copies of multiple extracts of "
-"restricted content available for any purpose"
+msgid "Systematically make printed or electronic copies of multiple extracts of restricted content available for any purpose"
 msgstr ""
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/). Stub is a technical term for a short Wikipedia article, use the appropriate Wikipedia term in your language.
 #: TWLight/templates/about.html:148
-msgid ""
-"Datamine metadata without permission, in order, for instance, to use "
-"metadata for auto-created stub articles"
+msgid "Datamine metadata without permission, in order, for instance, to use metadata for auto-created stub articles"
 msgstr ""
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:154
-msgid ""
-"Respecting these agreements allows us to continue growing the partnerships "
-"available to the community."
+msgid "Respecting these agreements allows us to continue growing the partnerships available to the community."
 msgstr ""
 
 #. Translators: This is the heading for a section on the About page (https://wikipedialibrary.wmflabs.org/about/).
@@ -2245,41 +1935,22 @@ msgstr "EZProxy"
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:164
-msgid ""
-"EZProxy is a proxy server used to authenticate users for many Wikipedia "
-"Library partners. Users sign into EZProxy via the Library Card platform to "
-"verify that they are authorized users, and then the server accesses "
-"requested resources using its own IP address."
+msgid "EZProxy is a proxy server used to authenticate users for many Wikipedia Library partners. Users sign into EZProxy via the Library Card platform to verify that they are authorized users, and then the server accesses requested resources using its own IP address."
 msgstr ""
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:173
-msgid ""
-"You may notice that when accessing resources via EZProxy that URLs are "
-"dynamically rewritten. This is why we recommend logging in via the Library "
-"Card platform rather than going directly to the unproxied partner website. "
-"When in doubt, check the URL for ‘idm.oclc’. If it’s there, then you’re "
-"connected via EZProxy."
+msgid "You may notice that when accessing resources via EZProxy that URLs are dynamically rewritten. This is why we recommend logging in via the Library Card platform rather than going directly to the unproxied partner website. When in doubt, check the URL for ‘idm.oclc’. If it’s there, then you’re connected via EZProxy."
 msgstr ""
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:182
-msgid ""
-"Typically once you’ve logged in your session will remain active in your "
-"browser for up to two hours after you’ve finished searching. Note that use "
-"of EZProxy requires you to enable cookies. If you are having problems you "
-"should also try clearing your cache and restarting your browser."
+msgid "Typically once you’ve logged in your session will remain active in your browser for up to two hours after you’ve finished searching. Note that use of EZProxy requires you to enable cookies. If you are having problems you should also try clearing your cache and restarting your browser."
 msgstr ""
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/)
 #: TWLight/templates/about.html:193
-msgid ""
-"The Library Bundle is a collection of resources for which no application is "
-"required. If you meet the criteria laid out above, you will be authorized "
-"for access automatically upon logging in to the platform. Only some of our "
-"content is currently included in the Library Bundle, however we hope to "
-"expand the collection as more publishers become comfortable with "
-"participating. All Bundle content is accessed via EZProxy."
+msgid "The Library Bundle is a collection of resources for which no application is required. If you meet the criteria laid out above, you will be authorized for access automatically upon logging in to the platform. Only some of our content is currently included in the Library Bundle, however we hope to expand the collection as more publishers become comfortable with participating. All Bundle content is accessed via EZProxy."
 msgstr ""
 
 #. Translators: This is the heading for a section on the About page (https://wikipedialibrary.wmflabs.org/about/).
@@ -2289,12 +1960,7 @@ msgstr ""
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:206
-msgid ""
-"Citation practices vary by project and even by article. Generally, we "
-"support editors citing where they found information, in a form that allows "
-"others to check it for themselves. That often means providing both original "
-"source details as well as a link to the partner database in which the source "
-"was found."
+msgid "Citation practices vary by project and even by article. Generally, we support editors citing where they found information, in a form that allows others to check it for themselves. That often means providing both original source details as well as a link to the partner database in which the source was found."
 msgstr ""
 
 #. Translators: This is the heading for a section on the About page (https://wikipedialibrary.wmflabs.org/about/).
@@ -2306,9 +1972,7 @@ msgstr "Liên lạc"
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:218
 #, python-format
-msgid ""
-"If you have questions, need help, or want to volunteer to help, please see "
-"our <a class=\"twl-links\" href=\"%(contact_url)s\">contact page</a>."
+msgid "If you have questions, need help, or want to volunteer to help, please see our <a class=\"twl-links\" href=\"%(contact_url)s\">contact page</a>."
 msgstr ""
 
 #. Translators: This is the title of the panel box detailing the contact information for the Wikipedia Library team.
@@ -2348,9 +2012,7 @@ msgstr "Trang Twitter Thư viện Wikipedia"
 #. Translators: This is the text that appears at the bottom of the contact us form directing users to the suggestions form.
 #: TWLight/templates/contact.html:48
 #, python-format
-msgid ""
-"(If you would like to suggest a partner, <a class=\"twl-links\" href="
-"\"%(suggest)s\"><strong>go here</strong></a>.)"
+msgid "(If you would like to suggest a partner, <a class=\"twl-links\" href=\"%(suggest)s\"><strong>go here</strong></a>.)"
 msgstr ""
 
 #. Translators: On a special 'link to search' page, this message is shown if JavaScript is disabled.
@@ -2408,9 +2070,7 @@ msgstr "Thư viện Wikipedia"
 #. Translators: Information about The Wikipedia Library.
 #: TWLight/templates/login_partial.html:53 TWLight/templates/new_base.html:21
 #, python-format
-msgid ""
-"More than 100 of the world's top subscription-only databases, with content "
-"in %(no_of_languages)s languages, free for Wikipedians of all backgrounds"
+msgid "More than 100 of the world's top subscription-only databases, with content in %(no_of_languages)s languages, free for Wikipedians of all backgrounds"
 msgstr ""
 
 #. Translators: Information about The Wikipedia Library.
@@ -2419,9 +2079,7 @@ msgid "Meet these criteria for automatic access"
 msgstr ""
 
 #: TWLight/templates/login_partial.html:69
-msgid ""
-"These criteria grant you access to certain collections but not all. Some "
-"collections are accessible on a per application basis only."
+msgid "These criteria grant you access to certain collections but not all. Some collections are accessible on a per application basis only."
 msgstr ""
 
 #: TWLight/templates/login_partial.html:89
@@ -2431,29 +2089,19 @@ msgstr "Đăng nhập qua Wikipedia"
 #. Translators: Shown if the current user doesn't have a registered email on their account. Don't translate contact_us_url or email_url.
 #: TWLight/templates/message_partial.html:15
 #, python-format
-msgid ""
-"You don't have an email on file. We can't finalize your access to partner "
-"resources, and you won't be able to <a class=\"twl-links\" href="
-"\"%(contact_us_url)s\">contact us</a> without an email. Please <a class="
-"\"twl-links\" href=\"%(email_url)s\">update your email</a>."
+msgid "You don't have an email on file. We can't finalize your access to partner resources, and you won't be able to <a class=\"twl-links\" href=\"%(contact_us_url)s\">contact us</a> without an email. Please <a class=\"twl-links\" href=\"%(email_url)s\">update your email</a>."
 msgstr ""
 
 #. Translators: Shown if the current user has requested the processing of their data should be restricted.
 #: TWLight/templates/message_partial.html:26
 #, python-format
-msgid ""
-"You have requested a restriction on the processing of your data. Most site "
-"functionality will not be available to you until you <a class=\"twl-links\" "
-"href=\"%(restrict_url)s\">lift this restriction</a>."
+msgid "You have requested a restriction on the processing of your data. Most site functionality will not be available to you until you <a class=\"twl-links\" href=\"%(restrict_url)s\">lift this restriction</a>."
 msgstr ""
 
 #. Translators: Shown if the current user has not agreed to the terms of use.
 #: TWLight/templates/message_partial.html:37
 #, python-format
-msgid ""
-"You have not agreed to the <a class=\"twl-links\" href=\"%(terms_url)s"
-"\">terms of use</a> of this site. Your applications will not be processed "
-"and you won't be able to apply or access resources you are approved for."
+msgid "You have not agreed to the <a class=\"twl-links\" href=\"%(terms_url)s\">terms of use</a> of this site. Your applications will not be processed and you won't be able to apply or access resources you are approved for."
 msgstr ""
 
 #. Translators: This link is at the bottom of every page and links to the 'About' page (https://wikipedialibrary.wmflabs.org/about/)
@@ -2500,12 +2148,8 @@ msgstr "Đặt lại mật khẩu"
 
 #. Translators: If a user goes to reset their password, this message asks them to enter their email to do so.
 #: TWLight/templates/registration/password_reset_form.html:13
-msgid ""
-"Forgot your password? Enter your email address below, and we'll email "
-"instructions for setting a new one."
-msgstr ""
-"Bạn quên mật khẩu? Hãy điền địa chỉ thư điện tử bên dưới để chúng tôi gửi "
-"bạn thư hướng dẫn lập mật khẩu mới."
+msgid "Forgot your password? Enter your email address below, and we'll email instructions for setting a new one."
+msgstr "Bạn quên mật khẩu? Hãy điền địa chỉ thư điện tử bên dưới để chúng tôi gửi bạn thư hướng dẫn lập mật khẩu mới."
 
 #. Translators: This is the label for a button that users click to update their public information.
 #: TWLight/users/forms.py:36
@@ -2549,16 +2193,12 @@ msgstr "Tôi chấp nhận các điều khoản sử dụng"
 
 #. Translators: This text explains how to disagree to the site's terms of use and the restrictions that will come into effect when users disagree to the terms of use.
 #: TWLight/users/forms.py:185
-msgid ""
-"By unchecking this box and clicking “Update” you may explore the site, but "
-"you will not be able to apply for access to materials or evaluate "
-"applications unless you agree with the terms of use."
+msgid "By unchecking this box and clicking “Update” you may explore the site, but you will not be able to apply for access to materials or evaluate applications unless you agree with the terms of use."
 msgstr ""
 
 #. Translators: Users click this button to set their website email address to the one linked to their Wikipedia account.
 #: TWLight/users/forms.py:211
-msgid ""
-"Use my Wikipedia email address (will be updated the next time you login)."
+msgid "Use my Wikipedia email address (will be updated the next time you login)."
 msgstr ""
 
 #. Translators: This labels a button which users click to change their email.
@@ -2569,17 +2209,8 @@ msgstr "Cập nhật địa chỉ thư điện tử"
 #. Translators: Shown if the current user tried to 'favorite' a partner they can't access. Do not translate '{partner}'
 #: TWLight/users/models.py:201
 #, python-brace-format
-msgid ""
-"Cannot add partner {partner} to your favorites because you don't have access "
-"to it"
+msgid "Cannot add partner {partner} to your favorites because you don't have access to it"
 msgstr ""
-
-#. Translators: Do not translate.
-#: TWLight/users/models.py:869
-#, fuzzy, python-brace-format
-#| msgid "Username"
-msgid "{wp_username}"
-msgstr "Tên người dùng"
 
 #. Translators: This error message is shown when there's a problem with the authenticated login process.
 #: TWLight/users/oauth.py:243
@@ -2599,9 +2230,7 @@ msgstr ""
 
 #. Translators: this message is displayed to users that don't have accounts and clicked on a proxied link.
 #: TWLight/users/oauth.py:388
-msgid ""
-"To view this link you need to be an eligible library user. Please login to "
-"continue."
+msgid "To view this link you need to be an eligible library user. Please login to continue."
 msgstr ""
 
 #. Translators: This warning message is shown to users when the response received from Wikimedia OAuth servers is not a valid one.
@@ -2637,17 +2266,12 @@ msgstr "Thông tin cá nhân"
 
 #. Translators: If the user tries to log in, but their account does not meet certain requirements, they cannot login.
 #: TWLight/users/oauth.py:528
-msgid ""
-"Your Wikipedia account does not meet the eligibility criteria in the terms "
-"of use, so your Wikipedia Library Card Platform account cannot be activated."
+msgid "Your Wikipedia account does not meet the eligibility criteria in the terms of use, so your Wikipedia Library Card Platform account cannot be activated."
 msgstr ""
 
 #. Translators: If the user tries to log in, but their account does not meet certain requirements, they cannot login.
 #: TWLight/users/oauth.py:536
-msgid ""
-"Your Wikipedia account no longer meets the eligibility criteria in the terms "
-"of use, so you cannot be logged in. If you think you should be able to log "
-"in, please email wikipedialibrary@wikimedia.org."
+msgid "Your Wikipedia account no longer meets the eligibility criteria in the terms of use, so you cannot be logged in. If you think you should be able to log in, please email wikipedialibrary@wikimedia.org."
 msgstr ""
 
 #. Translators: this message is displayed to users with brand new accounts.
@@ -2658,10 +2282,7 @@ msgstr ""
 #. Translators: This message is displayed on the confirmation page where users can return their access to partner collections.
 #: TWLight/users/templates/users/authorization_confirm_return.html:13
 #, python-format
-msgid ""
-"You will no longer be able to access <b>%(partner)s's</b> resources via the "
-"Library Card platform, but can request access again by clicking 'renew', if "
-"you change your mind. Are you sure you want to return your access?"
+msgid "You will no longer be able to access <b>%(partner)s's</b> resources via the Library Card platform, but can request access again by clicking 'renew', if you change your mind. Are you sure you want to return your access?"
 msgstr ""
 
 #. Translators: On the MyLibrary page (https://wikipedialibrary.wmflabs.org/users/my_library), this tab shows all favorite collections a user has.
@@ -2731,10 +2352,7 @@ msgstr "Dữ liệu biên tập viên"
 
 #. Translators: This is shown on editor profiles, in their profile page or on applications.
 #: TWLight/users/templates/users/editor_detail.html:59
-msgid ""
-"Information with an * was retrieved from Wikipedia directly. Other "
-"information was entered directly by users or site admins, in their preferred "
-"language."
+msgid "Information with an * was retrieved from Wikipedia directly. Other information was entered directly by users or site admins, in their preferred language."
 msgstr ""
 
 #. Translators: This distinguishes users who have been flagged as account coordinators. Don't translate username.
@@ -2745,10 +2363,7 @@ msgstr ""
 
 #. Translators: This is shown on editor profiles, under the heading for Wikipedia editor data.
 #: TWLight/users/templates/users/editor_detail_data.html:5
-msgid ""
-"This information is updated automatically from your Wikimedia account each "
-"time you log in, except for the Contributions field, where you can describe "
-"your Wikimedia editing history."
+msgid "This information is updated automatically from your Wikimedia account each time you log in, except for the Contributions field, where you can describe your Wikimedia editing history."
 msgstr ""
 
 #. Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this labels the user's username.
@@ -2778,17 +2393,13 @@ msgstr ""
 
 #. Translators: when viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this question has a yes or no answer.
 #: TWLight/users/templates/users/editor_detail_data.html:57
-msgid ""
-"at their last login, did this user meet the criteria set forth in the terms "
-"of use?"
+msgid "at their last login, did this user meet the criteria set forth in the terms of use?"
 msgstr ""
 
 #. Translators: When viewing a user's profile in an application, this message shows if the software doesn't think that the user is eligible for access. Don't translate username.
 #: TWLight/users/templates/users/editor_detail_data.html:72
 #, python-format
-msgid ""
-"%(username)s may still be eligible for access grants at the coordinators' "
-"discretion."
+msgid "%(username)s may still be eligible for access grants at the coordinators' discretion."
 msgstr ""
 
 #. Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this is the heading for a Yes/No ToU question.
@@ -2823,10 +2434,7 @@ msgstr ""
 #. Translators: This message is shown on a user's profile if their Wikimedia account is blocked on one or more projects. They may still be granted access to the Library Bundle, but need to contact Wikipedia Library staff to verify.
 #: TWLight/users/templates/users/editor_detail_data.html:137
 #, python-format
-msgid ""
-"It looks like you have an active block on your account. If you meet the "
-"other criteria you may still be permitted access to the library - please <a "
-"class=\"twl-links\" href=\"%(contact_url)s\">contact us</a>."
+msgid "It looks like you have an active block on your account. If you meet the other criteria you may still be permitted access to the library - please <a class=\"twl-links\" href=\"%(contact_url)s\">contact us</a>."
 msgstr ""
 
 #. Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this is the heading for a Yes/No program eligibility question.
@@ -2836,10 +2444,7 @@ msgstr ""
 
 #. Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this question has a Yes or No answer.
 #: TWLight/users/templates/users/editor_detail_data.html:156
-msgid ""
-"At their last login, did this user meet the criteria set forth in the "
-"Library Bundle? Note that satisfying terms of use is a prerequisite to "
-"bundle eligibility."
+msgid "At their last login, did this user meet the criteria set forth in the Library Bundle? Note that satisfying terms of use is a prerequisite to bundle eligibility."
 msgstr ""
 
 #. Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this is the heading for a Yes/No program eligibility question.
@@ -2884,18 +2489,13 @@ msgstr "Dữ liệu cá nhân"
 
 #. Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this text is in the 'Personal data' section. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/users/templates/users/editor_detail_data.html:262
-msgid ""
-"The following information is visible only to you, site administrators, "
-"publishing partners (where required), and volunteer Wikipedia Library "
-"coordinators (who have signed a Non-Disclosure Agreement)."
+msgid "The following information is visible only to you, site administrators, publishing partners (where required), and volunteer Wikipedia Library coordinators (who have signed a Non-Disclosure Agreement)."
 msgstr ""
 
 #. Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this labels a button which users can click to update or remove their personal information. Don't translate update_url.
 #: TWLight/users/templates/users/editor_detail_data.html:272
 #, python-format
-msgid ""
-"You may <a class=\"twl-links\" href=\"%(update_url)s\">update or delete</a> "
-"your data at any time."
+msgid "You may <a class=\"twl-links\" href=\"%(update_url)s\">update or delete</a> your data at any time."
 msgstr ""
 
 #. Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this labels the user's email. Don't remove the *.
@@ -2915,26 +2515,18 @@ msgstr ""
 
 #. Translators: This message tells users that they are not eligible to access The Wikipedia Library content.
 #: TWLight/users/templates/users/eligibility_modal.html:7
-msgid ""
-"Sorry, your Wikipedia account doesn’t currently qualify to access The "
-"Wikipedia Library."
+msgid "Sorry, your Wikipedia account doesn’t currently qualify to access The Wikipedia Library."
 msgstr ""
 
 #. Translators: This message tells users that they have not agreed to the terms of use, therefore are ineligible to access the content in The Wikipedia Library.
 #: TWLight/users/templates/users/eligibility_modal.html:30
 #, python-format
-msgid ""
-"Agreed with <a href=\"%(terms)s\" class=\"text-danger\"> terms of use </a>"
-msgstr ""
-"Chấp nhận các <a href=\"%(terms)s\" class=\"text-danger\">điều khoản sử "
-"dụng</a>"
+msgid "Agreed with <a href=\"%(terms)s\" class=\"text-danger\"> terms of use </a>"
+msgstr "Chấp nhận các <a href=\"%(terms)s\" class=\"text-danger\">điều khoản sử dụng</a>"
 
 #: TWLight/users/templates/users/eligibility_modal.html:40
 #, python-format
-msgid ""
-"It looks like you have an active block on your account. If you meet the "
-"other criteria you may still be permitted access to the library - please <a "
-"href=\"%(contact_url)s\">contact us</a>."
+msgid "It looks like you have an active block on your account. If you meet the other criteria you may still be permitted access to the library - please <a href=\"%(contact_url)s\">contact us</a>."
 msgstr ""
 
 #. Translators: Instructions to refresh a user's data.
@@ -2974,10 +2566,7 @@ msgstr "Chọn ngôn ngữ"
 
 #. Translators: This text on the user page helps users naviage to the TranslateWiki Wikipedia Library Card platform translation page.
 #: TWLight/users/templates/users/language_form.html:31
-msgid ""
-"You can help translate the tool at <a class=\"twl-links\" href=\"https://"
-"translatewiki.net/wiki/Translating:Wikipedia_Library_Card_Platform"
-"\">translatewiki.net</a>."
+msgid "You can help translate the tool at <a class=\"twl-links\" href=\"https://translatewiki.net/wiki/Translating:Wikipedia_Library_Card_Platform\">translatewiki.net</a>."
 msgstr ""
 
 #. Translators: When the user starts a new application and submits the application, the user can view the application and withdraw if need be. This changes the label for the Withdraw button.
@@ -2997,9 +2586,7 @@ msgstr "Xin gia hạn"
 
 #. Translators: On the page listing applications, this text explains a user they cannot renew their application since they've already requested a renewal or there aren't any renewals available.
 #: TWLight/users/templates/users/my_applications.html:79
-msgid ""
-"Renewals are either not required, not available right now, or you have "
-"already requested a renewal."
+msgid "Renewals are either not required, not available right now, or you have already requested a renewal."
 msgstr ""
 
 #. Translators: This text is the heading of a section in a user's profile where they can change their preferences.
@@ -3063,19 +2650,12 @@ msgstr "Hạn chế xử lý dữ liệu"
 
 #. Translators: This message is displayed on the page where users can request we stop processing their data.
 #: TWLight/users/templates/users/restrict_data.html:15
-msgid ""
-"Checking this box and clicking “Restrict” will pause all processing of the "
-"data you have entered into this website. You will not be able to apply for "
-"access to resources, your applications will not be further processed, and "
-"none of your data will be altered, until you return to this page and uncheck "
-"the box. This is not the same as deleting your data."
+msgid "Checking this box and clicking “Restrict” will pause all processing of the data you have entered into this website. You will not be able to apply for access to resources, your applications will not be further processed, and none of your data will be altered, until you return to this page and uncheck the box. This is not the same as deleting your data."
 msgstr ""
 
 #. Translators: This warning message is shown to coordinators who view the data restriction page.
 #: TWLight/users/templates/users/restrict_data.html:26
-msgid ""
-"You are a coordinator on this site. If you restrict the processing of your "
-"data, your coordinator flag will be removed."
+msgid "You are a coordinator on this site. If you restrict the processing of your data, your coordinator flag will be removed."
 msgstr ""
 
 #. Translators: use the date *when you are translating*, in a language-appropriate format.
@@ -3091,29 +2671,16 @@ msgstr "Quy định riêng tư của Quỹ Wikimedia"
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:41
 msgid "Wikipedia Library Card Terms of Use and Privacy Statement"
-msgstr ""
-"Điều khoản Sử dụng và Tuyên bố về Quyền riêng tư của Thẻ Thư viện Wikipedia"
+msgstr "Điều khoản Sử dụng và Tuyên bố về Quyền riêng tư của Thẻ Thư viện Wikipedia"
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:51
-msgid ""
-"<a class=\"twl-links\" href=\"https://meta.wikimedia.org/wiki/"
-"The_Wikipedia_Library\"> The Wikipedia Library </a> has partnered with "
-"publishers around the world to allow users to access otherwise paywalled "
-"resources. This website allows Wikipedia editors to search and access these "
-"resources."
+msgid "<a class=\"twl-links\" href=\"https://meta.wikimedia.org/wiki/The_Wikipedia_Library\"> The Wikipedia Library </a> has partnered with publishers around the world to allow users to access otherwise paywalled resources. This website allows Wikipedia editors to search and access these resources."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Wikimedia Foundation should not be translated. WMF should not be translated. Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:63
-msgid ""
-"This program is administered by the Wikimedia Foundation (WMF). These terms "
-"of use and privacy notice pertain to your application for access to "
-"resources through the Wikipedia Library, your use of this website, and your "
-"access to and use of those resources. They also describe our handling of the "
-"information you provide to us in order to create and administer your "
-"Wikipedia Library account. If we make material changes to the terms, we will "
-"notify users."
+msgid "This program is administered by the Wikimedia Foundation (WMF). These terms of use and privacy notice pertain to your application for access to resources through the Wikipedia Library, your use of this website, and your access to and use of those resources. They also describe our handling of the information you provide to us in order to create and administer your Wikipedia Library account. If we make material changes to the terms, we will notify users."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
@@ -3123,37 +2690,17 @@ msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:78
-msgid ""
-"Access to resources via The Wikipedia Library is reserved for community "
-"members who have demonstrated their commitment to the Wikimedia projects, "
-"and who will use their access to these resources to improve project content. "
-"To that end, in order to be eligible for The Wikipedia Library, we require "
-"that you be registered for a user account on the projects, with at least 500 "
-"edits, six (6) months of activity, and 10+ edits in the last month. We ask "
-"that you do not request access to any publishers with a limited number of "
-"available accounts whose resources you can already access for free through "
-"your local library or university, or another institution or organization, in "
-"order to provide that opportunity to others."
+msgid "Access to resources via The Wikipedia Library is reserved for community members who have demonstrated their commitment to the Wikimedia projects, and who will use their access to these resources to improve project content. To that end, in order to be eligible for The Wikipedia Library, we require that you be registered for a user account on the projects, with at least 500 edits, six (6) months of activity, and 10+ edits in the last month. We ask that you do not request access to any publishers with a limited number of available accounts whose resources you can already access for free through your local library or university, or another institution or organization, in order to provide that opportunity to others."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:94
-msgid ""
-"Additionally, if you are currently blocked or banned from a Wikimedia "
-"project, applications to resources may be rejected or restricted. If you "
-"obtain a Wikipedia Library account, but a block or ban is subsequently "
-"instituted against you on one of the projects, you may lose access to your "
-"Wikipedia Library account."
+msgid "Additionally, if you are currently blocked or banned from a Wikimedia project, applications to resources may be rejected or restricted. If you obtain a Wikipedia Library account, but a block or ban is subsequently instituted against you on one of the projects, you may lose access to your Wikipedia Library account."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:104
-msgid ""
-"Your eligibility to access The Wikipedia Library is assessed at each login. "
-"While more than half of the library's content is provided via this automated "
-"eligibility check, access to other publisher's content may be time limited, "
-"typically lapsing after one year, after which you will usually need to apply "
-"for renewal."
+msgid "Your eligibility to access The Wikipedia Library is assessed at each login. While more than half of the library's content is provided via this automated eligibility check, access to other publisher's content may be time limited, typically lapsing after one year, after which you will usually need to apply for renewal."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
@@ -3164,47 +2711,27 @@ msgstr "Mã truy cập Thư viện Wikipedia của bạn"
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:118
-msgid ""
-"In order to apply for access to a partner resource, you must provide us with "
-"certain information, which we will use to evaluate your application. If your "
-"application is approved, we may transfer the information you have given us "
-"to the publishers whose resources you wish to access. They will either "
-"contact you with the account information directly or we will send access "
-"information to you ourselves."
+msgid "In order to apply for access to a partner resource, you must provide us with certain information, which we will use to evaluate your application. If your application is approved, we may transfer the information you have given us to the publishers whose resources you wish to access. They will either contact you with the account information directly or we will send access information to you ourselves."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:130
-msgid ""
-"In addition to the basic information you provide to us, our system will "
-"retrieve some information directly from the Wikimedia projects: your "
-"username, email address, edit count, registration date, user ID number, "
-"groups to which you belong, and any special user rights."
+msgid "In addition to the basic information you provide to us, our system will retrieve some information directly from the Wikimedia projects: your username, email address, edit count, registration date, user ID number, groups to which you belong, and any special user rights."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:140
-msgid ""
-"Each time you log in to the Wikipedia Library Card Platform, this "
-"information will be automatically updated."
+msgid "Each time you log in to the Wikipedia Library Card Platform, this information will be automatically updated."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:148
-msgid ""
-"We will ask you to provide us with some information about your history of "
-"contributions to the Wikimedia projects. Information on contribution history "
-"is optional, but will greatly assist us in evaluating your application."
+msgid "We will ask you to provide us with some information about your history of contributions to the Wikimedia projects. Information on contribution history is optional, but will greatly assist us in evaluating your application."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). WMF should not be translated. Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:157
-msgid ""
-"The information you provide when creating your account will be visible to "
-"you while on the site but not to others unless they are approved Wikipedia "
-"Library Coordinators, WMF Staff, or WMF Contractors who need access to this "
-"data in order to carry out their work with the Wikipedia Library, all of "
-"whom are subject to non-disclosure obligations."
+msgid "The information you provide when creating your account will be visible to you while on the site but not to others unless they are approved Wikipedia Library Coordinators, WMF Staff, or WMF Contractors who need access to this data in order to carry out their work with the Wikipedia Library, all of whom are subject to non-disclosure obligations."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
@@ -3214,46 +2741,32 @@ msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:171
-msgid ""
-"In order to access an individual publisher’s resources, you must agree to "
-"that publisher’s terms of use and privacy policy. You agree that you will "
-"not violate such terms and policies in connection with your use of the "
-"Wikipedia Library. Additionally, the following activities are prohibited "
-"while accessing publisher resources through the Wikipedia Library."
+msgid "In order to access an individual publisher’s resources, you must agree to that publisher’s terms of use and privacy policy. You agree that you will not violate such terms and policies in connection with your use of the Wikipedia Library. Additionally, the following activities are prohibited while accessing publisher resources through the Wikipedia Library."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:184
-msgid ""
-"Sharing your Wikipedia account, usernames, passwords, or any access codes "
-"for publisher resources with others;"
+msgid "Sharing your Wikipedia account, usernames, passwords, or any access codes for publisher resources with others;"
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:191
-msgid ""
-"Automatically scraping or downloading restricted content from publishers;"
+msgid "Automatically scraping or downloading restricted content from publishers;"
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:197
-msgid ""
-"Systematically making printed or electronic copies of multiple extracts of "
-"restricted content available for any purpose;"
+msgid "Systematically making printed or electronic copies of multiple extracts of restricted content available for any purpose;"
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:204
-msgid ""
-"Data mining metadata without permission—for example, in order to use "
-"metadata for auto-created stub articles;"
+msgid "Data mining metadata without permission—for example, in order to use metadata for auto-created stub articles;"
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:211
-msgid ""
-"Using the access you receive through the Wikipedia Library for profit by "
-"selling access to your account or resources which you have through it."
+msgid "Using the access you receive through the Wikipedia Library for profit by selling access to your account or resources which you have through it."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
@@ -3263,21 +2776,13 @@ msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:224
-msgid ""
-"Certain resources may only be accessed using an external search service, "
-"such as the EBSCO Discovery Service, or a proxy service, such as OCLC "
-"EZProxy. If you use such external search and/or proxy services, please "
-"review the applicable terms of use and privacy policies."
+msgid "Certain resources may only be accessed using an external search service, such as the EBSCO Discovery Service, or a proxy service, such as OCLC EZProxy. If you use such external search and/or proxy services, please review the applicable terms of use and privacy policies."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:234
-msgid ""
-"In addition, if you use OCLC EZProxy, please note that you may not use it "
-"for commercial purposes."
-msgstr ""
-"Ngoài ra, nếu bạn dùng OCLC EZProxy, xin để ý đừng dùng công cụ này cho mục "
-"đích thương mại."
+msgid "In addition, if you use OCLC EZProxy, please note that you may not use it for commercial purposes."
+msgstr "Ngoài ra, nếu bạn dùng OCLC EZProxy, xin để ý đừng dùng công cụ này cho mục đích thương mại."
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:241
@@ -3286,120 +2791,49 @@ msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Wikimedia Foundation should not be translated. Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:245
-msgid ""
-"The Wikimedia Foundation and our service providers use your information for "
-"the legitimate purpose of providing Wikipedia Library services in support of "
-"our charitable mission. When you apply for a Wikipedia Library account, or "
-"use your Wikipedia Library account, we may routinely collect the following "
-"information: your username, email address, edit count, registration date, "
-"user ID number, groups to which you belong, and any special user rights; "
-"your name, country of residence, and/or affiliation, if required by a "
-"partner to which you are applying; your narrative description of your "
-"contributions and reasons for applying for access to partner resources; and "
-"the date you agree to these terms of use."
+msgid "The Wikimedia Foundation and our service providers use your information for the legitimate purpose of providing Wikipedia Library services in support of our charitable mission. When you apply for a Wikipedia Library account, or use your Wikipedia Library account, we may routinely collect the following information: your username, email address, edit count, registration date, user ID number, groups to which you belong, and any special user rights; your name, country of residence, and/or affiliation, if required by a partner to which you are applying; your narrative description of your contributions and reasons for applying for access to partner resources; and the date you agree to these terms of use."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:262
 #, python-format
-msgid ""
-"Each publisher who is a member of the Wikipedia Library program requires "
-"different specific information in the application. Some publishers may "
-"request only an email address, while others request more detailed data, such "
-"as your name, location, or institutional affiliation. When you complete your "
-"application, you will only be asked to supply information required by the "
-"publishers you have chosen, and each publisher will only receive the "
-"information they require for providing you with access. Please see our <a "
-"class=\"twl-links\" href=\"%(all_partners_url)s\">partner information</a> "
-"pages to learn what information is required by each publisher to gain access "
-"to their resources."
+msgid "Each publisher who is a member of the Wikipedia Library program requires different specific information in the application. Some publishers may request only an email address, while others request more detailed data, such as your name, location, or institutional affiliation. When you complete your application, you will only be asked to supply information required by the publishers you have chosen, and each publisher will only receive the information they require for providing you with access. Please see our <a class=\"twl-links\" href=\"%(all_partners_url)s\">partner information</a> pages to learn what information is required by each publisher to gain access to their resources."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Wikimedia Foundation should not be translated. Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:277
-msgid ""
-"Some Wikipedia Library pages are visible without logging in, but you will "
-"need to log in to apply or access proprietary partner resources. We use the "
-"data provided by you via OAuth and Wikimedia API calls to assess your "
-"application for access and to process approved requests."
+msgid "Some Wikipedia Library pages are visible without logging in, but you will need to log in to apply or access proprietary partner resources. We use the data provided by you via OAuth and Wikimedia API calls to assess your application for access and to process approved requests."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:288
 #, python-format
-msgid ""
-"In order to administer the Wikipedia Library program, we will retain the "
-"application data we collect from you for three years after your most recent "
-"login, unless you delete your account, as described below. You can log in "
-"and go to <a class=\"twl-links\" href=\"%(profile_url)s\">your profile page</"
-"a> in order to see the information associated with your account, and can "
-"download it in JSON format. You may access, update, restrict, or delete this "
-"information at any time, except for the information that is automatically "
-"retrieved from the projects. If you have any questions or concerns about the "
-"handling of your data, please contact <a class=\"twl-links\" href=\"mailto:"
-"wikipedialibrary@wikimedia.org?Subject=Wikipedia%%20Library%%20Card"
-"%%20account%%20deactivation\"> wikipedialibrary@wikimedia.org </a>."
+msgid "In order to administer the Wikipedia Library program, we will retain the application data we collect from you for three years after your most recent login, unless you delete your account, as described below. You can log in and go to <a class=\"twl-links\" href=\"%(profile_url)s\">your profile page</a> in order to see the information associated with your account, and can download it in JSON format. You may access, update, restrict, or delete this information at any time, except for the information that is automatically retrieved from the projects. If you have any questions or concerns about the handling of your data, please contact <a class=\"twl-links\" href=\"mailto:wikipedialibrary@wikimedia.org?Subject=Wikipedia%%20Library%%20Card%%20account%%20deactivation\"> wikipedialibrary@wikimedia.org </a>."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:305
-msgid ""
-"If you decide to disable your Wikipedia Library account, you can use the "
-"delete button on your profile to delete certain personal information "
-"associated with your account. We will delete your real name, institutional "
-"affiliation, and country of residence. Please note that the system will "
-"retain a record of your username, the publishers to which you applied or had "
-"access, and the dates of that access. Note that deletion is not reversible. "
-"Deletion of your Wikipedia Library account may also correspond with the "
-"removal of any resource access to which you were eligible or approved. If "
-"you request the deletion of account information and later wish to apply for "
-"a new account, you will need to provide the necessary information again."
+msgid "If you decide to disable your Wikipedia Library account, you can use the delete button on your profile to delete certain personal information associated with your account. We will delete your real name, institutional affiliation, and country of residence. Please note that the system will retain a record of your username, the publishers to which you applied or had access, and the dates of that access. Note that deletion is not reversible. Deletion of your Wikipedia Library account may also correspond with the removal of any resource access to which you were eligible or approved. If you request the deletion of account information and later wish to apply for a new account, you will need to provide the necessary information again."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). WMF should not be translated. Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:321
-msgid ""
-"The Wikipedia Library is run by WMF Staff, Contractors, and approved "
-"volunteer Coordinators. The data associated with your account will be shared "
-"with the WMF staff, contractors, service providers, and volunteer "
-"coordinators who need to process the information in connection with their "
-"work for the Wikipedia Library, and who are subject to confidentiality "
-"obligations. We will also use your data for internal Wikipedia Library "
-"purposes such as distributing user surveys and account notifications, and in "
-"a depersonalized or aggregated fashion for statistical analysis and "
-"administration. Finally, we will share your information with the publishers "
-"whom you specifically select in order to provide you with access to "
-"resources. Otherwise, your information will not be shared with third "
-"parties, with the exception of the circumstances described below."
+msgid "The Wikipedia Library is run by WMF Staff, Contractors, and approved volunteer Coordinators. The data associated with your account will be shared with the WMF staff, contractors, service providers, and volunteer coordinators who need to process the information in connection with their work for the Wikipedia Library, and who are subject to confidentiality obligations. We will also use your data for internal Wikipedia Library purposes such as distributing user surveys and account notifications, and in a depersonalized or aggregated fashion for statistical analysis and administration. Finally, we will share your information with the publishers whom you specifically select in order to provide you with access to resources. Otherwise, your information will not be shared with third parties, with the exception of the circumstances described below."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). WMF should not be translated.
 #: TWLight/users/templates/users/terms.html:338
-msgid ""
-"We may disclose any collected information when required by law, when we have "
-"your permission, when needed to protect our rights, privacy, safety, users, "
-"or the general public, and when necessary to enforce these terms, WMF’s "
-"general <a class=\"twl-links\" href=\"https://foundation.wikimedia.org/wiki/"
-"Terms_of_Use\">Terms of Use</a>, or any other WMF policy."
+msgid "We may disclose any collected information when required by law, when we have your permission, when needed to protect our rights, privacy, safety, users, or the general public, and when necessary to enforce these terms, WMF’s general <a class=\"twl-links\" href=\"https://foundation.wikimedia.org/wiki/Terms_of_Use\">Terms of Use</a>, or any other WMF policy."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:349
-msgid ""
-"We take the security of your personal data seriously, and take reasonable "
-"precautions to ensure your data is protected. These precautions include "
-"access controls to limit who has access to your data and security "
-"technologies to protect data stored on the server. However, we cannot "
-"guarantee the safety of your data as it is transmitted and stored."
+msgid "We take the security of your personal data seriously, and take reasonable precautions to ensure your data is protected. These precautions include access controls to limit who has access to your data and security technologies to protect data stored on the server. However, we cannot guarantee the safety of your data as it is transmitted and stored."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:360
-msgid ""
-"Please note that these terms do not control the use and handling of your "
-"data by the publishers and service providers whose resources you access or "
-"apply to access. Please read their individual privacy policies for that "
-"information."
+msgid "Please note that these terms do not control the use and handling of your data by the publishers and service providers whose resources you access or apply to access. Please read their individual privacy policies for that information."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
@@ -3409,34 +2843,17 @@ msgstr "Lưu ý quan trọng"
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Wikimedia Foundation should not be translated. Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:373
-msgid ""
-"The Wikimedia Foundation is a nonprofit organization based in San Francisco, "
-"California. The Wikipedia Library program provides access to resources held "
-"by publishers in multiple countries. If you apply for a Wikipedia Library "
-"account (whether you are inside or outside of the United States), you "
-"understand that your personal data will be collected, transferred, stored, "
-"processed, disclosed and otherwise used in the U.S. as described in this "
-"privacy policy. You also understand that your information may be transferred "
-"by us from the U.S. to other countries, which may have different or less "
-"stringent data protection laws than your country, in connection with "
-"providing services to you, including evaluating your application and "
-"securing access to your chosen publishers (locations for each publisher are "
-"outlined on their respective partner information pages)."
+msgid "The Wikimedia Foundation is a nonprofit organization based in San Francisco, California. The Wikipedia Library program provides access to resources held by publishers in multiple countries. If you apply for a Wikipedia Library account (whether you are inside or outside of the United States), you understand that your personal data will be collected, transferred, stored, processed, disclosed and otherwise used in the U.S. as described in this privacy policy. You also understand that your information may be transferred by us from the U.S. to other countries, which may have different or less stringent data protection laws than your country, in connection with providing services to you, including evaluating your application and securing access to your chosen publishers (locations for each publisher are outlined on their respective partner information pages)."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:392
-msgid ""
-"Please note that in the event of any differences in meaning or "
-"interpretation between the original English version of these terms and a "
-"translation, the original English version takes precedence."
+msgid "Please note that in the event of any differences in meaning or interpretation between the original English version of these terms and a translation, the original English version takes precedence."
 msgstr ""
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Wikimedia Foundation should not be translated.
 #: TWLight/users/templates/users/terms.html:403
-msgid ""
-"See also the <a class=\"twl-links\" href=\"https://wikimediafoundation.org/"
-"wiki/Privacy_policy\">Wikimedia Foundation Privacy Policy</a>."
+msgid "See also the <a class=\"twl-links\" href=\"https://wikimediafoundation.org/wiki/Privacy_policy\">Wikimedia Foundation Privacy Policy</a>."
 msgstr ""
 
 #. Translators: This is the second to last line of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
@@ -3457,11 +2874,7 @@ msgstr "Quy định riêng tư của Quỹ Wikimedia"
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:426
-msgid ""
-"By checking this box and clicking “Submit”, you agree that you have read the "
-"above terms and that you will adhere to the terms of use in your application "
-"to and use of the The Wikipedia Library, and the publishers’ services to "
-"which you gain access through The Wikipedia Library program."
+msgid "By checking this box and clicking “Submit”, you agree that you have read the above terms and that you will adhere to the terms of use in your application to and use of the The Wikipedia Library, and the publishers’ services to which you gain access through The Wikipedia Library program."
 msgstr ""
 
 #: TWLight/users/templates/users/user_collection_tile.html:32
@@ -3514,29 +2927,18 @@ msgstr "Xóa tất cả dữ liệu"
 
 #. Translators: This message is displayed on the page where users can request the deletion of their data.
 #: TWLight/users/templates/users/user_confirm_delete.html:17
-msgid ""
-"<b>Warning:</b> Performing this action will delete your Wikipedia Library "
-"Card user account and all associated applications. This process is not "
-"reversible. You may lose any partner accounts you were granted, and will not "
-"be able to renew those accounts or apply for new ones."
+msgid "<b>Warning:</b> Performing this action will delete your Wikipedia Library Card user account and all associated applications. This process is not reversible. You may lose any partner accounts you were granted, and will not be able to renew those accounts or apply for new ones."
 msgstr ""
 
 #. Translators: this should show up for people who log in with a username/password and not OAuth, so we don't know what their Wikipedia identity is.
-#.
 #: TWLight/users/templates/users/user_detail.html:12
 #, python-format
-msgid ""
-"Hi, %(username)s! You don't have a Wikipedia editor profile attached to your "
-"account here, so you are probably a site administrator."
+msgid "Hi, %(username)s! You don't have a Wikipedia editor profile attached to your account here, so you are probably a site administrator."
 msgstr ""
 
 #. Translators: In the unlikely scenario that someone is able to register an account without using OAuth (thus leaving us without some of the information required for applications), users will see this message, encouraging them to re-register.
 #: TWLight/users/templates/users/user_detail.html:20
-msgid ""
-"If you aren't a site administrator, something weird has happened. You won't "
-"be able to apply for access without a Wikipedia editor profile. You should "
-"log out and create a new account by logging in via OAuth, or contact a site "
-"administrator for help."
+msgid "If you aren't a site administrator, something weird has happened. You won't be able to apply for access without a Wikipedia editor profile. You should log out and create a new account by logging in via OAuth, or contact a site administrator for help."
 msgstr ""
 
 #. Translators: Labels a sections where coordinators can select their email preferences.
@@ -3547,21 +2949,13 @@ msgstr ""
 #. Translators: This message is shown on user's own profile page, encouraging them to make sure their information is up to date, so that account coordinators can use the information to judge applications.
 #: TWLight/users/views.py:176
 #, python-brace-format
-msgid ""
-"Please <a class='twl-links' href='{url}'>update your contributions</a> to "
-"Wikipedia to help coordinators evaluate your applications."
+msgid "Please <a class='twl-links' href='{url}'>update your contributions</a> to Wikipedia to help coordinators evaluate your applications."
 msgstr ""
 
 #. Translators: Coordinators are shown this message when they unselect all three types of reminder email options under preferences.
 #: TWLight/users/views.py:288
-msgid ""
-"You have chosen not to receive reminder emails. As a coordinator, you should "
-"receive at least one type of reminder emails, so consider changing your "
-"preferences."
-msgstr ""
-"Bạn đã chọn không nhận email nhắc nhở. Với tư cách là điều phối viên, bạn sẽ "
-"nhận được ít nhất một loại email nhắc nhở, vì vậy hãy cân nhắc thay đổi tùy "
-"chọn của mình."
+msgid "You have chosen not to receive reminder emails. As a coordinator, you should receive at least one type of reminder emails, so consider changing your preferences."
+msgstr "Bạn đã chọn không nhận email nhắc nhở. Với tư cách là điều phối viên, bạn sẽ nhận được ít nhất một loại email nhắc nhở, vì vậy hãy cân nhắc thay đổi tùy chọn của mình."
 
 #. Translators: Coordinators are shown this message when they make changes to their reminder email options under preferences.
 #: TWLight/users/views.py:296
@@ -3594,13 +2988,8 @@ msgstr "Địa chỉ thư điện tử của bạn đã được đổi thành {
 
 #. Translators: If the user has not filled out their email, they can browse the website but cannot apply for access to resources.
 #: TWLight/users/views.py:487
-msgid ""
-"Your email is blank. You can still explore the site, but you won't be able "
-"to apply for access to partner resources without an email."
-msgstr ""
-"Địa chỉ thư điện tử của bạn bị thiếu. Bạn vẫn có thể tìm duyệt trang này, "
-"nhưng bạn sẽ không thể yêu cầu cấp quyền truy cập tài nguyên của bên đối tác "
-"nếu không có địa chỉ thư điện tử."
+msgid "Your email is blank. You can still explore the site, but you won't be able to apply for access to partner resources without an email."
+msgstr "Địa chỉ thư điện tử của bạn bị thiếu. Bạn vẫn có thể tìm duyệt trang này, nhưng bạn sẽ không thể yêu cầu cấp quyền truy cập tài nguyên của bên đối tác nếu không có địa chỉ thư điện tử."
 
 #. Translators: This message is shown once the access to a partner has successfully been returned.
 #: TWLight/users/views.py:801
@@ -3634,31 +3023,3 @@ msgstr ""
 msgid "10+ edits in the last 30 days"
 msgstr "10+ lần sửa đổi trong tháng qua"
 
-#: tests/shunit/data/bad_i18n_comment_1.py:3
-#: tests/shunit/data/bad_i18n_newline_1.py:5
-msgid "1"
-msgstr ""
-
-#. Translators: Lorem ipsum dolor sit amet, consectetur adipiscing elit. Mauris vitae ipsum ut purus faucibus pretium. Proin tempus neque et aliquet consectetur. Ut egestas sapien in consectetur sagittis. Mauris neque lacus, dapibus non viverra vitae, interdum ut aenean ipsum.
-#. Translators: Lorem ipsum dolor sit amet, consectetur adipiscing elit. Mauris vitae ipsum ut purus faucibus pretium. Proin tempus neque et aliquet consectetur. Ut egestas sapien in consectetur sagittis. Mauris neque lacus, dapibus non.
-#: tests/shunit/data/bad_i18n_comment_2.py:4
-#: tests/shunit/data/bad_i18n_newline_2.py:5 tests/shunit/data/good_i18n_1.py:2
-#: tests/shunit/data/good_i18n_2.py:2
-msgid "2"
-msgstr ""
-
-#: tests/shunit/data/bad_i18n_newline_3.py:5
-msgid "3"
-msgstr ""
-
-#: tests/shunit/data/bad_i18n_newline_4.py:5
-msgid "4"
-msgstr ""
-
-#: tests/shunit/data/bad_i18n_newline_5.py:5
-msgid "5"
-msgstr ""
-
-#: tests/shunit/data/bad_i18n_newline_6.py:5
-msgid "6"
-msgstr ""

--- a/locale/zh_Hans/LC_MESSAGES/django.po
+++ b/locale/zh_Hans/LC_MESSAGES/django.po
@@ -26,6 +26,7 @@
 # Author: Shizhao
 # Author: SomeyaMako
 # Author: TsuyaMarisa
+# Author: XtexChooser
 # Author: Yfdyh000
 # Author: Zfshuo
 # Author: Zhang8569
@@ -38,10 +39,11 @@
 # Author: 科劳
 msgid ""
 msgstr ""
+""
 "Project-Id-Version: Wikipedia Library Card Platform - Website\n"
-"Report-Msgid-Bugs-To: wikipedialibrary@wikimedia.org\n"
+"Report-Msgid-Bugs-To: translatewiki.net\n"
 "POT-Creation-Date: 2024-07-11 20:54+0000\n"
-"PO-Revision-Date: 2024-07-11 12:30:20+0000\n"
+"PO-Revision-Date: 2024-07-15 12:29:20+0000\n"
 "Language: zh_hans\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
@@ -73,12 +75,8 @@ msgstr "关于你"
 #. Translators: This note appears in a section of a form where we ask users to enter info (like country of residence) when applying for resource access.
 #: TWLight/applications/forms.py:179
 #, python-brace-format
-msgid ""
-"<p><small><i>Your personal data will be processed according to our <a "
-"class='twl-links' href='{terms_url}'> privacy policy</a>.</i></small></p>"
-msgstr ""
-"<p><small><i>您的个人数据将根据我们的<a class='twl-links' href='{terms_url}'>"
-"隐私政策</a>处理。</i></small></p>"
+msgid "<p><small><i>Your personal data will be processed according to our <a class='twl-links' href='{terms_url}'> privacy policy</a>.</i></small></p>"
+msgstr "<p><small><i>您的个人数据将根据我们的<a class='twl-links' href='{terms_url}'>隐私政策</a>处理。</i></small></p>"
 
 #. Translators: This is the title of the application form page, where users enter information required for the application. It lets the user know which partner application they are entering data for. {partner}
 #: TWLight/applications/forms.py:189
@@ -119,9 +117,7 @@ msgstr "您在合作伙伴网站上的账户的电子邮件地址"
 #. Translators: This labels a choice field where users will have to select the number of months they wish to have their access for as part of the application renewal confirmation.
 #. Translators: When filling out an application, users may be required to enter the length of the account (expiry) they wish to have for proxy partners.
 #: TWLight/applications/forms.py:339 TWLight/applications/helpers.py:100
-msgid ""
-"The number of months you wish to have this access for before renewal is "
-"required"
+msgid "The number of months you wish to have this access for before renewal is required"
 msgstr "您希望在需要续订之前拥有此访问权限的月数"
 
 #. Translators: When filling out an application, users may need to specify their name
@@ -210,12 +206,8 @@ msgstr "电子邮件"
 
 #. Translators: This comment is added to pending applications when our terms of use change.
 #: TWLight/applications/management/commands/notify_applicants_tou_changes.py:54
-msgid ""
-"Our terms of use have changed. Your applications will not be processed until "
-"you log in and agree to our updated terms."
-msgstr ""
-"我们的使用条款已变更。 您必须先登录并同意我们已更新的条款，否则您的申请将不会"
-"得到处理。"
+msgid "Our terms of use have changed. Your applications will not be processed until you log in and agree to our updated terms."
+msgstr "我们的使用条款已变更。 您必须先登录并同意我们已更新的条款，否则您的申请将不会得到处理。"
 
 #. Translators: This is the status of an application that has not yet been reviewed.
 #: TWLight/applications/models.py:54
@@ -281,23 +273,17 @@ msgstr "访问网址：{access_url}"
 
 #. Translators: This text goes into account approval emails in the case that we need to send the user's details to a publisher for manual account setup.
 #: TWLight/applications/models.py:331
-msgid ""
-"You can expect to receive access details within a week or two once it has "
-"been processed."
+msgid "You can expect to receive access details within a week or two once it has been processed."
 msgstr "预计您可能会在处理后的一两周内收到访问权限的详细信息。"
 
 #. Translators: This comment is added to open applications when a partner joins the Library Bundle, which does not require applications.
 #: TWLight/applications/signals.py:247
-msgid ""
-"This partner joined the Library Bundle, which does not require applications. "
-"This application will be marked as invalid."
+msgid "This partner joined the Library Bundle, which does not require applications. This application will be marked as invalid."
 msgstr "该合作伙伴加入了“Library Bundle”，不需要申请。 该申请将被标记为无效。"
 
 #. Translators: This is shown to users if the application is to a partner for which we have run out of available accounts. The application is therefore on a 'waitlist', and will be reviewed when more accounts are available.
 #: TWLight/applications/templates/applications/application_evaluation.html:29
-msgid ""
-"This application is on the waitlist because this partner does not have any "
-"access grants available at this time."
+msgid "This application is on the waitlist because this partner does not have any access grants available at this time."
 msgstr "该申请正在在等待队列中，因为目前该和做伙伴没有任何可用的访问授权。"
 
 #. Translators: This message is shown on pages where coordinators can see personal information about applicants.
@@ -305,11 +291,8 @@ msgstr "该申请正在在等待队列中，因为目前该和做伙伴没有任
 #: TWLight/applications/templates/applications/application_list_include.html:6
 #: TWLight/applications/templates/applications/send_partner.html:45
 #: TWLight/resources/templates/resources/partner_users.html:18
-msgid ""
-"Coordinators: This page may contain personal information such as real names "
-"and email addresses. Please remember that this information is confidential."
-msgstr ""
-"协调员：此页面可能包含个人信息，如实名和电子邮件地址。谨记这些信息是保密的。"
+msgid "Coordinators: This page may contain personal information such as real names and email addresses. Please remember that this information is confidential."
+msgstr "协调员：此页面可能包含个人信息，如实名和电子邮件地址。谨记这些信息是保密的。"
 
 #. Translators: This is the title of the application page shown to users who are a coordinator, and are able to accept or reject the application.
 #: TWLight/applications/templates/applications/application_evaluation.html:39
@@ -318,9 +301,7 @@ msgstr "评估申请"
 
 #. Translators: This text is shown to coordinators on application pages if the applicant has restricted processing of their data.
 #: TWLight/applications/templates/applications/application_evaluation.html:42
-msgid ""
-"This user has requested a restriction on the processing of their data, so "
-"you cannot change the status of their application."
+msgid "This user has requested a restriction on the processing of their data, so you cannot change the status of their application."
 msgstr "该用户请求对其数据处理进行限制，因此您无法更改其申请的状态。"
 
 #. Translators: This is the title of the application page shown to users who are not a coordinator.
@@ -394,9 +375,7 @@ msgstr "未知"
 
 #. Translators: This is the text displayed to coordinators when an applicant has no country of residence in their profile.
 #: TWLight/applications/templates/applications/application_evaluation.html:123
-msgid ""
-"Please request the applicant add their country of residence to their profile "
-"before proceeding further."
+msgid "Please request the applicant add their country of residence to their profile before proceeding further."
 msgstr "请要求申请人在其个人资料中添加居住地之后再继续。"
 
 #. Translators: This labels the section of an application showing the total number of accounts available for a partner or their collection.
@@ -407,9 +386,7 @@ msgstr "可用账户"
 #. Translators: This labels the section of an application showing whether the user had agreed to the terms of use or not.
 #: TWLight/applications/templates/applications/application_evaluation.html:145
 #, python-format
-msgid ""
-"Has agreed to the site's <a class=\"twl-links\" href=\"%(terms_url)s\">terms "
-"of use</a>?"
+msgid "Has agreed to the site's <a class=\"twl-links\" href=\"%(terms_url)s\">terms of use</a>?"
 msgstr "是否同意该站点的<a href=\"%(terms_url)s\">使用条款</a>？"
 
 #. Translators: Displayed to coordinators when they've agreed to the terms of use.
@@ -445,9 +422,7 @@ msgstr "否"
 
 #. Translators: This is the text displayed to coordinators when an applicant has not agreed to the terms of use.
 #: TWLight/applications/templates/applications/application_evaluation.html:159
-msgid ""
-"Please request the applicant agree to the site's terms of use before "
-"approving this application."
+msgid "Please request the applicant agree to the site's terms of use before approving this application."
 msgstr "请要求申请人同意网站的使用条款后再批准。"
 
 #. Translators: This labels the section of an application containing the user's motivation for wanting access to this resource.
@@ -468,8 +443,7 @@ msgstr "续订现有的访问授权？"
 #. Translators: This message is shown next to the 'Renewal of existing access grant?' label if the application is a renewal. Don't translate HTML tags or parent_url.
 #: TWLight/applications/templates/applications/application_evaluation.html:195
 #, python-format
-msgid ""
-"Yes (<a class=\"twl-links\" href=\"%(parent_url)s\">previous application</a>)"
+msgid "Yes (<a class=\"twl-links\" href=\"%(parent_url)s\">previous application</a>)"
 msgstr "是（<a href=\"%(parent_url)s\">之前的申请</a>）"
 
 #. Translators: This labels the section of the application showing the length of access remaining on the user's previous authorization.
@@ -504,9 +478,7 @@ msgstr "留言"
 
 #. Translators: On an application page, this text tells users that the comments posted on the application are visible to coordinators and the submitting user only.
 #: TWLight/applications/templates/applications/application_evaluation.html:297
-msgid ""
-"Comments are visible to all coordinators and to the editor who submitted "
-"this application."
+msgid "Comments are visible to all coordinators and to the editor who submitted this application."
 msgstr "所有的协调员和提交此申请的编者都可以看到留言。"
 
 #. Translators: This is the title of the section of an application page which lists information about the user who submitted the application.
@@ -718,16 +690,8 @@ msgstr "设置状态"
 
 #: TWLight/applications/templates/applications/apply.html:20
 #, python-format
-msgid ""
-"If your application is successful we may share your email address with "
-"%(partner)s. This is required to set up your access to their resources. By "
-"submitting this form you agree to allow your email address to be shared with "
-"%(partner)s if your application is successful, for the purposes of account "
-"setup."
-msgstr ""
-"在您的申请获准后，我们可能与%(partner)s分享您的电子邮件地址。这是设定您有权访"
-"问其资源的必要条件。提交此表单即代表您同意在申请获准后与%(partner)s分享您的电"
-"子邮件地址用于设定账户。"
+msgid "If your application is successful we may share your email address with %(partner)s. This is required to set up your access to their resources. By submitting this form you agree to allow your email address to be shared with %(partner)s if your application is successful, for the purposes of account setup."
+msgstr "在您的申请获准后，我们可能与%(partner)s分享您的电子邮件地址。这是设定您有权访问其资源的必要条件。提交此表单即代表您同意在申请获准后与%(partner)s分享您的电子邮件地址用于设定账户。"
 
 #. Translators: This message is displayed on the page where users can confirm their renewal. Please do not translate partner.
 #: TWLight/applications/templates/applications/confirm_renewal.html:23
@@ -755,9 +719,7 @@ msgstr "您想访问哪些资源？"
 
 #. Translators: This text explains that Library Bundle partners are not shown in this list.
 #: TWLight/applications/templates/applications/request_for_application.html:26
-msgid ""
-"Library Bundle partners are not shown as eligibility is determined "
-"automatically."
+msgid "Library Bundle partners are not shown as eligibility is determined automatically."
 msgstr "Library Bundle合作伙伴未显示，其资格自动确定。"
 
 #. Translators: On the page where users can apply for multiple partners, this message shows next to the partner name, taking them to the full application page when clicked.
@@ -772,14 +734,8 @@ msgstr "尚未添加任何合作伙伴数据。"
 
 #. Translators: the HTML is so that the word 'waitlisted' will look the same as it does in the page above; please translate 'waitlisted' the same way you did elsewhere in this file.
 #: TWLight/applications/templates/applications/request_for_application.html:74
-msgid ""
-"You can apply to <span class=\"badge badge-warning\">Waitlisted</span> "
-"partners, but they don't have access grants available right now. We will "
-"process those applications when access becomes available."
-msgstr ""
-"您可以向位于<span class=\"badge badge-warning\">等待队列</span>中的合作伙伴提"
-"出申请，但是他们现在没有可用的访问授权。当访问变得可用时，我们将处理这些申"
-"请。"
+msgid "You can apply to <span class=\"badge badge-warning\">Waitlisted</span> partners, but they don't have access grants available right now. We will process those applications when access becomes available."
+msgstr "您可以向位于<span class=\"badge badge-warning\">等待队列</span>中的合作伙伴提出申请，但是他们现在没有可用的访问授权。当访问变得可用时，我们将处理这些申请。"
 
 #. Translators: On the page where coordinators can see approved applications which have not had their details sent to the partner, this message shows when there are applications ready to be processed.
 #: TWLight/applications/templates/applications/send.html:10
@@ -800,12 +756,8 @@ msgstr "%(object)s的申请数据"
 #. Translators: This message is shown when applications exceed the number of accounts available.
 #: TWLight/applications/templates/applications/send_partner.html:54
 #, python-format
-msgid ""
-"Application(s) for %(object)s, if sent, will exceed the total available "
-"accounts for the partner. Please proceed at your own discretion."
-msgstr ""
-"如果发送%(object)s的申请，则将超过合作伙伴的可用账户总数。请自行决定是否继"
-"续。"
+msgid "Application(s) for %(object)s, if sent, will exceed the total available accounts for the partner. Please proceed at your own discretion."
+msgstr "如果发送%(object)s的申请，则将超过合作伙伴的可用账户总数。请自行决定是否继续。"
 
 #. Translators: When viewing the list of applications ready to be sent for a particular partner, this is instructions for the coordinator to click the 'mark as sent' button after they have sent the information.
 #: TWLight/applications/templates/applications/send_partner.html:65
@@ -820,9 +772,7 @@ msgstr[0] "联系人"
 
 #. Translators: When viewing the list of applications ready to be sent for a particular partner, this message shows if there is no information about who the applications should be sent to. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/applications/templates/applications/send_partner.html:89
-msgid ""
-"Whoops, we don't have any listed contacts. Please notify Wikipedia Library "
-"administrators."
+msgid "Whoops, we don't have any listed contacts. Please notify Wikipedia Library administrators."
 msgstr "糟糕，我们没有列出任何联系人。请通知维基百科图书馆管理员。"
 
 #. Translators: When viewing the list of applications ready to be sent for a particular partner, this is the title of the section containing the information about those applications.
@@ -838,12 +788,8 @@ msgstr "标为发送"
 
 #. Translators: This text guides coordinators in using the code sending interface for approved applications.
 #: TWLight/applications/templates/applications/send_partner.html:152
-msgid ""
-"Use the dropdown menus to denote which editor will receive each code. Access "
-"codes will be sent to users automatically."
-msgstr ""
-"使用下拉菜单指定每个编者将要收到的代码。在单击\"标记为发送\"之前，请确保通过"
-"电子邮件发送了访问授权代码。"
+msgid "Use the dropdown menus to denote which editor will receive each code. Access codes will be sent to users automatically."
+msgstr "使用下拉菜单指定每个编者将要收到的代码。在单击\"标记为发送\"之前，请确保通过电子邮件发送了访问授权代码。"
 
 #. Translators: This labels a drop-down selection where staff can assign an access code to a user.
 #: TWLight/applications/templates/applications/send_partner.html:173
@@ -858,22 +804,14 @@ msgstr "没有已批准且未发送的申请。"
 #. Translators: When a user applies for a set of resources, they receive this message if none are currently available. They are instead placed on a 'waitlist' for later approval.
 #. Translators: When a user renews their resource, they receive this message if none are currently available. They are instead placed on a 'waitlist' for later approval.
 #: TWLight/applications/views.py:140 TWLight/applications/views.py:1282
-msgid ""
-"This partner does not have any access grants available at this time. You may "
-"still apply for access; your application will be reviewed when access grants "
-"become available."
-msgstr ""
-"该合作伙伴目前没有可用的访问授权。您仍然可以申请访问；当访问授权可用时，您的"
-"申请将被审核。"
+msgid "This partner does not have any access grants available at this time. You may still apply for access; your application will be reviewed when access grants become available."
+msgstr "该合作伙伴目前没有可用的访问授权。您仍然可以申请访问；当访问授权可用时，您的申请将被审核。"
 
 #. Translators: This message is shown to users once they've successfully submitted their application for review.
 #: TWLight/applications/views.py:163
 #, python-brace-format
-msgid ""
-"Your application has been submitted for review. Head over to <a "
-"href='{applications_url}'>My Applications</a> to view the status."
-msgstr ""
-"您的申请已提交审核。前往<a href='{applications_url}'>我的申请</a>查看状态。"
+msgid "Your application has been submitted for review. Head over to <a href='{applications_url}'>My Applications</a> to view the status."
+msgstr "您的申请已提交审核。前往<a href='{applications_url}'>我的申请</a>查看状态。"
 
 #. Translators: This text is displayed to users when the user has chosen to restrict data and is trying to apply for multiple partners
 #: TWLight/applications/views.py:276
@@ -921,19 +859,13 @@ msgstr "发送申请"
 
 #. Translators: After a coordinator has changed the status of an application to APPROVED, if the corresponding partner/collection is waitlisted this message appears.
 #: TWLight/applications/views.py:756
-msgid ""
-"Cannot approve application as partner with proxy authorization method is "
-"waitlisted."
+msgid "Cannot approve application as partner with proxy authorization method is waitlisted."
 msgstr "由于采用代理授权法的合作伙伴已列入等待队列，因此无法批准申请。"
 
 #. Translators: After a coordinator has changed the status of an application to APPROVED, if the corresponding partner/collection has no accounts for distribution, this message appears.
 #: TWLight/applications/views.py:780
-msgid ""
-"Cannot approve application as partner with proxy authorization method is "
-"waitlisted and (or) has zero accounts available for distribution."
-msgstr ""
-"由于采用代理授权法的合作伙伴已列入等待队列，并且（或）有零个帐户可供分配，因"
-"此无法批准该申请。"
+msgid "Cannot approve application as partner with proxy authorization method is waitlisted and (or) has zero accounts available for distribution."
+msgstr "由于采用代理授权法的合作伙伴已列入等待队列，并且（或）有零个帐户可供分配，因此无法批准该申请。"
 
 #. Translators: This message appears on an "access denied" screen that stops users who attempt to authorize an editor to access a resource during a time period for which they are already authorized.
 #: TWLight/applications/views.py:803
@@ -943,15 +875,8 @@ msgstr "您试图创建重复的授权。"
 #. Translators: This message is shown to users when they access an application page of a now Bundle partner (new applications aren't allowed for Bundle partners and the status of old applications cannot be modified)
 #: TWLight/applications/views.py:857
 #, python-brace-format
-msgid ""
-"This application cannot be modified since this partner is now part of our <a "
-"href='{bundle}'>bundle access</a>. If you are eligible, you can access this "
-"resource from <a href='{library}'>your library</a>. <a "
-"href='{contact}'>Contact us</a> if you have any questions."
-msgstr ""
-"该合作伙伴现在是我们<a href='{bundle}'>打包访问</a>的一部分，因此无法变更此申"
-"请。如果您符合资格，则可以从 <a href='{library}'>你的图书馆</a>访问此资源。如"
-"有任何疑问，请<a href='{contact}'>与我们联系</a>。"
+msgid "This application cannot be modified since this partner is now part of our <a href='{bundle}'>bundle access</a>. If you are eligible, you can access this resource from <a href='{library}'>your library</a>. <a href='{contact}'>Contact us</a> if you have any questions."
+msgstr "该合作伙伴现在是我们<a href='{bundle}'>打包访问</a>的一部分，因此无法变更此申请。如果您符合资格，则可以从 <a href='{library}'>你的图书馆</a>访问此资源。如有任何疑问，请<a href='{contact}'>与我们联系</a>。"
 
 #. Translators: this lets a reviewer set the status of a single application.
 #: TWLight/applications/views.py:873
@@ -960,9 +885,7 @@ msgstr "设置申请状态"
 
 #. Translators: This warning is message is shown to applicants when the number of pending applications is greater than the number of accounts available.
 #: TWLight/applications/views.py:891
-msgid ""
-"There are more pending applications than available accounts. Your "
-"application might get waitlisted."
+msgid "There are more pending applications than available accounts. Your application might get waitlisted."
 msgstr "有待处理的申请多于可用帐户。您的申请可能会被列入等待队列。"
 
 #. Translators: this message is shown to coordinators who attempt to change an application's Status from INVALID to any other Status.
@@ -982,15 +905,8 @@ msgstr "批量更新申请{}成功。"
 
 #. Translators: After a coordinator has changed the status of a number of applications to APPROVED, if the corresponding partner(s) is/are waitlisted or has no accounts for distribution, this message appears.
 #: TWLight/applications/views.py:1051
-msgid ""
-"Cannot approve application(s) {} as partner(s) with proxy authorization "
-"method is/are waitlisted and (or) has/have not enough accounts available. If "
-"not enough accounts are available, prioritise the applications and then "
-"approve applications equal to the accounts available."
-msgstr ""
-"由于采用代理授权法的合作伙伴已列入等待队列，并且（或）没有足够的可用帐户，因"
-"此无法批准{}申请。如果没有足够的可用帐户，请对申请进行优先级排序，然后批准与"
-"可用帐户数相等的申请。"
+msgid "Cannot approve application(s) {} as partner(s) with proxy authorization method is/are waitlisted and (or) has/have not enough accounts available. If not enough accounts are available, prioritise the applications and then approve applications equal to the accounts available."
+msgstr "由于采用代理授权法的合作伙伴已列入等待队列，并且（或）没有足够的可用帐户，因此无法批准{}申请。如果没有足够的可用帐户，请对申请进行优先级排序，然后批准与可用帐户数相等的申请。"
 
 #. Translators: This message is shown to coordinators who attempt to assign the same access code to multiple users.
 #: TWLight/applications/views.py:1191
@@ -1004,12 +920,8 @@ msgstr "所有选定的申请都已被标记为发送。"
 
 #. Translators: When a user tries to renew their resource, they receive this message if the partner is not available.
 #: TWLight/applications/views.py:1272
-msgid ""
-"Cannot renew application at this time as partner is not available. Please "
-"check back later, or contact us for more information."
-msgstr ""
-"由于目前合作伙伴不可用，因此无法续订申请。请稍后再回来检查，或与我们联系以获"
-"取更多信息。"
+msgid "Cannot renew application at this time as partner is not available. Please check back later, or contact us for more information."
+msgstr "由于目前合作伙伴不可用，因此无法续订申请。请稍后再回来检查，或与我们联系以获取更多信息。"
 
 #. Translators: This message is displayed when an attempt by a user to renew an application has been denied for some reason.
 #: TWLight/applications/views.py:1308
@@ -1019,16 +931,12 @@ msgstr "尝试续订未经批准的申请#{pk}已被拒绝"
 
 #. Translators: If a user requests the renewal of their account, but it wasn't renewed, this message is shown to them.
 #: TWLight/applications/views.py:1385
-msgid ""
-"This object cannot be renewed. (This probably means that you have already "
-"requested that it be renewed.)"
+msgid "This object cannot be renewed. (This probably means that you have already requested that it be renewed.)"
 msgstr "该对象无法续订。（这可能意味着您已经请求过续订了。）"
 
 #. Translators: If a user requests the renewal of their account, this message is shown to them.
 #: TWLight/applications/views.py:1395
-msgid ""
-"Your renewal request has been received. A coordinator will review your "
-"request."
+msgid "Your renewal request has been received. A coordinator will review your request."
 msgstr "您的续订请求已经收到。协调员会审核你的请求。"
 
 #. Translators: This labels a textfield where users can enter their email ID.
@@ -1038,12 +946,8 @@ msgstr "你的电子邮件"
 
 #. Translators: This is the help text for the email field in the contact us form letting users know the field is updated by value pulled from their respective user profiles.
 #: TWLight/emails/forms.py:21
-msgid ""
-"This field is automatically updated with the email from your <a class='twl-"
-"links' href='{}'>user profile</a>."
-msgstr ""
-"该字段会自动使用您的<a class='twl-links' href='{}'>用户个人资料</a>中的电子邮"
-"件进行更新。"
+msgid "This field is automatically updated with the email from your <a class='twl-links' href='{}'>user profile</a>."
+msgstr "该字段会自动使用您的<a class='twl-links' href='{}'>用户个人资料</a>中的电子邮件进行更新。"
 
 #. Translators: This labels a textfield where users can enter their email message.
 #: TWLight/emails/forms.py:26
@@ -1066,24 +970,14 @@ msgstr "提交"
 #. Translators: This email is sent to users with their access code. Don't translate Jinja variables in curly braces like user or partner. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/access_code_email-body-html.html:5
 #, python-format
-msgid ""
-"<p>Your approved application to %(partner)s has now been finalised. Your "
-"access code or login details can be found below:</p> <p><b>%(access_code)s</"
-"b></p> <p>%(user_instructions)s</p>"
-msgstr ""
-"<p>您对%(partner)s的申请现已批准。您的访问代码或登录详细信息可以在下面找到："
-"</p> <p><b>%(access_code)s</b></p> <p>%(user_instructions)s</p>"
+msgid "<p>Your approved application to %(partner)s has now been finalised. Your access code or login details can be found below:</p> <p><b>%(access_code)s</b></p> <p>%(user_instructions)s</p>"
+msgstr "<p>您对%(partner)s的申请现已批准。您的访问代码或登录详细信息可以在下面找到：</p> <p><b>%(access_code)s</b></p> <p>%(user_instructions)s</p>"
 
 #. Translators: This email is sent to users with their access code. Don't translate Jinja variables in curly braces like user or partner. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/access_code_email-body-text.html:3
 #, python-format
-msgid ""
-"Your approved application to %(partner)s has now been finalised. Your access "
-"code or login details can be found below: %(access_code)s "
-"%(user_instructions)s"
-msgstr ""
-"您对%(partner)s的申请现已批准。您的访问代码或登录详细信息可以在下面找到："
-"%(access_code)s %(user_instructions)s"
+msgid "Your approved application to %(partner)s has now been finalised. Your access code or login details can be found below: %(access_code)s %(user_instructions)s"
+msgstr "您对%(partner)s的申请现已批准。您的访问代码或登录详细信息可以在下面找到：%(access_code)s %(user_instructions)s"
 
 #. Translators: This is the subject line of an email sent to users with their access code.
 #: TWLight/emails/templates/emails/access_code_email-subject.html:3
@@ -1093,31 +987,14 @@ msgstr "您的维基百科图书馆访问代码"
 #. Translators: This email is sent to users when their application is approved. Don't translate Jinja variables in curly braces like user or partner; don't translate html tags either. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/approval_notification-body-html.html:5
 #, python-format
-msgid ""
-"<p>Dear %(user)s,</p> <p>Thank you for applying for access to %(partner)s "
-"resources through The Wikipedia Library. We are happy to inform you that "
-"your application has been approved.</p> <p>%(user_instructions)s</p> <p>You "
-"can view the collections you're authorized to access at My Library: "
-"%(link)s</p> <p>Cheers!</p> <p>The Wikipedia Library</p>"
-msgstr ""
-"<p>尊敬的%(user)s，</p><p>感谢您通过维基百科图书馆申请访问%(partner)s的资源。"
-"我们很高兴地通知您，您的申请已获批准。</p> <p>%(user_instructions)s</p><p>您"
-"可以在“我的图书馆”中查看您有权访问的馆藏：%(link)s</p> <p>再会！</p> <p>维基"
-"百科图书馆</p>"
+msgid "<p>Dear %(user)s,</p> <p>Thank you for applying for access to %(partner)s resources through The Wikipedia Library. We are happy to inform you that your application has been approved.</p> <p>%(user_instructions)s</p> <p>You can view the collections you're authorized to access at My Library: %(link)s</p> <p>Cheers!</p> <p>The Wikipedia Library</p>"
+msgstr "<p>尊敬的%(user)s，</p><p>感谢您通过维基百科图书馆申请访问%(partner)s的资源。我们很高兴地通知您，您的申请已获批准。</p> <p>%(user_instructions)s</p><p>您可以在“我的图书馆”中查看您有权访问的馆藏：%(link)s</p> <p>再会！</p> <p>维基百科图书馆</p>"
 
 #. Translators: This email is sent to users when their application is approved. Don't translate Jinja variables in curly braces like user or partner. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/approval_notification-body-text.html:3
 #, python-format
-msgid ""
-"Dear %(user)s, Thank you for applying for access to %(partner)s resources "
-"through The Wikipedia Library. We are happy to inform you that your "
-"application has been approved. %(user_instructions)s You can view the "
-"collections you're authorized to access at My Library: %(link)s Cheers! The "
-"Wikipedia Library"
-msgstr ""
-"尊敬的%(user)s，感谢您通过维基百科图书馆申请访问%(partner)s的资源。我们很高兴"
-"地通知您，您的申请已获批准。%(user_instructions)s您可以在“我的图书馆”中查看您"
-"有权访问的馆藏：%(link)s再会！维基百科图书馆"
+msgid "Dear %(user)s, Thank you for applying for access to %(partner)s resources through The Wikipedia Library. We are happy to inform you that your application has been approved. %(user_instructions)s You can view the collections you're authorized to access at My Library: %(link)s Cheers! The Wikipedia Library"
+msgstr "尊敬的%(user)s，感谢您通过维基百科图书馆申请访问%(partner)s的资源。我们很高兴地通知您，您的申请已获批准。%(user_instructions)s您可以在“我的图书馆”中查看您有权访问的馆藏：%(link)s再会！维基百科图书馆"
 
 #. Translators: This is the subject of an email which is sent to users when their application has been approved. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/approval_notification-subject.html:4
@@ -1127,25 +1004,14 @@ msgstr "您的维基百科图书馆申请已批准"
 #. Translators: This email is sent to coordinators when a comment is left on an application they are processing. Don't translate Jinja variables in curly braces like user or partner. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/comment_notification_coordinator-body-html.html:5
 #, python-format
-msgid ""
-"<p style=\"color: #500050\">%(submit_date)s - %(commenter)s</p> "
-"<blockquote><p>%(comment)s</p></blockquote> <p>Please reply to these at: <a "
-"href=\"%(app_url)s\">%(app_url)s</a></p> <p>Best,</p> <p>The Wikipedia "
-"Library</p>"
-msgstr ""
-"<p style=\"color: #500050\">%(submit_date)s - %(commenter)s</p> "
-"<blockquote><p>%(comment)s</p></blockquote> <p>回复请访问一下网址：<a href="
-"\"%(app_url)s\">%(app_url)s</a></p> <p>祝好，</p> <p>维基百科图书馆</p>"
+msgid "<p style=\"color: #500050\">%(submit_date)s - %(commenter)s</p> <blockquote><p>%(comment)s</p></blockquote> <p>Please reply to these at: <a href=\"%(app_url)s\">%(app_url)s</a></p> <p>Best,</p> <p>The Wikipedia Library</p>"
+msgstr "<p style=\"color: #500050\">%(submit_date)s - %(commenter)s</p> <blockquote><p>%(comment)s</p></blockquote> <p>回复请访问一下网址：<a href=\"%(app_url)s\">%(app_url)s</a></p> <p>祝好，</p> <p>维基百科图书馆</p>"
 
 #. Translators: This email is sent to coordinators when a comment is left on an application they are processing. Don't translate Jinja variables in curly braces like user or partner. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/comment_notification_coordinator-body-text.html:3
 #, python-format
-msgid ""
-"%(submit_date)s - %(commenter)s %(comment)s Please reply to this at: "
-"%(app_url)s Best, The Wikipedia Library"
-msgstr ""
-"%(submit_date)s - %(commenter)s %(comment)s请到这里回复：%(app_url)s 祝好，维"
-"基百科图书馆"
+msgid "%(submit_date)s - %(commenter)s %(comment)s Please reply to this at: %(app_url)s Best, The Wikipedia Library"
+msgstr "%(submit_date)s - %(commenter)s %(comment)s请到这里回复：%(app_url)s 祝好，维基百科图书馆"
 
 #. Translators: This is the subject line of an email sent to coordinators when a comment is left on an application they processed.
 #: TWLight/emails/templates/emails/comment_notification_coordinator-subject.html:3
@@ -1155,26 +1021,14 @@ msgstr "有新留言在您处理的维基百科图书馆申请中"
 #. Translators: This email is sent to users when they receive a comment on their application. Don't translate Jinja variables in curly braces like user or partner; don't translate html tags either. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/comment_notification_editors-body-html.html:5
 #, python-format
-msgid ""
-"<p style=\"color: #500050\">%(submit_date)s - %(commenter)s</p> "
-"<blockquote><p>%(comment)s</p></blockquote> <p>Please reply to these at <a "
-"href=\"%(app_url)s\">%(app_url)s</a> so we can evaluate your application.</"
-"p> <p>Best,</p> <p>The Wikipedia Library</p>"
-msgstr ""
-"<p style=\"color: #500050\">%(submit_date)s - %(commenter)s</p> "
-"<blockquote><p>%(comment)s</p></blockquote> <p>请在<a href=\"%(app_url)s\">"
-"%(app_url)s</a>进行回复，这样我们就可以评估您的申请。</p><p>祝好，</p><p>维基"
-"百科图书馆</p>"
+msgid "<p style=\"color: #500050\">%(submit_date)s - %(commenter)s</p> <blockquote><p>%(comment)s</p></blockquote> <p>Please reply to these at <a href=\"%(app_url)s\">%(app_url)s</a> so we can evaluate your application.</p> <p>Best,</p> <p>The Wikipedia Library</p>"
+msgstr "<p style=\"color: #500050\">%(submit_date)s - %(commenter)s</p> <blockquote><p>%(comment)s</p></blockquote> <p>请在<a href=\"%(app_url)s\">%(app_url)s</a>进行回复，这样我们就可以评估您的申请。</p><p>祝好，</p><p>维基百科图书馆</p>"
 
 #. Translators: This email is sent to users when they receive a comment on their application. Don't translate Jinja variables in curly braces like user or partner. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/comment_notification_editors-body-text.html:3
 #, python-format
-msgid ""
-"%(submit_date)s - %(commenter)s %(comment)s Please reply to these at: "
-"%(app_url)s so we can evaluate your application. Best, The Wikipedia Library"
-msgstr ""
-"%(submit_date)s - %(commenter)s %(comment)s请在这里回复：%(app_url)s 如此我们"
-"才可以评估您的申请。祝好，维基百科图书馆"
+msgid "%(submit_date)s - %(commenter)s %(comment)s Please reply to these at: %(app_url)s so we can evaluate your application. Best, The Wikipedia Library"
+msgstr "%(submit_date)s - %(commenter)s %(comment)s请在这里回复：%(app_url)s 如此我们才可以评估您的申请。祝好，维基百科图书馆"
 
 #. Translators: This is the subject line of an email sent to users who have a comment added to one of their applications. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/comment_notification_editors-subject.html:3
@@ -1184,24 +1038,14 @@ msgstr "新留言在您的维基百科图书馆申请中"
 #. Translators: This email is sent to users when an application they commented on receives another comment. Don't translate Jinja variables in curly braces like app_url; don't translate html tags either. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/comment_notification_others-body-html.html:5
 #, python-format
-msgid ""
-"<p style=\"color: #500050\">%(submit_date)s - %(commenter)s</p> "
-"<blockquote><p>%(comment)s</p></blockquote> See it at <a href=\"%(app_url)s"
-"\">%(app_url)s</a>. Thanks for helping review Wikipedia Library applications!"
-msgstr ""
-"<p style=\"color: #500050\">%(submit_date)s - %(commenter)s</p> "
-"<blockquote><p>%(comment)s</p></blockquote>在<a href=\"%(app_url)s\">"
-"%(app_url)s</a>中查看。感谢帮助审核维基百科图书馆申请！"
+msgid "<p style=\"color: #500050\">%(submit_date)s - %(commenter)s</p> <blockquote><p>%(comment)s</p></blockquote> See it at <a href=\"%(app_url)s\">%(app_url)s</a>. Thanks for helping review Wikipedia Library applications!"
+msgstr "<p style=\"color: #500050\">%(submit_date)s - %(commenter)s</p> <blockquote><p>%(comment)s</p></blockquote>在<a href=\"%(app_url)s\">%(app_url)s</a>中查看。感谢帮助审核维基百科图书馆申请！"
 
 #. Translators: This email is sent to users when an application they commented on receives another comment. Don't translate Jinja variables in curly braces like app_url. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/comment_notification_others-body-text.html:3
 #, python-format
-msgid ""
-"%(submit_date)s - %(commenter)s %(comment)s See it at: %(app_url)s Thanks "
-"for helping review Wikipedia Library applications!"
-msgstr ""
-"%(submit_date)s - %(commenter)s %(comment)s参见：%(app_url)s感谢帮助审核维基"
-"百科图书馆申请！"
+msgid "%(submit_date)s - %(commenter)s %(comment)s See it at: %(app_url)s Thanks for helping review Wikipedia Library applications!"
+msgstr "%(submit_date)s - %(commenter)s %(comment)s参见：%(app_url)s感谢帮助审核维基百科图书馆申请！"
 
 #. Translators: This is the subject line of an email sent to users who have a comment added to an application they also commented on. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/comment_notification_others-subject.html:4
@@ -1211,13 +1055,8 @@ msgstr "新留言在您维基百科图书馆申请的留言中"
 #. Translators: This text is part of a scheduled reminder email sent to coordinators who have applications requiring action. Don't translate Jinja variables in curly braces like total_apps, or user.
 #: TWLight/emails/templates/emails/coordinator_reminder_notification-body-html.html:5
 #, python-format
-msgid ""
-"<p>Dear %(user)s,</p> <p>Our records indicate that you are the designated "
-"coordinator for partners that have a total of %(total_apps)s applications.</"
-"p>"
-msgstr ""
-"<p>尊敬的%(user)s，</p><p>我们的记录表明，您总共有%(total_apps)s个申请的合作"
-"伙伴指定协调员</p>"
+msgid "<p>Dear %(user)s,</p> <p>Our records indicate that you are the designated coordinator for partners that have a total of %(total_apps)s applications.</p>"
+msgstr "<p>尊敬的%(user)s，</p><p>我们的记录表明，您总共有%(total_apps)s个申请的合作伙伴指定协调员</p>"
 
 #. Translators: Breakdown as in 'cost breakdown'; analysis.
 #: TWLight/emails/templates/emails/coordinator_reminder_notification-body-html.html:11
@@ -1252,41 +1091,20 @@ msgstr[0] "%(counter)s个批准的申请。"
 #. Translators: This text is part of a scheduled reminder email sent to coordinators who have applications requiring action. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library). Don't translate Jinja variables in curly braces like link; don't translate email addresses or html tags either.
 #: TWLight/emails/templates/emails/coordinator_reminder_notification-body-html.html:39
 #, python-format
-msgid ""
-"<p>This is a gentle reminder that you may review applications at <a href="
-"\"%(link)s\">%(link)s</a>.</p> <p>You can customise your reminders under "
-"'preferences' in your user profile.</p> <p>If you received this message in "
-"error, drop us a line at wikipedialibrary@wikimedia.org.</p> <p>Thanks for "
-"helping review Wikipedia Library applications!</p>"
-msgstr ""
-"<p>这是一个温馨的提醒，您可以在<a href=\"%(link)s\">%(link)s</a>中查看申请。"
-"</p><p>您可以在您的用户个人资料的“首选项”中自定义提醒。</p><p>如果您收到此消"
-"息有误，请通过wikipedialibrary@wikimedia.org给我们留言。</p><p>感谢您帮助审核"
-"维基百科图书馆的申请！<p>"
+msgid "<p>This is a gentle reminder that you may review applications at <a href=\"%(link)s\">%(link)s</a>.</p> <p>You can customise your reminders under 'preferences' in your user profile.</p> <p>If you received this message in error, drop us a line at wikipedialibrary@wikimedia.org.</p> <p>Thanks for helping review Wikipedia Library applications!</p>"
+msgstr "<p>这是一个温馨的提醒，您可以在<a href=\"%(link)s\">%(link)s</a>中查看申请。</p><p>您可以在您的用户个人资料的“首选项”中自定义提醒。</p><p>如果您收到此消息有误，请通过wikipedialibrary@wikimedia.org给我们留言。</p><p>感谢您帮助审核维基百科图书馆的申请！<p>"
 
 #. Translators: This text is part of a scheduled reminder email sent to coordinators who have applications requiring action. Don't translate Jinja variables in curly braces like total_apps, or user.
 #: TWLight/emails/templates/emails/coordinator_reminder_notification-body-text.html:3
 #, python-format
-msgid ""
-"Dear %(user)s, Our records indicate that you are the designated coordinator "
-"for partners that have a total of %(total_apps)s applications."
-msgstr ""
-"尊敬的%(user)s，我们的记录表明您是拥有%(total_apps)s个申请的合作伙伴的指定协"
-"调员。"
+msgid "Dear %(user)s, Our records indicate that you are the designated coordinator for partners that have a total of %(total_apps)s applications."
+msgstr "尊敬的%(user)s，我们的记录表明您是拥有%(total_apps)s个申请的合作伙伴的指定协调员。"
 
 #. Translators: This text is part of a scheduled reminder email sent to coordinators who have applications requiring action. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library). Don't translate Jinja variables in curly braces like link; don't translate the email address either.
 #: TWLight/emails/templates/emails/coordinator_reminder_notification-body-text.html:38
 #, python-format
-msgid ""
-"This is a gentle reminder that you may review applications at: %(link)s. You "
-"can customise your reminders under 'preferences' in your user profile. If "
-"you received this message in error, drop us a line at: "
-"wikipedialibrary@wikimedia.org Thanks for helping review Wikipedia Library "
-"applications!"
-msgstr ""
-"谨在此提醒您，您可以查看申请在：%(link)s。您可以在用户个人资料的“首选项”下自"
-"定义提醒。如果您错误地收到此消息，请给我们发送邮件至："
-"wikipedialibrary@wikimedia.org。感谢您帮助审核维基百科图书馆的申请！"
+msgid "This is a gentle reminder that you may review applications at: %(link)s. You can customise your reminders under 'preferences' in your user profile. If you received this message in error, drop us a line at: wikipedialibrary@wikimedia.org Thanks for helping review Wikipedia Library applications!"
+msgstr "谨在此提醒您，您可以查看申请在：%(link)s。您可以在用户个人资料的“首选项”下自定义提醒。如果您错误地收到此消息，请给我们发送邮件至：wikipedialibrary@wikimedia.org。感谢您帮助审核维基百科图书馆的申请！"
 
 #. Translators: This is the subject line of a scheduled reminder email sent to coordinators who have applications to review. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library). Do not translate items in curly braces.
 #: TWLight/emails/templates/emails/coordinator_reminder_notification-subject.html:4
@@ -1296,29 +1114,14 @@ msgstr "维基百科图书馆申请等待您的审核"
 #. Translators: This email is sent to users when their application is rejected. Don't translate Jinja variables in curly braces like user or partner; don't translate html tags either. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/rejection_notification-body-html.html:5
 #, python-format
-msgid ""
-"<p>Dear %(user)s,</p> <p>Thank you for applying for access to %(partner)s "
-"resources through The Wikipedia Library. Unfortunately at this time your "
-"application has not been approved. You can view your application and review "
-"comments at <a href=\"%(app_url)s\">%(app_url)s</a>.</p> <p>Best,</p> <p>The "
-"Wikipedia Library</p>"
-msgstr ""
-"<p>尊敬的的%(user)s，</p><p>谢谢您通过维基百科图书馆申请访问%(partner)s的资"
-"源。不幸的是，现在您的申请还没有被批准。您可以在<a href=\"%(app_url)s\">"
-"%(app_url)s</a>中查看申请和审核并留言。</p><p>祝好，</p><p>维基百科图书馆</p>"
+msgid "<p>Dear %(user)s,</p> <p>Thank you for applying for access to %(partner)s resources through The Wikipedia Library. Unfortunately at this time your application has not been approved. You can view your application and review comments at <a href=\"%(app_url)s\">%(app_url)s</a>.</p> <p>Best,</p> <p>The Wikipedia Library</p>"
+msgstr "<p>尊敬的的%(user)s，</p><p>谢谢您通过维基百科图书馆申请访问%(partner)s的资源。不幸的是，现在您的申请还没有被批准。您可以在<a href=\"%(app_url)s\">%(app_url)s</a>中查看申请和审核并留言。</p><p>祝好，</p><p>维基百科图书馆</p>"
 
 #. Translators: This email is sent to users when their application is rejected. Don't translate Jinja variables in curly braces like user or partner. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/rejection_notification-body-text.html:3
 #, python-format
-msgid ""
-"Dear %(user)s, Thank you for applying for access to %(partner)s resources "
-"through The Wikipedia Library. Unfortunately at this time your application "
-"has not been approved. You can view your application and review comments at: "
-"%(app_url)s Best, The Wikipedia Library"
-msgstr ""
-"尊敬的%(user)s，感谢您通过维基百科图书馆申请访问%(partner)s的资源。不幸的是，"
-"此时您的申请还没有被批准。您可以查看申请并在查看留言：%(app_url)s 祝好，维基"
-"百科图书馆"
+msgid "Dear %(user)s, Thank you for applying for access to %(partner)s resources through The Wikipedia Library. Unfortunately at this time your application has not been approved. You can view your application and review comments at: %(app_url)s Best, The Wikipedia Library"
+msgstr "尊敬的%(user)s，感谢您通过维基百科图书馆申请访问%(partner)s的资源。不幸的是，此时您的申请还没有被批准。您可以查看申请并在查看留言：%(app_url)s 祝好，维基百科图书馆"
 
 #. Translators: This is the subject of an email which is sent to users when their application has been rejected. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/rejection_notification-subject.html:4
@@ -1328,36 +1131,14 @@ msgstr "您的维基百科图书馆申请"
 #. Translators: This email is sent to users when they have an account that is soon to expire. Don't translate Jinja variables in curly braces like partner_name or partner_link; don't translate html tags either. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/user_renewal_notice-body-html.html:5
 #, python-format
-msgid ""
-"<p>Dear %(user)s,</p> <p>According to our records, your access to "
-"%(partner_name)s will soon expire and you may lose access. If you want to "
-"continue making use of your free account, you can request renewal of your "
-"account by clicking the 'Renew' or 'Extend' button at %(partner_link)s.</p> "
-"<p>Best,</p> <p>The Wikipedia Library</p> <p>You can disable these emails in "
-"your user page preferences: https://wikipedialibrary.wmflabs.org/users/</p>"
-msgstr ""
-"<p>尊敬的%(user)s，</p><p>根据我们的记录，您对%(partner_name)s的访问权限即将"
-"过期，并且您可能会失去访问权限。如果您想继续使用免费帐户，可以通过点"
-"击%(partner_link)s处的“续订”或“延长”按钮请求续订帐户。</p> <p>祝好，</p> <p>"
-"维基百科图书馆</p> <p>您可以在用户页面首选项中禁用这些电子邮件：https://"
-"wikipedialibrary.wmflabs.org/users/</p>"
+msgid "<p>Dear %(user)s,</p> <p>According to our records, your access to %(partner_name)s will soon expire and you may lose access. If you want to continue making use of your free account, you can request renewal of your account by clicking the 'Renew' or 'Extend' button at %(partner_link)s.</p> <p>Best,</p> <p>The Wikipedia Library</p> <p>You can disable these emails in your user page preferences: https://wikipedialibrary.wmflabs.org/users/</p>"
+msgstr "<p>尊敬的%(user)s，</p><p>根据我们的记录，您对%(partner_name)s的访问权限即将过期，并且您可能会失去访问权限。如果您想继续使用免费帐户，可以通过点击%(partner_link)s处的“续订”或“延长”按钮请求续订帐户。</p> <p>祝好，</p> <p>维基百科图书馆</p> <p>您可以在用户页面首选项中禁用这些电子邮件：https://wikipedialibrary.wmflabs.org/users/</p>"
 
 #. Translators: This email is sent to users when they have an account that is soon to expire. Don't translate Jinja variables in curly braces like partner_name or partner_link; don't translate html tags either. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/user_renewal_notice-body-text.html:3
 #, python-format
-msgid ""
-"Dear %(user)s, According to our records, your access to %(partner_name)s "
-"will soon expire and you may lose access. If you want to continue making use "
-"of your free account, you can request renewal of your account by clicking "
-"the Renew button at %(partner_link)s. Best, The Wikipedia Library You can "
-"disable these emails in your user page preferences: https://wikipedialibrary."
-"wmflabs.org/users/"
-msgstr ""
-"尊敬的%(user)s，根据我们的记录，您对%(partner_name)s的访问权限将很快到期，并"
-"且您可能会失去访问权限。如果您想继续使用免费帐户，可以通过点"
-"击%(partner_link)s上的“续订”按钮来请求续订帐户。祝好，维基百科图书馆。您可以"
-"在用户页面首选项中禁用这些电子邮件：https://wikipedialibrary.wmflabs.org/"
-"users/"
+msgid "Dear %(user)s, According to our records, your access to %(partner_name)s will soon expire and you may lose access. If you want to continue making use of your free account, you can request renewal of your account by clicking the Renew button at %(partner_link)s. Best, The Wikipedia Library You can disable these emails in your user page preferences: https://wikipedialibrary.wmflabs.org/users/"
+msgstr "尊敬的%(user)s，根据我们的记录，您对%(partner_name)s的访问权限将很快到期，并且您可能会失去访问权限。如果您想继续使用免费帐户，可以通过点击%(partner_link)s上的“续订”按钮来请求续订帐户。祝好，维基百科图书馆。您可以在用户页面首选项中禁用这些电子邮件：https://wikipedialibrary.wmflabs.org/users/"
 
 #. Translators: This is the subject of an email sent to users when they have an account that is soon to expire. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/user_renewal_notice-subject.html:4
@@ -1367,32 +1148,14 @@ msgstr "您的维基百科图书馆访问权限即将过期"
 #. Translators: This email is sent to users when their application is waitlisted because there are no more accounts available. Don't translate Jinja variables in curly braces like user or partner; don't translate html tags either. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/waitlist_notification-body-html.html:5
 #, python-format
-msgid ""
-"<p>Dear %(user)s,</p> <p>Thank you for applying for access to %(partner)s "
-"resources through The Wikipedia Library. There are no accounts currently "
-"available so your application has been waitlisted. Your application will be "
-"evaluated if/when more accounts become available. You can see all available "
-"resources at <a href=\"%(link)s\">%(link)s</a>.</p> <p>Best,</p> <p>The "
-"Wikipedia Library</p>"
-msgstr ""
-"<p>尊敬的%(user)s，</p><p>谢谢您通过维基百科图书馆申请访问%(partner)s的资源。"
-"目前没有可用的帐户，因此您的申请已被列入等待队列。如果/当更多的帐户可用时，您"
-"的申请将被评估。你可以在<a href=\"%(link)s\">%(link)s</a>上查看所有可用的资源"
-"</p> <p>祝好，</p><p>维基百科图书馆</p>"
+msgid "<p>Dear %(user)s,</p> <p>Thank you for applying for access to %(partner)s resources through The Wikipedia Library. There are no accounts currently available so your application has been waitlisted. Your application will be evaluated if/when more accounts become available. You can see all available resources at <a href=\"%(link)s\">%(link)s</a>.</p> <p>Best,</p> <p>The Wikipedia Library</p>"
+msgstr "<p>尊敬的%(user)s，</p><p>谢谢您通过维基百科图书馆申请访问%(partner)s的资源。目前没有可用的帐户，因此您的申请已被列入等待队列。如果/当更多的帐户可用时，您的申请将被评估。你可以在<a href=\"%(link)s\">%(link)s</a>上查看所有可用的资源</p> <p>祝好，</p><p>维基百科图书馆</p>"
 
 #. Translators: This email is sent to users when their application is waitlisted because there are no more accounts available. Don't translate Jinja variables in curly braces like user or partner. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/waitlist_notification-body-text.html:3
 #, python-format
-msgid ""
-"Dear %(user)s, Thank you for applying for access to %(partner)s resources "
-"through The Wikipedia Library. There are no accounts currently available so "
-"your application has been waitlisted. Your application will be evaluated if/"
-"when more accounts become available. You can see all available resources at: "
-"%(link)s Best, The Wikipedia Library"
-msgstr ""
-"尊敬的%(user)s，感谢您通过维基百科图书馆申请访问%(partner)s的资源。目前没有可"
-"用的账号，所以申请已被列入等待队列。如果/当更多帐户可用时，您的申请将被评。您"
-"可以查看所有可用的资源在：%(link)s 祝好，维基百科图书馆"
+msgid "Dear %(user)s, Thank you for applying for access to %(partner)s resources through The Wikipedia Library. There are no accounts currently available so your application has been waitlisted. Your application will be evaluated if/when more accounts become available. You can see all available resources at: %(link)s Best, The Wikipedia Library"
+msgstr "尊敬的%(user)s，感谢您通过维基百科图书馆申请访问%(partner)s的资源。目前没有可用的账号，所以申请已被列入等待队列。如果/当更多帐户可用时，您的申请将被评。您可以查看所有可用的资源在：%(link)s 祝好，维基百科图书馆"
 
 #. Translators: This is the subject of an email sent to users when their application is waitlisted because there are no more accounts available. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/waitlist_notification-subject.html:4
@@ -1553,17 +1316,14 @@ msgstr "不可用"
 #: TWLight/resources/templates/resources/filter_section.html:14
 #: TWLight/templates/about.html:12
 #: TWLight/users/templates/users/filter_section.html:13
-msgid ""
-"The Wikipedia Library allows active editors to access a wide range of "
-"collections of paywalled reliable sources for free!"
+msgid "The Wikipedia Library allows active editors to access a wide range of collections of paywalled reliable sources for free!"
 msgstr "维基百科图书馆允许活跃的编辑者免费访问各种广泛的付费可靠来源！"
 
 #. Translators: On the Browse Partners page (https://wikipedialibrary.wmflabs.org/partners/), this introduces users to The Wikipedia Library.
 #. Translators: On the MyLibrary page (https://wikipedialibrary.wmflabs.org/users/my_library), this introduces users to The Wikipedia Library.
 #: TWLight/resources/templates/resources/filter_section.html:17
 #: TWLight/users/templates/users/filter_section.html:15
-msgid ""
-"Start with the search bar at the top or browse publisher websites directly."
+msgid "Start with the search bar at the top or browse publisher websites directly."
 msgstr "在顶部搜索栏中搜索或者直接浏览出版者网站以开始。"
 
 #. Translators: On the Browse Partners page (https://wikipedialibrary.wmflabs.org/partners/), this appears below introductory text and links to the 'About' page (https://wikipedialibrary.wmflabs.org/about/)
@@ -1637,66 +1397,39 @@ msgstr "回到合作伙伴"
 #. Translators: If we have no available accounts for a partner, the coordinator can change the application system to a waiting list.
 #: TWLight/resources/templates/resources/partner_detail.html:36
 #: TWLight/resources/templates/resources/partner_detail_apply.html:17
-msgid ""
-"There are no access grants available for this partner at this time. You can "
-"still apply for access; applications will be processed when access is "
-"available."
-msgstr ""
-"目前没有该合作伙伴的访问授权。您仍然可以申请访问权限；可以访问时，将会处理申"
-"请。"
+msgid "There are no access grants available for this partner at this time. You can still apply for access; applications will be processed when access is available."
+msgstr "目前没有该合作伙伴的访问授权。您仍然可以申请访问权限；可以访问时，将会处理申请。"
 
 #. Translators: This text links to the minimum user requirements and terms of use on the partner page.
 #: TWLight/resources/templates/resources/partner_detail.html:48
 #: TWLight/resources/templates/resources/partner_detail_apply.html:29
 #, python-format
-msgid ""
-"Before applying, please review the <strong><a class=\"twl-links\" href="
-"\"%(about)s#req\">minimum requirements</a></strong> for access and our "
-"<strong><a class=\"twl-links\" href=\"%(terms)s\">terms of use</a></strong>."
-msgstr ""
-"申请之前，请查看<strong><a class=\"twl-links\" href=\"%(about)s#req\">获取访"
-"问权限的最低要求</a></strong>，以及我们的<strong><a class=\"twl-links\" href="
-"\"%(terms)s\">使用条款</a></strong>。"
+msgid "Before applying, please review the <strong><a class=\"twl-links\" href=\"%(about)s#req\">minimum requirements</a></strong> for access and our <strong><a class=\"twl-links\" href=\"%(terms)s\">terms of use</a></strong>."
+msgstr "申请之前，请查看<strong><a class=\"twl-links\" href=\"%(about)s#req\">获取访问权限的最低要求</a></strong>，以及我们的<strong><a class=\"twl-links\" href=\"%(terms)s\">使用条款</a></strong>。"
 
 #. Translators: This text refers to the page containing the content a user is authorized to access.
 #: TWLight/resources/templates/resources/partner_detail.html:69
 #, python-format
-msgid ""
-"View the status of your access in <strong><a class=\"twl-links\" href="
-"\"%(library_url)s\">My Library</a></strong> page."
-msgstr ""
-"在<strong><a class=\"twl-links\" href=\"%(library_url)s\">我的图书馆</a></"
-"strong>页面中查看访问状态。"
+msgid "View the status of your access in <strong><a class=\"twl-links\" href=\"%(library_url)s\">My Library</a></strong> page."
+msgstr "在<strong><a class=\"twl-links\" href=\"%(library_url)s\">我的图书馆</a></strong>页面中查看访问状态。"
 
 #. Translators: This message is shown when a user has open applications, linking to their respective applications page.
 #: TWLight/resources/templates/resources/partner_detail.html:78
 #, python-format
-msgid ""
-"View the status of your application(s) on your <strong><a class=\"twl-links"
-"\" href=\"%(applications_url)s\">My Applications</a></strong> page."
-msgstr ""
-"在<strong><a class=\"twl-links\" href=\"%(applications_url)s\">我的申请</a></"
-"strong>页面上查看申请状态。"
+msgid "View the status of your application(s) on your <strong><a class=\"twl-links\" href=\"%(applications_url)s\">My Applications</a></strong> page."
+msgstr "在<strong><a class=\"twl-links\" href=\"%(applications_url)s\">我的申请</a></strong>页面上查看申请状态。"
 
 #. Translators: This message is shown when a user has authorizations, linking to their respective collections page.
 #: TWLight/resources/templates/resources/partner_detail_apply.html:50
 #, python-format
-msgid ""
-"View the status of your access on your <strong><a href=\"%(library_url)s\" "
-"class=\"twl-links\">My Library</a></strong> page."
-msgstr ""
-"在<strong><a href=\"%(library_url)s\" class=\"twl-links\">我的图书馆</a></"
-"strong>页面上查看您的访问状态。"
+msgid "View the status of your access on your <strong><a href=\"%(library_url)s\" class=\"twl-links\">My Library</a></strong> page."
+msgstr "在<strong><a href=\"%(library_url)s\" class=\"twl-links\">我的图书馆</a></strong>页面上查看您的访问状态。"
 
 #. Translators: This message is shown when a user has open applications, linking to their respective applications page.
 #: TWLight/resources/templates/resources/partner_detail_apply.html:60
 #, python-format
-msgid ""
-"View the status of your application(s) on your <strong><a href="
-"\"%(applications_url)s\">My Applications</a></strong> page."
-msgstr ""
-"在<strong><a href=\"%(applications_url)s\">我的申请</a></strong>页面上查看申"
-"请状态。"
+msgid "View the status of your application(s) on your <strong><a href=\"%(applications_url)s\">My Applications</a></strong> page."
+msgstr "在<strong><a href=\"%(applications_url)s\">我的申请</a></strong>页面上查看申请状态。"
 
 #. Translators: One the partner detail page, this text labels the button which coordinators can click to remove a partner from waitlisted status.
 #: TWLight/resources/templates/resources/partner_detail_apply.html:73
@@ -1725,14 +1458,8 @@ msgstr "Special:EmailUser页面"
 
 #. Translators: If no account coordinator is assigned to a partner, the Wikipedia Library team will coordinate signups. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/resources/templates/resources/partner_detail_apply.html:112
-msgid ""
-"The Wikipedia Library team will process this application. Want to help? <a "
-"class=\"twl-links\" href=\"https://en.wikipedia.org/wiki/Wikipedia:"
-"The_Wikipedia_Library/Coordinators/Signup\">Sign up as a coordinator.</a>"
-msgstr ""
-"维基百科图书馆团队将处理此申请。想帮忙吗？<a class=\"twl-links\" href="
-"\"https://en.wikipedia.org/wiki/Wikipedia:The_Wikipedia_Library/Coordinators/"
-"Signup\">注册为协调员。</a>"
+msgid "The Wikipedia Library team will process this application. Want to help? <a class=\"twl-links\" href=\"https://en.wikipedia.org/wiki/Wikipedia:The_Wikipedia_Library/Coordinators/Signup\">Sign up as a coordinator.</a>"
+msgstr "维基百科图书馆团队将处理此申请。想帮忙吗？<a class=\"twl-links\" href=\"https://en.wikipedia.org/wiki/Wikipedia:The_Wikipedia_Library/Coordinators/Signup\">注册为协调员。</a>"
 
 #. Translators: This text labels a button coordinators can click to view a list of users who have applied for access for a particular partner
 #: TWLight/resources/templates/resources/partner_detail_apply.html:121
@@ -1761,21 +1488,14 @@ msgstr "Library bundle访问"
 
 #. Translators: Text shown to authenticated, bundle eligible users when they visit a Bundle partner page.
 #: TWLight/resources/templates/resources/partner_detail_apply.html:138
-msgid ""
-"You are eligible to access Library Bundle partners. Click the button above "
-"to access the collection."
+msgid "You are eligible to access Library Bundle partners. Click the button above to access the collection."
 msgstr "您有资格访问Library Bundle合作伙伴。点击上方按钮以访问馆藏。"
 
 #. Translators: Text shown to authenticated, bundle ineligible users when they visit a Bundle partner page.
 #: TWLight/resources/templates/resources/partner_detail_apply.html:152
 #, python-format
-msgid ""
-"You are not eligible to access Library Bundle partners. Visit the <a class="
-"\"twl-links\" href=\"%(homepage)s\">homepage</a> to check the eligibility "
-"criteria."
-msgstr ""
-"您没有资格访问Library Bundle合作伙伴。访问<a class=\"twl-links\" href="
-"\"%(homepage)s\">首页</a>检查资格标准。"
+msgid "You are not eligible to access Library Bundle partners. Visit the <a class=\"twl-links\" href=\"%(homepage)s\">homepage</a> to check the eligibility criteria."
+msgstr "您没有资格访问Library Bundle合作伙伴。访问<a class=\"twl-links\" href=\"%(homepage)s\">首页</a>检查资格标准。"
 
 #. Translators: Buttton prompting users to log in.
 #: TWLight/resources/templates/resources/partner_detail_apply.html:160
@@ -1786,14 +1506,8 @@ msgstr "登录"
 #. Translators: Text shown to unauthenticated users when they visit a Bundle partner page.
 #: TWLight/resources/templates/resources/partner_detail_apply.html:168
 #, python-format
-msgid ""
-"This resource is part of our <a class=\"twl-links\" href=\"%(about)s"
-"\">Library Bundle</a>, which you can access if you meet our minimum "
-"eligibility criteria. Log in to find out if you are eligible."
-msgstr ""
-"该资源是我们<a class=\"twl-links\" href=\"%(about)s\">Library Bundle</a>的一"
-"部分，如果您符合我们的最低资格标准，则可以访问该资源。登录以了解您是否符合条"
-"件。"
+msgid "This resource is part of our <a class=\"twl-links\" href=\"%(about)s\">Library Bundle</a>, which you can access if you meet our minimum eligibility criteria. Log in to find out if you are eligible."
+msgstr "该资源是我们<a class=\"twl-links\" href=\"%(about)s\">Library Bundle</a>的一部分，如果您符合我们的最低资格标准，则可以访问该资源。登录以了解您是否符合条件。"
 
 #. Translators: This is the label for a number which shows the total active accounts for one partner. (e.g. https://wikipedialibrary.wmflabs.org/partners/8/).
 #: TWLight/resources/templates/resources/partner_detail_stats.html:21
@@ -1843,31 +1557,20 @@ msgstr "摘录限制"
 #. Translators: If a partner has specified the excerpt limit both in words and percentage, this message will display the percentage of words and the number of words on the partner page.
 #: TWLight/resources/templates/resources/partner_detail_timeline.html:99
 #, python-format
-msgid ""
-"%(object)s allows a maximum of %(excerpt_limit)s words or "
-"%(excerpt_limit_percentage)s%% of an article be excerpted into a Wikipedia "
-"article."
-msgstr ""
-"%(object)s允许在维基百科条目中最多摘录文章的%(excerpt_limit)s个单词"
-"或%(excerpt_limit_percentage)s。"
+msgid "%(object)s allows a maximum of %(excerpt_limit)s words or %(excerpt_limit_percentage)s%% of an article be excerpted into a Wikipedia article."
+msgstr "%(object)s允许在维基百科条目中最多摘录文章的%(excerpt_limit)s个单词或%(excerpt_limit_percentage)s。"
 
 #. Translators: If a partner has specified the excerpt limit in words, this message will display the number of words on the partner page.
 #: TWLight/resources/templates/resources/partner_detail_timeline.html:106
 #, python-format
-msgid ""
-"%(object)s allows a maximum of %(excerpt_limit)s words be excerpted into a "
-"Wikipedia article."
+msgid "%(object)s allows a maximum of %(excerpt_limit)s words be excerpted into a Wikipedia article."
 msgstr "%(object)s允许最多%(excerpt_limit)s个单词被摘录到维基百科条目中。"
 
 #. Translators: If a partner has specified the excerpt limit in percentage, this message will display the percentage of words on the partner page.
 #: TWLight/resources/templates/resources/partner_detail_timeline.html:113
 #, python-format
-msgid ""
-"%(object)s allows a maximum of %(excerpt_limit_percentage)s%% of an article "
-"be excerpted into a Wikipedia article."
-msgstr ""
-"%(object)s允许一篇文章最多百分之%(excerpt_limit_percentage)s被摘录到维基百科"
-"条目中。"
+msgid "%(object)s allows a maximum of %(excerpt_limit_percentage)s%% of an article be excerpted into a Wikipedia article."
+msgstr "%(object)s允许一篇文章最多百分之%(excerpt_limit_percentage)s被摘录到维基百科条目中。"
 
 #. Translators: If a partner has other requirements for access, this text shows as the title for that information field. (e.g. https://wikipedialibrary.wmflabs.org/partners/10/).
 #: TWLight/resources/templates/resources/partner_detail_timeline.html:132
@@ -1877,9 +1580,7 @@ msgstr "申请人特殊要求"
 #. Translators: If a user must agree to a Terms of Use document, they see this message, and must enter the name of the resource. Don't translate publisher or url.
 #: TWLight/resources/templates/resources/partner_detail_timeline.html:140
 #, python-format
-msgid ""
-"%(publisher)s requires that you agree with its <a href=\"%(url)s\">terms of "
-"use</a>."
+msgid "%(publisher)s requires that you agree with its <a href=\"%(url)s\">terms of use</a>."
 msgstr "%(publisher)s要求您同意它的<a href=\"%(url)s\">使用条款</a>。"
 
 #. Translators: If a user must provide their real name to apply to a partner, they see this message, and must enter the name of the resource. Don't translate publisher.
@@ -1903,17 +1604,13 @@ msgstr "%(publisher)s要求您提供您的机构隶属关系。"
 #. Translators: If a user must select a specific resource to apply for, they see this message, and must enter the name of the resource. Don't translate publisher.
 #: TWLight/resources/templates/resources/partner_detail_timeline.html:177
 #, python-format
-msgid ""
-"%(publisher)s requires that you specify a particular title that you want to "
-"access."
+msgid "%(publisher)s requires that you specify a particular title that you want to access."
 msgstr "%(publisher)s要求您指定要访问的特定标题。"
 
 #. Translators: If a user must register on the partner website before applying, they see this message. Don't translate partner.
 #: TWLight/resources/templates/resources/partner_detail_timeline.html:187
 #, python-format
-msgid ""
-"%(publisher)s requires that you sign up for an account before applying for "
-"access."
+msgid "%(publisher)s requires that you sign up for an account before applying for access."
 msgstr "%(publisher)s要求您在申请访问权限之前注册账户。"
 
 #. Translators: If a partner has their location listed, this message is a label for that location
@@ -2040,9 +1737,7 @@ msgstr "您真的要删除<b>%(object)s</b>吗？"
 
 #. Translators: If multiple authorizations where returned for a collection, this message is shown to a user
 #: TWLight/resources/views.py:268
-msgid ""
-"Multiple authorizations were returned – something's wrong. Please contact us "
-"and don't forget to mention this message."
+msgid "Multiple authorizations were returned – something's wrong. Please contact us and don't forget to mention this message."
 msgstr "返回了多个授权-出了点问题。请与我们联系，不要忘记提及此消息。"
 
 #. Translators: This message is shown when user tries to access a NOT_AVAILABLE Partner
@@ -2083,21 +1778,8 @@ msgstr "对不起，我们不知道该怎么办。"
 #. Translators: Shown on the website's 400 page, when a user sends a bad request. Don't translate path or Phabricator.
 #: TWLight/templates/400.html:20
 #, python-format
-msgid ""
-"If you think we should know what to do with that, please email us about this "
-"error at <a class=\"twl-links\" href=\"mailto:wikipedialibrary@wikimedia.org?"
-"Subject=Wikipedia%%20Library%%20%(path)s%%20Permission%%20denied"
-"\">wikipedialibrary@wikimedia.org</a> or report it to us on <a class=\"twl-"
-"links\" href=\"https://phabricator.wikimedia.org/maniphest/task/edit/form/1/?"
-"projectPHIDs=Library-Card-Platform&title=Wikipedia%%20Library%%20%(path)s"
-"%%20Bad%%20Request\">Phabricator</a>"
-msgstr ""
-"如果您认为我们应该知道该怎么处理，请发邮件给我们<a class=\"twl-links\" href="
-"\"mailto:wikipedialibrary@wikimedia.org?Subject=Wikipedia%%20Library"
-"%%20%(path)s%%20Permission%%20denied\">wikipedialibrary@wikimedia.org</a>或"
-"<a class=\"twl-links\" href=\"https://phabricator.wikimedia.org/maniphest/"
-"task/edit/form/1/?projectPHIDs=Library-Card-Platform&title=Wikipedia"
-"%%20Library%%20%(path)s%%20Bad%%20Request\">报告给我们</a>"
+msgid "If you think we should know what to do with that, please email us about this error at <a class=\"twl-links\" href=\"mailto:wikipedialibrary@wikimedia.org?Subject=Wikipedia%%20Library%%20%(path)s%%20Permission%%20denied\">wikipedialibrary@wikimedia.org</a> or report it to us on <a class=\"twl-links\" href=\"https://phabricator.wikimedia.org/maniphest/task/edit/form/1/?projectPHIDs=Library-Card-Platform&title=Wikipedia%%20Library%%20%(path)s%%20Bad%%20Request\">Phabricator</a>"
+msgstr "如果您认为我们应该知道该怎么处理，请发邮件给我们<a class=\"twl-links\" href=\"mailto:wikipedialibrary@wikimedia.org?Subject=Wikipedia%%20Library%%20%(path)s%%20Permission%%20denied\">wikipedialibrary@wikimedia.org</a>或<a class=\"twl-links\" href=\"https://phabricator.wikimedia.org/maniphest/task/edit/form/1/?projectPHIDs=Library-Card-Platform&title=Wikipedia%%20Library%%20%(path)s%%20Bad%%20Request\">报告给我们</a>"
 
 #. Translators: Alt text for an image shown on the 400 error page.
 #. Translators: Alt text for an image shown on the 403 error page.
@@ -2118,23 +1800,8 @@ msgstr "对不起，您不能这样做。"
 #. Translators: Shown on the website's 403 page, when a user attempts to navigate to a page they don't have permission to view. Don't translate path or Phabricator.
 #: TWLight/templates/403.html:20
 #, python-format
-msgid ""
-"If you think your account should be able to do that, please email us about "
-"this error at <a class=\"twl-links\" href=\"mailto:"
-"wikipedialibrary@wikimedia.org?Subject=Wikipedia%%20Library%%20%(path)s"
-"%%20Permission%%20denied\">wikipedialibrary@wikimedia.org</a> or report it "
-"to us on <a class=\"twl-links\" href=\"https://phabricator.wikimedia.org/"
-"maniphest/task/edit/form/1/?projectPHIDs=Library-Card-"
-"Platform&title=Wikipedia%%20Library%%20%(path)s%%20Permission%%20denied"
-"\">Phabricator</a>"
-msgstr ""
-"如果您认为您的账户应该能够做到这一点，请在<a class=\"twl-links\" href="
-"\"mailto:wikipedialibrary@wikimedia.org?Subject=Wikipedia%%20Library"
-"%%20%(path)s%%20Permission%%20denied\">wikipedialibrary@wikimedia.org</a>给我"
-"们发电子邮件告知这个错误或在<a class=\"twl-links\" href=\"https://"
-"phabricator.wikimedia.org/maniphest/task/edit/form/1/?projectPHIDs=Library-"
-"Card-Platform&title=Wikipedia%%20Library%%20%(path)s%%20Permission%%20denied"
-"\">这里</a>报告给我们"
+msgid "If you think your account should be able to do that, please email us about this error at <a class=\"twl-links\" href=\"mailto:wikipedialibrary@wikimedia.org?Subject=Wikipedia%%20Library%%20%(path)s%%20Permission%%20denied\">wikipedialibrary@wikimedia.org</a> or report it to us on <a class=\"twl-links\" href=\"https://phabricator.wikimedia.org/maniphest/task/edit/form/1/?projectPHIDs=Library-Card-Platform&title=Wikipedia%%20Library%%20%(path)s%%20Permission%%20denied\">Phabricator</a>"
+msgstr "如果您认为您的账户应该能够做到这一点，请在<a class=\"twl-links\" href=\"mailto:wikipedialibrary@wikimedia.org?Subject=Wikipedia%%20Library%%20%(path)s%%20Permission%%20denied\">wikipedialibrary@wikimedia.org</a>给我们发电子邮件告知这个错误或在<a class=\"twl-links\" href=\"https://phabricator.wikimedia.org/maniphest/task/edit/form/1/?projectPHIDs=Library-Card-Platform&title=Wikipedia%%20Library%%20%(path)s%%20Permission%%20denied\">这里</a>报告给我们"
 
 #. Translators: Shown on the website's 404 page, when a user attempts to navigate to a page that doesn't exist.
 #: TWLight/templates/404.html:11
@@ -2149,22 +1816,8 @@ msgstr "对不起; 我们找不到。"
 #. Translators: Shown on the website's 404 page, when a user attempts to navigate to a page that doesn't exist. Don't translate path or Phabricator.
 #: TWLight/templates/404.html:19
 #, python-format
-msgid ""
-"If you are certain that something should be here, please email us about this "
-"error at <a class=\"twl-links\" href=\"mailto:wikipedialibrary@wikimedia.org?"
-"Subject=Wikipedia%%20Library%%20%(path)s%%20Not%%20found\"> "
-"wikipedialibrary@wikimedia.org</a> or report it to us on <a class=\"twl-links"
-"\" href=\"https://phabricator.wikimedia.org/maniphest/task/edit/form/1/?"
-"projectPHIDs=Library-Card-Platform&title=Wikipedia%%20Library%%20%(path)s"
-"%%20Not%%20found\">Phabricator</a>"
-msgstr ""
-"如果您确定应该有东西在这里，请<a class=\"twl-links\" href=\"mailto:"
-"wikipedialibrary@wikimedia.org?Subject=Wikipedia%%20Library%%20%(path)s"
-"%%20Not%%20found\"> wikipedialibrary@wikimedia.org</a>给我们发邮件告知此问题"
-"或者<a class=\"twl-links\" href=\"https://phabricator.wikimedia.org/"
-"maniphest/task/edit/form/1/?projectPHIDs=Library-Card-"
-"Platform&title=Wikipedia%%20Library%%20%(path)s%%20Not%%20found\">在网页中告"
-"知这个错误</a>"
+msgid "If you are certain that something should be here, please email us about this error at <a class=\"twl-links\" href=\"mailto:wikipedialibrary@wikimedia.org?Subject=Wikipedia%%20Library%%20%(path)s%%20Not%%20found\"> wikipedialibrary@wikimedia.org</a> or report it to us on <a class=\"twl-links\" href=\"https://phabricator.wikimedia.org/maniphest/task/edit/form/1/?projectPHIDs=Library-Card-Platform&title=Wikipedia%%20Library%%20%(path)s%%20Not%%20found\">Phabricator</a>"
+msgstr "如果您确定应该有东西在这里，请<a class=\"twl-links\" href=\"mailto:wikipedialibrary@wikimedia.org?Subject=Wikipedia%%20Library%%20%(path)s%%20Not%%20found\"> wikipedialibrary@wikimedia.org</a>给我们发邮件告知此问题或者<a class=\"twl-links\" href=\"https://phabricator.wikimedia.org/maniphest/task/edit/form/1/?projectPHIDs=Library-Card-Platform&title=Wikipedia%%20Library%%20%(path)s%%20Not%%20found\">在网页中告知这个错误</a>"
 
 #. Translators: Alt text for an image shown on the 404 error page.
 #: TWLight/templates/404.html:32
@@ -2178,42 +1831,19 @@ msgstr "关于维基百科图书馆"
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:20
-msgid ""
-"This platform is our central tool for facilitating access to our available "
-"collections. Here you can see which partnerships are available, search their "
-"contents, and apply for and access the ones you’re interested in."
-msgstr ""
-"此平台是我们的中心工具，用于审核申请并提供对我们可用馆藏的访问。在这里，您可"
-"以看到哪些合作伙伴可用，检索它们的内容，并申请以及访问您感兴趣的合作伙伴。"
+msgid "This platform is our central tool for facilitating access to our available collections. Here you can see which partnerships are available, search their contents, and apply for and access the ones you’re interested in."
+msgstr "此平台是我们的中心工具，用于审核申请并提供对我们可用馆藏的访问。在这里，您可以看到哪些合作伙伴可用，检索它们的内容，并申请以及访问您感兴趣的合作伙伴。"
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/). Wikimedia Foundation should not be translated.
 #: TWLight/templates/about.html:29
-msgid ""
-"All users receive immediate access to some collections, which can be browsed "
-"by clicking the 'Access collection' buttons or using the search bar at the "
-"top of the page. Other collections require an application before access is "
-"granted, and may be accessed directly or via an individual login or access "
-"code. Volunteer coordinators, who have signed non-disclosure agreements with "
-"the Wikimedia Foundation, review these applications and work with publishers "
-"to get you your free access."
-msgstr ""
-"所有用户都可以立即访问馆藏，您可以通过点击“访问馆藏”按钮或者使用页面顶部的搜"
-"索框来浏览。其他馆藏需要提交申请才能被授予访问权限，并且可直接访问或者通过个"
-"人登录或访问码访问。与维基媒体基金会签署了保密协议的志愿协调员会审查申请并与"
-"出版社合作，为您提供免费访问。"
+msgid "All users receive immediate access to some collections, which can be browsed by clicking the 'Access collection' buttons or using the search bar at the top of the page. Other collections require an application before access is granted, and may be accessed directly or via an individual login or access code. Volunteer coordinators, who have signed non-disclosure agreements with the Wikimedia Foundation, review these applications and work with publishers to get you your free access."
+msgstr "所有用户都可以立即访问馆藏，您可以通过点击“访问馆藏”按钮或者使用页面顶部的搜索框来浏览。其他馆藏需要提交申请才能被授予访问权限，并且可直接访问或者通过个人登录或访问码访问。与维基媒体基金会签署了保密协议的志愿协调员会审查申请并与出版社合作，为您提供免费访问。"
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/). Don't translate terms_url.
 #: TWLight/templates/about.html:43
 #, python-format
-msgid ""
-"For more information about how your information is stored and reviewed "
-"please see our <a class=\"twl-links\" href=\"%(terms_url)s\"> terms of use "
-"and privacy policy</a>. Accounts you apply for are also subject to the Terms "
-"of Use provided by each partner’s platform; please review them."
-msgstr ""
-"有关如何存储和审核你的信息的更多信息，请参阅我们的<a class=\"twl-links\" "
-"href=\"%(terms_url)s\">使用条款和隐私政策</a>。您申请的账户还必须遵守每个合作"
-"伙伴平台提供的使用条款；请对其检查。"
+msgid "For more information about how your information is stored and reviewed please see our <a class=\"twl-links\" href=\"%(terms_url)s\"> terms of use and privacy policy</a>. Accounts you apply for are also subject to the Terms of Use provided by each partner’s platform; please review them."
+msgstr "有关如何存储和审核你的信息的更多信息，请参阅我们的<a class=\"twl-links\" href=\"%(terms_url)s\">使用条款和隐私政策</a>。您申请的账户还必须遵守每个合作伙伴平台提供的使用条款；请对其检查。"
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:51
@@ -2222,16 +1852,8 @@ msgstr "谁可以获得访问权限？"
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/). Wikimedia Foundation should not be translated.
 #: TWLight/templates/about.html:55
-msgid ""
-"Any active editor in good standing can receive access. For publishers with "
-"limited numbers of accounts, applications are reviewed based on the editor’s "
-"needs and contributions. If you think you could use access to one of our "
-"partner resources and are an active editor in any project supported by the "
-"Wikimedia Foundation, please apply."
-msgstr ""
-"任何信誉良好的活跃编者都可以获得访问权限。对于帐户数量有限的出版商，将根据编"
-"者的需求和贡献来审核申请。如果您认为您需要使用我们的合作伙伴之一的资源访问权"
-"限，并且是在维基媒体基金会支持的任何项目中的一个活跃编者，那么请提出申请。"
+msgid "Any active editor in good standing can receive access. For publishers with limited numbers of accounts, applications are reviewed based on the editor’s needs and contributions. If you think you could use access to one of our partner resources and are an active editor in any project supported by the Wikimedia Foundation, please apply."
+msgstr "任何信誉良好的活跃编者都可以获得访问权限。对于帐户数量有限的出版商，将根据编者的需求和贡献来审核申请。如果您认为您需要使用我们的合作伙伴之一的资源访问权限，并且是在维基媒体基金会支持的任何项目中的一个活跃编者，那么请提出申请。"
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:65
@@ -2260,30 +1882,13 @@ msgstr "当前您没有被禁止编辑维基媒体项目"
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/)
 #: TWLight/templates/about.html:89
-msgid ""
-"If you are applying for an available collection, please first check that you "
-"don't already have access through another library or institution. If you do, "
-"please consider using that access rather than taking up a seat for this "
-"resource in The Wikipedia Library."
-msgstr ""
-"如果您打算申请可用的馆藏，请先检查您是否无法通过其他图书馆或机构的渠道访问馆"
-"藏。如果可以，请考虑其他渠道，而非在维基百科图书馆中占用此资源的席位。"
+msgid "If you are applying for an available collection, please first check that you don't already have access through another library or institution. If you do, please consider using that access rather than taking up a seat for this resource in The Wikipedia Library."
+msgstr "如果您打算申请可用的馆藏，请先检查您是否无法通过其他图书馆或机构的渠道访问馆藏。如果可以，请考虑其他渠道，而非在维基百科图书馆中占用此资源的席位。"
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/)
 #: TWLight/templates/about.html:99
-msgid ""
-"If your account is blocked on one or more Wikimedia projects, you may still "
-"be granted access to The Wikipedia Library. You will need to contact the "
-"Wikipedia Library team, who will review your blocks. If you have been "
-"blocked for content issues, most notably copyright violations, or have "
-"multiple long-term blocks, we may decline your request. Additionally, if "
-"your block status changes after being approved, you will need to request "
-"another review."
-msgstr ""
-"如果您的帐户在一个或多个维基媒体项目上被封禁，仍可能被获准访问维基百科图书"
-"馆。但您将需要与维基百科图书馆团队联系，以便他们检查您的封禁情况。如果您因内"
-"容问题而被封禁，特别是侵犯版权，或者是被多次长期封禁，我们可能会拒绝您的请"
-"求。此外，如果您的封禁状态在批准后发生了变化，您将需要再次申请审核。"
+msgid "If your account is blocked on one or more Wikimedia projects, you may still be granted access to The Wikipedia Library. You will need to contact the Wikipedia Library team, who will review your blocks. If you have been blocked for content issues, most notably copyright violations, or have multiple long-term blocks, we may decline your request. Additionally, if your block status changes after being approved, you will need to request another review."
+msgstr "如果您的帐户在一个或多个维基媒体项目上被封禁，仍可能被获准访问维基百科图书馆。但您将需要与维基百科图书馆团队联系，以便他们检查您的封禁情况。如果您因内容问题而被封禁，特别是侵犯版权，或者是被多次长期封禁，我们可能会拒绝您的请求。此外，如果您的封禁状态在批准后发生了变化，您将需要再次申请审核。"
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:110
@@ -2317,9 +1922,7 @@ msgstr "批准的编者<i>不应</i>："
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:136
-msgid ""
-"Share their account logins or passwords with others, or sell their access to "
-"other parties"
+msgid "Share their account logins or passwords with others, or sell their access to other parties"
 msgstr "同他人分享他们的登录账户或密码，或向其他伙伴出售自己的账户"
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
@@ -2329,24 +1932,17 @@ msgstr "大量抓取或大量下载合作伙伴的内容"
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:144
-msgid ""
-"Systematically make printed or electronic copies of multiple extracts of "
-"restricted content available for any purpose"
+msgid "Systematically make printed or electronic copies of multiple extracts of restricted content available for any purpose"
 msgstr "系统地制作可用于任何目的的受限内容的多个摘要的印刷或电子复制品"
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/). Stub is a technical term for a short Wikipedia article, use the appropriate Wikipedia term in your language.
 #: TWLight/templates/about.html:148
-msgid ""
-"Datamine metadata without permission, in order, for instance, to use "
-"metadata for auto-created stub articles"
-msgstr ""
-"未经许可就对数据挖掘元数据进行操作，例如为了自动创建小作品而是用元数据。"
+msgid "Datamine metadata without permission, in order, for instance, to use metadata for auto-created stub articles"
+msgstr "未经许可就对数据挖掘元数据进行操作，例如为了自动创建小作品而是用元数据。"
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:154
-msgid ""
-"Respecting these agreements allows us to continue growing the partnerships "
-"available to the community."
+msgid "Respecting these agreements allows us to continue growing the partnerships available to the community."
 msgstr "遵守这些协议才能使我们能够继续发展对社群可用的伙伴关系。"
 
 #. Translators: This is the heading for a section on the About page (https://wikipedialibrary.wmflabs.org/about/).
@@ -2356,55 +1952,23 @@ msgstr "EZProxy"
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:164
-msgid ""
-"EZProxy is a proxy server used to authenticate users for many Wikipedia "
-"Library partners. Users sign into EZProxy via the Library Card platform to "
-"verify that they are authorized users, and then the server accesses "
-"requested resources using its own IP address."
-msgstr ""
-"EZProxy是用于许多维基百科图书馆合作伙伴的认证用户的代理服务器。用户通过图书卡"
-"平台登录EZProxy以验证他们是否是授权用户，然后服务器使用其自己的IP地址访问请求"
-"的资源。"
+msgid "EZProxy is a proxy server used to authenticate users for many Wikipedia Library partners. Users sign into EZProxy via the Library Card platform to verify that they are authorized users, and then the server accesses requested resources using its own IP address."
+msgstr "EZProxy是用于许多维基百科图书馆合作伙伴的认证用户的代理服务器。用户通过图书卡平台登录EZProxy以验证他们是否是授权用户，然后服务器使用其自己的IP地址访问请求的资源。"
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:173
-msgid ""
-"You may notice that when accessing resources via EZProxy that URLs are "
-"dynamically rewritten. This is why we recommend logging in via the Library "
-"Card platform rather than going directly to the unproxied partner website. "
-"When in doubt, check the URL for ‘idm.oclc’. If it’s there, then you’re "
-"connected via EZProxy."
-msgstr ""
-"您可能会注意到，通过EZProxy访问资源时，URL是动态重写的。这就是为什么我们建议"
-"您通过图书卡平台登录而不是不通过代理直接访问合作伙伴网站的原因。如有疑问，请"
-"检查“idm.oclc”的网址。如果是这个网址，那么您将通过EZProxy连接。"
+msgid "You may notice that when accessing resources via EZProxy that URLs are dynamically rewritten. This is why we recommend logging in via the Library Card platform rather than going directly to the unproxied partner website. When in doubt, check the URL for ‘idm.oclc’. If it’s there, then you’re connected via EZProxy."
+msgstr "您可能会注意到，通过EZProxy访问资源时，URL是动态重写的。这就是为什么我们建议您通过图书卡平台登录而不是不通过代理直接访问合作伙伴网站的原因。如有疑问，请检查“idm.oclc”的网址。如果是这个网址，那么您将通过EZProxy连接。"
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:182
-msgid ""
-"Typically once you’ve logged in your session will remain active in your "
-"browser for up to two hours after you’ve finished searching. Note that use "
-"of EZProxy requires you to enable cookies. If you are having problems you "
-"should also try clearing your cache and restarting your browser."
-msgstr ""
-"通常在登录后，会话将在搜索完成后最多两个小时内在浏览器中保持活动状态。请注"
-"意，使用EZProxy要求您启用cookie。如果遇到问题，请尝试清除缓存并重新启动浏览"
-"器。"
+msgid "Typically once you’ve logged in your session will remain active in your browser for up to two hours after you’ve finished searching. Note that use of EZProxy requires you to enable cookies. If you are having problems you should also try clearing your cache and restarting your browser."
+msgstr "通常在登录后，会话将在搜索完成后最多两个小时内在浏览器中保持活动状态。请注意，使用EZProxy要求您启用cookie。如果遇到问题，请尝试清除缓存并重新启动浏览器。"
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/)
 #: TWLight/templates/about.html:193
-msgid ""
-"The Library Bundle is a collection of resources for which no application is "
-"required. If you meet the criteria laid out above, you will be authorized "
-"for access automatically upon logging in to the platform. Only some of our "
-"content is currently included in the Library Bundle, however we hope to "
-"expand the collection as more publishers become comfortable with "
-"participating. All Bundle content is accessed via EZProxy."
-msgstr ""
-"Library Bundle是不需要任何申请的资源馆藏。如果满足上述条件，则将在登录平台后"
-"自动获得访问权限。目前，我们的某些内容仅包含在“Library Bundle”中，但是随着更"
-"多出版商对参与的适应性提高，我们希望扩大馆藏。所有Bundle内容均可通过EZProxy访"
-"问。"
+msgid "The Library Bundle is a collection of resources for which no application is required. If you meet the criteria laid out above, you will be authorized for access automatically upon logging in to the platform. Only some of our content is currently included in the Library Bundle, however we hope to expand the collection as more publishers become comfortable with participating. All Bundle content is accessed via EZProxy."
+msgstr "Library Bundle是不需要任何申请的资源馆藏。如果满足上述条件，则将在登录平台后自动获得访问权限。目前，我们的某些内容仅包含在“Library Bundle”中，但是随着更多出版商对参与的适应性提高，我们希望扩大馆藏。所有Bundle内容均可通过EZProxy访问。"
 
 #. Translators: This is the heading for a section on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:202
@@ -2413,16 +1977,8 @@ msgstr "引用实践"
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:206
-msgid ""
-"Citation practices vary by project and even by article. Generally, we "
-"support editors citing where they found information, in a form that allows "
-"others to check it for themselves. That often means providing both original "
-"source details as well as a link to the partner database in which the source "
-"was found."
-msgstr ""
-"引文实践因项目甚至条目而不同。一般来说，我们支持编辑引用他们在某处找到的信"
-"息，允许别人自己检查的形式。这通常意味着提供原始来源的细节，以及提供指向找到"
-"的来源的合作伙伴数据库的链接。"
+msgid "Citation practices vary by project and even by article. Generally, we support editors citing where they found information, in a form that allows others to check it for themselves. That often means providing both original source details as well as a link to the partner database in which the source was found."
+msgstr "引文实践因项目甚至条目而不同。一般来说，我们支持编辑引用他们在某处找到的信息，允许别人自己检查的形式。这通常意味着提供原始来源的细节，以及提供指向找到的来源的合作伙伴数据库的链接。"
 
 #. Translators: This is the heading for a section on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #. Translators: This link is at the bottom of every page and can be clicked by users to contact the wikipedia library team.
@@ -2433,12 +1989,8 @@ msgstr "联系我们"
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:218
 #, python-format
-msgid ""
-"If you have questions, need help, or want to volunteer to help, please see "
-"our <a class=\"twl-links\" href=\"%(contact_url)s\">contact page</a>."
-msgstr ""
-"如果您有任何疑问，需要帮助或想自愿提供帮助，请参阅我们的<a class=\"twl-links"
-"\" href=\"%(contact_url)s\">联系页面</a>。"
+msgid "If you have questions, need help, or want to volunteer to help, please see our <a class=\"twl-links\" href=\"%(contact_url)s\">contact page</a>."
+msgstr "如果您有任何疑问，需要帮助或想自愿提供帮助，请参阅我们的<a class=\"twl-links\" href=\"%(contact_url)s\">联系页面</a>。"
 
 #. Translators: This is the title of the panel box detailing the contact information for the Wikipedia Library team.
 #: TWLight/templates/contact.html:14
@@ -2477,12 +2029,8 @@ msgstr "维基百科图书馆Twitter页面"
 #. Translators: This is the text that appears at the bottom of the contact us form directing users to the suggestions form.
 #: TWLight/templates/contact.html:48
 #, python-format
-msgid ""
-"(If you would like to suggest a partner, <a class=\"twl-links\" href="
-"\"%(suggest)s\"><strong>go here</strong></a>.)"
-msgstr ""
-"（如果您想建议一个合作伙伴，<a class=\"twl-links\" href=\"%(suggest)s"
-"\"><strong>请到这里</strong></a>。）"
+msgid "(If you would like to suggest a partner, <a class=\"twl-links\" href=\"%(suggest)s\"><strong>go here</strong></a>.)"
+msgstr "（如果您想建议一个合作伙伴，<a class=\"twl-links\" href=\"%(suggest)s\"><strong>请到这里</strong></a>。）"
 
 #. Translators: On a special 'link to search' page, this message is shown if JavaScript is disabled.
 #: TWLight/templates/eds_search_endpoint.html:7
@@ -2537,13 +2085,9 @@ msgstr "维基百科图书馆"
 
 #. Translators: Information about The Wikipedia Library.
 #: TWLight/templates/login_partial.html:53 TWLight/templates/new_base.html:21
-#, fuzzy, python-format
-msgid ""
-"More than 100 of the world's top subscription-only databases, with content "
-"in %(no_of_languages)s languages, free for Wikipedians of all backgrounds"
-msgstr ""
-"世界超过百分之九十的包含%(no_of_languages)s种语言的订阅制数据库对所有背景的维"
-"基百科人免费"
+#, python-format
+msgid "More than 100 of the world's top subscription-only databases, with content in %(no_of_languages)s languages, free for Wikipedians of all backgrounds"
+msgstr "世界上超过一百个包含%(no_of_languages)s种语言的订阅制数据库对任何背景的维基人免费"
 
 #. Translators: Information about The Wikipedia Library.
 #: TWLight/templates/login_partial.html:64
@@ -2551,12 +2095,8 @@ msgid "Meet these criteria for automatic access"
 msgstr "自动获准访问门槛"
 
 #: TWLight/templates/login_partial.html:69
-msgid ""
-"These criteria grant you access to certain collections but not all. Some "
-"collections are accessible on a per application basis only."
-msgstr ""
-"这些条件授予您访问某些集合（但不是所有集合）的权限。\n"
-"有些集合只能在每个应用程序的基础上访问。"
+msgid "These criteria grant you access to certain collections but not all. Some collections are accessible on a per application basis only."
+msgstr "这些条件授予您访问某些集合（但不是所有集合）的权限。\n有些集合只能在每个应用程序的基础上访问。"
 
 #: TWLight/templates/login_partial.html:89
 msgid "Login via Wikipedia"
@@ -2565,37 +2105,20 @@ msgstr "通过维基百科登录"
 #. Translators: Shown if the current user doesn't have a registered email on their account. Don't translate contact_us_url or email_url.
 #: TWLight/templates/message_partial.html:15
 #, python-format
-msgid ""
-"You don't have an email on file. We can't finalize your access to partner "
-"resources, and you won't be able to <a class=\"twl-links\" href="
-"\"%(contact_us_url)s\">contact us</a> without an email. Please <a class="
-"\"twl-links\" href=\"%(email_url)s\">update your email</a>."
-msgstr ""
-"文件中没有您的电子邮件地址。我们无法在没有电子邮件的情况下完成对合作伙伴资源"
-"的<a class=\"twl-links\" href=\"%(contact_us_url)s\">访问</a>。请<a class="
-"\"twl-links\" href=\"%(email_url)s\">更新您的电子邮件地址</a>。"
+msgid "You don't have an email on file. We can't finalize your access to partner resources, and you won't be able to <a class=\"twl-links\" href=\"%(contact_us_url)s\">contact us</a> without an email. Please <a class=\"twl-links\" href=\"%(email_url)s\">update your email</a>."
+msgstr "文件中没有您的电子邮件地址。我们无法在没有电子邮件的情况下完成对合作伙伴资源的<a class=\"twl-links\" href=\"%(contact_us_url)s\">访问</a>。请<a class=\"twl-links\" href=\"%(email_url)s\">更新您的电子邮件地址</a>。"
 
 #. Translators: Shown if the current user has requested the processing of their data should be restricted.
 #: TWLight/templates/message_partial.html:26
 #, python-format
-msgid ""
-"You have requested a restriction on the processing of your data. Most site "
-"functionality will not be available to you until you <a class=\"twl-links\" "
-"href=\"%(restrict_url)s\">lift this restriction</a>."
-msgstr ""
-"您已要求对数据的处理进行限制。大多数站点功能将无法提供给您，直到您<a class="
-"\"twl-links\" href=\"%(restrict_url)s\">解除此限制</a>。"
+msgid "You have requested a restriction on the processing of your data. Most site functionality will not be available to you until you <a class=\"twl-links\" href=\"%(restrict_url)s\">lift this restriction</a>."
+msgstr "您已要求对数据的处理进行限制。大多数站点功能将无法提供给您，直到您<a class=\"twl-links\" href=\"%(restrict_url)s\">解除此限制</a>。"
 
 #. Translators: Shown if the current user has not agreed to the terms of use.
 #: TWLight/templates/message_partial.html:37
 #, python-format
-msgid ""
-"You have not agreed to the <a class=\"twl-links\" href=\"%(terms_url)s"
-"\">terms of use</a> of this site. Your applications will not be processed "
-"and you won't be able to apply or access resources you are approved for."
-msgstr ""
-"您尚未同意本网站的<a class=\"twl-links\" href=\"%(terms_url)s\">使用条款</"
-"a>。您的申请将不会被处理，您将无法申请或访问被批准使用的资源。"
+msgid "You have not agreed to the <a class=\"twl-links\" href=\"%(terms_url)s\">terms of use</a> of this site. Your applications will not be processed and you won't be able to apply or access resources you are approved for."
+msgstr "您尚未同意本网站的<a class=\"twl-links\" href=\"%(terms_url)s\">使用条款</a>。您的申请将不会被处理，您将无法申请或访问被批准使用的资源。"
 
 #. Translators: This link is at the bottom of every page and links to the 'About' page (https://wikipedialibrary.wmflabs.org/about/)
 #: TWLight/templates/new_base.html:107
@@ -2641,12 +2164,8 @@ msgstr "重设密码"
 
 #. Translators: If a user goes to reset their password, this message asks them to enter their email to do so.
 #: TWLight/templates/registration/password_reset_form.html:13
-msgid ""
-"Forgot your password? Enter your email address below, and we'll email "
-"instructions for setting a new one."
-msgstr ""
-"忘记密码了吗？在下面输入您的电子邮件地址，我们将通过电子邮件发送有关设置新密"
-"码的说明。"
+msgid "Forgot your password? Enter your email address below, and we'll email instructions for setting a new one."
+msgstr "忘记密码了吗？在下面输入您的电子邮件地址，我们将通过电子邮件发送有关设置新密码的说明。"
 
 #. Translators: This is the label for a button that users click to update their public information.
 #: TWLight/users/forms.py:36
@@ -2690,18 +2209,12 @@ msgstr "我同意以上使用条款"
 
 #. Translators: This text explains how to disagree to the site's terms of use and the restrictions that will come into effect when users disagree to the terms of use.
 #: TWLight/users/forms.py:185
-msgid ""
-"By unchecking this box and clicking “Update” you may explore the site, but "
-"you will not be able to apply for access to materials or evaluate "
-"applications unless you agree with the terms of use."
-msgstr ""
-"通过取消选中此框并点击\"更新\"，您可以浏览网站，但除非您同意使用条款，否则您"
-"将无法获取资料或评估申请。"
+msgid "By unchecking this box and clicking “Update” you may explore the site, but you will not be able to apply for access to materials or evaluate applications unless you agree with the terms of use."
+msgstr "通过取消选中此框并点击\"更新\"，您可以浏览网站，但除非您同意使用条款，否则您将无法获取资料或评估申请。"
 
 #. Translators: Users click this button to set their website email address to the one linked to their Wikipedia account.
 #: TWLight/users/forms.py:211
-msgid ""
-"Use my Wikipedia email address (will be updated the next time you login)."
+msgid "Use my Wikipedia email address (will be updated the next time you login)."
 msgstr "使用我的维基百科电子邮件地址（下次登录时将更新）。"
 
 #. Translators: This labels a button which users click to change their email.
@@ -2712,17 +2225,8 @@ msgstr "更新电子邮件"
 #. Translators: Shown if the current user tried to 'favorite' a partner they can't access. Do not translate '{partner}'
 #: TWLight/users/models.py:201
 #, python-brace-format
-msgid ""
-"Cannot add partner {partner} to your favorites because you don't have access "
-"to it"
+msgid "Cannot add partner {partner} to your favorites because you don't have access to it"
 msgstr "无法将合作伙伴{partner}添加到您的收藏夹，因为您无权访问它"
-
-#. Translators: Do not translate.
-#: TWLight/users/models.py:869
-#, fuzzy, python-brace-format
-#| msgid "Username"
-msgid "{wp_username}"
-msgstr "用户名"
 
 #. Translators: This error message is shown when there's a problem with the authenticated login process.
 #: TWLight/users/oauth.py:243
@@ -2742,9 +2246,7 @@ msgstr "握手程序未启动，请尝试重新登录。"
 
 #. Translators: this message is displayed to users that don't have accounts and clicked on a proxied link.
 #: TWLight/users/oauth.py:388
-msgid ""
-"To view this link you need to be an eligible library user. Please login to "
-"continue."
+msgid "To view this link you need to be an eligible library user. Please login to continue."
 msgstr "要查看此链接，您需要是符合条件的图书馆用户。请先登录以继续。"
 
 #. Translators: This warning message is shown to users when the response received from Wikimedia OAuth servers is not a valid one.
@@ -2780,22 +2282,13 @@ msgstr "参见{issue}以获得更多信息"
 
 #. Translators: If the user tries to log in, but their account does not meet certain requirements, they cannot login.
 #: TWLight/users/oauth.py:528
-msgid ""
-"Your Wikipedia account does not meet the eligibility criteria in the terms "
-"of use, so your Wikipedia Library Card Platform account cannot be activated."
-msgstr ""
-"您的维基百科账号不符合使用条款中的资格标准，因此无法激活您的维基百科图书卡台"
-"帐户。"
+msgid "Your Wikipedia account does not meet the eligibility criteria in the terms of use, so your Wikipedia Library Card Platform account cannot be activated."
+msgstr "您的维基百科账号不符合使用条款中的资格标准，因此无法激活您的维基百科图书卡台帐户。"
 
 #. Translators: If the user tries to log in, but their account does not meet certain requirements, they cannot login.
 #: TWLight/users/oauth.py:536
-msgid ""
-"Your Wikipedia account no longer meets the eligibility criteria in the terms "
-"of use, so you cannot be logged in. If you think you should be able to log "
-"in, please email wikipedialibrary@wikimedia.org."
-msgstr ""
-"您的维基百科账号不再符合使用条款中的资格标准，因此您无法登录。如果您认为您应"
-"该能够登录，请发送电子邮件至wikipedialibrary@wikimedia.org。"
+msgid "Your Wikipedia account no longer meets the eligibility criteria in the terms of use, so you cannot be logged in. If you think you should be able to log in, please email wikipedialibrary@wikimedia.org."
+msgstr "您的维基百科账号不再符合使用条款中的资格标准，因此您无法登录。如果您认为您应该能够登录，请发送电子邮件至wikipedialibrary@wikimedia.org。"
 
 #. Translators: this message is displayed to users with brand new accounts.
 #: TWLight/users/oauth.py:549
@@ -2805,13 +2298,8 @@ msgstr "欢迎使用！请先同意使用条款。"
 #. Translators: This message is displayed on the confirmation page where users can return their access to partner collections.
 #: TWLight/users/templates/users/authorization_confirm_return.html:13
 #, python-format
-msgid ""
-"You will no longer be able to access <b>%(partner)s's</b> resources via the "
-"Library Card platform, but can request access again by clicking 'renew', if "
-"you change your mind. Are you sure you want to return your access?"
-msgstr ""
-"您将不再能够通过图书卡平台访问<b>%(partner)s's</b>的资源，但是如果您改变主"
-"意，可以通过点击“续订”再次请求访问权限。您确定要返回访问权限吗？"
+msgid "You will no longer be able to access <b>%(partner)s's</b> resources via the Library Card platform, but can request access again by clicking 'renew', if you change your mind. Are you sure you want to return your access?"
+msgstr "您将不再能够通过图书卡平台访问<b>%(partner)s's</b>的资源，但是如果您改变主意，可以通过点击“续订”再次请求访问权限。您确定要返回访问权限吗？"
 
 #. Translators: On the MyLibrary page (https://wikipedialibrary.wmflabs.org/users/my_library), this tab shows all favorite collections a user has.
 #: TWLight/users/templates/users/collections_section.html:9
@@ -2880,13 +2368,8 @@ msgstr "编者数据"
 
 #. Translators: This is shown on editor profiles, in their profile page or on applications.
 #: TWLight/users/templates/users/editor_detail.html:59
-msgid ""
-"Information with an * was retrieved from Wikipedia directly. Other "
-"information was entered directly by users or site admins, in their preferred "
-"language."
-msgstr ""
-"带*的信息是直接从维基百科获取的。其他信息由用户或站点管理员以其首选语言直接输"
-"入。"
+msgid "Information with an * was retrieved from Wikipedia directly. Other information was entered directly by users or site admins, in their preferred language."
+msgstr "带*的信息是直接从维基百科获取的。其他信息由用户或站点管理员以其首选语言直接输入。"
 
 #. Translators: This distinguishes users who have been flagged as account coordinators. Don't translate username.
 #: TWLight/users/templates/users/editor_detail.html:71
@@ -2896,13 +2379,8 @@ msgstr "%(username)s在本站拥有协调员权限。"
 
 #. Translators: This is shown on editor profiles, under the heading for Wikipedia editor data.
 #: TWLight/users/templates/users/editor_detail_data.html:5
-msgid ""
-"This information is updated automatically from your Wikimedia account each "
-"time you log in, except for the Contributions field, where you can describe "
-"your Wikimedia editing history."
-msgstr ""
-"除“贡献”字段之外，每次登录时，此信息都会从维基媒体账户自动更新，在该字段中，"
-"您可以描述维基媒体的编辑历史。"
+msgid "This information is updated automatically from your Wikimedia account each time you log in, except for the Contributions field, where you can describe your Wikimedia editing history."
+msgstr "除“贡献”字段之外，每次登录时，此信息都会从维基媒体账户自动更新。在“贡献”字段中，您可以描述维基媒体的编辑历史。"
 
 #. Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this labels the user's username.
 #: TWLight/users/templates/users/editor_detail_data.html:17
@@ -2931,17 +2409,13 @@ msgstr "满足使用条款吗？"
 
 #. Translators: when viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this question has a yes or no answer.
 #: TWLight/users/templates/users/editor_detail_data.html:57
-msgid ""
-"at their last login, did this user meet the criteria set forth in the terms "
-"of use?"
+msgid "at their last login, did this user meet the criteria set forth in the terms of use?"
 msgstr "在最后一次登录时，该用户是否符合使用条款中所规定的标准？"
 
 #. Translators: When viewing a user's profile in an application, this message shows if the software doesn't think that the user is eligible for access. Don't translate username.
 #: TWLight/users/templates/users/editor_detail_data.html:72
 #, python-format
-msgid ""
-"%(username)s may still be eligible for access grants at the coordinators' "
-"discretion."
+msgid "%(username)s may still be eligible for access grants at the coordinators' discretion."
 msgstr "%(username)s可能仍然有资格由协调员决定是否获得访问权限。"
 
 #. Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this is the heading for a Yes/No ToU question.
@@ -2971,18 +2445,13 @@ msgstr "没有在任何项目上被封禁？"
 #. Translators: If a user has received an exemption against a criterion, this is shown next to "No" on their user page and applications next to this criterion.
 #: TWLight/users/templates/users/editor_detail_data.html:132
 msgid "(exemption granted)"
-msgstr ""
+msgstr "（已授予豁免）"
 
 #. Translators: This message is shown on a user's profile if their Wikimedia account is blocked on one or more projects. They may still be granted access to the Library Bundle, but need to contact Wikipedia Library staff to verify.
 #: TWLight/users/templates/users/editor_detail_data.html:137
 #, python-format
-msgid ""
-"It looks like you have an active block on your account. If you meet the "
-"other criteria you may still be permitted access to the library - please <a "
-"class=\"twl-links\" href=\"%(contact_url)s\">contact us</a>."
-msgstr ""
-"看起来您的帐户有一个生效的封禁。如果您符合其他条件，我们仍可能允许您访问图书"
-"馆 - 请<a class=\"twl-links\" href=\"%(contact_url)s\">与我们联系</a>。"
+msgid "It looks like you have an active block on your account. If you meet the other criteria you may still be permitted access to the library - please <a class=\"twl-links\" href=\"%(contact_url)s\">contact us</a>."
+msgstr "看起来您的帐户有一个生效的封禁。如果您符合其他条件，我们仍可能允许您访问图书馆 - 请<a class=\"twl-links\" href=\"%(contact_url)s\">与我们联系</a>。"
 
 #. Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this is the heading for a Yes/No program eligibility question.
 #: TWLight/users/templates/users/editor_detail_data.html:153
@@ -2991,13 +2460,8 @@ msgstr "是否有使用Bundle的资格？"
 
 #. Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this question has a Yes or No answer.
 #: TWLight/users/templates/users/editor_detail_data.html:156
-msgid ""
-"At their last login, did this user meet the criteria set forth in the "
-"Library Bundle? Note that satisfying terms of use is a prerequisite to "
-"bundle eligibility."
-msgstr ""
-"上次登录时，该用户是否符合Library Bundle中所规定的标准？请注意，符合使用条款"
-"是Library Bundle资格的先决条件。"
+msgid "At their last login, did this user meet the criteria set forth in the Library Bundle? Note that satisfying terms of use is a prerequisite to bundle eligibility."
+msgstr "上次登录时，该用户是否符合Library Bundle中所规定的标准？请注意，符合使用条款是Library Bundle资格的先决条件。"
 
 #. Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this is the heading for a Yes/No program eligibility question.
 #: TWLight/users/templates/users/editor_detail_data.html:177
@@ -3041,23 +2505,14 @@ msgstr "个人数据"
 
 #. Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this text is in the 'Personal data' section. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/users/templates/users/editor_detail_data.html:262
-msgid ""
-"The following information is visible only to you, site administrators, "
-"publishing partners (where required), and volunteer Wikipedia Library "
-"coordinators (who have signed a Non-Disclosure Agreement)."
-msgstr ""
-"以下信息仅对您、站点管理员、出版商合作伙伴（如果需要）和维基百科图书馆志愿协"
-"调员（已签署保密协议）可见。"
+msgid "The following information is visible only to you, site administrators, publishing partners (where required), and volunteer Wikipedia Library coordinators (who have signed a Non-Disclosure Agreement)."
+msgstr "以下信息仅对您、站点管理员、出版商合作伙伴（如果需要）和维基百科图书馆志愿协调员（已签署保密协议）可见。"
 
 #. Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this labels a button which users can click to update or remove their personal information. Don't translate update_url.
 #: TWLight/users/templates/users/editor_detail_data.html:272
 #, python-format
-msgid ""
-"You may <a class=\"twl-links\" href=\"%(update_url)s\">update or delete</a> "
-"your data at any time."
-msgstr ""
-"你可以在任何时候修改、<a class=\"twl-links\" href=\"%(update_url)s\">更新或删"
-"除</a>你的数据。"
+msgid "You may <a class=\"twl-links\" href=\"%(update_url)s\">update or delete</a> your data at any time."
+msgstr "你可以在任何时候修改、<a class=\"twl-links\" href=\"%(update_url)s\">更新或删除</a>你的数据。"
 
 #. Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this labels the user's email. Don't remove the *.
 #: TWLight/users/templates/users/editor_detail_data.html:283
@@ -3076,28 +2531,19 @@ msgstr "所属机构"
 
 #. Translators: This message tells users that they are not eligible to access The Wikipedia Library content.
 #: TWLight/users/templates/users/eligibility_modal.html:7
-msgid ""
-"Sorry, your Wikipedia account doesn’t currently qualify to access The "
-"Wikipedia Library."
+msgid "Sorry, your Wikipedia account doesn’t currently qualify to access The Wikipedia Library."
 msgstr "抱歉，您的维基百科账户目前不满足访问维基百科图书馆的要求。"
 
 #. Translators: This message tells users that they have not agreed to the terms of use, therefore are ineligible to access the content in The Wikipedia Library.
 #: TWLight/users/templates/users/eligibility_modal.html:30
 #, python-format
-msgid ""
-"Agreed with <a href=\"%(terms)s\" class=\"text-danger\"> terms of use </a>"
-msgstr ""
-"是否同意该站点的<a href=\"%(terms)s\" class=\"text-danger\">使用条款</a>？"
+msgid "Agreed with <a href=\"%(terms)s\" class=\"text-danger\"> terms of use </a>"
+msgstr "是否同意该站点的<a href=\"%(terms)s\" class=\"text-danger\">使用条款</a>？"
 
 #: TWLight/users/templates/users/eligibility_modal.html:40
 #, python-format
-msgid ""
-"It looks like you have an active block on your account. If you meet the "
-"other criteria you may still be permitted access to the library - please <a "
-"href=\"%(contact_url)s\">contact us</a>."
-msgstr ""
-"看起来您的帐户有一个生效的封禁。如果您符合其他条件，我们仍可能允许您访问图书"
-"馆 - 请<a href=\"%(contact_url)s\">与我们联系</a>。"
+msgid "It looks like you have an active block on your account. If you meet the other criteria you may still be permitted access to the library - please <a href=\"%(contact_url)s\">contact us</a>."
+msgstr "看起来您的帐户有一个生效的封禁。如果您符合其他条件，我们仍可能允许您访问图书馆 - 请<a href=\"%(contact_url)s\">与我们联系</a>。"
 
 #. Translators: Instructions to refresh a user's data.
 #: TWLight/users/templates/users/eligibility_modal.html:50
@@ -3136,14 +2582,8 @@ msgstr "选择语言"
 
 #. Translators: This text on the user page helps users naviage to the TranslateWiki Wikipedia Library Card platform translation page.
 #: TWLight/users/templates/users/language_form.html:31
-msgid ""
-"You can help translate the tool at <a class=\"twl-links\" href=\"https://"
-"translatewiki.net/wiki/Translating:Wikipedia_Library_Card_Platform"
-"\">translatewiki.net</a>."
-msgstr ""
-"您可以在<a class=\"twl-links\" href=\"https://translatewiki.net/wiki/"
-"Translate:Wikipedia_Library_Card_Platform\">translatewiki.net</a>上帮助翻译该"
-"工具。"
+msgid "You can help translate the tool at <a class=\"twl-links\" href=\"https://translatewiki.net/wiki/Translating:Wikipedia_Library_Card_Platform\">translatewiki.net</a>."
+msgstr "您可以在<a class=\"twl-links\" href=\"https://translatewiki.net/wiki/Translate:Wikipedia_Library_Card_Platform\">translatewiki.net</a>上帮助翻译该工具。"
 
 #. Translators: When the user starts a new application and submits the application, the user can view the application and withdraw if need be. This changes the label for the Withdraw button.
 #: TWLight/users/templates/users/my_applications.html:65
@@ -3162,9 +2602,7 @@ msgstr "请求续订"
 
 #. Translators: On the page listing applications, this text explains a user they cannot renew their application since they've already requested a renewal or there aren't any renewals available.
 #: TWLight/users/templates/users/my_applications.html:79
-msgid ""
-"Renewals are either not required, not available right now, or you have "
-"already requested a renewal."
+msgid "Renewals are either not required, not available right now, or you have already requested a renewal."
 msgstr "不需要续订，或当前不可用，或者您已经请求续订。"
 
 #. Translators: This text is the heading of a section in a user's profile where they can change their preferences.
@@ -3228,22 +2666,12 @@ msgstr "限制数据处理"
 
 #. Translators: This message is displayed on the page where users can request we stop processing their data.
 #: TWLight/users/templates/users/restrict_data.html:15
-msgid ""
-"Checking this box and clicking “Restrict” will pause all processing of the "
-"data you have entered into this website. You will not be able to apply for "
-"access to resources, your applications will not be further processed, and "
-"none of your data will be altered, until you return to this page and uncheck "
-"the box. This is not the same as deleting your data."
-msgstr ""
-"选中此框并点击“限制”将暂停对您输入到本网站的数据的所有处理。您将无法申请访问"
-"资源，您将无法申请对资源的访问权限，并且将无法进一步处理您的申请。同时您的任"
-"何数据都不会更改，直到您返回此页面并取消选中该框。这与删除数据不同。"
+msgid "Checking this box and clicking “Restrict” will pause all processing of the data you have entered into this website. You will not be able to apply for access to resources, your applications will not be further processed, and none of your data will be altered, until you return to this page and uncheck the box. This is not the same as deleting your data."
+msgstr "选中此框并点击“限制”将暂停对您输入到本网站的数据的所有处理。您将无法申请访问资源，您将无法申请对资源的访问权限，并且将无法进一步处理您的申请。同时您的任何数据都不会更改，直到您返回此页面并取消选中该框。这与删除数据不同。"
 
 #. Translators: This warning message is shown to coordinators who view the data restriction page.
 #: TWLight/users/templates/users/restrict_data.html:26
-msgid ""
-"You are a coordinator on this site. If you restrict the processing of your "
-"data, your coordinator flag will be removed."
+msgid "You are a coordinator on this site. If you restrict the processing of your data, your coordinator flag will be removed."
 msgstr "您是本站的协调员。如果您限制数据处理，那么您的协调员标志将被删除。"
 
 #. Translators: use the date *when you are translating*, in a language-appropriate format.
@@ -3263,33 +2691,13 @@ msgstr "维基百科图书卡使用条款和隐私声明"
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:51
-msgid ""
-"<a class=\"twl-links\" href=\"https://meta.wikimedia.org/wiki/"
-"The_Wikipedia_Library\"> The Wikipedia Library </a> has partnered with "
-"publishers around the world to allow users to access otherwise paywalled "
-"resources. This website allows Wikipedia editors to search and access these "
-"resources."
-msgstr ""
-"<a class=\"twl-links\" href=\"https://meta.wikimedia.org/wiki/"
-"The_Wikipedia_Library/zh\">维基百科图书馆</a>已经与世界各地的出版商建立了合作"
-"伙伴关系，以允许用户访问其需要付费的资源。本网站允许维基百科编辑者搜索和访问"
-"这些资源。"
+msgid "<a class=\"twl-links\" href=\"https://meta.wikimedia.org/wiki/The_Wikipedia_Library\"> The Wikipedia Library </a> has partnered with publishers around the world to allow users to access otherwise paywalled resources. This website allows Wikipedia editors to search and access these resources."
+msgstr "<a class=\"twl-links\" href=\"https://meta.wikimedia.org/wiki/The_Wikipedia_Library/zh\">维基百科图书馆</a>已经与世界各地的出版商建立了合作伙伴关系，以允许用户访问其需要付费的资源。本网站允许维基百科编辑者搜索和访问这些资源。"
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Wikimedia Foundation should not be translated. WMF should not be translated. Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:63
-msgid ""
-"This program is administered by the Wikimedia Foundation (WMF). These terms "
-"of use and privacy notice pertain to your application for access to "
-"resources through the Wikipedia Library, your use of this website, and your "
-"access to and use of those resources. They also describe our handling of the "
-"information you provide to us in order to create and administer your "
-"Wikipedia Library account. If we make material changes to the terms, we will "
-"notify users."
-msgstr ""
-"本程序由维基媒体基金会（WMF）管理。这些使用条款和隐私声明涉及到使用维基百科图"
-"书馆资源的申请，以及对这些资源的访问和使用。它们还描述了我们对您提供给我们的"
-"信息的处理方式，以便创建和管理您的维基百科图书馆账户。如果我们对条款进行重大"
-"更改，我们将通知用户。"
+msgid "This program is administered by the Wikimedia Foundation (WMF). These terms of use and privacy notice pertain to your application for access to resources through the Wikipedia Library, your use of this website, and your access to and use of those resources. They also describe our handling of the information you provide to us in order to create and administer your Wikipedia Library account. If we make material changes to the terms, we will notify users."
+msgstr "本程序由维基媒体基金会（WMF）管理。这些使用条款和隐私声明涉及到使用维基百科图书馆资源的申请，以及对这些资源的访问和使用。它们还描述了我们对您提供给我们的信息的处理方式，以便创建和管理您的维基百科图书馆账户。如果我们对条款进行重大更改，我们将通知用户。"
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:74
@@ -3298,50 +2706,18 @@ msgstr "维基百科图书卡账户的要求"
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:78
-msgid ""
-"Access to resources via The Wikipedia Library is reserved for community "
-"members who have demonstrated their commitment to the Wikimedia projects, "
-"and who will use their access to these resources to improve project content. "
-"To that end, in order to be eligible for The Wikipedia Library, we require "
-"that you be registered for a user account on the projects, with at least 500 "
-"edits, six (6) months of activity, and 10+ edits in the last month. We ask "
-"that you do not request access to any publishers with a limited number of "
-"available accounts whose resources you can already access for free through "
-"your local library or university, or another institution or organization, in "
-"order to provide that opportunity to others."
-msgstr ""
-"透过维基百科图书馆取用资源的权限仅限于已经表明了对维基媒体项目的承诺，并将使"
-"用这些资源来改善项目的内容的维基人。对此，为了取得使用维基百科图书馆的资格，"
-"我们会要求您是项目上的已注册使用者。我们会优先考虑编辑超过500次，至少有6个月"
-"活动，且上个月编辑达10次以上的维基人使用。不过，若您已可以透过图书馆、大学、"
-"机构，或是其它组织来免费获得一些出版者的资源，我们请求您不要再向这些出版者提"
-"出申请，以便让机会留给其他人。"
+msgid "Access to resources via The Wikipedia Library is reserved for community members who have demonstrated their commitment to the Wikimedia projects, and who will use their access to these resources to improve project content. To that end, in order to be eligible for The Wikipedia Library, we require that you be registered for a user account on the projects, with at least 500 edits, six (6) months of activity, and 10+ edits in the last month. We ask that you do not request access to any publishers with a limited number of available accounts whose resources you can already access for free through your local library or university, or another institution or organization, in order to provide that opportunity to others."
+msgstr "透过维基百科图书馆取用资源的权限仅限于已经表明了对维基媒体项目的承诺，并将使用这些资源来改善项目的内容的维基人。对此，为了取得使用维基百科图书馆的资格，我们会要求您是项目上的已注册使用者。我们会优先考虑编辑超过500次，至少有6个月活动，且上个月编辑达10次以上的维基人使用。不过，若您已可以透过图书馆、大学、机构，或是其它组织来免费获得一些出版者的资源，我们请求您不要再向这些出版者提出申请，以便让机会留给其他人。"
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:94
-msgid ""
-"Additionally, if you are currently blocked or banned from a Wikimedia "
-"project, applications to resources may be rejected or restricted. If you "
-"obtain a Wikipedia Library account, but a block or ban is subsequently "
-"instituted against you on one of the projects, you may lose access to your "
-"Wikipedia Library account."
-msgstr ""
-"此外，如果您当前被维基媒体项目封禁或禁止编辑，对资源的申请可能会被拒绝或限"
-"制。如果您获得了维基百科图书馆账户，但随后其中一个项目对您实施了封禁或禁止编"
-"辑，那么您可能会失去对维基百科图书馆帐户的访问权限。"
+msgid "Additionally, if you are currently blocked or banned from a Wikimedia project, applications to resources may be rejected or restricted. If you obtain a Wikipedia Library account, but a block or ban is subsequently instituted against you on one of the projects, you may lose access to your Wikipedia Library account."
+msgstr "此外，如果您当前被维基媒体项目封禁或禁止编辑，对资源的申请可能会被拒绝或限制。如果您获得了维基百科图书馆账户，但随后其中一个项目对您实施了封禁或禁止编辑，那么您可能会失去对维基百科图书馆帐户的访问权限。"
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:104
-msgid ""
-"Your eligibility to access The Wikipedia Library is assessed at each login. "
-"While more than half of the library's content is provided via this automated "
-"eligibility check, access to other publisher's content may be time limited, "
-"typically lapsing after one year, after which you will usually need to apply "
-"for renewal."
-msgstr ""
-"每次登录都会评估您访问维基百科图书馆的资格。尽管图书馆超过一半的内容是通过此"
-"自动资格检查程序提供的，但对其他出版者内容的访问可能会有时间限制，通常会在一"
-"年后失效，在那之后您通常需要申请续订。"
+msgid "Your eligibility to access The Wikipedia Library is assessed at each login. While more than half of the library's content is provided via this automated eligibility check, access to other publisher's content may be time limited, typically lapsing after one year, after which you will usually need to apply for renewal."
+msgstr "每次登录都会评估您访问维基百科图书馆的资格。尽管图书馆超过一半的内容是通过此自动资格检查程序提供的，但对其他出版者内容的访问可能会有时间限制，通常会在一年后失效，在那之后您通常需要申请续订。"
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:114
@@ -3350,60 +2726,28 @@ msgstr "通过您的维基百科图书卡账户申请"
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:118
-msgid ""
-"In order to apply for access to a partner resource, you must provide us with "
-"certain information, which we will use to evaluate your application. If your "
-"application is approved, we may transfer the information you have given us "
-"to the publishers whose resources you wish to access. They will either "
-"contact you with the account information directly or we will send access "
-"information to you ourselves."
-msgstr ""
-"为了申请合作伙伴资源的访问权限，您必须向我们提供某些信息，我们将使用这些信息"
-"来评估您的申请。如果您的申请获得批准，我们可能会将您提供给我们的信息转递给您"
-"希望访问其资源的出版商。他们会直接与您联系并提供帐户信息，或者我们会自己将访"
-"问信息发送给您。"
+msgid "In order to apply for access to a partner resource, you must provide us with certain information, which we will use to evaluate your application. If your application is approved, we may transfer the information you have given us to the publishers whose resources you wish to access. They will either contact you with the account information directly or we will send access information to you ourselves."
+msgstr "为了申请合作伙伴资源的访问权限，您必须向我们提供某些信息，我们将使用这些信息来评估您的申请。如果您的申请获得批准，我们可能会将您提供给我们的信息转递给您希望访问其资源的出版商。他们会直接与您联系并提供帐户信息，或者我们会自己将访问信息发送给您。"
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:130
-msgid ""
-"In addition to the basic information you provide to us, our system will "
-"retrieve some information directly from the Wikimedia projects: your "
-"username, email address, edit count, registration date, user ID number, "
-"groups to which you belong, and any special user rights."
-msgstr ""
-"除了您提供给我们的基本信息之外，我们的系统还将直接从维基媒体项目中获取一些信"
-"息：您的用户名、电子邮件地址、编辑次数、注册日期、用户ID、您所属的用户组以及"
-"任何特殊的用户权限。"
+msgid "In addition to the basic information you provide to us, our system will retrieve some information directly from the Wikimedia projects: your username, email address, edit count, registration date, user ID number, groups to which you belong, and any special user rights."
+msgstr "除了您提供给我们的基本信息之外，我们的系统还将直接从维基媒体项目中获取一些信息：您的用户名、电子邮件地址、编辑次数、注册日期、用户ID、您所属的用户组以及任何特殊的用户权限。"
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:140
-msgid ""
-"Each time you log in to the Wikipedia Library Card Platform, this "
-"information will be automatically updated."
+msgid "Each time you log in to the Wikipedia Library Card Platform, this information will be automatically updated."
 msgstr "每次您登录维基百科图书卡平台时，此信息将自动更新。"
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:148
-msgid ""
-"We will ask you to provide us with some information about your history of "
-"contributions to the Wikimedia projects. Information on contribution history "
-"is optional, but will greatly assist us in evaluating your application."
-msgstr ""
-"我们将要求您向我们提供一些关于您在维基媒体项目上所做贡献的历史信息。贡献历史"
-"的信息是可选的，但将极大地帮助我们评估您的申请。"
+msgid "We will ask you to provide us with some information about your history of contributions to the Wikimedia projects. Information on contribution history is optional, but will greatly assist us in evaluating your application."
+msgstr "我们将要求您向我们提供一些关于您在维基媒体项目上所做贡献的历史信息。贡献历史的信息是可选的，但将极大地帮助我们评估您的申请。"
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). WMF should not be translated. Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:157
-msgid ""
-"The information you provide when creating your account will be visible to "
-"you while on the site but not to others unless they are approved Wikipedia "
-"Library Coordinators, WMF Staff, or WMF Contractors who need access to this "
-"data in order to carry out their work with the Wikipedia Library, all of "
-"whom are subject to non-disclosure obligations."
-msgstr ""
-"您在本站创建帐户时会看到您创建的信息，但对其他用户则不可见，除非他们是获得批"
-"准的维基百科图书馆协调员、WMF（维基媒体基金会）员工或 WMF承包商。他们需要访问"
-"这些数据才能与维基百科图书馆一起工作，所有这些人均须承担保密义务。"
+msgid "The information you provide when creating your account will be visible to you while on the site but not to others unless they are approved Wikipedia Library Coordinators, WMF Staff, or WMF Contractors who need access to this data in order to carry out their work with the Wikipedia Library, all of whom are subject to non-disclosure obligations."
+msgstr "您在本站创建帐户时会看到您创建的信息，但对其他用户则不可见，除非他们是获得批准的维基百科图书馆协调员、WMF（维基媒体基金会）员工或 WMF承包商。他们需要访问这些数据才能与维基百科图书馆一起工作，所有这些人均须承担保密义务。"
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:167
@@ -3412,53 +2756,33 @@ msgstr "您对出版商资源的使用"
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:171
-msgid ""
-"In order to access an individual publisher’s resources, you must agree to "
-"that publisher’s terms of use and privacy policy. You agree that you will "
-"not violate such terms and policies in connection with your use of the "
-"Wikipedia Library. Additionally, the following activities are prohibited "
-"while accessing publisher resources through the Wikipedia Library."
-msgstr ""
-"为了访问某个出版商的资源，您必须同意该出版商的使用条款和隐私政策。您同意不会"
-"因使用维基百科图书馆而违反此类条款和政策。此外，在通过维基百科图书馆访问出版"
-"商资源时，禁止以下活动。"
+msgid "In order to access an individual publisher’s resources, you must agree to that publisher’s terms of use and privacy policy. You agree that you will not violate such terms and policies in connection with your use of the Wikipedia Library. Additionally, the following activities are prohibited while accessing publisher resources through the Wikipedia Library."
+msgstr "为了访问某个出版商的资源，您必须同意该出版商的使用条款和隐私政策。您同意不会因使用维基百科图书馆而违反此类条款和政策。此外，在通过维基百科图书馆访问出版商资源时，禁止以下活动。"
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:184
-msgid ""
-"Sharing your Wikipedia account, usernames, passwords, or any access codes "
-"for publisher resources with others;"
+msgid "Sharing your Wikipedia account, usernames, passwords, or any access codes for publisher resources with others;"
 msgstr "与其他人分享您的维基百科账户、用户名、密码或任何访问出版商资源的代码；"
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:191
-msgid ""
-"Automatically scraping or downloading restricted content from publishers;"
+msgid "Automatically scraping or downloading restricted content from publishers;"
 msgstr "自动从出版商抓取或下载受限制的内容；"
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:197
-msgid ""
-"Systematically making printed or electronic copies of multiple extracts of "
-"restricted content available for any purpose;"
+msgid "Systematically making printed or electronic copies of multiple extracts of restricted content available for any purpose;"
 msgstr "有系统地制作多个受限制内容题录的印刷或电子复制品，以用于任何目的；"
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:204
-msgid ""
-"Data mining metadata without permission—for example, in order to use "
-"metadata for auto-created stub articles;"
-msgstr ""
-"未经许可进行元数据的数据挖掘——例如，为了将元数据用于自动创建小作品条目；"
+msgid "Data mining metadata without permission—for example, in order to use metadata for auto-created stub articles;"
+msgstr "未经许可进行元数据的数据挖掘——例如，为了将元数据用于自动创建小作品条目；"
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:211
-msgid ""
-"Using the access you receive through the Wikipedia Library for profit by "
-"selling access to your account or resources which you have through it."
-msgstr ""
-"利用您通过维基百科图书馆获得的访问权限，出售对您拥有的帐户或资源的访问权限来"
-"牟利。"
+msgid "Using the access you receive through the Wikipedia Library for profit by selling access to your account or resources which you have through it."
+msgstr "利用您通过维基百科图书馆获得的访问权限，出售对您拥有的帐户或资源的访问权限来牟利。"
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:220
@@ -3467,21 +2791,12 @@ msgstr "外部搜索和代理服务"
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:224
-msgid ""
-"Certain resources may only be accessed using an external search service, "
-"such as the EBSCO Discovery Service, or a proxy service, such as OCLC "
-"EZProxy. If you use such external search and/or proxy services, please "
-"review the applicable terms of use and privacy policies."
-msgstr ""
-"某些资源只能使用外部搜索服务（例如EBSCO发现服务）或代理服务（例如OCLC "
-"EZProxy）来访问。如果您使用此类外部搜索和/或代理服务，请查看适用的使用条款和"
-"隐私政策。"
+msgid "Certain resources may only be accessed using an external search service, such as the EBSCO Discovery Service, or a proxy service, such as OCLC EZProxy. If you use such external search and/or proxy services, please review the applicable terms of use and privacy policies."
+msgstr "某些资源只能使用外部搜索服务（例如EBSCO发现服务）或代理服务（例如OCLC EZProxy）来访问。如果您使用此类外部搜索和/或代理服务，请查看适用的使用条款和隐私政策。"
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:234
-msgid ""
-"In addition, if you use OCLC EZProxy, please note that you may not use it "
-"for commercial purposes."
+msgid "In addition, if you use OCLC EZProxy, please note that you may not use it for commercial purposes."
 msgstr "此外，如果您使用OCLC EZProxy，请注意，您不得将其用于商业目的。"
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
@@ -3491,164 +2806,50 @@ msgstr "数据保留与处理"
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Wikimedia Foundation should not be translated. Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:245
-msgid ""
-"The Wikimedia Foundation and our service providers use your information for "
-"the legitimate purpose of providing Wikipedia Library services in support of "
-"our charitable mission. When you apply for a Wikipedia Library account, or "
-"use your Wikipedia Library account, we may routinely collect the following "
-"information: your username, email address, edit count, registration date, "
-"user ID number, groups to which you belong, and any special user rights; "
-"your name, country of residence, and/or affiliation, if required by a "
-"partner to which you are applying; your narrative description of your "
-"contributions and reasons for applying for access to partner resources; and "
-"the date you agree to these terms of use."
-msgstr ""
-"维基媒体基金会和我们的服务提供商出于合法目的使用您的信息，以提供维基百科图书"
-"馆服务来支持我们的慈善使命。当您申请维基百科图书馆帐户或使用维基百科图书馆帐"
-"户时，我们可能会定期收集以下信息：您的用户名、电子邮件地址、编辑数量、注册日"
-"期、用户ID号、所属用户组以及任何特殊用户权限; 您的姓名、居住地以及隶属关系"
-"（如果您要申请的合作伙伴要求的话）；您对自己贡献的叙述性描述以及申请访问合作"
-"伙伴资源的原因；以及您同意这些使用条款的日期。"
+msgid "The Wikimedia Foundation and our service providers use your information for the legitimate purpose of providing Wikipedia Library services in support of our charitable mission. When you apply for a Wikipedia Library account, or use your Wikipedia Library account, we may routinely collect the following information: your username, email address, edit count, registration date, user ID number, groups to which you belong, and any special user rights; your name, country of residence, and/or affiliation, if required by a partner to which you are applying; your narrative description of your contributions and reasons for applying for access to partner resources; and the date you agree to these terms of use."
+msgstr "维基媒体基金会和我们的服务提供商出于合法目的使用您的信息，以提供维基百科图书馆服务来支持我们的慈善使命。当您申请维基百科图书馆帐户或使用维基百科图书馆帐户时，我们可能会定期收集以下信息：您的用户名、电子邮件地址、编辑数量、注册日期、用户ID号、所属用户组以及任何特殊用户权限; 您的姓名、居住地以及隶属关系（如果您要申请的合作伙伴要求的话）；您对自己贡献的叙述性描述以及申请访问合作伙伴资源的原因；以及您同意这些使用条款的日期。"
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:262
 #, python-format
-msgid ""
-"Each publisher who is a member of the Wikipedia Library program requires "
-"different specific information in the application. Some publishers may "
-"request only an email address, while others request more detailed data, such "
-"as your name, location, or institutional affiliation. When you complete your "
-"application, you will only be asked to supply information required by the "
-"publishers you have chosen, and each publisher will only receive the "
-"information they require for providing you with access. Please see our <a "
-"class=\"twl-links\" href=\"%(all_partners_url)s\">partner information</a> "
-"pages to learn what information is required by each publisher to gain access "
-"to their resources."
-msgstr ""
-"每个出版商都是维基百科图书馆程序的一个成员，在申请时需要不同的特定信息。有些"
-"出版商可能只要求一个电子邮件地址，而其他出版商则要求更详细的数据，如您的姓"
-"名、所在地或机构隶属关系。完成申请后，只会要求您提供您所选的出版商所需的信"
-"息，并且每个出版商将只会收到他们为您提供访问权限所需的信息。请参阅我们的<a "
-"class=\"twl-links\" href=\"%(all_partners_url)s\">合作伙伴信息</a>页面，以了"
-"解每个出版商需要哪些信息才能访问其资源。"
+msgid "Each publisher who is a member of the Wikipedia Library program requires different specific information in the application. Some publishers may request only an email address, while others request more detailed data, such as your name, location, or institutional affiliation. When you complete your application, you will only be asked to supply information required by the publishers you have chosen, and each publisher will only receive the information they require for providing you with access. Please see our <a class=\"twl-links\" href=\"%(all_partners_url)s\">partner information</a> pages to learn what information is required by each publisher to gain access to their resources."
+msgstr "每个出版商都是维基百科图书馆程序的一个成员，在申请时需要不同的特定信息。有些出版商可能只要求一个电子邮件地址，而其他出版商则要求更详细的数据，如您的姓名、所在地或机构隶属关系。完成申请后，只会要求您提供您所选的出版商所需的信息，并且每个出版商将只会收到他们为您提供访问权限所需的信息。请参阅我们的<a class=\"twl-links\" href=\"%(all_partners_url)s\">合作伙伴信息</a>页面，以了解每个出版商需要哪些信息才能访问其资源。"
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Wikimedia Foundation should not be translated. Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:277
-msgid ""
-"Some Wikipedia Library pages are visible without logging in, but you will "
-"need to log in to apply or access proprietary partner resources. We use the "
-"data provided by you via OAuth and Wikimedia API calls to assess your "
-"application for access and to process approved requests."
-msgstr ""
-"一些维基百科图书馆无需登录即可查看，但是您需要登录才能申请或访问专有合作伙伴"
-"的资源。我们使用您通过OAuth和Wikimedia API调用提供的数据来评估您申请的访问权"
-"限并处理批准的请求。"
+msgid "Some Wikipedia Library pages are visible without logging in, but you will need to log in to apply or access proprietary partner resources. We use the data provided by you via OAuth and Wikimedia API calls to assess your application for access and to process approved requests."
+msgstr "一些维基百科图书馆无需登录即可查看，但是您需要登录才能申请或访问专有合作伙伴的资源。我们使用您通过OAuth和Wikimedia API调用提供的数据来评估您申请的访问权限并处理批准的请求。"
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:288
 #, python-format
-msgid ""
-"In order to administer the Wikipedia Library program, we will retain the "
-"application data we collect from you for three years after your most recent "
-"login, unless you delete your account, as described below. You can log in "
-"and go to <a class=\"twl-links\" href=\"%(profile_url)s\">your profile page</"
-"a> in order to see the information associated with your account, and can "
-"download it in JSON format. You may access, update, restrict, or delete this "
-"information at any time, except for the information that is automatically "
-"retrieved from the projects. If you have any questions or concerns about the "
-"handling of your data, please contact <a class=\"twl-links\" href=\"mailto:"
-"wikipedialibrary@wikimedia.org?Subject=Wikipedia%%20Library%%20Card"
-"%%20account%%20deactivation\"> wikipedialibrary@wikimedia.org </a>."
-msgstr ""
-"为了管理Wikipedia Library程序，我们将保留无限期从你最近登录之后的三年收集的应"
-"用程序数据，除非您删除账户，如下所述。您可以登录并转到<a class=\"twl-links\" "
-"href=\"%(profile_url)s\">配置文件页</a>，以便查看与您的帐户相关联的信息，可以"
-"以 JSON 格式下载。您可以随时访问、更新、限制或删除此信息，除了从项目中自动检"
-"索的信息之外。如果您对数据的处理有任何疑问或疑虑，请联系 <a class=\"twl-links"
-"\" href=\"mailto:wikipedialibrary@wikimedia.org?Subject=Wikipedia%%20Library"
-"%%20Card%%20account%%20deactivation\"></a>。"
+msgid "In order to administer the Wikipedia Library program, we will retain the application data we collect from you for three years after your most recent login, unless you delete your account, as described below. You can log in and go to <a class=\"twl-links\" href=\"%(profile_url)s\">your profile page</a> in order to see the information associated with your account, and can download it in JSON format. You may access, update, restrict, or delete this information at any time, except for the information that is automatically retrieved from the projects. If you have any questions or concerns about the handling of your data, please contact <a class=\"twl-links\" href=\"mailto:wikipedialibrary@wikimedia.org?Subject=Wikipedia%%20Library%%20Card%%20account%%20deactivation\"> wikipedialibrary@wikimedia.org </a>."
+msgstr "为了管理Wikipedia Library程序，我们将保留无限期从你最近登录之后的三年收集的应用程序数据，除非您删除账户，如下所述。您可以登录并转到<a class=\"twl-links\" href=\"%(profile_url)s\">配置文件页</a>，以便查看与您的帐户相关联的信息，可以以 JSON 格式下载。您可以随时访问、更新、限制或删除此信息，除了从项目中自动检索的信息之外。如果您对数据的处理有任何疑问或疑虑，请联系 <a class=\"twl-links\" href=\"mailto:wikipedialibrary@wikimedia.org?Subject=Wikipedia%%20Library%%20Card%%20account%%20deactivation\"></a>。"
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:305
-msgid ""
-"If you decide to disable your Wikipedia Library account, you can use the "
-"delete button on your profile to delete certain personal information "
-"associated with your account. We will delete your real name, institutional "
-"affiliation, and country of residence. Please note that the system will "
-"retain a record of your username, the publishers to which you applied or had "
-"access, and the dates of that access. Note that deletion is not reversible. "
-"Deletion of your Wikipedia Library account may also correspond with the "
-"removal of any resource access to which you were eligible or approved. If "
-"you request the deletion of account information and later wish to apply for "
-"a new account, you will need to provide the necessary information again."
-msgstr ""
-"如果您决定注销您的维基百科图书馆账户，可以使用个人资料上的删除按钮删除与您的"
-"帐户相关联的某些个人信息。我们将删除您的真实姓名、机构隶属关系和居住地。请注"
-"意，系统将保留您的用户名，您已申请或有权访问的出版商，以及访问日期的记录。请"
-"注意，删除是不可逆的。删除维基百科图书馆帐户也可能与删除您有资格或被批准的任"
-"何资源访问权限相对应。如果您请求删除帐户信息，但以后又想申请一个新帐户，则需"
-"要再次提供必要的信息。"
+msgid "If you decide to disable your Wikipedia Library account, you can use the delete button on your profile to delete certain personal information associated with your account. We will delete your real name, institutional affiliation, and country of residence. Please note that the system will retain a record of your username, the publishers to which you applied or had access, and the dates of that access. Note that deletion is not reversible. Deletion of your Wikipedia Library account may also correspond with the removal of any resource access to which you were eligible or approved. If you request the deletion of account information and later wish to apply for a new account, you will need to provide the necessary information again."
+msgstr "如果您决定注销您的维基百科图书馆账户，可以使用个人资料上的删除按钮删除与您的帐户相关联的某些个人信息。我们将删除您的真实姓名、机构隶属关系和居住地。请注意，系统将保留您的用户名，您已申请或有权访问的出版商，以及访问日期的记录。请注意，删除是不可逆的。删除维基百科图书馆帐户也可能与删除您有资格或被批准的任何资源访问权限相对应。如果您请求删除帐户信息，但以后又想申请一个新帐户，则需要再次提供必要的信息。"
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). WMF should not be translated. Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:321
-msgid ""
-"The Wikipedia Library is run by WMF Staff, Contractors, and approved "
-"volunteer Coordinators. The data associated with your account will be shared "
-"with the WMF staff, contractors, service providers, and volunteer "
-"coordinators who need to process the information in connection with their "
-"work for the Wikipedia Library, and who are subject to confidentiality "
-"obligations. We will also use your data for internal Wikipedia Library "
-"purposes such as distributing user surveys and account notifications, and in "
-"a depersonalized or aggregated fashion for statistical analysis and "
-"administration. Finally, we will share your information with the publishers "
-"whom you specifically select in order to provide you with access to "
-"resources. Otherwise, your information will not be shared with third "
-"parties, with the exception of the circumstances described below."
-msgstr ""
-"维基百科图书馆由WMF工作人员、承包商和经批准的志愿者协调员管理。与您的帐户关联"
-"的数据将与WMF工作人员、承包商、服务提供商和志愿者协调员共享，他们需要处理与维"
-"基百科图书馆工作相关的信息，并承担保密义务。我们还会将您的数据用于维基百科图"
-"书馆的内部目的，例如分发用户调查和帐户通知，并以非个性化或汇总的方式进行统计"
-"分析和管理。最后，我们将与您专门选择的出版商共享您的信息，以便为您提供对资源"
-"的访问权限。否则，除下述情况外，您的信息将不会与第三方共享。"
+msgid "The Wikipedia Library is run by WMF Staff, Contractors, and approved volunteer Coordinators. The data associated with your account will be shared with the WMF staff, contractors, service providers, and volunteer coordinators who need to process the information in connection with their work for the Wikipedia Library, and who are subject to confidentiality obligations. We will also use your data for internal Wikipedia Library purposes such as distributing user surveys and account notifications, and in a depersonalized or aggregated fashion for statistical analysis and administration. Finally, we will share your information with the publishers whom you specifically select in order to provide you with access to resources. Otherwise, your information will not be shared with third parties, with the exception of the circumstances described below."
+msgstr "维基百科图书馆由WMF工作人员、承包商和经批准的志愿者协调员管理。与您的帐户关联的数据将与WMF工作人员、承包商、服务提供商和志愿者协调员共享，他们需要处理与维基百科图书馆工作相关的信息，并承担保密义务。我们还会将您的数据用于维基百科图书馆的内部目的，例如分发用户调查和帐户通知，并以非个性化或汇总的方式进行统计分析和管理。最后，我们将与您专门选择的出版商共享您的信息，以便为您提供对资源的访问权限。否则，除下述情况外，您的信息将不会与第三方共享。"
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). WMF should not be translated.
 #: TWLight/users/templates/users/terms.html:338
-msgid ""
-"We may disclose any collected information when required by law, when we have "
-"your permission, when needed to protect our rights, privacy, safety, users, "
-"or the general public, and when necessary to enforce these terms, WMF’s "
-"general <a class=\"twl-links\" href=\"https://foundation.wikimedia.org/wiki/"
-"Terms_of_Use\">Terms of Use</a>, or any other WMF policy."
-msgstr ""
-"我们可能会在法律要求时，当我们征得您的许可后，当需要保护我们的权利、隐私、安"
-"全、用户或公众时，以及为执行这些条款而有必要时，披露WMF的一般性<a class="
-"\"twl-links\" href =“ https://foundation.wikimedia.org/wiki/Terms_of_Use“>使"
-"用条款</a>或任何其他WMF政策。"
+msgid "We may disclose any collected information when required by law, when we have your permission, when needed to protect our rights, privacy, safety, users, or the general public, and when necessary to enforce these terms, WMF’s general <a class=\"twl-links\" href=\"https://foundation.wikimedia.org/wiki/Terms_of_Use\">Terms of Use</a>, or any other WMF policy."
+msgstr "我们可能会在法律要求时，当我们征得您的许可后，当需要保护我们的权利、隐私、安全、用户或公众时，以及为执行这些条款而有必要时，披露WMF的一般性<a class=\"twl-links\" href =“ https://foundation.wikimedia.org/wiki/Terms_of_Use“>使用条款</a>或任何其他WMF政策。"
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:349
-msgid ""
-"We take the security of your personal data seriously, and take reasonable "
-"precautions to ensure your data is protected. These precautions include "
-"access controls to limit who has access to your data and security "
-"technologies to protect data stored on the server. However, we cannot "
-"guarantee the safety of your data as it is transmitted and stored."
-msgstr ""
-"我们认真对待您的个人数据安全，并采取合理的预防措施以确保您的数据受到保护。这"
-"些预防措施包括访问控制，以限制谁可以访问您的数据，以及安全技术以保护存储在服"
-"务器上的数据。但是，我们无法保证您的数据在传输和存储时的安全性。"
+msgid "We take the security of your personal data seriously, and take reasonable precautions to ensure your data is protected. These precautions include access controls to limit who has access to your data and security technologies to protect data stored on the server. However, we cannot guarantee the safety of your data as it is transmitted and stored."
+msgstr "我们认真对待您的个人数据安全，并采取合理的预防措施以确保您的数据受到保护。这些预防措施包括访问控制，以限制谁可以访问您的数据，以及安全技术以保护存储在服务器上的数据。但是，我们无法保证您的数据在传输和存储时的安全性。"
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:360
-msgid ""
-"Please note that these terms do not control the use and handling of your "
-"data by the publishers and service providers whose resources you access or "
-"apply to access. Please read their individual privacy policies for that "
-"information."
-msgstr ""
-"请注意，这些条款并不控制您访问或申请访问其资源的出版商和服务提供商对数据的使"
-"用和处理。 请阅读他们的个人隐私政策以获取相关信息。"
+msgid "Please note that these terms do not control the use and handling of your data by the publishers and service providers whose resources you access or apply to access. Please read their individual privacy policies for that information."
+msgstr "请注意，这些条款并不控制您访问或申请访问其资源的出版商和服务提供商对数据的使用和处理。 请阅读他们的个人隐私政策以获取相关信息。"
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:368
@@ -3657,47 +2858,18 @@ msgstr "重要提示"
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Wikimedia Foundation should not be translated. Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:373
-msgid ""
-"The Wikimedia Foundation is a nonprofit organization based in San Francisco, "
-"California. The Wikipedia Library program provides access to resources held "
-"by publishers in multiple countries. If you apply for a Wikipedia Library "
-"account (whether you are inside or outside of the United States), you "
-"understand that your personal data will be collected, transferred, stored, "
-"processed, disclosed and otherwise used in the U.S. as described in this "
-"privacy policy. You also understand that your information may be transferred "
-"by us from the U.S. to other countries, which may have different or less "
-"stringent data protection laws than your country, in connection with "
-"providing services to you, including evaluating your application and "
-"securing access to your chosen publishers (locations for each publisher are "
-"outlined on their respective partner information pages)."
-msgstr ""
-"维基媒体基金会（Wikimedia Foundation）是总部设在美国加利福尼亚州旧金山的一家"
-"非营利性组织。维基百科图书馆提供对多个国家/地区出版商所拥有资源的访问权限。如"
-"果您申请维基百科图书馆账户（无论您在美国境内或境外），您都将了解，您的个人数"
-"据将按照本隐私政策的规定在美国收集、传输、存储、处理、披露和以其他方式使用。"
-"您还应了解，在向您提供服务（包括评估您的申请并确保对您选择内容的访问权限）方"
-"面，我们可能会将我们的信息从美国转移到其他国家，这些国家/地区的数据保护法律可"
-"能与您所在国家/地区的法律不同或更严格。出版商（每个出版商的所在地在其相应的合"
-"作伙伴信息页面上都有概述）。"
+msgid "The Wikimedia Foundation is a nonprofit organization based in San Francisco, California. The Wikipedia Library program provides access to resources held by publishers in multiple countries. If you apply for a Wikipedia Library account (whether you are inside or outside of the United States), you understand that your personal data will be collected, transferred, stored, processed, disclosed and otherwise used in the U.S. as described in this privacy policy. You also understand that your information may be transferred by us from the U.S. to other countries, which may have different or less stringent data protection laws than your country, in connection with providing services to you, including evaluating your application and securing access to your chosen publishers (locations for each publisher are outlined on their respective partner information pages)."
+msgstr "维基媒体基金会（Wikimedia Foundation）是总部设在美国加利福尼亚州旧金山的一家非营利性组织。维基百科图书馆提供对多个国家/地区出版商所拥有资源的访问权限。如果您申请维基百科图书馆账户（无论您在美国境内或境外），您都将了解，您的个人数据将按照本隐私政策的规定在美国收集、传输、存储、处理、披露和以其他方式使用。您还应了解，在向您提供服务（包括评估您的申请并确保对您选择内容的访问权限）方面，我们可能会将我们的信息从美国转移到其他国家，这些国家/地区的数据保护法律可能与您所在国家/地区的法律不同或更严格。出版商（每个出版商的所在地在其相应的合作伙伴信息页面上都有概述）。"
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:392
-msgid ""
-"Please note that in the event of any differences in meaning or "
-"interpretation between the original English version of these terms and a "
-"translation, the original English version takes precedence."
-msgstr ""
-"请注意，如果这些条款的原始英文版本与翻译之间在含义或解释上存在任何差异，则以"
-"原始英文版本为准。"
+msgid "Please note that in the event of any differences in meaning or interpretation between the original English version of these terms and a translation, the original English version takes precedence."
+msgstr "请注意，如果这些条款的原始英文版本与翻译之间在含义或解释上存在任何差异，则以原始英文版本为准。"
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Wikimedia Foundation should not be translated.
 #: TWLight/users/templates/users/terms.html:403
-msgid ""
-"See also the <a class=\"twl-links\" href=\"https://wikimediafoundation.org/"
-"wiki/Privacy_policy\">Wikimedia Foundation Privacy Policy</a>."
-msgstr ""
-"另请参见<a class=\"twl-links\" href=\"https://wikimediafoundation.org/wiki/"
-"Privacy_policy\">维基媒体基金会隐私政策</a>。"
+msgid "See also the <a class=\"twl-links\" href=\"https://wikimediafoundation.org/wiki/Privacy_policy\">Wikimedia Foundation Privacy Policy</a>."
+msgstr "另请参见<a class=\"twl-links\" href=\"https://wikimediafoundation.org/wiki/Privacy_policy\">维基媒体基金会隐私政策</a>。"
 
 #. Translators: This is the second to last line of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:412
@@ -3716,14 +2888,8 @@ msgstr "维基媒体基金会"
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:426
-msgid ""
-"By checking this box and clicking “Submit”, you agree that you have read the "
-"above terms and that you will adhere to the terms of use in your application "
-"to and use of the The Wikipedia Library, and the publishers’ services to "
-"which you gain access through The Wikipedia Library program."
-msgstr ""
-"选中此框并点击“提交”，即表示您已阅读并同意上述条款，并在维基百科图书馆申请"
-"时，以及您通过维基百科图书馆程序访问所获得的出版商服务中遵守这些使用条款。"
+msgid "By checking this box and clicking “Submit”, you agree that you have read the above terms and that you will adhere to the terms of use in your application to and use of the The Wikipedia Library, and the publishers’ services to which you gain access through The Wikipedia Library program."
+msgstr "选中此框并点击“提交”，即表示您已阅读并同意上述条款，并在维基百科图书馆申请时，以及您通过维基百科图书馆程序访问所获得的出版商服务中遵守这些使用条款。"
 
 #: TWLight/users/templates/users/user_collection_tile.html:32
 msgid "Remove this collection from favorites"
@@ -3775,38 +2941,19 @@ msgstr "删除所有数据"
 
 #. Translators: This message is displayed on the page where users can request the deletion of their data.
 #: TWLight/users/templates/users/user_confirm_delete.html:17
-msgid ""
-"<b>Warning:</b> Performing this action will delete your Wikipedia Library "
-"Card user account and all associated applications. This process is not "
-"reversible. You may lose any partner accounts you were granted, and will not "
-"be able to renew those accounts or apply for new ones."
-msgstr ""
-"<b>警告：</b>执行此操作将删除您的维基百科图书卡用户账户和所有关联的申请。这个"
-"过程是不可逆的。您可能会失去任何已被授予的合作伙伴帐户，并且将无法续订这些帐"
-"户或申请新的帐户。"
+msgid "<b>Warning:</b> Performing this action will delete your Wikipedia Library Card user account and all associated applications. This process is not reversible. You may lose any partner accounts you were granted, and will not be able to renew those accounts or apply for new ones."
+msgstr "<b>警告：</b>执行此操作将删除您的维基百科图书卡用户账户和所有关联的申请。这个过程是不可逆的。您可能会失去任何已被授予的合作伙伴帐户，并且将无法续订这些帐户或申请新的帐户。"
 
 #. Translators: this should show up for people who log in with a username/password and not OAuth, so we don't know what their Wikipedia identity is.
-#.
 #: TWLight/users/templates/users/user_detail.html:12
 #, python-format
-msgid ""
-"Hi, %(username)s! You don't have a Wikipedia editor profile attached to your "
-"account here, so you are probably a site administrator."
-msgstr ""
-"您好，%(username)s！您的帐户没有附加维基百科编者个人资料，因此您可能是本站管"
-"理员。"
+msgid "Hi, %(username)s! You don't have a Wikipedia editor profile attached to your account here, so you are probably a site administrator."
+msgstr "您好，%(username)s！您的帐户没有附加维基百科编者个人资料，因此您可能是本站管理员。"
 
 #. Translators: In the unlikely scenario that someone is able to register an account without using OAuth (thus leaving us without some of the information required for applications), users will see this message, encouraging them to re-register.
 #: TWLight/users/templates/users/user_detail.html:20
-msgid ""
-"If you aren't a site administrator, something weird has happened. You won't "
-"be able to apply for access without a Wikipedia editor profile. You should "
-"log out and create a new account by logging in via OAuth, or contact a site "
-"administrator for help."
-msgstr ""
-"如果您不是本站管理员，就发生了一些奇怪的事情。如果没有维基百科编者个人资料，"
-"您将无法申请访问权限。您应该注销并通过OAuth登录来创建新帐户，或者与本站管理员"
-"联系以获取帮助。"
+msgid "If you aren't a site administrator, something weird has happened. You won't be able to apply for access without a Wikipedia editor profile. You should log out and create a new account by logging in via OAuth, or contact a site administrator for help."
+msgstr "如果您不是本站管理员，就发生了一些奇怪的事情。如果没有维基百科编者个人资料，您将无法申请访问权限。您应该注销并通过OAuth登录来创建新帐户，或者与本站管理员联系以获取帮助。"
 
 #. Translators: Labels a sections where coordinators can select their email preferences.
 #: TWLight/users/templates/users/user_email_preferences.html:15
@@ -3816,22 +2963,13 @@ msgstr "仅协调员"
 #. Translators: This message is shown on user's own profile page, encouraging them to make sure their information is up to date, so that account coordinators can use the information to judge applications.
 #: TWLight/users/views.py:176
 #, python-brace-format
-msgid ""
-"Please <a class='twl-links' href='{url}'>update your contributions</a> to "
-"Wikipedia to help coordinators evaluate your applications."
-msgstr ""
-"请<a class=\"twl-links\" href='{url}'>更新</a>您对维基百科的贡献，以帮助协调"
-"员评估申请。"
+msgid "Please <a class='twl-links' href='{url}'>update your contributions</a> to Wikipedia to help coordinators evaluate your applications."
+msgstr "请<a class=\"twl-links\" href='{url}'>更新</a>您对维基百科的贡献，以帮助协调员评估申请。"
 
 #. Translators: Coordinators are shown this message when they unselect all three types of reminder email options under preferences.
 #: TWLight/users/views.py:288
-msgid ""
-"You have chosen not to receive reminder emails. As a coordinator, you should "
-"receive at least one type of reminder emails, so consider changing your "
-"preferences."
-msgstr ""
-"您已选择不接收提醒电子邮件。作为协调员，您应该至少收到一种提醒电子邮件，因此"
-"请考虑更改您的首选项。"
+msgid "You have chosen not to receive reminder emails. As a coordinator, you should receive at least one type of reminder emails, so consider changing your preferences."
+msgstr "您已选择不接收提醒电子邮件。作为协调员，您应该至少收到一种提醒电子邮件，因此请考虑更改您的首选项。"
 
 #. Translators: Coordinators are shown this message when they make changes to their reminder email options under preferences.
 #: TWLight/users/views.py:296
@@ -3864,12 +3002,8 @@ msgstr "您的电子邮箱已经被改变到{email}。"
 
 #. Translators: If the user has not filled out their email, they can browse the website but cannot apply for access to resources.
 #: TWLight/users/views.py:487
-msgid ""
-"Your email is blank. You can still explore the site, but you won't be able "
-"to apply for access to partner resources without an email."
-msgstr ""
-"您的电子邮件为空。您仍然可以浏览本站，但是如果没有电子邮件，您将无法申请合作"
-"伙伴资源的访问权限。"
+msgid "Your email is blank. You can still explore the site, but you won't be able to apply for access to partner resources without an email."
+msgstr "您的电子邮件为空。您仍然可以浏览本站，但是如果没有电子邮件，您将无法申请合作伙伴资源的访问权限。"
 
 #. Translators: This message is shown once the access to a partner has successfully been returned.
 #: TWLight/users/views.py:801
@@ -3901,31 +3035,3 @@ msgstr "没有生效的封禁"
 msgid "10+ edits in the last 30 days"
 msgstr "过去30天内至少编辑10次"
 
-#: tests/shunit/data/bad_i18n_comment_1.py:3
-#: tests/shunit/data/bad_i18n_newline_1.py:5
-msgid "1"
-msgstr ""
-
-#. Translators: Lorem ipsum dolor sit amet, consectetur adipiscing elit. Mauris vitae ipsum ut purus faucibus pretium. Proin tempus neque et aliquet consectetur. Ut egestas sapien in consectetur sagittis. Mauris neque lacus, dapibus non viverra vitae, interdum ut aenean ipsum.
-#. Translators: Lorem ipsum dolor sit amet, consectetur adipiscing elit. Mauris vitae ipsum ut purus faucibus pretium. Proin tempus neque et aliquet consectetur. Ut egestas sapien in consectetur sagittis. Mauris neque lacus, dapibus non.
-#: tests/shunit/data/bad_i18n_comment_2.py:4
-#: tests/shunit/data/bad_i18n_newline_2.py:5 tests/shunit/data/good_i18n_1.py:2
-#: tests/shunit/data/good_i18n_2.py:2
-msgid "2"
-msgstr ""
-
-#: tests/shunit/data/bad_i18n_newline_3.py:5
-msgid "3"
-msgstr ""
-
-#: tests/shunit/data/bad_i18n_newline_4.py:5
-msgid "4"
-msgstr ""
-
-#: tests/shunit/data/bad_i18n_newline_5.py:5
-msgid "5"
-msgstr ""
-
-#: tests/shunit/data/bad_i18n_newline_6.py:5
-msgid "6"
-msgstr ""

--- a/locale/zh_Hans/partner_descriptions.json
+++ b/locale/zh_Hans/partner_descriptions.json
@@ -8,6 +8,7 @@
 			"Sean0115",
 			"Shizhao",
 			"Tranve",
+			"XtexChooser",
 			"Yfdyh000",
 			"Zfshuo",
 			"Zhang8569"
@@ -76,7 +77,7 @@
 	"86_short_description": "<strong>Oxford Art Online</strong>可访问牛津的艺术参考作品：《Grove Art Online》和《Benezit Dictionary of Artists》，以及许多专门委托在线撰写的文章和参考书目。牛津在线艺术博物馆（Oxford Art Online）拥有20,000多张图片，以及超过23万份关于艺术和艺术家的作品。",
 	"87_short_description": "<strong>Oxford Bibliographies</strong>提供权威的研究指南，同时具有注解书目和高级百科全书的功能。此资源可指导研究人员获得涵盖各种学科的最佳可用的学问。",
 	"88_short_description": "<strong>Oxford Dictionary of National Biography</strong>是记录从罗马到21世纪在世界范围内影响英国历史和文化的男性与女性的国家记录。ODNB提供由专家撰写的简明最新传记。它由牛津大学的学术编辑监督。",
-	"93_short_description": "<strong>Oxford Academic</strong>包含众多牛津大学出版社期刊，涵盖多种学科。",
+	"93_short_description": "<strong>Oxford Academic</strong>包含众多牛津大学出版社期刊，涵盖多种学科。它还包括两本书集：Oxford Scholarship Online和Oxford Handbooks Online。",
 	"99_short_description": "<strong>Oxford University Press Law</strong>提供了一系列与国际法有关的资源。",
 	"90_short_description": "<strong>Grove Music Online</strong>是《Grove's Dictionary of Music and Musicians》的第八版，其中包含专门为该网站撰写的文章。Grove Music Online有100,000多个条目，主题从音乐家的传记到有关乐器的物理结构和组装的条目不等。",
 	"91_short_description": "<strong>Oxford Reference</strong>汇集了Oxford's Dictionaries，Companions和百科全书中的200万个数字化条目。",
@@ -131,5 +132,7 @@
 	"142_short_description": "<strong>杜克大学出版社</strong>以出版人文、社会科学和数学而闻名，每年出版约 120 本书和 50 多种期刊。",
 	"143_short_description": "<strong>Mohr Siebeck</strong>是德国一家历史悠久的学术出版商，专注于人文和社会科学。该电子图书馆包含2000多本书籍和众多期刊，涉及宗教研究、历史、哲学、法律、经济学和社会学。",
 	"144_short_description": "<strong>Perlego</strong>是一个数字在线图书馆，专注于提供学术、专业和非小说类电子书。",
-	"145_short_description": "<strong>De Standaard</strong> De Standaard 是由 Mediahuis 在比利时出版的佛兰德日报。"
+	"145_short_description": "<strong>De Standaard</strong> De Standaard 是由 Mediahuis 在比利时出版的佛兰德日报。",
+	"149_short_description": "<strong>The ACM Digital Library</strong>是一个来自计算机协会的研究、发现和连接平台。ACM数字图书馆包括所有ACM出版物的全文合集、精选出版商策划和托管的全文出版物合集、ACM计算文献指南等。",
+	"150_short_description": "<strong>IEEE Xplore</strong>是一个用于发现与取用电脑科学、电气工程、电子学及相关领域的期刊文章、会议论文集、技术标准和相关资料的研究资料库。"
 }

--- a/locale/zh_Hant/LC_MESSAGES/django.po
+++ b/locale/zh_Hant/LC_MESSAGES/django.po
@@ -20,10 +20,11 @@
 # Author: 捍粵者
 msgid ""
 msgstr ""
+""
 "Project-Id-Version: Wikipedia Library Card Platform - Website\n"
-"Report-Msgid-Bugs-To: wikipedialibrary@wikimedia.org\n"
+"Report-Msgid-Bugs-To: translatewiki.net\n"
 "POT-Creation-Date: 2024-07-11 20:54+0000\n"
-"PO-Revision-Date: 2024-07-11 12:30:20+0000\n"
+"PO-Revision-Date: 2024-07-15 12:29:20+0000\n"
 "Language: zh_hant\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
@@ -55,12 +56,8 @@ msgstr "關於您"
 #. Translators: This note appears in a section of a form where we ask users to enter info (like country of residence) when applying for resource access.
 #: TWLight/applications/forms.py:179
 #, python-brace-format
-msgid ""
-"<p><small><i>Your personal data will be processed according to our <a "
-"class='twl-links' href='{terms_url}'> privacy policy</a>.</i></small></p>"
-msgstr ""
-"<p><small><i>您的個人資料將會根據我們的<a class='twl-links' "
-"href='{terms_url}'>隱私方針</a>處理。</i></small></p>"
+msgid "<p><small><i>Your personal data will be processed according to our <a class='twl-links' href='{terms_url}'> privacy policy</a>.</i></small></p>"
+msgstr "<p><small><i>您的個人資料將會根據我們的<a class='twl-links' href='{terms_url}'>隱私方針</a>處理。</i></small></p>"
 
 #. Translators: This is the title of the application form page, where users enter information required for the application. It lets the user know which partner application they are entering data for. {partner}
 #: TWLight/applications/forms.py:189
@@ -101,9 +98,7 @@ msgstr "您在合作夥伴網站上帳號的電子郵件"
 #. Translators: This labels a choice field where users will have to select the number of months they wish to have their access for as part of the application renewal confirmation.
 #. Translators: When filling out an application, users may be required to enter the length of the account (expiry) they wish to have for proxy partners.
 #: TWLight/applications/forms.py:339 TWLight/applications/helpers.py:100
-msgid ""
-"The number of months you wish to have this access for before renewal is "
-"required"
+msgid "The number of months you wish to have this access for before renewal is required"
 msgstr "在需要續辦之前，您所想要取用的月數"
 
 #. Translators: When filling out an application, users may need to specify their name
@@ -192,12 +187,8 @@ msgstr "電子郵件"
 
 #. Translators: This comment is added to pending applications when our terms of use change.
 #: TWLight/applications/management/commands/notify_applicants_tou_changes.py:54
-msgid ""
-"Our terms of use have changed. Your applications will not be processed until "
-"you log in and agree to our updated terms."
-msgstr ""
-"我們的使用條款已有變動。在您登入並同意我們的更新條款之前，您的申請程序將不被"
-"處理。"
+msgid "Our terms of use have changed. Your applications will not be processed until you log in and agree to our updated terms."
+msgstr "我們的使用條款已有變動。在您登入並同意我們的更新條款之前，您的申請程序將不被處理。"
 
 #. Translators: This is the status of an application that has not yet been reviewed.
 #: TWLight/applications/models.py:54
@@ -263,23 +254,17 @@ msgstr "取用 URL：{access_url}"
 
 #. Translators: This text goes into account approval emails in the case that we need to send the user's details to a publisher for manual account setup.
 #: TWLight/applications/models.py:331
-msgid ""
-"You can expect to receive access details within a week or two once it has "
-"been processed."
+msgid "You can expect to receive access details within a week or two once it has been processed."
 msgstr "一旦處理完畢後，您可預期在一到兩週後收到取用詳情。"
 
 #. Translators: This comment is added to open applications when a partner joins the Library Bundle, which does not require applications.
 #: TWLight/applications/signals.py:247
-msgid ""
-"This partner joined the Library Bundle, which does not require applications. "
-"This application will be marked as invalid."
+msgid "This partner joined the Library Bundle, which does not require applications. This application will be marked as invalid."
 msgstr "這位伙伴加入圖書館綑綁計畫，並不需要申請，這次申請會被標示為無效。"
 
 #. Translators: This is shown to users if the application is to a partner for which we have run out of available accounts. The application is therefore on a 'waitlist', and will be reviewed when more accounts are available.
 #: TWLight/applications/templates/applications/application_evaluation.html:29
-msgid ""
-"This application is on the waitlist because this partner does not have any "
-"access grants available at this time."
+msgid "This application is on the waitlist because this partner does not have any access grants available at this time."
 msgstr "此申請程序在後補裡，出於此合作夥伴目前尚未有任何可用的取用授予。"
 
 #. Translators: This message is shown on pages where coordinators can see personal information about applicants.
@@ -287,12 +272,8 @@ msgstr "此申請程序在後補裡，出於此合作夥伴目前尚未有任何
 #: TWLight/applications/templates/applications/application_list_include.html:6
 #: TWLight/applications/templates/applications/send_partner.html:45
 #: TWLight/resources/templates/resources/partner_users.html:18
-msgid ""
-"Coordinators: This page may contain personal information such as real names "
-"and email addresses. Please remember that this information is confidential."
-msgstr ""
-"致協調員：此頁面可能包含像是真實姓名與電子郵件地址的個人資訊，請記住此資訊是"
-"保密的。"
+msgid "Coordinators: This page may contain personal information such as real names and email addresses. Please remember that this information is confidential."
+msgstr "致協調員：此頁面可能包含像是真實姓名與電子郵件地址的個人資訊，請記住此資訊是保密的。"
 
 #. Translators: This is the title of the application page shown to users who are a coordinator, and are able to accept or reject the application.
 #: TWLight/applications/templates/applications/application_evaluation.html:39
@@ -301,11 +282,8 @@ msgstr "評估申請程序"
 
 #. Translators: This text is shown to coordinators on application pages if the applicant has restricted processing of their data.
 #: TWLight/applications/templates/applications/application_evaluation.html:42
-msgid ""
-"This user has requested a restriction on the processing of their data, so "
-"you cannot change the status of their application."
-msgstr ""
-"此使用者已對於在處理他們的資料上請求限制，因此您不能更改他們的申請程序狀態。"
+msgid "This user has requested a restriction on the processing of their data, so you cannot change the status of their application."
+msgstr "此使用者已對於在處理他們的資料上請求限制，因此您不能更改他們的申請程序狀態。"
 
 #. Translators: This is the title of the application page shown to users who are not a coordinator.
 #: TWLight/applications/templates/applications/application_evaluation.html:48
@@ -378,9 +356,7 @@ msgstr "未知"
 
 #. Translators: This is the text displayed to coordinators when an applicant has no country of residence in their profile.
 #: TWLight/applications/templates/applications/application_evaluation.html:123
-msgid ""
-"Please request the applicant add their country of residence to their profile "
-"before proceeding further."
+msgid "Please request the applicant add their country of residence to their profile before proceeding further."
 msgstr "處理前請要求申請人在個人配置添加其居住國。"
 
 #. Translators: This labels the section of an application showing the total number of accounts available for a partner or their collection.
@@ -391,11 +367,8 @@ msgstr "可用帳號"
 #. Translators: This labels the section of an application showing whether the user had agreed to the terms of use or not.
 #: TWLight/applications/templates/applications/application_evaluation.html:145
 #, python-format
-msgid ""
-"Has agreed to the site's <a class=\"twl-links\" href=\"%(terms_url)s\">terms "
-"of use</a>?"
-msgstr ""
-"是否同意網站的<a class=\"twl-links\" href=\"%(terms_url)s\">使用條款</a>？"
+msgid "Has agreed to the site's <a class=\"twl-links\" href=\"%(terms_url)s\">terms of use</a>?"
+msgstr "是否同意網站的<a class=\"twl-links\" href=\"%(terms_url)s\">使用條款</a>？"
 
 #. Translators: Displayed to coordinators when they've agreed to the terms of use.
 #. Translators: Displayed if the user has agreed to the terms of use.
@@ -430,9 +403,7 @@ msgstr "否"
 
 #. Translators: This is the text displayed to coordinators when an applicant has not agreed to the terms of use.
 #: TWLight/applications/templates/applications/application_evaluation.html:159
-msgid ""
-"Please request the applicant agree to the site's terms of use before "
-"approving this application."
+msgid "Please request the applicant agree to the site's terms of use before approving this application."
 msgstr "在核准此申請程序前，請要求申請人同意網站的使用條款。"
 
 #. Translators: This labels the section of an application containing the user's motivation for wanting access to this resource.
@@ -453,10 +424,8 @@ msgstr "續辦現有的取用授予？"
 #. Translators: This message is shown next to the 'Renewal of existing access grant?' label if the application is a renewal. Don't translate HTML tags or parent_url.
 #: TWLight/applications/templates/applications/application_evaluation.html:195
 #, python-format
-msgid ""
-"Yes (<a class=\"twl-links\" href=\"%(parent_url)s\">previous application</a>)"
-msgstr ""
-"是（<a class=\"twl-links\" href=\"%(parent_url)s\">先前的申請程序</a>）"
+msgid "Yes (<a class=\"twl-links\" href=\"%(parent_url)s\">previous application</a>)"
+msgstr "是（<a class=\"twl-links\" href=\"%(parent_url)s\">先前的申請程序</a>）"
 
 #. Translators: This labels the section of the application showing the length of access remaining on the user's previous authorization.
 #: TWLight/applications/templates/applications/application_evaluation.html:208
@@ -490,9 +459,7 @@ msgstr "添加評註"
 
 #. Translators: On an application page, this text tells users that the comments posted on the application are visible to coordinators and the submitting user only.
 #: TWLight/applications/templates/applications/application_evaluation.html:297
-msgid ""
-"Comments are visible to all coordinators and to the editor who submitted "
-"this application."
+msgid "Comments are visible to all coordinators and to the editor who submitted this application."
 msgstr "所有協調員與有提交此申請程序的編輯者可看見評註。"
 
 #. Translators: This is the title of the section of an application page which lists information about the user who submitted the application.
@@ -704,16 +671,8 @@ msgstr "設定狀態"
 
 #: TWLight/applications/templates/applications/apply.html:20
 #, python-format
-msgid ""
-"If your application is successful we may share your email address with "
-"%(partner)s. This is required to set up your access to their resources. By "
-"submitting this form you agree to allow your email address to be shared with "
-"%(partner)s if your application is successful, for the purposes of account "
-"setup."
-msgstr ""
-"如果您的申請結果成功，我們可能會與 %(partner)s 分享您的電子郵件地址，這在設定"
-"您對他們資源的取用是必要條件。依據提交這份表格，代表您同意若您的申請成功時，"
-"您願意將電子郵件地址分享給 %(partner)s 以用於帳號設定。"
+msgid "If your application is successful we may share your email address with %(partner)s. This is required to set up your access to their resources. By submitting this form you agree to allow your email address to be shared with %(partner)s if your application is successful, for the purposes of account setup."
+msgstr "如果您的申請結果成功，我們可能會與 %(partner)s 分享您的電子郵件地址，這在設定您對他們資源的取用是必要條件。依據提交這份表格，代表您同意若您的申請成功時，您願意將電子郵件地址分享給 %(partner)s 以用於帳號設定。"
 
 #. Translators: This message is displayed on the page where users can confirm their renewal. Please do not translate partner.
 #: TWLight/applications/templates/applications/confirm_renewal.html:23
@@ -741,9 +700,7 @@ msgstr "您想取用哪些資源？"
 
 #. Translators: This text explains that Library Bundle partners are not shown in this list.
 #: TWLight/applications/templates/applications/request_for_application.html:26
-msgid ""
-"Library Bundle partners are not shown as eligibility is determined "
-"automatically."
+msgid "Library Bundle partners are not shown as eligibility is determined automatically."
 msgstr "Library Bundle 夥伴未顯示成標示是自動確認。"
 
 #. Translators: On the page where users can apply for multiple partners, this message shows next to the partner name, taking them to the full application page when clicked.
@@ -758,13 +715,8 @@ msgstr "尚未添加任何合作夥伴資料。"
 
 #. Translators: the HTML is so that the word 'waitlisted' will look the same as it does in the page above; please translate 'waitlisted' the same way you did elsewhere in this file.
 #: TWLight/applications/templates/applications/request_for_application.html:74
-msgid ""
-"You can apply to <span class=\"badge badge-warning\">Waitlisted</span> "
-"partners, but they don't have access grants available right now. We will "
-"process those applications when access becomes available."
-msgstr ""
-"您可以向目前為<span class=\"badge badge-warning\">候補</span>的合作夥伴做出申"
-"請，但他們現在會沒有可用的取用權限。我們會當取用為可用時處理這些申請程序。"
+msgid "You can apply to <span class=\"badge badge-warning\">Waitlisted</span> partners, but they don't have access grants available right now. We will process those applications when access becomes available."
+msgstr "您可以向目前為<span class=\"badge badge-warning\">候補</span>的合作夥伴做出申請，但他們現在會沒有可用的取用權限。我們會當取用為可用時處理這些申請程序。"
 
 #. Translators: On the page where coordinators can see approved applications which have not had their details sent to the partner, this message shows when there are applications ready to be processed.
 #: TWLight/applications/templates/applications/send.html:10
@@ -785,12 +737,8 @@ msgstr "%(object)s 的申請程序資料"
 #. Translators: This message is shown when applications exceed the number of accounts available.
 #: TWLight/applications/templates/applications/send_partner.html:54
 #, python-format
-msgid ""
-"Application(s) for %(object)s, if sent, will exceed the total available "
-"accounts for the partner. Please proceed at your own discretion."
-msgstr ""
-"若已發送 %(object)s 的申請程序，將會超出合作夥伴的可用帳號總數。請自行決定處"
-"理。"
+msgid "Application(s) for %(object)s, if sent, will exceed the total available accounts for the partner. Please proceed at your own discretion."
+msgstr "若已發送 %(object)s 的申請程序，將會超出合作夥伴的可用帳號總數。請自行決定處理。"
 
 #. Translators: When viewing the list of applications ready to be sent for a particular partner, this is instructions for the coordinator to click the 'mark as sent' button after they have sent the information.
 #: TWLight/applications/templates/applications/send_partner.html:65
@@ -805,9 +753,7 @@ msgstr[0] "聯絡"
 
 #. Translators: When viewing the list of applications ready to be sent for a particular partner, this message shows if there is no information about who the applications should be sent to. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/applications/templates/applications/send_partner.html:89
-msgid ""
-"Whoops, we don't have any listed contacts. Please notify Wikipedia Library "
-"administrators."
+msgid "Whoops, we don't have any listed contacts. Please notify Wikipedia Library administrators."
 msgstr "哎呀，我們沒有任何可列出的聯絡內容，請通知維基百科圖書館管理員。"
 
 #. Translators: When viewing the list of applications ready to be sent for a particular partner, this is the title of the section containing the information about those applications.
@@ -823,9 +769,7 @@ msgstr "標記為已發送"
 
 #. Translators: This text guides coordinators in using the code sending interface for approved applications.
 #: TWLight/applications/templates/applications/send_partner.html:152
-msgid ""
-"Use the dropdown menus to denote which editor will receive each code. Access "
-"codes will be sent to users automatically."
+msgid "Use the dropdown menus to denote which editor will receive each code. Access codes will be sent to users automatically."
 msgstr "使用下拉選單來指示會接收各代碼的編輯者。存取碼會自動發送給使用者。"
 
 #. Translators: This labels a drop-down selection where staff can assign an access code to a user.
@@ -841,23 +785,14 @@ msgstr "沒有已核准、尚未發送的申請程序。"
 #. Translators: When a user applies for a set of resources, they receive this message if none are currently available. They are instead placed on a 'waitlist' for later approval.
 #. Translators: When a user renews their resource, they receive this message if none are currently available. They are instead placed on a 'waitlist' for later approval.
 #: TWLight/applications/views.py:140 TWLight/applications/views.py:1282
-msgid ""
-"This partner does not have any access grants available at this time. You may "
-"still apply for access; your application will be reviewed when access grants "
-"become available."
-msgstr ""
-"此合作夥伴目前沒有任何可用的取用授予。您仍可以申請取用；但您的申請程序要在有"
-"可用取用授予時，才會進行審查。"
+msgid "This partner does not have any access grants available at this time. You may still apply for access; your application will be reviewed when access grants become available."
+msgstr "此合作夥伴目前沒有任何可用的取用授予。您仍可以申請取用；但您的申請程序要在有可用取用授予時，才會進行審查。"
 
 #. Translators: This message is shown to users once they've successfully submitted their application for review.
 #: TWLight/applications/views.py:163
 #, python-brace-format
-msgid ""
-"Your application has been submitted for review. Head over to <a "
-"href='{applications_url}'>My Applications</a> to view the status."
-msgstr ""
-"您的申請程序已提交於審核。您可以在此頁面上查閱<a href='{applications_url}'我"
-"的申請程序</a>狀態。"
+msgid "Your application has been submitted for review. Head over to <a href='{applications_url}'>My Applications</a> to view the status."
+msgstr "您的申請程序已提交於審核。您可以在此頁面上查閱<a href='{applications_url}'我的申請程序</a>狀態。"
 
 #. Translators: This text is displayed to users when the user has chosen to restrict data and is trying to apply for multiple partners
 #: TWLight/applications/views.py:276
@@ -905,16 +840,12 @@ msgstr "已發送申請程序"
 
 #. Translators: After a coordinator has changed the status of an application to APPROVED, if the corresponding partner/collection is waitlisted this message appears.
 #: TWLight/applications/views.py:756
-msgid ""
-"Cannot approve application as partner with proxy authorization method is "
-"waitlisted."
+msgid "Cannot approve application as partner with proxy authorization method is waitlisted."
 msgstr "代理方法的合作夥伴為候補，無法核准申請程序。"
 
 #. Translators: After a coordinator has changed the status of an application to APPROVED, if the corresponding partner/collection has no accounts for distribution, this message appears.
 #: TWLight/applications/views.py:780
-msgid ""
-"Cannot approve application as partner with proxy authorization method is "
-"waitlisted and (or) has zero accounts available for distribution."
+msgid "Cannot approve application as partner with proxy authorization method is waitlisted and (or) has zero accounts available for distribution."
 msgstr "代理方法的合作夥伴為候補或是沒有可分配的帳號，無法核准申請程序。"
 
 #. Translators: This message appears on an "access denied" screen that stops users who attempt to authorize an editor to access a resource during a time period for which they are already authorized.
@@ -925,15 +856,8 @@ msgstr "您嘗試建立重複的授權。"
 #. Translators: This message is shown to users when they access an application page of a now Bundle partner (new applications aren't allowed for Bundle partners and the status of old applications cannot be modified)
 #: TWLight/applications/views.py:857
 #, python-brace-format
-msgid ""
-"This application cannot be modified since this partner is now part of our <a "
-"href='{bundle}'>bundle access</a>. If you are eligible, you can access this "
-"resource from <a href='{library}'>your library</a>. <a "
-"href='{contact}'>Contact us</a> if you have any questions."
-msgstr ""
-"這次申請程序無法變動，因為這位伙伴已經屬於我們的<a href='{bundle}'>捆綁連結</"
-"a>。如果符合資格，你可以連接到 <a href='{library}'>你圖書館</a>的資源。如果有"
-"問題歡迎<a href='{contact}'>聯絡我們</a>。"
+msgid "This application cannot be modified since this partner is now part of our <a href='{bundle}'>bundle access</a>. If you are eligible, you can access this resource from <a href='{library}'>your library</a>. <a href='{contact}'>Contact us</a> if you have any questions."
+msgstr "這次申請程序無法變動，因為這位伙伴已經屬於我們的<a href='{bundle}'>捆綁連結</a>。如果符合資格，你可以連接到 <a href='{library}'>你圖書館</a>的資源。如果有問題歡迎<a href='{contact}'>聯絡我們</a>。"
 
 #. Translators: this lets a reviewer set the status of a single application.
 #: TWLight/applications/views.py:873
@@ -942,9 +866,7 @@ msgstr "設定申請程序狀態"
 
 #. Translators: This warning is message is shown to applicants when the number of pending applications is greater than the number of accounts available.
 #: TWLight/applications/views.py:891
-msgid ""
-"There are more pending applications than available accounts. Your "
-"application might get waitlisted."
+msgid "There are more pending applications than available accounts. Your application might get waitlisted."
 msgstr "等待審核的申請多於可用的帳號數量，你的申請將被放入等待名單當中。"
 
 #. Translators: this message is shown to coordinators who attempt to change an application's Status from INVALID to any other Status.
@@ -964,14 +886,8 @@ msgstr "申請程序{}批量更新成功。"
 
 #. Translators: After a coordinator has changed the status of a number of applications to APPROVED, if the corresponding partner(s) is/are waitlisted or has no accounts for distribution, this message appears.
 #: TWLight/applications/views.py:1051
-msgid ""
-"Cannot approve application(s) {} as partner(s) with proxy authorization "
-"method is/are waitlisted and (or) has/have not enough accounts available. If "
-"not enough accounts are available, prioritise the applications and then "
-"approve applications equal to the accounts available."
-msgstr ""
-"代理方法的合作夥伴為候補且（或是）沒有足夠的可用帳號，無法核准申請程序。若可"
-"用帳號不足，會按優先順序處理申請程序，且核准與可用帳號數相同的申請程序。"
+msgid "Cannot approve application(s) {} as partner(s) with proxy authorization method is/are waitlisted and (or) has/have not enough accounts available. If not enough accounts are available, prioritise the applications and then approve applications equal to the accounts available."
+msgstr "代理方法的合作夥伴為候補且（或是）沒有足夠的可用帳號，無法核准申請程序。若可用帳號不足，會按優先順序處理申請程序，且核准與可用帳號數相同的申請程序。"
 
 #. Translators: This message is shown to coordinators who attempt to assign the same access code to multiple users.
 #: TWLight/applications/views.py:1191
@@ -985,12 +901,8 @@ msgstr "所有選擇的申請程序被標記為已發送。"
 
 #. Translators: When a user tries to renew their resource, they receive this message if the partner is not available.
 #: TWLight/applications/views.py:1272
-msgid ""
-"Cannot renew application at this time as partner is not available. Please "
-"check back later, or contact us for more information."
-msgstr ""
-"由於合作夥伴已不可用，現在無法重新申請程序。請稍後回頭查看，或是聯絡我們來取"
-"得更多資訊。"
+msgid "Cannot renew application at this time as partner is not available. Please check back later, or contact us for more information."
+msgstr "由於合作夥伴已不可用，現在無法重新申請程序。請稍後回頭查看，或是聯絡我們來取得更多資訊。"
 
 #. Translators: This message is displayed when an attempt by a user to renew an application has been denied for some reason.
 #: TWLight/applications/views.py:1308
@@ -1000,16 +912,12 @@ msgstr "嘗試續辦未核准申請程序#{pk}已被拒絕"
 
 #. Translators: If a user requests the renewal of their account, but it wasn't renewed, this message is shown to them.
 #: TWLight/applications/views.py:1385
-msgid ""
-"This object cannot be renewed. (This probably means that you have already "
-"requested that it be renewed.)"
+msgid "This object cannot be renewed. (This probably means that you have already requested that it be renewed.)"
 msgstr "此對象無法續辦。（這通常代表您已經有請求過且已續辦。）"
 
 #. Translators: If a user requests the renewal of their account, this message is shown to them.
 #: TWLight/applications/views.py:1395
-msgid ""
-"Your renewal request has been received. A coordinator will review your "
-"request."
+msgid "Your renewal request has been received. A coordinator will review your request."
 msgstr "已收到您的續辦請求。協調員將會審查您的請求。"
 
 #. Translators: This labels a textfield where users can enter their email ID.
@@ -1019,12 +927,8 @@ msgstr "您的電子郵件"
 
 #. Translators: This is the help text for the email field in the contact us form letting users know the field is updated by value pulled from their respective user profiles.
 #: TWLight/emails/forms.py:21
-msgid ""
-"This field is automatically updated with the email from your <a class='twl-"
-"links' href='{}'>user profile</a>."
-msgstr ""
-"此欄位會以來自於您的<a class='twl-links' href='{}'>使用者配置</a>裡的電子郵件"
-"做自動更新。"
+msgid "This field is automatically updated with the email from your <a class='twl-links' href='{}'>user profile</a>."
+msgstr "此欄位會以來自於您的<a class='twl-links' href='{}'>使用者配置</a>裡的電子郵件做自動更新。"
 
 #. Translators: This labels a textfield where users can enter their email message.
 #: TWLight/emails/forms.py:26
@@ -1047,24 +951,14 @@ msgstr "提交"
 #. Translators: This email is sent to users with their access code. Don't translate Jinja variables in curly braces like user or partner. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/access_code_email-body-html.html:5
 #, python-format
-msgid ""
-"<p>Your approved application to %(partner)s has now been finalised. Your "
-"access code or login details can be found below:</p> <p><b>%(access_code)s</"
-"b></p> <p>%(user_instructions)s</p>"
-msgstr ""
-"<p>您對於%(partner)s的核准申請程序已完成。您的取用代碼或是登入詳情可在以下找"
-"出：</p> <p><b>%(access_code)s</b></p> <p>%(user_instructions)s</p>"
+msgid "<p>Your approved application to %(partner)s has now been finalised. Your access code or login details can be found below:</p> <p><b>%(access_code)s</b></p> <p>%(user_instructions)s</p>"
+msgstr "<p>您對於%(partner)s的核准申請程序已完成。您的取用代碼或是登入詳情可在以下找出：</p> <p><b>%(access_code)s</b></p> <p>%(user_instructions)s</p>"
 
 #. Translators: This email is sent to users with their access code. Don't translate Jinja variables in curly braces like user or partner. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/access_code_email-body-text.html:3
 #, python-format
-msgid ""
-"Your approved application to %(partner)s has now been finalised. Your access "
-"code or login details can be found below: %(access_code)s "
-"%(user_instructions)s"
-msgstr ""
-"您對於%(partner)s的核准申請程序已完成。您的取用代碼或是登入詳情可在以下找出："
-"%(access_code)s %(user_instructions)s"
+msgid "Your approved application to %(partner)s has now been finalised. Your access code or login details can be found below: %(access_code)s %(user_instructions)s"
+msgstr "您對於%(partner)s的核准申請程序已完成。您的取用代碼或是登入詳情可在以下找出：%(access_code)s %(user_instructions)s"
 
 #. Translators: This is the subject line of an email sent to users with their access code.
 #: TWLight/emails/templates/emails/access_code_email-subject.html:3
@@ -1074,32 +968,14 @@ msgstr "您的維基百科圖書館取用代碼"
 #. Translators: This email is sent to users when their application is approved. Don't translate Jinja variables in curly braces like user or partner; don't translate html tags either. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/approval_notification-body-html.html:5
 #, python-format
-msgid ""
-"<p>Dear %(user)s,</p> <p>Thank you for applying for access to %(partner)s "
-"resources through The Wikipedia Library. We are happy to inform you that "
-"your application has been approved.</p> <p>%(user_instructions)s</p> <p>You "
-"can view the collections you're authorized to access at My Library: "
-"%(link)s</p> <p>Cheers!</p> <p>The Wikipedia Library</p>"
-msgstr ""
-"<p>致 %(user)s：</p> <p>感謝您透過維基百科圖書館申請向 %(partner)s 取用資源。"
-"我們很高興向您通知您的申請程序已被核准。一旦處理完畢後，您可以在一到兩週內收"
-"到取用方面的細節。<p>%(user_instructions)s</p><p>您可以檢視在我的圖書館裡您被"
-"授權取用的典藏：%(link)s</p></p>這實在太好了！<p></p> <p>維基百科圖書館</p>"
+msgid "<p>Dear %(user)s,</p> <p>Thank you for applying for access to %(partner)s resources through The Wikipedia Library. We are happy to inform you that your application has been approved.</p> <p>%(user_instructions)s</p> <p>You can view the collections you're authorized to access at My Library: %(link)s</p> <p>Cheers!</p> <p>The Wikipedia Library</p>"
+msgstr "<p>致 %(user)s：</p> <p>感謝您透過維基百科圖書館申請向 %(partner)s 取用資源。我們很高興向您通知您的申請程序已被核准。一旦處理完畢後，您可以在一到兩週內收到取用方面的細節。<p>%(user_instructions)s</p><p>您可以檢視在我的圖書館裡您被授權取用的典藏：%(link)s</p></p>這實在太好了！<p></p> <p>維基百科圖書館</p>"
 
 #. Translators: This email is sent to users when their application is approved. Don't translate Jinja variables in curly braces like user or partner. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/approval_notification-body-text.html:3
 #, python-format
-msgid ""
-"Dear %(user)s, Thank you for applying for access to %(partner)s resources "
-"through The Wikipedia Library. We are happy to inform you that your "
-"application has been approved. %(user_instructions)s You can view the "
-"collections you're authorized to access at My Library: %(link)s Cheers! The "
-"Wikipedia Library"
-msgstr ""
-"致：%(user)s，感謝您透過維基百科圖書館申請向 %(partner)s 取用資源。我們很高興"
-"向您通知您的申請程序已被核准。一旦處理完畢後，您可以在一到兩週內收到取用方面"
-"的細節。%(user_instructions)s，您可以檢視在我的圖書館裡您被授權取用的典藏："
-"%(link)s，這實在太好了！維基百科圖書館"
+msgid "Dear %(user)s, Thank you for applying for access to %(partner)s resources through The Wikipedia Library. We are happy to inform you that your application has been approved. %(user_instructions)s You can view the collections you're authorized to access at My Library: %(link)s Cheers! The Wikipedia Library"
+msgstr "致：%(user)s，感謝您透過維基百科圖書館申請向 %(partner)s 取用資源。我們很高興向您通知您的申請程序已被核准。一旦處理完畢後，您可以在一到兩週內收到取用方面的細節。%(user_instructions)s，您可以檢視在我的圖書館裡您被授權取用的典藏：%(link)s，這實在太好了！維基百科圖書館"
 
 #. Translators: This is the subject of an email which is sent to users when their application has been approved. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/approval_notification-subject.html:4
@@ -1109,25 +985,14 @@ msgstr "您的維基百科圖書館申請程序已核准"
 #. Translators: This email is sent to coordinators when a comment is left on an application they are processing. Don't translate Jinja variables in curly braces like user or partner. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/comment_notification_coordinator-body-html.html:5
 #, python-format
-msgid ""
-"<p style=\"color: #500050\">%(submit_date)s - %(commenter)s</p> "
-"<blockquote><p>%(comment)s</p></blockquote> <p>Please reply to these at: <a "
-"href=\"%(app_url)s\">%(app_url)s</a></p> <p>Best,</p> <p>The Wikipedia "
-"Library</p>"
-msgstr ""
-"<p style=\"color: #500050\">%(submit_date)s - %(commenter)s</p> "
-"<blockquote><p>%(comment)s</p></blockquote> <p>請在：<a href=\"%(app_url)s\">"
-"%(app_url)s</a> 回覆</p> <p>在此獻上最好的祝福</p>，<p>維基百科圖書館</p>"
+msgid "<p style=\"color: #500050\">%(submit_date)s - %(commenter)s</p> <blockquote><p>%(comment)s</p></blockquote> <p>Please reply to these at: <a href=\"%(app_url)s\">%(app_url)s</a></p> <p>Best,</p> <p>The Wikipedia Library</p>"
+msgstr "<p style=\"color: #500050\">%(submit_date)s - %(commenter)s</p> <blockquote><p>%(comment)s</p></blockquote> <p>請在：<a href=\"%(app_url)s\">%(app_url)s</a> 回覆</p> <p>在此獻上最好的祝福</p>，<p>維基百科圖書館</p>"
 
 #. Translators: This email is sent to coordinators when a comment is left on an application they are processing. Don't translate Jinja variables in curly braces like user or partner. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/comment_notification_coordinator-body-text.html:3
 #, python-format
-msgid ""
-"%(submit_date)s - %(commenter)s %(comment)s Please reply to this at: "
-"%(app_url)s Best, The Wikipedia Library"
-msgstr ""
-"%(submit_date)s - %(commenter)s %(comment)s 請在：%(app_url)s 回覆。在此獻上"
-"最好的祝福，維基百科圖書館"
+msgid "%(submit_date)s - %(commenter)s %(comment)s Please reply to this at: %(app_url)s Best, The Wikipedia Library"
+msgstr "%(submit_date)s - %(commenter)s %(comment)s 請在：%(app_url)s 回覆。在此獻上最好的祝福，維基百科圖書館"
 
 #. Translators: This is the subject line of an email sent to coordinators when a comment is left on an application they processed.
 #: TWLight/emails/templates/emails/comment_notification_coordinator-subject.html:3
@@ -1137,26 +1002,14 @@ msgstr "在您所處裡維基百科圖書館申請程序上的新評註"
 #. Translators: This email is sent to users when they receive a comment on their application. Don't translate Jinja variables in curly braces like user or partner; don't translate html tags either. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/comment_notification_editors-body-html.html:5
 #, python-format
-msgid ""
-"<p style=\"color: #500050\">%(submit_date)s - %(commenter)s</p> "
-"<blockquote><p>%(comment)s</p></blockquote> <p>Please reply to these at <a "
-"href=\"%(app_url)s\">%(app_url)s</a> so we can evaluate your application.</"
-"p> <p>Best,</p> <p>The Wikipedia Library</p>"
-msgstr ""
-"<p style=\"color: #500050\">%(submit_date)s - %(commenter)s</p> "
-"<blockquote><p>%(comment)s</p></blockquote> <p>請在：<a href=\"%(app_url)s\">"
-"%(app_url)s</a> 回覆，以讓我們可以評估您的申請程序。</p> <p>在此獻上最好的祝"
-"福</p>，<p>維基百科圖書館</p>"
+msgid "<p style=\"color: #500050\">%(submit_date)s - %(commenter)s</p> <blockquote><p>%(comment)s</p></blockquote> <p>Please reply to these at <a href=\"%(app_url)s\">%(app_url)s</a> so we can evaluate your application.</p> <p>Best,</p> <p>The Wikipedia Library</p>"
+msgstr "<p style=\"color: #500050\">%(submit_date)s - %(commenter)s</p> <blockquote><p>%(comment)s</p></blockquote> <p>請在：<a href=\"%(app_url)s\">%(app_url)s</a> 回覆，以讓我們可以評估您的申請程序。</p> <p>在此獻上最好的祝福</p>，<p>維基百科圖書館</p>"
 
 #. Translators: This email is sent to users when they receive a comment on their application. Don't translate Jinja variables in curly braces like user or partner. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/comment_notification_editors-body-text.html:3
 #, python-format
-msgid ""
-"%(submit_date)s - %(commenter)s %(comment)s Please reply to these at: "
-"%(app_url)s so we can evaluate your application. Best, The Wikipedia Library"
-msgstr ""
-"%(submit_date)s - %(commenter)s %(comment)s 請在：%(app_url)s 回覆，以讓我們"
-"可以評估您的申請程序。在此獻上最好的祝福，維基百科圖書館"
+msgid "%(submit_date)s - %(commenter)s %(comment)s Please reply to these at: %(app_url)s so we can evaluate your application. Best, The Wikipedia Library"
+msgstr "%(submit_date)s - %(commenter)s %(comment)s 請在：%(app_url)s 回覆，以讓我們可以評估您的申請程序。在此獻上最好的祝福，維基百科圖書館"
 
 #. Translators: This is the subject line of an email sent to users who have a comment added to one of their applications. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/comment_notification_editors-subject.html:3
@@ -1166,24 +1019,14 @@ msgstr "在您維基百科圖書館申請程序的新評註"
 #. Translators: This email is sent to users when an application they commented on receives another comment. Don't translate Jinja variables in curly braces like app_url; don't translate html tags either. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/comment_notification_others-body-html.html:5
 #, python-format
-msgid ""
-"<p style=\"color: #500050\">%(submit_date)s - %(commenter)s</p> "
-"<blockquote><p>%(comment)s</p></blockquote> See it at <a href=\"%(app_url)s"
-"\">%(app_url)s</a>. Thanks for helping review Wikipedia Library applications!"
-msgstr ""
-"<p style=\"color: #500050\">%(submit_date)s - %(commenter)s</p> "
-"<blockquote><p>%(comment)s</p></blockquote> 請在 <a href=\"%(app_url)s\">"
-"%(app_url)s</a> 查看。感謝協助審查維基百科圖書館申請程序！"
+msgid "<p style=\"color: #500050\">%(submit_date)s - %(commenter)s</p> <blockquote><p>%(comment)s</p></blockquote> See it at <a href=\"%(app_url)s\">%(app_url)s</a>. Thanks for helping review Wikipedia Library applications!"
+msgstr "<p style=\"color: #500050\">%(submit_date)s - %(commenter)s</p> <blockquote><p>%(comment)s</p></blockquote> 請在 <a href=\"%(app_url)s\">%(app_url)s</a> 查看。感謝協助審查維基百科圖書館申請程序！"
 
 #. Translators: This email is sent to users when an application they commented on receives another comment. Don't translate Jinja variables in curly braces like app_url. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/comment_notification_others-body-text.html:3
 #, python-format
-msgid ""
-"%(submit_date)s - %(commenter)s %(comment)s See it at: %(app_url)s Thanks "
-"for helping review Wikipedia Library applications!"
-msgstr ""
-"%(submit_date)s - %(commenter)s %(comment)s 請在：%(app_url)s 查看。感謝協助"
-"審查維基百科圖書館申請程序！"
+msgid "%(submit_date)s - %(commenter)s %(comment)s See it at: %(app_url)s Thanks for helping review Wikipedia Library applications!"
+msgstr "%(submit_date)s - %(commenter)s %(comment)s 請在：%(app_url)s 查看。感謝協助審查維基百科圖書館申請程序！"
 
 #. Translators: This is the subject line of an email sent to users who have a comment added to an application they also commented on. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/comment_notification_others-subject.html:4
@@ -1193,13 +1036,8 @@ msgstr "在您曾評註過維基百科圖書館申請程序的新評註"
 #. Translators: This text is part of a scheduled reminder email sent to coordinators who have applications requiring action. Don't translate Jinja variables in curly braces like total_apps, or user.
 #: TWLight/emails/templates/emails/coordinator_reminder_notification-body-html.html:5
 #, python-format
-msgid ""
-"<p>Dear %(user)s,</p> <p>Our records indicate that you are the designated "
-"coordinator for partners that have a total of %(total_apps)s applications.</"
-"p>"
-msgstr ""
-"<p>致 %(user)s：</p><p>我們的紀錄指出，您是合作夥指定的協調員，且共有 "
-"%(total_apps)s 個申請程序。</p>"
+msgid "<p>Dear %(user)s,</p> <p>Our records indicate that you are the designated coordinator for partners that have a total of %(total_apps)s applications.</p>"
+msgstr "<p>致 %(user)s：</p><p>我們的紀錄指出，您是合作夥指定的協調員，且共有 %(total_apps)s 個申請程序。</p>"
 
 #. Translators: Breakdown as in 'cost breakdown'; analysis.
 #: TWLight/emails/templates/emails/coordinator_reminder_notification-body-html.html:11
@@ -1234,42 +1072,20 @@ msgstr[0] "%(counter)s 個已核准申請程序"
 #. Translators: This text is part of a scheduled reminder email sent to coordinators who have applications requiring action. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library). Don't translate Jinja variables in curly braces like link; don't translate email addresses or html tags either.
 #: TWLight/emails/templates/emails/coordinator_reminder_notification-body-html.html:39
 #, python-format
-msgid ""
-"<p>This is a gentle reminder that you may review applications at <a href="
-"\"%(link)s\">%(link)s</a>.</p> <p>You can customise your reminders under "
-"'preferences' in your user profile.</p> <p>If you received this message in "
-"error, drop us a line at wikipedialibrary@wikimedia.org.</p> <p>Thanks for "
-"helping review Wikipedia Library applications!</p>"
-msgstr ""
-"<p>此為讓您可以在：<a href=\"%(link)s\">%(link)s</a> 做審查的友善提醒。</p> "
-"<p>您可以在您的使用者個人檔案的「偏好設定」裡，來自定義您的提醒。若您不應收到"
-"此訊息，請在：wikipedialibrary@wikimedia.org 留言給我們。</p> <p>感謝您協助檢"
-"閱審查維基百科申請程序！</p>"
+msgid "<p>This is a gentle reminder that you may review applications at <a href=\"%(link)s\">%(link)s</a>.</p> <p>You can customise your reminders under 'preferences' in your user profile.</p> <p>If you received this message in error, drop us a line at wikipedialibrary@wikimedia.org.</p> <p>Thanks for helping review Wikipedia Library applications!</p>"
+msgstr "<p>此為讓您可以在：<a href=\"%(link)s\">%(link)s</a> 做審查的友善提醒。</p> <p>您可以在您的使用者個人檔案的「偏好設定」裡，來自定義您的提醒。若您不應收到此訊息，請在：wikipedialibrary@wikimedia.org 留言給我們。</p> <p>感謝您協助檢閱審查維基百科申請程序！</p>"
 
 #. Translators: This text is part of a scheduled reminder email sent to coordinators who have applications requiring action. Don't translate Jinja variables in curly braces like total_apps, or user.
 #: TWLight/emails/templates/emails/coordinator_reminder_notification-body-text.html:3
 #, python-format
-msgid ""
-"Dear %(user)s, Our records indicate that you are the designated coordinator "
-"for partners that have a total of %(total_apps)s applications."
-msgstr ""
-"致 %(user)s：我們的紀錄指示出，您是合作夥指定的協調員，且共有 %(total_apps)s "
-"個申請程序。"
+msgid "Dear %(user)s, Our records indicate that you are the designated coordinator for partners that have a total of %(total_apps)s applications."
+msgstr "致 %(user)s：我們的紀錄指示出，您是合作夥指定的協調員，且共有 %(total_apps)s 個申請程序。"
 
 #. Translators: This text is part of a scheduled reminder email sent to coordinators who have applications requiring action. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library). Don't translate Jinja variables in curly braces like link; don't translate the email address either.
 #: TWLight/emails/templates/emails/coordinator_reminder_notification-body-text.html:38
 #, python-format
-msgid ""
-"This is a gentle reminder that you may review applications at: %(link)s. You "
-"can customise your reminders under 'preferences' in your user profile. If "
-"you received this message in error, drop us a line at: "
-"wikipedialibrary@wikimedia.org Thanks for helping review Wikipedia Library "
-"applications!"
-msgstr ""
-"此為讓您可以在：%(link)s 做審查的友善提醒。您可以在您的使用者個人檔案的「偏好"
-"設定」裡，來自定義您的提醒。若您不應收到此訊息，請在："
-"wikipedialibrary@wikimedia.org 留言給我們。感謝您協助檢閱審查維基百科申請程"
-"序！"
+msgid "This is a gentle reminder that you may review applications at: %(link)s. You can customise your reminders under 'preferences' in your user profile. If you received this message in error, drop us a line at: wikipedialibrary@wikimedia.org Thanks for helping review Wikipedia Library applications!"
+msgstr "此為讓您可以在：%(link)s 做審查的友善提醒。您可以在您的使用者個人檔案的「偏好設定」裡，來自定義您的提醒。若您不應收到此訊息，請在：wikipedialibrary@wikimedia.org 留言給我們。感謝您協助檢閱審查維基百科申請程序！"
 
 #. Translators: This is the subject line of a scheduled reminder email sent to coordinators who have applications to review. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library). Do not translate items in curly braces.
 #: TWLight/emails/templates/emails/coordinator_reminder_notification-subject.html:4
@@ -1279,30 +1095,14 @@ msgstr "維基百科圖書館等待您的審查"
 #. Translators: This email is sent to users when their application is rejected. Don't translate Jinja variables in curly braces like user or partner; don't translate html tags either. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/rejection_notification-body-html.html:5
 #, python-format
-msgid ""
-"<p>Dear %(user)s,</p> <p>Thank you for applying for access to %(partner)s "
-"resources through The Wikipedia Library. Unfortunately at this time your "
-"application has not been approved. You can view your application and review "
-"comments at <a href=\"%(app_url)s\">%(app_url)s</a>.</p> <p>Best,</p> <p>The "
-"Wikipedia Library</p>"
-msgstr ""
-"<p>致 %(user)s：</p> <p>感謝您透過維基百科圖書館申請向 %(partner)s 取用資源。"
-"很遺憾地，您這次的申請程序未被核准。您可以在 <a href=\"%(app_url)s\">"
-"%(app_url)s</a> 來查看您的申請程序與審查評註。</p> <p>在此獻上最好的祝福</p> "
-"<p>維基百科圖書館</p>"
+msgid "<p>Dear %(user)s,</p> <p>Thank you for applying for access to %(partner)s resources through The Wikipedia Library. Unfortunately at this time your application has not been approved. You can view your application and review comments at <a href=\"%(app_url)s\">%(app_url)s</a>.</p> <p>Best,</p> <p>The Wikipedia Library</p>"
+msgstr "<p>致 %(user)s：</p> <p>感謝您透過維基百科圖書館申請向 %(partner)s 取用資源。很遺憾地，您這次的申請程序未被核准。您可以在 <a href=\"%(app_url)s\">%(app_url)s</a> 來查看您的申請程序與審查評註。</p> <p>在此獻上最好的祝福</p> <p>維基百科圖書館</p>"
 
 #. Translators: This email is sent to users when their application is rejected. Don't translate Jinja variables in curly braces like user or partner. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/rejection_notification-body-text.html:3
 #, python-format
-msgid ""
-"Dear %(user)s, Thank you for applying for access to %(partner)s resources "
-"through The Wikipedia Library. Unfortunately at this time your application "
-"has not been approved. You can view your application and review comments at: "
-"%(app_url)s Best, The Wikipedia Library"
-msgstr ""
-"致：%(user)s，感謝您透過維基百科圖書館來向 %(partner)s 申請資源。很遺憾地，您"
-"這次的申請程序未被核准。您可以在：%(app_url)s 來查看您的申請程序與審查評註。"
-"在此獻上最好的祝福，維基百科圖書館"
+msgid "Dear %(user)s, Thank you for applying for access to %(partner)s resources through The Wikipedia Library. Unfortunately at this time your application has not been approved. You can view your application and review comments at: %(app_url)s Best, The Wikipedia Library"
+msgstr "致：%(user)s，感謝您透過維基百科圖書館來向 %(partner)s 申請資源。很遺憾地，您這次的申請程序未被核准。您可以在：%(app_url)s 來查看您的申請程序與審查評註。在此獻上最好的祝福，維基百科圖書館"
 
 #. Translators: This is the subject of an email which is sent to users when their application has been rejected. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/rejection_notification-subject.html:4
@@ -1312,35 +1112,14 @@ msgstr "您的維基百科申請程序"
 #. Translators: This email is sent to users when they have an account that is soon to expire. Don't translate Jinja variables in curly braces like partner_name or partner_link; don't translate html tags either. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/user_renewal_notice-body-html.html:5
 #, python-format
-msgid ""
-"<p>Dear %(user)s,</p> <p>According to our records, your access to "
-"%(partner_name)s will soon expire and you may lose access. If you want to "
-"continue making use of your free account, you can request renewal of your "
-"account by clicking the 'Renew' or 'Extend' button at %(partner_link)s.</p> "
-"<p>Best,</p> <p>The Wikipedia Library</p> <p>You can disable these emails in "
-"your user page preferences: https://wikipedialibrary.wmflabs.org/users/</p>"
-msgstr ""
-"<p>致 %(user)s：</p><p>根據我們的紀錄，您向 %(partner_name)s 的取用即將逾期，"
-"到時您會無法取用。若您想繼續利用您的免費帳號，您可以透過點擊在 "
-"%(partner_link)s 的 [續辦] 或 [延長] 按鈕來請求續辦。</p><p>在此獻上最好的祝"
-"福，</p><p>維基百科圖書館。</p><p>您可以在您的使用者頁面偏好設定來停用這些電"
-"子郵件：https://wikipedialibrary.wmflabs.org/users/</p>"
+msgid "<p>Dear %(user)s,</p> <p>According to our records, your access to %(partner_name)s will soon expire and you may lose access. If you want to continue making use of your free account, you can request renewal of your account by clicking the 'Renew' or 'Extend' button at %(partner_link)s.</p> <p>Best,</p> <p>The Wikipedia Library</p> <p>You can disable these emails in your user page preferences: https://wikipedialibrary.wmflabs.org/users/</p>"
+msgstr "<p>致 %(user)s：</p><p>根據我們的紀錄，您向 %(partner_name)s 的取用即將逾期，到時您會無法取用。若您想繼續利用您的免費帳號，您可以透過點擊在 %(partner_link)s 的 [續辦] 或 [延長] 按鈕來請求續辦。</p><p>在此獻上最好的祝福，</p><p>維基百科圖書館。</p><p>您可以在您的使用者頁面偏好設定來停用這些電子郵件：https://wikipedialibrary.wmflabs.org/users/</p>"
 
 #. Translators: This email is sent to users when they have an account that is soon to expire. Don't translate Jinja variables in curly braces like partner_name or partner_link; don't translate html tags either. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/user_renewal_notice-body-text.html:3
 #, python-format
-msgid ""
-"Dear %(user)s, According to our records, your access to %(partner_name)s "
-"will soon expire and you may lose access. If you want to continue making use "
-"of your free account, you can request renewal of your account by clicking "
-"the Renew button at %(partner_link)s. Best, The Wikipedia Library You can "
-"disable these emails in your user page preferences: https://wikipedialibrary."
-"wmflabs.org/users/"
-msgstr ""
-"致 %(user)s：根據我們的紀錄，您向 %(partner_name)s 的取用即將逾期，到時您會無"
-"法取用。若您想繼續利用您的免費帳號，您可以透過點擊在 %(partner_link)s 的續辦"
-"按鈕來請求續辦。在此獻上最好的祝福，維基百科圖書館。您可以在您的使用者頁面偏"
-"好設定來停用這些電子郵件：https://wikipedialibrary.wmflabs.org/users/"
+msgid "Dear %(user)s, According to our records, your access to %(partner_name)s will soon expire and you may lose access. If you want to continue making use of your free account, you can request renewal of your account by clicking the Renew button at %(partner_link)s. Best, The Wikipedia Library You can disable these emails in your user page preferences: https://wikipedialibrary.wmflabs.org/users/"
+msgstr "致 %(user)s：根據我們的紀錄，您向 %(partner_name)s 的取用即將逾期，到時您會無法取用。若您想繼續利用您的免費帳號，您可以透過點擊在 %(partner_link)s 的續辦按鈕來請求續辦。在此獻上最好的祝福，維基百科圖書館。您可以在您的使用者頁面偏好設定來停用這些電子郵件：https://wikipedialibrary.wmflabs.org/users/"
 
 #. Translators: This is the subject of an email sent to users when they have an account that is soon to expire. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/user_renewal_notice-subject.html:4
@@ -1350,32 +1129,14 @@ msgstr "您的維基百科圖書館取用即將逾期"
 #. Translators: This email is sent to users when their application is waitlisted because there are no more accounts available. Don't translate Jinja variables in curly braces like user or partner; don't translate html tags either. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/waitlist_notification-body-html.html:5
 #, python-format
-msgid ""
-"<p>Dear %(user)s,</p> <p>Thank you for applying for access to %(partner)s "
-"resources through The Wikipedia Library. There are no accounts currently "
-"available so your application has been waitlisted. Your application will be "
-"evaluated if/when more accounts become available. You can see all available "
-"resources at <a href=\"%(link)s\">%(link)s</a>.</p> <p>Best,</p> <p>The "
-"Wikipedia Library</p>"
-msgstr ""
-"<p>致 %(user)s：</p> <p>感謝您透過維基百科圖書館來向 %(partner)s 申請資源。因"
-"目前沒有可用的帳號，所以您的申請程序為待辦。若/當有更多帳號用時，您的申請程序"
-"會被進行評估。您可以在 <a href=\"%(link)s\">%(link)s</a> 查看所有可用資源。</"
-"p> <p>在此獻上最好的祝福</p> <p>維基百科圖書館</p>"
+msgid "<p>Dear %(user)s,</p> <p>Thank you for applying for access to %(partner)s resources through The Wikipedia Library. There are no accounts currently available so your application has been waitlisted. Your application will be evaluated if/when more accounts become available. You can see all available resources at <a href=\"%(link)s\">%(link)s</a>.</p> <p>Best,</p> <p>The Wikipedia Library</p>"
+msgstr "<p>致 %(user)s：</p> <p>感謝您透過維基百科圖書館來向 %(partner)s 申請資源。因目前沒有可用的帳號，所以您的申請程序為待辦。若/當有更多帳號用時，您的申請程序會被進行評估。您可以在 <a href=\"%(link)s\">%(link)s</a> 查看所有可用資源。</p> <p>在此獻上最好的祝福</p> <p>維基百科圖書館</p>"
 
 #. Translators: This email is sent to users when their application is waitlisted because there are no more accounts available. Don't translate Jinja variables in curly braces like user or partner. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/waitlist_notification-body-text.html:3
 #, python-format
-msgid ""
-"Dear %(user)s, Thank you for applying for access to %(partner)s resources "
-"through The Wikipedia Library. There are no accounts currently available so "
-"your application has been waitlisted. Your application will be evaluated if/"
-"when more accounts become available. You can see all available resources at: "
-"%(link)s Best, The Wikipedia Library"
-msgstr ""
-"致：%(user)s，感謝您透過維基百科圖書館來向 %(partner)s 申請資源。因目前沒有可"
-"用的帳號，所以您的申請程序為待辦。若/當有更多帳號用時，您的申請程序會被進行評"
-"估。您可以在 %(link)s 查看所有可用資源。在此獻上最好的祝福，維基百科圖書館"
+msgid "Dear %(user)s, Thank you for applying for access to %(partner)s resources through The Wikipedia Library. There are no accounts currently available so your application has been waitlisted. Your application will be evaluated if/when more accounts become available. You can see all available resources at: %(link)s Best, The Wikipedia Library"
+msgstr "致：%(user)s，感謝您透過維基百科圖書館來向 %(partner)s 申請資源。因目前沒有可用的帳號，所以您的申請程序為待辦。若/當有更多帳號用時，您的申請程序會被進行評估。您可以在 %(link)s 查看所有可用資源。在此獻上最好的祝福，維基百科圖書館"
 
 #. Translators: This is the subject of an email sent to users when their application is waitlisted because there are no more accounts available. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/emails/templates/emails/waitlist_notification-subject.html:4
@@ -1536,17 +1297,14 @@ msgstr "不可用"
 #: TWLight/resources/templates/resources/filter_section.html:14
 #: TWLight/templates/about.html:12
 #: TWLight/users/templates/users/filter_section.html:13
-msgid ""
-"The Wikipedia Library allows active editors to access a wide range of "
-"collections of paywalled reliable sources for free!"
+msgid "The Wikipedia Library allows active editors to access a wide range of collections of paywalled reliable sources for free!"
 msgstr "維基百科圖書館允許活躍的編輯者免費訪問各種廣泛的付費可靠來源！"
 
 #. Translators: On the Browse Partners page (https://wikipedialibrary.wmflabs.org/partners/), this introduces users to The Wikipedia Library.
 #. Translators: On the MyLibrary page (https://wikipedialibrary.wmflabs.org/users/my_library), this introduces users to The Wikipedia Library.
 #: TWLight/resources/templates/resources/filter_section.html:17
 #: TWLight/users/templates/users/filter_section.html:15
-msgid ""
-"Start with the search bar at the top or browse publisher websites directly."
+msgid "Start with the search bar at the top or browse publisher websites directly."
 msgstr "在頂部搜尋欄中搜索或者直接瀏覽出版者網站以開始。"
 
 #. Translators: On the Browse Partners page (https://wikipedialibrary.wmflabs.org/partners/), this appears below introductory text and links to the 'About' page (https://wikipedialibrary.wmflabs.org/about/)
@@ -1620,66 +1378,39 @@ msgstr "回到合作夥伴"
 #. Translators: If we have no available accounts for a partner, the coordinator can change the application system to a waiting list.
 #: TWLight/resources/templates/resources/partner_detail.html:36
 #: TWLight/resources/templates/resources/partner_detail_apply.html:17
-msgid ""
-"There are no access grants available for this partner at this time. You can "
-"still apply for access; applications will be processed when access is "
-"available."
-msgstr ""
-"目前該合作夥伴沒有可用的取用授予。您仍可以申請取用；但申請程序要在有可用的取"
-"用時才會進行處理。"
+msgid "There are no access grants available for this partner at this time. You can still apply for access; applications will be processed when access is available."
+msgstr "目前該合作夥伴沒有可用的取用授予。您仍可以申請取用；但申請程序要在有可用的取用時才會進行處理。"
 
 #. Translators: This text links to the minimum user requirements and terms of use on the partner page.
 #: TWLight/resources/templates/resources/partner_detail.html:48
 #: TWLight/resources/templates/resources/partner_detail_apply.html:29
 #, python-format
-msgid ""
-"Before applying, please review the <strong><a class=\"twl-links\" href="
-"\"%(about)s#req\">minimum requirements</a></strong> for access and our "
-"<strong><a class=\"twl-links\" href=\"%(terms)s\">terms of use</a></strong>."
-msgstr ""
-"在申請之前，請先檢閱申請方面的<strong><a class=\"twl-links\" href="
-"\"%(about)s#req\">最低要求</a></strong>以及我們的<strong><a class=\"twl-links"
-"\" href=\"%(terms)s\">使用條款</a></strong>。"
+msgid "Before applying, please review the <strong><a class=\"twl-links\" href=\"%(about)s#req\">minimum requirements</a></strong> for access and our <strong><a class=\"twl-links\" href=\"%(terms)s\">terms of use</a></strong>."
+msgstr "在申請之前，請先檢閱申請方面的<strong><a class=\"twl-links\" href=\"%(about)s#req\">最低要求</a></strong>以及我們的<strong><a class=\"twl-links\" href=\"%(terms)s\">使用條款</a></strong>。"
 
 #. Translators: This text refers to the page containing the content a user is authorized to access.
 #: TWLight/resources/templates/resources/partner_detail.html:69
 #, python-format
-msgid ""
-"View the status of your access in <strong><a class=\"twl-links\" href="
-"\"%(library_url)s\">My Library</a></strong> page."
-msgstr ""
-"請在<strong><a class=\"twl-links\" href=\"%(library_url)s\">我的典藏</a></"
-"strong>頁面檢視您的取用狀態。"
+msgid "View the status of your access in <strong><a class=\"twl-links\" href=\"%(library_url)s\">My Library</a></strong> page."
+msgstr "請在<strong><a class=\"twl-links\" href=\"%(library_url)s\">我的典藏</a></strong>頁面檢視您的取用狀態。"
 
 #. Translators: This message is shown when a user has open applications, linking to their respective applications page.
 #: TWLight/resources/templates/resources/partner_detail.html:78
 #, python-format
-msgid ""
-"View the status of your application(s) on your <strong><a class=\"twl-links"
-"\" href=\"%(applications_url)s\">My Applications</a></strong> page."
-msgstr ""
-"請在<strong><a class=\"twl-links\" href=\"%(applications_url)s\">我的申請程序"
-"</a></strong>頁面檢視您的申請狀態。"
+msgid "View the status of your application(s) on your <strong><a class=\"twl-links\" href=\"%(applications_url)s\">My Applications</a></strong> page."
+msgstr "請在<strong><a class=\"twl-links\" href=\"%(applications_url)s\">我的申請程序</a></strong>頁面檢視您的申請狀態。"
 
 #. Translators: This message is shown when a user has authorizations, linking to their respective collections page.
 #: TWLight/resources/templates/resources/partner_detail_apply.html:50
 #, python-format
-msgid ""
-"View the status of your access on your <strong><a href=\"%(library_url)s\" "
-"class=\"twl-links\">My Library</a></strong> page."
-msgstr ""
-"請在<strong><a href=\"%(library_url)s\" class=\"twl-links\"></strong>頁面檢視"
-"您的取用狀態。"
+msgid "View the status of your access on your <strong><a href=\"%(library_url)s\" class=\"twl-links\">My Library</a></strong> page."
+msgstr "請在<strong><a href=\"%(library_url)s\" class=\"twl-links\"></strong>頁面檢視您的取用狀態。"
 
 #. Translators: This message is shown when a user has open applications, linking to their respective applications page.
 #: TWLight/resources/templates/resources/partner_detail_apply.html:60
 #, python-format
-msgid ""
-"View the status of your application(s) on your <strong><a href="
-"\"%(applications_url)s\">My Applications</a></strong> page."
-msgstr ""
-"請在<strong><a href=\"%(applications_url)s\">我的申請程序</a></strong>頁面檢"
-"視您的申請狀態。"
+msgid "View the status of your application(s) on your <strong><a href=\"%(applications_url)s\">My Applications</a></strong> page."
+msgstr "請在<strong><a href=\"%(applications_url)s\">我的申請程序</a></strong>頁面檢視您的申請狀態。"
 
 #. Translators: One the partner detail page, this text labels the button which coordinators can click to remove a partner from waitlisted status.
 #: TWLight/resources/templates/resources/partner_detail_apply.html:73
@@ -1708,14 +1439,8 @@ msgstr "Special:EmailUser 頁面"
 
 #. Translators: If no account coordinator is assigned to a partner, the Wikipedia Library team will coordinate signups. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/resources/templates/resources/partner_detail_apply.html:112
-msgid ""
-"The Wikipedia Library team will process this application. Want to help? <a "
-"class=\"twl-links\" href=\"https://en.wikipedia.org/wiki/Wikipedia:"
-"The_Wikipedia_Library/Coordinators/Signup\">Sign up as a coordinator.</a>"
-msgstr ""
-"維基百科圖書館團隊將會處理此申請程序。有意願協助嗎？<a class=\"twl-links\" "
-"href=\"https://en.wikipedia.org/wiki/Wikipedia:The_Wikipedia_Library/"
-"Coordinators/Signup\">註冊為協調員</a>。"
+msgid "The Wikipedia Library team will process this application. Want to help? <a class=\"twl-links\" href=\"https://en.wikipedia.org/wiki/Wikipedia:The_Wikipedia_Library/Coordinators/Signup\">Sign up as a coordinator.</a>"
+msgstr "維基百科圖書館團隊將會處理此申請程序。有意願協助嗎？<a class=\"twl-links\" href=\"https://en.wikipedia.org/wiki/Wikipedia:The_Wikipedia_Library/Coordinators/Signup\">註冊為協調員</a>。"
 
 #. Translators: This text labels a button coordinators can click to view a list of users who have applied for access for a particular partner
 #: TWLight/resources/templates/resources/partner_detail_apply.html:121
@@ -1744,21 +1469,14 @@ msgstr "Library Bundle 取用"
 
 #. Translators: Text shown to authenticated, bundle eligible users when they visit a Bundle partner page.
 #: TWLight/resources/templates/resources/partner_detail_apply.html:138
-msgid ""
-"You are eligible to access Library Bundle partners. Click the button above "
-"to access the collection."
+msgid "You are eligible to access Library Bundle partners. Click the button above to access the collection."
 msgstr "您符合取用 Library Bundle 合作夥伴的資源。請點擊上方按鈕來取用典藏。"
 
 #. Translators: Text shown to authenticated, bundle ineligible users when they visit a Bundle partner page.
 #: TWLight/resources/templates/resources/partner_detail_apply.html:152
 #, python-format
-msgid ""
-"You are not eligible to access Library Bundle partners. Visit the <a class="
-"\"twl-links\" href=\"%(homepage)s\">homepage</a> to check the eligibility "
-"criteria."
-msgstr ""
-"您沒有資格取用 Library Bundle 合作夥伴的資源。請參訪<a class=\"twl-links\" "
-"href=\"%(homepage)s\">首頁</a>來檢查是否符合條件。"
+msgid "You are not eligible to access Library Bundle partners. Visit the <a class=\"twl-links\" href=\"%(homepage)s\">homepage</a> to check the eligibility criteria."
+msgstr "您沒有資格取用 Library Bundle 合作夥伴的資源。請參訪<a class=\"twl-links\" href=\"%(homepage)s\">首頁</a>來檢查是否符合條件。"
 
 #. Translators: Buttton prompting users to log in.
 #: TWLight/resources/templates/resources/partner_detail_apply.html:160
@@ -1769,13 +1487,8 @@ msgstr "登入"
 #. Translators: Text shown to unauthenticated users when they visit a Bundle partner page.
 #: TWLight/resources/templates/resources/partner_detail_apply.html:168
 #, python-format
-msgid ""
-"This resource is part of our <a class=\"twl-links\" href=\"%(about)s"
-"\">Library Bundle</a>, which you can access if you meet our minimum "
-"eligibility criteria. Log in to find out if you are eligible."
-msgstr ""
-"此資源是我們的 <a class=\"twl-links\" href=\"%(about)s\">Library Bundle</a> "
-"一部分，若您符合我們的最低需求條件，便可以取用。請登入來確認您是否符合條件。"
+msgid "This resource is part of our <a class=\"twl-links\" href=\"%(about)s\">Library Bundle</a>, which you can access if you meet our minimum eligibility criteria. Log in to find out if you are eligible."
+msgstr "此資源是我們的 <a class=\"twl-links\" href=\"%(about)s\">Library Bundle</a> 一部分，若您符合我們的最低需求條件，便可以取用。請登入來確認您是否符合條件。"
 
 #. Translators: This is the label for a number which shows the total active accounts for one partner. (e.g. https://wikipedialibrary.wmflabs.org/partners/8/).
 #: TWLight/resources/templates/resources/partner_detail_stats.html:21
@@ -1825,31 +1538,20 @@ msgstr "摘錄限制"
 #. Translators: If a partner has specified the excerpt limit both in words and percentage, this message will display the percentage of words and the number of words on the partner page.
 #: TWLight/resources/templates/resources/partner_detail_timeline.html:99
 #, python-format
-msgid ""
-"%(object)s allows a maximum of %(excerpt_limit)s words or "
-"%(excerpt_limit_percentage)s%% of an article be excerpted into a Wikipedia "
-"article."
-msgstr ""
-"%(object)s 允許一篇文章裡最多 %(excerpt_limit)s 個字詞或百分之 "
-"%(excerpt_limit_percentage)s%% 的內容可摘錄至維基百科條目。"
+msgid "%(object)s allows a maximum of %(excerpt_limit)s words or %(excerpt_limit_percentage)s%% of an article be excerpted into a Wikipedia article."
+msgstr "%(object)s 允許一篇文章裡最多 %(excerpt_limit)s 個字詞或百分之 %(excerpt_limit_percentage)s%% 的內容可摘錄至維基百科條目。"
 
 #. Translators: If a partner has specified the excerpt limit in words, this message will display the number of words on the partner page.
 #: TWLight/resources/templates/resources/partner_detail_timeline.html:106
 #, python-format
-msgid ""
-"%(object)s allows a maximum of %(excerpt_limit)s words be excerpted into a "
-"Wikipedia article."
+msgid "%(object)s allows a maximum of %(excerpt_limit)s words be excerpted into a Wikipedia article."
 msgstr "%(object)s 允許最多可摘錄 %(excerpt_limit)s 個字詞至維基百科條目。"
 
 #. Translators: If a partner has specified the excerpt limit in percentage, this message will display the percentage of words on the partner page.
 #: TWLight/resources/templates/resources/partner_detail_timeline.html:113
 #, python-format
-msgid ""
-"%(object)s allows a maximum of %(excerpt_limit_percentage)s%% of an article "
-"be excerpted into a Wikipedia article."
-msgstr ""
-"%(object)s 允許最多可摘錄百分之 %(excerpt_limit_percentage)s%% 的內容至維基百"
-"科條目。"
+msgid "%(object)s allows a maximum of %(excerpt_limit_percentage)s%% of an article be excerpted into a Wikipedia article."
+msgstr "%(object)s 允許最多可摘錄百分之 %(excerpt_limit_percentage)s%% 的內容至維基百科條目。"
 
 #. Translators: If a partner has other requirements for access, this text shows as the title for that information field. (e.g. https://wikipedialibrary.wmflabs.org/partners/10/).
 #: TWLight/resources/templates/resources/partner_detail_timeline.html:132
@@ -1859,9 +1561,7 @@ msgstr "申請人特別需求"
 #. Translators: If a user must agree to a Terms of Use document, they see this message, and must enter the name of the resource. Don't translate publisher or url.
 #: TWLight/resources/templates/resources/partner_detail_timeline.html:140
 #, python-format
-msgid ""
-"%(publisher)s requires that you agree with its <a href=\"%(url)s\">terms of "
-"use</a>."
+msgid "%(publisher)s requires that you agree with its <a href=\"%(url)s\">terms of use</a>."
 msgstr "%(publisher)s 需要您同意他們的<a href=\"%(url)s\">使用條款</a>。"
 
 #. Translators: If a user must provide their real name to apply to a partner, they see this message, and must enter the name of the resource. Don't translate publisher.
@@ -1885,17 +1585,13 @@ msgstr "%(publisher)s 需要您提供您的所屬機構。"
 #. Translators: If a user must select a specific resource to apply for, they see this message, and must enter the name of the resource. Don't translate publisher.
 #: TWLight/resources/templates/resources/partner_detail_timeline.html:177
 #, python-format
-msgid ""
-"%(publisher)s requires that you specify a particular title that you want to "
-"access."
+msgid "%(publisher)s requires that you specify a particular title that you want to access."
 msgstr "%(publisher)s 需要您指定出您所想取用的特定標題。"
 
 #. Translators: If a user must register on the partner website before applying, they see this message. Don't translate partner.
 #: TWLight/resources/templates/resources/partner_detail_timeline.html:187
 #, python-format
-msgid ""
-"%(publisher)s requires that you sign up for an account before applying for "
-"access."
+msgid "%(publisher)s requires that you sign up for an account before applying for access."
 msgstr "%(publisher)s 需要您在申請取用之前，先註冊一個帳號。"
 
 #. Translators: If a partner has their location listed, this message is a label for that location
@@ -2022,9 +1718,7 @@ msgstr "您確定您要刪除<b>%(object)s</b>嗎？"
 
 #. Translators: If multiple authorizations where returned for a collection, this message is shown to a user
 #: TWLight/resources/views.py:268
-msgid ""
-"Multiple authorizations were returned – something's wrong. Please contact us "
-"and don't forget to mention this message."
+msgid "Multiple authorizations were returned – something's wrong. Please contact us and don't forget to mention this message."
 msgstr "有多個授權被回傳 - 發生了一些狀況。請聯絡我們，並不要忘記提及此訊息。"
 
 #. Translators: This message is shown when user tries to access a NOT_AVAILABLE Partner
@@ -2065,22 +1759,8 @@ msgstr "很抱歉，我們不曉得如何處理。"
 #. Translators: Shown on the website's 400 page, when a user sends a bad request. Don't translate path or Phabricator.
 #: TWLight/templates/400.html:20
 #, python-format
-msgid ""
-"If you think we should know what to do with that, please email us about this "
-"error at <a class=\"twl-links\" href=\"mailto:wikipedialibrary@wikimedia.org?"
-"Subject=Wikipedia%%20Library%%20%(path)s%%20Permission%%20denied"
-"\">wikipedialibrary@wikimedia.org</a> or report it to us on <a class=\"twl-"
-"links\" href=\"https://phabricator.wikimedia.org/maniphest/task/edit/form/1/?"
-"projectPHIDs=Library-Card-Platform&title=Wikipedia%%20Library%%20%(path)s"
-"%%20Bad%%20Request\">Phabricator</a>"
-msgstr ""
-"若您了解我們應如何處理，請將關於此錯誤發送電子郵件到 <a class=\"twl-links\" "
-"href=\"mailto:wikipedialibrary@wikimedia.org?Subject=Wikipedia%%20Library"
-"%%20%(path)s%%20Permission%%20denied\">wikipedialibrary@wikimedia.org</a> 給"
-"我們，或是在 <a class=\"twl-links\" href=\"https://phabricator.wikimedia.org/"
-"maniphest/task/edit/form/1/?projectPHIDs=Library-Card-"
-"Platform&title=Wikipedia%%20Library%%20%(path)s%%20Bad%%20Request"
-"\">Phabricator</a> 上回報。"
+msgid "If you think we should know what to do with that, please email us about this error at <a class=\"twl-links\" href=\"mailto:wikipedialibrary@wikimedia.org?Subject=Wikipedia%%20Library%%20%(path)s%%20Permission%%20denied\">wikipedialibrary@wikimedia.org</a> or report it to us on <a class=\"twl-links\" href=\"https://phabricator.wikimedia.org/maniphest/task/edit/form/1/?projectPHIDs=Library-Card-Platform&title=Wikipedia%%20Library%%20%(path)s%%20Bad%%20Request\">Phabricator</a>"
+msgstr "若您了解我們應如何處理，請將關於此錯誤發送電子郵件到 <a class=\"twl-links\" href=\"mailto:wikipedialibrary@wikimedia.org?Subject=Wikipedia%%20Library%%20%(path)s%%20Permission%%20denied\">wikipedialibrary@wikimedia.org</a> 給我們，或是在 <a class=\"twl-links\" href=\"https://phabricator.wikimedia.org/maniphest/task/edit/form/1/?projectPHIDs=Library-Card-Platform&title=Wikipedia%%20Library%%20%(path)s%%20Bad%%20Request\">Phabricator</a> 上回報。"
 
 #. Translators: Alt text for an image shown on the 400 error page.
 #. Translators: Alt text for an image shown on the 403 error page.
@@ -2101,23 +1781,8 @@ msgstr "很抱歉，您不被允許這樣做。"
 #. Translators: Shown on the website's 403 page, when a user attempts to navigate to a page they don't have permission to view. Don't translate path or Phabricator.
 #: TWLight/templates/403.html:20
 #, python-format
-msgid ""
-"If you think your account should be able to do that, please email us about "
-"this error at <a class=\"twl-links\" href=\"mailto:"
-"wikipedialibrary@wikimedia.org?Subject=Wikipedia%%20Library%%20%(path)s"
-"%%20Permission%%20denied\">wikipedialibrary@wikimedia.org</a> or report it "
-"to us on <a class=\"twl-links\" href=\"https://phabricator.wikimedia.org/"
-"maniphest/task/edit/form/1/?projectPHIDs=Library-Card-"
-"Platform&title=Wikipedia%%20Library%%20%(path)s%%20Permission%%20denied"
-"\">Phabricator</a>"
-msgstr ""
-"若您認為您的帳號應可進行才對，請將關於此錯誤發送電子郵件到 <a class=\"twl-"
-"links\" href=\"mailto:wikipedialibrary@wikimedia.org?Subject=Wikipedia"
-"%%20Library%%20%(path)s%%20Permission%%20denied\">wikipedialibrary@wikimedia."
-"org</a> 給我們，或是在 <a class=\"twl-links\" href=\"https://phabricator."
-"wikimedia.org/maniphest/task/edit/form/1/?projectPHIDs=Library-Card-"
-"Platform&title=Wikipedia%%20Library%%20%(path)s%%20Permission%%20denied"
-"\">Phabricator</a> 上回報。"
+msgid "If you think your account should be able to do that, please email us about this error at <a class=\"twl-links\" href=\"mailto:wikipedialibrary@wikimedia.org?Subject=Wikipedia%%20Library%%20%(path)s%%20Permission%%20denied\">wikipedialibrary@wikimedia.org</a> or report it to us on <a class=\"twl-links\" href=\"https://phabricator.wikimedia.org/maniphest/task/edit/form/1/?projectPHIDs=Library-Card-Platform&title=Wikipedia%%20Library%%20%(path)s%%20Permission%%20denied\">Phabricator</a>"
+msgstr "若您認為您的帳號應可進行才對，請將關於此錯誤發送電子郵件到 <a class=\"twl-links\" href=\"mailto:wikipedialibrary@wikimedia.org?Subject=Wikipedia%%20Library%%20%(path)s%%20Permission%%20denied\">wikipedialibrary@wikimedia.org</a> 給我們，或是在 <a class=\"twl-links\" href=\"https://phabricator.wikimedia.org/maniphest/task/edit/form/1/?projectPHIDs=Library-Card-Platform&title=Wikipedia%%20Library%%20%(path)s%%20Permission%%20denied\">Phabricator</a> 上回報。"
 
 #. Translators: Shown on the website's 404 page, when a user attempts to navigate to a page that doesn't exist.
 #: TWLight/templates/404.html:11
@@ -2132,22 +1797,8 @@ msgstr "很抱歉，我們並未找到。"
 #. Translators: Shown on the website's 404 page, when a user attempts to navigate to a page that doesn't exist. Don't translate path or Phabricator.
 #: TWLight/templates/404.html:19
 #, python-format
-msgid ""
-"If you are certain that something should be here, please email us about this "
-"error at <a class=\"twl-links\" href=\"mailto:wikipedialibrary@wikimedia.org?"
-"Subject=Wikipedia%%20Library%%20%(path)s%%20Not%%20found\"> "
-"wikipedialibrary@wikimedia.org</a> or report it to us on <a class=\"twl-links"
-"\" href=\"https://phabricator.wikimedia.org/maniphest/task/edit/form/1/?"
-"projectPHIDs=Library-Card-Platform&title=Wikipedia%%20Library%%20%(path)s"
-"%%20Not%%20found\">Phabricator</a>"
-msgstr ""
-"若您認為在此應該有頁面內容，請將關於此錯誤發送電子郵件到<a class=\"twl-links"
-"\" href=\"mailto:wikipedialibrary@wikimedia.org?Subject=Wikipedia%%20Library"
-"%%20%(path)s%%20Not%%20found\"> wikipedialibrary@wikimedia.org</a> 給我們，或"
-"是在 <a class=\"twl-links\" href=\"https://phabricator.wikimedia.org/"
-"maniphest/task/edit/form/1/?projectPHIDs=Library-Card-"
-"Platform&title=Wikipedia%%20Library%%20%(path)s%%20Not%%20found"
-"\">Phabricator</a> 上回報。"
+msgid "If you are certain that something should be here, please email us about this error at <a class=\"twl-links\" href=\"mailto:wikipedialibrary@wikimedia.org?Subject=Wikipedia%%20Library%%20%(path)s%%20Not%%20found\"> wikipedialibrary@wikimedia.org</a> or report it to us on <a class=\"twl-links\" href=\"https://phabricator.wikimedia.org/maniphest/task/edit/form/1/?projectPHIDs=Library-Card-Platform&title=Wikipedia%%20Library%%20%(path)s%%20Not%%20found\">Phabricator</a>"
+msgstr "若您認為在此應該有頁面內容，請將關於此錯誤發送電子郵件到<a class=\"twl-links\" href=\"mailto:wikipedialibrary@wikimedia.org?Subject=Wikipedia%%20Library%%20%(path)s%%20Not%%20found\"> wikipedialibrary@wikimedia.org</a> 給我們，或是在 <a class=\"twl-links\" href=\"https://phabricator.wikimedia.org/maniphest/task/edit/form/1/?projectPHIDs=Library-Card-Platform&title=Wikipedia%%20Library%%20%(path)s%%20Not%%20found\">Phabricator</a> 上回報。"
 
 #. Translators: Alt text for an image shown on the 404 error page.
 #: TWLight/templates/404.html:32
@@ -2161,44 +1812,19 @@ msgstr "關於維基百科圖書館"
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:20
-msgid ""
-"This platform is our central tool for facilitating access to our available "
-"collections. Here you can see which partnerships are available, search their "
-"contents, and apply for and access the ones you’re interested in."
-msgstr ""
-"此平台是我們用來審查申請程序，以及提供取用我們的典藏之中心工具。在這裡您可以"
-"查看有哪些可利用的合作夥伴關係，搜索他們的內容，並對您有興趣取用的資源做出申"
-"請。與維基媒體基金會簽署保密協議的協調員，負責審查申請程序並與出版者之間往"
-"來，為您爭取能自由取用的權利。部份內容則無需申請便可使用。"
+msgid "This platform is our central tool for facilitating access to our available collections. Here you can see which partnerships are available, search their contents, and apply for and access the ones you’re interested in."
+msgstr "此平台是我們用來審查申請程序，以及提供取用我們的典藏之中心工具。在這裡您可以查看有哪些可利用的合作夥伴關係，搜索他們的內容，並對您有興趣取用的資源做出申請。與維基媒體基金會簽署保密協議的協調員，負責審查申請程序並與出版者之間往來，為您爭取能自由取用的權利。部份內容則無需申請便可使用。"
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/). Wikimedia Foundation should not be translated.
 #: TWLight/templates/about.html:29
-msgid ""
-"All users receive immediate access to some collections, which can be browsed "
-"by clicking the 'Access collection' buttons or using the search bar at the "
-"top of the page. Other collections require an application before access is "
-"granted, and may be accessed directly or via an individual login or access "
-"code. Volunteer coordinators, who have signed non-disclosure agreements with "
-"the Wikimedia Foundation, review these applications and work with publishers "
-"to get you your free access."
-msgstr ""
-"所有使用者都可以透過點擊「取用典藏」按鈕來立即取用部份典藏，或是使用頁面頂部"
-"的搜尋工具來瀏覽內容。其他典藏需要先申請才能授予取用權限，之後可以直接取用"
-"（或是透過個人登入、取用代碼等方式）。與維基媒體基金會簽署過保密協議的志工協"
-"調員會審查這些申請，並與出版商合作來提供您免費取用。"
+msgid "All users receive immediate access to some collections, which can be browsed by clicking the 'Access collection' buttons or using the search bar at the top of the page. Other collections require an application before access is granted, and may be accessed directly or via an individual login or access code. Volunteer coordinators, who have signed non-disclosure agreements with the Wikimedia Foundation, review these applications and work with publishers to get you your free access."
+msgstr "所有使用者都可以透過點擊「取用典藏」按鈕來立即取用部份典藏，或是使用頁面頂部的搜尋工具來瀏覽內容。其他典藏需要先申請才能授予取用權限，之後可以直接取用（或是透過個人登入、取用代碼等方式）。與維基媒體基金會簽署過保密協議的志工協調員會審查這些申請，並與出版商合作來提供您免費取用。"
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/). Don't translate terms_url.
 #: TWLight/templates/about.html:43
 #, python-format
-msgid ""
-"For more information about how your information is stored and reviewed "
-"please see our <a class=\"twl-links\" href=\"%(terms_url)s\"> terms of use "
-"and privacy policy</a>. Accounts you apply for are also subject to the Terms "
-"of Use provided by each partner’s platform; please review them."
-msgstr ""
-"更多有關如何儲存以及審查您的資訊內容方面，請查看我們的<a class=\"twl-links\" "
-"href=\"%(terms_url)s\">使用條款與隱私方針</a>。您所申請的帳號也需遵守各合作夥"
-"伴平台所提出的使用條款，請記得檢閱那些條款內容。"
+msgid "For more information about how your information is stored and reviewed please see our <a class=\"twl-links\" href=\"%(terms_url)s\"> terms of use and privacy policy</a>. Accounts you apply for are also subject to the Terms of Use provided by each partner’s platform; please review them."
+msgstr "更多有關如何儲存以及審查您的資訊內容方面，請查看我們的<a class=\"twl-links\" href=\"%(terms_url)s\">使用條款與隱私方針</a>。您所申請的帳號也需遵守各合作夥伴平台所提出的使用條款，請記得檢閱那些條款內容。"
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:51
@@ -2207,16 +1833,8 @@ msgstr "誰能允許取用？"
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/). Wikimedia Foundation should not be translated.
 #: TWLight/templates/about.html:55
-msgid ""
-"Any active editor in good standing can receive access. For publishers with "
-"limited numbers of accounts, applications are reviewed based on the editor’s "
-"needs and contributions. If you think you could use access to one of our "
-"partner resources and are an active editor in any project supported by the "
-"Wikimedia Foundation, please apply."
-msgstr ""
-"任何符合資格的活躍編輯者都能允許取用。對於帳號數量有限的出版者，申請程序會基"
-"於編輯者所需以及貢獻程度來評估。若您是由維基媒體基金會所支援任一專案裡的活躍"
-"編輯者，並認為可去取用我們合作夥伴其一的資源，請申請。"
+msgid "Any active editor in good standing can receive access. For publishers with limited numbers of accounts, applications are reviewed based on the editor’s needs and contributions. If you think you could use access to one of our partner resources and are an active editor in any project supported by the Wikimedia Foundation, please apply."
+msgstr "任何符合資格的活躍編輯者都能允許取用。對於帳號數量有限的出版者，申請程序會基於編輯者所需以及貢獻程度來評估。若您是由維基媒體基金會所支援任一專案裡的活躍編輯者，並認為可去取用我們合作夥伴其一的資源，請申請。"
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:65
@@ -2245,31 +1863,13 @@ msgstr "您目前並沒有被禁止編輯維基媒體專案"
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/)
 #: TWLight/templates/about.html:89
-msgid ""
-"If you are applying for an available collection, please first check that you "
-"don't already have access through another library or institution. If you do, "
-"please consider using that access rather than taking up a seat for this "
-"resource in The Wikipedia Library."
-msgstr ""
-"如果您正在申請可用的館藏，請首先確認您尚未通過其他圖書館或機構申請該館藏。如"
-"果您這樣做，請考慮使用該訪問權限，而不是在維基百科圖書館中為該資源佔用一個席"
-"位。"
+msgid "If you are applying for an available collection, please first check that you don't already have access through another library or institution. If you do, please consider using that access rather than taking up a seat for this resource in The Wikipedia Library."
+msgstr "如果您正在申請可用的館藏，請首先確認您尚未通過其他圖書館或機構申請該館藏。如果您這樣做，請考慮使用該訪問權限，而不是在維基百科圖書館中為該資源佔用一個席位。"
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/)
 #: TWLight/templates/about.html:99
-msgid ""
-"If your account is blocked on one or more Wikimedia projects, you may still "
-"be granted access to The Wikipedia Library. You will need to contact the "
-"Wikipedia Library team, who will review your blocks. If you have been "
-"blocked for content issues, most notably copyright violations, or have "
-"multiple long-term blocks, we may decline your request. Additionally, if "
-"your block status changes after being approved, you will need to request "
-"another review."
-msgstr ""
-"若您的帳號被一個或以上的維基媒體計劃給封鎖，您仍可以被授予取用維基百科圖書"
-"館。您會需要聯絡維基百科圖書館團隊，我們會審核有關您的封鎖。若您是出自內容上"
-"的問題被封鎖，尤其像是侵犯版權、或是被長期封鎖，我們可能會拒絕您的請求。另"
-"外，若您的封鎖狀態在被允許後有變動，您會需要再次請求審核。"
+msgid "If your account is blocked on one or more Wikimedia projects, you may still be granted access to The Wikipedia Library. You will need to contact the Wikipedia Library team, who will review your blocks. If you have been blocked for content issues, most notably copyright violations, or have multiple long-term blocks, we may decline your request. Additionally, if your block status changes after being approved, you will need to request another review."
+msgstr "若您的帳號被一個或以上的維基媒體計劃給封鎖，您仍可以被授予取用維基百科圖書館。您會需要聯絡維基百科圖書館團隊，我們會審核有關您的封鎖。若您是出自內容上的問題被封鎖，尤其像是侵犯版權、或是被長期封鎖，我們可能會拒絕您的請求。另外，若您的封鎖狀態在被允許後有變動，您會需要再次請求審核。"
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:110
@@ -2303,9 +1903,7 @@ msgstr "經核准的編輯者<i>不應該</i>做出："
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:136
-msgid ""
-"Share their account logins or passwords with others, or sell their access to "
-"other parties"
+msgid "Share their account logins or passwords with others, or sell their access to other parties"
 msgstr "將登入帳號或密碼給其他人得知，或是販賣自己的帳號"
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
@@ -2315,25 +1913,17 @@ msgstr "大規模抓取，或海量下載合作夥伴的內容"
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:144
-msgid ""
-"Systematically make printed or electronic copies of multiple extracts of "
-"restricted content available for any purpose"
+msgid "Systematically make printed or electronic copies of multiple extracts of restricted content available for any purpose"
 msgstr "對多個有限制可用內容的摘錄，系統化地製作出用於任何目的之列印或電子複本"
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/). Stub is a technical term for a short Wikipedia article, use the appropriate Wikipedia term in your language.
 #: TWLight/templates/about.html:148
-msgid ""
-"Datamine metadata without permission, in order, for instance, to use "
-"metadata for auto-created stub articles"
-msgstr ""
-"未經許可之下，基於目的對詮釋資料進行資料探勘。例如，使用詮釋資料來自動化建立"
-"小條目"
+msgid "Datamine metadata without permission, in order, for instance, to use metadata for auto-created stub articles"
+msgstr "未經許可之下，基於目的對詮釋資料進行資料探勘。例如，使用詮釋資料來自動化建立小條目"
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:154
-msgid ""
-"Respecting these agreements allows us to continue growing the partnerships "
-"available to the community."
+msgid "Respecting these agreements allows us to continue growing the partnerships available to the community."
 msgstr "請遵守這些協議，使得我們可以讓社群與合作夥伴之間關係能夠持續建立。"
 
 #. Translators: This is the heading for a section on the About page (https://wikipedialibrary.wmflabs.org/about/).
@@ -2343,56 +1933,23 @@ msgstr "EZProxy"
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:164
-msgid ""
-"EZProxy is a proxy server used to authenticate users for many Wikipedia "
-"Library partners. Users sign into EZProxy via the Library Card platform to "
-"verify that they are authorized users, and then the server accesses "
-"requested resources using its own IP address."
-msgstr ""
-"EZProxy 是用來驗證許多維基百科圖書館合作夥伴使用者的代理伺服器。使用者透過圖"
-"書館借閱卡平台來登入到 EZProxy 來核對他們是否為驗證的使用者，然後伺服器使用本"
-"身的 IP 位址來取用所請求的資源。"
+msgid "EZProxy is a proxy server used to authenticate users for many Wikipedia Library partners. Users sign into EZProxy via the Library Card platform to verify that they are authorized users, and then the server accesses requested resources using its own IP address."
+msgstr "EZProxy 是用來驗證許多維基百科圖書館合作夥伴使用者的代理伺服器。使用者透過圖書館借閱卡平台來登入到 EZProxy 來核對他們是否為驗證的使用者，然後伺服器使用本身的 IP 位址來取用所請求的資源。"
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:173
-msgid ""
-"You may notice that when accessing resources via EZProxy that URLs are "
-"dynamically rewritten. This is why we recommend logging in via the Library "
-"Card platform rather than going directly to the unproxied partner website. "
-"When in doubt, check the URL for ‘idm.oclc’. If it’s there, then you’re "
-"connected via EZProxy."
-msgstr ""
-"您可能會注意到當透過 EZProxy 來取用資源時，URL 會是動態改寫的。這就是為什麼我"
-"們建議透過圖書館借閱卡平台而不是直接前往未代理的合作夥伴網站來登入。如果不確"
-"定的話，請檢查是否為「idm.oclc」的 URL，若是如此的話那您便是透過 EZProxy 做連"
-"接。"
+msgid "You may notice that when accessing resources via EZProxy that URLs are dynamically rewritten. This is why we recommend logging in via the Library Card platform rather than going directly to the unproxied partner website. When in doubt, check the URL for ‘idm.oclc’. If it’s there, then you’re connected via EZProxy."
+msgstr "您可能會注意到當透過 EZProxy 來取用資源時，URL 會是動態改寫的。這就是為什麼我們建議透過圖書館借閱卡平台而不是直接前往未代理的合作夥伴網站來登入。如果不確定的話，請檢查是否為「idm.oclc」的 URL，若是如此的話那您便是透過 EZProxy 做連接。"
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:182
-msgid ""
-"Typically once you’ve logged in your session will remain active in your "
-"browser for up to two hours after you’ve finished searching. Note that use "
-"of EZProxy requires you to enable cookies. If you are having problems you "
-"should also try clearing your cache and restarting your browser."
-msgstr ""
-"通常您一旦登入並完成搜尋後，您的 session 內容會保留兩個小時。請注意使用 "
-"EZProxy 需要您啟用瀏覽器的 cookie 功能。若您出現問題，您可以嘗試清除在瀏覽器"
-"上的快取，並重新開啟瀏覽器。"
+msgid "Typically once you’ve logged in your session will remain active in your browser for up to two hours after you’ve finished searching. Note that use of EZProxy requires you to enable cookies. If you are having problems you should also try clearing your cache and restarting your browser."
+msgstr "通常您一旦登入並完成搜尋後，您的 session 內容會保留兩個小時。請注意使用 EZProxy 需要您啟用瀏覽器的 cookie 功能。若您出現問題，您可以嘗試清除在瀏覽器上的快取，並重新開啟瀏覽器。"
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/)
 #: TWLight/templates/about.html:193
-msgid ""
-"The Library Bundle is a collection of resources for which no application is "
-"required. If you meet the criteria laid out above, you will be authorized "
-"for access automatically upon logging in to the platform. Only some of our "
-"content is currently included in the Library Bundle, however we hope to "
-"expand the collection as more publishers become comfortable with "
-"participating. All Bundle content is accessed via EZProxy."
-msgstr ""
-"Library Bundle 是可不經由申請，便能取用的資源典藏。若您符合上述條件，在登入到"
-"平台時會自動授予您取用的權限。雖然我們的部分內容目前僅包含在 Library Bundle，"
-"但我們希望隨著有更多出版方在參與後感到滿意，進而擴大典藏內容。所有的綑綁內容"
-"可透過 EZProxy 取用。"
+msgid "The Library Bundle is a collection of resources for which no application is required. If you meet the criteria laid out above, you will be authorized for access automatically upon logging in to the platform. Only some of our content is currently included in the Library Bundle, however we hope to expand the collection as more publishers become comfortable with participating. All Bundle content is accessed via EZProxy."
+msgstr "Library Bundle 是可不經由申請，便能取用的資源典藏。若您符合上述條件，在登入到平台時會自動授予您取用的權限。雖然我們的部分內容目前僅包含在 Library Bundle，但我們希望隨著有更多出版方在參與後感到滿意，進而擴大典藏內容。所有的綑綁內容可透過 EZProxy 取用。"
 
 #. Translators: This is the heading for a section on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:202
@@ -2401,16 +1958,8 @@ msgstr "引文實踐"
 
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:206
-msgid ""
-"Citation practices vary by project and even by article. Generally, we "
-"support editors citing where they found information, in a form that allows "
-"others to check it for themselves. That often means providing both original "
-"source details as well as a link to the partner database in which the source "
-"was found."
-msgstr ""
-"引文實踐會依專案甚至條目而有所不同。一般來說，我們支援編輯者引用他們所找到的"
-"資訊，來允許讓其他人替編輯者檢查的形式。這通常代表著會提供原始來源詳情，以及"
-"在該來源上會連至合作夥伴資料庫的連結。"
+msgid "Citation practices vary by project and even by article. Generally, we support editors citing where they found information, in a form that allows others to check it for themselves. That often means providing both original source details as well as a link to the partner database in which the source was found."
+msgstr "引文實踐會依專案甚至條目而有所不同。一般來說，我們支援編輯者引用他們所找到的資訊，來允許讓其他人替編輯者檢查的形式。這通常代表著會提供原始來源詳情，以及在該來源上會連至合作夥伴資料庫的連結。"
 
 #. Translators: This is the heading for a section on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #. Translators: This link is at the bottom of every page and can be clicked by users to contact the wikipedia library team.
@@ -2421,12 +1970,8 @@ msgstr "聯絡我們"
 #. Translators: This text is found on the About page (https://wikipedialibrary.wmflabs.org/about/).
 #: TWLight/templates/about.html:218
 #, python-format
-msgid ""
-"If you have questions, need help, or want to volunteer to help, please see "
-"our <a class=\"twl-links\" href=\"%(contact_url)s\">contact page</a>."
-msgstr ""
-"若您有問題需要協助，或是想有意為別人協助，請查看我們的<a class=\"twl-links\" "
-"href=\"%(contact_url)s\">聯絡頁面</a>。"
+msgid "If you have questions, need help, or want to volunteer to help, please see our <a class=\"twl-links\" href=\"%(contact_url)s\">contact page</a>."
+msgstr "若您有問題需要協助，或是想有意為別人協助，請查看我們的<a class=\"twl-links\" href=\"%(contact_url)s\">聯絡頁面</a>。"
 
 #. Translators: This is the title of the panel box detailing the contact information for the Wikipedia Library team.
 #: TWLight/templates/contact.html:14
@@ -2465,12 +2010,8 @@ msgstr "維基百科圖書館推特頁面"
 #. Translators: This is the text that appears at the bottom of the contact us form directing users to the suggestions form.
 #: TWLight/templates/contact.html:48
 #, python-format
-msgid ""
-"(If you would like to suggest a partner, <a class=\"twl-links\" href="
-"\"%(suggest)s\"><strong>go here</strong></a>.)"
-msgstr ""
-"（若您想提議一個合作夥伴，請按<a class=\"twl-links\" href=\"%(suggest)s"
-"\"><strong>此</strong></a>。）"
+msgid "(If you would like to suggest a partner, <a class=\"twl-links\" href=\"%(suggest)s\"><strong>go here</strong></a>.)"
+msgstr "（若您想提議一個合作夥伴，請按<a class=\"twl-links\" href=\"%(suggest)s\"><strong>此</strong></a>。）"
 
 #. Translators: On a special 'link to search' page, this message is shown if JavaScript is disabled.
 #: TWLight/templates/eds_search_endpoint.html:7
@@ -2526,12 +2067,8 @@ msgstr "維基百科圖書館"
 #. Translators: Information about The Wikipedia Library.
 #: TWLight/templates/login_partial.html:53 TWLight/templates/new_base.html:21
 #, python-format
-msgid ""
-"More than 100 of the world's top subscription-only databases, with content "
-"in %(no_of_languages)s languages, free for Wikipedians of all backgrounds"
-msgstr ""
-"100 個以上世界頂級訂閱制資料庫、內容包含 %(no_of_languages)s 種語言，若您身分"
-"是維基百科人都可以免費使用"
+msgid "More than 100 of the world's top subscription-only databases, with content in %(no_of_languages)s languages, free for Wikipedians of all backgrounds"
+msgstr "100 個以上世界頂級訂閱制資料庫、內容包含 %(no_of_languages)s 種語言，若您身分是維基百科人都可以免費使用"
 
 #. Translators: Information about The Wikipedia Library.
 #: TWLight/templates/login_partial.html:64
@@ -2539,12 +2076,8 @@ msgid "Meet these criteria for automatic access"
 msgstr "滿足此自動取用標準"
 
 #: TWLight/templates/login_partial.html:69
-msgid ""
-"These criteria grant you access to certain collections but not all. Some "
-"collections are accessible on a per application basis only."
-msgstr ""
-"這些條件授予您訪問某些集合的權限（但不是所有集合）的權限。\n"
-"有些集合只能在每個應用程序的基礎上訪問。"
+msgid "These criteria grant you access to certain collections but not all. Some collections are accessible on a per application basis only."
+msgstr "這些條件授予您訪問某些集合的權限（但不是所有集合）的權限。\n有些集合只能在每個應用程序的基礎上訪問。"
 
 #: TWLight/templates/login_partial.html:89
 msgid "Login via Wikipedia"
@@ -2553,38 +2086,20 @@ msgstr "透過維基百科登入"
 #. Translators: Shown if the current user doesn't have a registered email on their account. Don't translate contact_us_url or email_url.
 #: TWLight/templates/message_partial.html:15
 #, python-format
-msgid ""
-"You don't have an email on file. We can't finalize your access to partner "
-"resources, and you won't be able to <a class=\"twl-links\" href="
-"\"%(contact_us_url)s\">contact us</a> without an email. Please <a class="
-"\"twl-links\" href=\"%(email_url)s\">update your email</a>."
-msgstr ""
-"您在檔案裡尚未有電子郵件。在沒有電子郵件的情況下，我們無法完成您向合夥夥伴資"
-"源的取用，而您也會無法<a class=\"twl-links\" href=\"%(contact_us_url)s\">聯絡"
-"我們</a>。請先<a class=\"twl-links\" href=\"%(email_url)s\">更新您的電子郵件"
-"</a>。"
+msgid "You don't have an email on file. We can't finalize your access to partner resources, and you won't be able to <a class=\"twl-links\" href=\"%(contact_us_url)s\">contact us</a> without an email. Please <a class=\"twl-links\" href=\"%(email_url)s\">update your email</a>."
+msgstr "您在檔案裡尚未有電子郵件。在沒有電子郵件的情況下，我們無法完成您向合夥夥伴資源的取用，而您也會無法<a class=\"twl-links\" href=\"%(contact_us_url)s\">聯絡我們</a>。請先<a class=\"twl-links\" href=\"%(email_url)s\">更新您的電子郵件</a>。"
 
 #. Translators: Shown if the current user has requested the processing of their data should be restricted.
 #: TWLight/templates/message_partial.html:26
 #, python-format
-msgid ""
-"You have requested a restriction on the processing of your data. Most site "
-"functionality will not be available to you until you <a class=\"twl-links\" "
-"href=\"%(restrict_url)s\">lift this restriction</a>."
-msgstr ""
-"您已請求對處理您的資料進行限制。您將不再能使用網站上的多數功能，除非您<a "
-"class=\"twl-links\" href=\"%(restrict_url)s\">解除此限制</a>。"
+msgid "You have requested a restriction on the processing of your data. Most site functionality will not be available to you until you <a class=\"twl-links\" href=\"%(restrict_url)s\">lift this restriction</a>."
+msgstr "您已請求對處理您的資料進行限制。您將不再能使用網站上的多數功能，除非您<a class=\"twl-links\" href=\"%(restrict_url)s\">解除此限制</a>。"
 
 #. Translators: Shown if the current user has not agreed to the terms of use.
 #: TWLight/templates/message_partial.html:37
 #, python-format
-msgid ""
-"You have not agreed to the <a class=\"twl-links\" href=\"%(terms_url)s"
-"\">terms of use</a> of this site. Your applications will not be processed "
-"and you won't be able to apply or access resources you are approved for."
-msgstr ""
-"您還沒有同意網站的<a class=\"twl-links\" href=\"%(terms_url)s\">使用條款</"
-"a>。您的申請程序會不被處理，並且會無法應用或取用所被核准的資源。"
+msgid "You have not agreed to the <a class=\"twl-links\" href=\"%(terms_url)s\">terms of use</a> of this site. Your applications will not be processed and you won't be able to apply or access resources you are approved for."
+msgstr "您還沒有同意網站的<a class=\"twl-links\" href=\"%(terms_url)s\">使用條款</a>。您的申請程序會不被處理，並且會無法應用或取用所被核准的資源。"
 
 #. Translators: This link is at the bottom of every page and links to the 'About' page (https://wikipedialibrary.wmflabs.org/about/)
 #: TWLight/templates/new_base.html:107
@@ -2630,12 +2145,8 @@ msgstr "重新設定密碼"
 
 #. Translators: If a user goes to reset their password, this message asks them to enter their email to do so.
 #: TWLight/templates/registration/password_reset_form.html:13
-msgid ""
-"Forgot your password? Enter your email address below, and we'll email "
-"instructions for setting a new one."
-msgstr ""
-"忘記您的密碼了嗎？請在下方輸入您的電子郵件地址，我們將會寄送一封用來說明設定"
-"新密碼的電子郵件。"
+msgid "Forgot your password? Enter your email address below, and we'll email instructions for setting a new one."
+msgstr "忘記您的密碼了嗎？請在下方輸入您的電子郵件地址，我們將會寄送一封用來說明設定新密碼的電子郵件。"
 
 #. Translators: This is the label for a button that users click to update their public information.
 #: TWLight/users/forms.py:36
@@ -2679,18 +2190,12 @@ msgstr "我同意以上使用條款"
 
 #. Translators: This text explains how to disagree to the site's terms of use and the restrictions that will come into effect when users disagree to the terms of use.
 #: TWLight/users/forms.py:185
-msgid ""
-"By unchecking this box and clicking “Update” you may explore the site, but "
-"you will not be able to apply for access to materials or evaluate "
-"applications unless you agree with the terms of use."
-msgstr ""
-"透過取消勾選此方框並點擊「更新」後，您仍可以瀏覽網站，但除非同意使用條款，否"
-"則無法申請資源取用或是評估申請程序。"
+msgid "By unchecking this box and clicking “Update” you may explore the site, but you will not be able to apply for access to materials or evaluate applications unless you agree with the terms of use."
+msgstr "透過取消勾選此方框並點擊「更新」後，您仍可以瀏覽網站，但除非同意使用條款，否則無法申請資源取用或是評估申請程序。"
 
 #. Translators: Users click this button to set their website email address to the one linked to their Wikipedia account.
 #: TWLight/users/forms.py:211
-msgid ""
-"Use my Wikipedia email address (will be updated the next time you login)."
+msgid "Use my Wikipedia email address (will be updated the next time you login)."
 msgstr "使用我的維基百科電子郵件地址（會在您下一次登入時更新）。"
 
 #. Translators: This labels a button which users click to change their email.
@@ -2701,17 +2206,8 @@ msgstr "更新電子郵件"
 #. Translators: Shown if the current user tried to 'favorite' a partner they can't access. Do not translate '{partner}'
 #: TWLight/users/models.py:201
 #, python-brace-format
-msgid ""
-"Cannot add partner {partner} to your favorites because you don't have access "
-"to it"
+msgid "Cannot add partner {partner} to your favorites because you don't have access to it"
 msgstr "無法添加合作夥伴 {partner} 到您的個人最愛，因為您無法取用他"
-
-#. Translators: Do not translate.
-#: TWLight/users/models.py:869
-#, fuzzy, python-brace-format
-#| msgid "Username"
-msgid "{wp_username}"
-msgstr "使用者名稱"
 
 #. Translators: This error message is shown when there's a problem with the authenticated login process.
 #: TWLight/users/oauth.py:243
@@ -2731,9 +2227,7 @@ msgstr "Handshaker 未發起，請嘗試重新登入。"
 
 #. Translators: this message is displayed to users that don't have accounts and clicked on a proxied link.
 #: TWLight/users/oauth.py:388
-msgid ""
-"To view this link you need to be an eligible library user. Please login to "
-"continue."
+msgid "To view this link you need to be an eligible library user. Please login to continue."
 msgstr "您需要是符合條件的圖書館使用者才能要查看此連結。請先登入以繼續。"
 
 #. Translators: This warning message is shown to users when the response received from Wikimedia OAuth servers is not a valid one.
@@ -2769,22 +2263,13 @@ msgstr "查看{issue}來取得更多資訊"
 
 #. Translators: If the user tries to log in, but their account does not meet certain requirements, they cannot login.
 #: TWLight/users/oauth.py:528
-msgid ""
-"Your Wikipedia account does not meet the eligibility criteria in the terms "
-"of use, so your Wikipedia Library Card Platform account cannot be activated."
-msgstr ""
-"您的維基百科帳號尚未符合使用條款資格標準，因此無法啟用您的維基百科圖書館借閱"
-"卡平台帳號。"
+msgid "Your Wikipedia account does not meet the eligibility criteria in the terms of use, so your Wikipedia Library Card Platform account cannot be activated."
+msgstr "您的維基百科帳號尚未符合使用條款資格標準，因此無法啟用您的維基百科圖書館借閱卡平台帳號。"
 
 #. Translators: If the user tries to log in, but their account does not meet certain requirements, they cannot login.
 #: TWLight/users/oauth.py:536
-msgid ""
-"Your Wikipedia account no longer meets the eligibility criteria in the terms "
-"of use, so you cannot be logged in. If you think you should be able to log "
-"in, please email wikipedialibrary@wikimedia.org."
-msgstr ""
-"您的維基百科帳號尚未符合使用條款資格標準，因此您無法登入。若您認為您應是可登"
-"入的，請發送電子郵件至：wikipedialibrary@wikimedia.org。"
+msgid "Your Wikipedia account no longer meets the eligibility criteria in the terms of use, so you cannot be logged in. If you think you should be able to log in, please email wikipedialibrary@wikimedia.org."
+msgstr "您的維基百科帳號尚未符合使用條款資格標準，因此您無法登入。若您認為您應是可登入的，請發送電子郵件至：wikipedialibrary@wikimedia.org。"
 
 #. Translators: this message is displayed to users with brand new accounts.
 #: TWLight/users/oauth.py:549
@@ -2794,13 +2279,8 @@ msgstr "歡迎！請您先同意使用條款。"
 #. Translators: This message is displayed on the confirmation page where users can return their access to partner collections.
 #: TWLight/users/templates/users/authorization_confirm_return.html:13
 #, python-format
-msgid ""
-"You will no longer be able to access <b>%(partner)s's</b> resources via the "
-"Library Card platform, but can request access again by clicking 'renew', if "
-"you change your mind. Are you sure you want to return your access?"
-msgstr ""
-"您不再能透過借閱卡平台來取用 <b>%(partner)s</b> 的資源，但若您改變心意，可以"
-"透過點擊「續辦」來再次請求取用。您確定要歸還您的取用嗎？"
+msgid "You will no longer be able to access <b>%(partner)s's</b> resources via the Library Card platform, but can request access again by clicking 'renew', if you change your mind. Are you sure you want to return your access?"
+msgstr "您不再能透過借閱卡平台來取用 <b>%(partner)s</b> 的資源，但若您改變心意，可以透過點擊「續辦」來再次請求取用。您確定要歸還您的取用嗎？"
 
 #. Translators: On the MyLibrary page (https://wikipedialibrary.wmflabs.org/users/my_library), this tab shows all favorite collections a user has.
 #: TWLight/users/templates/users/collections_section.html:9
@@ -2869,13 +2349,8 @@ msgstr "編輯者資料"
 
 #. Translators: This is shown on editor profiles, in their profile page or on applications.
 #: TWLight/users/templates/users/editor_detail.html:59
-msgid ""
-"Information with an * was retrieved from Wikipedia directly. Other "
-"information was entered directly by users or site admins, in their preferred "
-"language."
-msgstr ""
-"帶有「*」符號的資訊代表是直接從維基百科取得。其它資訊是由使用者或網站管理員直"
-"接輸入以他們的首選語言所描述內容。"
+msgid "Information with an * was retrieved from Wikipedia directly. Other information was entered directly by users or site admins, in their preferred language."
+msgstr "帶有「*」符號的資訊代表是直接從維基百科取得。其它資訊是由使用者或網站管理員直接輸入以他們的首選語言所描述內容。"
 
 #. Translators: This distinguishes users who have been flagged as account coordinators. Don't translate username.
 #: TWLight/users/templates/users/editor_detail.html:71
@@ -2885,13 +2360,8 @@ msgstr "%(username)s 在此網站上有協調員權限。"
 
 #. Translators: This is shown on editor profiles, under the heading for Wikipedia editor data.
 #: TWLight/users/templates/users/editor_detail_data.html:5
-msgid ""
-"This information is updated automatically from your Wikimedia account each "
-"time you log in, except for the Contributions field, where you can describe "
-"your Wikimedia editing history."
-msgstr ""
-"除了貢獻欄位以外，此頁資訊會在您每一次登入時，從維基百科做自動更新。您可以在"
-"貢獻欄位描述您的維基媒體編輯歷史。"
+msgid "This information is updated automatically from your Wikimedia account each time you log in, except for the Contributions field, where you can describe your Wikimedia editing history."
+msgstr "除了貢獻欄位以外，此頁資訊會在您每一次登入時，從維基百科做自動更新。您可以在貢獻欄位描述您的維基媒體編輯歷史。"
 
 #. Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this labels the user's username.
 #: TWLight/users/templates/users/editor_detail_data.html:17
@@ -2920,17 +2390,13 @@ msgstr "符合使用條款？"
 
 #. Translators: when viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this question has a yes or no answer.
 #: TWLight/users/templates/users/editor_detail_data.html:57
-msgid ""
-"at their last login, did this user meet the criteria set forth in the terms "
-"of use?"
+msgid "at their last login, did this user meet the criteria set forth in the terms of use?"
 msgstr "在上一次登入時，此使用者是否符合使用條款闡述的標準？"
 
 #. Translators: When viewing a user's profile in an application, this message shows if the software doesn't think that the user is eligible for access. Don't translate username.
 #: TWLight/users/templates/users/editor_detail_data.html:72
 #, python-format
-msgid ""
-"%(username)s may still be eligible for access grants at the coordinators' "
-"discretion."
+msgid "%(username)s may still be eligible for access grants at the coordinators' discretion."
 msgstr "%(username)s 在協調員的考量裡，仍有授予取用的資格。"
 
 #. Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this is the heading for a Yes/No ToU question.
@@ -2965,14 +2431,8 @@ msgstr "（授予豁免）"
 #. Translators: This message is shown on a user's profile if their Wikimedia account is blocked on one or more projects. They may still be granted access to the Library Bundle, but need to contact Wikipedia Library staff to verify.
 #: TWLight/users/templates/users/editor_detail_data.html:137
 #, python-format
-msgid ""
-"It looks like you have an active block on your account. If you meet the "
-"other criteria you may still be permitted access to the library - please <a "
-"class=\"twl-links\" href=\"%(contact_url)s\">contact us</a>."
-msgstr ""
-"看起來您的帳號上現在有生效中的封鎖。若您符合其它條件，您仍可以允許取用 "
-"Library Bundle - 請<a class=\"twl-links\" href=\"%(contact_url)s\">聯絡我們</"
-"a>。"
+msgid "It looks like you have an active block on your account. If you meet the other criteria you may still be permitted access to the library - please <a class=\"twl-links\" href=\"%(contact_url)s\">contact us</a>."
+msgstr "看起來您的帳號上現在有生效中的封鎖。若您符合其它條件，您仍可以允許取用 Library Bundle - 請<a class=\"twl-links\" href=\"%(contact_url)s\">聯絡我們</a>。"
 
 #. Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this is the heading for a Yes/No program eligibility question.
 #: TWLight/users/templates/users/editor_detail_data.html:153
@@ -2981,13 +2441,8 @@ msgstr "符合 Bundle？"
 
 #. Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this question has a Yes or No answer.
 #: TWLight/users/templates/users/editor_detail_data.html:156
-msgid ""
-"At their last login, did this user meet the criteria set forth in the "
-"Library Bundle? Note that satisfying terms of use is a prerequisite to "
-"bundle eligibility."
-msgstr ""
-"在上一次登入時，此使用者是否符合列在 Library Bundle 的標準？請注意，滿足使用"
-"條款是符合 Bundle 的先決條件。"
+msgid "At their last login, did this user meet the criteria set forth in the Library Bundle? Note that satisfying terms of use is a prerequisite to bundle eligibility."
+msgstr "在上一次登入時，此使用者是否符合列在 Library Bundle 的標準？請注意，滿足使用條款是符合 Bundle 的先決條件。"
 
 #. Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this is the heading for a Yes/No program eligibility question.
 #: TWLight/users/templates/users/editor_detail_data.html:177
@@ -3031,23 +2486,14 @@ msgstr "個人資料"
 
 #. Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this text is in the 'Personal data' section. Translate Wikipedia Library in the same way as the global branch is named (click through from https://meta.wikimedia.org/wiki/The_Wikipedia_Library).
 #: TWLight/users/templates/users/editor_detail_data.html:262
-msgid ""
-"The following information is visible only to you, site administrators, "
-"publishing partners (where required), and volunteer Wikipedia Library "
-"coordinators (who have signed a Non-Disclosure Agreement)."
-msgstr ""
-"以下資訊僅有您自己、網站管理員、出版方合作夥伴（當有需求時），以及維基百科圖"
-"書館協調員（已簽署保密協議）可查看。"
+msgid "The following information is visible only to you, site administrators, publishing partners (where required), and volunteer Wikipedia Library coordinators (who have signed a Non-Disclosure Agreement)."
+msgstr "以下資訊僅有您自己、網站管理員、出版方合作夥伴（當有需求時），以及維基百科圖書館協調員（已簽署保密協議）可查看。"
 
 #. Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this labels a button which users can click to update or remove their personal information. Don't translate update_url.
 #: TWLight/users/templates/users/editor_detail_data.html:272
 #, python-format
-msgid ""
-"You may <a class=\"twl-links\" href=\"%(update_url)s\">update or delete</a> "
-"your data at any time."
-msgstr ""
-"您可以隨時<a class=\"twl-links\" href=\"%(update_url)s\">更新或刪除</a>您的資"
-"料。"
+msgid "You may <a class=\"twl-links\" href=\"%(update_url)s\">update or delete</a> your data at any time."
+msgstr "您可以隨時<a class=\"twl-links\" href=\"%(update_url)s\">更新或刪除</a>您的資料。"
 
 #. Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this labels the user's email. Don't remove the *.
 #: TWLight/users/templates/users/editor_detail_data.html:283
@@ -3066,27 +2512,19 @@ msgstr "所屬機構"
 
 #. Translators: This message tells users that they are not eligible to access The Wikipedia Library content.
 #: TWLight/users/templates/users/eligibility_modal.html:7
-msgid ""
-"Sorry, your Wikipedia account doesn’t currently qualify to access The "
-"Wikipedia Library."
+msgid "Sorry, your Wikipedia account doesn’t currently qualify to access The Wikipedia Library."
 msgstr "抱歉，您的維基百科帳戶目前不滿足訪問維基百科圖書館的要求。"
 
 #. Translators: This message tells users that they have not agreed to the terms of use, therefore are ineligible to access the content in The Wikipedia Library.
 #: TWLight/users/templates/users/eligibility_modal.html:30
 #, python-format
-msgid ""
-"Agreed with <a href=\"%(terms)s\" class=\"text-danger\"> terms of use </a>"
+msgid "Agreed with <a href=\"%(terms)s\" class=\"text-danger\"> terms of use </a>"
 msgstr "是否同意<a href=\"%(terms)s\" class=\"text-danger\">使用條款</a>？"
 
 #: TWLight/users/templates/users/eligibility_modal.html:40
 #, python-format
-msgid ""
-"It looks like you have an active block on your account. If you meet the "
-"other criteria you may still be permitted access to the library - please <a "
-"href=\"%(contact_url)s\">contact us</a>."
-msgstr ""
-"看起來您的帳號上現在有生效中的封鎖。若您符合其它條件，您仍可以允許取用 "
-"Library Bundle - 請<a href=\"%(contact_url)s\">聯絡我們</a>。"
+msgid "It looks like you have an active block on your account. If you meet the other criteria you may still be permitted access to the library - please <a href=\"%(contact_url)s\">contact us</a>."
+msgstr "看起來您的帳號上現在有生效中的封鎖。若您符合其它條件，您仍可以允許取用 Library Bundle - 請<a href=\"%(contact_url)s\">聯絡我們</a>。"
 
 #. Translators: Instructions to refresh a user's data.
 #: TWLight/users/templates/users/eligibility_modal.html:50
@@ -3125,14 +2563,8 @@ msgstr "設定語言"
 
 #. Translators: This text on the user page helps users naviage to the TranslateWiki Wikipedia Library Card platform translation page.
 #: TWLight/users/templates/users/language_form.html:31
-msgid ""
-"You can help translate the tool at <a class=\"twl-links\" href=\"https://"
-"translatewiki.net/wiki/Translating:Wikipedia_Library_Card_Platform"
-"\">translatewiki.net</a>."
-msgstr ""
-"您可以在 <a class=\"twl-links\" href=\"https://translatewiki.net/wiki/"
-"Translating:Wikipedia_Library_Card_Platform\">translatewiki.net</a> 上協助翻"
-"譯此工具。"
+msgid "You can help translate the tool at <a class=\"twl-links\" href=\"https://translatewiki.net/wiki/Translating:Wikipedia_Library_Card_Platform\">translatewiki.net</a>."
+msgstr "您可以在 <a class=\"twl-links\" href=\"https://translatewiki.net/wiki/Translating:Wikipedia_Library_Card_Platform\">translatewiki.net</a> 上協助翻譯此工具。"
 
 #. Translators: When the user starts a new application and submits the application, the user can view the application and withdraw if need be. This changes the label for the Withdraw button.
 #: TWLight/users/templates/users/my_applications.html:65
@@ -3151,9 +2583,7 @@ msgstr "請求續辦"
 
 #. Translators: On the page listing applications, this text explains a user they cannot renew their application since they've already requested a renewal or there aren't any renewals available.
 #: TWLight/users/templates/users/my_applications.html:79
-msgid ""
-"Renewals are either not required, not available right now, or you have "
-"already requested a renewal."
+msgid "Renewals are either not required, not available right now, or you have already requested a renewal."
 msgstr "續辦為非必要，或是現在不可用，或著是您已經有請求續辦。"
 
 #. Translators: This text is the heading of a section in a user's profile where they can change their preferences.
@@ -3217,22 +2647,12 @@ msgstr "限制資料處理"
 
 #. Translators: This message is displayed on the page where users can request we stop processing their data.
 #: TWLight/users/templates/users/restrict_data.html:15
-msgid ""
-"Checking this box and clicking “Restrict” will pause all processing of the "
-"data you have entered into this website. You will not be able to apply for "
-"access to resources, your applications will not be further processed, and "
-"none of your data will be altered, until you return to this page and uncheck "
-"the box. This is not the same as deleting your data."
-msgstr ""
-"勾選此方框並點擊「限制」，將會暫停處理所有您所輸入至此網站的資料。除非您回到"
-"此頁面並取消勾選此方框，否則您將無法申請取用資料，您的申請程序也將不會有進一"
-"步處理，而您的資料也不會被更改。這和「刪除您的資料」是不同的情況。"
+msgid "Checking this box and clicking “Restrict” will pause all processing of the data you have entered into this website. You will not be able to apply for access to resources, your applications will not be further processed, and none of your data will be altered, until you return to this page and uncheck the box. This is not the same as deleting your data."
+msgstr "勾選此方框並點擊「限制」，將會暫停處理所有您所輸入至此網站的資料。除非您回到此頁面並取消勾選此方框，否則您將無法申請取用資料，您的申請程序也將不會有進一步處理，而您的資料也不會被更改。這和「刪除您的資料」是不同的情況。"
 
 #. Translators: This warning message is shown to coordinators who view the data restriction page.
 #: TWLight/users/templates/users/restrict_data.html:26
-msgid ""
-"You are a coordinator on this site. If you restrict the processing of your "
-"data, your coordinator flag will be removed."
+msgid "You are a coordinator on this site. If you restrict the processing of your data, your coordinator flag will be removed."
 msgstr "您是此網站的協調員。若您限制您資料的處理，您的協調人標籤會被移除。"
 
 #. Translators: use the date *when you are translating*, in a language-appropriate format.
@@ -3252,34 +2672,13 @@ msgstr "維基百科圖書館借閱卡使用條款與隱私聲明"
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:51
-msgid ""
-"<a class=\"twl-links\" href=\"https://meta.wikimedia.org/wiki/"
-"The_Wikipedia_Library\"> The Wikipedia Library </a> has partnered with "
-"publishers around the world to allow users to access otherwise paywalled "
-"resources. This website allows Wikipedia editors to search and access these "
-"resources."
-msgstr ""
-"<a class=\"twl-links\" href=\"https://meta.wikimedia.org/wiki/"
-"The_Wikipedia_Library/zh\">維基百科圖書館</a>與全球裡允許使用者來自由取用付費"
-"牆形式資源的出版者合作。此網站允許使用者向多個出版者的資料同時申請取用，並且"
-"讓管理存取維基百科圖書館帳號方面變得簡單有效。"
+msgid "<a class=\"twl-links\" href=\"https://meta.wikimedia.org/wiki/The_Wikipedia_Library\"> The Wikipedia Library </a> has partnered with publishers around the world to allow users to access otherwise paywalled resources. This website allows Wikipedia editors to search and access these resources."
+msgstr "<a class=\"twl-links\" href=\"https://meta.wikimedia.org/wiki/The_Wikipedia_Library/zh\">維基百科圖書館</a>與全球裡允許使用者來自由取用付費牆形式資源的出版者合作。此網站允許使用者向多個出版者的資料同時申請取用，並且讓管理存取維基百科圖書館帳號方面變得簡單有效。"
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Wikimedia Foundation should not be translated. WMF should not be translated. Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:63
-msgid ""
-"This program is administered by the Wikimedia Foundation (WMF). These terms "
-"of use and privacy notice pertain to your application for access to "
-"resources through the Wikipedia Library, your use of this website, and your "
-"access to and use of those resources. They also describe our handling of the "
-"information you provide to us in order to create and administer your "
-"Wikipedia Library account. If we make material changes to the terms, we will "
-"notify users."
-msgstr ""
-"此方案是由維基媒體基金會（Wikimedia Foundation、WMF）管理。這些使用條款與隱私"
-"聲明涉及您透過維基百科圖書館來取用資源的申請程序、您對本網站的使用、以及您對"
-"這些資源利用的取用。這些另外描述了我們如何處理您提供給我們的資訊，以便建立和"
-"管理您的維基百科圖書館帳號。如果我們有對條款進行重大更改，我們將會通知使用"
-"者。"
+msgid "This program is administered by the Wikimedia Foundation (WMF). These terms of use and privacy notice pertain to your application for access to resources through the Wikipedia Library, your use of this website, and your access to and use of those resources. They also describe our handling of the information you provide to us in order to create and administer your Wikipedia Library account. If we make material changes to the terms, we will notify users."
+msgstr "此方案是由維基媒體基金會（Wikimedia Foundation、WMF）管理。這些使用條款與隱私聲明涉及您透過維基百科圖書館來取用資源的申請程序、您對本網站的使用、以及您對這些資源利用的取用。這些另外描述了我們如何處理您提供給我們的資訊，以便建立和管理您的維基百科圖書館帳號。如果我們有對條款進行重大更改，我們將會通知使用者。"
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:74
@@ -3288,50 +2687,18 @@ msgstr "維基百科圖書館借閱卡帳號的需求"
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:78
-msgid ""
-"Access to resources via The Wikipedia Library is reserved for community "
-"members who have demonstrated their commitment to the Wikimedia projects, "
-"and who will use their access to these resources to improve project content. "
-"To that end, in order to be eligible for The Wikipedia Library, we require "
-"that you be registered for a user account on the projects, with at least 500 "
-"edits, six (6) months of activity, and 10+ edits in the last month. We ask "
-"that you do not request access to any publishers with a limited number of "
-"available accounts whose resources you can already access for free through "
-"your local library or university, or another institution or organization, in "
-"order to provide that opportunity to others."
-msgstr ""
-"透過維基百科圖書館取用資源的權限僅限於已經表明了對維基媒體項目的承諾，並將使"
-"用這些資源來改善項目的內容的維基人。對此，為了取得使用維基百科圖書館的資格，"
-"我們會要求您是專案上的已註冊使用者。我們會優先考慮編輯超過500次，至少有6個月"
-"活動，且上個月編輯達10次以上的維基人使用。不過，若您已可以透過圖書館、大學、"
-"機構，或是其它組織來免費獲得一些出版者的資源，我們請求您不要再向這些出版者提"
-"出申請，以便讓機會留給其他人。"
+msgid "Access to resources via The Wikipedia Library is reserved for community members who have demonstrated their commitment to the Wikimedia projects, and who will use their access to these resources to improve project content. To that end, in order to be eligible for The Wikipedia Library, we require that you be registered for a user account on the projects, with at least 500 edits, six (6) months of activity, and 10+ edits in the last month. We ask that you do not request access to any publishers with a limited number of available accounts whose resources you can already access for free through your local library or university, or another institution or organization, in order to provide that opportunity to others."
+msgstr "透過維基百科圖書館取用資源的權限僅限於已經表明了對維基媒體項目的承諾，並將使用這些資源來改善項目的內容的維基人。對此，為了取得使用維基百科圖書館的資格，我們會要求您是專案上的已註冊使用者。我們會優先考慮編輯超過500次，至少有6個月活動，且上個月編輯達10次以上的維基人使用。不過，若您已可以透過圖書館、大學、機構，或是其它組織來免費獲得一些出版者的資源，我們請求您不要再向這些出版者提出申請，以便讓機會留給其他人。"
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:94
-msgid ""
-"Additionally, if you are currently blocked or banned from a Wikimedia "
-"project, applications to resources may be rejected or restricted. If you "
-"obtain a Wikipedia Library account, but a block or ban is subsequently "
-"instituted against you on one of the projects, you may lose access to your "
-"Wikipedia Library account."
-msgstr ""
-"此外，如果您目前正被維基媒體專案封鎖或禁止編輯，對資源的申請可能會遭到拒絕或"
-"受限制。若您已取得維基百科圖書館帳號，但隨後在任一專案上被長期封鎖或禁止使"
-"用，那麼您可能會失去對維基百科圖書館帳戶的訪問權限。"
+msgid "Additionally, if you are currently blocked or banned from a Wikimedia project, applications to resources may be rejected or restricted. If you obtain a Wikipedia Library account, but a block or ban is subsequently instituted against you on one of the projects, you may lose access to your Wikipedia Library account."
+msgstr "此外，如果您目前正被維基媒體專案封鎖或禁止編輯，對資源的申請可能會遭到拒絕或受限制。若您已取得維基百科圖書館帳號，但隨後在任一專案上被長期封鎖或禁止使用，那麼您可能會失去對維基百科圖書館帳戶的訪問權限。"
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:104
-msgid ""
-"Your eligibility to access The Wikipedia Library is assessed at each login. "
-"While more than half of the library's content is provided via this automated "
-"eligibility check, access to other publisher's content may be time limited, "
-"typically lapsing after one year, after which you will usually need to apply "
-"for renewal."
-msgstr ""
-"維基百科圖書館在您每次登錄時都會評估您訪問的資格。儘管圖書館超過一半的內容是"
-"通過此自動資格檢查程式就會提供的，但對其他出版者內容的訪問可能有時效性，通常"
-"會在一年後失效，在那之後您通常需要申請續訂。"
+msgid "Your eligibility to access The Wikipedia Library is assessed at each login. While more than half of the library's content is provided via this automated eligibility check, access to other publisher's content may be time limited, typically lapsing after one year, after which you will usually need to apply for renewal."
+msgstr "維基百科圖書館在您每次登錄時都會評估您訪問的資格。儘管圖書館超過一半的內容是通過此自動資格檢查程式就會提供的，但對其他出版者內容的訪問可能有時效性，通常會在一年後失效，在那之後您通常需要申請續訂。"
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:114
@@ -3340,60 +2707,28 @@ msgstr "透過您的維基百科圖書館借閱卡帳號來申請"
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:118
-msgid ""
-"In order to apply for access to a partner resource, you must provide us with "
-"certain information, which we will use to evaluate your application. If your "
-"application is approved, we may transfer the information you have given us "
-"to the publishers whose resources you wish to access. They will either "
-"contact you with the account information directly or we will send access "
-"information to you ourselves."
-msgstr ""
-"為了申請取用合作夥伴的資源，您必須提供給我們某些資訊，讓我們可以使用來評估您"
-"的申請程序。若您的申請程序已核准，我們會轉送您提供給我們的資訊，給您所想取用"
-"資源的出版者。出版者到時會直接連絡給您帳號資訊，或是由我們發送帳號資訊給您。"
+msgid "In order to apply for access to a partner resource, you must provide us with certain information, which we will use to evaluate your application. If your application is approved, we may transfer the information you have given us to the publishers whose resources you wish to access. They will either contact you with the account information directly or we will send access information to you ourselves."
+msgstr "為了申請取用合作夥伴的資源，您必須提供給我們某些資訊，讓我們可以使用來評估您的申請程序。若您的申請程序已核准，我們會轉送您提供給我們的資訊，給您所想取用資源的出版者。出版者到時會直接連絡給您帳號資訊，或是由我們發送帳號資訊給您。"
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:130
-msgid ""
-"In addition to the basic information you provide to us, our system will "
-"retrieve some information directly from the Wikimedia projects: your "
-"username, email address, edit count, registration date, user ID number, "
-"groups to which you belong, and any special user rights."
-msgstr ""
-"除了您提供給我們的基本資訊之外，我們的系統會直接從維基媒體計劃裡檢索一些資"
-"訊：您的使用者名稱、電子郵件地址、編輯次數、註冊日期、使用者 ID 號碼、您所隸"
-"屬的群組、和任何特殊使用者權限。"
+msgid "In addition to the basic information you provide to us, our system will retrieve some information directly from the Wikimedia projects: your username, email address, edit count, registration date, user ID number, groups to which you belong, and any special user rights."
+msgstr "除了您提供給我們的基本資訊之外，我們的系統會直接從維基媒體計劃裡檢索一些資訊：您的使用者名稱、電子郵件地址、編輯次數、註冊日期、使用者 ID 號碼、您所隸屬的群組、和任何特殊使用者權限。"
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:140
-msgid ""
-"Each time you log in to the Wikipedia Library Card Platform, this "
-"information will be automatically updated."
+msgid "Each time you log in to the Wikipedia Library Card Platform, this information will be automatically updated."
 msgstr "每一次您登入到維基百科圖書館借閱卡平台時，此資訊都會自動更新。"
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:148
-msgid ""
-"We will ask you to provide us with some information about your history of "
-"contributions to the Wikimedia projects. Information on contribution history "
-"is optional, but will greatly assist us in evaluating your application."
-msgstr ""
-"我們會請求您提供給我們一些有關您在維基媒體計劃上的貢獻歷史紀錄資訊。貢獻歷史"
-"紀錄方面的資訊雖為可選，但若有提供可讓我們在評估您的申請程序時獲得極大幫助。"
+msgid "We will ask you to provide us with some information about your history of contributions to the Wikimedia projects. Information on contribution history is optional, but will greatly assist us in evaluating your application."
+msgstr "我們會請求您提供給我們一些有關您在維基媒體計劃上的貢獻歷史紀錄資訊。貢獻歷史紀錄方面的資訊雖為可選，但若有提供可讓我們在評估您的申請程序時獲得極大幫助。"
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). WMF should not be translated. Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:157
-msgid ""
-"The information you provide when creating your account will be visible to "
-"you while on the site but not to others unless they are approved Wikipedia "
-"Library Coordinators, WMF Staff, or WMF Contractors who need access to this "
-"data in order to carry out their work with the Wikipedia Library, all of "
-"whom are subject to non-disclosure obligations."
-msgstr ""
-"當創建您的帳號時，您所提供的資訊在整個網站裡除了您之外，其他人皆不可見，除非"
-"他們是被認可為維基百科圖書館協調員、維基媒體基金會機構人員、或維基媒體基金會"
-"承包人，這些需要存取資料才能進行他們在維基百科圖書館上事項的人員之外，而以上"
-"這些人皆有保密的義務。"
+msgid "The information you provide when creating your account will be visible to you while on the site but not to others unless they are approved Wikipedia Library Coordinators, WMF Staff, or WMF Contractors who need access to this data in order to carry out their work with the Wikipedia Library, all of whom are subject to non-disclosure obligations."
+msgstr "當創建您的帳號時，您所提供的資訊在整個網站裡除了您之外，其他人皆不可見，除非他們是被認可為維基百科圖書館協調員、維基媒體基金會機構人員、或維基媒體基金會承包人，這些需要存取資料才能進行他們在維基百科圖書館上事項的人員之外，而以上這些人皆有保密的義務。"
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:167
@@ -3402,54 +2737,33 @@ msgstr "您的出版方資源使用"
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:171
-msgid ""
-"In order to access an individual publisher’s resources, you must agree to "
-"that publisher’s terms of use and privacy policy. You agree that you will "
-"not violate such terms and policies in connection with your use of the "
-"Wikipedia Library. Additionally, the following activities are prohibited "
-"while accessing publisher resources through the Wikipedia Library."
-msgstr ""
-"為了取用各出版者的資源，您必須同意該出版者的使用條款和隱私方針。您同意您將不"
-"會違反使用維基百科圖書館的相關條款與方針。另外，當您透過維基百科圖書館來取用"
-"出版者資源時，禁止以下的行為。"
+msgid "In order to access an individual publisher’s resources, you must agree to that publisher’s terms of use and privacy policy. You agree that you will not violate such terms and policies in connection with your use of the Wikipedia Library. Additionally, the following activities are prohibited while accessing publisher resources through the Wikipedia Library."
+msgstr "為了取用各出版者的資源，您必須同意該出版者的使用條款和隱私方針。您同意您將不會違反使用維基百科圖書館的相關條款與方針。另外，當您透過維基百科圖書館來取用出版者資源時，禁止以下的行為。"
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:184
-msgid ""
-"Sharing your Wikipedia account, usernames, passwords, or any access codes "
-"for publisher resources with others;"
-msgstr ""
-"與其他人分享您的維基百科帳戶、使用者名稱、密碼或任何訪問出版商資源的代碼。"
+msgid "Sharing your Wikipedia account, usernames, passwords, or any access codes for publisher resources with others;"
+msgstr "與其他人分享您的維基百科帳戶、使用者名稱、密碼或任何訪問出版商資源的代碼。"
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:191
-msgid ""
-"Automatically scraping or downloading restricted content from publishers;"
+msgid "Automatically scraping or downloading restricted content from publishers;"
 msgstr "自動抓取或下載來自出版方的受限內容。"
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:197
-msgid ""
-"Systematically making printed or electronic copies of multiple extracts of "
-"restricted content available for any purpose;"
-msgstr ""
-"有系統地針對多個有限制可用內容的摘錄，製作出用於任何目的之列印或電子複本。"
+msgid "Systematically making printed or electronic copies of multiple extracts of restricted content available for any purpose;"
+msgstr "有系統地針對多個有限制可用內容的摘錄，製作出用於任何目的之列印或電子複本。"
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:204
-msgid ""
-"Data mining metadata without permission—for example, in order to use "
-"metadata for auto-created stub articles;"
+msgid "Data mining metadata without permission—for example, in order to use metadata for auto-created stub articles;"
 msgstr "未經許可探勘詮釋資料—如用詮釋資料來自動建立小條目。"
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:211
-msgid ""
-"Using the access you receive through the Wikipedia Library for profit by "
-"selling access to your account or resources which you have through it."
-msgstr ""
-"利用您透過維基百科圖書館獲取的取用權限，來透過販售您的帳號取用權限或資源獲得"
-"牟利。"
+msgid "Using the access you receive through the Wikipedia Library for profit by selling access to your account or resources which you have through it."
+msgstr "利用您透過維基百科圖書館獲取的取用權限，來透過販售您的帳號取用權限或資源獲得牟利。"
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:220
@@ -3458,21 +2772,12 @@ msgstr "外部搜尋與代理服務"
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:224
-msgid ""
-"Certain resources may only be accessed using an external search service, "
-"such as the EBSCO Discovery Service, or a proxy service, such as OCLC "
-"EZProxy. If you use such external search and/or proxy services, please "
-"review the applicable terms of use and privacy policies."
-msgstr ""
-"某些資源僅能透過使用外部搜尋服務來取用，例如像是 EBSCO 探索服務，或是像是 "
-"OCLC EZProxy 的代理服務。如果您使用此類的外部搜尋服務以及/或是代理服務，請檢"
-"閱適當的使用條款與隱私方針。"
+msgid "Certain resources may only be accessed using an external search service, such as the EBSCO Discovery Service, or a proxy service, such as OCLC EZProxy. If you use such external search and/or proxy services, please review the applicable terms of use and privacy policies."
+msgstr "某些資源僅能透過使用外部搜尋服務來取用，例如像是 EBSCO 探索服務，或是像是 OCLC EZProxy 的代理服務。如果您使用此類的外部搜尋服務以及/或是代理服務，請檢閱適當的使用條款與隱私方針。"
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:234
-msgid ""
-"In addition, if you use OCLC EZProxy, please note that you may not use it "
-"for commercial purposes."
+msgid "In addition, if you use OCLC EZProxy, please note that you may not use it for commercial purposes."
 msgstr "此外，若您使用 OCLC EZProxy，請留意您不會使用於商業目的上。"
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
@@ -3482,166 +2787,50 @@ msgstr "資料保存與處理"
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Wikimedia Foundation should not be translated. Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:245
-msgid ""
-"The Wikimedia Foundation and our service providers use your information for "
-"the legitimate purpose of providing Wikipedia Library services in support of "
-"our charitable mission. When you apply for a Wikipedia Library account, or "
-"use your Wikipedia Library account, we may routinely collect the following "
-"information: your username, email address, edit count, registration date, "
-"user ID number, groups to which you belong, and any special user rights; "
-"your name, country of residence, and/or affiliation, if required by a "
-"partner to which you are applying; your narrative description of your "
-"contributions and reasons for applying for access to partner resources; and "
-"the date you agree to these terms of use."
-msgstr ""
-"維基媒體基金會與我們的服務提供方會合法使用您的資訊，提供給維基百科圖書館服務"
-"來支援我們的慈善使命。當您申請維基百科圖書館帳號，或是使用維基百科圖書館帳號"
-"時，我們可能會定期收集以下資訊：您的使用者名稱、電子郵件位址、編輯次數、註冊"
-"日期、使用者 ID 號碼、所屬群組、任何特殊使用者權限、您的名稱、居住國家、以及/"
-"或是從屬關係（若您所申請的合作夥伴有需求）、您對於您所做出貢獻的敘述性描述、"
-"以及申請取用合作夥伴資源的原因、和您同意這些使用條款的日期。"
+msgid "The Wikimedia Foundation and our service providers use your information for the legitimate purpose of providing Wikipedia Library services in support of our charitable mission. When you apply for a Wikipedia Library account, or use your Wikipedia Library account, we may routinely collect the following information: your username, email address, edit count, registration date, user ID number, groups to which you belong, and any special user rights; your name, country of residence, and/or affiliation, if required by a partner to which you are applying; your narrative description of your contributions and reasons for applying for access to partner resources; and the date you agree to these terms of use."
+msgstr "維基媒體基金會與我們的服務提供方會合法使用您的資訊，提供給維基百科圖書館服務來支援我們的慈善使命。當您申請維基百科圖書館帳號，或是使用維基百科圖書館帳號時，我們可能會定期收集以下資訊：您的使用者名稱、電子郵件位址、編輯次數、註冊日期、使用者 ID 號碼、所屬群組、任何特殊使用者權限、您的名稱、居住國家、以及/或是從屬關係（若您所申請的合作夥伴有需求）、您對於您所做出貢獻的敘述性描述、以及申請取用合作夥伴資源的原因、和您同意這些使用條款的日期。"
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:262
 #, python-format
-msgid ""
-"Each publisher who is a member of the Wikipedia Library program requires "
-"different specific information in the application. Some publishers may "
-"request only an email address, while others request more detailed data, such "
-"as your name, location, or institutional affiliation. When you complete your "
-"application, you will only be asked to supply information required by the "
-"publishers you have chosen, and each publisher will only receive the "
-"information they require for providing you with access. Please see our <a "
-"class=\"twl-links\" href=\"%(all_partners_url)s\">partner information</a> "
-"pages to learn what information is required by each publisher to gain access "
-"to their resources."
-msgstr ""
-"各出版方皆為維基百科圖書館方案的成員，會在申請程序裡需要不同的特定資訊。一些"
-"出版方可能會僅需要電子郵件地址，其他則會需要更多的詳細資料，例如您的名稱、地"
-"點、或是所屬機構。當您完成您的申請程序後，您僅會被您所挑選的出版者請求提供所"
-"需資訊，且各出版方僅會接收到他們所需資訊來提供給您取用權限。請查看我們的<a "
-"class=\"twl-links\" href=\"%(all_partners_url)s\">合作夥伴資訊</a>頁面來了解"
-"各出版方所需資訊，以獲得取用他們的資源。"
+msgid "Each publisher who is a member of the Wikipedia Library program requires different specific information in the application. Some publishers may request only an email address, while others request more detailed data, such as your name, location, or institutional affiliation. When you complete your application, you will only be asked to supply information required by the publishers you have chosen, and each publisher will only receive the information they require for providing you with access. Please see our <a class=\"twl-links\" href=\"%(all_partners_url)s\">partner information</a> pages to learn what information is required by each publisher to gain access to their resources."
+msgstr "各出版方皆為維基百科圖書館方案的成員，會在申請程序裡需要不同的特定資訊。一些出版方可能會僅需要電子郵件地址，其他則會需要更多的詳細資料，例如您的名稱、地點、或是所屬機構。當您完成您的申請程序後，您僅會被您所挑選的出版者請求提供所需資訊，且各出版方僅會接收到他們所需資訊來提供給您取用權限。請查看我們的<a class=\"twl-links\" href=\"%(all_partners_url)s\">合作夥伴資訊</a>頁面來了解各出版方所需資訊，以獲得取用他們的資源。"
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Wikimedia Foundation should not be translated. Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:277
-msgid ""
-"Some Wikipedia Library pages are visible without logging in, but you will "
-"need to log in to apply or access proprietary partner resources. We use the "
-"data provided by you via OAuth and Wikimedia API calls to assess your "
-"application for access and to process approved requests."
-msgstr ""
-"一些維基百科圖書館的資料無需登錄即可查看，但是您需要登錄才能申請或訪問專有合"
-"作夥伴的資源。我們使用您通過OAuth和Wikimedia API調用提供的資料來評估您申請的"
-"存取權限並處理批准的申請。"
+msgid "Some Wikipedia Library pages are visible without logging in, but you will need to log in to apply or access proprietary partner resources. We use the data provided by you via OAuth and Wikimedia API calls to assess your application for access and to process approved requests."
+msgstr "一些維基百科圖書館的資料無需登錄即可查看，但是您需要登錄才能申請或訪問專有合作夥伴的資源。我們使用您通過OAuth和Wikimedia API調用提供的資料來評估您申請的存取權限並處理批准的申請。"
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:288
 #, python-format
-msgid ""
-"In order to administer the Wikipedia Library program, we will retain the "
-"application data we collect from you for three years after your most recent "
-"login, unless you delete your account, as described below. You can log in "
-"and go to <a class=\"twl-links\" href=\"%(profile_url)s\">your profile page</"
-"a> in order to see the information associated with your account, and can "
-"download it in JSON format. You may access, update, restrict, or delete this "
-"information at any time, except for the information that is automatically "
-"retrieved from the projects. If you have any questions or concerns about the "
-"handling of your data, please contact <a class=\"twl-links\" href=\"mailto:"
-"wikipedialibrary@wikimedia.org?Subject=Wikipedia%%20Library%%20Card"
-"%%20account%%20deactivation\"> wikipedialibrary@wikimedia.org </a>."
-msgstr ""
-"為了管理維基百科圖書館方案，我們會從您最近一次登入時所收集到的資料保存三年，"
-"除非您如後面所述，有意刪除您的帳號。您可以登入並前往您的<a class=\"twl-links"
-"\" href=\"%(profile_url)s\">配置頁面</a>，來查看有哪些資訊相關到您的帳號，並"
-"且可下載成 JSON 格式。排除是從專案裡自動檢索出的資訊以外，您可以隨時存取、更"
-"新、限制、或是刪除此資訊。若您有任何問題，或是對於處理您的資料方面有所疑慮，"
-"請聯絡 <a class=\"twl-links\" href=\"mailto:wikipedialibrary@wikimedia.org?"
-"Subject=Wikipedia%%20Library%%20Card%%20account%%20deactivation"
-"\">wikipedialibrary@wikimedia.org</a>。"
+msgid "In order to administer the Wikipedia Library program, we will retain the application data we collect from you for three years after your most recent login, unless you delete your account, as described below. You can log in and go to <a class=\"twl-links\" href=\"%(profile_url)s\">your profile page</a> in order to see the information associated with your account, and can download it in JSON format. You may access, update, restrict, or delete this information at any time, except for the information that is automatically retrieved from the projects. If you have any questions or concerns about the handling of your data, please contact <a class=\"twl-links\" href=\"mailto:wikipedialibrary@wikimedia.org?Subject=Wikipedia%%20Library%%20Card%%20account%%20deactivation\"> wikipedialibrary@wikimedia.org </a>."
+msgstr "為了管理維基百科圖書館方案，我們會從您最近一次登入時所收集到的資料保存三年，除非您如後面所述，有意刪除您的帳號。您可以登入並前往您的<a class=\"twl-links\" href=\"%(profile_url)s\">配置頁面</a>，來查看有哪些資訊相關到您的帳號，並且可下載成 JSON 格式。排除是從專案裡自動檢索出的資訊以外，您可以隨時存取、更新、限制、或是刪除此資訊。若您有任何問題，或是對於處理您的資料方面有所疑慮，請聯絡 <a class=\"twl-links\" href=\"mailto:wikipedialibrary@wikimedia.org?Subject=Wikipedia%%20Library%%20Card%%20account%%20deactivation\">wikipedialibrary@wikimedia.org</a>。"
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:305
-msgid ""
-"If you decide to disable your Wikipedia Library account, you can use the "
-"delete button on your profile to delete certain personal information "
-"associated with your account. We will delete your real name, institutional "
-"affiliation, and country of residence. Please note that the system will "
-"retain a record of your username, the publishers to which you applied or had "
-"access, and the dates of that access. Note that deletion is not reversible. "
-"Deletion of your Wikipedia Library account may also correspond with the "
-"removal of any resource access to which you were eligible or approved. If "
-"you request the deletion of account information and later wish to apply for "
-"a new account, you will need to provide the necessary information again."
-msgstr ""
-"若您打算停用您的維基百科圖書館帳號，您可以電子郵件給我們到 <a href=\"mailto:"
-"wikipedialibrary@wikimedia.org?Subject=Wikipedia%%20Library%%20Card%"
-"%20account%%20deactivation\">wikipedialibrary@wikimedia.org</a>，來請求刪除與"
-"您帳號相關的某些個人資訊。我們將會刪除您的真實姓名、所屬機構、以及居住國家。"
-"另外請留意，系統會保留您的使用者名稱紀錄，您所申請過或擁有取用權限的出版者，"
-"以及取用日期。若您請求了刪除帳號資訊，並日後想再申請新的帳號，您需要再次提供"
-"必要的資訊。"
+msgid "If you decide to disable your Wikipedia Library account, you can use the delete button on your profile to delete certain personal information associated with your account. We will delete your real name, institutional affiliation, and country of residence. Please note that the system will retain a record of your username, the publishers to which you applied or had access, and the dates of that access. Note that deletion is not reversible. Deletion of your Wikipedia Library account may also correspond with the removal of any resource access to which you were eligible or approved. If you request the deletion of account information and later wish to apply for a new account, you will need to provide the necessary information again."
+msgstr "若您打算停用您的維基百科圖書館帳號，您可以電子郵件給我們到 <a href=\"mailto:wikipedialibrary@wikimedia.org?Subject=Wikipedia%%20Library%%20Card%%20account%%20deactivation\">wikipedialibrary@wikimedia.org</a>，來請求刪除與您帳號相關的某些個人資訊。我們將會刪除您的真實姓名、所屬機構、以及居住國家。另外請留意，系統會保留您的使用者名稱紀錄，您所申請過或擁有取用權限的出版者，以及取用日期。若您請求了刪除帳號資訊，並日後想再申請新的帳號，您需要再次提供必要的資訊。"
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). WMF should not be translated. Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:321
-msgid ""
-"The Wikipedia Library is run by WMF Staff, Contractors, and approved "
-"volunteer Coordinators. The data associated with your account will be shared "
-"with the WMF staff, contractors, service providers, and volunteer "
-"coordinators who need to process the information in connection with their "
-"work for the Wikipedia Library, and who are subject to confidentiality "
-"obligations. We will also use your data for internal Wikipedia Library "
-"purposes such as distributing user surveys and account notifications, and in "
-"a depersonalized or aggregated fashion for statistical analysis and "
-"administration. Finally, we will share your information with the publishers "
-"whom you specifically select in order to provide you with access to "
-"resources. Otherwise, your information will not be shared with third "
-"parties, with the exception of the circumstances described below."
-msgstr ""
-"維基百科圖書館是由維基媒體基金會成員、承包人，以及經核准的協調員所運作。與您"
-"帳號所關聯的資料會分享給維基媒體成員、承包人、服務提供者，和需處理與維基百科"
-"圖書館事項相關資訊且有義務保密的協調員。我們會另外使用您的資料用於維基百科圖"
-"書館內部方面，例如分佈使用者調查、帳號通知、去人格化與整合方式的統計分析、以"
-"及管理。最後，我們會與您所指定挑選的出版者分享您的資料，以便提供您資源上的取"
-"用。排除如下所述的情況之外，您的資料不會與第三方分享。"
+msgid "The Wikipedia Library is run by WMF Staff, Contractors, and approved volunteer Coordinators. The data associated with your account will be shared with the WMF staff, contractors, service providers, and volunteer coordinators who need to process the information in connection with their work for the Wikipedia Library, and who are subject to confidentiality obligations. We will also use your data for internal Wikipedia Library purposes such as distributing user surveys and account notifications, and in a depersonalized or aggregated fashion for statistical analysis and administration. Finally, we will share your information with the publishers whom you specifically select in order to provide you with access to resources. Otherwise, your information will not be shared with third parties, with the exception of the circumstances described below."
+msgstr "維基百科圖書館是由維基媒體基金會成員、承包人，以及經核准的協調員所運作。與您帳號所關聯的資料會分享給維基媒體成員、承包人、服務提供者，和需處理與維基百科圖書館事項相關資訊且有義務保密的協調員。我們會另外使用您的資料用於維基百科圖書館內部方面，例如分佈使用者調查、帳號通知、去人格化與整合方式的統計分析、以及管理。最後，我們會與您所指定挑選的出版者分享您的資料，以便提供您資源上的取用。排除如下所述的情況之外，您的資料不會與第三方分享。"
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). WMF should not be translated.
 #: TWLight/users/templates/users/terms.html:338
-msgid ""
-"We may disclose any collected information when required by law, when we have "
-"your permission, when needed to protect our rights, privacy, safety, users, "
-"or the general public, and when necessary to enforce these terms, WMF’s "
-"general <a class=\"twl-links\" href=\"https://foundation.wikimedia.org/wiki/"
-"Terms_of_Use\">Terms of Use</a>, or any other WMF policy."
-msgstr ""
-"當有法律上的需求或我們得到了您的許可，或著是需要保護我們的權利、隱私、使用"
-"者、公眾的時候，以及有必要執行這些條款、維基媒體基金會的一般<a class=\"twl-"
-"links\" href=\"https://foundation.wikimedia.org/wiki/Terms_of_Use\">使用條款"
-"</a>、或任何維基媒體基金會方針的時機裡，我們可能會披露出任何所收集到的資訊。"
+msgid "We may disclose any collected information when required by law, when we have your permission, when needed to protect our rights, privacy, safety, users, or the general public, and when necessary to enforce these terms, WMF’s general <a class=\"twl-links\" href=\"https://foundation.wikimedia.org/wiki/Terms_of_Use\">Terms of Use</a>, or any other WMF policy."
+msgstr "當有法律上的需求或我們得到了您的許可，或著是需要保護我們的權利、隱私、使用者、公眾的時候，以及有必要執行這些條款、維基媒體基金會的一般<a class=\"twl-links\" href=\"https://foundation.wikimedia.org/wiki/Terms_of_Use\">使用條款</a>、或任何維基媒體基金會方針的時機裡，我們可能會披露出任何所收集到的資訊。"
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:349
-msgid ""
-"We take the security of your personal data seriously, and take reasonable "
-"precautions to ensure your data is protected. These precautions include "
-"access controls to limit who has access to your data and security "
-"technologies to protect data stored on the server. However, we cannot "
-"guarantee the safety of your data as it is transmitted and stored."
-msgstr ""
-"我們會認真對待您個人資料方面的安全，並採取合理的預防措施，來確保您的資料是受"
-"保護的。這些預防錯誤包含限制可存取您資料對象的存取控制，與資安技術來保護儲存"
-"在伺服器上的資料。然而，我們無法保證您的資料在傳輸與儲存時的安全性。"
+msgid "We take the security of your personal data seriously, and take reasonable precautions to ensure your data is protected. These precautions include access controls to limit who has access to your data and security technologies to protect data stored on the server. However, we cannot guarantee the safety of your data as it is transmitted and stored."
+msgstr "我們會認真對待您個人資料方面的安全，並採取合理的預防措施，來確保您的資料是受保護的。這些預防錯誤包含限制可存取您資料對象的存取控制，與資安技術來保護儲存在伺服器上的資料。然而，我們無法保證您的資料在傳輸與儲存時的安全性。"
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:360
-msgid ""
-"Please note that these terms do not control the use and handling of your "
-"data by the publishers and service providers whose resources you access or "
-"apply to access. Please read their individual privacy policies for that "
-"information."
-msgstr ""
-"另外請注意，您所取用或申請資源的出版者與服務提供方，在使用並處理您的資料不受"
-"這些條款所控制。請閱讀他們自身擁有的隱私方針資訊。"
+msgid "Please note that these terms do not control the use and handling of your data by the publishers and service providers whose resources you access or apply to access. Please read their individual privacy policies for that information."
+msgstr "另外請注意，您所取用或申請資源的出版者與服務提供方，在使用並處理您的資料不受這些條款所控制。請閱讀他們自身擁有的隱私方針資訊。"
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:368
@@ -3650,46 +2839,18 @@ msgstr "重要提示"
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Wikimedia Foundation should not be translated. Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:373
-msgid ""
-"The Wikimedia Foundation is a nonprofit organization based in San Francisco, "
-"California. The Wikipedia Library program provides access to resources held "
-"by publishers in multiple countries. If you apply for a Wikipedia Library "
-"account (whether you are inside or outside of the United States), you "
-"understand that your personal data will be collected, transferred, stored, "
-"processed, disclosed and otherwise used in the U.S. as described in this "
-"privacy policy. You also understand that your information may be transferred "
-"by us from the U.S. to other countries, which may have different or less "
-"stringent data protection laws than your country, in connection with "
-"providing services to you, including evaluating your application and "
-"securing access to your chosen publishers (locations for each publisher are "
-"outlined on their respective partner information pages)."
-msgstr ""
-"維基媒體基金會是設於加利福尼亞州舊金山的非營利組織，維基媒體圖書館方案提供可"
-"取用多個國家出版者持有的資源。若您申請維基百科圖書館帳號（無論您是位於美國境"
-"內或境外），代表您了解您的個人資料會如隱私方針所述，在美國境內被收集、轉移、"
-"儲存、處理、披露，以及其它用途。您也了解您的資訊可能會從美國轉移至其它國家，"
-"而那些國家與您的國家相比之下，在向您提供服務方面可能會有差別或較不嚴謹的資料"
-"保護法律，包含評估您的申請程序，與保護對您所挑選出版者的取用權限（各出版者的"
-"所在地點會概述在他們各自合作夥伴資訊頁面裡）。"
+msgid "The Wikimedia Foundation is a nonprofit organization based in San Francisco, California. The Wikipedia Library program provides access to resources held by publishers in multiple countries. If you apply for a Wikipedia Library account (whether you are inside or outside of the United States), you understand that your personal data will be collected, transferred, stored, processed, disclosed and otherwise used in the U.S. as described in this privacy policy. You also understand that your information may be transferred by us from the U.S. to other countries, which may have different or less stringent data protection laws than your country, in connection with providing services to you, including evaluating your application and securing access to your chosen publishers (locations for each publisher are outlined on their respective partner information pages)."
+msgstr "維基媒體基金會是設於加利福尼亞州舊金山的非營利組織，維基媒體圖書館方案提供可取用多個國家出版者持有的資源。若您申請維基百科圖書館帳號（無論您是位於美國境內或境外），代表您了解您的個人資料會如隱私方針所述，在美國境內被收集、轉移、儲存、處理、披露，以及其它用途。您也了解您的資訊可能會從美國轉移至其它國家，而那些國家與您的國家相比之下，在向您提供服務方面可能會有差別或較不嚴謹的資料保護法律，包含評估您的申請程序，與保護對您所挑選出版者的取用權限（各出版者的所在地點會概述在他們各自合作夥伴資訊頁面裡）。"
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:392
-msgid ""
-"Please note that in the event of any differences in meaning or "
-"interpretation between the original English version of these terms and a "
-"translation, the original English version takes precedence."
-msgstr ""
-"請注意，若這些條款的英語版本與譯文版本之間，存在含意或解譯上的差異，請以原始"
-"的英語版本為準。"
+msgid "Please note that in the event of any differences in meaning or interpretation between the original English version of these terms and a translation, the original English version takes precedence."
+msgstr "請注意，若這些條款的英語版本與譯文版本之間，存在含意或解譯上的差異，請以原始的英語版本為準。"
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Wikimedia Foundation should not be translated.
 #: TWLight/users/templates/users/terms.html:403
-msgid ""
-"See also the <a class=\"twl-links\" href=\"https://wikimediafoundation.org/"
-"wiki/Privacy_policy\">Wikimedia Foundation Privacy Policy</a>."
-msgstr ""
-"另請查看<a class=\"twl-links\" href=\"https://meta.wikimedia.org/wiki/"
-"Privacy_policy/zh\">維基媒體基金會隱私政策</a>。"
+msgid "See also the <a class=\"twl-links\" href=\"https://wikimediafoundation.org/wiki/Privacy_policy\">Wikimedia Foundation Privacy Policy</a>."
+msgstr "另請查看<a class=\"twl-links\" href=\"https://meta.wikimedia.org/wiki/Privacy_policy/zh\">維基媒體基金會隱私政策</a>。"
 
 #. Translators: This is the second to last line of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/).
 #: TWLight/users/templates/users/terms.html:412
@@ -3708,15 +2869,8 @@ msgstr "維基媒體基金會"
 
 #. Translators: This is a section of the Terms of Use (https://wikipedialibrary.wmflabs.org/terms/). Translate Wikipedia Library in the same way as the global branch is named in the language you are translating (click through the language from https://meta.wikimedia.org/wiki/The_Wikipedia_Library/Global). If the language is not available, do not translate Wikipedia Library.
 #: TWLight/users/templates/users/terms.html:426
-msgid ""
-"By checking this box and clicking “Submit”, you agree that you have read the "
-"above terms and that you will adhere to the terms of use in your application "
-"to and use of the The Wikipedia Library, and the publishers’ services to "
-"which you gain access through The Wikipedia Library program."
-msgstr ""
-"透過勾選方框並點擊「提交」，代表您同意您已閱讀過以上條款，並且會遵守申請程"
-"序、維基百科圖書館的利用，以及透過維基百科圖書館方案獲得取用出版者服務的使用"
-"條款。"
+msgid "By checking this box and clicking “Submit”, you agree that you have read the above terms and that you will adhere to the terms of use in your application to and use of the The Wikipedia Library, and the publishers’ services to which you gain access through The Wikipedia Library program."
+msgstr "透過勾選方框並點擊「提交」，代表您同意您已閱讀過以上條款，並且會遵守申請程序、維基百科圖書館的利用，以及透過維基百科圖書館方案獲得取用出版者服務的使用條款。"
 
 #: TWLight/users/templates/users/user_collection_tile.html:32
 msgid "Remove this collection from favorites"
@@ -3768,38 +2922,19 @@ msgstr "刪除全部資料"
 
 #. Translators: This message is displayed on the page where users can request the deletion of their data.
 #: TWLight/users/templates/users/user_confirm_delete.html:17
-msgid ""
-"<b>Warning:</b> Performing this action will delete your Wikipedia Library "
-"Card user account and all associated applications. This process is not "
-"reversible. You may lose any partner accounts you were granted, and will not "
-"be able to renew those accounts or apply for new ones."
-msgstr ""
-"<b>警告：</b>執行此操作將會刪除您的維基百科圖書館借閱卡使用者帳號，和所有相關"
-"的申請程序。此處理是不可撤回的，您會失去任何您所授予到的合作夥伴帳號，並無法"
-"續辦或申請新帳號。"
+msgid "<b>Warning:</b> Performing this action will delete your Wikipedia Library Card user account and all associated applications. This process is not reversible. You may lose any partner accounts you were granted, and will not be able to renew those accounts or apply for new ones."
+msgstr "<b>警告：</b>執行此操作將會刪除您的維基百科圖書館借閱卡使用者帳號，和所有相關的申請程序。此處理是不可撤回的，您會失去任何您所授予到的合作夥伴帳號，並無法續辦或申請新帳號。"
 
 #. Translators: this should show up for people who log in with a username/password and not OAuth, so we don't know what their Wikipedia identity is.
-#.
 #: TWLight/users/templates/users/user_detail.html:12
 #, python-format
-msgid ""
-"Hi, %(username)s! You don't have a Wikipedia editor profile attached to your "
-"account here, so you are probably a site administrator."
-msgstr ""
-"嗨，%(username)s！您並沒有可附加至您在此帳號的維基百科編輯者個人配置，因此您"
-"可能是名網站管理員。"
+msgid "Hi, %(username)s! You don't have a Wikipedia editor profile attached to your account here, so you are probably a site administrator."
+msgstr "嗨，%(username)s！您並沒有可附加至您在此帳號的維基百科編輯者個人配置，因此您可能是名網站管理員。"
 
 #. Translators: In the unlikely scenario that someone is able to register an account without using OAuth (thus leaving us without some of the information required for applications), users will see this message, encouraging them to re-register.
 #: TWLight/users/templates/users/user_detail.html:20
-msgid ""
-"If you aren't a site administrator, something weird has happened. You won't "
-"be able to apply for access without a Wikipedia editor profile. You should "
-"log out and create a new account by logging in via OAuth, or contact a site "
-"administrator for help."
-msgstr ""
-"若您不是網站管理員，會有異常情況發生。如果沒有維基百科編輯者個人配置，您會無"
-"法申請取用。您應先登出後透過經由 OAuth 登入來建立新的帳號，或是聯絡網站管理員"
-"請求協助。"
+msgid "If you aren't a site administrator, something weird has happened. You won't be able to apply for access without a Wikipedia editor profile. You should log out and create a new account by logging in via OAuth, or contact a site administrator for help."
+msgstr "若您不是網站管理員，會有異常情況發生。如果沒有維基百科編輯者個人配置，您會無法申請取用。您應先登出後透過經由 OAuth 登入來建立新的帳號，或是聯絡網站管理員請求協助。"
 
 #. Translators: Labels a sections where coordinators can select their email preferences.
 #: TWLight/users/templates/users/user_email_preferences.html:15
@@ -3809,22 +2944,13 @@ msgstr "僅限協調員"
 #. Translators: This message is shown on user's own profile page, encouraging them to make sure their information is up to date, so that account coordinators can use the information to judge applications.
 #: TWLight/users/views.py:176
 #, python-brace-format
-msgid ""
-"Please <a class='twl-links' href='{url}'>update your contributions</a> to "
-"Wikipedia to help coordinators evaluate your applications."
-msgstr ""
-"請更新<a class='twl-links' href='{url}'>您對於維基百科的貢獻</a>，來協助協調"
-"員評估您的申請程序。"
+msgid "Please <a class='twl-links' href='{url}'>update your contributions</a> to Wikipedia to help coordinators evaluate your applications."
+msgstr "請更新<a class='twl-links' href='{url}'>您對於維基百科的貢獻</a>，來協助協調員評估您的申請程序。"
 
 #. Translators: Coordinators are shown this message when they unselect all three types of reminder email options under preferences.
 #: TWLight/users/views.py:288
-msgid ""
-"You have chosen not to receive reminder emails. As a coordinator, you should "
-"receive at least one type of reminder emails, so consider changing your "
-"preferences."
-msgstr ""
-"您已選擇不接收電子郵件提醒。作為一名協調者，您應至少接收一種電子郵件提醒，所"
-"以請考慮更改您的偏好設定。"
+msgid "You have chosen not to receive reminder emails. As a coordinator, you should receive at least one type of reminder emails, so consider changing your preferences."
+msgstr "您已選擇不接收電子郵件提醒。作為一名協調者，您應至少接收一種電子郵件提醒，所以請考慮更改您的偏好設定。"
 
 #. Translators: Coordinators are shown this message when they make changes to their reminder email options under preferences.
 #: TWLight/users/views.py:296
@@ -3857,12 +2983,8 @@ msgstr "您的電子郵件已更改成 {email}。"
 
 #. Translators: If the user has not filled out their email, they can browse the website but cannot apply for access to resources.
 #: TWLight/users/views.py:487
-msgid ""
-"Your email is blank. You can still explore the site, but you won't be able "
-"to apply for access to partner resources without an email."
-msgstr ""
-"您尚未填選電子郵件。雖然您仍可以瀏覽網站，但沒有電子郵件便無法對合作夥伴的資"
-"源提出申請。"
+msgid "Your email is blank. You can still explore the site, but you won't be able to apply for access to partner resources without an email."
+msgstr "您尚未填選電子郵件。雖然您仍可以瀏覽網站，但沒有電子郵件便無法對合作夥伴的資源提出申請。"
 
 #. Translators: This message is shown once the access to a partner has successfully been returned.
 #: TWLight/users/views.py:801
@@ -3894,31 +3016,3 @@ msgstr "沒有生效的封鎖"
 msgid "10+ edits in the last 30 days"
 msgstr "過去 30 天有 10 次以上的編輯數"
 
-#: tests/shunit/data/bad_i18n_comment_1.py:3
-#: tests/shunit/data/bad_i18n_newline_1.py:5
-msgid "1"
-msgstr ""
-
-#. Translators: Lorem ipsum dolor sit amet, consectetur adipiscing elit. Mauris vitae ipsum ut purus faucibus pretium. Proin tempus neque et aliquet consectetur. Ut egestas sapien in consectetur sagittis. Mauris neque lacus, dapibus non viverra vitae, interdum ut aenean ipsum.
-#. Translators: Lorem ipsum dolor sit amet, consectetur adipiscing elit. Mauris vitae ipsum ut purus faucibus pretium. Proin tempus neque et aliquet consectetur. Ut egestas sapien in consectetur sagittis. Mauris neque lacus, dapibus non.
-#: tests/shunit/data/bad_i18n_comment_2.py:4
-#: tests/shunit/data/bad_i18n_newline_2.py:5 tests/shunit/data/good_i18n_1.py:2
-#: tests/shunit/data/good_i18n_2.py:2
-msgid "2"
-msgstr ""
-
-#: tests/shunit/data/bad_i18n_newline_3.py:5
-msgid "3"
-msgstr ""
-
-#: tests/shunit/data/bad_i18n_newline_4.py:5
-msgid "4"
-msgstr ""
-
-#: tests/shunit/data/bad_i18n_newline_5.py:5
-msgid "5"
-msgstr ""
-
-#: tests/shunit/data/bad_i18n_newline_6.py:5
-msgid "6"
-msgstr ""


### PR DESCRIPTION
Bug: T368663

[//]: # (Thank you for uploading a PR to the Wikipedia Library!)

## Description
Describe your changes in detail following the [commit message guidelines](https://www.mediawiki.org/wiki/Gerrit/Commit_message_guidelines)

Better error handling for users that do not exist. 

## Rationale
[//]: # (Why is this change required? What problem does it solve?)

- Glitchtip errors
- In the oauth.py flow, a try/except clause searches for the user with User.objects.get() that should catch when a user doesn't exist. That doesn't seem to happen, so we should change how we get the user. We should change the logic to User.objects.filter().first() and then check if the user is None.

## Phabricator Ticket
[//]: # (Link to the Phabricator ticket)
https://phabricator.wikimedia.org/T368663

## How Has This Been Tested?
[//]: # (- Did you add tests to your changes? Did you modify tests to accommodate your changes?)
Ran unit tests to ensure no existing functionality broke.
Tested login flow locally. 

##  Can this change be tested manually? How?
Yes, ensure that you can log in as a new user and an existing user.


## Types of changes
What types of changes does your code introduce? Add an `x` in all the boxes that apply:
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Minor change (fix a typo, add a translation tag, add section to README, etc.)
