### PR TITLE
Delete previous sessions when a user logs in

### DIFF
--- a/TWLight/users/admin.py
+++ b/TWLight/users/admin.py
@@ -162,6 +162,8 @@ class SessionAdmin(admin.ModelAdmin):
         return obj.get_decoded()
 
     list_display = ["account_id", "session_key", "_session_data", "expire_date"]
+    list_filter = ["account_id"]
+    search_fields = ["account_id"]
 
 
 admin.site.register(Session, SessionAdmin)

--- a/TWLight/users/oauth.py
+++ b/TWLight/users/oauth.py
@@ -24,7 +24,7 @@ from django.utils.translation import (
 
 from urllib.parse import urlencode
 
-from .models import Editor
+from .models import Editor, Session
 
 
 logger = logging.getLogger(__name__)
@@ -271,6 +271,12 @@ class OAuthBackend(object):
             logger.info("User has been updated.")
 
         request.session["user_created"] = created
+
+        # Checking if more than one session exists
+        sessions = Session.objects.filter(account_id=user.pk)
+        if sessions.count() >= 1:
+            logger.info("Deleting all previous sessions.")
+            sessions.delete()
 
         # The authenticate() function of a Django auth backend must return
         # the user.
@@ -524,7 +530,6 @@ class OAuthCallbackView(View):
                     # fmt: on
                 ),
             )
-            local_redirect = reverse_lazy("homepage")
 
         user = authenticate(
             request=request, access_token=access_token, handshaker=handshaker

--- a/TWLight/users/oauth.py
+++ b/TWLight/users/oauth.py
@@ -274,7 +274,7 @@ class OAuthBackend(object):
 
         # Checking if more than one session exists
         sessions = Session.objects.filter(account_id=user.pk)
-        if sessions.count() >= 1:
+        if sessions.exists():
             logger.info("Deleting all previous sessions.")
             sessions.delete()
 


### PR DESCRIPTION
## Description
- Delete previous sessions when a user logs in
- Added filters and search in sessions admin interface

## Rationale
Users may have multiple sessions open and can access pages simultaneously without
the user being notified, which extends the time available for the attacker to perform illegitimate
actions on the platform on their behalf.

## Phabricator Ticket
[//]: # (Link to the Phabricator ticket)
[T358124](https://phabricator.wikimedia.org/T358124)

## How Has This Been Tested?
[//]: # (- Did you add tests to your changes? Did you modify tests to accommodate your changes?)
[//]: # (- Can this change be tested manually? How?)
1. Log-in in a browser tab. Do not log out
2. Open a private/different session in your browser and log in
3. Refresh the first browser tab. You should be logged out
4. Check in /admin that there is only one session per user

## Screenshots of your changes (if appropriate):
[//]: # (It can also be a GIF to prove that your changes are working)

## Types of changes
What types of changes does your code introduce? Add an `x` in all the boxes that apply:
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Minor change (fix a typo, add a translation tag, add section to README, etc.)
