### PR TITLE
en_Gb/django.po: Remove non en-gb translation

### DIFF
--- a/locale/en_Gb/LC_MESSAGES/django.po
+++ b/locale/en_Gb/LC_MESSAGES/django.po
@@ -2464,7 +2464,7 @@ msgstr ""
 #: TWLight/users/templates/users/editor_detail_data.html:137
 #, python-format
 msgid "It looks like you have an active block on your account. If you meet the other criteria you may still be permitted access to the library - please <a class=\"twl-links\" href=\"%(contact_url)s\">contact us</a>."
-msgstr "Ga alama kuna da toshe mai aiki akan asusunka. Idan kun cika wasu ƙa'idodin har yanzu ana iya ba ku izinin shiga ɗakin karatu - don Allah <a class=\"twl-links\" href=\"%(contact_url)s\"> tuntube mu </a>."
+msgstr ""
 
 #. Translators: When viewing a user's profile (e.g. https://wikipedialibrary.wmflabs.org/users/ when logged in), this is the heading for a Yes/No program eligibility question.
 #: TWLight/users/templates/users/editor_detail_data.html:153


### PR DESCRIPTION
[//]: # (Thank you for uploading a PR to the Wikipedia Library!)

## Description
Removed a message that isn't actually en-gb

## Rationale
Messages that aren't in en-gb shouldn't be shown to users using en-gb

## Phabricator Ticket
n/a

## How Has This Been Tested?
No

## Screenshots of your changes (if appropriate):
n/a

## Types of changes
What types of changes does your code introduce? Add an `x` in all the boxes that apply:
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Minor change (fix a typo, add a translation tag, add section to README, etc.)
