### PR TITLE
Add user agent to globaluserinfo call

### DIFF
--- a/TWLight/users/helpers/editor_data.py
+++ b/TWLight/users/helpers/editor_data.py
@@ -10,6 +10,13 @@ from djmail import template_mail
 
 logger = logging.getLogger(__name__)
 
+# Wikimedia's User-Agent policy requires a descriptive User-Agent with contact
+# information; the generic Python-urllib default is blocked with HTTP 403.
+# https://meta.wikimedia.org/wiki/User-Agent_policy
+TWLIGHT_USER_AGENT = "TWLight/1.0 (https://wikipedialibrary.wmflabs.org/; {contact}) Python-urllib".format(
+    contact=os.environ.get("TWLIGHT_ERROR_MAILTO", "wikipedialibrary@wikimedia.org")
+)
+
 
 def editor_global_userinfo(wp_sub: int):
     """
@@ -63,7 +70,8 @@ def _get_user_info_request(wp_param_name: str, wp_param: str):
     query = "{endpoint}?action=query&meta=globaluserinfo&{wp_param_name}={wp_param}&guiprop=editcount|merged&format=json&formatversion=2".format(
         endpoint=endpoint, wp_param_name=wp_param_name, wp_param=wp_param
     )
-    return json.loads(urllib.request.urlopen(query).read())
+    request = urllib.request.Request(query, headers={"User-Agent": TWLIGHT_USER_AGENT})
+    return json.loads(urllib.request.urlopen(request).read())
 
 
 def editor_reg_date(identity: dict, global_userinfo: dict):

--- a/TWLight/users/helpers/editor_data.py
+++ b/TWLight/users/helpers/editor_data.py
@@ -13,8 +13,11 @@ logger = logging.getLogger(__name__)
 # Wikimedia's User-Agent policy requires a descriptive User-Agent with contact
 # information; the generic Python-urllib default is blocked with HTTP 403.
 # https://meta.wikimedia.org/wiki/User-Agent_policy
-TWLIGHT_USER_AGENT = "TWLight/1.0 (https://wikipedialibrary.wmflabs.org/; {contact}) Python-urllib".format(
-    contact=os.environ.get("TWLIGHT_ERROR_MAILTO", "wikipedialibrary@wikimedia.org")
+# The environment (local/staging/production) is included so Wikimedia can
+# distinguish development and staging traffic from production.
+TWLIGHT_USER_AGENT = "TWLight/1.0 ({env}; https://wikipedialibrary.wmflabs.org/; {contact}) Python-urllib".format(
+    env=settings.TWLIGHT_ENV or "unknown",
+    contact=os.environ.get("TWLIGHT_ERROR_MAILTO", "wikipedialibrary@wikimedia.org"),
 )
 
 


### PR DESCRIPTION
## Description
Set a compliant User-Agent header on globaluserinfo API requests

The _get_user_info_request helper in TWLight/users/helpers/editor_data.py issued requests via urllib.request.urlopen() without setting a User-Agent header, so requests went out with Python's default Python-urllib/x.y agent. Wikimedia blocks this generic agent per its User Agent policy, returning HTTP 403 Forbidden.

Add a descriptive `TWLIGHT_USER_AGENT` constant containing the application name, URL, and contact address (sourced from `TWLIGHT_ERROR_MAILTO`), and send it via urllib.request.Request on the globaluserinfo query.

## Phabricator Ticket
- https://phabricator.wikimedia.org/T431808

## How Has This Been Tested?
- Verified against the live endpoint from the running container: the globaluserinfo call now returns 200 with real data (`{'id': 69468694, 'name': 'TheresNoTime-WMF', 'editcount': 709}`) instead of 403 Forbidden, and the full OAuth login / editor-creation path completes without the 500.
- Ran the existing users test suite (python manage.py test TWLight.users.tests)

## Types of changes
What types of changes does your code introduce? Add an `x` in all the boxes that apply:
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Minor change (fix a typo, add a translation tag, add section to README, etc.)
