### PR TITLE
remove T332650 warning now that issue is resolved

### DIFF
--- a/TWLight/users/oauth.py
+++ b/TWLight/users/oauth.py
@@ -529,19 +529,6 @@ class OAuthCallbackView(View):
                 # Translators: This message is shown when the OAuth login process fails.
                 _("Access token generation failed, please try logging in again."),
             )
-            # @TODO: revert the following after T332650 is resolved
-            # raise PermissionDenied
-            messages.warning(
-                request,
-                mark_safe(
-                    # fmt: off
-                    # Translators: This message is shown when more information is available on another page. Do not translate {issue}
-                    _("See {issue} for more information").format(
-                        issue="<a href='https://phabricator.wikimedia.org/T332650' target='_blank' rel='noopener noreferrer'>T332650</a>"
-                    )
-                    # fmt: on
-                ),
-            )
 
         user = authenticate(
             request=request, access_token=access_token, handshaker=handshaker


### PR DESCRIPTION
Bug: T332650

[//]: # (Thank you for uploading a PR to the Wikipedia Library!)

## Description
Describe your changes in detail following the [commit message guidelines](https://www.mediawiki.org/wiki/Gerrit/Commit_message_guidelines)

## Rationale
Since the underlying issue was resolved, ephemeral oauth error messages for token generation are misleading.

## Phabricator Ticket
https://phabricator.wikimedia.org/T332650

## How Has This Been Tested?
I manually tested by removing the guard clause on L#536 and verifying that the message displays
https://github.com/WikipediaLibrary/TWLight/pull/1429/files#diff-465b30964899d780b370c6c0dd59a6c827f82e4060bc3513394c20183cb3d9e9L526

## Screenshots of your changes (if appropriate):
before:
![image](https://github.com/user-attachments/assets/93d3c02e-4784-47de-80e9-7db9e67d0b1d)


after:
![image](https://github.com/user-attachments/assets/10ac21a4-d20c-44d1-917f-15c4a4c32f27)

## Types of changes
What types of changes does your code introduce? Add an `x` in all the boxes that apply:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Minor change (fix a typo, add a translation tag, add section to README, etc.)
