### PR TITLE
POC: Add email sender with API:Emailuser

### DIFF
--- a/TWLight/emails/management/commands/send_email_via_api.py
+++ b/TWLight/emails/management/commands/send_email_via_api.py
@@ -1,0 +1,125 @@
+import logging
+import os
+import requests
+
+from django.core.management.base import BaseCommand, CommandError
+
+logger = logging.getLogger("django")
+
+
+class Command(BaseCommand):
+    help = "Command that sends emails via API:Emailuser in MediaWiki"
+
+    def info(self, msg):
+        # Log and print so that messages are visible
+        # in docker logs (log) and cron job logs (print)
+        logger.info(msg)
+        self.stdout.write(msg)
+        self.stdout.flush()
+
+    def add_arguments(self, parser):
+        # Named (optional) arguments
+        parser.add_argument(
+            "--target",
+            type=str,
+            help="The Wikipedia username you want to send the email to.",
+        )
+        parser.add_argument(
+            "--subject",
+            type=str,
+            help="The subject of the email.",
+        )
+        parser.add_argument(
+            "--body",
+            type=str,
+            help="The body of the email.",
+        )
+
+    def handle(self, *args, **options):
+        if not options["target"]:
+            raise CommandError("You need to specify a user to send the email to")
+
+        if not options["subject"]:
+            raise CommandError("You need to specify the subject of the email")
+
+        if not options["body"]:
+            raise CommandError("You need to specify the body of the email")
+
+        target = options["target"]
+        subject = options["subject"]
+        body = options["body"]
+
+        email_bot_username = os.environ.get("EMAILWIKIBOTUSERNAME", None)
+        email_bot_password = os.environ.get("EMAILWIKIBOTPASSWORD", None)
+
+        if email_bot_username is None or email_bot_password is None:
+            # Bot credentials not provided; exiting gracefully
+            raise CommandError(
+                "The email bot username and/or password were not provided. Exiting..."
+            )
+        # Code taken in part from https://www.mediawiki.org/wiki/API:Emailuser#Python
+        session = requests.Session()
+        # TODO: See if we need to change this to Meta or the user's home wiki?
+        # Or is this wiki fine?
+        url = "https://test.wikipedia.org/w/api.php"
+
+        # Step 1: GET request to fetch login token
+        login_token_params = {
+            "action": "query",
+            "meta": "tokens",
+            "type": "login",
+            "format": "json",
+        }
+
+        self.info("Getting login token...")
+        response_login_token = session.get(url=url, params=login_token_params)
+        if response_login_token.status_code != 200:
+            raise CommandError(
+                "There was an error in the request for obtaining the login token."
+            )
+        login_token_data = response_login_token.json()
+
+        login_token = login_token_data["query"]["tokens"]["logintoken"]
+
+        if not login_token:
+            raise CommandError("There was an error obtaining the login token.")
+
+        # Step 2: POST request to log in. Use of main account for login is not
+        # supported. Obtain credentials via Special:BotPasswords
+        # (https://www.mediawiki.org/wiki/Special:BotPasswords) for lgname & lgpassword
+        login_params = {
+            "action": "login",
+            "lgname": email_bot_username,
+            "lgpassword": email_bot_password,
+            "lgtoken": login_token,
+            "format": "json",
+        }
+
+        self.info("Signing in...")
+        login_response = session.post(url, data=login_params)
+        if login_response.status_code != 200:
+            raise CommandError("There was an error in the request for the login.")
+
+        # Step 3: GET request to fetch Email token
+        email_token_params = {"action": "query", "meta": "tokens", "format": "json"}
+
+        self.info("Getting emwail token...")
+        email_token_response = session.get(url=url, params=email_token_params)
+        email_token_data = email_token_response.json()
+
+        email_token = email_token_data["query"]["tokens"]["csrftoken"]
+
+        # Step 4: POST request to send an email
+        email_params = {
+            "action": "emailuser",
+            "target": target,
+            "subject": subject,
+            "text": body,
+            "token": email_token,
+            "format": "json",
+        }
+
+        self.info("Sending email...")
+        email_response = session.post(url, data=email_params)
+        if email_response.status_code != 200:
+            raise CommandError("There was an error when trying to send the email.")

--- a/TWLight/users/management/commands/retrieve_monthly_users.py
+++ b/TWLight/users/management/commands/retrieve_monthly_users.py
@@ -1,15 +1,24 @@
 import calendar
 import datetime
 from dateutil.relativedelta import relativedelta
+import logging
 
+from django.core.management import call_command
 from django.core.management.base import BaseCommand
 from django.db import connection
 
-from TWLight.users.signals import UserLoginRetrieval
+logger = logging.getLogger("django")
 
 
 class Command(BaseCommand):
     help = "Retrieves user names that have logged-in in the past month and have approved applications and current authorizations."
+
+    def info(self, msg):
+        # Log and print so that messages are visible
+        # in docker logs (log) and cron job logs (print)
+        logger.info(msg)
+        self.stdout.write(msg)
+        self.stdout.flush()
 
     def handle(self, *args, **options):
         current_date = datetime.datetime.now(datetime.timezone.utc).date()
@@ -18,6 +27,7 @@ class Command(BaseCommand):
         _, last_day = calendar.monthrange(last_month.year, last_month.month)
         last_day_last_month = datetime.date(last_month.year, last_month.month, last_day)
 
+        self.info("Getting query...")
         raw_query = """SELECT users_editor.wp_username, IF(
             -- has application status APPROVED = 2 SENT = 4
             (applications_application.status = 2 OR applications_application.status = 4), 'true', 'false') AS has_approved_apps,
@@ -44,12 +54,17 @@ class Command(BaseCommand):
             last_day_last_month=last_day_last_month,
         )
 
+        self.info("Creating monthly users...")
         with connection.cursor() as cursor:
             cursor.execute(raw_query)
             columns = [col[0] for col in cursor.description]
             monthly_users = [dict(zip(columns, row)) for row in cursor.fetchall()]
 
         if monthly_users:
-            UserLoginRetrieval.user_retrieve_monthly_logins.send(
-                sender=self.__class__, monthly_users=monthly_users
+            self.info("Sending email...")
+            call_command(
+                "send_email_via_api",
+                target="Suecarmol",  # TODO: change to Vipin's user
+                subject="Monthly user report",
+                body=f"Here is a list of monthly users: {monthly_users}",
             )

--- a/conf/local.twlight.env
+++ b/conf/local.twlight.env
@@ -21,3 +21,5 @@ TWLIGHT_API_PROVIDER_ENDPOINT=https://meta.wikimedia.org/w/api.php
 TWLIGHT_EZPROXY_URL=https://ezproxy.dev.localdomain:2443
 # seeem to be having troubles with --workers > 1
 GUNICORN_CMD_ARGS=--name twlight --workers 1 --backlog 2048 --timeout 300 --bind=0.0.0.0:80 --forwarded-allow-ips * --reload --log-level=info
+EMAILWIKIBOTUSERNAME=Add-bot-name
+EMAILWIKIBOTPASSWORD=Add-bot-password

--- a/conf/production.twlight.env
+++ b/conf/production.twlight.env
@@ -21,3 +21,5 @@ TWLIGHT_OAUTH_PROVIDER_URL=https://meta.wikimedia.org/w/index.php
 TWLIGHT_API_PROVIDER_ENDPOINT=https://meta.wikimedia.org/w/api.php
 TWLIGHT_EZPROXY_URL=https://wikipedialibrary.idm.oclc.org
 GUNICORN_CMD_ARGS=--name twlight --worker-class gthread --workers 9 --threads 1 --timeout 30 --backlog 2048 --bind=0.0.0.0:80 --forwarded-allow-ips * --reload --log-level=info
+EMAILWIKIBOTUSERNAME=Add-bot-name
+EMAILWIKIBOTPASSWORD=Add-bot-password

--- a/conf/staging.twlight.env
+++ b/conf/staging.twlight.env
@@ -21,3 +21,5 @@ TWLIGHT_OAUTH_PROVIDER_URL=https://meta.wikimedia.org/w/index.php
 TWLIGHT_API_PROVIDER_ENDPOINT=https://meta.wikimedia.org/w/api.php
 TWLIGHT_EZPROXY_URL=https://wikipedialibrary.idm.oclc.org:9443
 GUNICORN_CMD_ARGS=--name twlight --worker-class gthread --workers 4 --threads 1 --timeout 30 --backlog 2048 --bind=0.0.0.0:80 --forwarded-allow-ips * --reload --log-level=info
+EMAILWIKIBOTUSERNAME=Add-bot-name
+EMAILWIKIBOTPASSWORD=Add-bot-password

--- a/docker-compose.debug_toolbar.yml
+++ b/docker-compose.debug_toolbar.yml
@@ -1,7 +1,5 @@
 ---
 
-version: '3.4'
-
 services:
   twlight:
     build:

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -1,7 +1,5 @@
 ---
 
-version: '3.4'
-
 # Local environment should mount plaintext files as secrets
 secrets:
   DJANGO_DB_NAME:

--- a/docker-compose.production.yml
+++ b/docker-compose.production.yml
@@ -1,7 +1,5 @@
 ---
 
-version: '3.4'
-
 secrets:
   DJANGO_DB_NAME:
     external: true

--- a/docker-compose.staging.yml
+++ b/docker-compose.staging.yml
@@ -1,7 +1,5 @@
 ---
 
-version: '3.4'
-
 secrets:
   DJANGO_DB_NAME:
     external: true

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,5 @@
 ---
 
-version: '3.4'
-
 volumes:
   mysql:
 


### PR DESCRIPTION
## Description
- Removed the `version` item in all docker-compose files (the warning was bothering me)
- Created the send_email_via_api command for other services to send emails from

Caveats from this approach:
- Rate-limiting handling had not been implemented
- If TWL users have a different email address from their Wikipedia account, it could be unwelcome to send an email to that address
- If a TWL user does not have the `Allow other users to email me` option set in Special:Preferences, then they will not receive an email

## Rationale
Our email sending system has issues when sending to certain accounts. This is a possible solution to that problem.

## Phabricator Ticket
[T383070](https://phabricator.wikimedia.org/T383070)

## How Has This Been Tested?
Tested locally. You can run `python manage.py retrieve_monthly_users` and change the `target` parameter to your Wikipedia username.

## Screenshots of your changes (if appropriate):
[//]: # (It can also be a GIF to prove that your changes are working)

## Types of changes
What types of changes does your code introduce? Add an `x` in all the boxes that apply:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Minor change (fix a typo, add a translation tag, add section to README, etc.)
