### PR TITLE
Revert "Tests: Use .copy() to prevent mutation of shared module-level test data"

### DIFF
--- a/TWLight/users/tests.py
+++ b/TWLight/users/tests.py
@@ -1692,8 +1692,8 @@ class EditorModelTestCase(TestCase):
         platform, we shouldn't be overwriting it with a blank string.
         """
         new_editor = EditorFactory(wp_registered=None)
-        new_identity = copy.copy(FAKE_IDENTITY)
-        new_global_userinfo = copy.copy(FAKE_GLOBAL_USERINFO)
+        new_identity = FAKE_IDENTITY
+        new_global_userinfo = FAKE_GLOBAL_USERINFO
         new_identity["sub"] = new_editor.wp_sub
         new_global_userinfo["id"] = new_identity["sub"]
 
@@ -1715,8 +1715,8 @@ class EditorModelTestCase(TestCase):
         platform, we shouldn't be overwriting it with a blank string.
         """
         new_editor = EditorFactory(wp_registered=None)
-        new_identity = copy.copy(FAKE_IDENTITY)
-        new_global_userinfo = copy.copy(FAKE_GLOBAL_USERINFO)
+        new_identity = FAKE_IDENTITY
+        new_global_userinfo = FAKE_GLOBAL_USERINFO
         new_identity["sub"] = new_editor.wp_sub
         new_global_userinfo["id"] = new_identity["sub"]
 
@@ -1741,33 +1741,36 @@ class OAuthTestCase(TestCase):
         for editor in Editor.objects.all():
             editor.delete()
 
-    @patch("urllib.request.urlopen")
-    def test_create_user_and_editor(self, mock_urlopen):
-        """
-        OAuthBackend._create_user_and_editor() should:
-        * create a user
-            * with a suitable username and email
-            * without a password
-        * And a matching editor
-        """
-        oauth_backend = OAuthBackend()
-        oauth_data = copy.copy(FAKE_IDENTITY_DATA)
-        identity = copy.copy(FAKE_IDENTITY)
+        @patch("urllib.request.urlopen")
+        def test_create_user_and_editor(self, mock_urlopen):
+            """
+            OAuthBackend._create_user_and_editor() should:
+            * create a user
+                * with a suitable username and email
+                * without a password
+            * And a matching editor
+            """
+            # HOTFIX: this test was failing in CI, but passing locally, just skipping it for now
+            # see: https://phabricator.wikimedia.org/T352896
+            self.skipTest("See: https://phabricator.wikimedia.org/T352896")
+            oauth_backend = OAuthBackend()
+            oauth_data = FAKE_IDENTITY_DATA
+            identity = FAKE_IDENTITY
 
-        mock_response = Mock()
-        mock_response.read.side_effect = [json.dumps(oauth_data)] * 7
-        mock_urlopen.return_value = mock_response
+            mock_response = Mock()
+            mock_response.read.side_effect = [json.dumps(oauth_data)] * 7
+            mock_urlopen.return_value = mock_response
 
-        user, editor = oauth_backend._create_user_and_editor(identity)
+            user, editor = oauth_backend._create_user_and_editor(identity)
 
-        self.assertEqual(user.email, "alice@example.com")
-        self.assertEqual(user.username, "567823")
-        self.assertFalse(user.has_usable_password())
+            self.assertEqual(user.email, "alice@example.com")
+            self.assertEqual(user.username, "567823")
+            self.assertFalse(user.has_usable_password())
 
-        self.assertEqual(editor.user, user)
-        self.assertEqual(editor.wp_sub, 567823)
-        # We won't test the fields set by update_from_wikipedia, as they are
-        # tested elsewhere.
+            self.assertEqual(editor.user, user)
+            self.assertEqual(editor.wp_sub, 567823)
+            # We won't test the fields set by update_from_wikipedia, as they are
+            # tested elsewhere.
 
     # We mock out this function for two reasons:
     # 1) To prevent its call to an external API, which we would have otherwise


### PR DESCRIPTION
Reverts WikipediaLibrary/TWLight#1535