### PR TITLE
Partially revert bf6ede6 to shorten message

### DIFF
--- a/TWLight/resources/filters.py
+++ b/TWLight/resources/filters.py
@@ -74,7 +74,7 @@ class PartnerFilter(MainPartnerFilter):
     """
 
     searchable = django_filters.MultipleChoiceFilter(
-        # Translators: On the MyLibrary page (https://wikipedialibrary.wmflabs.org/users/my_library), this text is shown to indicate if a collection is searchable in the "global search bar" present in the top of the Library website. It indexes some of the partners content to list all results from the different partners in one page.
+        # Translators: On the MyLibrary page (https://wikipedialibrary.wmflabs.org/users/my_library), this text is shown to indicate if a collection is searchable in the "global search bar" present in the top of the Library website.
         label=_("Searchable"),
         choices=Partner.SEARCHABLE_CHOICES,
         widget=forms.CheckboxSelectMultiple,


### PR DESCRIPTION
I merged #1537 but one of the translator messages was too long, causing a [test failure](https://github.com/WikipediaLibrary/TWLight/actions/runs/31806710419/job/94787281283) with:

```
Checking for localization issues
ERROR: Missing or overlong (> 240 chars) translator comment
TWLight/resources/filters.py:78
        label=_("Searchable"),
```

To quickly resolve this, let's shorten the message

```diff
diff --git a/TWLight/resources/filters.py b/TWLight/resources/filters.py
index 41e26ebcf..023fba94d 100644
--- a/TWLight/resources/filters.py
+++ b/TWLight/resources/filters.py
@@ -74,7 +74,7 @@ class PartnerFilter(MainPartnerFilter):
     """

     searchable = django_filters.MultipleChoiceFilter(
-        # Translators: On the MyLibrary page (https://wikipedialibrary.wmflabs.org/users/my_library), this text is shown to indicate if a collection is searchable in the "global search bar" present in the top of the Library website. It indexes some of the partners content to list all results from the different partners in one page.
+        # Translators: On the MyLibrary page (https://wikipedialibrary.wmflabs.org/users/my_library), this text is shown to indicate if a collection is searchable in the "global search bar" present in the top of the Library website.
         label=_("Searchable"),
         choices=Partner.SEARCHABLE_CHOICES,
         widget=forms.CheckboxSelectMultiple,
```