### PR TITLE
Upgrade TWL to Django 5.2

### DIFF
--- a/TWLight/applications/forms.py
+++ b/TWLight/applications/forms.py
@@ -55,8 +55,6 @@ from .models import Application
 
 logger = logging.getLogger(__name__)
 
-coordinators = get_coordinators()
-
 
 class StylableSubmit(BaseInput):
     """
@@ -256,7 +254,7 @@ class ApplicationAutocomplete(forms.ModelForm):
                 "company_name"
             )
 
-        elif coordinators in user.groups.all():
+        elif get_coordinators() in user.groups.all():
             self.fields["editor"].queryset = Editor.objects.filter(
                 applications__partner__coordinator__pk=user.pk
             ).order_by("wp_username")

--- a/TWLight/applications/migrations/0001_initial_squashed_0029_remove_application_hidden.py
+++ b/TWLight/applications/migrations/0001_initial_squashed_0029_remove_application_hidden.py
@@ -6,7 +6,6 @@ from django.db import migrations, models
 import django.db.models.deletion
 import django.db.models.manager
 import django.utils.timezone
-from django.utils.timezone import utc
 
 
 # Functions from the following migrations need manual copying.
@@ -92,7 +91,7 @@ class Migration(migrations.Migration):
                     models.DateField(
                         auto_now_add=True,
                         default=datetime.datetime(
-                            2016, 4, 26, 15, 54, 22, 38710, tzinfo=utc
+                            2016, 4, 26, 15, 54, 22, 38710, tzinfo=datetime.timezone.utc
                         ),
                     ),
                 ),

--- a/TWLight/applications/tests.py
+++ b/TWLight/applications/tests.py
@@ -463,8 +463,7 @@ class SubmitApplicationTest(BaseApplicationViewTest):
             self.assertEqual(response.url, expected_url)
         else:
             self.assertFormError(
-                response,
-                "form",
+                response.context["form"],
                 "partner_{id}_rationale".format(id=p1.id),
                 "This field consists only of restricted text.",
             )

--- a/TWLight/applications/views.py
+++ b/TWLight/applications/views.py
@@ -65,8 +65,6 @@ from .models import Application
 
 logger = logging.getLogger(__name__)
 
-coordinators = get_coordinators()
-
 PARTNERS_SESSION_KEY = "applications_request__partner_ids"
 
 
@@ -80,7 +78,7 @@ class EditorAutocompleteView(autocomplete.Select2QuerySetView):
                 editor_qs = editor_qs.filter(wp_username__istartswith=self.q).order_by(
                     "wp_username"
                 )
-        elif coordinators in self.request.user.groups.all():
+        elif get_coordinators() in self.request.user.groups.all():
             editor_qs = Editor.objects.filter(
                 applications__partner__coordinator__pk=self.request.user.pk
             ).order_by("wp_username")
@@ -106,7 +104,7 @@ class PartnerAutocompleteView(autocomplete.Select2QuerySetView):
                 partner_qs = partner_qs.filter(
                     company_name__istartswith=self.q
                 ).order_by("company_name")
-        elif coordinators in self.request.user.groups.all():
+        elif get_coordinators() in self.request.user.groups.all():
             partner_qs = Partner.objects.filter(
                 coordinator__pk=self.request.user.pk
             ).order_by("company_name")

--- a/TWLight/resources/migrations/0001_initial_squashed_0062_auto_20190220_1639.py
+++ b/TWLight/resources/migrations/0001_initial_squashed_0062_auto_20190220_1639.py
@@ -6,7 +6,6 @@ from django.conf import settings
 import django.core.validators
 from django.db import migrations, models
 import django.db.models.manager
-from django.utils.timezone import utc
 import django_countries.fields
 
 
@@ -172,7 +171,7 @@ class Migration(migrations.Migration):
                     models.DateField(
                         auto_now_add=True,
                         default=datetime.datetime(
-                            2016, 5, 9, 19, 18, 3, 475335, tzinfo=utc
+                            2016, 5, 9, 19, 18, 3, 475335, tzinfo=datetime.timezone.utc
                         ),
                     ),
                 ),

--- a/TWLight/resources/tests.py
+++ b/TWLight/resources/tests.py
@@ -681,7 +681,7 @@ class PartnerViewTests(TestCase):
 
         cls.partner = PartnerFactory()
         editor = EditorFactory()
-        cls.user = UserFactory(editor=editor)
+        cls.user = UserFactory()
         cls.coordinator = UserFactory()
         cls.coordinator2 = UserFactory()
 
@@ -1260,7 +1260,7 @@ class PartnerSuggestionViewTests(TestCase):
         cls.suggestion_to_delete = SuggestionFactory()
         cls.editor = EditorCraftRoom(cls, Terms=True, Coordinator=True)
         cls.upvoter = EditorCraftRoom(cls, Terms=True)
-        cls.user = UserFactory(editor=cls.editor)
+        cls.user = UserFactory()
         cls.suggestion.author = cls.editor.user
         cls.suggestion_to_delete.author = cls.editor.user
 

--- a/TWLight/settings/base.py
+++ b/TWLight/settings/base.py
@@ -329,8 +329,6 @@ TIME_ZONE = "UTC"
 
 USE_I18N = True
 
-USE_L10N = True
-
 USE_TZ = True
 
 

--- a/TWLight/static/css/new-local.css
+++ b/TWLight/static/css/new-local.css
@@ -58,6 +58,17 @@ COMMON CONTENT BLOCK CSS
     text-align: right;
 }
 
+.nav-logout-form {
+  display: inline;
+  margin: 0;
+}
+.nav-logout-form button.nav-link {
+  background: none;
+  border: none;
+  margin: 0;
+  -webkit-appearance: none;
+}
+
 .twl-btn {
   white-space: nowrap;
   font-family: Roboto;

--- a/TWLight/templates/header_partial_b4.html
+++ b/TWLight/templates/header_partial_b4.html
@@ -115,10 +115,13 @@
               </a>
             </li>
             <li role="presentation" class="mobile-menu align-middle nav-item">
-              {% comment %}Translators: Shown in the top bar to let users log out of The Wikipedia Library. {% endcomment %}
-              <a class="nav-link nav-links" href="{% url 'auth_logout' %}?next=/">
-                {% trans "Log out" %}
-              </a>
+              <form action="{% url 'auth_logout' %}?next=/" method="post" class="nav-logout-form">
+                {% csrf_token %}
+                {% comment %}Translators: Shown in the top bar to let users log out of The Wikipedia Library. {% endcomment %}
+                <button type="submit" class="nav-link nav-links">
+                  {% trans "Log out" %}
+                </button>
+              </form>
             </li>
           {% else %}
             <li role="presentation" class="mobile-menu align-middle nav-item">

--- a/TWLight/tests.py
+++ b/TWLight/tests.py
@@ -41,9 +41,6 @@ from .view_mixins import (
 )
 
 
-coordinators = get_coordinators()
-
-
 class ObjGet(object):
     """
     Some view mixins assume that the thing they're mixed with will define
@@ -121,7 +118,7 @@ class ViewMixinTests(TestCase):
         PartnerCoordinatorOrSelf should allow coordinators.
         """
         user = UserFactory()
-        coordinators.user_set.add(user)
+        get_coordinators().user_set.add(user)
 
         req = RequestFactory()
         req.user = user
@@ -194,7 +191,7 @@ class ViewMixinTests(TestCase):
         CoordinatorsOnly should allow coordinators.
         """
         user = UserFactory()
-        coordinators.user_set.add(user)
+        get_coordinators().user_set.add(user)
 
         req = RequestFactory()
         req.user = user
@@ -558,7 +555,7 @@ class AuthorizationBaseTestCase(TestCase):
 
         # Editor 5 is a coordinator without a session and with no designated partners.
         cls.editor5 = EditorFactory()
-        coordinators.user_set.add(cls.editor5.user)
+        get_coordinators().user_set.add(cls.editor5.user)
 
         # Create applications.
         cls.app1 = ApplicationFactory(

--- a/TWLight/users/models.py
+++ b/TWLight/users/models.py
@@ -973,8 +973,6 @@ class Authorization(models.Model):
         verbose_name = "authorization"
         verbose_name_plural = "authorizations"
 
-    coordinators = get_coordinators()
-
     # Users may have multiple authorizations.
     user = models.ForeignKey(
         settings.AUTH_USER_MODEL,

--- a/TWLight/users/templates/users/eligibility_modal.html
+++ b/TWLight/users/templates/users/eligibility_modal.html
@@ -59,11 +59,14 @@
           </a>
         </div>
         <div class="col-lg-6 col-md-6 col-sm-12">
-          <a href="{% url 'auth_logout' %}?next=/" class="btn btn-outline-secondary
-              eligibility-modal-button">
+          <form action="{% url 'auth_logout' %}?next=/" method="post">
+            {% csrf_token %}
             {% comment %}Translators: A button to log out of The Wikipedia Library. {% endcomment %}
-            {% trans "Log out" %}
-          </a>
+            <button type="submit" class="btn btn-outline-secondary
+                eligibility-modal-button">
+              {% trans "Log out" %}
+            </button>
+          </form>
         </div>
       </div>
     </div>

--- a/bin/virtualenv_test.sh
+++ b/bin/virtualenv_test.sh
@@ -8,6 +8,9 @@ set -euo pipefail
     # print the date for logging purposes
     echo "[$(date)]"
 
+    # print the Django version
+    echo "Django version: $(python -c 'import django; print(django.get_version())')"
+
     # Load virtual environment
     if source "${TWLIGHT_HOME}/bin/virtualenv_activate.sh"
     then

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -2,7 +2,7 @@ black==24.3.0
 bleach==6.2.0
 click==8.0.4 # This version of click has to be set because 8.1 breaks black formatting
 defusedxml==0.7.1
-django==4.2.30
+django==5.0.14
 django-annoying==0.10.7
 django-autocomplete-light==3.11.0
 django-contrib-comments==2.2.0

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -2,13 +2,13 @@ black==24.3.0
 bleach==6.2.0
 click==8.0.4 # This version of click has to be set because 8.1 breaks black formatting
 defusedxml==0.7.1
-django==5.0.14
+django==5.1.15
 django-annoying==0.10.7
 django-autocomplete-light==3.11.0
 django-contrib-comments==2.2.0
 django-countries==7.6.1
 django-crispy-forms==1.14.0
-django_cron==0.6.0
+git+https://github.com/theresnotime/django-cron.git@T429273 # Django 5.1 compatible fork (move to WikipediaLibrary/)
 git+https://github.com/WikipediaLibrary/django-dkim.git@Jsn.sherman/mailfrom
 django-durationfield==0.5.5
 django_extensions==3.2.3

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -2,7 +2,7 @@ black==24.3.0
 bleach==6.2.0
 click==8.0.4 # This version of click has to be set because 8.1 breaks black formatting
 defusedxml==0.7.1
-django==5.1.15
+django==5.2.15
 django-annoying==0.10.7
 django-autocomplete-light==3.11.0
 django-contrib-comments==2.2.0


### PR DESCRIPTION
## Description
Upgrade TWL's Django dep to v5.2

Upgrade Django from 4.2 to 5.2, stepping between versions per commit

Bug: T429273

## Rationale
Django 4.2's support ended in April 2026. For this reason, we need to upgrade the Wikipedia Library to Django 5.2.

## Phabricator Ticket
[T429273](https://phabricator.wikimedia.org/T429273)

## How Has This Been Tested?
- Smoke testing by using the web interface
- Running `docker compose exec twlight bin/virtualenv_test.sh`