### PR TITLE
Fix "Unable to get Editor email address from Wikipedia." error

### DIFF
--- a/TWLight/users/models.py
+++ b/TWLight/users/models.py
@@ -892,7 +892,7 @@ class Editor(models.Model):
             if "email" in identity and identity["email"] and identity["email"] != "":
                 self.user.email = identity["email"]
             else:
-                logger.exception("Unable to get Editor email address from Wikipedia.")
+                logger.warning("Unable to get Editor email address from Wikipedia.")
 
         self.user.save()
 


### PR DESCRIPTION
Fix "Unable to get Editor email address from Wikipedia." error
- change logging to warning level as we are not guaranteed to have the user's email address if they have not confirmed it.

Bug: T368661

## Description
Describe your changes in detail following the [commit message guidelines](https://www.mediawiki.org/wiki/Gerrit/Commit_message_guidelines)

Changing our log level to a warning.

## Rationale
[//]: # (Why is this change required? What problem does it solve?)

Fix noisy error logging. This is not necessarily an error case as a user who has not confirmed their email address will not have an email set in the payload.

## Phabricator Ticket
[//]: # (Link to the Phabricator ticket)

https://phabricator.wikimedia.org/T368661

## How Has This Been Tested?
[//]: # (- Did you add tests to your changes? Did you modify tests to accommodate your changes?)
[//]: # (- Can this change be tested manually? How?)
Ran unit tests and ensured they all passed. 


## Screenshots of your changes (if appropriate):
[//]: # (It can also be a GIF to prove that your changes are working)

## Types of changes
What types of changes does your code introduce? Add an `x` in all the boxes that apply:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] Minor change (fix a typo, add a translation tag, add section to README, etc.)
