### PR TITLE
Tests: Use .copy() to prevent mutation of shared module-level test data

### DIFF
--- a/TWLight/users/tests.py
+++ b/TWLight/users/tests.py
@@ -1692,8 +1692,8 @@ class EditorModelTestCase(TestCase):
         platform, we shouldn't be overwriting it with a blank string.
         """
         new_editor = EditorFactory(wp_registered=None)
-        new_identity = FAKE_IDENTITY
-        new_global_userinfo = FAKE_GLOBAL_USERINFO
+        new_identity = copy.copy(FAKE_IDENTITY)
+        new_global_userinfo = copy.copy(FAKE_GLOBAL_USERINFO)
         new_identity["sub"] = new_editor.wp_sub
         new_global_userinfo["id"] = new_identity["sub"]
 
@@ -1715,8 +1715,8 @@ class EditorModelTestCase(TestCase):
         platform, we shouldn't be overwriting it with a blank string.
         """
         new_editor = EditorFactory(wp_registered=None)
-        new_identity = FAKE_IDENTITY
-        new_global_userinfo = FAKE_GLOBAL_USERINFO
+        new_identity = copy.copy(FAKE_IDENTITY)
+        new_global_userinfo = copy.copy(FAKE_GLOBAL_USERINFO)
         new_identity["sub"] = new_editor.wp_sub
         new_global_userinfo["id"] = new_identity["sub"]
 
@@ -1741,36 +1741,33 @@ class OAuthTestCase(TestCase):
         for editor in Editor.objects.all():
             editor.delete()
 
-        @patch("urllib.request.urlopen")
-        def test_create_user_and_editor(self, mock_urlopen):
-            """
-            OAuthBackend._create_user_and_editor() should:
-            * create a user
-                * with a suitable username and email
-                * without a password
-            * And a matching editor
-            """
-            # HOTFIX: this test was failing in CI, but passing locally, just skipping it for now
-            # see: https://phabricator.wikimedia.org/T352896
-            self.skipTest("See: https://phabricator.wikimedia.org/T352896")
-            oauth_backend = OAuthBackend()
-            oauth_data = FAKE_IDENTITY_DATA
-            identity = FAKE_IDENTITY
+    @patch("urllib.request.urlopen")
+    def test_create_user_and_editor(self, mock_urlopen):
+        """
+        OAuthBackend._create_user_and_editor() should:
+        * create a user
+            * with a suitable username and email
+            * without a password
+        * And a matching editor
+        """
+        oauth_backend = OAuthBackend()
+        oauth_data = copy.copy(FAKE_IDENTITY_DATA)
+        identity = copy.copy(FAKE_IDENTITY)
 
-            mock_response = Mock()
-            mock_response.read.side_effect = [json.dumps(oauth_data)] * 7
-            mock_urlopen.return_value = mock_response
+        mock_response = Mock()
+        mock_response.read.side_effect = [json.dumps(oauth_data)] * 7
+        mock_urlopen.return_value = mock_response
 
-            user, editor = oauth_backend._create_user_and_editor(identity)
+        user, editor = oauth_backend._create_user_and_editor(identity)
 
-            self.assertEqual(user.email, "alice@example.com")
-            self.assertEqual(user.username, "567823")
-            self.assertFalse(user.has_usable_password())
+        self.assertEqual(user.email, "alice@example.com")
+        self.assertEqual(user.username, "567823")
+        self.assertFalse(user.has_usable_password())
 
-            self.assertEqual(editor.user, user)
-            self.assertEqual(editor.wp_sub, 567823)
-            # We won't test the fields set by update_from_wikipedia, as they are
-            # tested elsewhere.
+        self.assertEqual(editor.user, user)
+        self.assertEqual(editor.wp_sub, 567823)
+        # We won't test the fields set by update_from_wikipedia, as they are
+        # tested elsewhere.
 
     # We mock out this function for two reasons:
     # 1) To prevent its call to an external API, which we would have otherwise


### PR DESCRIPTION
My thinking so far is when tests run in a certain order (especially with `--parallel`), the email-related tests would mutate `FAKE_IDENTITY["email"]` to `None` or `""` _before_ `test_create_user_and_editor` ran, causing its `assertEqual(user.email, "alice@example.com")` assertion to fail.

Bug: [T352896](https://phabricator.wikimedia.org/T352896)

<!--[//]: # (Thank you for uploading a PR to the Wikipedia Library!)

## Description
Describe your changes in detail following the [commit message guidelines](https://www.mediawiki.org/wiki/Gerrit/Commit_message_guidelines)

## Rationale
[//]: # (Why is this change required? What problem does it solve?)

## Phabricator Ticket
[//]: # (Link to the Phabricator ticket)

## How Has This Been Tested?
[//]: # (- Did you add tests to your changes? Did you modify tests to accommodate your changes?)
[//]: # (- Can this change be tested manually? How?)

## Screenshots of your changes (if appropriate):
[//]: # (It can also be a GIF to prove that your changes are working)

## Types of changes
What types of changes does your code introduce? Add an `x` in all the boxes that apply:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Minor change (fix a typo, add a translation tag, add section to README, etc.)
-->