### PR TITLE
Add default labels for tags and languages

### DIFF
--- a/TWLight/resources/filters.py
+++ b/TWLight/resources/filters.py
@@ -27,12 +27,16 @@ class MainPartnerFilter(django_filters.FilterSet):
         label=_("Topics"),
         choices=get_tag_choices(),
         method="tags_filter",
+        # Translators: On the My Library page, this text is shown as the default option when no specific tag filter is selected.
+        empty_label=_("All tags"),
     )
 
     languages = django_filters.ModelChoiceFilter(
         # Translators: On the MyLibrary page (https://wikipedialibrary.wmflabs.org/users/my_library), this text is shown to indicate how many languages a collection supports.
         label=_("Languages"),
         queryset=Language.objects.all(),
+        # Translators: On the My Library page, this text is shown as the default option when no specific language filter is selected.
+        empty_label=_("All languages"),
     )
 
     def __init__(self, data=None, *args, **kwargs):


### PR DESCRIPTION
## Description
Added "All tags" and "All languages" descriptors for the default 'all' filter options on the resources page.

## Rationale
It was previously unclear what the default option did.

## Phabricator Ticket
[T277141](https://phabricator.wikimedia.org/T277141)

## How Has This Been Tested?
Tried to test locally but ran into build issues - posted in Slack.

## Types of changes
What types of changes does your code introduce? Add an `x` in all the boxes that apply:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] Minor change (fix a typo, add a translation tag, add section to README, etc.)
