### PR TITLE
Improve wording in TWL portal interface (T430924)

### DIFF
--- a/TWLight/emails/templates/emails/approval_notification-body-html.html
+++ b/TWLight/emails/templates/emails/approval_notification-body-html.html
@@ -6,7 +6,7 @@
   <p>Dear {{ user }},</p>
   <p>Thank you for applying for access to {{ partner }} resources through The Wikipedia Library. We are happy to inform you that your application has been approved.</p>
   <p>{{ user_instructions }}</p>
-  <p>You can view the collections you're authorized to access at My Library: {{ link }}</p>
+  <p>You can view the collections you're authorized to access at the My Library page: {{ link }}</p>
   <p>Cheers!</p>
   <p>The Wikipedia Library</p>
 {% endblocktranslate %}

--- a/TWLight/emails/templates/emails/approval_notification-body-text.html
+++ b/TWLight/emails/templates/emails/approval_notification-body-text.html
@@ -9,7 +9,7 @@ been approved.
 
 {{ user_instructions }}
 
-You can view the collections you're authorized to access at My Library: {{ link }}
+You can view the collections you're authorized to access at the My Library page: {{ link }}
 
 Cheers!
 

--- a/TWLight/resources/filters.py
+++ b/TWLight/resources/filters.py
@@ -13,7 +13,7 @@ ACCESS_CHOICES = (
     # Translators: On the MyLibrary page (https://wikipedialibrary.wmflabs.org/users/my_library), this indicates that a collection may be accessed immediately.
     (INSTANT, _("Instant (proxy) access")),
     # Translators: On the MyLibrary page (https://wikipedialibrary.wmflabs.org/users/my_library), this indicates that a collection may be accessed only after additional steps, such as submitting an application and awaiting approval.
-    (MULTI_STEP, _("Multi-step access")),
+    (MULTI_STEP, _("Access upon application")),
 )
 
 
@@ -75,7 +75,7 @@ class PartnerFilter(MainPartnerFilter):
 
     searchable = django_filters.MultipleChoiceFilter(
         # Translators: On the MyLibrary page (https://wikipedialibrary.wmflabs.org/users/my_library), this text is shown to indicate if a collection is searchable.
-        label=_("Searchable"),
+        label=_("Indexed in the Library's search engine"),
         choices=Partner.SEARCHABLE_CHOICES,
         widget=forms.CheckboxSelectMultiple,
     )

--- a/TWLight/resources/templates/resources/filter_section.html
+++ b/TWLight/resources/templates/resources/filter_section.html
@@ -51,6 +51,6 @@
     <div class="dropdown-divider"></div>
     {% comment %}Translators: On the Browse Partners page (https://wikipedialibrary.wmflabs.org/partners/), this is a placeholder for an input that helps users filter collections. {% endcomment %}
     <input id="collection-live-search" class="form-control form-control-sm mr-sm-2"
-        type="search" placeholder="{% trans 'Filter collections' %}" aria-label="Filter">
+        type="search" placeholder="{% trans 'Search the collection descriptions' %}" aria-label="Filter">
   </div>
 </nav>

--- a/TWLight/users/templates/users/filter_section.html
+++ b/TWLight/users/templates/users/filter_section.html
@@ -79,6 +79,6 @@
     <div class="dropdown-divider"></div>
     {% comment %}Translators: On the MyLibrary page (https://wikipedialibrary.wmflabs.org/users/my_library), this is a placeholder for an input that helps users filter collections. {% endcomment %}
     <input id="collection-live-search" class="form-control form-control-sm mr-sm-2"
-        type="search" placeholder="{% trans 'Filter collections' %}" aria-label="Filter">
+        type="search" placeholder="{% trans 'Search the collection descriptions' %}" aria-label="Filter">
   </div>
 </nav>

--- a/TWLight/users/templates/users/my_applications.html
+++ b/TWLight/users/templates/users/my_applications.html
@@ -76,7 +76,7 @@
                 <a class="btn twl-secondary-btn btn-sm" href="{% url 'applications:renew' app.pk %}">{% trans "Request renewal" %}</a>
               {% else %}
                 {% comment %}Translators: On the page listing applications, this text explains a user they cannot renew their application since they've already requested a renewal or there aren't any renewals available.{% endcomment %}
-                <em>{% trans "Renewals are either not required, not available right now, or you have already requested a renewal." %}</em>
+                <em>{% trans "It is not possible to request a renewal because it is not necessary, you have already requested one, or it is not currently available." %}</em>
               {% endif %}
             </div>
           {% endif %}


### PR DESCRIPTION
## Description
Improves several small text labels on the TWL portal interface based on user feedback in the linked ticket:

1. Clarified that "My Library" refers to a page name in the approval notification emails (added "page").
2. Changed the partner filter label "Multi-step access" to "Access upon application" for clarity.
3. Changed the partner filter label "Searchable" to "Indexed in the Library's search engine" to clarify it refers to the global search engine, not individual partner sites.
4. Changed the "Filter collections" search placeholder to "Search the collection descriptions" to clarify what field is being searched.
5. Simplified the renewal status message on the My Applications page to avoid repeating the word "renewal" twice.

## Rationale
These changes were suggested by a user in the linked Phabricator ticket, who noted that several small text labels on the portal were unclear or ambiguous. The new wording aims to make these labels more self-explanatory for both new and existing users.

## Phabricator Ticket
https://phabricator.wikimedia.org/T430924

## How Has This Been Tested?
This is a text-only change. Each string was located in the codebase and verified against the surrounding context (filters, templates, email notifications) to confirm it matches the intended display location. No functional/logic changes were made.

## Screenshots of your changes (if appropriate):
N/A - text/wording only changes

## Types of changes
What types of changes does your code introduce? Add an `x` in all the boxes that apply:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Minor change (fix a typo, add a translation tag, add section to README, etc.)