### PR TITLE
"contact The Wikipedia Library team" / "contact_link" appear to be un…

### DIFF
--- a/TWLight/users/oauth.py
+++ b/TWLight/users/oauth.py
@@ -251,7 +251,7 @@ class OAuthBackend(object):
             logger.warning(e)
             # Translators: The message shown for the contact link
             # to the Wikipedia Library team upon errors when logging in.
-            contact_message = "contact The Wikipedia Library team"
+            contact_message = _("contact The Wikipedia Library team")
             messages.warning(
                 request,
                 # Translators: This error message is shown when there's a problem with the authenticated login process.

--- a/TWLight/users/oauth.py
+++ b/TWLight/users/oauth.py
@@ -26,7 +26,6 @@ from urllib.parse import urlencode
 
 from .models import Editor, Session
 
-
 logger = logging.getLogger(__name__)
 
 
@@ -250,7 +249,8 @@ class OAuthBackend(object):
         except OAuthException as e:
             contact_url = reverse("contact")
             logger.warning(e)
-            # Translators: This message is shown in the url to contact the Wikipedia Library when errors logging in.
+            # Translators: The message shown for the contact link
+            # to the Wikipedia Library team upon errors when logging in.
             contact_message = "contact The Wikipedia Library team"
             messages.warning(
                 request,

--- a/TWLight/users/oauth.py
+++ b/TWLight/users/oauth.py
@@ -249,21 +249,24 @@ class OAuthBackend(object):
         except OAuthException as e:
             contact_url = reverse("contact")
             logger.warning(e)
-            # Translators: The message shown for the contact link
-            # to the Wikipedia Library team upon errors when logging in.
-            contact_message = _("contact The Wikipedia Library team")
+            # Translators: The message shown for the contact link to the team when errors logging in.
+            contact_link_string = _("contact The Wikipedia Library team")
+            # Translators: This error message is shown when there's a problem with the authenticated login process.
+            contact_string = _(
+                """There was a problem with the access token. Please try again later or {contact_link} if the"
+                problem persists."""
+            )
             messages.warning(
                 request,
-                # Translators: This error message is shown when there's a problem with the authenticated login process.
                 mark_safe(
                     # fmt: off
-                    _("There was a problem with the access token. Please try again later or {contact_link} if the problem persists.")
+                    contact_string
                     # fmt: on
                     .format(
                         contact_link="<a href='"
                         + contact_url
                         + "' class='twl-links' target='_blank' rel='noopener noreferrer'>"
-                        + contact_message
+                        + contact_link_string
                         + "</a>"
                     )
                 ),

--- a/TWLight/users/oauth.py
+++ b/TWLight/users/oauth.py
@@ -249,24 +249,19 @@ class OAuthBackend(object):
         except OAuthException as e:
             contact_url = reverse("contact")
             logger.warning(e)
-            # Translators: The message shown for the contact link to the team when errors logging in.
-            contact_link_string = _("contact The Wikipedia Library team")
-            # Translators: This error message is shown when there's a problem with the authenticated login process.
-            contact_string = _(
-                """There was a problem with the access token. Please try again later or {contact_link} if the"
-                problem persists."""
-            )
             messages.warning(
                 request,
                 mark_safe(
                     # fmt: off
-                    contact_string
+                    # Translators: This error message is shown when there's a problem with the authenticated login process.
+                    _("There was a problem with the access token. Please try again later or {contact_link} if the problem persists.")
                     # fmt: on
                     .format(
                         contact_link="<a href='"
                         + contact_url
                         + "' class='twl-links' target='_blank' rel='noopener noreferrer'>"
-                        + contact_link_string
+                        # Translators: The message shown for the contact link to the team when errors logging in.
+                        + _("contact The Wikipedia Library team")
                         + "</a>"
                     )
                 ),

--- a/TWLight/users/oauth.py
+++ b/TWLight/users/oauth.py
@@ -250,6 +250,8 @@ class OAuthBackend(object):
         except OAuthException as e:
             contact_url = reverse("contact")
             logger.warning(e)
+            # Translators: This message is shown in the url to contact the Wikipedia Library when errors logging in.
+            contact_message = "contact The Wikipedia Library team"
             messages.warning(
                 request,
                 # Translators: This error message is shown when there's a problem with the authenticated login process.
@@ -260,7 +262,9 @@ class OAuthBackend(object):
                     .format(
                         contact_link="<a href='"
                         + contact_url
-                        + "' class='twl-links' target='_blank' rel='noopener noreferrer'>contact The Wikipedia Library team</a>"
+                        + "' class='twl-links' target='_blank' rel='noopener noreferrer'>"
+                        + contact_message
+                        + "</a>"
                     )
                 ),
             )


### PR DESCRIPTION
…translatable

Bug: T380688

## Description
Describe your changes in detail following the [commit message guidelines](https://www.mediawiki.org/wiki/Gerrit/Commit_message_guidelines)

This fixes the contact link to be a translatable string. 

## Rationale

Messages should be translatable. 

## Phabricator Ticket
[//]: # (Link to the Phabricator ticket)
https://phabricator.wikimedia.org/T380688

## How Has This Been Tested?
 
Not sure how to test this locally- I ran the translation command from cicd.yml and am still only seeing the message show up in english. 

## Screenshots of your changes (if appropriate):
[//]: # (It can also be a GIF to prove that your changes are working)

## Types of changes
What types of changes does your code introduce? Add an `x` in all the boxes that apply:
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Minor change (fix a typo, add a translation tag, add section to README, etc.)
