### PR TITLE
Update /admin help text to remove reference to collections

### DIFF
--- a/TWLight/resources/models.py
+++ b/TWLight/resources/models.py
@@ -226,9 +226,7 @@ class Partner(models.Model):
         null=True,
         help_text="Optional instructions for editors to use access codes "
         "or free signup URLs for this partner. Sent via email upon "
-        "application approval (for links) or access code assignment. "
-        "If this partner has collections, fill out user instructions "
-        "on each collection instead.",
+        "application approval (for links) or access code assignment.",
     )
 
     excerpt_limit = models.PositiveSmallIntegerField(


### PR DESCRIPTION
Collections are no longer part of TWLight, so this sentence is unnecessary/confusing.

<img width="1330" alt="Screenshot 2025-02-26 at 10 31 35" src="https://github.com/user-attachments/assets/9107e765-3d28-4f4a-8e8e-ad30c468bb33" />
