### PR TITLE
delete sessions when user marked inactive

### DIFF
--- a/TWLight/settings/base.py
+++ b/TWLight/settings/base.py
@@ -284,6 +284,9 @@ MESSAGE_TAGS = {messages.ERROR: "danger"}
 # Eliminate duplicate messages
 MESSAGE_STORAGE = "TWLight.message_storage.SessionDedupStorage"
 
+# use our own session engine to allow deletion of individual users' sessions
+SESSION_ENGINE = "TWLight.users.models"
+
 # Overwrite django default SESSION_COOKIE_AGE
 SESSION_COOKIE_AGE = 259200
 

--- a/TWLight/users/admin.py
+++ b/TWLight/users/admin.py
@@ -3,7 +3,6 @@
 from django.contrib import admin
 from django.contrib.auth.admin import UserAdmin as AuthUserAdmin
 from django.contrib.auth.models import User
-from django.contrib.sessions.models import Session
 
 from TWLight.users.models import (
     Editor,
@@ -11,6 +10,7 @@ from TWLight.users.models import (
     UserProfile,
     Authorization,
     get_company_name,
+    Session,
 )
 from TWLight.users.forms import AuthorizationAdminForm
 
@@ -161,7 +161,7 @@ class SessionAdmin(admin.ModelAdmin):
     def _session_data(self, obj):
         return obj.get_decoded()
 
-    list_display = ["session_key", "_session_data", "expire_date"]
+    list_display = ["account_id", "session_key", "_session_data", "expire_date"]
 
 
 admin.site.register(Session, SessionAdmin)

--- a/TWLight/users/signals.py
+++ b/TWLight/users/signals.py
@@ -1,10 +1,11 @@
 from datetime import timedelta
 from django.conf import settings
+from django.contrib.auth.models import User
 from django.dispatch import receiver, Signal
 from django.db import transaction
 from django.db.models.signals import pre_save, post_save
 from TWLight.users.helpers.authorizations import get_all_bundle_authorizations
-from TWLight.users.models import Authorization, UserProfile
+from TWLight.users.models import Authorization, UserProfile, Session
 from TWLight.resources.models import Partner
 
 """
@@ -22,6 +23,15 @@ providing_args=[
 
 class Notice(object):
     user_renewal_notice = Signal()
+
+
+@receiver(post_save, sender=User)
+def clear_inactive_user_sessions(sender, instance, **kwargs):
+    """Clear sessions after user is marked as inactive."""
+    if instance.is_active:
+        return
+    sessions = Session.objects.filter(account_id=(instance.pk))
+    sessions.delete()
 
 
 @receiver(post_save, sender=Authorization)


### PR DESCRIPTION
## Description
- use custom session engine that stores account id
- add listener to delete sessions for user post_save

## Rationale
This will improve our process for responding to ezproxy abuse

## Phabricator Ticket
https://phabricator.wikimedia.org/T370182

## How Has This Been Tested?
While logged into admin with one account, I unchecked the "active" flag for an account signed in from another browser session. The session was deleted and the other user account logged out. Note that deploying this change invalidates all existing sessions.

## Screenshots of your changes (if appropriate):
N/A

## Types of changes
What types of changes does your code introduce? Add an `x` in all the boxes that apply:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Minor change (fix a typo, add a translation tag, add section to README, etc.)
