### PR TITLE
Kgraessl/t368663

### DIFF
--- a/TWLight/resources/tests.py
+++ b/TWLight/resources/tests.py
@@ -1328,7 +1328,7 @@ class PartnerSuggestionViewTests(TestCase):
 
         # Create a coordinator with a test client session
         EditorCraftRoom(self, Terms=True, Coordinator=True)
-        request = self.client.get(path=suggestion_url, follow=True)
+        request = self.client.post(path=suggestion_url, follow=True)
 
         suggestion = Suggestion.objects.get(pk=self.suggestion.pk)
 

--- a/TWLight/users/oauth.py
+++ b/TWLight/users/oauth.py
@@ -173,41 +173,36 @@ class OAuthBackend(object):
         call and False if we did not.
         """
         logger.info("Attempting to update editor after OAuth login.")
-        try:
-            username = self._get_username(identity)
-            user = User.objects.get(username=username)
-            should_update_lang = _check_user_preferred_language(user)
-            if should_update_lang:
-                user.userprofile.lang = get_language()
-                user.userprofile.save()
-
-            # This login path should only be used for accounts created via
-            # Wikipedia login, which all have editor objects.
-            if hasattr(user, "editor"):
-                editor = user.editor
-
-                lang = user.userprofile.lang
-                editor.update_from_wikipedia(
-                    identity, lang
-                )  # This call also saves the editor
-                logger.info("Editor updated.")
-
-                created = False
-            else:
-                try:
-                    logger.warning(
-                        "A user tried using the Wikipedia OAuth "
-                        "login path but does not have an attached editor."
-                    )
-                    editor = self._create_editor(user, identity)
-                    created = True
-                except:
-                    raise PermissionDenied
-
-        except User.DoesNotExist:
+        created = False
+        username = self._get_username(identity)
+        user = User.objects.filter(username=username).first()
+        if user is None:
             logger.info("Can't find user; creating one.")
             user, editor = self._create_user_and_editor(identity)
             created = True
+        should_update_lang = _check_user_preferred_language(user)
+        if should_update_lang:
+            user.userprofile.lang = get_language()
+            user.userprofile.save()
+        # This login path should only be used for accounts created via
+        # Wikipedia login, which all have editor objects.
+        if hasattr(user, "editor"):
+            editor = user.editor
+            lang = user.userprofile.lang
+            editor.update_from_wikipedia(
+                identity, lang
+            )  # This call also saves the editor
+            logger.info("Editor updated.")
+        else:
+            try:
+                logger.warning(
+                    "A user tried using the Wikipedia OAuth "
+                    "login path but does not have an attached editor."
+                )
+                editor = self._create_editor(user, identity)
+                created = True
+            except:
+                raise PermissionDenied
         return user, created
 
     def authenticate(self, request=None, access_token=None, handshaker=None):

--- a/TWLight/users/oauth.py
+++ b/TWLight/users/oauth.py
@@ -173,26 +173,29 @@ class OAuthBackend(object):
         call and False if we did not.
         """
         logger.info("Attempting to update editor after OAuth login.")
-        created = False
         username = self._get_username(identity)
         user = User.objects.filter(username=username).first()
         if user is None:
             logger.info("Can't find user; creating one.")
             user, editor = self._create_user_and_editor(identity)
-            created = True
+            return user, True
         should_update_lang = _check_user_preferred_language(user)
         if should_update_lang:
             user.userprofile.lang = get_language()
             user.userprofile.save()
+
         # This login path should only be used for accounts created via
         # Wikipedia login, which all have editor objects.
         if hasattr(user, "editor"):
             editor = user.editor
+
             lang = user.userprofile.lang
             editor.update_from_wikipedia(
                 identity, lang
             )  # This call also saves the editor
             logger.info("Editor updated.")
+
+            created = False
         else:
             try:
                 logger.warning(


### PR DESCRIPTION
Bug: T368663

[//]: # (Thank you for uploading a PR to the Wikipedia Library!)

## Description
Describe your changes in detail following the [commit message guidelines](https://www.mediawiki.org/wiki/Gerrit/Commit_message_guidelines)

Better error handling for users that do not exist.

## Rationale
[//]: # (Why is this change required? What problem does it solve?)

- Glitchtip errors
- In the oauth.py flow, a try/except clause searches for the user with User.objects.get() that should catch when a user doesn't exist. That doesn't seem to happen, so we should change how we get the user. We should change the logic to User.objects.filter().first() and then check if the user is None.

## Phabricator Ticket
[//]: # (Link to the Phabricator ticket)
https://phabricator.wikimedia.org/T368663

## How Has This Been Tested?
[//]: # (- Did you add tests to your changes? Did you modify tests to accommodate your changes?)
Ran unit tests to ensure no existing functionality broke.
Tested login flow locally.

##  Can this change be tested manually? How?
Yes, ensure that you can log in as a new user and an existing user.


## Types of changes
What types of changes does your code introduce? Add an `x` in all the boxes that apply:
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Minor change (fix a typo, add a translation tag, add section to README, etc.)
