### PR TITLE
Fix login for new users

### DIFF
--- a/TWLight/users/models.py
+++ b/TWLight/users/models.py
@@ -697,7 +697,7 @@ class Editor(models.Model):
             return self.get_bundle_authorization.is_valid
 
     def get_global_userinfo(self, identity):
-        self.check_sub(identity["sub"])
+        self.check_sub(int(identity["sub"]))
         return editor_global_userinfo(identity["sub"])
 
     def check_sub(self, wp_sub):
@@ -705,7 +705,7 @@ class Editor(models.Model):
         Verifies that the supplied Global Wikipedia User ID matches stored editor ID.
         Parameters
         ----------
-        wp_sub : str
+        wp_sub : int
             Global Wikipedia User ID, used for guiid parameter in globaluserinfo calls.
 
         Returns
@@ -713,7 +713,7 @@ class Editor(models.Model):
         None
         """
 
-        if self.wp_sub != int(wp_sub):
+        if int(self.wp_sub) != wp_sub:
             raise SuspiciousOperation(
                 "Was asked to update Editor data, but the "
                 "WP sub in the identity passed in did not match the wp_sub on "
@@ -851,7 +851,7 @@ class Editor(models.Model):
             current_datetime = timezone.now()
 
         if global_userinfo:
-            self.check_sub(global_userinfo["id"])
+            self.check_sub(int(global_userinfo["id"]))
         else:
             global_userinfo = self.get_global_userinfo(identity)
 


### PR DESCRIPTION
## Description
- Cast the wp_sub to int when calling the function and cast `self.wp_sub`

## Rationale
[//]: # (Why is this change required? What problem does it solve?)
- New logins weren't working correctly.

## Phabricator Ticket
[//]: # (Link to the Phabricator ticket)
[T383891](https://phabricator.wikimedia.org/T383891)

## How Has This Been Tested?
[//]: # (- Did you add tests to your changes? Did you modify tests to accommodate your changes?)
[//]: # (- Can this change be tested manually? How?)
1. Login as an already-created user.
2. It should work.
3. Delete your user.
4. Try logging in again.
5. It should work

## Screenshots of your changes (if appropriate):
[//]: # (It can also be a GIF to prove that your changes are working)

## Types of changes
What types of changes does your code introduce? Add an `x` in all the boxes that apply:
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Minor change (fix a typo, add a translation tag, add section to README, etc.)
