### PR TITLE
Only mark reminder_email_sent when the renewal actually sends

### DIFF
--- a/TWLight/emails/tasks.py
+++ b/TWLight/emails/tasks.py
@@ -24,6 +24,7 @@ settings.DJMAIL_REAL_BACKEND.
 
 from djmail import template_mail
 from djmail.template_mail import MagicMailBuilder, InlineCSSTemplateMail
+from concurrent.futures import Future
 import logging
 import os
 from uuid import uuid4
@@ -164,6 +165,10 @@ def send_user_renewal_notice_emails(sender, **kwargs):
     """
     Any time the related managment command is run, this sends email to
     users who have authorizations that are soon to expire.
+
+    Returns True only if the email was really sent. The caller uses this
+    result. It must not mark the authorization as reminded after a failed
+    send (T407250).
     """
     user_wp_username = kwargs["user_wp_username"]
     user_email = kwargs["user_email"]
@@ -176,7 +181,7 @@ def send_user_renewal_notice_emails(sender, **kwargs):
 
     email = UserRenewalNotice()
 
-    email.send(
+    result = email.send(
         user_email,
         {
             "user": user_wp_username,
@@ -185,6 +190,21 @@ def send_user_renewal_notice_emails(sender, **kwargs):
             "partner_link": partner_link,
         },
     )
+
+    # The async back-end returns a Future and sends in a worker thread.
+    # Wait for the result. Then we know if the send was a success.
+    # A synchronous back-end returns the sent count and does not use a Future.
+    if isinstance(result, Future):
+        try:
+            result = result.result()
+        except Exception:
+            logger.exception(
+                "Renewal notice email failed to send for user %s.",
+                user_wp_username,
+            )
+            return False
+
+    return bool(result)
 
 
 def send_survey_active_user_email(connection=email_connection(), **kwargs):

--- a/TWLight/emails/tests.py
+++ b/TWLight/emails/tests.py
@@ -647,6 +647,54 @@ class UserRenewalNoticeTest(TestCase):
         call_command("user_renewal_notice")
         self.assertEqual(len(mail.outbox), 1)
 
+    @patch("TWLight.emails.tasks.UserRenewalNotice.send", return_value=0)
+    def test_user_renewal_notice_not_marked_when_send_fails(self, mock_send):
+        """
+        Per T407250, if the email does not actually send, we must not mark
+        reminder_email_sent. Otherwise the user never gets a reminder and the
+        authorization is skipped forever.
+        """
+        call_command("user_renewal_notice")
+
+        # We tried to send.
+        self.assertTrue(mock_send.called)
+
+        # The send failed, so the flag stays False for a retry.
+        self.authorization.refresh_from_db()
+        self.assertFalse(self.authorization.reminder_email_sent)
+
+    @patch("TWLight.emails.tasks.UserRenewalNotice.send", return_value=0)
+    def test_user_renewal_notice_retries_after_failed_send(self, mock_send):
+        """
+        A failed send must leave the authorization eligible. A later run, when
+        sending works again, then sends the email and marks the flag.
+        """
+        # First run fails.
+        call_command("user_renewal_notice")
+        self.authorization.refresh_from_db()
+        self.assertFalse(self.authorization.reminder_email_sent)
+
+        # Now sending works. The authorization is still eligible.
+        mock_send.return_value = 1
+        call_command("user_renewal_notice")
+        self.authorization.refresh_from_db()
+        self.assertTrue(self.authorization.reminder_email_sent)
+
+    @patch(
+        "TWLight.emails.tasks.UserRenewalNotice.send",
+        side_effect=Exception("simulated send failure"),
+    )
+    def test_user_renewal_notice_batch_survives_send_exception(self, mock_send):
+        """
+        If one send raises, the command must not crash and must not mark the
+        authorization. The next run tries again.
+        """
+        # The command must not raise.
+        call_command("user_renewal_notice")
+
+        self.authorization.refresh_from_db()
+        self.assertFalse(self.authorization.reminder_email_sent)
+
 
 class CoordinatorReminderEmailTest(TestCase):
     @classmethod

--- a/TWLight/users/management/commands/user_renewal_notice.py
+++ b/TWLight/users/management/commands/user_renewal_notice.py
@@ -1,4 +1,5 @@
 from datetime import datetime, timedelta
+import logging
 
 from django.contrib.auth.models import User
 from django.core.management.base import BaseCommand
@@ -9,6 +10,8 @@ from TWLight.applications.models import Application
 from TWLight.resources.models import Partner
 from TWLight.users.signals import Notice
 from TWLight.users.models import Authorization, get_company_name, Editor
+
+logger = logging.getLogger(__name__)
 
 
 class Command(BaseCommand):
@@ -59,15 +62,34 @@ class Command(BaseCommand):
         for authorization_object in expiring_authorizations.exclude(
             pk__in=no_email_list
         ):
-            Notice.user_renewal_notice.send(
-                sender=self.__class__,
-                user_wp_username=authorization_object.user.editor.wp_username,
-                user_email=authorization_object.user.email,
-                user_lang=authorization_object.user.userprofile.lang,
-                partner_name=get_company_name(authorization_object),
-                partner_link=reverse("users:my_library"),
-            )
+            try:
+                responses = Notice.user_renewal_notice.send(
+                    sender=self.__class__,
+                    user_wp_username=authorization_object.user.editor.wp_username,
+                    user_email=authorization_object.user.email,
+                    user_lang=authorization_object.user.userprofile.lang,
+                    partner_name=get_company_name(authorization_object),
+                    partner_link=reverse("users:my_library"),
+                )
+            except Exception:
+                # Do not stop the batch if one send fails. Do not mark the
+                # authorization. The next run tries again.
+                logger.exception(
+                    "Failed to send renewal notice for authorization %s.",
+                    authorization_object.pk,
+                )
+                continue
 
-            # Record that we sent the email so that we only send one.
-            authorization_object.reminder_email_sent = True
-            authorization_object.save()
+            # Record that we sent the email so that we only send one. Mark the
+            # authorization only if the email was really sent. If we mark it
+            # after a failed send, the user never gets a reminder (T407250).
+            email_sent = any(response for receiver, response in responses)
+            if email_sent:
+                authorization_object.reminder_email_sent = True
+                authorization_object.save()
+            else:
+                logger.warning(
+                    "Renewal notice was not sent for authorization %s. "
+                    "reminder_email_sent stays False for a retry.",
+                    authorization_object.pk,
+                )

--- a/TWLight/users/management/commands/user_renewal_notice_diagnostics.py
+++ b/TWLight/users/management/commands/user_renewal_notice_diagnostics.py
@@ -1,0 +1,216 @@
+from datetime import datetime, timedelta
+
+from django.conf import settings
+from django.contrib.auth.models import User
+from django.core.management.base import BaseCommand
+from django.db.models import Count, Prefetch, Q
+from django.utils import timezone
+
+from djmail.models import Message
+
+from TWLight.applications.models import Application
+from TWLight.resources.models import Partner
+from TWLight.users.models import Authorization, Editor
+
+
+class Command(BaseCommand):
+    help = (
+        "READ-ONLY diagnostics for the user_renewal_notice command (T407250). "
+        "Reports why expiry-notice emails may not be going out. "
+        "Sends no email and writes no data."
+    )
+
+    # English subject from user_renewal_notice-subject.html. Non-English
+    # messages are stored translated, so this match is best-effort; the
+    # Authorization-side counts and the global djmail stats do not depend
+    # on it.
+    RENEWAL_SUBJECT_FRAGMENT = "access may soon expire"
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--days",
+            type=int,
+            default=100,
+            help="Window (days) for the recent djmail message stats. "
+            "Default matches the djmail_delete_old_messages retention (100).",
+        )
+
+    def handle(self, *args, **options):
+        days = options["days"]
+        today = datetime.today()
+
+        w = self.stdout.write
+
+        w("== user_renewal_notice diagnostics (READ-ONLY) ==")
+        w("Today: {}".format(today.date()))
+
+        # --- 1. Config sanity ------------------------------------------------
+        real_backend = getattr(
+            settings,
+            "DJMAIL_REAL_BACKEND",
+            "django.core.mail.backends.console.EmailBackend",
+        )
+        w("")
+        w("[Config]")
+        w("  EMAIL_BACKEND       : {}".format(getattr(settings, "EMAIL_BACKEND", "?")))
+        w("  DJMAIL_REAL_BACKEND : {}".format(real_backend))
+
+        # --- 2. What the command WOULD email today --------------------------
+        # This replicates user_renewal_notice.Command.handle() exactly, but
+        # only counts. Keep in sync with that command.
+        editor_qs = Editor.objects.select_related("user")
+        applications_for_renewal = (
+            Application.objects.prefetch_related(Prefetch("editor", queryset=editor_qs))
+            .values("editor__user__pk", "partner__pk")
+            .filter(
+                ~Q(partner__authorization_method=Partner.BUNDLE),
+                status__in=[Application.PENDING, Application.QUESTION],
+                parent__isnull=False,
+                editor__isnull=False,
+            )
+            .order_by("-date_created")
+        )
+
+        user_qs = User.objects.select_related("userprofile")
+        expiring_authorizations = (
+            Authorization.objects.prefetch_related(Prefetch("user", queryset=user_qs))
+            .filter(
+                date_expires__lt=today + timedelta(weeks=2),
+                date_expires__gte=today,
+                reminder_email_sent=False,
+                partners__isnull=False,
+            )
+            .exclude(user__userprofile__send_renewal_notices=False)
+        )
+
+        no_email_list = []
+        for application in applications_for_renewal:
+            no_email_list.append(
+                expiring_authorizations.values_list("pk").filter(
+                    partners=application["partner__pk"],
+                    user=application["editor__user__pk"],
+                )
+            )
+
+        would_email = expiring_authorizations.exclude(pk__in=no_email_list).count()
+
+        w("")
+        w(
+            "[Query] authorizations the command WOULD email today: {}".format(
+                would_email
+            )
+        )
+        w(
+            "  (in-window & un-reminded, before renewal-filed exclusion: {})".format(
+                expiring_authorizations.count()
+            )
+        )
+        w(
+            "  excluded because a renewal was already filed: {}".format(
+                len(no_email_list)
+            )
+        )
+
+        # --- 3. Sticky-flag suppression (Authorization-side, locale-neutral) -
+        marked = Authorization.objects.filter(reminder_email_sent=True)
+        marked_total = marked.count()
+        marked_not_expired = marked.filter(date_expires__gte=today).count()
+        marked_in_window = marked.filter(
+            date_expires__gte=today,
+            date_expires__lt=today + timedelta(weeks=2),
+        ).count()
+
+        w("")
+        w("[Suppression] reminder_email_sent=True ...")
+        w("  total                                   : {}".format(marked_total))
+        w(
+            "  AND not yet expired (date_expires>=today): {}   <-- marked but access still live".format(
+                marked_not_expired
+            )
+        )
+        w(
+            "  AND still inside the 2-week notice window: {}   <-- would email if flag were reset".format(
+                marked_in_window
+            )
+        )
+
+        # --- 4. djmail send-path health -------------------------------------
+        status_names = {
+            Message.STATUS_DRAFT: "DRAFT",
+            Message.STATUS_PENDING: "PENDING",
+            Message.STATUS_SENT: "SENT",
+            Message.STATUS_FAILED: "FAILED",
+            Message.STATUS_DISCARDED: "DISCARDED",
+        }
+
+        def status_breakdown(qs):
+            counts = {
+                row["status"]: row["c"]
+                for row in qs.values("status").annotate(c=Count("pk"))
+            }
+            return {status_names.get(k, k): v for k, v in sorted(counts.items())}
+
+        # created_at is a DateTimeField; use an aware value under USE_TZ.
+        since = timezone.now() - timedelta(days=days)
+        recent = Message.objects.filter(created_at__gte=since)
+
+        w("")
+        w("[djmail] ALL messages, last {} days".format(days))
+        w("  total                 : {}".format(recent.count()))
+        w("  by status             : {}".format(status_breakdown(recent)))
+        w(
+            "  with recorded exception: {}".format(
+                recent.exclude(exception="").exclude(exception__isnull=True).count()
+            )
+        )
+
+        latest_exc = (
+            Message.objects.exclude(exception="")
+            .exclude(exception__isnull=True)
+            .order_by("-created_at")
+            .first()
+        )
+        if latest_exc:
+            exc_text = (latest_exc.exception or "").strip().replace("\n", " ")
+            w(
+                "  latest exception ({}): {}".format(
+                    latest_exc.created_at.date(), exc_text[:300]
+                )
+            )
+        else:
+            w("  latest exception      : (none recorded)")
+
+        # --- 5. Renewal-subject messages (best-effort, English only) --------
+        renewal_msgs = Message.objects.filter(
+            subject__icontains=self.RENEWAL_SUBJECT_FRAGMENT
+        )
+        w("")
+        w(
+            "[djmail] renewal-notice messages (subject ~ '{}', English only)".format(
+                self.RENEWAL_SUBJECT_FRAGMENT
+            )
+        )
+        w("  total                 : {}".format(renewal_msgs.count()))
+        w("  by status             : {}".format(status_breakdown(renewal_msgs)))
+        if renewal_msgs.exists():
+            oldest = renewal_msgs.order_by("created_at").first().created_at.date()
+            newest = renewal_msgs.order_by("-created_at").first().created_at.date()
+            w("  date range            : {} .. {}".format(oldest, newest))
+
+        # --- 6. Interpretation ----------------------------------------------
+        w("")
+        w("[How to read this]")
+        w(
+            "  * Many 'marked but not yet expired' + few SENT renewal messages"
+            " => sticky-flag suppression (auths marked reminded without delivery)."
+        )
+        w(
+            "  * djmail DRAFT/FAILED with exceptions => the real backend is failing;"
+            " the async command exits 0 and marks reminder_email_sent anyway."
+        )
+        w(
+            "  * would-email=0 AND no in-window auths => genuinely nobody to notify"
+            " (not a bug)."
+        )
+        w("")
+        w("Done. No data was modified.")


### PR DESCRIPTION
Add a diagnostic command for renewal emails (this can probably be dropped in the future if no longer needed)
Only mark reminder_email_sent when the renewal email _actually_ sends

Bug: [T407250](https://phabricator.wikimedia.org/T407250)
