### PR TITLE
Add platform attribute to docker services

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,7 @@
 ---
 services:
   db:
+    platform: linux/amd64
     image: quay.io/wikipedialibrary/mariadb:10-updated
     volumes:
       - mysql:/var/lib/mysql
@@ -46,6 +47,7 @@ services:
       - MW_API_EMAIL_PASSWORD
     command: [ "/venv/bin/gunicorn", "TWLight.wsgi" ]
   web:
+    platform: linux/amd64
     image: quay.io/wikipedialibrary/nginx:latest-updated
     depends_on:
       - 'twlight'


### PR DESCRIPTION
[//]: # (Thank you for uploading a PR to the Wikipedia Library!)

## Description
When trying to build and run TWL locally, I had the following error:

> no matching manifest for linux/arm64/v8 in the manifest list entries

This is solved by adding `platform: linux/amd64` to the `db` and `web` services.

## Rationale
Adding this will help us run TWL locally.

## Phabricator Ticket
N/A

## How Has This Been Tested?
[//]: # (- Did you add tests to your changes? Did you modify tests to accommodate your changes?)
[//]: # (- Can this change be tested manually? How?)

## Screenshots of your changes (if appropriate):
[//]: # (It can also be a GIF to prove that your changes are working)

## Types of changes
What types of changes does your code introduce? Add an `x` in all the boxes that apply:
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Minor change (fix a typo, add a translation tag, add section to README, etc.)
