### PR TITLE
Change simple URL methods from re_path to path

### DIFF
--- a/TWLight/applications/urls.py
+++ b/TWLight/applications/urls.py
@@ -1,4 +1,4 @@
-from django.urls import re_path
+from django.urls import re_path, path
 from django.contrib.auth.decorators import login_required
 
 from TWLight.applications import views
@@ -6,13 +6,13 @@ from TWLight.users.models import Editor
 from TWLight.resources.models import Partner
 
 urlpatterns = [
-    re_path(
-        r"editor/autocomplete/",
+    path(
+        "editor/autocomplete/",
         views.EditorAutocompleteView.as_view(model=Editor),
         name="editor_autocomplete",
     ),
-    re_path(
-        r"^partner/autocomplete/$",
+    path(
+        "partner/autocomplete/",
         views.PartnerAutocompleteView.as_view(model=Partner),
         name="partner_autocomplete",
     ),
@@ -26,31 +26,29 @@ urlpatterns = [
         login_required(views.EvaluateApplicationView.as_view()),
         name="evaluate",
     ),
-    re_path(
-        r"^list/$", login_required(views.ListApplicationsView.as_view()), name="list"
-    ),
-    re_path(
-        r"^list/approved/$",
+    path("list/", login_required(views.ListApplicationsView.as_view()), name="list"),
+    path(
+        "list/approved/",
         login_required(views.ListApprovedApplicationsView.as_view()),
         name="list_approved",
     ),
-    re_path(
-        r"^list/rejected/$",
+    path(
+        "list/rejected/",
         login_required(views.ListRejectedApplicationsView.as_view()),
         name="list_rejected",
     ),
-    re_path(
-        r"^list/expiring/$",
+    path(
+        "list/expiring/",
         login_required(views.ListRenewalApplicationsView.as_view()),
         name="list_renewal",
     ),
-    re_path(
-        r"^list/sent/$",
+    path(
+        "list/sent/",
         login_required(views.ListSentApplicationsView.as_view()),
         name="list_sent",
     ),
-    re_path(
-        r"^send/$",
+    path(
+        "send/",
         login_required(views.ListReadyApplicationsView.as_view()),
         name="send",
     ),
@@ -59,8 +57,8 @@ urlpatterns = [
         login_required(views.SendReadyApplicationsView.as_view()),
         name="send_partner",
     ),
-    re_path(
-        r"^batch_edit/$",
+    path(
+        "batch_edit/",
         login_required(views.BatchEditView.as_view()),
         name="batch_edit",
     ),

--- a/TWLight/urls.py
+++ b/TWLight/urls.py
@@ -36,49 +36,47 @@ handler400 = "TWLight.views.bad_request"
 
 urlpatterns = [
     # Built-in -----------------------------------------------------------------
-    re_path(r"^admin/doc", include(admindocs)),
-    re_path(r"^admin/", admin.site.urls),
-    re_path(r"^accounts/login/", auth_views.LoginView.as_view(), name="auth_login"),
-    re_path(
-        r"^accounts/logout/",
+    path("admin/doc", include(admindocs)),
+    path("admin/", admin.site.urls),
+    path("accounts/login/", auth_views.LoginView.as_view(), name="auth_login"),
+    path(
+        "accounts/logout/",
         auth_views.LogoutView.as_view(),
         {"next_page": "/"},
         name="auth_logout",
     ),
-    re_path(
-        r"^password/change/$",
+    path(
+        "password/change/",
         auth_views.PasswordChangeView.as_view(),
         {"post_change_redirect": "users:home"},
         name="password_change",
     ),
-    re_path(
-        r"^password/reset/$",
+    path(
+        "password/reset/",
         auth_views.PasswordResetView.as_view(),
         {"post_reset_redirect": "users:home"},
         name="password_reset",
     ),
     # Third-party --------------------------------------------------------------
-    re_path(r"^comments/", include("django_comments.urls")),
+    path("comments/", include("django_comments.urls")),
     # TWLight apps -------------------------------------------------------------
     # This makes our custom set language form  available.
-    re_path(r"^i18n/", include("TWLight.i18n.urls")),
-    re_path(r"^api/", include((api_urls, "api"), namespace="api")),
-    re_path(r"^users/", include((users_urls, "users"), namespace="users")),
-    re_path(
-        r"^applications/",
+    path("i18n/", include("TWLight.i18n.urls")),
+    path("api/", include((api_urls, "api"), namespace="api")),
+    path("users/", include((users_urls, "users"), namespace="users")),
+    path(
+        "applications/",
         include((applications_urls, "applications"), namespace="applications"),
     ),
-    re_path(r"^partners/", include((partners_urls, "resources"), namespace="partners")),
-    re_path(r"^ezproxy/", include((ezproxy_urls, "ezproxy"), namespace="ezproxy")),
+    path("partners/", include((partners_urls, "resources"), namespace="partners")),
+    path("ezproxy/", include((ezproxy_urls, "ezproxy"), namespace="ezproxy")),
     # Other TWLight views
-    re_path(r"^oauth/login/$", auth.OAuthInitializeView.as_view(), name="oauth_login"),
-    re_path(
-        r"^oauth/callback/$", auth.OAuthCallbackView.as_view(), name="oauth_callback"
-    ),
-    re_path(r"^terms/$", TermsView.as_view(), name="terms"),
+    path("oauth/login/", auth.OAuthInitializeView.as_view(), name="oauth_login"),
+    path("oauth/callback/", auth.OAuthCallbackView.as_view(), name="oauth_callback"),
+    path("terms/", TermsView.as_view(), name="terms"),
     # For partner suggestions
-    re_path(r"^suggest/$", PartnerSuggestionView.as_view(), name="suggest"),
-    re_path(r"^suggest/merge/$", SuggestionMergeView.as_view(), name="suggest-merge"),
+    path("suggest/", PartnerSuggestionView.as_view(), name="suggest"),
+    re_path("suggest/merge/", SuggestionMergeView.as_view(), name="suggest-merge"),
     re_path(
         r"^suggest/(?P<pk>[0-9]+)/delete/$",
         login_required(SuggestionDeleteView.as_view()),
@@ -90,13 +88,11 @@ urlpatterns = [
         name="upvote",
     ),
     # For contact us form
-    re_path(r"^contact/$", ContactUsView.as_view(), name="contact"),
-    re_path(r"^$", NewHomePageView.as_view(), name="homepage"),
-    re_path(
-        r"^about/$", TemplateView.as_view(template_name="about.html"), name="about"
-    ),
-    re_path(
-        r"^search/$",
+    path("contact/", ContactUsView.as_view(), name="contact"),
+    path("", NewHomePageView.as_view(), name="homepage"),
+    path("about/", TemplateView.as_view(template_name="about.html"), name="about"),
+    path(
+        "search/",
         login_required(SearchEndpointFormView.as_view()),
         name="search",
     ),
@@ -114,8 +110,8 @@ if (
     # To better debug and improve the error pages, we are making them pages
     # available when django debug toolbar is enabled
     urlpatterns += [
-        re_path(r"^400/$", TemplateView.as_view(template_name="400.html")),
-        re_path(r"^403/$", TemplateView.as_view(template_name="403.html")),
-        re_path(r"^404/$", TemplateView.as_view(template_name="404.html")),
-        re_path(r"^500/$", TemplateView.as_view(template_name="500/500.html")),
+        path("400/", TemplateView.as_view(template_name="400.html")),
+        path("403/", TemplateView.as_view(template_name="403.html")),
+        path("404/", TemplateView.as_view(template_name="404.html")),
+        path("500/", TemplateView.as_view(template_name="500/500.html")),
     ]

--- a/TWLight/users/urls.py
+++ b/TWLight/users/urls.py
@@ -1,10 +1,10 @@
-from django.urls import re_path
+from django.urls import re_path, path
 from django.contrib.auth.decorators import login_required
 
 from TWLight.users import views
 
 urlpatterns = [
-    re_path(r"^$", login_required(views.UserHomeView.as_view()), name="home"),
+    path("", login_required(views.UserHomeView.as_view()), name="home"),
     re_path(
         r"^(?P<pk>\d+)/$",
         login_required(views.EditorDetailView.as_view()),
@@ -15,16 +15,14 @@ urlpatterns = [
         login_required(views.EditorUpdateView.as_view()),
         name="editor_update",
     ),
-    re_path(
-        r"^email_change/$",
+    path(
+        "email_change/",
         login_required(views.EmailChangeView.as_view()),
         name="email_change",
     ),
-    re_path(
-        r"^update/$", login_required(views.PIIUpdateView.as_view()), name="pii_update"
-    ),
-    re_path(
-        r"^restrict_data/$",
+    path("update/", login_required(views.PIIUpdateView.as_view()), name="pii_update"),
+    path(
+        "restrict_data/",
         login_required(views.RestrictDataView.as_view()),
         name="restrict_data",
     ),
@@ -33,8 +31,8 @@ urlpatterns = [
         login_required(views.DeleteDataView.as_view()),
         name="delete_data",
     ),
-    re_path(
-        r"^my_library/$",
+    path(
+        "my_library/",
         login_required(views.MyLibraryView.as_view()),
         name="my_library",
     ),
@@ -59,8 +57,8 @@ urlpatterns = [
         login_required(views.WithdrawApplication.as_view()),
         name="withdraw",
     ),
-    re_path(
-        r"^favorite_collection/$",
+    path(
+        "favorite_collection/",
         login_required(views.FavoriteCollectionView.as_view()),
         name="favorite_collection",
     ),


### PR DESCRIPTION
Bug: T361515

## Description
Describe your changes in detail following the [commit message guidelines](https://www.mediawiki.org/wiki/Gerrit/Commit_message_guidelines)

Change URL methods from re_path to path. 

## Rationale
[//]: # (Why is this change required? What problem does it solve?)

Upgrading to Django  4.2, and we can now simplify our url path method calls. 

## Phabricator Ticket
[//]: # (Link to the Phabricator ticket)
https://phabricator.wikimedia.org/T361515

## How Has This Been Tested?
[//]: # (- Did you add tests to your changes? Did you modify tests to accommodate your changes?)
No tests, but did run full suite of unit tests to ensure they passed. 

[//]: # (- Can this change be tested manually? How?)
Smoke test

## Screenshots of your changes (if appropriate):
[//]: # (It can also be a GIF to prove that your changes are working)

## Types of changes
What types of changes does your code introduce? Add an `x` in all the boxes that apply:
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Minor change (fix a typo, add a translation tag, add section to README, etc.)
