### PR TITLE
Add API endpoint to check for TWL eligibility

### DIFF
--- a/TWLight/api/urls.py
+++ b/TWLight/api/urls.py
@@ -6,5 +6,9 @@ urlpatterns = [
     re_path(
         r"^(?P<version>(v0))/users/authorizations/partner/(?P<pk>\d+)/$",
         views.AuthorizedUsers.as_view(),
-    )
+    ),
+    re_path(
+        r"^(?P<version>(v0))/users/eligibility/(?P<wp_username>[\w\s\S]+)/$",
+        views.UserEligibility.as_view(),
+    ),
 ]

--- a/TWLight/users/serializers.py
+++ b/TWLight/users/serializers.py
@@ -1,7 +1,7 @@
 from django.contrib.auth.models import User
 from django.shortcuts import get_object_or_404
 from rest_framework import serializers
-from TWLight.users.models import UserProfile
+from TWLight.users.models import UserProfile, Editor
 
 
 class FavoriteCollectionSerializer(serializers.Serializer):
@@ -40,4 +40,14 @@ class UserSerializer(serializers.ModelSerializer):
         model = User
         # Since we only care about one field we could probably return data in a more
         # sensible format, but this is totally functional.
-        fields = ("wp_username",)
+        fields = ["wp_username"]
+
+
+class ElegibilitySerializer(serializers.ModelSerializer):
+    wp_sub = serializers.IntegerField()
+    wp_username = serializers.CharField()
+    wp_bundle_authorized = serializers.BooleanField()
+
+    class Meta:
+        model = Editor
+        fields = ["wp_sub", "wp_username", "wp_bundle_authorized"]


### PR DESCRIPTION
## Description
An API endpoint was added to check if a Wikipedia user is eligible to use the Wikipedia Library.

## Rationale
[//]: # (Why is this change required? What problem does it solve?)
This endpoint will be useful for external tools, like Copyvio Detector to check for a Wikipedia user's eligibility.

## Phabricator Ticket
[//]: # (Link to the Phabricator ticket)
[T372853](https://phabricator.wikimedia.org/T372853)

## How Has This Been Tested?
[//]: # (- Did you add tests to your changes? Did you modify tests to accommodate your changes?)
[//]: # (- Can this change be tested manually? How?)
- Tested manually by going to the API endpoint `api/v0/users/eligibility/<ENTER USERNAME HERE>/` and testing with different usernames
- Added automatic testing

## Screenshots of your changes (if appropriate):
[//]: # (It can also be a GIF to prove that your changes are working)
![Screenshot 2024-11-05 at 18 58 55](https://github.com/user-attachments/assets/00e692f2-175f-462e-9b59-e3adf31c26cb)


## Types of changes
What types of changes does your code introduce? Add an `x` in all the boxes that apply:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Minor change (fix a typo, add a translation tag, add section to README, etc.)
